### PR TITLE
Upload metadata files to cloud storages in extended metadata_strategy

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -42,6 +42,7 @@ from galaxy.model import (
     Dataset,
     HistoryDatasetAssociation,
     Job,
+    MetadataFile,
     store,
 )
 from galaxy.model.custom_types import total_size
@@ -420,6 +421,13 @@ def set_metadata_portable():
                     dataset.dataset.external_filename = None
                     dataset.dataset.extra_files_path = None
                 export_store.add_dataset(dataset)
+                for metadata in dataset.metadata.values():
+                    if isinstance(metadata, MetadataFile):
+                        object_store.update_from_file(metadata,
+                                                      file_name=metadata.file_name,
+                                                      extra_dir='_metadata_files',
+                                                      extra_dir_at_root=True,
+                                                      alt_name=os.path.basename(metadata.file_name))
             else:
                 dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
 


### PR DESCRIPTION
When using cloud object store (ex. s3, cloud), files created in object_store_cache directory should be uploaded to the cloud storage.
But with extended metadata_strategy,files in the object_store_cache/_metadata_files directory are not uploaded to the cloud storage at all, and only files of size 0 are created.

I cannot write unit test because it requires cloud storage.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Use cloud object store like s3 or cloud.
  2. Set metadata_strategy: extended in galaxy.yml.
  3. Configure job_conf.xml file to use a JobRunner other than LocalJobRunner. 
　(Because ExtendedMode does not work properly with LocalJob), 
  4. Upload BAM to galaxy.
  5. Check that metadata file size in the cloud storage is not 0.  

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
