### PR TITLE
[21.09] Add profile version to ethercalc

### DIFF
--- a/tools/interactive/interactivetool_ethercalc.xml
+++ b/tools/interactive/interactivetool_ethercalc.xml
@@ -1,4 +1,4 @@
-<tool id="interactive_tool_ethercalc" tool_type="interactive" name="EtherCalc" version="0.1">
+<tool id="interactive_tool_ethercalc" tool_type="interactive" name="EtherCalc" version="0.1" profile="20.01">
     <requirements>
         <container type="docker">shiltemann/ethercalc-galaxy-ie:17.05</container>
     </requirements>


### PR DESCRIPTION
It writes to stderr, so that fails on most job runners (why not all???).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Use the local runner, start up ethercalc and stop it. The dataset should not be in error

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
