### PR TITLE
[21.09] Call encodeURIComponent on plain text tool id before pushing into router

### DIFF
--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -53,7 +53,8 @@ function addIframe() {
     fetch("/training-material/")
         .then((response) => {
             if (!response.ok) {
-                url = "https://training.galaxyproject.org/training-material/?utm_source=webhook&utm_medium=noproxy&utm_campaign=gxy";
+                url =
+                    "https://training.galaxyproject.org/training-material/?utm_source=webhook&utm_medium=noproxy&utm_campaign=gxy";
                 message = `
                         <span>
                             <a href="https://docs.galaxyproject.org/en/master/admin/special_topics/gtn.html">Click to run</a> unavailable.
@@ -131,7 +132,7 @@ function addIframe() {
                     if (tool_id === "upload1" || tool_id === "upload") {
                         document.getElementById("tool-panel-upload-button").click();
                     } else {
-                        Galaxy.router.push(`?tool_id=${tool_id}`);
+                        Galaxy.router.push(`?tool_id=${encodeURIComponent(tool_id)}`);
                     }
                     removeOverlay();
                 });


### PR DESCRIPTION
Could be an alternative to https://github.com/galaxyproject/galaxy/pull/13204 (which only went to 22.01).

```
Galaxy.router.push(`?tool_id=${encodeURIComponent("toolshed.g2.bx.psu.edu/repos/bgruening/alevin/alevin/1.3.0+galaxy2")}`)
``` 
seems to work on usegalaxy.eu


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
