### PR TITLE
[22.01] Fix yaml preview in firefox

### DIFF
--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -886,9 +886,9 @@ class Yaml(Text):
 
     def _yield_user_file_content(self, trans, from_dataset, filename, headers: Headers):
         # Override non-standard application/yaml mediatype with
-        # non-standard text/x-yaml, so preview is shown in preview iframe,
+        # text/plain, so preview is shown in preview iframe,
         # instead of downloading the file.
-        headers['content-type'] = 'text/x-yaml'
+        headers["content-type"] = "text/plain"
         return super()._yield_user_file_content(trans, from_dataset, filename, headers)
 
     def _looks_like_yaml(self, file_prefix: FilePrefix):


### PR DESCRIPTION
by using standard text/plain content-type.
Fixes https://github.com/galaxyproject/galaxy/issues/13295.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Upload a yaml file, and click on the eye icon in firefox, the dataset should display in the center panel instead of triggering a download.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
