### PR TITLE
Fix `UnhandledPromiseRejection` in client tests

### DIFF
--- a/client/src/components/Workflow/Editor/Index.test.js
+++ b/client/src/components/Workflow/Editor/Index.test.js
@@ -15,8 +15,8 @@ jest.mock("app");
 
 import { getDatatypesMapper } from "components/Datatypes/factory";
 import { testDatatypesMapper } from "components/Datatypes/test_fixtures";
-import { loadWorkflow } from "./modules/services";
-import { saveAs } from "./modules/utilities";
+import { getVersions, loadWorkflow } from "./modules/services";
+import { getStateUpgradeMessages, saveAs } from "./modules/utilities";
 import { getAppRoot } from "onload/loadConfig";
 import WorkflowCanvas from "./modules/canvas";
 
@@ -27,6 +27,8 @@ describe("Index", () => {
 
     beforeEach(() => {
         getDatatypesMapper.mockResolvedValue(testDatatypesMapper);
+        getStateUpgradeMessages.mockImplementation(() => []);
+        getVersions.mockResolvedValue((id) => []);
         WorkflowCanvas.mockClear();
     });
 

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -9,10 +9,13 @@ import moment from "moment";
 const localVue = getLocalVue();
 
 describe("Invocations.vue without invocation", () => {
+    let axiosMock;
     let wrapper;
     let propsData;
 
     beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+        axiosMock.onAny().reply(200, [], { total_matches: "0" });
         propsData = {
             ownerGrid: false,
         };
@@ -20,6 +23,10 @@ describe("Invocations.vue without invocation", () => {
             propsData,
             localVue,
         });
+    });
+
+    afterEach(() => {
+        axiosMock.reset();
     });
 
     it("title should be shown", async () => {
@@ -38,7 +45,9 @@ describe("Invocations.vue with invocation", () => {
 
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
-        axiosMock.onGet("/api/invocations").reply(200, [mockInvocationData], { total_matches: "1" });
+        axiosMock
+            .onGet("/api/invocations", { params: { limit: 50, offset: 0, include_terminal: false } })
+            .reply(200, [mockInvocationData], { total_matches: "1" });
         propsData = {
             ownerGrid: false,
             loading: false,
@@ -50,6 +59,9 @@ describe("Invocations.vue with invocation", () => {
                 getWorkflowByInstanceId: (state) => (id) => {
                     return { id: "workflowId" };
                 },
+                getHistoryById: (state) => (id) => {
+                    return { id: "historyId" };
+                },
                 getHistoryNameById: () => () => "history name",
             },
             stubs: {
@@ -59,6 +71,10 @@ describe("Invocations.vue with invocation", () => {
             },
             localVue,
         });
+    });
+
+    afterEach(() => {
+        axiosMock.reset();
     });
 
     it("renders one row", async () => {


### PR DESCRIPTION
Fixes #13409

After some serious debugging I finally found out the root cause of the `UnhandledPromiseRejection` errors in those tests. For more details see commit messages.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Make sure you are using Node v16
  - Run `yarn jest` in `dev` branch (without these changes)
  - Observe that [Invocations.test.js](https://github.com/galaxyproject/galaxy/blob/dev/client/src/components/Workflow/Invocations.test.js) and [Editor/Index.test.js](https://github.com/galaxyproject/galaxy/blob/dev/client/src/components/Workflow/Editor/Index.test.js) fail locally.
  - Apply these changes and run again `yarn jest`
  - No errors!

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
