### PR TITLE
[22.01] Fix `UnboundLocalError` in sort collection tool 

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3294,9 +3294,7 @@ class SortTool(DatabaseOperationTool):
             presort_elements = [(dce.element_identifier, dce) for dce in elements]
         elif sorttype == 'numeric':
             presort_elements = [(int(re.sub('[^0-9]', '', dce.element_identifier)), dce) for dce in elements]
-        if presort_elements:
-            sorted_elements = [x[1] for x in sorted(presort_elements, key=lambda x: x[0])]
-        if sorttype == 'file':
+        elif sorttype == 'file':
             hda = incoming["sort_type"]["sort_file"]
             data_lines = hda.metadata.get('data_lines', 0)
             if data_lines == len(elements):
@@ -3313,6 +3311,11 @@ class SortTool(DatabaseOperationTool):
             else:
                 message = "Number of lines must match number of list elements (%i), but file has %i lines"
                 raise Exception(message % (data_lines, len(elements)))
+        else:
+            raise Exception(f"Unknown sort_type '{sorttype}'")
+
+        if presort_elements:
+            sorted_elements = [x[1] for x in sorted(presort_elements, key=lambda x: x[0])]
 
         for dce in sorted_elements:
             dce_object = dce.element_object

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3309,8 +3309,8 @@ class SortTool(DatabaseOperationTool):
                     message = f"List of element identifiers does not match element identifiers in collection '{hdca_history_name}'"
                     raise Exception(message)
             else:
-                message = "Number of lines must match number of list elements (%i), but file has %i lines"
-                raise Exception(message % (data_lines, len(elements)))
+                message = f"Number of lines must match number of list elements ({len(elements)}), but file has {data_lines} lines"
+                raise Exception(message)
         else:
             raise Exception(f"Unknown sort_type '{sorttype}'")
 


### PR DESCRIPTION
Should fix https://github.com/galaxyproject/galaxy/issues/13302

I tried to add a test to the [Sort Collection tool](https://github.com/davelopez/galaxy/blob/fix_sort_collection_tool/lib/galaxy/tools/sort_collection_list.xml#L31) like:
```xml
<test expect_failure="true">
    <!-- test invalid sort_type-->
    <param name="input">
        <collection type="list">
            <element name="element_1" value="simple_line_alternative.txt"/>
            <element name="element_2" value="simple_line.txt"/>
        </collection>
    </param>
    <param name="sort_type" value="unknown"/>
</test>
```
But for some reason, the test fails with `Expected job to fail but Galaxy indicated the job successfully completed.` Probably this is not the correct way of testing the wrong parameter?

#### Bonus Points
Also fixes an error message text with swapped placeholders.


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
