### PR TITLE
[22.01] Fix history search help popover not closing on click outside

### DIFF
--- a/client/src/ui/search-input.js
+++ b/client/src/ui/search-input.js
@@ -152,6 +152,18 @@ function searchInput(parentNode, options) {
                     .popover("show");
             });
     }
+    // Hack to hide the advanced search popover when clicking outside
+    $("body").on("click", function (e) {
+        $('[data-toggle="advSearchPopover"]').each(function () {
+            if (
+                !$(this).is(e.target) &&
+                $(this).has(e.target).length === 0 &&
+                $(".popover").has(e.target).length === 0
+            ) {
+                $(this).popover("hide");
+            }
+        });
+    });
 
     // .................................................................... loadingIndicator rendering
     // a button for clearing the search bar, placed on the right hand side


### PR DESCRIPTION
Partially fixes #13350

This is a temporal hack to mitigate the issue until the new history is in place. 
Now the popover will not require you to toggle the button to close and will close If you click outside (so you can safely click the link inside).
Please notice that if you click on the central panel/iframe the popover will still *not close* but it should if you click anywhere else.


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow instructions on #13350

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
