### PR TITLE
[21.09] Fix resuming job when job has optional data parameters

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -675,12 +675,13 @@ class DefaultToolAction:
         return remapped_hdas
 
     def __remap_parameters(self, job_to_remap, jtid, jtod, out_data):
-        input_values = {p.name: json.loads(p.value) for p in job_to_remap.parameters}
+        input_values = {p.name: json.loads(p.value) for p in job_to_remap.parameters if p.value is not None}
         old_dataset_id = jtod.dataset_id
         new_dataset_id = out_data[jtod.name].id
         input_values = update_dataset_ids(input_values, {old_dataset_id: new_dataset_id}, src='hda')
         for p in job_to_remap.parameters:
-            p.value = json.dumps(input_values[p.name])
+            if p.name in input_values:
+                p.value = json.dumps(input_values[p.name])
         jtid.dataset = out_data[jtod.name]
         jtid.dataset.hid = jtod.dataset.hid
         log.info(f'Job {job_to_remap.id} input HDA {jtod.dataset.id} remapped to new HDA {jtid.dataset.id}')

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -967,6 +967,7 @@ steps:
           cond_param_inner: true
           input1:
             $link: 0/out_file1
+    thedata: null
   cat:
     tool_id: cat1
     in:

--- a/test/functional/tools/identifier_multiple_in_conditional.xml
+++ b/test/functional/tools/identifier_multiple_in_conditional.xml
@@ -16,6 +16,7 @@
                 </conditional>
             </when>
         </conditional>
+        <param name="thedata" type="data" optional="true" label="Optional dummy data"/>
     </inputs>
     <outputs>
         <data name="output1" format="tabular" from_work_dir="output1" />


### PR DESCRIPTION
This fixes
```
ERROR    galaxy.tools.actions:__init__.py:683 Cannot remap rerun dependencies.
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/actions/__init__.py", line 664, in _remap_job_on_rerun
    self.__remap_parameters(job_to_remap, jtid, jtod, out_data)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/actions/__init__.py", line 694, in __remap_parameters
    input_values = {p.name: json.loads(p.value) for p in job_to_remap.parameters}
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/actions/__init__.py", line 694, in <dictcomp>
    input_values = {p.name: json.loads(p.value) for p in job_to_remap.parameters}
  File "/usr/local/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not
NoneType
```

Optional data inputs or optional selects are stored as `None` (super inconsistent, since most other parameters are stored as JSON. We should create "basic_2.py" using pydantic at one point not too far into the future ...). This means we can't call `json.loads` on these. Fortunately this is the only place we do it, and we don't need to consider optional parameters here anyway.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
