### PR TITLE
Add built-in converters to tool panel

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4818,4 +4818,14 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``display_builtin_converters``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Display built-in converters in the tool panel.
+:Default: ``true``
+:Type: bool
+
+
 

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -337,7 +337,8 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         # Load history import/export tools.
         load_lib_tools(self.toolbox)
         # Load built-in converters
-        self.toolbox.load_builtin_converters()
+        if self.config.display_builtin_converters:
+            self.toolbox.load_builtin_converters()
         self.toolbox.persist_cache(register_postfork=True)
         # visualizations registry: associates resources with visualizations, controls how to render
         self.visualizations_registry = self._register_singleton(

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -336,6 +336,8 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         self.datatypes_registry.load_external_metadata_tool(self.toolbox)
         # Load history import/export tools.
         load_lib_tools(self.toolbox)
+        # Load built-in converters
+        self.toolbox.load_builtin_converters()
         self.toolbox.persist_cache(register_postfork=True)
         # visualizations registry: associates resources with visualizations, controls how to render
         self.visualizations_registry = self._register_singleton(

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2347,3 +2347,6 @@ galaxy:
   # <config_dir>.
   #vault_config_file: vault_conf.yml
 
+  # Display built-in converters in the tool panel.
+  #display_builtin_converters: true
+

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3505,3 +3505,9 @@ mapping:
         required: false
         desc: |
           Vault config file.
+
+      display_builtin_converters:
+        type: bool
+        default: true
+        required: false
+        desc: Display built-in converters in the tool panel.

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -1445,3 +1445,16 @@ class BaseGalaxyToolBox(AbstractToolBox):
 
     def reload_dependency_manager(self):
         self._init_dependency_manager()
+
+    def load_builtin_converters(self):
+        id = "builtin_converters"
+        section = ToolSection({"name": "Built-in Converters", "id": id})
+        self._tool_panel[id] = section
+
+        converters = self.app.datatypes_registry.datatype_converters
+        for source, targets in converters.items():
+            for target, tool in targets.items():
+                tool.name = f"{source}-to-{target}"
+                tool.description = "converter"
+                tool.hidden = False
+                section.elems.append_tool(tool)


### PR DESCRIPTION
Ref #9649 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Do nothing: observe "Built-in Converters" section in the tool panel. Set the `display_builtin_converters` option to `false`: section should not be displayed.



## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
