### PR TITLE
Split loading current history from loading all histories

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -16,7 +16,11 @@
             </template>
 
             <b-dropdown-text>
-                <span>You have {{ histories.length }} histories.</span>
+                <div v-if="userHistoriesLoading">
+                    <b-spinner small v-if="userHistoriesLoading" />
+                    <span>Fetching histories from server</span>
+                </div>
+                <span v-else>You have {{ histories.length }} histories.</span>
             </b-dropdown-text>
 
             <b-dropdown-divider></b-dropdown-divider>
@@ -75,6 +79,7 @@ export default {
         histories: { type: Array, required: true },
         currentHistory: { type: History, required: true },
         title: { type: String, required: false, default: "Histories" },
+        userHistoriesLoading: { type: Boolean, required: false, default: false },
     },
     methods: {
         switchToLegacyHistoryPanel,

--- a/client/src/components/History/Index.vue
+++ b/client/src/components/History/Index.vue
@@ -1,6 +1,9 @@
 <template>
     <CurrentUser class="d-flex flex-column" v-slot="{ user }">
-        <UserHistories v-if="user" :user="user" v-slot="{ currentHistory, histories, handlers }">
+        <UserHistories
+            v-if="user"
+            :user="user"
+            v-slot="{ currentHistory, histories, handlers, userHistoriesLoading: userHistoriesLoading }">
             <div v-if="currentHistory" id="current-history-panel" class="history-index">
                 <CurrentHistory
                     v-if="!breadcrumbs.length"
@@ -11,6 +14,7 @@
                         <HistoryNavigation
                             v-on="handlers"
                             :histories="histories"
+                            :user-histories-loading="userHistoriesLoading"
                             :current-history="currentHistory"
                             title="Histories" />
                     </template>

--- a/client/src/components/History/model/historyStore.js
+++ b/client/src/components/History/model/historyStore.js
@@ -73,12 +73,14 @@ const promises = {
 };
 
 export const actions = {
+    loadCurrentHistory({ dispatch, commit }) {
+        getCurrentHistoryFromServer().then((history) => dispatch("selectHistory", history));
+    },
     loadUserHistories({ dispatch, commit }) {
         if (!promises.load) {
-            promises.load = Promise.all([getHistoryList(), getCurrentHistoryFromServer()])
-                .then(([list, history]) => {
+            promises.load = getHistoryList()
+                .then((list) => {
                     commit("setHistories", list);
-                    dispatch("selectHistory", history);
                 })
                 .catch((err) => {
                     console.warn("loadUserHistories error", err);

--- a/client/src/components/History/model/historyStore.js
+++ b/client/src/components/History/model/historyStore.js
@@ -21,6 +21,7 @@ export const state = {
     currentHistoryId: null,
     // histories for current user
     histories: {},
+    userHistoriesLoading: false,
 };
 
 export const mutations = {
@@ -39,6 +40,9 @@ export const mutations = {
     },
     setLoadedForUser(state, userId) {
         state.loadedForUser = userId;
+    },
+    setUserHistoriesLoading(state, isLoading) {
+        state.userHistoriesLoading = isLoading;
     },
 };
 
@@ -64,6 +68,9 @@ export const getters = {
     getHistoryById: (state) => (id) => {
         return id in state.histories ? state.histories[id] : null;
     },
+    userHistoriesLoading: (state) => {
+        return state.userHistoriesLoading;
+    },
 };
 
 // Holds promises for in-flight loads
@@ -78,6 +85,7 @@ export const actions = {
     },
     loadUserHistories({ dispatch, commit }) {
         if (!promises.load) {
+            commit("setUserHistoriesLoading", true);
             promises.load = getHistoryList()
                 .then((list) => {
                     commit("setHistories", list);
@@ -87,6 +95,7 @@ export const actions = {
                 })
                 .finally(() => {
                     promises.load = null;
+                    commit("setUserHistoriesLoading", false);
                 });
         }
     },

--- a/client/src/components/providers/UserHistories.js
+++ b/client/src/components/providers/UserHistories.js
@@ -20,7 +20,7 @@ export default {
         user: { type: Object, required: true },
     },
     computed: {
-        ...mapGetters("betaHistory", ["currentHistoryId", "currentHistory", "histories"]),
+        ...mapGetters("betaHistory", ["currentHistoryId", "currentHistory", "histories", "userHistoriesLoading"]),
 
         currentHistoryModel() {
             if (this.currentHistory !== null) {
@@ -70,6 +70,7 @@ export default {
             // currently selected history object, should be a full object not just a summary
             currentHistory: this.currentHistoryModel,
             currentHistoryId: this.currentHistoryId,
+            userHistoriesLoading: this.userHistoriesLoading,
 
             handlers: {
                 // Updates the history in the store without a trip to the server, in the event that a

--- a/client/src/store/userStore/userStore.js
+++ b/client/src/store/userStore/userStore.js
@@ -42,7 +42,8 @@ const actions = {
     },
     async setCurrentUser({ commit, dispatch }, user) {
         commit("setCurrentUser", user);
-        await dispatch("betaHistory/loadUserHistories", user, { root: true });
+        dispatch("betaHistory/loadCurrentHistory", user, { root: true });
+        dispatch("betaHistory/loadUserHistories", user, { root: true });
     },
 };
 


### PR DESCRIPTION
Makes https://github.com/galaxyproject/galaxy/issues/13366 much less painful.

See how the history summary load is still pending, but the history is already rendered:
<img width="1723" alt="Screenshot 2022-02-14 at 10 56 13" src="https://user-images.githubusercontent.com/6804901/153841705-c0839676-4b3e-48b3-a9a6-b761c9249720.png">

Here's an update gif with the spinner:
![history_loading_spinner](https://user-images.githubusercontent.com/6804901/160109235-a3088546-0f04-41bb-ae21-ef5890361ab7.gif)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
