### PR TITLE
Remove uwsgi mention from debug config option

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2714,11 +2714,6 @@
     use_printdebug.  It also causes the files used by PBS/SGE
     (submission script, output, and error) to remain on disk after the
     job is complete.
-    In addition, this will set uWSGI's `honour-stdin` option to
-    `true`; thus, preventing uWSGI from remapping stdin to `/dev/null`
-    and enabling debugging with tools like pdb. To keep uWSGI's
-    default setting, set `honor-stdin` to `false` in the `uwsgi`
-    section of this configuration file.
 :Default: ``false``
 :Type: bool
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2760,9 +2760,7 @@
     are responsible for preparing/submitting and collecting/finishing
     jobs, and which can cause job errors if not shut down cleanly. If
     using supervisord, consider also increasing the value of
-    `stopwaitsecs`. If using job handler mules, consider also setting
-    the `mule-reload-mercy` uWSGI option. See the Galaxy Admin
-    Documentation for more.
+    `stopwaitsecs`. See the Galaxy Admin Documentation for more.
 :Default: ``30``
 :Type: int
 
@@ -2786,8 +2784,7 @@
 :Description:
     Control the period (in seconds) between dumps. Use -1 to disable.
     Regardless of this setting, if use_heartbeat is enabled, you can
-    send a Galaxy process (unless running with uWSGI) SIGUSR1 (`kill
-    -USR1`) to force a dump.
+    send a Galaxy process SIGUSR1 (`kill -USR1`) to force a dump.
 :Default: ``20``
 :Type: int
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1370,9 +1370,7 @@ galaxy:
   # responsible for preparing/submitting and collecting/finishing jobs,
   # and which can cause job errors if not shut down cleanly. If using
   # supervisord, consider also increasing the value of `stopwaitsecs`.
-  # If using job handler mules, consider also setting the
-  # `mule-reload-mercy` uWSGI option. See the Galaxy Admin Documentation
-  # for more.
+  # See the Galaxy Admin Documentation for more.
   #monitor_thread_join_timeout: 30
 
   # Write thread status periodically to 'heartbeat.log',  (careful, uses
@@ -1382,8 +1380,7 @@ galaxy:
 
   # Control the period (in seconds) between dumps. Use -1 to disable.
   # Regardless of this setting, if use_heartbeat is enabled, you can
-  # send a Galaxy process (unless running with uWSGI) SIGUSR1 (`kill
-  # -USR1`) to force a dump.
+  # send a Galaxy process SIGUSR1 (`kill -USR1`) to force a dump.
   #heartbeat_interval: 20
 
   # Heartbeat log filename. Can accept the template variables

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1352,11 +1352,6 @@ galaxy:
   # use_printdebug.  It also causes the files used by PBS/SGE
   # (submission script, output, and error) to remain on disk after the
   # job is complete.
-  # In addition, this will set uWSGI's `honour-stdin` option to `true`;
-  # thus, preventing uWSGI from remapping stdin to `/dev/null` and
-  # enabling debugging with tools like pdb. To keep uWSGI's default
-  # setting, set `honor-stdin` to `false` in the `uwsgi` section of this
-  # configuration file.
   #debug: false
 
   # Check for WSGI compliance.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1975,12 +1975,6 @@ mapping:
           causes the files used by PBS/SGE (submission script, output, and error)
           to remain on disk after the job is complete.
 
-          In addition, this will set uWSGI's `honour-stdin` option to `true`;
-          thus, preventing uWSGI from remapping stdin to `/dev/null` and
-          enabling debugging with tools like pdb. To keep uWSGI's default
-          setting, set `honor-stdin` to `false` in the `uwsgi` section of this
-          configuration file.
-
       use_lint:
         type: bool
         default: false

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2006,9 +2006,8 @@ mapping:
           terminate without waiting. Among others, these threads include the job handler
           workers, which are responsible for preparing/submitting and collecting/finishing
           jobs, and which can cause job errors if not shut down cleanly. If using
-          supervisord, consider also increasing the value of `stopwaitsecs`. If using job
-          handler mules, consider also setting the `mule-reload-mercy` uWSGI option. See
-          the Galaxy Admin Documentation for more.
+          supervisord, consider also increasing the value of `stopwaitsecs`. See the
+          Galaxy Admin Documentation for more.
 
       use_heartbeat:
         type: bool

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2026,7 +2026,7 @@ mapping:
         desc: |
           Control the period (in seconds) between dumps. Use -1 to disable. Regardless
           of this setting, if use_heartbeat is enabled, you can send a Galaxy process
-          (unless running with uWSGI) SIGUSR1 (`kill -USR1`) to force a dump.
+          SIGUSR1 (`kill -USR1`) to force a dump.
 
       heartbeat_log:
         type: str


### PR DESCRIPTION
Ref #12257 

Should we remove this now or wait until 22.05? (Given that this detail is only relevant to developers, my vote is to remove).


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
