### PR TITLE
Relax checks for `test_github_search`

### DIFF
--- a/test/unit/tool_util/mulled/test_mulled_search.py
+++ b/test/unit/tool_util/mulled/test_mulled_search.py
@@ -39,7 +39,9 @@ def test_github_search():
     search1 = t.process_json(t.get_json("adsfasdf"), "adsfasdf")
     search2 = t.process_json(t.get_json("bioconductor-gosemsim"), "bioconductor-gosemsim")
     assert search1 == []
-    assert {"path": "recipes/bioconductor-gosemsim/meta.yaml", "name": "meta.yaml"} in search2
+    assert search2
+    for item in search2:
+        assert "bioconductor-gosemsim" in item["path"]
 
 
 @external_dependency_management


### PR DESCRIPTION
The Github search API seems flaky and sometimes it returns the expected `meta.yaml` element, sometimes the other `build.sh` element, sometimes both and I think sometimes none... :roll_eyes: 

Hopefully, this is a good enough check and will avoid some of the failures and make it less noisy.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
