### PR TITLE
Run jest tests using node 16 in CI

### DIFF
--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14]
+        node: [16]
     steps:
     - uses: actions/checkout@v2
     - name: Setup node

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -3,9 +3,11 @@ on:
   push:
     paths:
       - 'client/**'
+      - '.github/workflows/jest.yaml'
   pull_request:
     paths:
       - 'client/**'
+      - '.github/workflows/jest.yaml'
 concurrency:
   group: client-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
I think this was meant to be changed in https://github.com/galaxyproject/galaxy/pull/13282

If my assumption is correct this will make the tests in https://github.com/galaxyproject/galaxy/issues/13409 actually fail instead of just displaying a warning.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
