### PR TITLE
[22.01] Clarify that history exports are not kept forever

### DIFF
--- a/client/src/components/HistoryExport/ToLink.vue
+++ b/client/src/components/HistoryExport/ToLink.vue
@@ -17,7 +17,11 @@
         <div v-else-if="latestExportReady">
             Link for download ready
             <export-link :history-export="latestExport" />
-            . Use this link to download the archive or import it on another Galaxy server.
+            <p>Use this link to download the archive or import it on another Galaxy server.</p>
+            <b-alert show variant="warning"
+                >History archives are removed at regular intervals. For permanent storage download the archive, export
+                to a remote file or import the archive on another Galaxy server.
+            </b-alert>
         </div>
         <div v-else-if="hasReadyExport">
             <p>An out of date export is ready <export-link :history-export="latestReadyExport" />.</p>


### PR DESCRIPTION
With that I think we can close https://github.com/galaxyproject/galaxy/issues/13331
<img width="878" alt="Screenshot 2022-02-16 at 12 22 49" src="https://user-images.githubusercontent.com/6804901/154255089-ff919a3f-2f05-4d8e-8ac6-dc56aa19de13.png">


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
