### PR TITLE
Update to new @galaxyproject/bootstrap-tour to fix tour anchor selection

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
     "@fortawesome/vue-fontawesome": "^2.0.6",
-    "@galaxyproject/bootstrap-tour": "^0.12.1",
+    "@galaxyproject/bootstrap-tour": "0.12.2",
     "@handsontable/vue": "^2.0.0-beta1",
     "@hirez_io/observer-spy": "^2.1.2",
     "@johmun/vue-tags-input": "^2.1.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1167,10 +1167,10 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-2.0.6.tgz#87e691ed87f28f4667238573a29743f543a087f6"
   integrity sha512-V3vT3flY15AKbUS31aZOP12awQI3aAzkr2B1KnqcHLmwrmy51DW3pwyBczKdypV8QxBZ8U68Hl2XxK2nudTxpg==
 
-"@galaxyproject/bootstrap-tour@^0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@galaxyproject/bootstrap-tour/-/bootstrap-tour-0.12.1.tgz#138ab9d993fda658220dea2662fc8e0d0c720577"
-  integrity sha512-fnDLpaQx/RFKLL9xtuaVz2RTCo4qQrWYrvFspu6h5ZObgFmTGLTQm3tjiZ0qWBV7Npmwt7X9mc8lUpSCwFPmQw==
+"@galaxyproject/bootstrap-tour@0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@galaxyproject/bootstrap-tour/-/bootstrap-tour-0.12.2.tgz#9277e2dd976b8c778927c70d8180bb7a7090f009"
+  integrity sha512-iGmRhRhoq5vuhgVNig5/Hiu+86emgBDMtB12vo0ApAh9K+1lSnb8NLvfxDOOD7XlO9n4UMFJ5xnjSzeKCnOhqQ==
   dependencies:
     bootstrap ">=4.0.0-beta"
     jquery "^3.0.0"


### PR DESCRIPTION
This should fix the multiple highlighting issue, pins to our specific patch version instead of a range.  Deploys https://github.com/dannon/bootstrap-tour/pull/1 and https://github.com/dannon/bootstrap-tour/pull/2 from @itisAliRH, which are now published on npm as `@galaxyproject/bootstrap-tour (0.12.2)`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
