### PR TITLE
[22.01] Fix typo in vault docs

### DIFF
--- a/doc/source/admin/special_topics/vault.md
+++ b/doc/source/admin/special_topics/vault.md
@@ -85,6 +85,7 @@ Fernet key, use the following Python code:
 ```python
 from cryptography.fernet import Fernet
 Fernet.generate_key().decode('utf-8')
+```
 
 If multiple encryption keys are defined, only the first key is used to encrypt secrets. The remaining keys are tried in turn during decryption. This is useful for key rotation.
 We recommend periodically generating a new fernet key and rotating old keys. However, before removing an old key, make sure that any data encrypted using that old key is no longer


### PR DESCRIPTION
Minor typo fix.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
