### PR TITLE
[21.09] Backport blame ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Migrate code style to Prettier
+5b2928f851bd5ea3b9c2a04abf2cee9ff0bc54cc
+87873c5e2f4e6b97fe0f2084bfca0295fcd471de


### PR DESCRIPTION
xref: https://gitter.im/galaxyproject/dev?at=62026f5ca41d896a2085ff48

Keeps `git blame` working smoothly when switching between recent branches.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Set up git blame config per #11162, try a `git blame` in 21.09.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
