### PR TITLE
Block workflow invocation if wrong tool versions installed

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRunForm.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunForm.vue
@@ -206,6 +206,9 @@ export default {
                 // Tool form always wants a list of invocations back
                 // so that inputs can be batched.
                 batch: true,
+                // the user is already warned if tool versions are wrong,
+                // they can still choose to invoke the workflow anyway.
+                require_exact_tool_versions: false,
             };
 
             console.debug("WorkflowRunForm::onExecute()", "Ready for submission.", jobDef);

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -114,6 +114,7 @@ export default {
                 inputs_by: "step_index",
                 batch: true,
                 use_cached_job: this.useJobCache,
+                require_exact_tool_versions: false,
             };
             if (this.targetHistory == "current") {
                 data.history_id = this.model.historyId;

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1581,15 +1581,16 @@ class WorkflowContentsManager(UsesAnnotations):
             dry_run=refactor_request.dry_run,
         )
 
-    def get_all_tool_ids(self, workflow):
-        tool_ids = set()
+    def get_all_tools(self, workflow):
+        tools = []
         for step in workflow.steps:
             if step.type == "tool":
                 if step.tool_id:
-                    tool_ids.add(step.tool_id)
+                    if {"tool_id": step.tool_id, "tool_version": step.tool_version} not in tools:
+                        tools.append({"tool_id": step.tool_id, "tool_version": step.tool_version})
             elif step.type == "subworkflow":
-                tool_ids.update(self.get_all_tool_ids(step.subworkflow))
-        return tool_ids
+                tools.extend(self.get_all_tools(step.subworkflow))
+        return tools
 
 
 class RefactorRequest(RefactorActions):

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -668,7 +668,9 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                     return self._tools_by_id[tool_id]
                 elif tool_version in self._tool_versions_by_id[tool_id]:
                     return self._tool_versions_by_id[tool_id][tool_version]
-            if exact:
+            # should be if exact=True not elif? Otherwise we can end up doing non-exact searches even
+            # if exact=True. Anyway, changing it breaks a lot of tests involving built-in tools
+            elif exact:
                 # We're looking for an exact match, so we skip lineage and
                 # versionless mapping, though we may want to check duplicate
                 # toolsheds

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -668,7 +668,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                     return self._tools_by_id[tool_id]
                 elif tool_version in self._tool_versions_by_id[tool_id]:
                     return self._tool_versions_by_id[tool_id][tool_version]
-            elif exact:
+            if exact:
                 # We're looking for an exact match, so we skip lineage and
                 # versionless mapping, though we may want to check duplicate
                 # toolsheds

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -31,6 +31,7 @@ from galaxy_test.base.populators import (
     wait_on,
     WorkflowPopulator,
 )
+from galaxy_test.base.uses_shed import UsesShed
 from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_NESTED_REPLACEMENT_PARAMETER,
     WORKFLOW_NESTED_RUNTIME_PARAMETER,
@@ -228,7 +229,7 @@ input1:
 # - Allow post to workflows/<workflow_id>/run in addition to posting to
 #    /workflows with id in payload.
 # - Much more testing obviously, always more testing.
-class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
+class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase, UsesShed):
     def test_show_valid(self):
         workflow_id = self.workflow_populator.simple_workflow("dummy")
         workflow_id = self.workflow_populator.simple_workflow("test_regular")
@@ -920,17 +921,35 @@ steps:
         assert invocation["state"] == "scheduled", invocation
 
     def test_run_workflow_with_missing_tool(self):
+        self.install_repository("iuc", "compose_text_param", "feb3acba1e0a")  # 0.1.0
         with self.dataset_populator.test_history() as history_id:
             workflow_id = self._upload_yaml_workflow(
                 """
 class: GalaxyWorkflow
 steps:
-  step1:
+  nonexistent:
     tool_id: nonexistent_tool
     tool_version: "0.1"
+    label: nonexistent
+  compose_text_param:
+    tool_id: compose_text_param
+    tool_version: 0.0.1
+    label: compose_text_param
 """
             )
-            invocation_response = self.__invoke_workflow(workflow_id, history_id=history_id, assert_ok=False)
+            # should fail and return both tool ids since version 0.0.1 of compose_text_param does not exist
+            invocation_response = self.__invoke_workflow(
+                workflow_id, history_id=history_id, assert_ok=False, request={"require_exact_tool_versions": True}
+            )
+            self._assert_status_code_is(invocation_response, 400)
+            self.assertEqual(
+                invocation_response.json().get("err_msg"),
+                "Workflow was not invoked; the following required tools are not installed: nonexistent_tool (version 0.1), compose_text_param (version 0.0.1)",
+            )
+            # should fail but return only the tool_id of non_existent tool as another version of compose_text_param is installed
+            invocation_response = self.__invoke_workflow(
+                workflow_id, history_id=history_id, assert_ok=False, request={"require_exact_tool_versions": False}
+            )
             self._assert_status_code_is(invocation_response, 400)
             self.assertEqual(
                 invocation_response.json().get("err_msg"),

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -31,7 +31,6 @@ from galaxy_test.base.populators import (
     wait_on,
     WorkflowPopulator,
 )
-from galaxy_test.base.uses_shed import UsesShed
 from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_NESTED_REPLACEMENT_PARAMETER,
     WORKFLOW_NESTED_RUNTIME_PARAMETER,
@@ -229,7 +228,7 @@ input1:
 # - Allow post to workflows/<workflow_id>/run in addition to posting to
 #    /workflows with id in payload.
 # - Much more testing obviously, always more testing.
-class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase, UsesShed):
+class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
     def test_show_valid(self):
         workflow_id = self.workflow_populator.simple_workflow("dummy")
         workflow_id = self.workflow_populator.simple_workflow("test_regular")
@@ -921,7 +920,6 @@ steps:
         assert invocation["state"] == "scheduled", invocation
 
     def test_run_workflow_with_missing_tool(self):
-        self.install_repository("iuc", "compose_text_param", "feb3acba1e0a")  # 0.1.0
         with self.dataset_populator.test_history() as history_id:
             workflow_id = self._upload_yaml_workflow(
                 """
@@ -932,21 +930,21 @@ steps:
     tool_version: "0.1"
     label: nonexistent
   compose_text_param:
-    tool_id: compose_text_param
-    tool_version: 0.0.1
-    label: compose_text_param
+    tool_id: multiple_versions
+    tool_version: 0.3
+    label: multiple_versions
 """
             )
-            # should fail and return both tool ids since version 0.0.1 of compose_text_param does not exist
+            # should fail and return both tool ids since version 0.3 of multiple_versions does not exist
             invocation_response = self.__invoke_workflow(
                 workflow_id, history_id=history_id, assert_ok=False, request={"require_exact_tool_versions": True}
             )
             self._assert_status_code_is(invocation_response, 400)
             self.assertEqual(
                 invocation_response.json().get("err_msg"),
-                "Workflow was not invoked; the following required tools are not installed: nonexistent_tool (version 0.1), compose_text_param (version 0.0.1)",
+                "Workflow was not invoked; the following required tools are not installed: nonexistent_tool (version 0.1), multiple_versions (version 0.3)",
             )
-            # should fail but return only the tool_id of non_existent tool as another version of compose_text_param is installed
+            # should fail but return only the tool_id of non_existent tool as another version of multiple_versions is installed
             invocation_response = self.__invoke_workflow(
                 workflow_id, history_id=history_id, assert_ok=False, request={"require_exact_tool_versions": False}
             )

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -919,41 +919,6 @@ steps:
         invocation = self._invocation_details(workflow_id, invocation_id)
         assert invocation["state"] == "scheduled", invocation
 
-    def test_run_workflow_with_missing_tool(self):
-        with self.dataset_populator.test_history() as history_id:
-            workflow_id = self._upload_yaml_workflow(
-                """
-class: GalaxyWorkflow
-steps:
-  nonexistent:
-    tool_id: nonexistent_tool
-    tool_version: "0.1"
-    label: nonexistent
-  compose_text_param:
-    tool_id: multiple_versions
-    tool_version: 0.3
-    label: multiple_versions
-"""
-            )
-            # should fail and return both tool ids since version 0.3 of multiple_versions does not exist
-            invocation_response = self.__invoke_workflow(
-                workflow_id, history_id=history_id, assert_ok=False, request={"require_exact_tool_versions": True}
-            )
-            self._assert_status_code_is(invocation_response, 400)
-            self.assertEqual(
-                invocation_response.json().get("err_msg"),
-                "Workflow was not invoked; the following required tools are not installed: nonexistent_tool (version 0.1), multiple_versions (version 0.3)",
-            )
-            # should fail but return only the tool_id of non_existent tool as another version of multiple_versions is installed
-            invocation_response = self.__invoke_workflow(
-                workflow_id, history_id=history_id, assert_ok=False, request={"require_exact_tool_versions": False}
-            )
-            self._assert_status_code_is(invocation_response, 400)
-            self.assertEqual(
-                invocation_response.json().get("err_msg"),
-                "Workflow was not invoked; the following required tools are not installed: nonexistent_tool",
-            )
-
     @skip_without_tool("collection_creates_pair")
     def test_workflow_run_output_collections(self) -> None:
         with self.dataset_populator.test_history() as history_id:

--- a/test/integration/test_workflow_invocation.py
+++ b/test/integration/test_workflow_invocation.py
@@ -1,0 +1,55 @@
+"""Integration tests for workflow syncing."""
+
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    WorkflowPopulator,
+)
+from galaxy_test.base.uses_shed import UsesShed
+from galaxy_test.driver import integration_util
+
+
+class WorkflowInvocationTestCase(integration_util.IntegrationTestCase, UsesShed):
+
+    framework_tool_and_types = True
+    require_admin_user = False
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
+
+    def test_run_workflow_with_missing_tool(self):
+        self.install_repository("iuc", "compose_text_param", "feb3acba1e0a")  # 0.1.0
+        with self.dataset_populator.test_history() as history_id:
+            workflow_id = self.workflow_populator.upload_yaml_workflow(
+                """
+class: GalaxyWorkflow
+steps:
+  nonexistent:
+    tool_id: nonexistent_tool
+    tool_version: "0.1"
+    label: nonexistent
+  compose_text_param:
+    tool_id: compose_text_param
+    tool_version: "0.0.1"
+    label: compose_text_param
+"""
+            )
+            # should fail and return both tool ids since version 0.0.1 of compose_text_param does not exist
+            invocation_response = self.workflow_populator.invoke_workflow(
+                workflow_id, history_id=history_id, assert_ok=False, request={"require_exact_tool_versions": True}
+            )
+            self._assert_status_code_is(invocation_response, 400)
+            self.assertEqual(
+                invocation_response.json().get("err_msg"),
+                "Workflow was not invoked; the following required tools are not installed: nonexistent_tool (version 0.1), compose_text_param (version 0.0.1)",
+            )
+            # should fail but return only the tool_id of non_existent tool as another version of compose_text_param is installed
+            invocation_response = self.workflow_populator.invoke_workflow(
+                workflow_id, history_id=history_id, assert_ok=False, request={"require_exact_tool_versions": False}
+            )
+            self._assert_status_code_is(invocation_response, 400)
+            self.assertEqual(
+                invocation_response.json().get("err_msg"),
+                "Workflow was not invoked; the following required tools are not installed: nonexistent_tool",
+            )


### PR DESCRIPTION
When checking whether tools are installed before invoking a workflow (implemented in #11844), also optionally check whether the tool versions are installed. On the frontend this `require_exact_tool_versions` option is set to false, as the user is already warned about missing tool versions prior to submission.

Motivation: this is needed to ensure the tests for the IWC autoupdate PRs are testing workflows with the right tool versions.

ping @bgruening re our lunchtime discussion yesterday

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
