### PR TITLE
Run tests with ``metadata_strategy: extended`` on weekly schedule

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -11,6 +11,8 @@ on:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
 env:
+  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
+  GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT: '1'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT: '1'

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -10,12 +10,13 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+  schedule:
+    # Run at midnight UTC every Tuesday
+    - cron: '0 0 * * 2'
 env:
-  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
   GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT: '1'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
-  GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT: '1'
   GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
 concurrency:
   group: api-${{ github.ref }}
@@ -37,6 +38,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - if: github.event_name == 'schedule'
+        run: |
+          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+          echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           path: 'galaxy root'

--- a/.github/workflows/api_paste.yaml
+++ b/.github/workflows/api_paste.yaml
@@ -15,7 +15,6 @@ env:
   GALAXY_TEST_USE_UVICORN: false
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
-  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
 concurrency:
   group: api-legacy-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/api_paste.yaml
+++ b/.github/workflows/api_paste.yaml
@@ -15,6 +15,7 @@ env:
   GALAXY_TEST_USE_UVICORN: false
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
+  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
 concurrency:
   group: api-legacy-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -10,6 +10,7 @@ on:
       - 'doc/**'
 env:
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
+  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
 concurrency:
   group: converter-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -8,9 +8,11 @@ on:
     paths-ignore:
       - 'client/**'
       - 'doc/**'
+  schedule:
+    # Run at midnight UTC every Tuesday
+    - cron: '0 0 * * 2'
 env:
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
-  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
 concurrency:
   group: converter-${{ github.ref }}
   cancel-in-progress: true
@@ -22,6 +24,10 @@ jobs:
       matrix:
         python-version: ['3.7']
     steps:
+    - if: github.event_name == 'schedule'
+      run: |
+        echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+        echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
     - uses: actions/checkout@v2
       with:
         path: 'galaxy root'

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -13,6 +13,7 @@ on:
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
+  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
 concurrency:
   group: framework-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -10,10 +10,12 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+  schedule:
+    # Run at midnight UTC every Tuesday
+    - cron: '0 0 * * 2'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
-  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
 concurrency:
   group: framework-${{ github.ref }}
   cancel-in-progress: true
@@ -34,6 +36,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - if: github.event_name == 'schedule'
+        run: |
+          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+          echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           path: 'galaxy root'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -47,6 +47,8 @@ jobs:
       - if: github.event_name == 'schedule'
         run: |
           echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+          # Skip outputs_to_working_directory: true in integration tests, doesn't work with pulsar
+          # echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
       - name: Prune unused docker image, volumes and containers
         run: docker system prune -a -f
       - name: Clean dotnet folder for space

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -11,6 +11,7 @@ on:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
 env:
+  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
   GALAXY_TEST_AMQP_URL: 'amqp://localhost:5672//'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -10,8 +10,10 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+  schedule:
+    # Run at midnight UTC every Tuesday
+    - cron: '0 0 * * 2'
 env:
-  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
   GALAXY_TEST_AMQP_URL: 'amqp://localhost:5672//'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
@@ -42,6 +44,9 @@ jobs:
         ports:
           - 5672:5672
     steps:
+      - if: github.event_name == 'schedule'
+        run: |
+          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
       - name: Prune unused docker image, volumes and containers
         run: docker system prune -a -f
       - name: Clean dotnet folder for space

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -6,8 +6,10 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
+  schedule:
+    # Run at midnight UTC every Tuesday
+    - cron: '0 0 * * 2'
 env:
-  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
   GALAXY_SKIP_CLIENT_BUILD: '0'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
@@ -34,6 +36,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - if: github.event_name == 'schedule'
+        run: |
+          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+          echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
       - name: Prune unused docker image, volumes and containers
         run: docker system prune -a -f
       - uses: actions/checkout@v2

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - 'doc/**'
 env:
+  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
   GALAXY_SKIP_CLIENT_BUILD: '0'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -10,8 +10,10 @@ on:
       - 'client/**'
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
+  schedule:
+    # Run at midnight UTC every Tuesday
+    - cron: '0 0 * * 2'
 env:
-  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
 concurrency:
   group: performance-${{ github.ref }}
@@ -33,6 +35,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - if: github.event_name == 'schedule'
+        run: |
+          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+          echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           path: 'galaxy root'

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -11,6 +11,7 @@ on:
       - 'doc/**'
       - 'lib/galaxy_test/selenium/**'
 env:
+  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
 concurrency:
   group: performance-${{ github.ref }}

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -6,9 +6,11 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
+  schedule:
+    # Run at midnight UTC every Tuesday
+    - cron: '0 0 * * 2'
 env:
   GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
-  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_TEST_SELENIUM_RETRIES: 1
@@ -37,6 +39,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - if: github.event_name == 'schedule'
+        run: |
+          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+          echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           path: 'galaxy root'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -8,6 +8,7 @@ on:
       - 'doc/**'
 env:
   GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
+  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_TEST_SELENIUM_RETRIES: 1

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     paths-ignore:
       - 'doc/**'
+  schedule:
+    # Run at midnight UTC every Tuesday
+    - cron: '0 0 * * 2'
 env:
   GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
@@ -15,8 +18,6 @@ env:
   GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
   YARN_INSTALL_OPTS: --frozen-lockfile
   GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
-  GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
-  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
 concurrency:
   group: selenium-beta-${{ github.ref }}
   cancel-in-progress: true
@@ -39,6 +40,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+      - if: github.event_name == 'schedule'
+        run: |
+          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+          echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           path: 'galaxy root'

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -15,6 +15,8 @@ env:
   GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
   YARN_INSTALL_OPTS: --frozen-lockfile
   GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
+  GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
+  GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY: 'extended'
 concurrency:
   group: selenium-beta-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
We don't have capacity to run this on every PR, but this is a good compromise that should catch regressions.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
