### PR TITLE
[22.01] Try to unit test more of DictParser in Viz component.

### DIFF
--- a/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
+++ b/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
@@ -32,6 +32,13 @@ config1 = """\
     <params>
         <param type="dataset" var_name_in_template="hda" required="true">dataset_id</param>
     </params>
+    <specs>
+        <exports>
+            <exports>png</exports>
+            <exports>svg</exports>
+            <exports>pdf</exports>
+        </exports>
+    </specs>
     <template>scatterplot.mako</template>
 </visualization>
 """
@@ -120,6 +127,16 @@ class VisualizationsRegistry_TestCase(VisualizationsBase_TestCase):
         self.assertTrue(vis1.serves_templates)
         self.assertEqual(vis1.template_path, os.path.join(vis1.path, 'templates'))
         self.assertEqual(vis1.template_lookup.__class__.__name__, 'TemplateLookup')
+
+        vis1_as_dict = vis1.to_dict()
+        assert vis1_as_dict["specs"]
+        specs = vis1_as_dict["specs"]
+        assert "exports" in specs
+        exports = specs["exports"]
+        assert len(exports) == 3
+        assert "png" in exports
+        assert "svg" in exports
+        assert "pdf" in exports
 
         vis2 = plugin_mgr.plugins['vis2']
         self.assertEqual(vis2.name, 'vis2')


### PR DESCRIPTION
Changed a little during 22.01 release cycle - making sure did not regress.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
