### PR TITLE
Fix `make diff-format`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ docs-develop: ## Fast doc generation and more warnings (for development)
 setup-venv:
 	if [ ! -f $(VENV)/bin/activate ]; then bash scripts/common_startup.sh --dev-wheels; fi
 
-diff-format:  ## Format Python code changes
-	$(IN_VENV) darker -r $(TARGET_BRANCH)
+diff-format:  ## Format Python code changes since last commit
+	$(IN_VENV) darker .
 
 format:  ## Format Python code base
 	$(IN_VENV) isort .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ extend-exclude = '''
 '''
 force-exclude = 'lib/galaxy/util/jstree.py'
 
+[tool.darker]
+isort = true
+
 [tool.poetry]
 name = "galaxy"
 version = "22.01.dev0"


### PR DESCRIPTION
- The path is required
- The target revision may be a release branch, so use the default (i.e. last commit)
- Run `isort` in addition to `black`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Modify a Python file so that it would require formatting changes, e.g. swap two import lines
  2. Run `make diff-format` and check that the modified file is formatted correctly

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
