### PR TITLE
[21.01] Initial fix for quay.io repo query issue

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -66,9 +66,9 @@ def _namespace_has_repo_name(namespace, repo_name, resolution_cache):
     else:
         next_page = None
         repo_names = []
+        repos_headers = {"Accept-encoding": "gzip", "Accept": "application/json"}
         while True:
-            repos_parameters = {"public": "true", "namespace": namespace, "next_page": next_page}
-            repos_headers = {"Accept-encoding": "gzip", "Accept": "application/json"}
+            repos_parameters = {"public": "true", "namespace": namespace, "next_page": next_page}         
             repos_response = requests.get(
                 QUAY_REPOSITORY_API_ENDPOINT, headers=repos_headers, params=repos_parameters, timeout=QUAY_IO_TIMEOUT)
             repos_response_json = repos_response.json()

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -64,13 +64,19 @@ def _namespace_has_repo_name(namespace, repo_name, resolution_cache):
     if resolution_cache is not None and cache_key in resolution_cache:
         repo_names = resolution_cache.get(cache_key)
     else:
-        repos_parameters = {'public': 'true', 'namespace': namespace}
-        repos_headers = {'Accept-encoding': 'gzip', 'Accept': 'application/json'}
-        repos_response = requests.get(
-            QUAY_REPOSITORY_API_ENDPOINT, headers=repos_headers, params=repos_parameters, timeout=QUAY_IO_TIMEOUT)
-
-        repos = repos_response.json()['repositories']
-        repo_names = [r["name"] for r in repos]
+        next_page = None
+        repo_names = []
+        while True:
+            repos_parameters = {"public": "true", "namespace": namespace, "next_page": next_page}
+            repos_headers = {"Accept-encoding": "gzip", "Accept": "application/json"}
+            repos_response = requests.get(
+                QUAY_REPOSITORY_API_ENDPOINT, headers=repos_headers, params=repos_parameters, timeout=QUAY_IO_TIMEOUT)
+            repos_response_json = repos_response.json()
+            repos = repos_response_json["repositories"]
+            repo_names += [r["name"] for r in repos]
+            next_page = repos_response_json.get("next_page")
+            if not next_page:
+                break
         if resolution_cache is not None:
             resolution_cache[cache_key] = repo_names
     return repo_name in repo_names

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -68,7 +68,7 @@ def _namespace_has_repo_name(namespace, repo_name, resolution_cache):
         repo_names = []
         repos_headers = {"Accept-encoding": "gzip", "Accept": "application/json"}
         while True:
-            repos_parameters = {"public": "true", "namespace": namespace, "next_page": next_page}         
+            repos_parameters = {"public": "true", "namespace": namespace, "next_page": next_page}
             repos_response = requests.get(
                 QUAY_REPOSITORY_API_ENDPOINT, headers=repos_headers, params=repos_parameters, timeout=QUAY_IO_TIMEOUT)
             repos_response_json = repos_response.json()


### PR DESCRIPTION
Fixes not getting a full list of images in a repo. Without this fix some container images are not resolvable.

I understand there's more to be done, but this is a major fix we should get out ASAP.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
