### PR TITLE
Feature/hujambo dunia/issue 12022/20220211 workflows node overlap enhancement

### DIFF
--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -151,6 +151,7 @@ export default {
         this.activeOutputs = new ActiveOutputs();
         this.element = this.$el;
         this.content_id = this.contentId;
+
         // Set initial scroll position
         const step = this.step;
         const el = this.$el;

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -164,8 +164,8 @@ export default {
             const p = document.getElementById("canvas-viewport");
             const o = document.getElementById("canvas-container");
             if (p && o) {
-                const left = -o.offsetLeft + (p.offsetWidth - el.offsetWidth) / 2 + this.offsetToPreventNodeOverlap(OFFSET_RANGE);
-                const top = -o.offsetTop + (p.offsetHeight - el.offsetHeight) / 2 + this.offsetToPreventNodeOverlap(OFFSET_RANGE);
+                const left = -o.offsetLeft + (p.offsetWidth - el.offsetWidth) / 2 + this.offsetVaryPosition(OFFSET_RANGE);
+                const top = -o.offsetTop + (p.offsetHeight - el.offsetHeight) / 2 + this.offsetVaryPosition(OFFSET_RANGE);
                 el.style.top = `${top}px`;
                 el.style.left = `${left}px`;
             }
@@ -346,8 +346,8 @@ export default {
             // Remove active class
             element.classList.remove("node-active");
         },
-        offsetToPreventNodeOverlap(maxPixelsOffset) {
-            return Math.floor(Math.random() * maxPixelsOffset);
+        offsetVaryPosition(offsetRange) {
+            return Math.floor(Math.random() * offsetRange);
         },
     },
 };

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -164,8 +164,10 @@ export default {
             const p = document.getElementById("canvas-viewport");
             const o = document.getElementById("canvas-container");
             if (p && o) {
-                const left = -o.offsetLeft + (p.offsetWidth - el.offsetWidth) / 2 + this.offsetVaryPosition(OFFSET_RANGE);
-                const top = -o.offsetTop + (p.offsetHeight - el.offsetHeight) / 2 + this.offsetVaryPosition(OFFSET_RANGE);
+                const left =
+                    -o.offsetLeft + (p.offsetWidth - el.offsetWidth) / 2 + this.offsetVaryPosition(OFFSET_RANGE);
+                const top =
+                    -o.offsetTop + (p.offsetHeight - el.offsetHeight) / 2 + this.offsetVaryPosition(OFFSET_RANGE);
                 el.style.top = `${top}px`;
                 el.style.left = `${left}px`;
             }

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -88,6 +88,8 @@ import { ActiveOutputs } from "./modules/outputs";
 import { attachDragging } from "./modules/dragging";
 Vue.use(BootstrapVue);
 
+const OFFSET_RANGE = 100;
+
 export default {
     components: {
         LoadingSpan,
@@ -156,14 +158,14 @@ export default {
         const step = this.step;
         const el = this.$el;
         if (step.position) {
-            el.style.top = (step.position.top + this.offsetToPreventNodeOverlap(100)) + "px";
-            el.style.left = (step.position.left + this.offsetToPreventNodeOverlap(100)) + "px";
+            el.style.top = step.position.top + "px";
+            el.style.left = step.position.left + "px";
         } else {
             const p = document.getElementById("canvas-viewport");
             const o = document.getElementById("canvas-container");
             if (p && o) {
-                const left = -o.offsetLeft + (p.offsetWidth - el.offsetWidth) / 2 + this.offsetToPreventNodeOverlap(100);
-                const top = -o.offsetTop + (p.offsetHeight - el.offsetHeight) / 2 + this.offsetToPreventNodeOverlap(100);
+                const left = -o.offsetLeft + (p.offsetWidth - el.offsetWidth) / 2 + this.offsetToPreventNodeOverlap(OFFSET_RANGE);
+                const top = -o.offsetTop + (p.offsetHeight - el.offsetHeight) / 2 + this.offsetToPreventNodeOverlap(OFFSET_RANGE);
                 el.style.top = `${top}px`;
                 el.style.left = `${left}px`;
             }

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -151,19 +151,18 @@ export default {
         this.activeOutputs = new ActiveOutputs();
         this.element = this.$el;
         this.content_id = this.contentId;
-
         // Set initial scroll position
         const step = this.step;
         const el = this.$el;
         if (step.position) {
-            el.style.top = step.position.top + "px";
-            el.style.left = step.position.left + "px";
+            el.style.top = (step.position.top + this.offsetToPreventNodeOverlap(100)) + "px";
+            el.style.left = (step.position.left + this.offsetToPreventNodeOverlap(100)) + "px";
         } else {
             const p = document.getElementById("canvas-viewport");
             const o = document.getElementById("canvas-container");
             if (p && o) {
-                const left = -o.offsetLeft + (p.offsetWidth - el.offsetWidth) / 2;
-                const top = -o.offsetTop + (p.offsetHeight - el.offsetHeight) / 2;
+                const left = -o.offsetLeft + (p.offsetWidth - el.offsetWidth) / 2 + this.offsetToPreventNodeOverlap(100);
+                const top = -o.offsetTop + (p.offsetHeight - el.offsetHeight) / 2 + this.offsetToPreventNodeOverlap(100);
                 el.style.top = `${top}px`;
                 el.style.left = `${left}px`;
             }
@@ -343,6 +342,9 @@ export default {
             })(element.parentNode);
             // Remove active class
             element.classList.remove("node-active");
+        },
+        offsetToPreventNodeOverlap(maxPixelsOffset) {
+            return Math.floor(Math.random() * maxPixelsOffset);
         },
     },
 };


### PR DESCRIPTION
Hi Galaxy Dev Team,

Here is my experience on trying to fix Issue #12022:

**My Experience**

	1.	Galaxy Install Process - It was a bit time-consuming for me and I definitely lost time here.
	⁃	First Try - The install instructions mention allowing for Python higher than 3.6.10 version. However, just so you know, when I installed Python 3.10.2 (one of the more recent stable versions), there was an error in the install output stream: "RuntimeWarning: NumPy 1.21.1 may not yet support Python 3.10". Perhaps that was just my experience though! (Or if others find the same issue, maybe could add a list of "recommended Python versions" to the Readme doc.)
	⁃	Second Try - Then, I uninstalled Python 3.10. Next, I installed Python 3.8. However, that generated several "non-specific root cause" errors which took even longer to debug than the "First Try" :) So, the issue here was a combination of needing a symlink and reconfiguring pip.
	⁃	Third Try - Finally, I uninstalled Python 3.8. Then, I installed Python 3.7.6 and the Galaxy project did build smoothly without any (blocking) errors in the install output stream. As you are aware, the first time install the process took quite a while.
	2.	Galaxy IDE Setup Process - I used VSCode because that is what I happened to have on my machine. Dannon sent me a helpful link to the dev-setup option which I didn't feel like I had time to do given that I had already spent a lot of time on the install process but also felt like I could work around that nice-to-have feature once I realized what Issue #12022 was asking.
	3.	Galaxy Issue Fix Approach - There were three approaches which readily came to mind, I took the first - again because I wasn't sure about time expectations here and just wanted to be as quick about things as I could and wasn't sure what the priority on this task was. That said, I think the 3rd option/"Free Space" was my personal favorite approach.
	⁃	(A) Approach: Random Number Offset - generate two random numbers between 1-100 pixels to use as the Top and Left offset value for each Node.
	⁃	(B) Approach: Cascading Node Offset - find the Top and Last positions for the most recently created Node and add a static value so the Nodes partially overlap but are still distinct from one another.
	⁃	(C) Approach: Visible Free Space Offset - calculate the most under utilized "free space" on the Canvas and place the Node in the center of that "free space." This was probably my favorite approach, but would require a deeper level understanding of the codebase and more time.

--Michelle

![demo_Galaxy_Issue_12022_Approach_B](https://user-images.githubusercontent.com/3672779/153775179-57d13149-6f3a-4454-859a-0721498049a9.gif)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
