### PR TITLE
Fixes for mulled search

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_search.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_search.py
@@ -12,17 +12,14 @@ from datetime import (
 
 import requests
 
+from galaxy.tool_util.deps.conda_util import CondaContext
+from galaxy.util import which
 from .mulled_list import get_singularity_containers
 from .util import (
     build_target,
     MULLED_SOCKET_TIMEOUT,
     v2_image_name,
 )
-
-try:
-    from conda.cli.python_api import run_command
-except ImportError:
-    run_command = None
 
 try:
     from whoosh.fields import (
@@ -36,6 +33,7 @@ except ImportError:
     Schema = TEXT = STORED = create_in = QueryParser = None
 
 QUAY_API_URL = "https://quay.io/api/v1/repository"
+conda_path = which("conda")
 
 
 class QuaySearch:
@@ -131,11 +129,13 @@ class CondaSearch:
         Function takes search_string variable and returns results from the bioconda channel in JSON format
 
         """
-        if run_command is None:
-            raise Exception(f"Invalid search destination. {deps_error_message('conda')}")
-        raw_out, err, exit_code = run_command("search", "-c", self.channel, search_string, use_exception_handler=True)
-        if exit_code != 0:
-            logging.info(f"Search failed with: {err}")
+        if not conda_path:
+            raise Exception("Invalid search destination. Required dependency [conda] is not in your PATH.")
+        try:
+            conda_context = CondaContext(conda_exec=conda_path, ensure_channels=self.channel)
+            raw_out = conda_context.exec_search([search_string])
+        except Exception as e:
+            logging.info(f"Search failed with: {e}")
             return []
         return [
             {"package": n.split()[0], "version": n.split()[1], "build": n.split()[2]} for n in raw_out.split("\n")[2:-1]
@@ -355,7 +355,7 @@ def main(argv=None):
         return
 
     destination_defaults = ["quay", "singularity", "github"]
-    if run_command is not None:
+    if conda_path:
         destination_defaults.append("conda")
 
     parser = argparse.ArgumentParser(description="Searches in a given quay organization for a repository")
@@ -379,7 +379,7 @@ def main(argv=None):
         "--channel",
         dest="channel_string",
         default="bioconda",
-        help="Change conda channel to search; default is bioconda.",
+        help="Change conda channels to search; default is bioconda.",
     )
     parser.add_argument(
         "--non-strict",

--- a/lib/galaxy/tool_util/deps/mulled/mulled_search.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_search.py
@@ -5,6 +5,10 @@ import json
 import logging
 import sys
 import tempfile
+from datetime import (
+    datetime,
+    timezone,
+)
 
 import requests
 
@@ -143,14 +147,29 @@ class GitHubSearch:
     Tool to search the GitHub bioconda-recipes repo
     """
 
+    @staticmethod
+    def _check_response_rate_limit(response):
+        if response.status_code == 403 and "API rate limit exceeded" in response.json()["message"]:
+            # It can take tens of minutes before the rate limit window resets
+            message = "GitHub API rate limit exceeded."
+            rate_limit_reset_UTC_timestamp = response.headers.get("X-RateLimit-Reset")
+            if rate_limit_reset_UTC_timestamp:
+                rate_limit_reset_datetime = datetime.fromtimestamp(int(rate_limit_reset_UTC_timestamp), tz=timezone.utc)
+                message += f" The rate limit window will reset at {rate_limit_reset_datetime.isoformat()}."
+            raise Exception(message)
+
     def get_json(self, search_string):
         """
         Takes search_string variable and return results from the bioconda-recipes github repository in JSON format
+
+        DEPRECATED: this method is currently unreliable because the API query
+        sometimes succeeds but returns no items.
         """
         response = requests.get(
             f"https://api.github.com/search/code?q={search_string}+in:path+repo:bioconda/bioconda-recipes+path:recipes",
             timeout=MULLED_SOCKET_TIMEOUT,
         )
+        self._check_response_rate_limit(response)
         response.raise_for_status()
         return response.json()
 
@@ -169,6 +188,7 @@ class GitHubSearch:
             f"https://api.github.com/repos/bioconda/bioconda-recipes/contents/recipes/{search_string}",
             timeout=MULLED_SOCKET_TIMEOUT,
         )
+        self._check_response_rate_limit(response)
         return response.status_code == 200
 
 
@@ -392,10 +412,11 @@ def main(argv=None):
         github = GitHubSearch()
 
         for item in args.search:
-            github_json = github.get_json(item)
-            github_results[item] = github.process_json(github_json, item)
             if github.recipe_present(item):
                 github_recipe_present.append(item)
+            else:
+                github_json = github.get_json(item)
+                github_results[item] = github.process_json(github_json, item)
 
         json_results["github"] = github_results
         json_results["github_recipe_present"] = {"recipes": github_recipe_present}

--- a/test/unit/tool_util/mulled/test_mulled_search.py
+++ b/test/unit/tool_util/mulled/test_mulled_search.py
@@ -1,11 +1,11 @@
 import pytest
 
 from galaxy.tool_util.deps.mulled.mulled_search import (
+    conda_path,
     CondaSearch,
     get_package_hash,
     GitHubSearch,
     QuaySearch,
-    run_command,
     singularity_search,
 )
 from ..util import external_dependency_management
@@ -22,15 +22,13 @@ def test_quay_search():
 
 
 @external_dependency_management
-@pytest.mark.skipif(run_command is None, reason="requires import from conda library")
+@pytest.mark.skipif(not conda_path, reason="requires conda on path")
 def test_conda_search():
     t = CondaSearch("bioconda")
     search1 = t.get_json("asdfasdf")
     search2 = t.get_json("bioconductor-gosemsim")
     assert search1 == []
-    assert search2["version"] == "2.2.0"
-    assert search2["package"] == "bioconductor-gosemsim"
-    assert search2["build"] == "0"
+    assert all(r["package"] == "bioconductor-gosemsim" for r in search2)
 
 
 @external_dependency_management

--- a/test/unit/tool_util/mulled/test_mulled_search.py
+++ b/test/unit/tool_util/mulled/test_mulled_search.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from galaxy.tool_util.deps.mulled.mulled_search import (
@@ -36,23 +34,21 @@ def test_conda_search():
 
 
 @external_dependency_management
-def test_github_search():
+def test_github_recipe_present():
     t = GitHubSearch()
 
-    search1 = t.process_json(t.get_json("adsfasdf"), "adsfasdf")
-    assert search1 == []
-
-    # The search sometimes returns no results so we retry a couple of times
-    num_retries = 5
-    search2 = t.process_json(t.get_json("bioconductor-gosemsim"), "bioconductor-gosemsim")
-    while not search2 and num_retries:
-        num_retries -= 1
-        time.sleep(2)  # Wait a bit, otherwise, the search may fail because of throttling
-        search2 = t.process_json(t.get_json("bioconductor-gosemsim"), "bioconductor-gosemsim")
-
-    assert search2
-    for item in search2:
-        assert "bioconductor-gosemsim" in item["path"]
+    search_string2expected = {
+        "adsfasdf": False,
+        "bioconductor-gosemsim": True,
+    }
+    for search_string, expected in search_string2expected.items():
+        try:
+            is_recipe_present = t.recipe_present(search_string)
+        except Exception as e:
+            if "API rate limit" in str(e):
+                pytest.skip("Hitting GitHub API rate limit")
+            raise
+        assert is_recipe_present is expected
 
 
 @external_dependency_management


### PR DESCRIPTION
- Check GitHub API rate limit in `GitHubSearch`. Deprecate `get_json()` search.
   Follow-up on https://github.com/galaxyproject/galaxy/pull/13509 .
-  Fix `CondaSearch` to use `conda` from PATH and a new `CondaContext.exec_search()` method
   The `conda` package on PyPI is severely outdated and unmaintained, and the output of `run_command("search", ...)` did not parse correctly.
- Rework `best_search_result()` and `CondaInDockerContext` to use `CondaContext.exec_search()`.
- Fix broken `test_conda_search` unit test.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
