### PR TITLE
Drop uWSGI from Galaxy Reports documentation

### DIFF
--- a/doc/source/admin/reports.rst
+++ b/doc/source/admin/reports.rst
@@ -41,7 +41,7 @@ following (and more):
 Configuration
 ----------------------------
 
-- Configure ``config/reports.yml`` in the same manner as your main galaxy instance (i.e., same database connection, but different web server port). This is a uWSGI YAML configuration file and should contain a ``reports`` section with app-specific configuration (options described below).
+- Configure ``config/reports.yml`` in the same manner as your main galaxy instance (i.e., same database connection, but different web server port). This is a YAML configuration file and should contain a ``reports`` section with app-specific configuration (options described below).
 
     - The default port for the reports application is ``9001``, and like Galaxy it only binds to localhost by default.
     - ``database_connection`` should match the value used in your Galaxy configuration
@@ -49,7 +49,7 @@ Configuration
       experimental support for MySQL is available but SQLite is not supported
       at all.
 
-- Run reports in a uWSGI server with ``sh run_reports.sh``
+- Run reports in a Gunicorn server with ``sh run_reports.sh``
 - Use a web browser and go to the address you configured in ``reports.yml`` (defaults to http://localhost:9001/)
 - If you'd like the report tool to persist between sessions then use
   ``sh run_reports.sh --daemon`` to run it as a background process. As with


### PR DESCRIPTION
I suppose that's all the edits that are needed for Reports documentation.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
