### PR TITLE
[22.01] Fix extended_metadata jobs with dce inputs

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1079,6 +1079,10 @@ class DirectoryImportModelStoreLatest(BaseDirectoryImportModelStore):
                 else:
                     raise NotImplementedError()
                 new_obj = obj.copy()
+                if not new_id and self.import_options.allow_edit:
+                    # We may not have exported all job parameters, such as dces,
+                    # but we shouldn't set the object_id to none in that case.
+                    new_id = obj["id"]
                 new_obj["id"] = new_id
                 return (k, new_obj)
 


### PR DESCRIPTION
This broke when we started re-exporting jobs to update their command
line in https://github.com/galaxyproject/galaxy/pull/12459/commits/65e0ee213ae574bc0a45dfcc60e997863ff96a7c#diff-bfb854f344e56a25a86761f80a639de09add404a7a53ebde45afb908762fc1eaR161:

```
ERROR    galaxy.jobs:__init__.py:1836 problem importing job outputs. stdout [] stderr [
Traceback (most recent call last):
  File "metadata/set.py", line 1, in <module>
    from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/metadata/set_metadata.py", line 121, in set_metadata
    set_metadata_portable()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/metadata/set_metadata.py", line 307, in set_metadata_portable
    export_store.export_job(job, include_job_data=False)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/__init__.py", line 1320, in export_job
    self.export_jobs([job], include_job_data=include_job_data)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/store/__init__.py", line 1336, in export_jobs
    job_attrs = job.serialize(self.security, self.serialization_options)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/__init__.py", line 339, in serialize
    return self._serialize(id_encoder, serialization_options)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/__init__.py", line 1447, in _serialize
    params_objects = remap(params_objects, remap_objects)
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/boltons/iterutils.py", line 1128, in remap
    visited_item = visit(path, key, value)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/__init__.py", line 1441, in remap_objects
    new_id = serialization_options.get_identifier_for_id(id_encoder, obj["id"])
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/model/__init__.py", line 323, in get_identifier_for_id
    raise NotImplementedError()
NotImplementedError
]
```

To test run `GALAXY_CONFIG_METADATA_STRATEGY=extended ./run_tests.sh
-api
lib/galaxy_test/api/test_jobs.py::JobsApiTestCase::test_dce_submission_security`

The scheduled tests caught this (xref #13551 )
 
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
