### PR TITLE
More small atomic enhancements from the deferred data branch.

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -773,12 +773,14 @@ class ModelSerializer(HasAModelManager[T]):
         """
         Converts a known view into a list of keys.
 
-        :raises ModelSerializingError: if the view is not listed in `self.views`.
+        :raises RequestParameterInvalidException: if the view is not listed in `self.views`.
         """
         if view is None:
             view = self.default_view
         if view not in self.views:
-            raise ModelSerializingError("unknown view", view=view, available_views=self.views)
+            raise exceptions.RequestParameterInvalidException(
+                f"unknown view - {view}", view=view, available_views=self.views
+            )
         return self.views[view][:]
 
 

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -1,0 +1,38 @@
+from galaxy import model
+from galaxy.app import MinimalManagerApp
+from galaxy.jobs.manager import JobManager
+from galaxy.managers.histories import HistoryManager
+from galaxy.model.scoped_session import galaxy_scoped_session
+from galaxy.schema.tasks import SetupHistoryExportJob
+
+
+class ModelStoreManager:
+    def __init__(
+        self,
+        app: MinimalManagerApp,
+        history_manager: HistoryManager,
+        sa_session: galaxy_scoped_session,
+        job_manager: JobManager,
+    ):
+        self._app = app
+        self._sa_session = sa_session
+        self._job_manager = job_manager
+        self._history_manager = history_manager
+
+    def setup_history_export_job(self, request: SetupHistoryExportJob):
+        history_id = request.history_id
+        job_id = request.job_id
+        include_hidden = request.include_hidden
+        include_deleted = request.include_deleted
+        store_directory = request.store_directory
+
+        history = self._sa_session.query(model.History).get(history_id)
+        # symlink files on export, on worker files will tarred up in a dereferenced manner.
+        with model.store.DirectoryModelExportStore(
+            store_directory, app=self._app, export_files="symlink"
+        ) as export_store:
+            export_store.export_history(history, include_hidden=include_hidden, include_deleted=include_deleted)
+        job = self._sa_session.query(model.Job).get(job_id)
+        job.state = model.Job.states.NEW
+        self._sa_session.flush()
+        self._job_manager.enqueue(job)

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class SetupHistoryExportJob(BaseModel):
+    history_id: int
+    job_id: int
+    store_directory: str
+    include_files: bool
+    include_hidden: bool
+    include_deleted: bool

--- a/lib/galaxy_test/api/test_pages.py
+++ b/lib/galaxy_test/api/test_pages.py
@@ -14,11 +14,13 @@ from ._framework import ApiTestCase
 
 
 class BasePageApiTestCase(ApiTestCase):
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
+
     def _create_valid_page_with_slug(self, slug):
-        page_request = self._test_page_payload(slug=slug)
-        page_response = self._post("pages", page_request, json=True)
-        self._assert_status_code_is(page_response, 200)
-        return page_response.json()
+        return self.dataset_populator.new_page(slug=slug)
 
     def _create_valid_page_as(self, other_email, slug):
         run_as_user = self._setup_user(other_email)
@@ -28,29 +30,12 @@ class BasePageApiTestCase(ApiTestCase):
         return page_response.json()
 
     def _test_page_payload(self, **kwds):
-        content_format = kwds.get("content_format", "html")
-        if content_format == "html":
-            content = "<p>Page!</p>"
-        else:
-            content = "*Page*\n\n"
-        request = dict(
-            slug="mypage",
-            title="MY PAGE",
-            content=content,
-            content_format=content_format,
-        )
-        request.update(**kwds)
-        return request
+        return self.dataset_populator.new_page_payload(**kwds)
 
 
 class PageApiTestCase(BasePageApiTestCase, SharingApiTests):
 
     api_name = "pages"
-
-    def setUp(self):
-        super().setUp()
-        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
-        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
 
     def create(self, name: str) -> str:
         response_json = self._create_valid_page_with_slug(name)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1077,6 +1077,36 @@ class BaseDatasetPopulator(BasePopulator):
             timeout=timeout,
         )
 
+    def new_page(
+        self, slug: str = "mypage", title: str = "MY PAGE", content_format: str = "html", content: Optional[str] = None
+    ) -> Dict[str, Any]:
+        page_response = self.new_page_raw(slug=slug, title=title, content_format=content_format, content=content)
+        page_response.raise_for_status()
+        return page_response.json()
+
+    def new_page_raw(
+        self, slug: str = "mypage", title: str = "MY PAGE", content_format: str = "html", content: Optional[str] = None
+    ) -> Response:
+        page_request = self.new_page_payload(slug=slug, title=title, content_format=content_format, content=content)
+        page_response = self._post("pages", page_request, json=True)
+        return page_response
+
+    def new_page_payload(
+        self, slug: str = "mypage", title: str = "MY PAGE", content_format: str = "html", content: Optional[str] = None
+    ) -> Dict[str, str]:
+        if content is None:
+            if content_format == "html":
+                content = "<p>Page!</p>"
+            else:
+                content = "*Page*\n\n"
+        request = dict(
+            slug=slug,
+            title=title,
+            content=content,
+            content_format=content_format,
+        )
+        return request
+
 
 class GalaxyInteractorHttpMixin:
     galaxy_interactor: ApiTestInteractor


### PR DESCRIPTION

- Fix bug where API returns a 5XX error status instead of a 4XX if a bad "view" is passed in by the caller.
- Allow reuse of page fixture creation stuff from API tests via populators.
- Add a model stores manager to simplify galaxy.celery.tasks. This manager currently just has the logic for setting up the export job but is used over and over downstream. It also establishes the galaxy.schema.tasks file which is used over and over downstream in the deferred data branch.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
