### PR TITLE
Dataset annotations are optional and should not be required

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -257,6 +257,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                     "type": "text",
                     "area": True,
                     "label": "Annotation",
+                    "optional": True,
                     "value": self.get_item_annotation_str(trans.sa_session, trans.user, data),
                     "help": "Add an annotation or notes to a dataset; annotations are available when a history is viewed.",
                 },


### PR DESCRIPTION
Fixes #13401. Thanks for reporting it @blankenberg. Follow the referenced issue for a description on how to test this fix.
 
## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
