### PR TITLE
Add API endpoint to recalculate user disk usage

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -1,0 +1,39 @@
+from galaxy import exceptions as glx_exceptions
+from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.users import UserManager
+from galaxy.queue_worker import send_local_control_task
+from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.webapps.galaxy.services.base import ServiceBase
+
+
+class UsersService(ServiceBase):
+    """Common interface/service logic for interactions with users in the context of the API.
+
+    Provides the logic of the actions invoked by API controllers and uses type definitions
+    and pydantic models to declare its parameters and return types.
+    """
+
+    def __init__(
+        self,
+        security: IdEncodingHelper,
+        user_manager: UserManager,
+    ):
+        super().__init__(security)
+        self.user_manager = user_manager
+
+    def recalculate_disk_usage(
+        self,
+        trans: ProvidesUserContext,
+    ):
+        if trans.anonymous:
+            raise glx_exceptions.AuthenticationRequired("Only registered users can recalculate disk usage.")
+        if trans.app.config.enable_celery_tasks:
+            from galaxy.celery.tasks import recalculate_user_disk_usage
+
+            recalculate_user_disk_usage.delay(user_id=trans.user.id)
+        else:
+            send_local_control_task(
+                trans.app,
+                "recalculate_user_disk_usage",
+                kwargs={"user_id": self.encode_id(trans.user.id)},
+            )


### PR DESCRIPTION
This is part of https://github.com/galaxyproject/galaxy/issues/13479 and will be integrated into https://github.com/galaxyproject/galaxy/pull/13113

This adds a new endpoint to the Users API to trigger disk usage recalculation for the current user.

### Some questions
- Is there a nice way to test this?
- Can we know somehow when the recalculation is done after it has been dispatched?

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to http://127.0.0.1:8080/api/docs#/users
  - Try the endpoint
    ![Screenshot from 2022-03-09 11-16-38](https://user-images.githubusercontent.com/46503462/157421677-bb145fc3-8948-4633-bf9d-b25f8e9edaba.png)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
