### PR TITLE
[21.09] Allow UNIVA destinations without runtime and memory max given in the nativespec

### DIFF
--- a/lib/galaxy/jobs/runners/univa.py
+++ b/lib/galaxy/jobs/runners/univa.py
@@ -32,6 +32,7 @@ import logging
 import re
 import signal
 import time
+from math import inf
 
 from galaxy.jobs.runners.drmaa import DRMAAJobRunner
 from galaxy.util import (
@@ -566,8 +567,8 @@ def _parse_native_specs(job_id, native_spec):
     specification string passed to GE
     return time,mem (or None,None if nothing found)
     """
-    tme = None
-    mem = None
+    tme = inf
+    mem = inf
     # parse time
     m = re.search(r"rt=([0-9:]+)[\s,]*", native_spec)
     if m is not None:


### PR DESCRIPTION
if no `nativeSpecification` is given for a univa destination, the runner does not know how much run time / memory was given to a job which led to a comparison with `None`.

Now we default to infinite runtime and memory.

May fix https://github.com/galaxyproject/galaxy/issues/13298

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

I can't test this. Maybe @ajs6f can?

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
