### PR TITLE
[21.09] Pin corresponding playbook repo to sync with Galaxy release

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -22,6 +22,7 @@ ARG STAGE1_BASE=python:3.7-slim
 ARG FINAL_STAGE_BASE=$STAGE1_BASE
 ARG GALAXY_USER=galaxy
 ARG GALAXY_PLAYBOOK_REPO=https://github.com/galaxyproject/galaxy-docker-k8s
+ARG GALAXY_PLAYBOOK_BRANCH=v2.0.0
 
 ARG GIT_COMMIT=unspecified
 ARG BUILD_DATE=unspecified
@@ -34,6 +35,7 @@ FROM $STAGE1_BASE AS stage1
 ARG DEBIAN_FRONTEND=noninteractive
 ARG SERVER_DIR
 ARG GALAXY_PLAYBOOK_REPO
+ARG GALAXY_PLAYBOOK_BRANCH
 
 # Init Env
 ENV LC_ALL=en_US.UTF-8
@@ -57,7 +59,7 @@ RUN set -xe; \
 WORKDIR /tmp/ansible
 RUN rm -rf *
 ENV LC_ALL en_US.UTF-8
-RUN git clone --depth 1 $GALAXY_PLAYBOOK_REPO galaxy-docker
+RUN git clone --depth 1 --branch $GALAXY_PLAYBOOK_BRANCH $GALAXY_PLAYBOOK_REPO galaxy-docker
 WORKDIR /tmp/ansible/galaxy-docker
 RUN ansible-galaxy install -r requirements.yml -p roles --force-with-deps
 


### PR DESCRIPTION
Pin the playbook branch so we can make sure it remains in sync with the Galaxy release.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
