### PR TITLE
Progress towards SQLAlchemy 2.0 (backref_cascade issue)

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9683,6 +9683,8 @@ def receive_init(target, args, kwargs):
     Addresses SQLAlchemy 2.0 compatibility issue: see inline documentation for
     `add_object_to_object_session` in galaxy.model.orm.util.
     """
-    history = kwargs.get("history")
-    if history:
-        add_object_to_object_session(target, history)
+    for key in ("history", "copied_from_history_dataset_collection_association"):
+        obj = kwargs.get(key)
+        if obj:
+            add_object_to_object_session(target, obj)
+            return  # Once is enough.

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -120,10 +120,7 @@ from galaxy.model.item_attrs import (
     UsesAnnotations,
 )
 from galaxy.model.orm.now import now
-from galaxy.model.orm.util import (
-    add_object_to_object_session,
-    add_object_to_session,
-)
+from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.model.view import HistoryDatasetCollectionJobStateSummary
 from galaxy.security import get_permitted_actions
 from galaxy.security.idencoding import IdEncodingHelper
@@ -3729,7 +3726,7 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
             if flush:
                 sa_session.add(dataset)
                 sa_session.flush()
-        add_object_to_session(self, sa_session)
+        add_object_to_object_session(self, dataset)
         self.dataset = dataset
         self.parent_id = parent_id
 
@@ -4287,7 +4284,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         DatasetInstance.__init__(self, sa_session=sa_session, **kwd)
         self.hid = hid
         # Relationships
-        add_object_to_session(self, sa_session)
+        add_object_to_object_session(self, history)
         self.history = history
         self.copied_from_history_dataset_association = copied_from_history_dataset_association
         self.copied_from_library_dataset_dataset_association = copied_from_library_dataset_dataset_association

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9000,6 +9000,7 @@ class HistoryRatingAssociation(ItemRatingAssociation, RepresentById):
     user = relationship("User")
 
     def _set_item(self, history):
+        add_object_to_object_session(self, history)
         self.history = history
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2978,6 +2978,7 @@ class UserRoleAssociation(Base, RepresentById):
     role = relationship("Role", back_populates="users")
 
     def __init__(self, user, role):
+        add_object_to_object_session(self, user)
         self.user = user
         self.role = role
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1873,6 +1873,7 @@ class JobToInputDatasetAssociation(Base, RepresentById):
 
     def __init__(self, name, dataset):
         self.name = name
+        add_object_to_object_session(self, dataset)
         self.dataset = dataset
         self.dataset_version = 0  # We start with version 0 and update once the job is ready
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2184,6 +2184,8 @@ class JobExportHistoryArchive(Base, RepresentById):
     ATTRS_FILENAME_HISTORY = "history_attrs.txt"
 
     def __init__(self, compressed=False, **kwd):
+        if 'history' in kwd:
+            add_object_to_object_session(self, kwd['history'])
         super().__init__(**kwd)
         self.compressed = compressed
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1274,7 +1274,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         self.input_datasets.append(assoc)
 
     def add_output_dataset(self, name, dataset):
-        self.output_datasets.append(JobToOutputDatasetAssociation(name, dataset))
+        joda = JobToOutputDatasetAssociation(name, dataset)
+        add_object_to_object_session(self, joda)
+        self.output_datasets.append(joda)
 
     def add_input_dataset_collection(self, name, dataset_collection):
         self.input_dataset_collections.append(JobToInputDatasetCollectionAssociation(name, dataset_collection))

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3725,6 +3725,7 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
             if flush:
                 sa_session.add(dataset)
                 sa_session.flush()
+        add_object_to_session(self, sa_session)
         self.dataset = dataset
         self.parent_id = parent_id
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2534,6 +2534,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         self.purged = False
         self.importing = False
         self.published = False
+        add_object_to_object_session(self, user)
         self.user = user
         # Objects to eventually add to history
         self._pending_additions = []

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1273,6 +1273,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         assoc = JobToInputDatasetAssociation(name, dataset)
         if dataset is None and dataset_id is not None:
             assoc.dataset_id = dataset_id
+        add_object_to_object_session(self, assoc)
         self.input_datasets.append(assoc)
 
     def add_output_dataset(self, name, dataset):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1890,6 +1890,7 @@ class JobToOutputDatasetAssociation(Base, RepresentById):
 
     def __init__(self, name, dataset):
         self.name = name
+        add_object_to_object_session(self, dataset)
         self.dataset = dataset
 
     @property

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2627,6 +2627,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
                 dataset.hid = self._next_hid()
         if quota and is_dataset and self.user:
             self.user.adjust_total_disk_usage(dataset.quota_amount(self.user))
+        add_object_to_object_session(dataset, self)
         dataset.history = self
         if is_dataset and genome_build not in [None, "?"]:
             self.genome_build = genome_build

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2673,6 +2673,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     def add_dataset_collection(self, history_dataset_collection, set_hid=True):
         if set_hid:
             history_dataset_collection.hid = self._next_hid()
+        add_object_to_object_session(history_dataset_collection, self)
         history_dataset_collection.history = self
         # TODO: quota?
         self.dataset_collections.append(history_dataset_collection)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6262,6 +6262,7 @@ class DatasetCollectionElement(Base, Dictifiable, Serializable):
             raise AttributeError(f"Unknown element type provided: {type(element)}")
 
         self.id = id
+        add_object_to_object_session(self, collection)
         self.collection = collection
         self.element_index = element_index
         self.element_identifier = element_identifier or str(element_index)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -120,6 +120,10 @@ from galaxy.model.item_attrs import (
     UsesAnnotations,
 )
 from galaxy.model.orm.now import now
+from galaxy.model.orm.util import (
+    add_object_to_object_session,
+    add_object_to_session,
+)
 from galaxy.model.view import HistoryDatasetCollectionJobStateSummary
 from galaxy.security import get_permitted_actions
 from galaxy.security.idencoding import IdEncodingHelper
@@ -4278,6 +4282,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         DatasetInstance.__init__(self, sa_session=sa_session, **kwd)
         self.hid = hid
         # Relationships
+        add_object_to_session(self, sa_session)
         self.history = history
         self.copied_from_history_dataset_association = copied_from_history_dataset_association
         self.copied_from_library_dataset_dataset_association = copied_from_library_dataset_dataset_association

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3266,6 +3266,7 @@ class DefaultUserPermissions(Base, RepresentById):
     role = relationship("Role")
 
     def __init__(self, user, action, role):
+        add_object_to_object_session(self, user)
         self.user = user
         self.action = action
         self.role = role

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3165,6 +3165,7 @@ class DatasetPermissions(Base, RepresentById):
 
     def __init__(self, action, dataset, role=None, role_id=None):
         self.action = action
+        add_object_to_object_session(self, dataset)
         self.dataset = dataset
         if role is not None:
             self.role = role

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2184,8 +2184,8 @@ class JobExportHistoryArchive(Base, RepresentById):
     ATTRS_FILENAME_HISTORY = "history_attrs.txt"
 
     def __init__(self, compressed=False, **kwd):
-        if 'history' in kwd:
-            add_object_to_object_session(self, kwd['history'])
+        if "history" in kwd:
+            add_object_to_object_session(self, kwd["history"])
         super().__init__(**kwd)
         self.compressed = compressed
 

--- a/lib/galaxy/model/dataset_collections/builder.py
+++ b/lib/galaxy/model/dataset_collections/builder.py
@@ -1,4 +1,5 @@
 from galaxy import model
+from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.util.oset import OrderedSet
 from .type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
 
@@ -23,6 +24,7 @@ def set_collection_elements(dataset_collection, type, dataset_instances, associa
     elements = []
     for element in type.generate_elements(new_dataset_instances):
         element.element_index = element_index
+        add_object_to_object_session(element, dataset_collection)
         element.collection = dataset_collection
         elements.append(element)
 

--- a/lib/galaxy/model/orm/util.py
+++ b/lib/galaxy/model/orm/util.py
@@ -16,11 +16,17 @@ def add_object_to_object_session(object, object_with_session):
       along the backref cascade path...'
     """
     if object_with_session:
-        session = inpsect(object_with_session).session
-        add_object_to_session(object, session)
+        session = get_object_session(object_with_session)
+        if session:
+            add_object_to_session(object, session)
 
 
 def add_object_to_session(object, session):
     """ Explicitly add object to the session."""
     if session and object:
         session.add(object)
+
+
+def get_object_session(object):
+    if object:
+        return inspect(object).session

--- a/lib/galaxy/model/orm/util.py
+++ b/lib/galaxy/model/orm/util.py
@@ -3,7 +3,7 @@ from sqlalchemy import inspect
 
 def add_object_to_object_session(object, object_with_session):
     """
-    Explicitly add object to the session. 
+    Explicitly add object to the session.
     Addresses SQLAlchemy 2.0 compatibility issue:
     https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#cascade-backrefs-behavior-deprecated-for-removal-in-2-0
 
@@ -22,7 +22,7 @@ def add_object_to_object_session(object, object_with_session):
 
 
 def add_object_to_session(object, session):
-    """ Explicitly add object to the session."""
+    """Explicitly add object to the session."""
     if session and object:
         session.add(object)
 

--- a/lib/galaxy/model/orm/util.py
+++ b/lib/galaxy/model/orm/util.py
@@ -1,0 +1,26 @@
+from sqlalchemy import inspect
+
+
+def add_object_to_object_session(object, object_with_session):
+    """
+    Explicitly add object to the session. 
+    Addresses SQLAlchemy 2.0 compatibility issue:
+    https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#cascade-backrefs-behavior-deprecated-for-removal-in-2-0
+
+    This function preserves SQLAlchemy's pre-2.0 logic and should be used when:
+    1. foo and bar are model instances, that are associated (via SQLAlchemy's relationship), AND
+    2. bar is assigned to foo's bar relationship (e.g. foo.bar = bar), AND
+    3. bar is in a session and foo is not, AND
+    4. foo is implicitly added to bar's session upon assignment(2), as indicated
+      by a RemovedIn20Warning specifying that the '"foo" object is being merged into a Session
+      along the backref cascade path...'
+    """
+    if object_with_session:
+        session = inpsect(object_with_session).session
+        add_object_to_session(object, session)
+
+
+def add_object_to_session(object, session):
+    """ Explicitly add object to the session."""
+    if session and object:
+        session.add(object)

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -31,6 +31,7 @@ from galaxy.exceptions import (
 )
 from galaxy.model.metadata import MetadataCollection
 from galaxy.model.orm.util import (
+    add_object_to_object_session,
     add_object_to_session,
     get_object_session,
 )
@@ -784,6 +785,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             icj.jobs = []
             for order_index, job in enumerate(icj_attrs["jobs"]):
                 icja = model.ImplicitCollectionJobsJobAssociation()
+                add_object_to_object_session(icja, icj)
                 icja.implicit_collection_jobs = icj
                 if job in object_import_tracker.jobs_by_key:
                     icja.job = object_import_tracker.jobs_by_key[job]

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -29,6 +29,7 @@ from galaxy.exceptions import (
     MalformedContents,
     ObjectNotFound,
 )
+from galaxy.model.orm.util import add_object_to_session
 from galaxy.model.metadata import MetadataCollection
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import (
@@ -597,6 +598,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                     )
                     self._attach_raw_id_if_editing(hdca, collection_attrs)
 
+                    add_object_to_session(hdca, self.sa_session)
                     hdca.history = history
                     if new_history and self.trust_hid(collection_attrs):
                         hdca.hid = collection_attrs["hid"]

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -586,6 +586,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             self._session_add(dc)
             return dc
 
+        history_sa_session = get_object_session(history)
         for collection_attrs in collections_attrs:
             if "collection" in collection_attrs:
                 dc = import_collection(collection_attrs["collection"])
@@ -601,7 +602,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                     )
                     self._attach_raw_id_if_editing(hdca, collection_attrs)
 
-                    add_object_to_session(hdca, self.sa_session)
+                    add_object_to_session(hdca, history_sa_session)
                     hdca.history = history
                     if new_history and self.trust_hid(collection_attrs):
                         hdca.hid = collection_attrs["hid"]

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -22,7 +22,6 @@ from typing import (
 
 from bdbag import bdbag_api as bdb
 from boltons.iterutils import remap
-from sqlalchemy import inspect
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import expression
 
@@ -30,11 +29,11 @@ from galaxy.exceptions import (
     MalformedContents,
     ObjectNotFound,
 )
+from galaxy.model.metadata import MetadataCollection
 from galaxy.model.orm.util import (
     add_object_to_session,
     get_object_session,
 )
-from galaxy.model.metadata import MetadataCollection
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import (
     FILENAME_VALID_CHARS,

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -788,7 +788,9 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 add_object_to_object_session(icja, icj)
                 icja.implicit_collection_jobs = icj
                 if job in object_import_tracker.jobs_by_key:
-                    icja.job = object_import_tracker.jobs_by_key[job]
+                    job_instance = object_import_tracker.jobs_by_key[job]
+                    add_object_to_object_session(icja, job_instance)
+                    icja.job = job_instance
                 icja.order_index = order_index
                 icj.jobs.append(icja)
                 self._session_add(icja)

--- a/test/unit/app/tools/test_history_imp_exp.py
+++ b/test/unit/app/tools/test_history_imp_exp.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 from galaxy import model
 from galaxy.app_unittest_utils.galaxy_mock import MockApp
 from galaxy.exceptions import MalformedContents
+from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.objectstore.unittest_utils import Config as TestConfig
 from galaxy.tools.imp_exp import (
     JobExportHistoryArchiveWrapper,
@@ -387,11 +388,13 @@ def test_export_collection_with_mapping_history():
     ija1 = model.ImplicitCollectionJobsJobAssociation()
     ija1.order_index = 0
     ija1.implicit_collection_jobs = implicit_collection_jobs
+    add_object_to_object_session(ija1, j1)
     ija1.job = j1
 
     j2.add_output_dataset_collection("out_file1", hc2)  # really?
     ija2 = model.ImplicitCollectionJobsJobAssociation()
     ija2.order_index = 1
+    add_object_to_object_session(ija2, implicit_collection_jobs)
     ija2.implicit_collection_jobs = implicit_collection_jobs
     ija2.job = j2
 

--- a/test/unit/data/model/mapping/test_install_model_mapping.py
+++ b/test/unit/data/model/mapping/test_install_model_mapping.py
@@ -150,10 +150,9 @@ class TestRepositoryDependency(BaseTest):
     def test_columns(self, session, cls_, repository):
         create_time = datetime.now()
         update_time = create_time + timedelta(hours=1)
-        obj = cls_()
+        obj = cls_(repository.id)
         obj.create_time = create_time
         obj.update_time = update_time
-        obj.repository = repository
 
         with dbcleanup(session, obj) as obj_id:
             stored_obj = get_stored_obj(session, cls_, obj_id)
@@ -163,8 +162,7 @@ class TestRepositoryDependency(BaseTest):
             assert stored_obj.tool_shed_repository_id == repository.id
 
     def test_relationships(self, session, cls_, repository):
-        obj = cls_()
-        obj.repository = repository
+        obj = cls_(repository.id)
 
         with dbcleanup(session, obj) as obj_id:
             stored_obj = get_stored_obj(session, cls_, obj_id)
@@ -313,8 +311,7 @@ def repository_repository_dependency_association(session):
 
 @pytest.fixture
 def repository_dependency(session, repository):
-    instance = model.RepositoryDependency()
-    instance.repository = repository
+    instance = model.RepositoryDependency(repository.id)
     yield from dbcleanup_wrapper(session, instance)
 
 

--- a/test/unit/data/model/mapping/test_model_mapping.py
+++ b/test/unit/data/model/mapping/test_model_mapping.py
@@ -7076,7 +7076,7 @@ def visualization_rating_association(session, user, visualization):
 
 @pytest.fixture
 def visualization_revision(session, visualization):
-    instance = model.VisualizationRevision(visualization=visualization)
+    instance = model.VisualizationRevision(visualization_id=visualization.id)
     yield from dbcleanup_wrapper(session, instance)
 
 

--- a/test/unit/data/model/mapping/test_model_mapping.py
+++ b/test/unit/data/model/mapping/test_model_mapping.py
@@ -7344,8 +7344,8 @@ def visualization_rating_association_factory():
 @pytest.fixture
 def visualization_revision_factory(visualization):
     def make_instance(*args, **kwds):
-        if "visualization" not in kwds:
-            kwds["visualization"] = visualization
+        if "visualization_id" not in kwds:
+            kwds["visualization_id"] = visualization.id
         return model.VisualizationRevision(*args, **kwds)
 
     return make_instance

--- a/test/unit/data/model/mapping/test_model_mapping.py
+++ b/test/unit/data/model/mapping/test_model_mapping.py
@@ -430,7 +430,6 @@ class TestDataManagerJobAssociation(BaseTest):
         obj = cls_()
         obj.create_time = create_time
         obj.update_time = update_time
-        session.add(job)  # must be bound to a session for lazy load of attributes
         obj.job = job
         obj.data_manager_id = data_manager_id
 
@@ -443,7 +442,6 @@ class TestDataManagerJobAssociation(BaseTest):
             assert stored_obj.data_manager_id == data_manager_id
 
     def test_relationships(self, session, cls_, job):
-        session.add(job)  # must be bound to a session for lazy load of attributes
         obj = cls_(job=job)
 
         with dbcleanup(session, obj) as obj_id:


### PR DESCRIPTION
Ref #12541 
(addresses step 6. Migration to 2.0 Step Three - Resolve all RemovedIn20Warnings)

This PR does not cover all such cases; I'll be submitting additional fixes on a case-by-case basis.

This addresses the backrer_cascade issue (see this [ref](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#cascade-backrefs-behavior-deprecated-for-removal-in-2-0)).

Consider the following example:
```py
class User():
    ...
    addresses = relationship(Address, back_populates='user')

class Address():
    ...
    user = relationship(User, back_populates='address')

u = User()
session.add(u)
a = Address()
a.user = u  # in 1.4, `a` is added to `session`. In 2.0, `a` is NOT added to `session`.
```
As a result, once we enable the `future=True` flag on the Session constructor (step 8 in #12541), any model instance that was implicitly added to the session (but was never explicitly added) will no longer be in the session - which may lead to hard-to-track bugs. In the proposed solution, we explicitly add the sessionless object to the session whenever such behavior is spotted via the `SQLALCHEMY_WARN_20=1` flag. Once we move to 2.0 and verify that the system is stable, we can remove such fixes, explicitly adding objects to the session (via `session.add()`) in the right place and at the right time, when needed.

I considered automating this for all models, but that would be problematic due to the very large number of bidirectional relationships (as well as too much introspection into the object's internals); a case-by-case approach based on identified occurrences seems a better choice.
 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
