### PR TITLE
[21.05] Fix sff_extract tool, drop type annotation

### DIFF
--- a/tools/filters/sff_extract.py
+++ b/tools/filters/sff_extract.py
@@ -31,7 +31,6 @@ import struct
 import subprocess
 import sys
 import tempfile
-from typing import Dict, List
 
 __author__ = 'Jose Blanca and Bastien Chevreux'
 __copyright__ = 'Copyright 2008, Jose Blanca, COMAV, and Bastien Chevreux'
@@ -43,9 +42,9 @@ __status__ = 'beta'
 fake_sff_name = 'fake_sff_name'
 
 # readname as key: lines with matches from SSAHA, one best match
-ssahapematches: Dict[str, List] = {}
+ssahapematches = {}  # type: ignore
 # linker readname as key: length of linker sequence
-linkerlengths: Dict[str, int] = {}
+linkerlengths = {}  # type: ignore
 
 # set to true if something really fishy is going on with the sequences
 stern_warning = True

--- a/tools/filters/sff_extractor.xml
+++ b/tools/filters/sff_extractor.xml
@@ -57,5 +57,3 @@ Clippings (XML)
 
     </help>
 </tool>
-
-


### PR DESCRIPTION
I don't think this tool is really used much, but it is loaded in `tool_conf.xml`.
https://github.com/galaxyproject/galaxy/pull/11877 added type annotations, and that's a syntax error on Python 2.7 .

The alternative would be to fix the rest of the tool for 3.x, but I think we're just wasting our time there and we shouldn't touch this again.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Run tool tests with `./run_tests.sh --skip-common-startup  --skip_flakey_fails -framework -id Sff_extractor`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
