### PR TITLE
[22.01] Backport reset button fix rule builder

### DIFF
--- a/client/src/components/Upload/Collection.vue
+++ b/client/src/components/Upload/Collection.vue
@@ -99,7 +99,6 @@
                 class="ui-button-default"
                 id="btn-ftp"
                 @click="_eventRemoteFiles"
-                :title="btnFilesTitle"
                 :disabled="!enableSources"
                 v-if="remoteFiles">
                 <span class="fa fa-folder-open-o"></span>{{ btnFilesTitle }}

--- a/client/src/components/Upload/Collection.vue
+++ b/client/src/components/Upload/Collection.vue
@@ -39,7 +39,12 @@
             </select2>
         </template>
         <template v-slot:buttons>
-            <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="$emit('dismiss')">
+            <b-button
+                ref="btnClose"
+                class="ui-button-default"
+                id="btn-close"
+                :title="btnCloseTitle"
+                @click="$emit('dismiss')">
                 {{ btnCloseTitle | localize }}
             </b-button>
             <b-button
@@ -47,6 +52,7 @@
                 class="ui-button-default"
                 id="btn-reset"
                 @click="_eventReset"
+                :title="btnResetTitle"
                 :disabled="!enableReset">
                 {{ btnResetTitle }}
             </b-button>
@@ -55,6 +61,7 @@
                 class="ui-button-default"
                 id="btn-stop"
                 @click="_eventStop"
+                :title="btnStopTitle"
                 :disabled="counterRunning == 0">
                 {{ btnStopTitle }}
             </b-button>
@@ -64,6 +71,7 @@
                 id="btn-build"
                 @click="_eventBuild"
                 :disabled="!enableBuild"
+                :title="btnBuildTitle"
                 :variant="enableBuild ? 'primary' : ''">
                 {{ btnBuildTitle }}
             </b-button>
@@ -72,6 +80,7 @@
                 class="ui-button-default"
                 id="btn-start"
                 @click="_eventStart"
+                :title="btnStartTitle"
                 :disabled="!enableStart"
                 :variant="enableStart ? 'primary' : ''">
                 {{ btnStartTitle }}
@@ -81,6 +90,7 @@
                 class="ui-button-default"
                 id="btn-new"
                 @click="_eventCreate(false)"
+                :title="btnCreateTitle"
                 :disabled="!enableSources">
                 <span class="fa fa-edit"></span>{{ btnCreateTitle }}
             </b-button>
@@ -89,6 +99,7 @@
                 class="ui-button-default"
                 id="btn-ftp"
                 @click="_eventRemoteFiles"
+                :title="btnFilesTitle"
                 :disabled="!enableSources"
                 v-if="remoteFiles">
                 <span class="fa fa-folder-open-o"></span>{{ btnFilesTitle }}

--- a/client/src/components/Upload/Composite.vue
+++ b/client/src/components/Upload/Composite.vue
@@ -33,7 +33,7 @@
             </select2>
         </template>
         <template v-slot:buttons>
-            <b-button ref="btnClose" class="ui-button-default" @click="$emit('dismiss')">
+            <b-button ref="btnClose" class="ui-button-default" :title="btnCloseTitle" @click="$emit('dismiss')">
                 {{ btnCloseTitle | localize }}
             </b-button>
             <b-button
@@ -42,10 +42,16 @@
                 @click="_eventStart"
                 id="btn-start"
                 :disabled="!readyStart"
+                :title="btnStartTitle"
                 :variant="readyStart ? 'primary' : ''">
                 {{ btnStartTitle }}
             </b-button>
-            <b-button ref="btnReset" class="ui-button-default" id="btn-reset" @click="_eventReset">
+            <b-button
+                ref="btnReset"
+                class="ui-button-default"
+                id="btn-reset"
+                :title="btnResetTitle"
+                @click="_eventReset">
                 {{ btnResetTitle }}
             </b-button>
         </template>

--- a/client/src/components/Upload/Default.vue
+++ b/client/src/components/Upload/Default.vue
@@ -94,7 +94,6 @@
                 class="ui-button-default"
                 id="btn-ftp"
                 @click="_eventRemoteFiles"
-                :title="btnFilesTitle"
                 :disabled="!enableSources"
                 v-if="remoteFiles">
                 <span class="fa fa-folder-open-o"></span>{{ btnFilesTitle }}

--- a/client/src/components/Upload/Default.vue
+++ b/client/src/components/Upload/Default.vue
@@ -33,7 +33,12 @@
             </select2>
         </template>
         <template v-slot:buttons>
-            <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="$emit('dismiss')">
+            <b-button
+                ref="btnClose"
+                class="ui-button-default"
+                id="btn-close"
+                :title="btnCloseTitle"
+                @click="$emit('dismiss')">
                 {{ btnCloseTitle }}
             </b-button>
             <b-button
@@ -41,6 +46,7 @@
                 class="ui-button-default"
                 id="btn-reset"
                 @click="_eventReset"
+                :title="btnResetTitle"
                 :disabled="!enableReset">
                 {{ btnResetTitle }}
             </b-button>
@@ -49,6 +55,7 @@
                 class="ui-button-default"
                 id="btn-stop"
                 @click="_eventStop"
+                :title="btnStopTitle"
                 :disabled="counterRunning == 0">
                 {{ btnStopTitle }}
             </b-button>
@@ -59,6 +66,7 @@
                 @click="_eventSelect"
                 v-if="selectable"
                 :disabled="!enableBuild"
+                :title="btnSelectTitle"
                 :variant="enableBuild ? 'primary' : ''">
                 {{ btnSelectTitle }}
             </b-button>
@@ -68,6 +76,7 @@
                 id="btn-start"
                 @click="_eventStart"
                 :disabled="!enableStart"
+                :title="btnStartTitle"
                 :variant="enableStart ? 'primary' : ''">
                 {{ btnStartTitle }}
             </b-button>
@@ -76,6 +85,7 @@
                 class="ui-button-default"
                 id="btn-new"
                 @click="_eventCreate(true)"
+                :title="btnCreateTitle"
                 :disabled="!enableSources">
                 <span class="fa fa-edit"></span>{{ btnCreateTitle }}
             </b-button>
@@ -84,6 +94,7 @@
                 class="ui-button-default"
                 id="btn-ftp"
                 @click="_eventRemoteFiles"
+                :title="btnFilesTitle"
                 :disabled="!enableSources"
                 v-if="remoteFiles">
                 <span class="fa fa-folder-open-o"></span>{{ btnFilesTitle }}

--- a/client/src/components/Upload/RulesInput.test.js
+++ b/client/src/components/Upload/RulesInput.test.js
@@ -6,4 +6,16 @@ describe("RulesInput.vue", () => {
         const { wrapper } = mountWithApp(RulesInput);
         expect(wrapper.find("#btn-reset").classes()).toEqual(expect.arrayContaining(["disabled"]));
     });
+
+    it("enables reset when sourceContent is populated", async () => {
+        const { wrapper } = mountWithApp(RulesInput);
+        const textInput = wrapper.find(".upload-rule-source-content");
+        expect(textInput.element.value).toBe("");
+        await textInput.setValue("a b c d");
+        expect(textInput.element.value).toBe("a b c d");
+        expect(wrapper.find("#btn-reset").classes()).not.toEqual(expect.arrayContaining(["disabled"]));
+        await wrapper.find("#btn-reset").trigger("click");
+        expect(textInput.element.value).toBe("");
+        expect(wrapper.find("#btn-reset").classes()).toEqual(expect.arrayContaining(["disabled"]));
+    });
 });

--- a/client/src/components/Upload/RulesInput.vue
+++ b/client/src/components/Upload/RulesInput.vue
@@ -65,7 +65,7 @@
                 id="btn-reset"
                 @click="_eventReset"
                 :title="btnResetTitle"
-                :disabled="!sourceContentPopulated">
+                :disabled="!enableReset">
                 {{ btnResetTitle | l }}
             </b-button>
         </template>
@@ -141,7 +141,7 @@ export default {
         },
     },
     computed: {
-        sourceContentPopulated: function () {
+        enableReset: function () {
             return this.sourceContent.length > 0;
         },
     },

--- a/client/src/components/Upload/RulesInput.vue
+++ b/client/src/components/Upload/RulesInput.vue
@@ -58,7 +58,7 @@
                 class="ui-button-default"
                 id="btn-reset"
                 @click="_eventReset"
-                :disabled="!enableReset">
+                :disabled="!sourceContentPopulated">
                 {{ btnResetTitle | l }}
             </b-button>
         </template>
@@ -88,7 +88,6 @@ export default {
             ftpFiles: [],
             uris: [],
             topInfo: "Tabular source data to extract collection files and metadata from",
-            enableReset: false,
             enableBuild: false,
             dataType: "datasets",
             selectedDatasetId: null,
@@ -132,6 +131,11 @@ export default {
                     this.sourceContent = response.data;
                 })
                 .catch((error) => console.log(error));
+        },
+    },
+    computed: {
+        sourceContentPopulated: function () {
+            return this.sourceContent.length > 0;
         },
     },
     methods: {

--- a/client/src/components/Upload/RulesInput.vue
+++ b/client/src/components/Upload/RulesInput.vue
@@ -41,7 +41,12 @@
                 :disabled="selectionType != 'paste'"></textarea>
         </span>
         <template v-slot:buttons>
-            <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="$emit('dismiss')">
+            <b-button
+                ref="btnClose"
+                class="ui-button-default"
+                id="btn-close"
+                :title="btnCloseTitle"
+                @click="$emit('dismiss')">
                 {{ btnCloseTitle | l }}
             </b-button>
             <b-button
@@ -50,6 +55,7 @@
                 id="btn-build"
                 @click="_eventBuild"
                 :disabled="!sourceContent"
+                :title="btnBuildTitle"
                 :variant="sourceContent ? 'primary' : ''">
                 {{ btnBuildTitle | l }}
             </b-button>
@@ -58,6 +64,7 @@
                 class="ui-button-default"
                 id="btn-reset"
                 @click="_eventReset"
+                :title="btnResetTitle"
                 :disabled="!sourceContentPopulated">
                 {{ btnResetTitle | l }}
             </b-button>


### PR DESCRIPTION
Backport of https://github.com/galaxyproject/galaxy/pull/13443

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
