### PR TITLE
Implement test data resolver for online test data

### DIFF
--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -539,9 +539,17 @@ class XmlToolSource(ToolSource):
     def parse_tests_to_dict(self):
         tests_elem = self.root.find("tests")
         tests = []
-        rval = dict(tests=tests)
+        test_data_resolver = []
+        rval = dict(tests=tests, test_data_resolver=test_data_resolver)
 
         if tests_elem is not None:
+            for resolver in tests_elem.findall("test_data_resolver"):
+                test_data_resolver.append(
+                    {
+                        "checksum": resolver.attrib.get("checksum", ""),
+                        "value": resolver.attrib["value"]
+                    }
+                )
             for i, test_elem in enumerate(tests_elem.findall("test")):
                 profile = self.parse_profile()
                 tests.append(_test_elem_to_dict(test_elem, i, profile))

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -170,8 +170,8 @@ class YamlToolSource(ToolSource):
 
     def parse_tests_to_dict(self):
         tests = []
-        rval = dict(tests=tests)
-
+        rval = dict(tests=tests, test_data=None)
+        # TODO parse test_data from yaml
         for i, test_dict in enumerate(self.root_dict.get("tests", [])):
             tests.append(_parse_test(i, test_dict))
 

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -40,18 +40,22 @@ def verify(
     keep_outputs_dir=None,
     verify_extra_files=None,
     mode="file",
+    test_data_resolver=None,
 ):
     """Verify the content of a test output using test definitions described by attributes.
 
     Throw an informative assertion error if any of these tests fail.
     """
     if get_filename is None:
+        if test_data_resolver is not None:
+            get_filecontent = test_data_resolver.get_filecontent
         if get_filecontent is None:
             get_filecontent = DEFAULT_TEST_DATA_RESOLVER.get_filecontent
 
         def get_filename(filename):
             file_content = get_filecontent(filename)
             local_name = make_temp_fname(fname=filename)
+            # TODO why create a tmp copy?
             with open(local_name, "wb") as f:
                 f.write(file_content)
             return local_name

--- a/lib/galaxy/tool_util/verify/test_data.py
+++ b/lib/galaxy/tool_util/verify/test_data.py
@@ -2,13 +2,17 @@ import hashlib
 import os
 import re
 import subprocess
+from abc import abstractmethod
 from string import Template
+from tempfile import NamedTemporaryFile
 
 from galaxy.util import (
     asbool,
+    download_to_file,
     in_directory,
     smart_str,
 )
+from galaxy.util.compression_utils import CompressedFile
 
 UPDATE_TEMPLATE = Template(
     "git --work-tree $dir --git-dir $dir/.git fetch && " "git --work-tree $dir --git-dir $dir/.git merge origin/master"
@@ -55,6 +59,8 @@ class TestDataResolver:
 def build_resolver(uri, environ):
     if uri.startswith("http") and uri.endswith(".git"):
         return GitDataResolver(uri, environ)
+    elif uri.startswith("http"):
+        return HttpDataResolver(uri, environ)
     else:
         return FileDataResolver(uri)
 
@@ -71,13 +77,14 @@ class FileDataResolver:
         return os.path.join(self.file_dir, filename)
 
 
-class GitDataResolver(FileDataResolver):
-    def __init__(self, repository, environ):
-        self.repository = repository
+class CachedFileDataResolver(FileDataResolver):
+    def __init__(self, uri, environ):
+        self.uri = uri
         self.updated = False
+
         repo_cache = environ.get("GALAXY_TEST_DATA_REPO_CACHE", "test-data-cache")
         m = hashlib.md5()
-        m.update(smart_str(repository))
+        m.update(smart_str(uri))
         repo_path = os.path.join(repo_cache, m.hexdigest())
         super().__init__(repo_path)
         # My preference would be for this to be false, but for backward compat
@@ -88,16 +95,24 @@ class GitDataResolver(FileDataResolver):
         exists_now = super().exists(filename)
         if exists_now or not self.fetch_data or self.updated:
             return exists_now
-        self.update_repository()
+        self.update()
         return super().exists(filename)
 
-    def update_repository(self):
+    @abstractmethod
+    def update(self):
+        pass
+
+
+class GitDataResolver(CachedFileDataResolver):
+
+    def update(self):
         self.updated = True
         if not os.path.exists(self.file_dir):
             parent_dir = os.path.dirname(self.file_dir)
             if not os.path.exists(parent_dir):
                 os.makedirs(parent_dir)
-            self.execute(f"git clone '{self.repository}' '{self.file_dir}'")
+            # TODO use execute from galaxy.util
+            self.execute(f"git clone '{self.uri}' '{self.file_dir}'")
         update_command = UPDATE_TEMPLATE.safe_substitute(dir=self.file_dir)
         self.execute(update_command)
 
@@ -117,3 +132,29 @@ class GitDataResolver(FileDataResolver):
                 "stderr": stderr,
             }
             print(UPDATE_FAILED_TEMPLATE.substitute(**kwds))
+
+
+class HttpDataResolver(CachedFileDataResolver):
+
+    def __init__(self, uri, environ):
+        uri, self.hash_type, self.hash_value = uri.split("$")
+        super().__init__(uri, environ)
+
+    def update(self):
+        self.updated = True
+        if not os.path.exists(self.file_dir):
+            with NamedTemporaryFile() as tmp_fh:
+                # download
+                download_to_file(self.uri, tmp_fh.name)
+                # check checksum
+                tmp_fh.seek(0)
+                h = hashlib.new(self.hash_type)
+                h.update(tmp_fh.read())
+                if self.hash_value != h.hexdigest():
+                    log.error(f"Hash does not match {self.hash_value} != {h.digest}")
+                    return
+                # extract
+                tmp_fh.seek(0)
+                os.makedirs(self.file_dir)
+                zip_fh = CompressedFile(tmp_fh.name)
+                zip_fh.extract(self.file_dir)

--- a/lib/galaxy/tool_util/verify/test_data.py
+++ b/lib/galaxy/tool_util/verify/test_data.py
@@ -151,7 +151,6 @@ class HttpDataResolver(CachedFileDataResolver):
                 h = hashlib.new(self.hash_type)
                 h.update(tmp_fh.read())
                 if self.hash_value != h.hexdigest():
-                    log.error(f"Hash does not match {self.hash_value} != {h.digest}")
                     return
                 # extract
                 tmp_fh.seek(0)

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -33,14 +33,15 @@ def parse_tests(tool, tests_source):
     return default interactor (if any).
     """
     raw_tests_dict = tests_source.parse_tests_to_dict()
+    test_data_resolver = raw_tests_dict.get("test_data_resolver")
     tests = []
     for i, raw_test_dict in enumerate(raw_tests_dict.get("tests", [])):
-        test = description_from_tool_object(tool, i, raw_test_dict)
+        test = description_from_tool_object(tool, i, raw_test_dict, test_data_resolver)
         tests.append(test)
     return tests
 
 
-def description_from_tool_object(tool, test_index, raw_test_dict):
+def description_from_tool_object(tool, test_index, raw_test_dict, test_data_resolver):
     required_files: List[Tuple[str, dict]] = []
     required_data_tables: List[str] = []
     required_loc_files: List[str] = []
@@ -72,6 +73,7 @@ def description_from_tool_object(tool, test_index, raw_test_dict):
             "tool_version": tool.version,
             "test_index": test_index,
             "error": False,
+            "test_data_resolver": test_data_resolver,
         }
     except Exception as e:
         log.exception("Failed to load tool test number [%d] for %s" % (test_index, tool.id))

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -249,6 +249,7 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
 
         test_defs = []
         for tool in tools:
+            log.error(f"{tool}")
             test_defs.extend([t.to_dict() for t in tool.tests])
         return test_defs
 

--- a/test/functional/tools/http_test_data_single.xml
+++ b/test/functional/tools/http_test_data_single.xml
@@ -1,0 +1,21 @@
+<tool id="http_test_data_single" name="http test data single" version="1.0.0" profile="22.01">
+    <command><![CDATA[
+        cat '$input1' > '$output'
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" format="txt" label="Input 1" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" location="https://zenodo.org/record/6566747/files/online_test_dir.tar.gz?download=1" />
+            <output name="output">
+                <assert_contents>
+                    <has_line line="hooray" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/http_test_data_zip.xml
+++ b/test/functional/tools/http_test_data_zip.xml
@@ -1,0 +1,30 @@
+<tool id="http_test_data_zip" name="http test data zip" version="1.0.0" profile="22.01">
+    <command><![CDATA[
+        cat '$input1' > '$output'
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" format="txt" label="Input 1" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <tests>
+        <test_data_resolver value="https://zenodo.org/record/6566747/files/online_test_dir.tar.gz?download=1" checksum="md5$93129a5e362dce3cd6cd4b229ab27ccb"/>
+        <test>
+            <param name="input1" value="online_test_file.txt" />
+            <output name="output">
+                <assert_contents>
+                    <has_line line="hooray" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="input1" value="online_test_file2.txt" />
+            <output name="output">
+                <assert_contents>
+                    <has_line line="booo" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>


### PR DESCRIPTION
xref: https://github.com/galaxyproject/galaxy/issues/7900 https://github.com/galaxyproject/galaxy/issues/3714

With this PR it is possible to **specify one or more test data resolvers** for tool tests.
In addition to the local file and git resolvers I **added a resolver of online test data**.

Syntax is currently:

```
<tests>
   <test_data_resolver value="http://www.zenodo.org/..." checksum="sha256$2bec523db6dfa6e97a54d0ecc539023c910b349b72c14cf618485b256a529868"/>
   ...
</tests>
```

multiple resolvers are also possible

```
<tests>
   <test_data_resolver value="http://www.zenodo.org/..." checksum="sha256$2bec523db6dfa6e97a54d0ecc539023c910b349b72c14cf618485b256a529868"/>
   <test_data_resolver value="test-data"/>
   ...
</tests>
```

The current state is that I did one successful test with one of the IUC tools
where I removed the `test-data` directory and used an online zip file.

I guess some tests would be good. If someone has an suggestion how tests
might be implemented best and where (functional tool test / unit test / ...).
I did not touch yet all branches of `stage_data_async`, but only those
necessary to make the planemo test succeed. All the possibilities to get test
data (just local files, test data download via API, etc are still confusing
to me).

Nevertheless the current state should be good to gather some first feedback.

TODOs:

- [ ] add to xsd
- [ ] currently checksum is not enforced, but probbaly it should be?
- [ ] should we restrict to https?
- [ ] add linting for test_data_resolver
- [x] remove debug code 
- [ ] implement test_data_resolver for yaml tools
- [ ] solve TODOs 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
