### PR TITLE
[22.01] Minor fixes from sentry data

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -157,7 +157,6 @@ class DataMetaFilter(Filter):
             self.column = d_option.column_spec_to_index(self.column)
         self.multiple = string_as_bool(elem.get("multiple", "False"))
         self.separator = elem.get("separator", ",")
-        log.error(f"data_meta.init: ref_name {self.ref_name} key {self.key} column {self.column} multiple {self.multiple} separator {self.separator}")
 
     def get_dependency_name(self):
         return self.ref_name

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -47,7 +47,7 @@ from galaxy.webapps.galaxy.api.common import (
 )
 from galaxy.webapps.galaxy.services.datasets import (
     ConvertedDatasetsMap,
-    DatasetInheritanceChainEntry,
+    DatasetInheritanceChain,
     DatasetsService,
     DatasetStorageDetails,
     DatasetTextContentDetails,
@@ -122,7 +122,7 @@ class FastAPIDatasets:
         trans=DependsOnTrans,
         dataset_id: EncodedDatabaseIdField = DatasetIDPathParam,
         hda_ldda: DatasetSourceType = DatasetSourceQueryParam,
-    ) -> List[DatasetInheritanceChainEntry]:
+    ) -> DatasetInheritanceChain:
         return self.service.show_inheritance_chain(trans, dataset_id, hda_ldda)
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -104,6 +104,13 @@ class DatasetInheritanceChainEntry(Model):
     )
 
 
+class DatasetInheritanceChain(Model):
+    __root__: List[DatasetInheritanceChainEntry] = Field(
+        default=[],
+        title="Dataset inheritance chain",
+    )
+
+
 class ExtraFilesEntryClass(str, Enum):
     Directory = "Directory"
     File = "File"
@@ -310,7 +317,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         trans: ProvidesHistoryContext,
         dataset_id: EncodedDatabaseIdField,
         hda_ldda: DatasetSourceType = DatasetSourceType.hda,
-    ) -> List[DatasetInheritanceChainEntry]:
+    ) -> DatasetInheritanceChain:
         """
         Display inheritance chain for the given dataset.
         """
@@ -321,7 +328,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         for dep in inherit_chain:
             result.append(DatasetInheritanceChainEntry(name=f"{dep[0].name}", dep=dep[1]))
 
-        return result
+        return DatasetInheritanceChain(__root__=result)
 
     def update_permissions(
         self,

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -163,7 +163,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
         self._assert_status_code_is(show_response, 200)
         self.__assert_matches_hda(hda1, show_response.json())
 
-    def test_hda_copy(self):
+    def _create_copy(self):
         hda1 = self.dataset_populator.new_dataset(self.history_id)
         create_data = dict(
             source='hda',
@@ -173,7 +173,18 @@ class HistoryContentsApiTestCase(ApiTestCase):
         assert self.__count_contents(second_history_id) == 0
         create_response = self._post(f"histories/{second_history_id}/contents", create_data, json=True)
         self._assert_status_code_is(create_response, 200)
-        assert self.__count_contents(second_history_id) == 1
+        return create_response.json()
+
+    def test_hda_copy(self):
+        response = self._create_copy()
+        assert self.__count_contents(response['history_id']) == 1
+
+    def test_inheritance_chain(self):
+        response = self._create_copy()
+        inheritance_chain_response = self._get(f"datasets/{response['id']}/inheritance_chain")
+        self._assert_status_code_is_ok(inheritance_chain_response)
+        inheritance_chain = inheritance_chain_response.json()
+        assert len(inheritance_chain) == 1
 
     def test_library_copy(self):
         ld = self.library_populator.new_library_dataset("lda_test_library")


### PR DESCRIPTION
One noisy logging statement that was a leftover from debugging, I guess and one case of inheritance_chain failing to serialize when not used under fastAPI (the `isinstance(item, pydantic.BaseModel)` if we return lists or dicts of pydantic models).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
