### PR TITLE
[21.09] Fix creating tags within sessionless context

### DIFF
--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -134,7 +134,8 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
             primary_data.created_from_basename = created_from_basename
 
         if tag_list:
-            self.tag_handler.add_tags_from_list(self.job.user, primary_data, tag_list, flush=False)
+            job = getattr(self, "job", None)
+            self.tag_handler.add_tags_from_list(job and job.user, primary_data, tag_list, flush=False)
 
         # If match specified a name use otherwise generate one from
         # designation.
@@ -415,7 +416,6 @@ class SessionlessModelPersistenceContext(ModelPersistenceContext):
         self.object_store = object_store
         self.export_store = export_store
         self.flush_per_n_datasets = None
-
         self.job_working_directory = working_directory  # TODO: rename...
 
     @property
@@ -626,6 +626,7 @@ def persist_hdas(elements, model_persistence_context, final_job_state='ok'):
                 ext = fields_match.ext
                 dbkey = fields_match.dbkey
                 info = element.get("info", None)
+                tag_list = element.get("tags")
                 link_data = discovered_file.match.link_data
 
                 # Create new primary dataset
@@ -654,6 +655,7 @@ def persist_hdas(elements, model_persistence_context, final_job_state='ok'):
                     filename=discovered_file.path,
                     extra_files=extra_files,
                     info=info,
+                    tag_list=tag_list,
                     link_data=link_data,
                     primary_data=primary_dataset,
                     sources=sources,

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -426,7 +426,7 @@ class GalaxySessionlessTagHandler(GalaxyTagHandlerSession):
         return self.created_tags.get(tag_name)
 
     def get_tag_by_name(self, tag_name):
-        self.created_tags.get(tag_name)
+        return self.created_tags.get(tag_name)
 
 
 class CommunityTagHandler(TagHandler):

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -248,8 +248,10 @@ class TagHandler:
 
     def _create_tag_instance(self, tag_name):
         # For good performance caller should first check if there's already an appropriate tag
-        Session = sessionmaker(self.sa_session.bind)
         tag = galaxy.model.Tag(type=0, name=tag_name)
+        if not self.sa_session:
+            return tag
+        Session = sessionmaker(self.sa_session.bind)
         with Session() as separate_session:
             separate_session.add(tag)
             try:

--- a/test/unit/test_model_discovery.py
+++ b/test/unit/test_model_discovery.py
@@ -21,6 +21,7 @@ def test_model_create_context_persist_hdas():
             "dbkey": "hg19",
             "name": "my file",
             "md5": "e5d21b1ea57fc9a31f8ea0110531bf3d",
+            "tags": ["name:value"]
         }],
     }
     app = _mock_app(store_by="uuid")
@@ -37,6 +38,9 @@ def test_model_create_context_persist_hdas():
     assert imported_hda.metadata.data_lines == 2
     assert len(imported_hda.dataset.hashes) == 1
     assert imported_hda.dataset.hashes[0].hash_value == "e5d21b1ea57fc9a31f8ea0110531bf3d"
+    tags = imported_hda.tags
+    assert len(tags) == 1
+    assert tags[0].value == "value"
 
     with open(imported_hda.file_name) as f:
         assert f.read().startswith("hello world\n")
@@ -228,7 +232,7 @@ def _import_directory_to_history(app, target, work_directory):
     assert len(import_history.datasets) == 0
 
     import_options = store.ImportOptions(allow_dataset_object_edit=True)
-    import_model_store = store.get_import_model_store_for_directory(target, app=app, user=u, import_options=import_options)
+    import_model_store = store.get_import_model_store_for_directory(target, app=app, user=u, import_options=import_options, tag_handler=app.tag_handler.create_tag_handler_session())
     with import_model_store.target_history(default_history=import_history):
         import_model_store.perform_import(import_history)
 


### PR DESCRIPTION
xref: https://github.com/galaxyproject/galaxy/issues/13551, fixes `test_collection_tools_tag_propagation`
```
galaxy.jobs ERROR 2022-03-15 00:21:29,515 [pN:main,p:2180,tN:LocalRunner.work_thread-3] problem importing job outputs. stdout [] stderr [
Traceback (most recent call last):
  File "metadata/set.py", line 1, in <module>
    from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/metadata/set_metadata.py", line 121, in set_metadata
    set_metadata_portable()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/metadata/set_metadata.py", line 291, in set_metadata_portable
    collect_dynamic_outputs(job_context, output_collections)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/job_execution/output_collect.py", line 147, in collect_dynamic_outputs
    persist_elements_to_hdca(job_context, elements, hdca, collector=DEFAULT_DATASET_COLLECTOR)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/discover.py", line 719, in persist_elements_to_hdca
    filenames,
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/discover.py", line 292, in populate_collection_elements
    final_job_state=final_job_state,
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/discover.py", line 354, in _populate_elements
    self.add_tags_to_datasets(datasets=element_datasets["datasets"], tag_lists=element_datasets["tag_lists"])
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/discover.py", line 576, in add_tags_to_datasets
    self.tag_handler.add_tags_from_list(user, dataset, tags, flush=False)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/tags.py", line 61, in add_tags_from_list
    return self.set_tags_from_list(user, item, new_tags_set, flush=flush)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/tags.py", line 75, in set_tags_from_list
    self.apply_item_tags(user, item, unicodify(new_tags_str, "utf-8"), flush=flush)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/tags.py", line 207, in apply_item_tags
    self.apply_item_tag(user, item, name, value, flush=flush)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/tags.py", line 179, in apply_item_tag
    tag = self._get_or_create_tag(lc_name)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/tags.py", line 281, in _get_or_create_tag
    tag = self._create_tag(scrubbed_tag_str)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/tags.py", line 246, in _create_tag
    tag = self._create_tag_instance(tag_name)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/tags.py", line 428, in _create_tag_instance
    tag = super()._create_tag_instance(tag_name)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/tags.py", line 259, in _create_tag_instance
    Session = sessionmaker(self.sa_session.bind)
AttributeError: 'NoneType' object has no attribute 'bind'
]
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/__init__.py", line 1828, in finish
    import_model_store.perform_import(history=job.history, job=job)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/__init__.py", line 209, in perform_import
    datasets_attrs = self.datasets_properties()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/__init__.py", line 930, in datasets_properties
    datasets_attrs = load(open(datasets_attrs_file_name))
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp19s6x278/tmpt0rr8vmw/tmp2mjq6ysx/database/job_working_directory1/000/7/metadata/outputs_populated/datasets_attrs.txt'
galaxy.jobs.runners ERROR 2022-03-15 00:21:29,516 [pN:main,p:2180,tN:LocalRunner.work_thread-3] (7/) Job wrapper finish method failed
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/runners/__init__.py", line 594, in _finish_or_resubmit_job
    job_stderr=job_stderr,
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/__init__.py", line 1828, in finish
    import_model_store.perform_import(history=job.history, job=job)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/__init__.py", line 209, in perform_import
    datasets_attrs = self.datasets_properties()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/__init__.py", line 930, in datasets_properties
    datasets_attrs = load(open(datasets_attrs_file_name))
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp19s6x278/tmpt0rr8vmw/tmp2mjq6ysx/database/job_working_directory1/000/7/metadata/outputs_populated/datasets_attrs.txt'
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
