### PR TITLE
[21.09] Fix repository uploads with remove_repo_files_not_in_tar

### DIFF
--- a/lib/tool_shed/util/commit_util.py
+++ b/lib/tool_shed/util/commit_util.py
@@ -154,7 +154,7 @@ def handle_directory_changes(app, host, username, repository, full_path, filenam
     repo_path = repository.repo_path(app)
     content_alert_str = ''
     files_to_remove = []
-    filenames_in_archive = [os.path.join(full_path, name) for name in filenames_in_archive]
+    filenames_in_archive = [os.path.normpath(os.path.join(full_path, name)) for name in filenames_in_archive]
     if remove_repo_files_not_in_tar and not repository.is_new():
         # We have a repository that is not new (it contains files), so discover those files that are in the
         # repository, but not in the uploaded archive.


### PR DESCRIPTION
This fixes erroneously deleting the just uploaded files, which otherwise
happens in
```
                    if full_name not in filenames_in_archive:
                        files_to_remove.append(full_name)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

Upload a repository archive to the TS, and keep `Remove files in the repository (relative to the root or selected upload point) that are not in the uploaded archive?` selected.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
