### PR TITLE
[22.01] Fix jqplot_bar import, adjust plugin hash saving

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -130,8 +130,18 @@ function buildPlugins(callback, forceRebuild) {
                         }
                     );
                     console.log(`Building ${pluginName}`);
-                    child_process.spawnSync("yarn", ["build"], { cwd: f, stdio: "inherit", shell: true });
-                    child_process.exec(`(git rev-parse HEAD 2>/dev/null || echo \`\`) > ${hashFilePath}`);
+
+                    if (
+                        child_process.spawnSync("yarn", ["build"], { cwd: f, stdio: "inherit", shell: true }).status ===
+                        0
+                    ) {
+                        console.log(`Successfully built, saving build state to ${hashFilePath}`);
+                        child_process.exec(`(git rev-parse HEAD 2>/dev/null || echo \`\`) > ${hashFilePath}`);
+                    } else {
+                        console.error(
+                            `Error building ${pluginName}, not saving build state.  Please report this issue to the Galaxy Team.`
+                        );
+                    }
                 }
             });
         });

--- a/config/plugins/visualizations/jqplot/jqplot_bar/src/script.js
+++ b/config/plugins/visualizations/jqplot/jqplot_bar/src/script.js
@@ -3,7 +3,7 @@ import _ from "underscore";
 import jqplot from 'jqplot-exported/jqplot';
 import { LineRenderer } from 'jqplot-exported/LineRenderer';
 import { BarRenderer } from 'jqplot-exported/plugins/BarRenderer';
-import { OHLCRenderer } from 'jqplot-exported/plugins/OHLCRenderer';
+import { OHLCRenderer } from 'jqplot-exported/plugins/OhlcRenderer';
 import { EnhancedLegendRenderer } from 'jqplot-exported/plugins/EnhancedLegendRenderer';
 
 import { getDomains, makeCategories, makeTickFormat, makeSeries, mapCategories } from "@galaxyproject/charts/lib/utilities/series";


### PR DESCRIPTION
Fixes jqplot bar import.  This was causing a build failure -- was this originally built on a case insensitive system maybe?

Also updates plugin hash saving to only save on success.  This should prevent users from getting into the situation where a failed build isn't retried.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Rebuild viz.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
