### PR TITLE
[22.01] Ensure $GRAVITY_STATE_DIR is present in venv activate script any time run.sh/common_startup.sh is called normally

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -122,7 +122,6 @@ if [ $SET_VENV -eq 1 ] && [ $CREATE_VENV -eq 1 ]; then
                 conda_activate
             fi
             virtualenv "$GALAXY_VIRTUAL_ENV"
-            setup_gravity_state_dir
         else
             # If $GALAXY_VIRTUAL_ENV does not exist, and there is no conda available, attempt to create it.
             if [ -z "$GALAXY_PYTHON" ]; then
@@ -140,7 +139,6 @@ if [ $SET_VENV -eq 1 ] && [ $CREATE_VENV -eq 1 ]; then
             echo "existing environment before starting Galaxy."
             if command -v virtualenv >/dev/null; then
                 virtualenv -p "$GALAXY_PYTHON" "$GALAXY_VIRTUAL_ENV"
-                setup_gravity_state_dir
             else
                 vvers=16.7.9
                 vurl="https://files.pythonhosted.org/packages/source/v/virtualenv/virtualenv-${vvers}.tar.gz"
@@ -167,10 +165,10 @@ urlretrieve('$vurl', '$vsrc')"
                 tar zxf "$vsrc" -C "$vtmp"
                 "$GALAXY_PYTHON" "$vtmp/virtualenv-$vvers/virtualenv.py" "$GALAXY_VIRTUAL_ENV"
                 rm -rf "$vtmp"
-                setup_gravity_state_dir
             fi
         fi
     fi
+    setup_gravity_state_dir
 fi
 
 # activate virtualenv or conda env, sets $GALAXY_VIRTUAL_ENV and $GALAXY_CONDA_ENV


### PR DESCRIPTION
(i.e. when called without `--skip-venv` or `--no-create-venv`).

Originally I didn't want to modify the venv unless I knew we created it but since this is all happening through `run.sh` and friends I think this is fine. This should make the behavior of new clones and existing clones that update to 22.01+ behave the same wrt. per-instance Gravity state.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `git checkout release_21.09`
  2. `sh ./scripts/common_startup.sh`
  3. `git checkout <this PR>`
  4. sh ./scripts/common_startup.sh`
  5. `. ./.venv/bin/activate`
  6. `echo $GRAVITY_STATE_DIR`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
