### PR TITLE
[22.01] Fix macro parsing

### DIFF
--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -100,17 +100,13 @@ class XMLLintMessageLine(LintMessage):
     def __init__(self, level: str, message: str, node: Optional[etree.Element] = None):
         super().__init__(level, message)
         self.line = None
-        self.fname = None
         if node is not None:
             self.line = node.sourceline
-            self.fname = node.base
 
     def __str__(self) -> str:
         rval = super().__str__()
         if self.line is not None:
             rval += " ("
-            if self.fname:
-                rval += f"{self.fname}:"
             rval += str(self.line)
             rval += ")"
         return rval

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -50,9 +50,11 @@ from boltons.iterutils import (
 LXML_AVAILABLE = True
 try:
     from lxml import etree
+    Element = etree._Element
 except ImportError:
     LXML_AVAILABLE = False
     import xml.etree.ElementTree as etree  # type: ignore[assignment,no-redef]
+    Element = etree.Element
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -19,7 +19,7 @@ def load_with_references(path):
     if macros_el is None:
         return tree, []
 
-    macros = {}
+    macros: Dict[str, XmlMacroDef] = {}
     macro_paths = _import_macros(macros_el, path, macros)
     macros_el.clear()
 

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -1,5 +1,6 @@
 import os
 from copy import deepcopy
+from typing import Dict
 
 from galaxy.util import parse_xml
 

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -1,6 +1,6 @@
 import os
 from copy import deepcopy
-from typing import Dict
+from typing import Dict, List
 
 from galaxy.util import parse_xml
 
@@ -20,7 +20,7 @@ def load_with_references(path):
     if macros_el is None:
         return tree, []
 
-    macros: Dict[str, XmlMacroDef] = {}
+    macros: Dict[str, List[XmlMacroDef]] = {}
     macro_paths = _import_macros(macros_el, path, macros)
     macros_el.clear()
 

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -2,7 +2,10 @@ import os
 from copy import deepcopy
 from typing import Dict, List
 
-from galaxy.util import parse_xml
+from galaxy.util import (
+    Element,
+    parse_xml,
+)
 
 REQUIRED_PARAMETER = object()
 
@@ -20,7 +23,7 @@ def load_with_references(path):
     if macros_el is None:
         return tree, []
 
-    macros: Dict[str, List[XmlMacroDef]] = {}
+    macros: Dict[str, List[Element]] = {}
     macro_paths = _import_macros(macros_el, path, macros)
     macros_el.clear()
 

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -283,15 +283,6 @@ def _imported_macro_paths_from_el(macros_el):
 
 def _load_macro_file(path, xml_base_dir):
     tree = parse_xml(path, strip_whitespace=False)
-    for node in tree.iter():
-        # little hack: node.base contains that path to the file which is used in
-        # the linter. it is a property that apparently is determined from the
-        # xmltree, so if the macro is inserted into the main xml node.base will
-        # give the path of the main xml file.
-        # luckily lxml allows to set the property by adding xml:base to the node
-        # which will be returned if the property is read
-        # https://github.com/lxml/lxml/blob/5a5c7fb01d15af58def4bab2ba7b15c937042835/src/lxml/etree.pyx#L1106
-        node.base = node.base
     root = tree.getroot()
     return _load_macros(root, xml_base_dir)
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1285,7 +1285,7 @@ COMPLETE_MACROS = """<macros>
 """
 
 
-def test_tool_and_macro_xml(lint_ctx_xpath):
+def test_tool_and_macro_xml(lint_ctx_xpath, lint_ctx):
     """
     test linters (all of them via lint_tool_source_with) on a tool and macro xml file
     checking a list of asserts, where each assert is a 4-tuple:
@@ -1304,21 +1304,29 @@ def test_tool_and_macro_xml(lint_ctx_xpath):
         tool_xml, _ = load_with_references(tool_path)
 
     tool_source = XmlToolSource(tool_xml)
+    # lint once with the lint context using XMLLintMessageXPath and XMLLintMessageLine
     lint_tool_source_with(lint_ctx_xpath, tool_source)
+    lint_tool_source_with(lint_ctx, tool_source)
 
     asserts = (
-        ("Select parameter [select] has multiple options with the same value", "tool.xml", 5, "/tool/inputs/param[1]"),
-        ("Found param input with no name specified.", "tool.xml", 13, "/tool/inputs/param[2]"),
-        ("Param input [No_type] input with no type specified.", "macros.xml", 3, "/tool/inputs/param[3]")
+        ("Select parameter [select] has multiple options with the same value", 5, "/tool/inputs/param[1]"),
+        ("Found param input with no name specified.", 13, "/tool/inputs/param[2]"),
+        ("Param input [No_type] input with no type specified.", 3, "/tool/inputs/param[3]")
     )
     for a in asserts:
-        message, fname, line, xpath = a
+        message, line, xpath = a
         found = False
         for lint_message in lint_ctx_xpath.message_list:
             if lint_message.message != message:
                 continue
             found = True
-            assert lint_message.xpath == xpath, f"Assumed xpath {xpath} xpath {lint_message.xpath} for: {message}"
+            assert lint_message.xpath == xpath, f"Assumed xpath {xpath}; found xpath {lint_message.xpath} for: {message}"
+        assert found, f"Did not find {message}"
+        for lint_message in lint_ctx.message_list:
+            if lint_message.message != message:
+                continue
+            found = True
+            assert lint_message.line == line, f"Assumed line {line}; found line {lint_message.line} for: {message}"
         assert found, f"Did not find {message}"
 
 

--- a/test/unit/tool_util/test_tool_loader.py
+++ b/test/unit/tool_util/test_tool_loader.py
@@ -642,11 +642,12 @@ def test_loader_specify_nested_macro_by_token():
         # test with re because loading from external macros
         # adds a xml:base property (containing the source path)
         # to the node which is printed
+        print(f"{xml_to_string(xml, pretty=True)}")
         assert re.match(r"""<\?xml version="1\.0" \?>
 <tool>
     <macros/>
-    <A xml:base=".*/external.xml"/>
-    <B xml:base=".*/external.xml"/>
+    <A/>
+    <B/>
 </tool>""", xml_to_string(xml, pretty=True), re.MULTILINE)
 
 


### PR DESCRIPTION
fixes https://github.com/galaxyproject/galaxy/issues/13277

follow up on https://github.com/galaxyproject/galaxy/pull/13186 and https://github.com/galaxyproject/galaxy/pull/12978

The mentioned PRs tried to store the path to macro files for xml nodes loaded from imported macros (to get a more meaningful lint error message). Unfortunately lxml does this by adding a `xml:base` attribute to the nodes which has all sorts of side effects:

- xsd linting stumbles over these forbidden attributes
- for some reason just storing this attribute increases the time needed for parsing the tools dramatically (for OpenMS which heavily use macros from ~16s to 50s)

The primary change of this PR is to revert storing this additional information. 

The subsequent commits aim at speeding up parsing a bit more: So far imported macros were added to the macros node just to be removed again at the end. Now they are directly stored in lists.





## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
