### PR TITLE
[22.01] Return actual tool id instead of specified tool id in workflow step

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1424,7 +1424,7 @@ class ToolModule(WorkflowModule):
         return self.tool.name if self.tool else self.tool_id
 
     def get_content_id(self):
-        return self.tool_id
+        return self.tool.id if self.tool else self.tool_id
 
     def get_version(self):
         return self.tool.version if self.tool else self.tool_version

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -395,6 +395,12 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin):
         save_button.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_RENDER)
 
+    @retry_assertion_during_transitions
+    def assert_modal_has_text(self, expected_text):
+        modal_element = self.components.workflow_editor.state_modal_body.wait_for_visible()
+        text = modal_element.text
+        assert expected_text in text, f"Failed to find expected text [{expected_text}] in modal text [{text}]"
+
     def workflow_upload_yaml_with_random_name(self, content, **kwds):
         workflow_populator = self.workflow_populator
         name = self._get_random_name()

--- a/test/integration_selenium/test_workflow_repository_tool_update.py
+++ b/test/integration_selenium/test_workflow_repository_tool_update.py
@@ -37,3 +37,25 @@ steps:
         workflow = self.workflow_populator.download_workflow(workflow_id)
         assert workflow['steps']['0']['tool_version'] == '0.1.1'
         assert workflow['steps']['0']['tool_id'] == 'toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1'
+
+    @selenium_test
+    def test_tool_shed_unmatched_version_upgrade(self):
+        self.install_repository("iuc", "compose_text_param", "e188c9826e0f")  # 0.1.1
+        self.login()
+        workflow_id = self.workflow_populator.upload_yaml_workflow("""class: GalaxyWorkflow
+inputs: []
+steps:
+  - tool_id: toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.0.0
+    tool_version: 0.0.0
+    label: compose_text_param
+        """)
+        self.workflow_index_open()
+        self.workflow_index_click_option("Edit")
+        self.assert_modal_has_text("Using version '0.1.1' instead of version '0.0.0'")
+        self.screenshot("workflow_editor_tool_repository_upgrade")
+        self.components.workflow_editor.modal_button_continue.wait_for_and_click()
+        self.assert_workflow_has_changes_and_save()
+        workflow = self.workflow_populator.download_workflow(workflow_id)
+        assert workflow['steps']['0']['content_id'] == 'toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1'
+        assert workflow['steps']['0']['tool_id'] == 'toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1'
+        assert workflow['steps']['0']['tool_version'] == '0.1.1'


### PR DESCRIPTION
We do also return the version changes in the module, so this should be
fine. Fixes https://github.com/galaxyproject/galaxy/issues/13524.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
