### PR TITLE
Add version.json for exposing extra api information about docker container

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -176,6 +176,10 @@ COPY --chown=$GALAXY_USER:$GALAXY_USER --from=server_build $ROOT_DIR .
 COPY --chown=$GALAXY_USER:$GALAXY_USER --from=client_build $SERVER_DIR/static ./server/static
 
 WORKDIR $SERVER_DIR
+
+# The data in version.json will be displayed in Galaxy's /api/version endpoint
+RUN printf "{\n  \"git_commit\": \"$(cat GITREVISION)\",\n  \"build_date\": \"$BUILD_DATE\",\n  \"image_tag\": \"$IMAGE_TAG\"\n}\n" > version.json
+
 EXPOSE 8080
 USER $GALAXY_USER
 


### PR DESCRIPTION
`curl http://localhost:8080/api/version`

```json
{
  "version_major": "21.09",
  "version_minor": "1.dev0",
  "extra": {
    "git_commit": "e82b50d5121c5d7b649607d816ab5a4b87ad2193",
    "build_date": "unspecified",
    "image_tag": "unspecified"
  }
}
```
`build_date` and `image_tag` will be populated correctly in a CI built container.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Build docker container and run above curl command

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
