### PR TITLE
Rerunning failed jobs should by default resume consecutive jobs

### DIFF
--- a/client/src/components/Tool/ToolForm.test.js
+++ b/client/src/components/Tool/ToolForm.test.js
@@ -57,5 +57,6 @@ describe("ToolForm", () => {
         expect(dropdown.length).toBe(2);
         const help = wrapper.find(".form-help");
         expect(help.text()).toBe("help_text");
+        expect(wrapper.vm.useJobRemapping).toBe(true);
     });
 });

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -152,7 +152,7 @@ export default {
             messageText: "",
             useCachedJobs: false,
             useEmail: false,
-            useJobRemapping: false,
+            useJobRemapping: true,
             entryPoints: [],
             jobDef: {},
             jobResponse: {},


### PR DESCRIPTION
Currently rerunning a failed job does not resume consecutive/paused jobs by default. Instead users have to explicitly click on the resume option. This PR fixes this issue by switching the resume option on by default.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  1. Run a workflow containing a step which fails
  2. Select the failed job in the history and click to rerun the job
  3. Notice that the resume switch at the bottom of the tool options is set to `true`.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
