### PR TITLE
[22.01] Wrap reports app in static, fix tool shed entry point

### DIFF
--- a/lib/galaxy/web_stack/__init__.py
+++ b/lib/galaxy/web_stack/__init__.py
@@ -264,7 +264,7 @@ class UWSGIApplicationStack(MessageApplicationStack):
     """
     name = 'uWSGI'
     prohibited_middleware = frozenset({
-        'wrap_in_static',
+        'build_url_map',
         'EvalException',
     })
     transport_class = UWSGIFarmMessageTransport

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -983,7 +983,7 @@ def build_native_uwsgi_app(paste_factory, config_section):
     return uwsgi_app
 
 
-def build_url_map(app, global_conf, local_conf):
+def build_url_map(app, global_conf, **local_conf):
     from paste.urlmap import URLMap
     from galaxy.web.framework.middleware.static import CacheableStaticURLParser as Static
     urlmap = URLMap()
@@ -1013,4 +1013,4 @@ def build_url_map(app, global_conf, local_conf):
 
     if 'static_local_dir' in conf:
         urlmap["/static_local"] = Static(conf["static_local_dir"], cache_time)
-    return urlmap, cache_time
+    return urlmap

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -25,6 +25,7 @@ from galaxy.web.framework.middleware.batch import BatchMiddleware
 from galaxy.web.framework.middleware.error import ErrorMiddleware
 from galaxy.web.framework.middleware.request_id import RequestIDMiddleware
 from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
+from galaxy.webapps.base.webapp import build_url_map
 from galaxy.webapps.util import wrap_if_allowed
 
 log = logging.getLogger(__name__)
@@ -209,9 +210,9 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     if kwargs.get('middleware', True):
         webapp = wrap_in_middleware(webapp, global_conf, app.application_stack, **kwargs)
     if asbool(kwargs.get('static_enabled', True)):
-        webapp = wrap_if_allowed(webapp, app.application_stack, wrap_in_static,
+        webapp = wrap_if_allowed(webapp, app.application_stack, build_url_map,
                                  args=(global_conf,),
-                                 kwargs=dict(plugin_frameworks=[app.visualizations_registry], **kwargs))
+                                 kwargs=kwargs)
     app.application_stack.register_postfork_function(postfork_setup)
 
     for th in threading.enumerate():
@@ -1400,8 +1401,3 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         from galaxy.web.framework.middleware.sqldebug import SQLDebugMiddleware
         app = wrap_if_allowed(app, stack, SQLDebugMiddleware, args=(webapp, {}))
     return app
-
-
-def wrap_in_static(app, global_conf, plugin_frameworks=None, **local_conf):
-    urlmap, cache_time = galaxy.webapps.base.webapp.build_url_map(app, global_conf, local_conf)
-    return urlmap

--- a/lib/galaxy/webapps/reports/buildapp.py
+++ b/lib/galaxy/webapps/reports/buildapp.py
@@ -13,6 +13,7 @@ import galaxy.model.mapping
 import galaxy.webapps.base.webapp
 from galaxy.util import asbool
 from galaxy.util.properties import load_app_properties
+from galaxy.webapps.base.webapp import build_url_map
 from galaxy.webapps.util import wrap_if_allowed
 
 log = logging.getLogger(__name__)
@@ -68,6 +69,10 @@ def app_factory(global_conf, load_app_kwds=None, **kwargs):
     # Wrap the webapp in some useful middleware
     if kwargs.get('middleware', True):
         webapp = wrap_in_middleware(webapp, global_conf, app.application_stack, **kwargs)
+    if asbool(kwargs.get('static_enabled', True)):
+        webapp = wrap_if_allowed(webapp, app.application_stack, build_url_map,
+                                 args=(global_conf,),
+                                 kwargs=kwargs)
     return webapp
 
 

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -15,6 +15,7 @@ import galaxy.webapps.base.webapp
 from galaxy import util
 from galaxy.util import asbool
 from galaxy.util.properties import load_app_properties
+from galaxy.webapps.base.webapp import build_url_map
 from galaxy.webapps.util import wrap_if_allowed
 
 log = logging.getLogger(__name__)
@@ -190,6 +191,10 @@ def app_factory(global_conf, load_app_kwds=None, **kwargs):
     # Wrap the webapp in some useful middleware
     if kwargs.get('middleware', True):
         webapp = wrap_in_middleware(webapp, global_conf, app.application_stack, **kwargs)
+    if asbool(kwargs.get('static_enabled', True)):
+        webapp = wrap_if_allowed(webapp, app.application_stack, build_url_map,
+                                 args=(global_conf,),
+                                 kwargs=kwargs)
     return webapp
 
 

--- a/run_tool_shed.sh
+++ b/run_tool_shed.sh
@@ -26,7 +26,7 @@ if [ $? -eq 0 ] ; then
 fi
 
 if [ -z "$TOOL_SHED_CONFIG_FILE" ]; then
-    TOOL_SHED_CONFIG_FILE=$(PYTHONPATH=lib python -c "from __future__ import print_function; from galaxy.util.properties import find_config_file; print(find_config_file(['tool_shed', 'tool_shed_wsgi']) or '')")
+    TOOL_SHED_CONFIG_FILE=$(PYTHONPATH=lib python -c "from __future__ import print_function; from galaxy.util.properties import find_config_file; print(find_config_file(['tool_shed', 'tool_shed_wsgi'], include_samples=True) or '')")
     export TOOL_SHED_CONFIG_FILE
 fi
 

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -163,8 +163,10 @@ find_server() {
             ;;
         reports)
             # TODO: don't override this var, and is this really the only way to configure the port?
-            GUNICORN_CMD_ARGS="--bind=localhost:9001"
+            GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-\"--bind=localhost:9001\"}
             ;;
+        tool_shed)
+            GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-\"--bind=localhost:9009\"}
     esac
 
     APP_WEBSERVER=${APP_WEBSERVER:-$default_webserver}
@@ -188,11 +190,10 @@ find_server() {
         server_args="$server_args $uwsgi_args"
     elif [ "$APP_WEBSERVER" = "gunicorn" ]; then
         run_server="gunicorn"
+        export GUNICORN_CMD_ARGS
         if [ "$server_app" = "tool_shed" ]; then
             server_args="'${server_app}.webapp.fast_factory:factory()' --pythonpath lib -k ${gunicorn_worker:-$default_gunicorn_worker} $gunicorn_args"
-            export GUNICORN_CMD_ARGS="${GUNICORN_CMD_ARGS:-\"--bind=localhost:9009\"}"
         else
-            export GUNICORN_CMD_ARGS="${GUNICORN_CMD_ARGS:-\"--bind=localhost:8080\"}"
             server_args="'galaxy.webapps.${server_app}.fast_factory:factory()' --pythonpath lib -k ${gunicorn_worker:-$default_gunicorn_worker} $gunicorn_args"
         fi
         if [ "$add_pid_arg" -eq 1 ]; then

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -163,10 +163,10 @@ find_server() {
             ;;
         reports)
             # TODO: is this really the only way to configure the port?
-            GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-\"--bind=localhost:9001\"}
+            GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-"--bind=localhost:9001"}
             ;;
         tool_shed)
-            GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-\"--bind=localhost:9009\"}
+            GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-"--bind=localhost:9009"}
     esac
 
     APP_WEBSERVER=${APP_WEBSERVER:-$default_webserver}

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -162,7 +162,7 @@ find_server() {
             gunicorn_worker="galaxy.webapps.galaxy.workers.Worker"
             ;;
         reports)
-            # TODO: don't override this var, and is this really the only way to configure the port?
+            # TODO: is this really the only way to configure the port?
             GUNICORN_CMD_ARGS=${GUNICORN_CMD_ARGS:-\"--bind=localhost:9001\"}
             ;;
         tool_shed)

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -187,9 +187,14 @@ find_server() {
         fi
         server_args="$server_args $uwsgi_args"
     elif [ "$APP_WEBSERVER" = "gunicorn" ]; then
-        export GUNICORN_CMD_ARGS="${GUNICORN_CMD_ARGS:-\"--bind=localhost:8080\"}"
         run_server="gunicorn"
-        server_args="'galaxy.webapps.${server_app}.fast_factory:factory()' --pythonpath lib -k ${gunicorn_worker:-$default_gunicorn_worker} $gunicorn_args"
+        if [ "$server_app" = "tool_shed" ]; then
+            server_args="'${server_app}.webapp.fast_factory:factory()' --pythonpath lib -k ${gunicorn_worker:-$default_gunicorn_worker} $gunicorn_args"
+            export GUNICORN_CMD_ARGS="${GUNICORN_CMD_ARGS:-\"--bind=localhost:9009\"}"
+        else
+            export GUNICORN_CMD_ARGS="${GUNICORN_CMD_ARGS:-\"--bind=localhost:8080\"}"
+            server_args="'galaxy.webapps.${server_app}.fast_factory:factory()' --pythonpath lib -k ${gunicorn_worker:-$default_gunicorn_worker} $gunicorn_args"
+        fi
         if [ "$add_pid_arg" -eq 1 ]; then
             server_args="$server_args --pid \"$PID_FILE\""
         fi


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/13400.

We should document `GUNICORN_CMD_ARGS` too or add some other way to set the ports for the reports and tool_shed app, but this is the minimal fix.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

Start tool_shed (`./run_tool_shed.sh` ) and reports (`./run_reports.sh`) and make sure you can reach both apps on their default ports (9009 and 9001 respectively).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
