### PR TITLE
Downgraded mercurial to 6.0.2 as wheels for 6.0.3 is not available

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -93,7 +93,7 @@ mako==1.1.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (pyt
 markdown-it-reporter==0.0.2
 markdown==3.3.6; python_version >= "3.6"
 markupsafe==2.1.0; python_version >= "3.7"
-mercurial==6.0.3
+mercurial==6.0.2
 mirakuru==2.4.2; python_version >= "3.7"
 mistune==0.8.4; python_version >= "3.7" and python_version < "4"
 mrcfile==1.3.0

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -76,7 +76,7 @@ lxml==4.8.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (pyt
 mako==1.1.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 markdown==3.3.6; python_version >= "3.6"
 markupsafe==2.1.0; python_version >= "3.7"
-mercurial==6.0.3
+mercurial==6.0.2
 mistune==0.8.4; python_version >= "3.7" and python_version < "4"
 mrcfile==1.3.0
 msgpack==1.0.3; python_version >= "3.7" and python_version < "4"


### PR DESCRIPTION
(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
