### PR TITLE
Expand input parameter workflow steps in workflow run form

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRun.test.js
+++ b/client/src/components/Workflow/Run/WorkflowRun.test.js
@@ -57,6 +57,11 @@ describe("WorkflowRun.vue", () => {
         expect(model.hasUpgradeMessages).toBe(false);
         expect(model.hasStepVersionChanges).toBe(false);
         expect(model.wpInputs.wf_param.label).toBe("wf_param");
+        // all steps are expanded since data and parameter steps are expanded by default,
+        // the same is true for tools with unconnected data inputs.
+        model.steps.forEach((step) => {
+            expect(step.expanded).toBe(true);
+        });
     });
 
     it("displays submission error", async () => {

--- a/client/src/components/Workflow/Run/model.js
+++ b/client/src/components/Workflow/Run/model.js
@@ -25,6 +25,7 @@ export class WorkflowRunModel {
         let hasReplacementParametersInToolForm = false;
 
         _.each(runData.steps, (step, i) => {
+            const isParameterStep = step.step_type == "parameter_input";
             var title = `${parseInt(i + 1)}: ${step.step_label || step.step_name}`;
             if (step.annotation) {
                 title += ` - ${step.annotation}`;
@@ -36,7 +37,7 @@ export class WorkflowRunModel {
                 {
                     index: i,
                     fixed_title: _.escape(title),
-                    expanded: i == 0 || isDataStep(step),
+                    expanded: i == 0 || isDataStep(step) || isParameterStep,
                     errors: step.messages,
                 },
                 step
@@ -44,7 +45,7 @@ export class WorkflowRunModel {
             this.steps[i] = step;
             this.links[i] = [];
             this.parms[i] = {};
-            if (step.step_type == "parameter_input" && step.step_label) {
+            if (isParameterStep && step.step_label) {
                 this.parameterInputLabels.push(step.step_label);
             }
         });

--- a/client/src/components/Workflow/Run/testdata/run1.json
+++ b/client/src/components/Workflow/Run/testdata/run1.json
@@ -748,6 +748,32 @@
       "action": "/tool_runner/index",
       "model_class": "Tool",
       "display": true
+    },
+    {
+      "inputs":[
+        {
+          "area":false,
+          "argument":null,
+          "datalist":[],
+          "help":null,
+          "hidden":false,
+          "is_dynamic":false,
+          "label":"",
+          "model_class":"TextToolParameter",
+          "name":"input",
+          "optional":false,
+          "refresh_on_change":false,
+          "type":"text",
+          "value":null
+        }
+      ],
+      "output_connections":[],
+      "replacement_parameters":[],
+      "step_index":4,
+      "step_label":"",
+      "step_name":"Input parameter",
+      "step_type":"parameter_input",
+      "step_version":null
     }
   ],
   "has_upgrade_messages": false,


### PR DESCRIPTION
Fixes #13340. This PR augments the step expansion criteria such that `parameter_input` steps are now expanded by default. The complete set of current conditions is as follows: 1) The first step is always expanded regardless of type, 2) all data input steps are expanded, 3) all parameter input steps are expanded and 4) remaining tool steps are expanded if the step contains an unconnected data input.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
