### PR TITLE
Enable automatically loading webhook based on url

### DIFF
--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -1,6 +1,8 @@
 (function () {
     var gtnWebhookLoaded = false;
     var lastUpdate = 0;
+    var urlParams = new URLSearchParams(document.location.search);
+    var autoLoadTutorial = urlParams.get('autoload_gtn_tutorial') === null ? "" : urlParams.get('autoload_gtn_tutorial');
 
     function removeOverlay() {
         const container = document.getElementById("gtn-container");
@@ -58,7 +60,7 @@
             .then((response) => {
                 if (!response.ok) {
                     url =
-                        "https://training.galaxyproject.org/training-material/?utm_source=webhook&utm_medium=noproxy&utm_campaign=gxy";
+                        `https://training.galaxyproject.org/training-material/${autoLoadTutorial}?utm_source=webhook&utm_medium=noproxy&utm_campaign=gxy`;
                     message = `
                         <span>
                             <a href="https://docs.galaxyproject.org/en/master/admin/special_topics/gtn.html">Click to run</a> unavailable.
@@ -75,7 +77,7 @@
                         onloadscroll = storedLocation.split(" ")[0];
                         url = storedLocation.split(" ")[1];
                     } else {
-                        url = "/training-material/?utm_source=webhook&utm_medium=proxy&utm_campaign=gxy";
+                        url = `/training-material/${autoLoadTutorial}?utm_source=webhook&utm_medium=proxy&utm_campaign=gxy`;
                     }
                     message = "";
                 }
@@ -181,6 +183,9 @@
                 showOverlay();
             }
         });
+        if(autoLoadTutorial){
+            clean.click();
+        }
     });
 
     // Remove the overlay on escape button click


### PR DESCRIPTION
This updates the GTN webhook to support a URL parameter:

```
?autoload_gtn_tutorial=topics/assembly/tutorials/mrsa-nanopore/tutorial.html
```

And by supplying this URL parameter, we can automatically activate the webhook, pointed at the correct tutorial. This will be used in the GTN (e.g. click to follow this tutorial on usegalaxy.eu) or in the GTN Video Library with the same purpose

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Start Galaxy
  2. Visit http://localhost:8080/?autoload_gtn_tutorial=topics/assembly/tutorials/mrsa-nanopore/tutorial.html 
  3. Check that it loads that tutorial.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
