### PR TITLE
[21.09] Allow admin access to datasets API (before refactoring)

### DIFF
--- a/lib/galaxy/managers/lddas.py
+++ b/lib/galaxy/managers/lddas.py
@@ -1,6 +1,6 @@
 import logging
 
-from galaxy import model, util
+from galaxy import model
 from galaxy.managers import base as manager_base
 from galaxy.managers.datasets import DatasetAssociationManager
 from galaxy.structured_app import MinimalManagerApp
@@ -18,6 +18,7 @@ class LDDAManager(DatasetAssociationManager):
         """
         Set up and initialize other managers needed by lddas.
         """
+        super().__init__(app)
 
     def get(self, trans, id, check_accessible=True):
         return manager_base.get_object(trans, id,
@@ -26,56 +27,6 @@ class LDDAManager(DatasetAssociationManager):
                                        check_accessible=check_accessible)
 
     def _set_permissions(self, trans, library_dataset, role_ids_dict):
-        dataset = library_dataset.library_dataset_dataset_association.dataset
-        new_access_roles_ids = role_ids_dict["DATASET_ACCESS"]
-        new_manage_roles_ids = role_ids_dict["DATASET_MANAGE_PERMISSIONS"]
-        new_modify_roles_ids = role_ids_dict["LIBRARY_MODIFY"]
-
-        # ACCESS DATASET ROLES
-        valid_access_roles = []
-        invalid_access_roles_ids = []
-        valid_roles_for_dataset, total_roles = trans.app.security_agent.get_valid_roles(trans, dataset)
-        if new_access_roles_ids is None:
-            trans.app.security_agent.make_dataset_public(dataset)
-        else:
-            for role_id in new_access_roles_ids:
-                role = self.role_manager.get(trans, self.app, role_id)
-                if role in valid_roles_for_dataset:
-                    valid_access_roles.append(role)
-                else:
-                    invalid_access_roles_ids.append(role_id)
-            if len(invalid_access_roles_ids) > 0:
-                log.warning(f"The following roles could not be added to the dataset access permission: {str(invalid_access_roles_ids)}")
-
-            access_permission = dict(access=valid_access_roles)
-            trans.app.security_agent.set_dataset_permission(dataset, access_permission)
-
-        # MANAGE DATASET ROLES
-        valid_manage_roles = []
-        invalid_manage_roles_ids = []
-        new_manage_roles_ids = util.listify(new_manage_roles_ids)
-        for role_id in new_manage_roles_ids:
-            role = self.role_manager.get(trans, self.app, role_id)
-            if role in valid_roles_for_dataset:
-                valid_manage_roles.append(role)
-            else:
-                invalid_manage_roles_ids.append(role_id)
-        if len(invalid_manage_roles_ids) > 0:
-            log.warning(f"The following roles could not be added to the dataset manage permission: {str(invalid_manage_roles_ids)}")
-        manage_permission = {trans.app.security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS: valid_manage_roles}
-        trans.app.security_agent.set_dataset_permission(dataset, manage_permission)
-
-        # MODIFY LIBRARY ITEM ROLES
-        valid_modify_roles = []
-        invalid_modify_roles_ids = []
-        new_modify_roles_ids = util.listify(new_modify_roles_ids)
-        for role_id in new_modify_roles_ids:
-            role = self.role_manager.get(trans, self.app, role_id)
-            if role in valid_roles_for_dataset:
-                valid_modify_roles.append(role)
-            else:
-                invalid_modify_roles_ids.append(role_id)
-        if len(invalid_modify_roles_ids) > 0:
-            log.warning(f"The following roles could not be added to the dataset modify permission: {str(invalid_modify_roles_ids)}")
-        modify_permission = {trans.app.security_agent.permitted_actions.LIBRARY_MODIFY: valid_modify_roles}
-        trans.app.security_agent.set_library_item_permission(library_dataset, modify_permission)
+        # Check Git history for an older broken implementation, but it was broken
+        # and security related and had not test coverage so it was deleted.
+        raise NotImplementedError()

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -106,8 +106,23 @@ class DatasetsApiTestCase(ApiTestCase):
         self.dataset_populator.make_private(history_id=self.history_id, dataset_id=hda['id'])
         with self._different_user():
             show_response = self._get(f"datasets/{hda['id']}")
-            self._assert_status_code_is(show_response, 400)
-            assert show_response.json()['err_msg'] == 'You are not allowed to access this dataset'
+            self._assert_status_code_is(show_response, 403)
+
+    def test_admin_can_update_permissions(self):
+        # Create private dataset
+        hda = self.dataset_populator.new_dataset(self.history_id)
+        dataset_id = hda['id']
+        self.dataset_populator.make_private(history_id=self.history_id, dataset_id=dataset_id)
+
+        # Admin removes restrictions
+        payload = {"action": "remove_restrictions"}
+        update_response = self._put(f"datasets/{dataset_id}/permissions", payload, admin=True, json=True)
+        self._assert_status_code_is_ok(update_response)
+
+        # Other users can access the dataset
+        with self._different_user():
+            show_response = self._get(f"datasets/{hda['id']}")
+            self._assert_status_code_is_ok(show_response)
 
     def __assert_matches_hda(self, input_hda, query_hda):
         self._assert_has_keys(query_hda, "id", "name")

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -575,7 +575,7 @@ class SharingHistoryTestCase(ApiTestCase, BaseHistories, SharingApiTests):
         # Other users cannot access the dataset
         with self._different_user():
             show_response = self._get(f"datasets/{hda_id}")
-            self._assert_status_code_is(show_response, 400)
+            self._assert_status_code_is(show_response, 403)
 
         sharing_response = self._set_resource_sharing(history_id, "publish")
         assert sharing_response["published"] is True


### PR DESCRIPTION
21.09 version of the patch in https://github.com/galaxyproject/galaxy/pull/13537

Do not merge this commit forward.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
