### PR TITLE
Card expansion animation in new history

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -79,7 +79,9 @@
             </div>
         </div>
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
-        <DatasetDetails v-if="expandDataset" @edit="onEdit" :item="item" />
+        <div class="detail-animation-wrapper" :class="expandDataset ? '' : 'collapsed'">
+            <DatasetDetails v-if="expandDataset" @edit="onEdit" :item="item" />
+        </div>
     </div>
 </template>
 
@@ -203,5 +205,14 @@ export default {
     .name {
         word-wrap: break-word;
     }
+}
+.detail-animation-wrapper {
+    overflow: hidden;
+    transition: max-height 0.5s ease-out;
+    height: auto;
+    max-height: 400px;
+}
+.detail-animation-wrapper.collapsed {
+    max-height: 0;
 }
 </style>


### PR DESCRIPTION
Adds back a card expand animation in the history, as seen in the old one.  Collapse is now (intentionally) immediate, but we can have a transition there as well if folks want.


## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. In beta history, click a dataset.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
