### PR TITLE
[22.01] Fix toolbox handling of spaces in old tools

### DIFF
--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -166,8 +166,9 @@ export default {
             } else if (tool.form_style === "regular") {
                 evt.preventDefault();
                 const Galaxy = getGalaxyInstance();
+                // encode spaces in tool.id
                 Galaxy.router.push("/", {
-                    tool_id: tool.id,
+                    tool_id: tool.id.replace(/ /g, "%20"),
                     version: tool.version,
                 });
             }


### PR DESCRIPTION
This fixes https://github.com/galaxyproject/galaxy/issues/13346 in a minimal way, but I'm not thrilled about it.  We need a consistent encoding that's probably going to involve tweaking the 'link' generated on the backend, but I don't know what else that's going to touch yet.  Right now it looks like some tool encoding uses `%2b`, `%2F`, etc. to generate the link, while for spaces it's a '+'.  A more comprehensive fix might be to have whatever is generating these URLs on the backend use `%20` for encoding spaces.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
