### PR TITLE
Fix for uploading metadata to remote object store 

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -42,7 +42,6 @@ from galaxy.model import (
     Dataset,
     HistoryDatasetAssociation,
     Job,
-    MetadataFile,
     store,
 )
 from galaxy.model.custom_types import total_size
@@ -421,9 +420,6 @@ def set_metadata_portable():
                     dataset.dataset.external_filename = None
                     dataset.dataset.extra_files_path = None
                 export_store.add_dataset(dataset)
-                for metadata in dataset.metadata.values():
-                    if isinstance(metadata, MetadataFile):
-                        metadata.update_from_file(metadata.file_name)
             else:
                 dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
 
@@ -436,6 +432,7 @@ def set_metadata_portable():
             )  # setting metadata has failed somehow
 
     if export_store:
+        export_store.push_metadata_files()
         export_store._finalize()
     write_job_metadata(tool_job_working_directory, job_metadata, set_meta, tool_provided_metadata)
 

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -42,6 +42,7 @@ from galaxy.model import (
     Dataset,
     HistoryDatasetAssociation,
     Job,
+    MetadataFile,
     store,
 )
 from galaxy.model.custom_types import total_size
@@ -420,6 +421,15 @@ def set_metadata_portable():
                     dataset.dataset.external_filename = None
                     dataset.dataset.extra_files_path = None
                 export_store.add_dataset(dataset)
+                for metadata in dataset.metadata.values():
+                    if isinstance(metadata, MetadataFile):
+                        object_store.update_from_file(
+                            metadata,
+                            file_name=metadata.file_name,
+                            extra_dir="_metadata_files",
+                            extra_dir_at_root=True,
+                            alt_name=os.path.basename(metadata.file_name),
+                        )
             else:
                 dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
 

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -423,13 +423,7 @@ def set_metadata_portable():
                 export_store.add_dataset(dataset)
                 for metadata in dataset.metadata.values():
                     if isinstance(metadata, MetadataFile):
-                        object_store.update_from_file(
-                            metadata,
-                            file_name=metadata.file_name,
-                            extra_dir="_metadata_files",
-                            extra_dir_at_root=True,
-                            alt_name=os.path.basename(metadata.file_name),
-                        )
+                        metadata.update_from_file(metadata.file_name)
             else:
                 dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
 

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -649,13 +649,7 @@ class FileParameter(MetadataParameter):
                 # Job may have run with a different (non-local) tmp/working
                 # directory. Correct.
                 file_name = path_rewriter(file_name)
-            parent.dataset.object_store.update_from_file(
-                mf,
-                file_name=file_name,
-                extra_dir="_metadata_files",
-                extra_dir_at_root=True,
-                alt_name=os.path.basename(mf.file_name),
-            )
+            mf.update_from_file(file_name)
             os.unlink(file_name)
             value = mf.id
         return value

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -604,6 +604,10 @@ class FileParameter(MetadataParameter):
         session = target_context._object_session(target_context.parent)
         value = self.wrap(value, session=session)
         target_dataset = target_context.parent.dataset
+        if value and not value.id:
+            # This is a new MetadataFile object, we're not copying to another dataset.
+            # Just use it.
+            return self.unwrap(value)
         if value and target_dataset.object_store.exists(target_dataset):
             # Only copy MetadataFile if the target dataset has been created in an object store.
             # All current datatypes re-generate MetadataFile objects when setting metadata,

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -6,7 +6,6 @@ import copy
 import json
 import logging
 import os
-import shutil
 import sys
 import tempfile
 import weakref
@@ -615,10 +614,10 @@ class FileParameter(MetadataParameter):
             new_value = galaxy.model.MetadataFile(dataset=target_context.parent, name=self.spec.name)
             session.add(new_value)
             try:
-                shutil.copy(value.file_name, new_value.file_name)
+                new_value.update_from_file(value.file_name)
             except AssertionError:
                 session(target_context.parent).flush()
-                shutil.copy(value.file_name, new_value.file_name)
+                new_value.update_from_file(value.file_name)
             return self.unwrap(new_value)
         return None
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1298,6 +1298,12 @@ class DirectoryModelExportStore(ModelExportStore):
     def __enter__(self):
         return self
 
+    def push_metadata_files(self):
+        for dataset in self.included_datasets:
+            for metadata_element in dataset.metadata.values():
+                if isinstance(metadata_element, model.MetadataFile):
+                    metadata_element.update_from_file(metadata_element.file_name)
+
     def export_job(self, job: model.Job, tool=None, include_job_data=True):
         self.export_jobs([job], include_job_data=include_job_data)
         tool_source = getattr(tool, "tool_source", None)

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -256,12 +256,12 @@ class FastAPIDatasets:
         trans=DependsOnTrans,
         history_id: EncodedDatabaseIdField = HistoryIDPathParam,
         history_content_id: EncodedDatabaseIdField = DatasetIDPathParam,
-        metadata_name: str = Query(
+        metadata_file: str = Query(
             ...,
             description="The name of the metadata file to retrieve.",
         ),
     ):
-        metadata_file_path, headers = self.service.get_metadata_file(trans, history_content_id, metadata_name)
+        metadata_file_path, headers = self.service.get_metadata_file(trans, history_content_id, metadata_file)
         return FileResponse(path=cast(str, metadata_file_path), headers=headers)
 
     @router.get(
@@ -446,13 +446,13 @@ class DatasetsController(BaseGalaxyAPIController):
         return self.service.get_content_as_text(trans, dataset_id)
 
     @web.expose_api_raw_anonymous_and_sessionless
-    def get_metadata_file(self, trans, history_content_id, history_id, metadata_name, **kwd):
+    def get_metadata_file(self, trans, history_content_id, history_id, metadata_file, **kwd):
         """
         GET /api/histories/{history_id}/contents/{history_content_id}/metadata_file
         """
         # TODO: remove open_file parameter when deleting this legacy endpoint
         metadata_file, headers = self.service.get_metadata_file(
-            trans, history_content_id, metadata_name, open_file=True
+            trans, history_content_id, metadata_file, open_file=True
         )
         trans.response.headers.update(headers)
         return metadata_file

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -256,12 +256,12 @@ class FastAPIDatasets:
         trans=DependsOnTrans,
         history_id: EncodedDatabaseIdField = HistoryIDPathParam,
         history_content_id: EncodedDatabaseIdField = DatasetIDPathParam,
-        metadata_file: Optional[str] = Query(
-            default=None,
+        metadata_name: str = Query(
+            ...,
             description="The name of the metadata file to retrieve.",
         ),
     ):
-        metadata_file_path, headers = self.service.get_metadata_file(trans, history_content_id, metadata_file)
+        metadata_file_path, headers = self.service.get_metadata_file(trans, history_content_id, metadata_name)
         return FileResponse(path=cast(str, metadata_file_path), headers=headers)
 
     @router.get(
@@ -446,13 +446,13 @@ class DatasetsController(BaseGalaxyAPIController):
         return self.service.get_content_as_text(trans, dataset_id)
 
     @web.expose_api_raw_anonymous_and_sessionless
-    def get_metadata_file(self, trans, history_content_id, history_id, metadata_file=None, **kwd):
+    def get_metadata_file(self, trans, history_content_id, history_id, metadata_name, **kwd):
         """
         GET /api/histories/{history_id}/contents/{history_content_id}/metadata_file
         """
         # TODO: remove open_file parameter when deleting this legacy endpoint
         metadata_file, headers = self.service.get_metadata_file(
-            trans, history_content_id, metadata_file, open_file=True
+            trans, history_content_id, metadata_name, open_file=True
         )
         trans.response.headers.update(headers)
         return metadata_file

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -135,7 +135,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         return "This link may not be followed from within Galaxy."
 
     @web.expose
-    def get_metadata_file(self, trans, hda_id, metadata_name):
+    def get_metadata_file(self, trans, hda_id, metadata_file):
         """Allows the downloading of metadata files associated with datasets (eg. bai index for bam files)"""
         data = trans.sa_session.query(trans.app.model.HistoryDatasetAssociation).get(self.decode_id(hda_id))
         if not data or not self._can_access_dataset(trans, data):
@@ -143,10 +143,10 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
 
         fname = "".join(c in util.FILENAME_VALID_CHARS and c or "_" for c in data.name)[0:150]
 
-        file_ext = data.metadata.spec.get(metadata_name).get("file_ext", metadata_name)
+        file_ext = data.metadata.spec.get(metadata_file).get("file_ext", metadata_file)
         trans.response.headers["Content-Type"] = "application/octet-stream"
         trans.response.headers["Content-Disposition"] = f'attachment; filename="Galaxy{data.hid}-[{fname}].{file_ext}"'
-        return open(data.metadata.get(metadata_name).file_name, "rb")
+        return open(data.metadata.get(metadata_file).file_name, "rb")
 
     def _check_dataset(self, trans, hda_id):
         # DEPRECATION: We still support unencoded ids for backward compatibility

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -434,7 +434,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         self,
         trans: ProvidesHistoryContext,
         history_content_id: EncodedDatabaseIdField,
-        metadata_name: str,
+        metadata_file: str,
         open_file: bool = False,
     ):
         """
@@ -445,12 +445,12 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         """
         decoded_content_id = self.decode_id(history_content_id)
         hda = self.hda_manager.get_accessible(decoded_content_id, trans.user)
-        file_ext = hda.metadata.spec.get(metadata_name).get("file_ext", metadata_name)
+        file_ext = hda.metadata.spec.get(metadata_file).get("file_ext", metadata_file)
         fname = "".join(c in util.FILENAME_VALID_CHARS and c or "_" for c in hda.name)[0:150]
         headers = {}
         headers["Content-Type"] = "application/octet-stream"
         headers["Content-Disposition"] = f'attachment; filename="Galaxy{hda.hid}-[{fname}].{file_ext}"'
-        file_path = hda.metadata.get(metadata_name).file_name
+        file_path = hda.metadata.get(metadata_file).file_name
         if open_file:
             return open(file_path, "rb"), headers
         return file_path, headers

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -434,7 +434,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         self,
         trans: ProvidesHistoryContext,
         history_content_id: EncodedDatabaseIdField,
-        metadata_file: Optional[str] = None,
+        metadata_name: str,
         open_file: bool = False,
     ):
         """
@@ -445,12 +445,12 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         """
         decoded_content_id = self.decode_id(history_content_id)
         hda = self.hda_manager.get_accessible(decoded_content_id, trans.user)
-        file_ext = hda.metadata.spec.get(metadata_file).get("file_ext", metadata_file)
+        file_ext = hda.metadata.spec.get(metadata_name).get("file_ext", metadata_name)
         fname = "".join(c in util.FILENAME_VALID_CHARS and c or "_" for c in hda.name)[0:150]
         headers = {}
         headers["Content-Type"] = "application/octet-stream"
         headers["Content-Disposition"] = f'attachment; filename="Galaxy{hda.hid}-[{fname}].{file_ext}"'
-        file_path = hda.metadata.get(metadata_file).file_name
+        file_path = hda.metadata.get(metadata_name).file_name
         if open_file:
             return open(file_path, "rb"), headers
         return file_path, headers

--- a/test/integration/objectstore/test_remote_objectstore_cache_operations.py
+++ b/test/integration/objectstore/test_remote_objectstore_cache_operations.py
@@ -20,6 +20,13 @@ class CacheOperationTestCase(BaseSwiftObjectStoreIntegrationTestCase):
         hda = self.dataset_populator.new_dataset(history_id, content="123", wait=True)
         return hda
 
+    def upload_bam_dataset(self):
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(
+            history_id, content=open(self.test_data_resolver.get_filename("1.bam"), "rb"), file_type="bam", wait=True
+        )
+        return hda
+
     def test_cache_populated(self):
         self.upload_dataset()
         assert files_count(self.object_store_cache_path) == 1
@@ -33,6 +40,23 @@ class CacheOperationTestCase(BaseSwiftObjectStoreIntegrationTestCase):
         content = self.dataset_populator.get_history_dataset_content(hda["history_id"], content_id=hda["id"])
         assert content == "123\n"
         assert files_count(self.object_store_cache_path) == 1
+
+    def test_cache_repopulated_metadata_file(self):
+        hda = self.upload_bam_dataset()
+        assert files_count(self.object_store_cache_path) == 2
+        response = self._get(
+            f'histories/{hda["history_id"]}/contents/{hda["id"]}/metadata_file?metadata_name=bam_index'
+        )
+        assert len(response.content) > 0
+        response.raise_for_status()
+        shutil.rmtree(self.object_store_cache_path)
+        assert files_count(self.object_store_cache_path) == 0
+        response = self._get(
+            f'histories/{hda["history_id"]}/contents/{hda["id"]}/metadata_file?metadata_name=bam_index'
+        )
+        response.raise_for_status()
+        assert files_count(self.object_store_cache_path) == 1
+        assert len(response.content) > 0
 
     def test_delete_item_not_in_cache(self):
         hda = self.upload_dataset()

--- a/test/integration/objectstore/test_remote_objectstore_cache_operations.py
+++ b/test/integration/objectstore/test_remote_objectstore_cache_operations.py
@@ -45,14 +45,14 @@ class CacheOperationTestCase(BaseSwiftObjectStoreIntegrationTestCase):
         hda = self.upload_bam_dataset()
         assert files_count(self.object_store_cache_path) == 2
         response = self._get(
-            f'histories/{hda["history_id"]}/contents/{hda["id"]}/metadata_file?metadata_name=bam_index'
+            f'histories/{hda["history_id"]}/contents/{hda["id"]}/metadata_file?metadata_file=bam_index'
         )
         assert len(response.content) > 0
         response.raise_for_status()
         shutil.rmtree(self.object_store_cache_path)
         assert files_count(self.object_store_cache_path) == 0
         response = self._get(
-            f'histories/{hda["history_id"]}/contents/{hda["id"]}/metadata_file?metadata_name=bam_index'
+            f'histories/{hda["history_id"]}/contents/{hda["id"]}/metadata_file?metadata_file=bam_index'
         )
         response.raise_for_status()
         assert files_count(self.object_store_cache_path) == 1


### PR DESCRIPTION
This is a continuation of https://github.com/galaxyproject/galaxy/pull/13334.

If fixes not pushing MetadataFile to an object store (particularly bad for object stores that use a object_store_cache_path), and overwriting the MetadataFile with a new file while importing the metadata.

Also includes a minor fix by making the metadata element mandatory in the API.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
