### PR TITLE
[22.01] Fix history exports import by url

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -59,7 +59,7 @@ from galaxy.web import (
     expose_api,
     expose_api_anonymous,
     expose_api_anonymous_and_sessionless,
-    expose_api_raw,
+    expose_api_raw_anonymous,
 )
 from galaxy.webapps.galaxy.api.common import (
     parse_serialization_params,
@@ -765,7 +765,7 @@ class HistoriesController(BaseGalaxyAPIController):
             trans.response.status = 202
         return export_result
 
-    @expose_api_raw
+    @expose_api_raw_anonymous
     def archive_download(self, trans, id, jeha_id, **kwds):
         """
         GET /api/histories/{id}/exports/{jeha_id}

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -59,7 +59,7 @@ from galaxy.web import (
     expose_api,
     expose_api_anonymous,
     expose_api_anonymous_and_sessionless,
-    expose_api_raw_anonymous,
+    expose_api_raw_anonymous_and_sessionless,
 )
 from galaxy.webapps.galaxy.api.common import (
     parse_serialization_params,
@@ -765,7 +765,7 @@ class HistoriesController(BaseGalaxyAPIController):
             trans.response.status = 202
         return export_result
 
-    @expose_api_raw_anonymous
+    @expose_api_raw_anonymous_and_sessionless
     def archive_download(self, trans, id, jeha_id, **kwds):
         """
         GET /api/histories/{id}/exports/{jeha_id}

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -390,7 +390,7 @@ class ImportExportTests(BaseHistories):
         self.dataset_populator.wait_for_history(history_id, assert_ok=assert_ok)
 
         return self.dataset_populator.reimport_history(
-            history_id, history_name, wait_on_history_length=wait_on_history_length, export_kwds=export_kwds, api_key=self.galaxy_interactor.api_key
+            history_id, history_name, wait_on_history_length=wait_on_history_length, export_kwds=export_kwds,
         )
 
     def _import_history_and_wait(self, import_data, history_name, wait_on_history_length=None):

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -499,7 +499,7 @@ test_data:
                 history_length = self.dataset_populator.history_length(history_id)
 
             new_history_id = self.dataset_populator.reimport_history(
-                history_id, history_name, wait_on_history_length=history_length, export_kwds={}, api_key=self.galaxy_interactor.api_key
+                history_id, history_name, wait_on_history_length=history_length, export_kwds={},
             )
             # wait a little more for those jobs, todo fix to wait for history imported false or
             # for a specific number of jobs...

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -972,20 +972,19 @@ class BaseDatasetPopulator(BasePopulator):
             assert "job_id" in job_desc
             return self.wait_for_job(job_desc["job_id"])
 
-    def export_url(self, history_id: str, data, api_key: str, check_download: bool = True) -> str:
+    def export_url(self, history_id: str, data, check_download: bool = True) -> str:
         put_response = self.prepare_export(history_id, data)
         response = put_response.json()
         api_asserts.assert_has_keys(response, "download_url")
         download_url = urllib.parse.urljoin(self.galaxy_interactor.api_url, response["download_url"].strip('/'))
 
         if check_download:
-            self.get_export_url(download_url, api_key)
+            self.get_export_url(download_url)
 
         return download_url
 
-    def get_export_url(self, export_url, api_key) -> Response:
-        full_download_url = f"{export_url}?key={api_key}"
-        download_response = self._get(full_download_url)
+    def get_export_url(self, export_url) -> Response:
+        download_response = self._get(export_url)
         api_asserts.assert_status_code_is(download_response, 200)
         return download_response
 
@@ -1041,11 +1040,11 @@ class BaseDatasetPopulator(BasePopulator):
         contents = contents_response.json()
         return len(contents)
 
-    def reimport_history(self, history_id, history_name, wait_on_history_length, export_kwds, api_key):
+    def reimport_history(self, history_id, history_name, wait_on_history_length, export_kwds):
         # Make history public so we can import by url
         self.make_public(history_id)
         # Export the history.
-        download_url = self.export_url(history_id, export_kwds, api_key, check_download=True)
+        download_url = self.export_url(history_id, export_kwds, check_download=True)
 
         import_data = dict(archive_source=download_url, archive_type="url")
 


### PR DESCRIPTION
We used the old controller route on 21.09, that's why we never noticed this.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
