### PR TITLE
Update Favorite Icon Style (Fixes #12622)

### DIFF
--- a/client/src/components/Panels/Buttons/FavoritesButton.vue
+++ b/client/src/components/Panels/Buttons/FavoritesButton.vue
@@ -1,6 +1,6 @@
 <template>
     <a
-        class="panel-header-button"
+        class="panel-header-button-toolbox"
         @click="onFavorites"
         v-b-tooltip.hover
         :title="tooltipText"

--- a/client/src/components/Panels/Buttons/PanelViewButton.vue
+++ b/client/src/components/Panels/Buttons/PanelViewButton.vue
@@ -7,7 +7,7 @@
         variant="link"
         aria-label="View all tool panel configurations"
         class="tool-panel-dropdown float-right"
-        toggle-class = "panel-header-button-toolbox float-right"
+        toggle-class="panel-header-button-toolbox float-right"
         size="sm"
         v-b-tooltip.hover>
         <template v-slot:button-content>

--- a/client/src/components/Panels/Buttons/PanelViewButton.vue
+++ b/client/src/components/Panels/Buttons/PanelViewButton.vue
@@ -7,6 +7,7 @@
         variant="link"
         aria-label="View all tool panel configurations"
         class="tool-panel-dropdown float-right"
+        toggle-class = "panel-header-button-toolbox float-right"
         size="sm"
         v-b-tooltip.hover>
         <template v-slot:button-content>

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -243,9 +243,9 @@ body {
         .panel-header-button-toolbox {
             color: $brand-dark;
             flex: 1;
-            padding: 6px;
+            @extend .p-1;
             text-align: center;
-            font-size: 17px;
+            font-size: $h4-font-size;
             align-items: center;
             &:hover {
                 color: $brand-info;
@@ -253,7 +253,6 @@ body {
                 text-decoration: none !important;
                 border-color: $brand-light;
             }
-            text-decoration: none !important;
         }
     }
 }

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -225,10 +225,12 @@ body {
         min-width: max-content;
         align-items: center;
         justify-content: space-between;
+        display: flex;
     }
     .panel-header-buttons {
         @extend .float-right;
         order: 9999;
+        display: flex;
         .panel-header-button {
             text-align: center;
             &:not(:last-child) {
@@ -237,6 +239,21 @@ body {
             &:hover {
                 color: $brand-info;
             }
+        }
+        .panel-header-button-toolbox {
+            color: $brand-dark;
+            flex: 1;
+            padding: 6px;
+            text-align: center;
+            font-size: 17px;
+            align-items: center;
+            &:hover {
+                color: $brand-info;
+                background-color: $brand-light;
+                text-decoration: none !important;
+                border-color: $brand-light;
+            }
+            text-decoration: none !important;
         }
     }
 }


### PR DESCRIPTION
The panel icon and the favorite icon star in the tool panel header had different styles. They were to be aligned.
I did the following: 
- I matched the color for both icons
- Removed hover highlighting from the Panel Header icon

Changes were made to base.scss for color formatting, and changing the class/toggle-class in the .vue files for the two buttons helped apply those changes.

Original Icons:
![](https://user-images.githubusercontent.com/2105447/135680461-cfd8dbbb-8e6e-4da1-b87c-5e4917b1d160.png)

New Icons:
<img width="859" alt="Screen Shot 2022-02-08 at 7 43 48 PM" src="https://user-images.githubusercontent.com/78516064/153100336-34af2a0f-9c5c-467a-9f33-c4932895cc13.png">

Note: Pay attention to the difference in hover styling for the Panel View icon.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
