### PR TITLE
[22.01] Fix toolbox cache

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -99,7 +99,7 @@
     "vueisotope": "^3.1.2",
     "vuex": "^3.4.0",
     "vuex-cache": "^3.2.0",
-    "vuex-persist": "^3.1.3",
+    "vuex-persist": "2.3",
     "xml-beautifier": "^0.5.0"
   },
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -56,6 +56,7 @@
     "jquery.cookie": "^1.4.1",
     "jspdf": "^2.4.0",
     "linkifyjs": "^2.1.9",
+    "localforage": "^1.10.0",
     "markdown-it": "^12.3.2",
     "markdown-it-regexp": "^0.4.0",
     "moment": "2.29.1",

--- a/client/package.json
+++ b/client/package.json
@@ -99,7 +99,6 @@
     "vuex": "^3.4.0",
     "vuex-cache": "^3.2.0",
     "vuex-persist": "^3.1.3",
-    "vuex-persistedstate": "^4.1.0",
     "xml-beautifier": "^0.5.0"
   },
   "scripts": {

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -36,13 +36,13 @@ import { syncVuextoGalaxy } from "./syncVuextoGalaxy";
 
 Vue.use(Vuex);
 
-const galaxyStorage = localForage.createInstance({})
+const galaxyStorage = localForage.createInstance({});
 galaxyStorage.config({
-    driver      : localForage.INDEXEDDB,
-    name        : 'galaxyIndexedDB',
-    version     : 1.0,
-    storeName   : 'galaxyStore',
-})
+    driver: [localForage.INDEXEDDB, localForage.LOCALSTORAGE],
+    name: "galaxyIndexedDB",
+    version: 1.0,
+    storeName: "galaxyStore",
+});
 
 const panelsPersistence = new VuexPersistence({
     storage: galaxyStorage,

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -5,7 +5,7 @@
 import Vue from "vue";
 import Vuex from "vuex";
 import createCache from "vuex-cache";
-import createPersistedState from "vuex-persistedstate";
+import VuexPersistence from "vuex-persist";
 
 import config from "config";
 
@@ -35,13 +35,15 @@ import { syncVuextoGalaxy } from "./syncVuextoGalaxy";
 
 Vue.use(Vuex);
 
-const panelsState = createPersistedState({
-    paths: ["panels"],
+// Create vuexpersistence
+const panelsPersistence = new VuexPersistence({
+    storage: window.localStorage,
+    modules: ["panels"],
 });
 
 export function createStore() {
     const storeConfig = {
-        plugins: [createCache(), panelsState],
+        plugins: [createCache(), panelsPersistence.plugin],
         modules: {
             user: userStore,
             config: configStore,

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -6,6 +6,7 @@ import Vue from "vue";
 import Vuex from "vuex";
 import createCache from "vuex-cache";
 import VuexPersistence from "vuex-persist";
+import localForage from "localforage";
 
 import config from "config";
 
@@ -35,9 +36,9 @@ import { syncVuextoGalaxy } from "./syncVuextoGalaxy";
 
 Vue.use(Vuex);
 
-// Create vuexpersistence
 const panelsPersistence = new VuexPersistence({
-    storage: window.localStorage,
+    storage: localForage,
+    asyncStorage: true,
     modules: ["panels"],
 });
 
@@ -49,7 +50,6 @@ export function createStore() {
             config: configStore,
             betaHistory: betaHistoryStore,
             panels: panelStore,
-
             // TODO: please namespace all store modules
             gridSearch: gridSearchStore,
             histories: historyStore,

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -36,8 +36,16 @@ import { syncVuextoGalaxy } from "./syncVuextoGalaxy";
 
 Vue.use(Vuex);
 
+const galaxyStorage = localForage.createInstance({})
+galaxyStorage.config({
+    driver      : localForage.INDEXEDDB,
+    name        : 'galaxyIndexedDB',
+    version     : 1.0,
+    storeName   : 'galaxyStore',
+})
+
 const panelsPersistence = new VuexPersistence({
-    storage: localForage,
+    storage: galaxyStorage,
     asyncStorage: true,
     modules: ["panels"],
 });

--- a/client/src/store/panelStore.js
+++ b/client/src/store/panelStore.js
@@ -44,7 +44,6 @@ const actions = {
     },
     fetchPanel: async ({ commit }, panelView) => {
         const { data } = await axios.get(`${getAppRoot()}api/tools?in_panel=true&view=${panelView}`);
-        // wait for 15 seconds before committing
         commit("savePanelView", { panelView, panel: data });
     },
 };

--- a/client/src/store/panelStore.js
+++ b/client/src/store/panelStore.js
@@ -51,7 +51,6 @@ const actions = {
 
 const mutations = {
     savePanelView: (state, { panelView, panel }) => {
-        console.debug("savePanelView data, size is", JSON.stringify(panel).length);
         Vue.set(state.panel, panelView, panel);
     },
     setCurrentPanelView: (state, { panelView }) => {

--- a/client/src/store/panelStore.js
+++ b/client/src/store/panelStore.js
@@ -44,12 +44,14 @@ const actions = {
     },
     fetchPanel: async ({ commit }, panelView) => {
         const { data } = await axios.get(`${getAppRoot()}api/tools?in_panel=true&view=${panelView}`);
+        // wait for 15 seconds before committing
         commit("savePanelView", { panelView, panel: data });
     },
 };
 
 const mutations = {
     savePanelView: (state, { panelView, panel }) => {
+        console.debug("savePanelView data, size is", JSON.stringify(panel).length);
         Vue.set(state.panel, panelView, panel);
     },
     setCurrentPanelView: (state, { panelView }) => {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11402,11 +11402,6 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shvl@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/shvl/-/shvl-2.0.3.tgz#eb4bd37644f5684bba1fc52c3010c96fb5e6afd1"
-  integrity sha512-V7C6S9Hlol6SzOJPnQ7qzOVEWUQImt3BNmmzh40wObhla3XOYMe4gGiYzLrJd5TFa+cI2f9LKIRJTTKZSTbWgw==
-
 side-channel@^1.0.3, side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -13128,14 +13123,6 @@ vuex-persist@^3.1.3:
   dependencies:
     deepmerge "^4.2.2"
     flatted "^3.0.5"
-
-vuex-persistedstate@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/vuex-persistedstate/-/vuex-persistedstate-4.1.0.tgz#127165f85f5b4534fb3170a5d3a8be9811bd2a53"
-  integrity sha512-3SkEj4NqwM69ikJdFVw6gObeB0NHyspRYMYkR/EbhR0hbvAKyR5gksVhtAfY1UYuWUOCCA0QNGwv9pOwdj+XUQ==
-  dependencies:
-    deepmerge "^4.2.2"
-    shvl "^2.0.3"
 
 vuex@^3.4.0:
   version "3.6.2"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5469,7 +5469,12 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
-flatted@^3.0.5, flatted@^3.1.0, flatted@^3.2.4:
+flatted@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
+  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+flatted@^3.1.0, flatted@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.4.tgz#28d9969ea90661b5134259f312ab6aa7929ac5e2"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
@@ -13136,13 +13141,13 @@ vuex-cache@^3.2.0:
   resolved "https://registry.yarnpkg.com/vuex-cache/-/vuex-cache-3.4.0.tgz#0aec66b7abb370b1a089f678681af8efe5a9289b"
   integrity sha512-C0HJvVTEdjn8gq0EXemcJCBgAyPLnms8VGz/kMakrpaF6XNwkZY5KvySkdBJSY6rp0eTdWMoHPVU2Oq+dK7WEQ==
 
-vuex-persist@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/vuex-persist/-/vuex-persist-3.1.3.tgz#518c722a2ca3026bcee5732f99d24f75cee0f3b6"
-  integrity sha512-QWOpP4SxmJDC5Y1+0+Yl/F4n7z27syd1St/oP+IYCGe0X0GFio0Zan6kngZFufdIhJm+5dFGDo3VG5kdkCGeRQ==
+vuex-persist@2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vuex-persist/-/vuex-persist-2.3.0.tgz#f3d21b6d631078667d6834f2f74442ee332ac281"
+  integrity sha512-0QPZQYgQ72SbXkdwctXGFQJhlRiySP0z9wHDBTlyHvNy3CneKvgyJ7Lfob8NUiYbaurJepaC+JFynwshp59FGA==
   dependencies:
-    deepmerge "^4.2.2"
-    flatted "^3.0.5"
+    flatted "^2.0.0"
+    lodash "^4.17.19"
 
 vuex@^3.4.0:
   version "3.6.2"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8093,6 +8093,13 @@ loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
+localforage@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
+
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -8966,17 +8973,30 @@ object-hash@^2.2.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
   integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
-object-inspect@^1.11.0, object-inspect@^1.9.0:
+object-inspect@^1.11.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
   integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
 
-object-is@^1.0.1, object-is@^1.1.4:
+object-inspect@^1.9.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
+  integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
+object-is@^1.0.1:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
   integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
   dependencies:
     call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
+object-is@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz#63d6c83c00a43f4cbc9434eb9757c8a5b8565068"
+  integrity sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==
+  dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
 
 object-keys@^1.0.12, object-keys@^1.1.1:


### PR DESCRIPTION
Fixes the toolbox cache (xref #13015) overflowing localstorage.  Tried a bunch of options and this was super clean to implement and seems to work really well in my testing.

This drops vuex-persistedstate which is now deprecated and abandoned for vuex-persist, and adds localForage as a storage backend that will push key-value pairs into indexedDB.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Use this client against EU's toolbox, view EDAM varieties.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
