### PR TITLE
Remove custom serialization views for new history, strip unused visualization details

### DIFF
--- a/client/src/components/History/History.vue
+++ b/client/src/components/History/History.vue
@@ -136,9 +136,9 @@ export default {
     },
     computed: {
         dataUrl() {
-            return `api/histories/${this.historyId}/contents/before/${this.maxHid + this.maxNew}/${this.pageSize}?view=detailed&${
-                this.queryString
-            }`;
+            return `api/histories/${this.historyId}/contents/before/${this.maxHid + this.maxNew}/${
+                this.pageSize
+            }?view=detailed&${this.queryString}`;
         },
         historyId() {
             return this.history.id;

--- a/client/src/components/History/History.vue
+++ b/client/src/components/History/History.vue
@@ -136,7 +136,7 @@ export default {
     },
     computed: {
         dataUrl() {
-            return `api/histories/${this.historyId}/contents/before/${this.maxHid + this.maxNew}/${this.pageSize}?${
+            return `api/histories/${this.historyId}/contents/before/${this.maxHid + this.maxNew}/${this.pageSize}?view=detailed&${
                 this.queryString
             }`;
         },

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -80,9 +80,7 @@ function formData(fields = {}) {
 
 // #region History Queries
 
-const stdHistoryParams = {
-    view: "betawebclient",
-};
+const stdHistoryParams = {};
 
 /**
  * Return list of available histories
@@ -287,7 +285,7 @@ export async function contentUpdate(history, type_ids = [], fields = {}) {
     });
 
     const { id } = history;
-    const url = `/histories/${id}/contents?view=betawebclient`;
+    const url = `/histories/${id}/contents`;
     const payload = Object.assign({}, fields, { items });
     const response = await api.put(url, payload);
     console.debug("Submitted request to update selected content.", response);
@@ -309,7 +307,7 @@ export async function createDatasetCollection(history, inputs = {}) {
     };
 
     const payload = Object.assign({}, defaults, inputs);
-    const url = `/histories/${history.id}/contents?view=betawebclient`; // keys=${keys}`;
+    const url = `/histories/${history.id}/contents`;
     const response = await api.post(url, payload);
     return doResponse(response);
 }

--- a/client/src/mvc/dataset/dataset-li-edit.js
+++ b/client/src/mvc/dataset/dataset-li-edit.js
@@ -268,44 +268,27 @@ var DatasetListItemEdit = _super.extend(
 
         /** Render an icon-button or popupmenu of links based on the applicable visualizations */
         _renderVisualizationsButton: function () {
-            //TODO: someday - lazyload visualizations
             const Galaxy = getGalaxyInstance();
-            const visualizations = this.model.get("visualizations");
-            if (
-                !Galaxy.config.visualizations_visible ||
-                this.model.isDeletedOrPurged() ||
-                !this.hasUser ||
-                !this.model.hasData() ||
-                _.isEmpty(visualizations)
-            ) {
-                return null;
-            }
-            if (!_.isObject(visualizations[0])) {
-                this.warn("Visualizations have been switched off");
-                return null;
-            }
-            if (visualizations.length >= 1) {
-                const dsid = this.model.get("element_id") || this.model.get("id");
-                const url = getAppRoot() + "visualizations?dataset_id=" + dsid;
-                return faIconButton({
-                    title: _l("Visualize this data"),
-                    href: url,
-                    classes: "visualization-link",
-                    faIcon: "fa-bar-chart-o",
-                    onclick: (ev) => {
-                        if (Galaxy.frame && Galaxy.frame.active) {
-                            ev.preventDefault();
-                            Galaxy.frame.add({ url: url, title: "Visualization" });
-                        } else if (Galaxy.router) {
-                            ev.preventDefault();
-                            Galaxy.router.push("visualizations", {
-                                dataset_id: dsid,
-                            });
-                            Galaxy.trigger("activate-hda", dsid);
-                        }
-                    },
-                });
-            }
+            const dsid = this.model.get("element_id") || this.model.get("id");
+            const url = getAppRoot() + "visualizations?dataset_id=" + dsid;
+            return faIconButton({
+                title: _l("Visualize this data"),
+                href: url,
+                classes: "visualization-link",
+                faIcon: "fa-bar-chart-o",
+                onclick: (ev) => {
+                    if (Galaxy.frame && Galaxy.frame.active) {
+                        ev.preventDefault();
+                        Galaxy.frame.add({ url: url, title: "Visualization" });
+                    } else if (Galaxy.router) {
+                        ev.preventDefault();
+                        Galaxy.router.push("visualizations", {
+                            dataset_id: dsid,
+                        });
+                        Galaxy.trigger("activate-hda", dsid);
+                    }
+                },
+            });
         },
 
         /** Render the tags list/control */

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -760,7 +760,7 @@ class ModelSerializer(HasAModelManager[T]):
         else:
             if keys:
                 all_keys = keys
-            elif default_view:
+            else:
                 all_keys = self._view_to_keys(default_view)
 
         return self.serialize(item, all_keys, **context)

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -336,7 +336,6 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                 "file_name",
                 "display_apps",
                 "display_types",
-                "visualizations",
                 "validated_state",
                 "validated_state_message",
                 # 'url',
@@ -364,58 +363,6 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
         self.add_view(
             "inaccessible",
             ["accessible", "id", "name", "history_id", "hid", "history_content_type", "state", "deleted", "visible"],
-        )
-
-        # fields for new beta web client, there is no summary/detailed split any more
-        self.add_view(
-            "betawebclient",
-            [
-                # common to hdca
-                "create_time",
-                "deleted",
-                "hid",
-                "history_content_type",
-                "history_id",
-                "id",
-                "name",
-                "tags",
-                "type",
-                "type_id",
-                "update_time",
-                "url",
-                "visible",
-                # dataset only
-                "accessible",
-                "api_type",
-                "annotation",
-                "created_from_basename",
-                "creating_job",
-                "dataset_id",
-                "data_type",
-                "display_apps",
-                "display_types",
-                "download_url",
-                "extension",
-                "file_ext",
-                "file_name",
-                "file_size",
-                "genome_build",
-                "hda_ldda",
-                "meta_files",
-                "misc_blurb",
-                "misc_info",
-                "model_class",
-                "peek",
-                "purged",
-                "rerunnable",
-                "resubmitted",
-                "state",
-                "uuid",
-                "validated_state",
-                "validated_state_message",
-                "hashes",
-                "sources",
-            ],
         )
 
     def serialize_copied_from_ldda_id(self, item, key, **context):
@@ -446,7 +393,6 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
             "resubmitted": lambda item, key, **context: self.hda_manager.has_been_resubmitted(item),
             "display_apps": self.serialize_display_apps,
             "display_types": self.serialize_old_display_applications,
-            "visualizations": self.serialize_visualization_links,
             # 'url'   : url_for( 'history_content_typed', history_id=encoded_history_id, id=encoded_id, type="dataset" ),
             # TODO: this intermittently causes a routes.GenerationException - temp use the legacy route to prevent this
             #   see also: https://trello.com/c/5d6j4X5y
@@ -530,17 +476,6 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                     display_apps.append(dict(label=display_label, links=app_links))
 
         return display_apps
-
-    def serialize_visualization_links(self, item, key, trans=None, **context):
-        """
-        Return a list of dictionaries with links to visualization pages
-        for those visualizations that apply to this hda.
-        """
-        hda = item
-        # use older system if registry is off in the config
-        if not self.app.visualizations_registry:
-            return hda.get_visualizations()
-        return self.app.visualizations_registry.get_visualizations(trans, hda)
 
     def serialize_urls(self, item, key, **context):
         """

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -323,10 +323,7 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
         return contents_url
 
     def serialize_job_state_summary(self, item, key, **context):
-        states = item.job_state_summary.__dict__.copy()
-        del states["_sa_instance_state"]
-        del states["hdca_id"]
-        return states
+        return item.job_state_summary_dict
 
     def serialize_elements_datatypes(self, item, key, **context):
         extensions_set = item.dataset_dbkeys_and_extensions_summary[1]

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -279,39 +279,6 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
         )
         self.add_view("detailed", ["populated", "elements"], include_keys_from="summary")
 
-        # fields for new beta web client, there is no summary/detailed split any more
-        self.add_view(
-            "betawebclient",
-            [
-                # common to hda
-                "create_time",
-                "deleted",
-                "hid",
-                "history_content_type",
-                "history_id",
-                "id",
-                "name",
-                "tags",
-                "type",
-                "type_id",
-                "update_time",
-                "url",
-                "visible",
-                # hdca only
-                "collection_id",
-                "collection_type",
-                "contents_url",
-                "element_count",
-                "job_source_id",
-                "job_source_type",
-                "job_state_summary",
-                "populated",
-                "populated_state",
-                "populated_state_message",
-                "elements_datatypes",
-            ],
-        )
-
     def add_serializers(self):
         super().add_serializers()
         taggable.TaggableSerializerMixin.add_serializers(self)

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -256,6 +256,7 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
                 "type_id",
                 "name",
                 "history_id",
+                "collection_id",
                 "hid",
                 "history_content_type",
                 "collection_type",
@@ -264,20 +265,28 @@ class HDCASerializer(DCASerializer, taggable.TaggableSerializerMixin, annotatabl
                 "element_count",
                 "job_source_id",
                 "job_source_type",
+                "job_state_summary",
                 "name",
                 "type_id",
                 "deleted",
-                # 'purged',
                 "visible",
                 "type",
                 "url",
                 "create_time",
                 "update_time",
-                "tags",  # TODO: detail view only (maybe),
+                "tags",
                 "contents_url",
             ],
         )
-        self.add_view("detailed", ["populated", "elements"], include_keys_from="summary")
+        self.add_view(
+            "detailed",
+            [
+                "populated",
+                "elements",
+                "elements_datatypes",
+            ],
+            include_keys_from="summary",
+        )
 
     def add_serializers(self):
         super().add_serializers()

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -442,6 +442,7 @@ class HistorySerializer(sharable.SharableModelSerializer, deletable.PurgableSeri
                 "state",
                 "state_details",
                 "state_ids",
+                "hid_counter",
                 # 'community_rating',
                 # 'user_rating',
             ],

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -469,36 +469,6 @@ class HistorySerializer(sharable.SharableModelSerializer, deletable.PurgableSeri
             include_keys_from="summary",
         )
 
-        # beta web client fields, no summary/detailed/dev-detailed blah
-        self.add_view(
-            "betawebclient",
-            [
-                "annotation",
-                "contents_active",
-                "contents_url",
-                "create_time",
-                "deleted",
-                "empty",
-                "genome_build",
-                "hid_counter",
-                "id",
-                "importable",
-                "name",
-                "nice_size",
-                "published",
-                "purged",
-                # 'shared',
-                "size",
-                "slug",
-                "state",
-                "tags",
-                "update_time",
-                "url",
-                "username_and_slug",
-                "user_id",
-            ],
-        )
-
     # assumes: outgoing to json.dumps and sanitized
     def add_serializers(self):
         super().add_serializers()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5809,7 +5809,7 @@ class DatasetCollectionInstance(HasName, UsesCreateAndUpdateTime):
             populated_state=self.collection.populated_state,
             populated_state_message=self.collection.populated_state_message,
             element_count=self.collection.element_count,
-            elements_datatypes=self.dataset_dbkeys_and_extensions_summary[1],
+            elements_datatypes=list(self.dataset_dbkeys_and_extensions_summary[1]),
             type="collection",  # contents type (distinguished from file or folder (in case of library))
         )
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5803,11 +5803,13 @@ class DatasetCollectionInstance(HasName, UsesCreateAndUpdateTime):
         return dict(
             id=self.id,
             name=self.name,
+            collection_id=self.collection_id,
             collection_type=self.collection.collection_type,
             populated=self.populated,
             populated_state=self.collection.populated_state,
             populated_state_message=self.collection.populated_state_message,
             element_count=self.collection.element_count,
+            elements_datatypes=self.dataset_dbkeys_and_extensions_summary[1],
             type="collection",  # contents type (distinguished from file or folder (in case of library))
         )
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5954,6 +5954,14 @@ class HistoryDatasetCollectionAssociation(
             return None
 
     @property
+    def job_state_summary_dict(self):
+        if self.job_state_summary:
+            states = self.job_state_summary.__dict__.copy()
+            del states["_sa_instance_state"]
+            del states["hdca_id"]
+            return states
+
+    @property
     def dataset_dbkeys_and_extensions_summary(self):
         if not hasattr(self, "_dataset_dbkeys_and_extensions_summary"):
             rows = self.collection._get_nested_collection_attributes(hda_attributes=("_metadata", "extension"))
@@ -6039,6 +6047,7 @@ class HistoryDatasetCollectionAssociation(
                 deleted=self.deleted,
                 job_source_id=self.job_source_id,
                 job_source_type=self.job_source_type,
+                job_state_summary=self.job_state_summary_dict,
                 create_time=self.create_time.isoformat(),
                 update_time=self.update_time.isoformat(),
                 **self._base_to_dict(view=view),

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -581,13 +581,6 @@ class HDAExtended(HDADetailed):
     )
 
 
-class HDABeta(HDADetailed):  # TODO: change HDABeta name to a more appropriate one.
-    """History Dataset Association information used in the new Beta History."""
-
-    # Equivalent to `betawebclient` serialization view for HDAs
-    pass
-
-
 class DCSummary(Model):
     """Dataset Collection summary information."""
 
@@ -1228,27 +1221,6 @@ class HDCJobStateSummary(Model):
         0,
         title="Upload jobs",
         description="Number of jobs in the `upload` state.",
-    )
-
-
-class HDCABeta(HDCADetailed):  # TODO: change HDCABeta name to a more appropriate one.
-    """History Dataset Collection Association information used in the new Beta History."""
-
-    # Equivalent to `betawebclient` serialization view for HDCAs
-    collection_id: EncodedDatabaseIdField = Field(
-        # TODO: inconsistency? the equivalent counterpart for HDAs, `dataset_id`, is declared in `HDASummary` scope
-        # while in HDCAs it is only serialized in the new `betawebclient` view?
-        ...,
-        title="Collection ID",
-        description="The encoded ID of the dataset collection associated with this HDCA.",
-    )
-    job_state_summary: Optional[HDCJobStateSummary] = Field(
-        None,
-        title="Job State Summary",
-        description="Overview of the job states working inside the dataset collection.",
-    )
-    elements_datatypes: Set[str] = Field(
-        ..., description="A set containing all the different element datatypes in the collection."
     )
 
 
@@ -2407,8 +2379,8 @@ class CustomHistoryItem(Model):
         extra = Extra.allow
 
 
-AnyHDA = Union[HDABeta, HDADetailed, HDASummary]
-AnyHDCA = Union[HDCABeta, HDCADetailed, HDCASummary]
+AnyHDA = Union[HDADetailed, HDASummary]
+AnyHDCA = Union[HDCADetailed, HDCASummary]
 AnyHistoryContentItem = Union[
     AnyHDA,
     AnyHDCA,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -656,6 +656,76 @@ class DCDetailed(DCSummary):
     elements: List[DCESummary] = ElementsField
 
 
+class HDCJobStateSummary(Model):
+    """Overview of the job states working inside a dataset collection."""
+
+    all_jobs: int = Field(
+        0,
+        title="All jobs",
+        description="Total number of jobs associated with a dataset collection.",
+    )
+    new: int = Field(
+        0,
+        title="New jobs",
+        description="Number of jobs in the `new` state.",
+    )
+    waiting: int = Field(
+        0,
+        title="Waiting jobs",
+        description="Number of jobs in the `waiting` state.",
+    )
+    running: int = Field(
+        0,
+        title="Running jobs",
+        description="Number of jobs in the `running` state.",
+    )
+    error: int = Field(
+        0,
+        title="Jobs with errors",
+        description="Number of jobs in the `error` state.",
+    )
+    paused: int = Field(
+        0,
+        title="Paused jobs",
+        description="Number of jobs in the `paused` state.",
+    )
+    deleted_new: int = Field(
+        0,
+        title="Deleted new jobs",
+        description="Number of jobs in the `deleted_new` state.",
+    )
+    resubmitted: int = Field(
+        0,
+        title="Resubmitted jobs",
+        description="Number of jobs in the `resubmitted` state.",
+    )
+    queued: int = Field(
+        0,
+        title="Queued jobs",
+        description="Number of jobs in the `queued` state.",
+    )
+    ok: int = Field(
+        0,
+        title="OK jobs",
+        description="Number of jobs in the `ok` state.",
+    )
+    failed: int = Field(
+        0,
+        title="Failed jobs",
+        description="Number of jobs in the `failed` state.",
+    )
+    deleted: int = Field(
+        0,
+        title="Deleted jobs",
+        description="Number of jobs in the `deleted` state.",
+    )
+    upload: int = Field(
+        0,
+        title="Upload jobs",
+        description="Number of jobs in the `upload` state.",
+    )
+
+
 class HDCASummary(HistoryItemCommon):
     """History Dataset Collection Association summary information."""
 
@@ -682,7 +752,17 @@ class HDCASummary(HistoryItemCommon):
         title="Job Source Type",
         description="The type of job (model class) that produced this dataset collection. Used to track the state of the job.",
     )
+    job_state_summary: Optional[HDCJobStateSummary] = Field(
+        None,
+        title="Job State Summary",
+        description="Overview of the job states working inside the dataset collection.",
+    )
     contents_url: RelativeUrl = ContentsUrlField
+    collection_id: EncodedDatabaseIdField = Field(
+        ...,
+        title="Collection ID",
+        description="The encoded ID of the dataset collection associated with this HDCA.",
+    )
 
 
 class HDCADetailed(HDCASummary):
@@ -690,6 +770,9 @@ class HDCADetailed(HDCASummary):
 
     populated: bool = PopulatedField
     elements: List[DCESummary] = ElementsField
+    elements_datatypes: Set[str] = Field(
+        ..., description="A set containing all the different element datatypes in the collection."
+    )
 
 
 class HistoryBase(BaseModel):
@@ -1151,76 +1234,6 @@ class JobIdResponse(BaseModel):
         ...,
         title="Job ID",
         description="The encoded database ID of the job that is currently processing a particular request.",
-    )
-
-
-class HDCJobStateSummary(Model):
-    """Overview of the job states working inside a dataset collection."""
-
-    all_jobs: int = Field(
-        0,
-        title="All jobs",
-        description="Total number of jobs associated with a dataset collection.",
-    )
-    new: int = Field(
-        0,
-        title="New jobs",
-        description="Number of jobs in the `new` state.",
-    )
-    waiting: int = Field(
-        0,
-        title="Waiting jobs",
-        description="Number of jobs in the `waiting` state.",
-    )
-    running: int = Field(
-        0,
-        title="Running jobs",
-        description="Number of jobs in the `running` state.",
-    )
-    error: int = Field(
-        0,
-        title="Jobs with errors",
-        description="Number of jobs in the `error` state.",
-    )
-    paused: int = Field(
-        0,
-        title="Paused jobs",
-        description="Number of jobs in the `paused` state.",
-    )
-    deleted_new: int = Field(
-        0,
-        title="Deleted new jobs",
-        description="Number of jobs in the `deleted_new` state.",
-    )
-    resubmitted: int = Field(
-        0,
-        title="Resubmitted jobs",
-        description="Number of jobs in the `resubmitted` state.",
-    )
-    queued: int = Field(
-        0,
-        title="Queued jobs",
-        description="Number of jobs in the `queued` state.",
-    )
-    ok: int = Field(
-        0,
-        title="OK jobs",
-        description="Number of jobs in the `ok` state.",
-    )
-    failed: int = Field(
-        0,
-        title="Failed jobs",
-        description="Number of jobs in the `failed` state.",
-    )
-    deleted: int = Field(
-        0,
-        title="Deleted jobs",
-        description="Number of jobs in the `deleted` state.",
-    )
-    upload: int = Field(
-        0,
-        title="Upload jobs",
-        description="Number of jobs in the `upload` state.",
     )
 
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -710,7 +710,6 @@ class FastAPIHistoryContents:
                   Example:
                     ?update_time-gt=2015-01-29
         """
-        serialization_params.default_view = serialization_params.default_view or "betawebclient"
 
         # Needed to parse arbitrary query parameter names for the filters.
         # Since we are directly accessing the request's query_params we also need to exclude the
@@ -1186,7 +1185,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
 
         GET /api/histories/{history_id}/contents/{direction:near|before|after}/{hid}/{limit}
         """
-        serialization_params = parse_serialization_params(default_view="betawebclient", **kwd)
+        serialization_params = parse_serialization_params(**kwd)
 
         since_str = kwd.pop("since", None)
         if since_str:

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -189,7 +189,6 @@ class DatasetsApiTestCase(ApiTestCase):
         original_hda = self._get(f"histories/{self.history_id}/contents/{hda_id}").json()
         assert original_hda["extension"] == "txt"
         assert original_hda["data_type"] == "galaxy.datatypes.data.Text"
-        assert "scatterplot" not in [viz["name"] for viz in original_hda["visualizations"]]
 
         inputs = {
             "input1": {"src": "hda", "id": hda_id},
@@ -214,7 +213,6 @@ class DatasetsApiTestCase(ApiTestCase):
         ).json()
         assert successful_updated_hda_response["extension"] == "tabular"
         assert successful_updated_hda_response["data_type"] == "galaxy.datatypes.tabular.Tabular"
-        assert "scatterplot" in [viz["name"] for viz in successful_updated_hda_response["visualizations"]]
 
         invalidly_updated_hda_response = self._put(  # try updating with invalid datatype
             f"histories/{self.history_id}/contents/{hda_id}", data={"datatype": "invalid"}, json=True

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -819,7 +819,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
 
     def _assert_collection_has_expected_elements_datatypes(self, history_id, collection_name, expected_datatypes):
         contents_response = self._get(
-            f"histories/{history_id}/contents?v=dev&view=betawebclient&q=name-eq&qv={collection_name}"
+            f"histories/{history_id}/contents?v=dev&view=detailed&q=name-eq&qv={collection_name}"
         )
         self._assert_status_code_is(contents_response, 200)
         collection = contents_response.json()[0]

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -417,8 +417,8 @@ class HDASerializerTestCase(HDATestCase):
         self.assertKeys(serialized, self.hda_serializer.views["summary"] + ["uuid"])
 
         self.log("should be able to use keys on their own")
-        serialized = self.hda_serializer.serialize_to_view(hda, keys=["file_path", "visualizations"])
-        self.assertKeys(serialized, ["file_path", "visualizations"])
+        serialized = self.hda_serializer.serialize_to_view(hda, keys=["file_path"])
+        self.assertKeys(serialized, ["file_path"])
 
     def test_serializers(self):
         hda = self._create_vanilla_hda()
@@ -459,7 +459,6 @@ class HDASerializerTestCase(HDATestCase):
         self.assertIsInstance(serialized["resubmitted"], bool)
         self.assertIsInstance(serialized["display_apps"], list)
         self.assertIsInstance(serialized["display_types"], list)
-        self.assertIsInstance(serialized["visualizations"], list)
 
         # remapped
         self.assertNullableBasestring(serialized["misc_info"])
@@ -523,9 +522,7 @@ class HDASerializerTestCase(HDATestCase):
         self.log("file_name should be included if app configured to do so")
         self.dataset_manager.permissions.set_private_to_one_user(dataset1, owner)
         # request random crap
-        serialized = self.hda_serializer.serialize_to_view(
-            item1, view="detailed", keys=["file_path", "visualizations"], user=non_owner
-        )
+        serialized = self.hda_serializer.serialize_to_view(item1, view="detailed", keys=["file_path"], user=non_owner)
         self.assertEqual(sorted(keys_in_inaccessible_view), sorted(serialized.keys()))
 
     # TODO: test extra_files_path as well

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -378,7 +378,8 @@ history_dataset_collection_display(history_dataset_collection_id=1)
         from galaxy.managers.hdcas import HDCASerializer
 
         with mock.patch.object(HDCASerializer, "url_for", return_value="http://google.com"):
-            export, extra_data = self._ready_export(example)
+            with mock.patch.object(HDCASerializer, "serialize_job_state_summary", return_value={}):
+                export, extra_data = self._ready_export(example)
         assert "history_dataset_collections" in extra_data
         assert len(extra_data.get("history_dataset_collections")) == 1
 

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -378,8 +378,7 @@ history_dataset_collection_display(history_dataset_collection_id=1)
         from galaxy.managers.hdcas import HDCASerializer
 
         with mock.patch.object(HDCASerializer, "url_for", return_value="http://google.com"):
-            with mock.patch.object(HDCASerializer, "serialize_job_state_summary", return_value={}):
-                export, extra_data = self._ready_export(example)
+            export, extra_data = self._ready_export(example)
         assert "history_dataset_collections" in extra_data
         assert len(extra_data.get("history_dataset_collections")) == 1
 


### PR DESCRIPTION
Requires #13318. This PR removes the custom `betawebclient` views which were specified in the backend serializers, probably as placeholders for future extension but are not providing much benefit as of right now. Instead we will use the common views `summary` and `detailed`. These common views provide almost all necessary information for the rendering of the new history components. This is also much more consistent, since the previous beta history approach did not consequently query the `betawebclient` views which led to odd bugs. Attributes were sometimes available in a response and sometimes not e.g. the `history.empty` attribute which was only set during every other request caused UI delays. Data was not displayed properly although already available. Another reason for this is that two different history stores are being used while both, old and new, history are being synced. Consolidating the history stores is a likely additional step for the future. For now, this PR will avoid issues caused by this modeling approach by restoring consistent serialization. This PR also strips the visualization details from dataset responses since they are not used by the client anymore, neither for the old nor new history. These unused details commonly amounted to the largest chunk of data send for datasets. The old history button has been adjusted accordingly.

Thanks @mvdbeek for helping with the new/current serialization model.

**NOTE:**
This PR currently temporarily moves the `job_state_summary` for collections into the `summary` view. This property is needed in order to determine the state of a collection i.e. ok, error, paused. However this property might be fairly time consuming for the server. After discussions, the plan is to leave the property in within this PR to help with the development of the new history but this property will be removed before release 22.05 unless additional performance analysis clearly demonstrates that it is after all an efficient property. At that stage the history should be progressed far enough such that we can find an alternative, for now removing this property will lead to test failures in the new history and stifle the transition.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.