### PR TITLE
Fix history export include hidden

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1470,7 +1470,7 @@ class DirectoryModelExportStore(ModelExportStore):
         datasets = query.all()
         for dataset in datasets:
             dataset.annotation = get_item_annotation_str(sa_session, history.user, dataset)
-            add_dataset = (not dataset.visible or not include_hidden) and (not dataset.deleted or include_deleted)
+            add_dataset = (dataset.visible or include_hidden) and (not dataset.deleted or include_deleted)
             if dataset.id in self.collection_datasets:
                 add_dataset = True
 

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -44,6 +44,30 @@ def test_import_export_history_failed_job():
     _assert_simple_cat_job_imported(imported_history, state="error")
 
 
+def test_import_export_history_hidden_false_with_hidden_dataset():
+    app = _mock_app()
+
+    u, h, d1, d2, j = _setup_simple_cat_job(app)
+    d2.visible = False
+    app.model.session.flush()
+
+    imported_history = _import_export_history(app, h, export_files="copy", include_hidden=False)
+    assert d2.dataset.get_size() > 0
+    assert imported_history.datasets[-1].get_size() == 0
+
+
+def test_import_export_history_hidden_true_with_hidden_dataset():
+    app = _mock_app()
+
+    u, h, d1, d2, j = _setup_simple_cat_job(app)
+    d2.visible = False
+    app.model.session.flush()
+
+    imported_history = _import_export_history(app, h, export_files="copy", include_hidden=True)
+    assert d2.dataset.get_size() > 0
+    assert imported_history.datasets[-1].get_size() > 0
+
+
 def test_import_export_bag_archive():
     """Test a simple job import/export using a BagIt archive."""
     dest_parent = mkdtemp()
@@ -488,13 +512,13 @@ def _setup_simple_cat_job(app, state="ok"):
     return u, h, d1, d2, j
 
 
-def _import_export_history(app, h, dest_export=None, export_files=None):
+def _import_export_history(app, h, dest_export=None, export_files=None, include_hidden=False):
     if dest_export is None:
         dest_parent = mkdtemp()
         dest_export = os.path.join(dest_parent, "moo.tgz")
 
     with store.TarModelExportStore(dest_export, app=app, export_files=export_files) as export_store:
-        export_store.export_history(h)
+        export_store.export_history(h, include_hidden=include_hidden)
 
     imported_history = import_archive(dest_export, app, h.user)
     assert imported_history


### PR DESCRIPTION
This is the same as https://github.com/galaxyproject/galaxy/pull/13387, but some of the tests against 20.05 still ran against Jenkins, it seems, so not putting a lot of faith into that.
If the tests pass here we should merge https://github.com/galaxyproject/galaxy/pull/13387.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
