### PR TITLE
Small enhancements from the deferred data branch.

### DIFF
--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -502,6 +502,13 @@ mapping:
         desc: |
           Configured FileSource plugins.
 
+      file_sources:
+        type: seq
+        sequence:
+          - type: any
+        desc: |
+          FileSource plugins described embedded into Galaxy's config.
+
       enable_mulled_containers:
         type: bool
         default: true

--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -176,10 +176,14 @@ class ConfiguredFileSources:
     @staticmethod
     def from_app_config(config):
         config_file = config.file_sources_config_file
-        if not os.path.exists(config_file):
+        config_dict = None
+        if not config_file or not os.path.exists(config_file):
             config_file = None
+            config_dict = config.file_sources
         file_sources_config = ConfiguredFileSourcesConfig.from_app_config(config)
-        return ConfiguredFileSources(file_sources_config, config_file, load_stock_plugins=True)
+        return ConfiguredFileSources(
+            file_sources_config, conf_file=config_file, conf_dict=config_dict, load_stock_plugins=True
+        )
 
     @staticmethod
     def from_dict(as_dict):

--- a/test/unit/app/tools/test_data_fetch.py
+++ b/test/unit/app/tools/test_data_fetch.py
@@ -31,8 +31,8 @@ def test_simple_path_get():
             ]
         }
         execute_context.execute_request(request)
-        galaxy_json = execute_context.galaxy_json
-        assert "__unnamed_outputs" in galaxy_json
+        output = _unnamed_output(execute_context)
+        assert output
 
 
 def test_simple_list_path_get():
@@ -53,9 +53,7 @@ def test_simple_list_path_get():
             ]
         }
         execute_context.execute_request(request)
-        galaxy_json = execute_context.galaxy_json
-        assert "__unnamed_outputs" in galaxy_json
-        output = galaxy_json.get("__unnamed_outputs")[0]
+        output = _unnamed_output(execute_context)
         destination = output["destination"]
         assert "object_id" in destination
         assert destination["object_id"] == 76
@@ -85,9 +83,7 @@ def test_hdas_single_url_error():
             ]
         }
         execute_context.execute_request(request)
-        galaxy_json = execute_context.galaxy_json
-        assert "__unnamed_outputs" in galaxy_json
-        output = galaxy_json.get("__unnamed_outputs")[0]
+        output = _unnamed_output(execute_context)
         assert "elements" in output
         elements = output["elements"]
         assert len(elements) == 2
@@ -123,9 +119,7 @@ def test_hdca_collection_element_failed():
             ]
         }
         execute_context.execute_request(request)
-        galaxy_json = execute_context.galaxy_json
-        assert "__unnamed_outputs" in galaxy_json
-        output = galaxy_json.get("__unnamed_outputs")[0]
+        output = _unnamed_output(execute_context)
         assert "error_message" in output
         error = output["error_message"]
         assert (
@@ -158,9 +152,7 @@ def test_hdca_allow_failed_collections():
             ],
         }
         execute_context.execute_request(request)
-        galaxy_json = execute_context.galaxy_json
-        assert "__unnamed_outputs" in galaxy_json
-        output = galaxy_json.get("__unnamed_outputs")[0]
+        output = _unnamed_output(execute_context)
         assert "error_message" not in output
         assert "elements" in output
         elements = output["elements"]
@@ -193,9 +185,7 @@ def test_hdca_failed_expansion():
             ]
         }
         execute_context.execute_request(request)
-        galaxy_json = execute_context.galaxy_json
-        assert "__unnamed_outputs" in galaxy_json
-        output = galaxy_json.get("__unnamed_outputs")[0]
+        output = _unnamed_output(execute_context)
         assert "elements" in output
         elements = output["elements"]
         assert len(elements) == 0
@@ -210,6 +200,16 @@ def _execute_context():
         yield ExecuteContext(job_directory)
     finally:
         rmtree(job_directory)
+
+
+def _unnamed_output(execute_context: "ExecuteContext"):
+    galaxy_json = execute_context.galaxy_json
+    assert "__unnamed_outputs" in galaxy_json
+    unnamed_outputs = galaxy_json.get("__unnamed_outputs")
+    assert isinstance(unnamed_outputs, list)
+    assert len(unnamed_outputs) > 0
+    output = unnamed_outputs[0]
+    return output
 
 
 class ExecuteContext:


### PR DESCRIPTION
See individual commits for details.
- More typing for model stores.
- Less duplication in data fetch testing.
- Allow embedding files source configs right in Galaxy's config YAML.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
