### PR TITLE
Add retries to `test_github_search`

### DIFF
--- a/test/unit/tool_util/mulled/test_mulled_search.py
+++ b/test/unit/tool_util/mulled/test_mulled_search.py
@@ -43,11 +43,11 @@ def test_github_search():
     assert search1 == []
 
     # The search sometimes returns no results so we retry a couple of times
-    num_retries = 3
+    num_retries = 5
     search2 = t.process_json(t.get_json("bioconductor-gosemsim"), "bioconductor-gosemsim")
     while not search2 and num_retries:
         num_retries -= 1
-        time.sleep(1)  # Wait a bit, otherwise, the search may fail because of throttling
+        time.sleep(2)  # Wait a bit, otherwise, the search may fail because of throttling
         search2 = t.process_json(t.get_json("bioconductor-gosemsim"), "bioconductor-gosemsim")
 
     assert search2


### PR DESCRIPTION
This is a follow up on https://github.com/galaxyproject/galaxy/pull/13410

The test is still flaky because sometimes the Github search API returns no result. This will retry a couple of times increasing the chance of success.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Run multiple times in quick succession: 
    ```
    GALAXY_TEST_INCLUDE_SLOW=1 ./run_tests.sh -unit test/unit/tool_util/mulled/test_mulled_search.py::test_github_search
    ```
  - Notice that is less probable to get a failed status.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
