### PR TITLE
Add source_metadata column to workflow table as alembic revision

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
@@ -9,6 +9,7 @@ from alembic import op
 from sqlalchemy import Column
 
 from galaxy.model.custom_types import JSONType
+from galaxy.model.migrations.util import drop_column
 
 # revision identifiers, used by Alembic.
 revision = "b182f655505f"
@@ -22,5 +23,4 @@ def upgrade():
 
 
 def downgrade():
-    with op.batch_alter_table("workflow") as batch_op:
-        batch_op.drop_column("source_metadata")
+    drop_column("workflow", "source_metadata")

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
@@ -1,0 +1,27 @@
+"""add workflow.source_metadata column
+
+Revision ID: b182f655505f
+Revises: e7b6dcb09efd
+Create Date: 2022-03-14 12:56:57.067748
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import Column
+
+from galaxy.model.custom_types import JSONType
+
+# revision identifiers, used by Alembic.
+revision = "b182f655505f"
+down_revision = "e7b6dcb09efd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("workflow", Column("source_metadata", JSONType))
+
+
+def downgrade():
+    with op.batch_alter_table("workflow") as batch_op:
+        batch_op.drop_column("source_metadata")

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
@@ -5,7 +5,6 @@ Revises: e7b6dcb09efd
 Create Date: 2022-03-14 12:56:57.067748
 
 """
-import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import Column
 

--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -1,0 +1,6 @@
+from alembic import op
+
+
+def drop_column(table, column):
+    with op.batch_alter_table("workflow") as batch_op:
+        batch_op.drop_column("source_metadata")

--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -2,5 +2,5 @@ from alembic import op
 
 
 def drop_column(table, column):
-    with op.batch_alter_table("workflow") as batch_op:
-        batch_op.drop_column("source_metadata")
+    with op.batch_alter_table(table) as batch_op:
+        batch_op.drop_column(column)


### PR DESCRIPTION
Add alembic revision to restore db schema change introduced in #13376 (sqlalchemy migrate revision removed in #13513).

NOTE: The context manager in the downgrade() function is a standard workaround for dealing with the limitations of SQLite's alter_table statement.

Ref:
https://alembic.sqlalchemy.org/en/latest/ops.html?highlight=batch_alter_table#alembic.operations.Operations.batch_alter_table
https://alembic.sqlalchemy.org/en/latest/batch.html#batch-migrations

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
