### PR TITLE
Use timeout instead of interval when polling, optionally terminate polling

### DIFF
--- a/client/src/components/DatasetInformation/DatasetDetails.vue
+++ b/client/src/components/DatasetInformation/DatasetDetails.vue
@@ -10,6 +10,7 @@
                     <JobDetailsProvider
                         v-if="!isDatasetLoading && dataset.creating_job !== null"
                         :jobid="dataset.creating_job"
+                        auto-refresh
                         v-slot="{ result: job, loading: isJobLoading }">
                         <div v-if="!isJobLoading">
                             <dataset-information class="detail" :hda_id="datasetId" />

--- a/client/src/components/History/ContentItem/GenericContentItem/GenericHistoryContent.vue
+++ b/client/src/components/History/ContentItem/GenericContentItem/GenericHistoryContent.vue
@@ -1,5 +1,5 @@
 <template>
-    <component :is="providerComponent" :id="data_item.id" v-slot="{ result: item, loading }">
+    <component :is="providerComponent" :id="data_item.id" auto-refresh v-slot="{ result: item, loading }">
         <div>
             <loading-span v-if="loading" message="Loading dataset" />
             <component :is="renderComponent" v-if="item" :item="item"> </component>

--- a/client/src/components/JobInformation/JobInformation.test.js
+++ b/client/src/components/JobInformation/JobInformation.test.js
@@ -1,40 +1,17 @@
-import Vuex from "vuex";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import JobInformation from "./JobInformation";
-import datasetResponse from "components/DatasetInformation/testData/datasetResponse";
 import jobResponse from "./testData/jobInformationResponse.json";
 
 import flushPromises from "flush-promises";
-import createCache from "vuex-cache";
 
 jest.mock("app");
 
 const JOB_ID = "test_id";
 
 const localVue = getLocalVue();
-
-const jobStore = new Vuex.Store({
-    plugins: [createCache()],
-    modules: {
-        jobStore: {
-            actions: {
-                fetchDataset: jest.fn(),
-                fetchJob: jest.fn(),
-            },
-            getters: {
-                dataset: (state) => (hda_id) => {
-                    return datasetResponse;
-                },
-                job: (state) => (hda_id) => {
-                    return jobResponse;
-                },
-            },
-        },
-    },
-});
 
 describe("JobInformation/JobInformation.vue", () => {
     let wrapper;
@@ -44,6 +21,7 @@ describe("JobInformation/JobInformation.vue", () => {
     beforeEach(() => {
         axiosMock = new MockAdapter(axios);
         axiosMock.onGet(new RegExp(`api/configuration/decode/*`)).reply(200, { decoded_id: 123 });
+        axiosMock.onGet("/api/jobs/test_id?full=True").reply(200, jobResponse);
     });
 
     afterEach(() => {
@@ -65,14 +43,12 @@ describe("JobInformation/JobInformation.vue", () => {
         const propsData = {
             job_id: JOB_ID,
         };
-
         wrapper = mount(JobInformation, {
-            store: jobStore,
             propsData,
             localVue,
         });
-        jobInfoTable = wrapper.find("#job-information");
         await flushPromises();
+        jobInfoTable = wrapper.find("#job-information");
     });
 
     it("job information table should be rendered", async () => {

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -1,81 +1,87 @@
 <template>
-    <div>
-        <h3>Job Information</h3>
-        <table id="job-information" class="tabletip info_data_table">
-            <tbody>
-                <tr v-if="job && job.tool_id">
-                    <td>Galaxy Tool ID:</td>
-                    <td id="galaxy-tool-id">
-                        {{ job.tool_id }}
-                        <copy-to-clipboard
-                            message="Tool ID was copied to your clipboard"
-                            :text="job.tool_id"
-                            title="Copy Tool ID" />
-                    </td>
-                </tr>
-                <tr v-if="job && job.tool_version">
-                    <td>Galaxy Tool Version:</td>
-                    <td id="galaxy-tool-version">{{ job.tool_version }}</td>
-                </tr>
-                <tr v-if="job && includeTimes">
-                    <td>Created</td>
-                    <td id="created" v-if="job.create_time">
-                        <UtcDate :date="job.create_time" mode="pretty" />
-                    </td>
-                </tr>
-                <tr v-if="job && includeTimes">
-                    <td>Updated</td>
-                    <td id="updated" v-if="job.update_time">
-                        <UtcDate :date="job.update_time" mode="pretty" />
-                    </td>
-                </tr>
-                <tr v-if="job && includeTimes && jobIsTerminal">
-                    <td>Time To Finish</td>
-                    <td id="runtime">
-                        {{ runTime }}
-                    </td>
-                </tr>
-                <code-row id="command-line" v-if="job" :code-label="'Command Line'" :code-item="job.command_line" />
-                <code-row id="stdout" v-if="job" :code-label="'Tool Standard Output'" :code-item="job.tool_stdout" />
-                <code-row id="stderr" v-if="job" :code-label="'Tool Standard Error'" :code-item="job.tool_stderr" />
-                <code-row
-                    id="traceback"
-                    v-if="job && job.traceback"
-                    :code-label="'Unexpected Job Errors'"
-                    :code-item="job.traceback" />
-                <tr v-if="job">
-                    <td>Tool Exit Code:</td>
-                    <td id="exist-code">{{ job.exit_code }}</td>
-                </tr>
-                <tr id="job-messages" v-if="job && job.job_messages && job.job_messages.length > 0">
-                    <td>Job Messages</td>
-                    <td>
-                        <ul style="padding-left: 15px; margin-bottom: 0px">
-                            <li v-for="(message, index) in job.job_messages" :key="index">{{ message }}</li>
-                        </ul>
-                    </td>
-                </tr>
-                <slot></slot>
-                <tr v-if="job && job.id">
-                    <td>Job API ID:</td>
-                    <td id="encoded-job-id">{{ job.id }} <decoded-id :id="job.id" /></td>
-                </tr>
-                <tr v-if="job && job.copied_from_job_id">
-                    <td>Copied from Job API ID:</td>
-                    <td id="encoded-copied-from-job-id">
-                        {{ job.copied_from_job_id }} <decoded-id :id="job.copied_from_job_id" />
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
+    <job-details-provider v-on:update:result="updateJob" auto-refresh :jobid="job_id">
+        <div>
+            <h3>Job Information</h3>
+            <table id="job-information" class="tabletip info_data_table">
+                <tbody>
+                    <tr v-if="job && job.tool_id">
+                        <td>Galaxy Tool ID:</td>
+                        <td id="galaxy-tool-id">
+                            {{ job.tool_id }}
+                            <copy-to-clipboard
+                                message="Tool ID was copied to your clipboard"
+                                :text="job.tool_id"
+                                title="Copy Tool ID" />
+                        </td>
+                    </tr>
+                    <tr v-if="job && job.tool_version">
+                        <td>Galaxy Tool Version:</td>
+                        <td id="galaxy-tool-version">{{ job.tool_version }}</td>
+                    </tr>
+                    <tr v-if="job && includeTimes">
+                        <td>Created</td>
+                        <td id="created" v-if="job.create_time">
+                            <UtcDate :date="job.create_time" mode="pretty" />
+                        </td>
+                    </tr>
+                    <tr v-if="job && includeTimes">
+                        <td>Updated</td>
+                        <td id="updated" v-if="job.update_time">
+                            <UtcDate :date="job.update_time" mode="pretty" />
+                        </td>
+                    </tr>
+                    <tr v-if="job && includeTimes && jobIsTerminal">
+                        <td>Time To Finish</td>
+                        <td id="runtime">
+                            {{ runTime }}
+                        </td>
+                    </tr>
+                    <code-row id="command-line" v-if="job" :code-label="'Command Line'" :code-item="job.command_line" />
+                    <code-row
+                        id="stdout"
+                        v-if="job"
+                        :code-label="'Tool Standard Output'"
+                        :code-item="job.tool_stdout" />
+                    <code-row id="stderr" v-if="job" :code-label="'Tool Standard Error'" :code-item="job.tool_stderr" />
+                    <code-row
+                        id="traceback"
+                        v-if="job && job.traceback"
+                        :code-label="'Unexpected Job Errors'"
+                        :code-item="job.traceback" />
+                    <tr v-if="job">
+                        <td>Tool Exit Code:</td>
+                        <td id="exist-code">{{ job.exit_code }}</td>
+                    </tr>
+                    <tr id="job-messages" v-if="job && job.job_messages && job.job_messages.length > 0">
+                        <td>Job Messages</td>
+                        <td>
+                            <ul style="padding-left: 15px; margin-bottom: 0px">
+                                <li v-for="(message, index) in job.job_messages" :key="index">{{ message }}</li>
+                            </ul>
+                        </td>
+                    </tr>
+                    <slot></slot>
+                    <tr v-if="job && job.id">
+                        <td>Job API ID:</td>
+                        <td id="encoded-job-id">{{ job.id }} <decoded-id :id="job.id" /></td>
+                    </tr>
+                    <tr v-if="job && job.copied_from_job_id">
+                        <td>Copied from Job API ID:</td>
+                        <td id="encoded-copied-from-job-id">
+                            {{ job.copied_from_job_id }} <decoded-id :id="job.copied_from_job_id" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </job-details-provider>
 </template>
 
 <script>
-import { mapCacheActions } from "vuex-cache";
 import { getAppRoot } from "onload/loadConfig";
 import DecodedId from "../DecodedId.vue";
 import CodeRow from "./CodeRow.vue";
+import { JobDetailsProvider } from "components/providers/JobProvider";
 import UtcDate from "components/UtcDate";
 import CopyToClipboard from "components/CopyToClipboard";
 import JOB_STATES_MODEL from "mvc/history/job-states-model";
@@ -85,6 +91,7 @@ export default {
     components: {
         CodeRow,
         DecodedId,
+        JobDetailsProvider,
         UtcDate,
         CopyToClipboard,
     },
@@ -98,26 +105,27 @@ export default {
             default: false,
         },
     },
-    created: function () {
-        this.fetchJob(this.job_id);
+    data() {
+        return {
+            job: null,
+        };
     },
     computed: {
-        job: function () {
-            return this.$store.getters.job(this.job_id);
-        },
         runTime: function () {
             return formatDuration(
                 intervalToDuration({ start: new Date(this.job.create_time), end: new Date(this.job.update_time) })
             );
         },
         jobIsTerminal() {
-            return !JOB_STATES_MODEL.NON_TERMINAL_STATES.includes(this.job.state);
+            return this.job && !JOB_STATES_MODEL.NON_TERMINAL_STATES.includes(this.job.state);
         },
     },
     methods: {
-        ...mapCacheActions(["fetchJob"]),
         getAppRoot() {
             return getAppRoot();
+        },
+        updateJob(job) {
+            this.job = job;
         },
     },
 };

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -1,80 +1,75 @@
 <template>
-    <job-details-provider v-on:update:result="updateJob" auto-refresh :jobid="job_id">
-        <div>
-            <h3>Job Information</h3>
-            <table id="job-information" class="tabletip info_data_table">
-                <tbody>
-                    <tr v-if="job && job.tool_id">
-                        <td>Galaxy Tool ID:</td>
-                        <td id="galaxy-tool-id">
-                            {{ job.tool_id }}
-                            <copy-to-clipboard
-                                message="Tool ID was copied to your clipboard"
-                                :text="job.tool_id"
-                                title="Copy Tool ID" />
-                        </td>
-                    </tr>
-                    <tr v-if="job && job.tool_version">
-                        <td>Galaxy Tool Version:</td>
-                        <td id="galaxy-tool-version">{{ job.tool_version }}</td>
-                    </tr>
-                    <tr v-if="job && includeTimes">
-                        <td>Created</td>
-                        <td id="created" v-if="job.create_time">
-                            <UtcDate :date="job.create_time" mode="pretty" />
-                        </td>
-                    </tr>
-                    <tr v-if="job && includeTimes">
-                        <td>Updated</td>
-                        <td id="updated" v-if="job.update_time">
-                            <UtcDate :date="job.update_time" mode="pretty" />
-                        </td>
-                    </tr>
-                    <tr v-if="job && includeTimes && jobIsTerminal">
-                        <td>Time To Finish</td>
-                        <td id="runtime">
-                            {{ runTime }}
-                        </td>
-                    </tr>
-                    <code-row id="command-line" v-if="job" :code-label="'Command Line'" :code-item="job.command_line" />
-                    <code-row
-                        id="stdout"
-                        v-if="job"
-                        :code-label="'Tool Standard Output'"
-                        :code-item="job.tool_stdout" />
-                    <code-row id="stderr" v-if="job" :code-label="'Tool Standard Error'" :code-item="job.tool_stderr" />
-                    <code-row
-                        id="traceback"
-                        v-if="job && job.traceback"
-                        :code-label="'Unexpected Job Errors'"
-                        :code-item="job.traceback" />
-                    <tr v-if="job">
-                        <td>Tool Exit Code:</td>
-                        <td id="exist-code">{{ job.exit_code }}</td>
-                    </tr>
-                    <tr id="job-messages" v-if="job && job.job_messages && job.job_messages.length > 0">
-                        <td>Job Messages</td>
-                        <td>
-                            <ul style="padding-left: 15px; margin-bottom: 0px">
-                                <li v-for="(message, index) in job.job_messages" :key="index">{{ message }}</li>
-                            </ul>
-                        </td>
-                    </tr>
-                    <slot></slot>
-                    <tr v-if="job && job.id">
-                        <td>Job API ID:</td>
-                        <td id="encoded-job-id">{{ job.id }} <decoded-id :id="job.id" /></td>
-                    </tr>
-                    <tr v-if="job && job.copied_from_job_id">
-                        <td>Copied from Job API ID:</td>
-                        <td id="encoded-copied-from-job-id">
-                            {{ job.copied_from_job_id }} <decoded-id :id="job.copied_from_job_id" />
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </job-details-provider>
+    <div>
+        <job-details-provider v-on:update:result="updateJob" auto-refresh :jobid="job_id" />
+        <h3>Job Information</h3>
+        <table id="job-information" class="tabletip info_data_table">
+            <tbody>
+                <tr v-if="job && job.tool_id">
+                    <td>Galaxy Tool ID:</td>
+                    <td id="galaxy-tool-id">
+                        {{ job.tool_id }}
+                        <copy-to-clipboard
+                            message="Tool ID was copied to your clipboard"
+                            :text="job.tool_id"
+                            title="Copy Tool ID" />
+                    </td>
+                </tr>
+                <tr v-if="job && job.tool_version">
+                    <td>Galaxy Tool Version:</td>
+                    <td id="galaxy-tool-version">{{ job.tool_version }}</td>
+                </tr>
+                <tr v-if="job && includeTimes">
+                    <td>Created</td>
+                    <td id="created" v-if="job.create_time">
+                        <UtcDate :date="job.create_time" mode="pretty" />
+                    </td>
+                </tr>
+                <tr v-if="job && includeTimes">
+                    <td>Updated</td>
+                    <td id="updated" v-if="job.update_time">
+                        <UtcDate :date="job.update_time" mode="pretty" />
+                    </td>
+                </tr>
+                <tr v-if="job && includeTimes && jobIsTerminal">
+                    <td>Time To Finish</td>
+                    <td id="runtime">
+                        {{ runTime }}
+                    </td>
+                </tr>
+                <code-row id="command-line" v-if="job" :code-label="'Command Line'" :code-item="job.command_line" />
+                <code-row id="stdout" v-if="job" :code-label="'Tool Standard Output'" :code-item="job.tool_stdout" />
+                <code-row id="stderr" v-if="job" :code-label="'Tool Standard Error'" :code-item="job.tool_stderr" />
+                <code-row
+                    id="traceback"
+                    v-if="job && job.traceback"
+                    :code-label="'Unexpected Job Errors'"
+                    :code-item="job.traceback" />
+                <tr v-if="job">
+                    <td>Tool Exit Code:</td>
+                    <td id="exist-code">{{ job.exit_code }}</td>
+                </tr>
+                <tr id="job-messages" v-if="job && job.job_messages && job.job_messages.length > 0">
+                    <td>Job Messages</td>
+                    <td>
+                        <ul style="padding-left: 15px; margin-bottom: 0px">
+                            <li v-for="(message, index) in job.job_messages" :key="index">{{ message }}</li>
+                        </ul>
+                    </td>
+                </tr>
+                <slot></slot>
+                <tr v-if="job && job.id">
+                    <td>Job API ID:</td>
+                    <td id="encoded-job-id">{{ job.id }} <decoded-id :id="job.id" /></td>
+                </tr>
+                <tr v-if="job && job.copied_from_job_id">
+                    <td>Copied from Job API ID:</td>
+                    <td id="encoded-copied-from-job-id">
+                        {{ job.copied_from_job_id }} <decoded-id :id="job.copied_from_job_id" />
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
 </template>
 
 <script>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -11,7 +11,7 @@
                 <InvocationStepProvider
                     v-if="isReady && invocationStepId !== undefined"
                     :id="invocationStepId"
-                    auto-refresh="true"
+                    auto-refresh
                     v-slot="{ result: stepDetails, loading }">
                     <div style="min-width: 1">
                         <loading-span v-if="loading" :message="`Loading invocation step details`"> </loading-span>

--- a/client/src/components/providers/DatasetCollectionProvider.js
+++ b/client/src/components/providers/DatasetCollectionProvider.js
@@ -13,4 +13,6 @@ async function getDatasetCollection({ id }) {
     }
 }
 
-export default SingleQueryProvider(getDatasetCollection);
+// There isn't really a good way to know when to stop polling for HDCA updates,
+// but we know the populated_state should at least be ok.
+export default SingleQueryProvider(getDatasetCollection, (result) => result.populated_state === "ok");

--- a/client/src/components/providers/DatasetProvider.js
+++ b/client/src/components/providers/DatasetProvider.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import { getAppRoot } from "onload/loadConfig";
 import { SingleQueryProvider } from "components/providers/SingleQueryProvider";
 import { rethrowSimple } from "utils/simple-error";
+import { stateIsTerminal } from "./utils";
 
 async function getDataset({ id }) {
     const url = `${getAppRoot()}api/datasets/${id}`;
@@ -24,4 +25,4 @@ async function getDatasetAttributes({ id }) {
 }
 
 export const DatasetAttributesProvider = SingleQueryProvider(getDatasetAttributes);
-export default SingleQueryProvider(getDataset);
+export default SingleQueryProvider(getDataset, stateIsTerminal);

--- a/client/src/components/providers/JobProvider.js
+++ b/client/src/components/providers/JobProvider.js
@@ -2,6 +2,7 @@ import axios from "axios";
 import { getAppRoot } from "onload/loadConfig";
 import { SingleQueryProvider } from "components/providers/SingleQueryProvider";
 import { rethrowSimple } from "utils/simple-error";
+import { stateIsTerminal } from "./utils";
 
 async function jobDetails({ jobid }) {
     const url = `${getAppRoot()}api/jobs/${jobid}?full=True`;
@@ -23,5 +24,5 @@ async function jobProblems({ jobid }) {
     }
 }
 
-export const JobDetailsProvider = SingleQueryProvider(jobDetails);
-export const JobProblemProvider = SingleQueryProvider(jobProblems);
+export const JobDetailsProvider = SingleQueryProvider(jobDetails, stateIsTerminal);
+export const JobProblemProvider = SingleQueryProvider(jobProblems, stateIsTerminal);

--- a/client/src/components/providers/SingleQueryProvider.js
+++ b/client/src/components/providers/SingleQueryProvider.js
@@ -55,11 +55,14 @@ export const SingleQueryProvider = (lookup, stopRefresh = (result) => false) => 
             }
         },
         render() {
-            return this.$scopedSlots.default({
-                loading: this.loading,
-                result: this.result,
-                error: this.error,
-            });
+            return (
+                this.$scopedSlots.default &&
+                this.$scopedSlots.default({
+                    loading: this.loading,
+                    result: this.result,
+                    error: this.error,
+                })
+            );
         },
         methods: {
             doQuery() {

--- a/client/src/components/providers/utils.js
+++ b/client/src/components/providers/utils.js
@@ -1,0 +1,5 @@
+import JOB_STATES_MODEL from "mvc/history/job-states-model";
+
+export function stateIsTerminal(result) {
+    return !JOB_STATES_MODEL.NON_TERMINAL_STATES.includes(result.state);
+}


### PR DESCRIPTION
Depending on the response time using setInterval can lead to a pileup of
requests, see
https://developer.mozilla.org/en-US/docs/Web/API/setInterval#ensure_that_execution_duration_is_shorter_than_interval_frequency.
We've already had issues with this before.

Fixes https://github.com/galaxyproject/galaxy/issues/13415

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
