### PR TITLE
History bulk operations

### DIFF
--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -1,7 +1,6 @@
 /**
- * This is simple list management for the moment, but if I remember right we have plans for a more
- * abstracted selection scheme in the future for purposes of handling large bulk operations on the
- * server, this is a good place to implement that logic.
+ * This component deals with item selection inside a history.
+ * It allows to select individual items or perform a query selection.
  */
 
 export default {
@@ -13,16 +12,24 @@ export default {
         return {
             items: new Map(),
             showSelection: false,
+            totalItemsInQuery: 0,
         };
     },
     computed: {
         selectionSize() {
-            return this.items.size;
+            return this.isQuerySelection ? this.totalItemsInQuery : this.items.size;
+        },
+        isQuerySelection() {
+            return this.totalItemsInQuery !== this.items.size;
         },
     },
     methods: {
         setShowSelection(val) {
             this.showSelection = val;
+        },
+        selectAllInCurrentQuery(loadedItems = [], totalItemsInQuery) {
+            this.selectItems(loadedItems);
+            this.totalItemsInQuery = totalItemsInQuery;
         },
         isSelected(item) {
             const key = this.getItemKey(item);
@@ -33,6 +40,7 @@ export default {
             const newSelected = new Map(this.items);
             selected ? newSelected.set(key, item) : newSelected.delete(key);
             this.items = newSelected;
+            this.resetQuerySelection();
         },
         selectItems(items = []) {
             const newItems = [...this.items.values(), ...items];
@@ -41,9 +49,14 @@ export default {
                 return [key, item];
             });
             this.items = new Map(newEntries);
+            this.resetQuerySelection();
+        },
+        resetQuerySelection() {
+            this.totalItemsInQuery = this.items.size;
         },
         reset() {
             this.items = new Map();
+            this.resetQuerySelection();
         },
     },
     watch: {
@@ -67,7 +80,10 @@ export default {
         return this.$scopedSlots.default({
             selectedItems: this.items,
             showSelection: this.showSelection,
+            isQuerySelection: this.isQuerySelection,
+            selectionSize: this.selectionSize,
             setShowSelection: this.setShowSelection,
+            selectAllInCurrentQuery: this.selectAllInCurrentQuery,
             selectItems: this.selectItems,
             isSelected: this.isSelected,
             setSelected: this.setSelected,

--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -3,10 +3,13 @@
  * It allows to select individual items or perform a query selection.
  */
 
+import { getFilters, testFilters } from "store/historyStore/historyItemsFiltering";
+
 export default {
     props: {
         scopeKey: { type: String, required: true },
         getItemKey: { type: Function, required: true },
+        filterText: { type: String, required: true },
     },
     data() {
         return {
@@ -22,6 +25,9 @@ export default {
         isQuerySelection() {
             return this.totalItemsInQuery !== this.items.size;
         },
+        currentFilters() {
+            return getFilters(this.filterText);
+        },
     },
     methods: {
         setShowSelection(val) {
@@ -32,6 +38,9 @@ export default {
             this.totalItemsInQuery = totalItemsInQuery;
         },
         isSelected(item) {
+            if (this.isQuerySelection) {
+                return testFilters(this.currentFilters, item);
+            }
             const key = this.getItemKey(item);
             return this.items.has(key);
         },

--- a/client/src/components/History/CurrentHistory/HistoryOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations.vue
@@ -150,6 +150,7 @@ export default {
         filterText: { type: String, required: true },
         contentSelection: { type: Map, required: true },
         selectionSize: { type: Number, required: true },
+        isQuerySelection: { type: Boolean, required: true },
         showSelection: { type: Boolean, required: true },
         hasMatches: { type: Boolean, required: true },
         expandedCount: { type: Number, required: false, default: 0 },
@@ -210,11 +211,15 @@ export default {
             this.runOnSelection(purgeSelectedContent);
         },
         async runOnSelection(fn) {
-            const items = Array.from(this.contentSelection.values());
-            const type_ids = items.map((o) => o.type_id);
-            await fn(this.history, type_ids);
-            this.$emit("hide-selection", items);
+            let type_ids = [];
+            if (!this.isQuerySelection) {
+                const items = Array.from(this.contentSelection.values());
+                type_ids = items.map((o) => o.type_id);
+            }
+
+            await fn(this.history, type_ids, this.params);
             this.$emit("reset-selection");
+            this.$emit("reload");
         },
 
         // collection creation, fires up a modal

--- a/client/src/components/History/CurrentHistory/HistoryOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations.vue
@@ -123,7 +123,8 @@
         </b-modal>
 
         <b-modal id="purge-all-deleted-content" title="Purge Deleted Datasets" title-tag="h2" @ok="purgeAllDeleted">
-            <p v-localize>"Really delete all deleted datasets permanently? This cannot be undone.</p>
+            <p v-localize>Really permanently delete all deleted datasets?</p>
+            <p><strong class="text-danger" v-localize>Warning, this operation cannot be undone.</strong></p>
         </b-modal>
     </section>
 </template>

--- a/client/src/components/History/CurrentHistory/HistoryOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations.vue
@@ -188,15 +188,12 @@ export default {
         // History-wide bulk updates, does server query first to determine "selection"
         async unhideAll(evt) {
             await unhideAllHiddenContent(this.history);
-            this.$emit("reload");
         },
         async deleteAllHidden(evt) {
             await deleteAllHiddenContent(this.history);
-            this.$emit("reload");
         },
         async purgeAllDeleted(evt) {
             await purgeAllDeletedContent(this.history);
-            this.$emit("reload");
         },
 
         // Selected content manipulation, hide/show/delete/purge
@@ -220,7 +217,6 @@ export default {
             const filters = getFilters(this.filterText);
             await fn(this.history, filters, items);
             this.$emit("reset-selection");
-            this.$emit("reload");
         },
         getExplicitlySelectedItems() {
             if (this.isQuerySelection) {

--- a/client/src/components/History/CurrentHistory/HistoryOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations.vue
@@ -88,7 +88,7 @@
                         <span v-localize>Delete All Hidden Content</span>
                     </b-dropdown-item>
                     <b-dropdown-item v-b-modal:purge-all-deleted-content>
-                        <span v-localize>Purge All Hidden Content</span>
+                        <span v-localize>Permanently Delete All Deleted Content</span>
                     </b-dropdown-item>
                 </b-dropdown>
             </b-button-group>
@@ -149,6 +149,7 @@ export default {
         history: { type: History, required: true },
         filterText: { type: String, required: true },
         contentSelection: { type: Map, required: true },
+        selectionSize: { type: Number, required: true },
         showSelection: { type: Boolean, required: true },
         hasMatches: { type: Boolean, required: true },
         expandedCount: { type: Number, required: false, default: 0 },
@@ -164,7 +165,7 @@ export default {
             return !this.showHidden && !this.showDeleted;
         },
         numSelected() {
-            return this.contentSelection.size || 0;
+            return this.selectionSize;
         },
         hasSelection() {
             return this.numSelected > 0;

--- a/client/src/components/History/CurrentHistory/HistoryOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations.vue
@@ -142,7 +142,7 @@ import {
 } from "components/History/model";
 import { createDatasetCollection } from "components/History/model/queries";
 import { buildCollectionModal } from "components/History/adapters/buildCollectionModal";
-import { checkFilter, getFilters } from "store/historyStore/historyItemsFiltering";
+import { checkFilter, getQueryDict } from "store/historyStore/historyItemsFiltering";
 import { iframeRedirect } from "components/plugins/legacyNavigation";
 export default {
     props: {
@@ -214,7 +214,7 @@ export default {
         },
         async runOnSelection(fn) {
             const items = this.getExplicitlySelectedItems();
-            const filters = getFilters(this.filterText);
+            const filters = getQueryDict(this.filterText);
             await fn(this.history, filters, items);
             this.$emit("reset-selection");
         },

--- a/client/src/components/History/CurrentHistory/HistoryOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations.vue
@@ -163,7 +163,7 @@ export default {
             return checkFilter(this.filterText, "deleted", true);
         },
         showBuildOptions() {
-            return !this.showHidden && !this.showDeleted;
+            return !this.isQuerySelection && !this.showHidden && !this.showDeleted;
         },
         numSelected() {
             return this.selectionSize;

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -52,7 +52,6 @@
                             v-if="showSelection"
                             class="p-2"
                             :has-filters="hasFilters"
-                            :is-query-selection="isQuerySelection"
                             :selection-size="selectionSize"
                             :total-items-in-query="totalItemsInQuery"
                             @select-all="selectAllInCurrentQuery(payload, totalItemsInQuery)"

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -4,7 +4,7 @@
         :history-id="historyId"
         :offset="offset"
         :filter-text="filterText"
-        v-slot="{ loading, result: payload, totalMatches }">
+        v-slot="{ loading, result: payload, count: totalItemsInQuery }">
         <ExpandedItems
             :scope-key="historyId"
             :get-item-key="(item) => item.type_id"
@@ -53,8 +53,8 @@
                             :has-filters="hasFilters"
                             :is-query-selection="isQuerySelection"
                             :selection-size="selectionSize"
-                            :total-items-in-query="totalMatches"
-                            @select-all="selectAllInCurrentQuery(payload, totalMatches)"
+                            :total-items-in-query="totalItemsInQuery"
+                            @select-all="selectAllInCurrentQuery(payload, totalItemsInQuery)"
                             @clear-selection="resetSelection" />
                     </section>
                     <section v-if="!showAdvanced" class="position-relative flex-grow-1 scroller">

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -12,6 +12,7 @@
             <SelectedItems
                 :scope-key="queryKey"
                 :get-item-key="(item) => item.type_id"
+                :filter-text="filterText"
                 v-slot="{
                     selectedItems,
                     showSelection,

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -38,12 +38,14 @@
                             :filter-text="filterText"
                             :content-selection="selectedItems"
                             :selection-size="selectionSize"
+                            :is-query-selection="isQuerySelection"
                             :show-selection="showSelection"
                             :expanded-count="expandedCount"
                             :has-matches="hasMatches(payload)"
                             @update:content-selection="selectItems"
                             @update:show-selection="setShowSelection"
                             @hide-selection="onHideSelection"
+                            @reset-selection="resetSelection"
                             @collapse-all="collapseAll" />
                         <transition name="shutterfade">
                             <HistorySelectionStatus

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -47,17 +47,15 @@
                             @hide-selection="onHideSelection"
                             @reset-selection="resetSelection"
                             @collapse-all="collapseAll" />
-                        <transition name="shutterfade">
-                            <HistorySelectionStatus
-                                v-if="showSelection"
-                                class="p-2"
-                                :has-filters="hasFilters"
-                                :is-query-selection="isQuerySelection"
-                                :selection-size="selectionSize"
-                                :total-items-in-query="totalMatches"
-                                @select-all="selectAllInCurrentQuery(payload, totalMatches)"
-                                @clear-selection="resetSelection" />
-                        </transition>
+                        <HistorySelectionStatus
+                            v-if="showSelection"
+                            class="p-2"
+                            :has-filters="hasFilters"
+                            :is-query-selection="isQuerySelection"
+                            :selection-size="selectionSize"
+                            :total-items-in-query="totalMatches"
+                            @select-all="selectAllInCurrentQuery(payload, totalMatches)"
+                            @clear-selection="resetSelection" />
                     </section>
                     <section v-if="!showAdvanced" class="position-relative flex-grow-1 scroller">
                         <div>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -1,12 +1,12 @@
 <template>
     <HistoryItemsProvider
-        :key="history.id"
+        :key="historyId"
         :history-id="historyId"
         :offset="offset"
         :filter-text="filterText"
         v-slot="{ loading, result: payload, totalMatches }">
         <ExpandedItems
-            :scope-key="history.id"
+            :scope-key="historyId"
             :get-item-key="(item) => item.type_id"
             v-slot="{ expandedCount, isExpanded, setExpanded, collapseAll }">
             <SelectedItems
@@ -152,15 +152,19 @@ export default {
         },
     },
     computed: {
+        /** @returns {String} */
         historyId() {
             return this.history.id;
         },
+        /** @returns {String} */
         queryKey() {
             return `${this.historyId}-${this.filterText}`;
         },
+        /** @returns {Boolean} */
         queryDefault() {
             return !this.filterText;
         },
+        /** @returns {Boolean} */
         hasFilters() {
             return !this.queryDefault;
         },

--- a/client/src/components/History/CurrentHistory/HistorySelectionStatus.test.js
+++ b/client/src/components/History/CurrentHistory/HistorySelectionStatus.test.js
@@ -1,0 +1,131 @@
+import { mount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { getLocalVue } from "jest/helpers";
+import HistorySelectionStatus from "./HistorySelectionStatus.vue";
+
+const localVue = getLocalVue();
+
+const SELECT_ALL_BTN = '[data-test-id="select-all-btn"]';
+const CLEAR_BTN = '[data-test-id="clear-btn"]';
+const EMPTY_SELECTION_STATUS = '[data-test-id="empty-selection"]';
+const ALL_IN_FILTER_SELECTED_STATUS = '[data-test-id="all-filter-selected"]';
+const ALL_ACTIVE_SELECTED_STATUS = '[data-test-id="all-active-selected"]';
+const NUM_IN_FILTER_SELECTED_STATUS = '[data-test-id="num-filter-selected"]';
+const NUM_ACTIVE_SELECTED_STATUS = '[data-test-id="num-active-selected"]';
+
+const NOTHING_SELECTED = {
+    hasFilters: false,
+    selectionSize: 0,
+    totalItemsInQuery: 0,
+};
+
+const ONE_ITEM_SELECTED = {
+    hasFilters: false,
+    selectionSize: 1,
+    totalItemsInQuery: 0,
+};
+
+const NO_ITEMS_TO_SELECT = {
+    hasFilters: false,
+    selectionSize: 0,
+    totalItemsInQuery: 0,
+};
+
+const ALL_ITEMS_SELECTED = {
+    hasFilters: false,
+    selectionSize: 10,
+    totalItemsInQuery: 10,
+};
+
+const SOME_ITEMS_IN_QUERY_SELECTED = {
+    hasFilters: false,
+    selectionSize: 5,
+    totalItemsInQuery: 10,
+};
+
+async function mountHistorySelectionStatusWith(props) {
+    const wrapper = mount(HistorySelectionStatus, { propsData: props }, localVue);
+    await flushPromises();
+    return wrapper;
+}
+
+describe("HistorySelectionStatus", () => {
+    describe("Clear Selection Button", () => {
+        it("should be only visible when there is something selected", async () => {
+            const wrapper = await mountHistorySelectionStatusWith(NOTHING_SELECTED);
+            expect(wrapper.find(CLEAR_BTN).exists()).toBe(false);
+
+            await wrapper.setProps({ selectionSize: 1 });
+            expect(wrapper.find(CLEAR_BTN).exists()).toBe(true);
+        });
+
+        it("should emit the expected event when pressed", async () => {
+            const wrapper = await mountHistorySelectionStatusWith(ONE_ITEM_SELECTED);
+            await expectWrapperButtonToEmitEvent(wrapper, CLEAR_BTN, "clear-selection");
+        });
+    });
+
+    describe("Select All Button", () => {
+        it("should be only visible when there are items in the current query that are not selected yet", async () => {
+            const wrapper = await mountHistorySelectionStatusWith(NO_ITEMS_TO_SELECT);
+            expect(wrapper.find(SELECT_ALL_BTN).exists()).toBe(false);
+
+            await wrapper.setProps({ totalItemsInQuery: 1000 });
+            expect(wrapper.find(SELECT_ALL_BTN).exists()).toBe(true);
+        });
+
+        it("should emit the expected event when pressed", async () => {
+            const wrapper = await mountHistorySelectionStatusWith(ONE_ITEM_SELECTED);
+            await expectWrapperButtonToEmitEvent(wrapper, SELECT_ALL_BTN, "select-all");
+        });
+    });
+
+    describe("Selection Status", () => {
+        it("should display empty selection status when nothing is selected", async () => {
+            const wrapper = await mountHistorySelectionStatusWith(NOTHING_SELECTED);
+            expect(wrapper.find(EMPTY_SELECTION_STATUS).exists()).toBe(true);
+            expect(wrapper.find(ALL_ACTIVE_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(ALL_IN_FILTER_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(NUM_ACTIVE_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(NUM_IN_FILTER_SELECTED_STATUS).exists()).toBe(false);
+        });
+
+        it("should display all items selected status when all items in query are selected", async () => {
+            const wrapper = await mountHistorySelectionStatusWith(ALL_ITEMS_SELECTED);
+            expect(wrapper.find(EMPTY_SELECTION_STATUS).exists()).toBe(false);
+            expect(wrapper.find(ALL_ACTIVE_SELECTED_STATUS).exists()).toBe(true);
+            expect(wrapper.find(ALL_IN_FILTER_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(NUM_ACTIVE_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(NUM_IN_FILTER_SELECTED_STATUS).exists()).toBe(false);
+
+            await wrapper.setProps({ hasFilters: true });
+            expect(wrapper.find(EMPTY_SELECTION_STATUS).exists()).toBe(false);
+            expect(wrapper.find(ALL_ACTIVE_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(ALL_IN_FILTER_SELECTED_STATUS).exists()).toBe(true);
+            expect(wrapper.find(NUM_ACTIVE_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(NUM_IN_FILTER_SELECTED_STATUS).exists()).toBe(false);
+        });
+
+        it("should display number of items selected when some items in query are selected", async () => {
+            const wrapper = await mountHistorySelectionStatusWith(SOME_ITEMS_IN_QUERY_SELECTED);
+            expect(wrapper.find(EMPTY_SELECTION_STATUS).exists()).toBe(false);
+            expect(wrapper.find(ALL_ACTIVE_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(ALL_IN_FILTER_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(NUM_ACTIVE_SELECTED_STATUS).exists()).toBe(true);
+            expect(wrapper.find(NUM_IN_FILTER_SELECTED_STATUS).exists()).toBe(false);
+
+            await wrapper.setProps({ hasFilters: true });
+            expect(wrapper.find(EMPTY_SELECTION_STATUS).exists()).toBe(false);
+            expect(wrapper.find(ALL_ACTIVE_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(ALL_IN_FILTER_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(NUM_ACTIVE_SELECTED_STATUS).exists()).toBe(false);
+            expect(wrapper.find(NUM_IN_FILTER_SELECTED_STATUS).exists()).toBe(true);
+        });
+    });
+});
+
+async function expectWrapperButtonToEmitEvent(wrapper, buttonSelector, expectedEvent) {
+    expect(wrapper.emitted()).not.toHaveProperty(expectedEvent);
+    await wrapper.find(buttonSelector).trigger("click");
+    expect(wrapper.emitted()).toHaveProperty(expectedEvent);
+}

--- a/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
+++ b/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
@@ -32,7 +32,7 @@ export default {
         },
         /** @returns {Boolean} */
         canSelectAll() {
-            return !this.selectionMatchesQuery;
+            return this.queryMatchesItems && !this.selectionMatchesQuery;
         },
         /** @returns {Boolean} */
         selectAllOptionText() {
@@ -45,14 +45,15 @@ export default {
             if (this.isQuerySelection) {
                 return true;
             }
-            return this.hasFilters
-                ? this.numTotalItemsInCurrentSearch === this.selectionSize
-                : this.numTotalItemsInHistory === this.selectionSize;
+            return this.queryMatchesItems && this.totalItemsInQuery === this.selectionSize;
+        },
+        queryMatchesItems() {
+            return !isNaN(this.totalItemsInQuery);
         },
     },
     methods: {
         onSelectAllItemsInQuery() {
-            this.$emit("select-all", this.numTotalItemsInHistory);
+            this.$emit("select-all", this.totalItemsInQuery);
         },
         clearSelection() {
             this.$emit("clear-selection");

--- a/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
+++ b/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
@@ -47,6 +47,7 @@ export default {
             }
             return this.queryMatchesItems && this.totalItemsInQuery === this.selectionSize;
         },
+        /** @returns {Boolean} */
         queryMatchesItems() {
             return !isNaN(this.totalItemsInQuery);
         },

--- a/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
+++ b/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
@@ -1,0 +1,62 @@
+<template>
+    <div class="text-center">
+        <div v-if="!hasSelection">No items selected</div>
+        <div v-else>
+            <div v-if="isQuerySelection">
+                <div v-if="hasFilters">All {{ totalItemsInQuery }} items that match the filters are selected</div>
+                <div v-else>All {{ totalItemsInQuery }} active items in history are selected</div>
+            </div>
+            <div v-else>{{ selectionSize }} items selected</div>
+        </div>
+        <div v-if="canSelectAll">
+            <b-link @click="onSelectAllItemsInQuery">
+                {{ selectAllOptionText }}
+            </b-link>
+        </div>
+        <b-link v-if="hasSelection" @click="clearSelection"> Clear selection </b-link>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        hasFilters: { type: Boolean, required: true },
+        isQuerySelection: { type: Boolean, required: true },
+        selectionSize: { type: Number, required: true },
+        totalItemsInQuery: { type: Number, required: true },
+    },
+    computed: {
+        /** @returns {Boolean} */
+        hasSelection() {
+            return this.selectionSize > 0;
+        },
+        /** @returns {Boolean} */
+        canSelectAll() {
+            return !this.selectionMatchesQuery;
+        },
+        /** @returns {Boolean} */
+        selectAllOptionText() {
+            return this.hasFilters
+                ? `Select all ${this.totalItemsInQuery} items that match the current filters`
+                : `Select all ${this.totalItemsInQuery} active items in history`;
+        },
+        /** @returns {Boolean} */
+        selectionMatchesQuery() {
+            if (this.isQuerySelection) {
+                return true;
+            }
+            return this.hasFilters
+                ? this.numTotalItemsInCurrentSearch === this.selectionSize
+                : this.numTotalItemsInHistory === this.selectionSize;
+        },
+    },
+    methods: {
+        onSelectAllItemsInQuery() {
+            this.$emit("select-all", this.numTotalItemsInHistory);
+        },
+        clearSelection() {
+            this.$emit("clear-selection");
+        },
+    },
+};
+</script>

--- a/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
+++ b/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
@@ -1,19 +1,33 @@
 <template>
-    <div class="text-center">
-        <div v-if="!hasSelection">No items selected</div>
-        <div v-else>
-            <div v-if="isQuerySelection">
-                <div v-if="hasFilters">All {{ totalItemsInQuery }} items that match the filters are selected</div>
-                <div v-else>All {{ totalItemsInQuery }} active items in history are selected</div>
+    <div class="text-center p-0">
+        <div v-if="canSelectAll || hasSelection">
+            <b-button-group size="sm" class="mb-2">
+                <b-button v-if="canSelectAll" @click="selectAllItemsInQuery">Select All</b-button>
+                <b-button v-if="hasSelection" @click="clearSelection">Clear selection</b-button>
+            </b-button-group>
+        </div>
+
+        <b-alert show :variant="selectionAlertVariant" class="mb-0 p-2">
+            <div v-if="!hasSelection">No items selected</div>
+            <div v-else>
+                <div v-if="isQuerySelection">
+                    <div v-if="hasFilters">
+                        All <b>{{ totalItemsInQuery }}</b> items that match the filters are selected
+                    </div>
+                    <div v-else>
+                        All <b>{{ totalItemsInQuery }}</b> active items in history are selected
+                    </div>
+                </div>
+                <div v-else>
+                    <div v-if="hasFilters">
+                        <b>{{ selectionSize }}</b> of {{ totalItemsInQuery }} items that match the filters are selected
+                    </div>
+                    <div v-else>
+                        <b>{{ selectionSize }}</b> of {{ totalItemsInQuery }} active items in history are selected
+                    </div>
+                </div>
             </div>
-            <div v-else>{{ selectionSize }} items selected</div>
-        </div>
-        <div v-if="canSelectAll">
-            <b-link @click="onSelectAllItemsInQuery">
-                {{ selectAllOptionText }}
-            </b-link>
-        </div>
-        <b-link v-if="hasSelection" @click="clearSelection"> Clear selection </b-link>
+        </b-alert>
     </div>
 </template>
 
@@ -32,29 +46,20 @@ export default {
         },
         /** @returns {Boolean} */
         canSelectAll() {
-            return this.queryMatchesItems && !this.selectionMatchesQuery;
-        },
-        /** @returns {Boolean} */
-        selectAllOptionText() {
-            return this.hasFilters
-                ? `Select all ${this.totalItemsInQuery} items that match the current filters`
-                : `Select all ${this.totalItemsInQuery} active items in history`;
+            return !this.selectionMatchesQuery;
         },
         /** @returns {Boolean} */
         selectionMatchesQuery() {
-            if (this.isQuerySelection) {
-                return true;
-            }
-            return this.queryMatchesItems && this.totalItemsInQuery === this.selectionSize;
+            return this.totalItemsInQuery === this.selectionSize;
         },
-        /** @returns {Boolean} */
-        queryMatchesItems() {
-            return !isNaN(this.totalItemsInQuery);
+        /** @returns {String} */
+        selectionAlertVariant() {
+            return this.hasSelection ? "info" : "secondary";
         },
     },
     methods: {
-        onSelectAllItemsInQuery() {
-            this.$emit("select-all", this.totalItemsInQuery);
+        selectAllItemsInQuery() {
+            this.$emit("select-all");
         },
         clearSelection() {
             this.$emit("clear-selection");

--- a/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
+++ b/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
@@ -2,27 +2,31 @@
     <div class="text-center p-0">
         <div v-if="canSelectAll || hasSelection">
             <b-button-group size="sm" class="mb-2">
-                <b-button v-if="canSelectAll" @click="selectAllItemsInQuery">Select All</b-button>
-                <b-button v-if="hasSelection" @click="clearSelection">Clear selection</b-button>
+                <b-button v-if="canSelectAll" @click="selectAllItemsInQuery" data-test-id="select-all-btn">
+                    Select All
+                </b-button>
+                <b-button v-if="hasSelection" @click="clearSelection" data-test-id="clear-btn">
+                    Clear selection
+                </b-button>
             </b-button-group>
         </div>
 
         <b-alert show :variant="selectionAlertVariant" class="mb-0 p-2">
-            <div v-if="!hasSelection">No items selected</div>
+            <div v-if="!hasSelection" data-test-id="empty-selection">No items selected</div>
             <div v-else>
                 <div v-if="selectionMatchesQuery">
-                    <div v-if="hasFilters">
+                    <div v-if="hasFilters" data-test-id="all-filter-selected">
                         All <b>{{ totalItemsInQuery }}</b> items that match the filters are selected
                     </div>
-                    <div v-else>
+                    <div v-else data-test-id="all-active-selected">
                         All <b>{{ totalItemsInQuery }}</b> active items in history are selected
                     </div>
                 </div>
                 <div v-else>
-                    <div v-if="hasFilters">
+                    <div v-if="hasFilters" data-test-id="num-filter-selected">
                         <b>{{ selectionSize }}</b> of {{ totalItemsInQuery }} items that match the filters are selected
                     </div>
-                    <div v-else>
+                    <div v-else data-test-id="num-active-selected">
                         <b>{{ selectionSize }}</b> of {{ totalItemsInQuery }} active items in history are selected
                     </div>
                 </div>
@@ -32,6 +36,11 @@
 </template>
 
 <script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+
+Vue.use(BootstrapVue);
+
 export default {
     props: {
         hasFilters: { type: Boolean, required: true },

--- a/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
+++ b/client/src/components/History/CurrentHistory/HistorySelectionStatus.vue
@@ -10,7 +10,7 @@
         <b-alert show :variant="selectionAlertVariant" class="mb-0 p-2">
             <div v-if="!hasSelection">No items selected</div>
             <div v-else>
-                <div v-if="isQuerySelection">
+                <div v-if="selectionMatchesQuery">
                     <div v-if="hasFilters">
                         All <b>{{ totalItemsInQuery }}</b> items that match the filters are selected
                     </div>
@@ -35,7 +35,6 @@
 export default {
     props: {
         hasFilters: { type: Boolean, required: true },
-        isQuerySelection: { type: Boolean, required: true },
         selectionSize: { type: Number, required: true },
         totalItemsInQuery: { type: Number, required: true },
     },

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -4,40 +4,40 @@ import { bulkUpdate } from "./queries";
  * Content operations
  */
 
-export async function hideSelectedContent(history, type_ids, filterParams) {
-    return await bulkUpdate(history, "hide", type_ids, filterParams);
+export async function hideSelectedContent(history, filters, items) {
+    return await bulkUpdate(history, "hide", filters, items);
 }
 
-export async function unhideSelectedContent(history, type_ids, filterParams) {
-    return await bulkUpdate(history, "unhide", type_ids, filterParams);
+export async function unhideSelectedContent(history, filters, items) {
+    return await bulkUpdate(history, "unhide", filters, items);
 }
 
-export async function deleteSelectedContent(history, type_ids, filterParams) {
-    return await bulkUpdate(history, "delete", type_ids, filterParams);
+export async function deleteSelectedContent(history, filters, items) {
+    return await bulkUpdate(history, "delete", filters, items);
 }
 
-export async function undeleteSelectedContent(history, type_ids, filterParams) {
-    return await bulkUpdate(history, "undelete", type_ids, filterParams);
+export async function undeleteSelectedContent(history, filters, items) {
+    return await bulkUpdate(history, "undelete", filters, items);
 }
 
-export async function purgeSelectedContent(history, type_ids, filterParams) {
-    return await bulkUpdate(history, "purge", type_ids, filterParams);
+export async function purgeSelectedContent(history, filters, items) {
+    return await bulkUpdate(history, "purge", filters, items);
 }
 
 export async function unhideAllHiddenContent(history) {
-    const type_ids = [];
-    const filterParams = { filterText: "", showDeleted: false, showHidden: true };
-    return await unhideSelectedContent(history, type_ids, filterParams);
+    const filters = [["visible", false]];
+    return await unhideSelectedContent(history, filters);
 }
 
 export async function deleteAllHiddenContent(history) {
-    const type_ids = [];
-    const filterParams = { filterText: "", showDeleted: false, showHidden: true };
-    return await deleteSelectedContent(history, type_ids, filterParams);
+    const filters = [
+        ["deleted", false],
+        ["visible", false],
+    ];
+    return await deleteSelectedContent(history, filters);
 }
 
 export async function purgeAllDeletedContent(history) {
-    const type_ids = [];
-    const filterParams = { filterText: "", showDeleted: true, showHidden: false };
-    return await purgeSelectedContent(history, type_ids, filterParams);
+    const filters = [["deleted", true]];
+    return await purgeSelectedContent(history, filters);
 }

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -1,4 +1,4 @@
-import { bulkUpdate, getAllContentByFilter } from "./queries";
+import { bulkUpdate } from "./queries";
 
 /**
  * Content operations
@@ -25,31 +25,19 @@ export async function purgeSelectedContent(history, type_ids, filterParams) {
 }
 
 export async function unhideAllHiddenContent(history) {
-    const filter = { visible: false };
-    const selection = await getAllContentByFilter(history, filter);
-    if (selection.length) {
-        const type_ids = selection.map((c) => c.type_id);
-        return await unhideSelectedContent(history, type_ids);
-    }
-    return [];
+    const type_ids = [];
+    const filterParams = { filterText: "", showDeleted: false, showHidden: true };
+    return await unhideSelectedContent(history, type_ids, filterParams);
 }
 
 export async function deleteAllHiddenContent(history) {
-    const filter = { visible: false };
-    const selection = await getAllContentByFilter(history, filter);
-    if (selection.length) {
-        const type_ids = selection.map((c) => c.type_id);
-        return await deleteSelectedContent(history, type_ids);
-    }
-    return [];
+    const type_ids = [];
+    const filterParams = { filterText: "", showDeleted: false, showHidden: true };
+    return await deleteSelectedContent(history, type_ids, filterParams);
 }
 
 export async function purgeAllDeletedContent(history) {
-    const filter = { deleted: true, purged: false };
-    const selection = await getAllContentByFilter(history, filter);
-    if (selection.length) {
-        const type_ids = selection.map((c) => c.type_id);
-        return await purgeSelectedContent(history, type_ids);
-    }
-    return [];
+    const type_ids = [];
+    const filterParams = { filterText: "", showDeleted: true, showHidden: false };
+    return await purgeSelectedContent(history, type_ids, filterParams);
 }

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -25,19 +25,16 @@ export async function purgeSelectedContent(history, filters, items) {
 }
 
 export async function unhideAllHiddenContent(history) {
-    const filters = [["visible", false]];
+    const filters = { visible: false };
     return await unhideSelectedContent(history, filters);
 }
 
 export async function deleteAllHiddenContent(history) {
-    const filters = [
-        ["deleted", false],
-        ["visible", false],
-    ];
+    const filters = { deleted: false, visible: false };
     return await deleteSelectedContent(history, filters);
 }
 
 export async function purgeAllDeletedContent(history) {
-    const filters = [["deleted", true]];
+    const filters = { deleted: true };
     return await purgeSelectedContent(history, filters);
 }

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -1,38 +1,27 @@
-import { contentUpdate, getAllContentByFilter } from "./queries";
+import { bulkUpdate, getAllContentByFilter } from "./queries";
 
 /**
  * Content operations
  */
 
-export async function hideSelectedContent(history, type_ids) {
-    return await contentUpdate(history, type_ids, {
-        visible: false,
-    });
+export async function hideSelectedContent(history, type_ids, filterParams) {
+    return await bulkUpdate(history, "hide", type_ids, filterParams);
 }
 
-export async function unhideSelectedContent(history, type_ids) {
-    return await contentUpdate(history, type_ids, {
-        visible: true,
-    });
+export async function unhideSelectedContent(history, type_ids, filterParams) {
+    return await bulkUpdate(history, "unhide", type_ids, filterParams);
 }
 
-export async function deleteSelectedContent(history, type_ids) {
-    return await contentUpdate(history, type_ids, {
-        deleted: true,
-    });
+export async function deleteSelectedContent(history, type_ids, filterParams) {
+    return await bulkUpdate(history, "delete", type_ids, filterParams);
 }
 
-export async function undeleteSelectedContent(history, type_ids) {
-    return await contentUpdate(history, type_ids, {
-        deleted: false,
-    });
+export async function undeleteSelectedContent(history, type_ids, filterParams) {
+    return await bulkUpdate(history, "undelete", type_ids, filterParams);
 }
 
-export async function purgeSelectedContent(history, type_ids) {
-    return await contentUpdate(history, type_ids, {
-        deleted: true,
-        purged: true,
-    });
+export async function purgeSelectedContent(history, type_ids, filterParams) {
+    return await bulkUpdate(history, "purge", type_ids, filterParams);
 }
 
 export async function unhideAllHiddenContent(history) {

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -8,7 +8,6 @@
 import axios from "axios";
 import moment from "moment";
 import { prependPath } from "utils/redirect";
-import { getQueryDictFromFilters } from "../../../store/historyStore/historyItemsFiltering";
 import { History } from "./History";
 
 // #region setup & utils
@@ -37,9 +36,8 @@ const doResponse = (response) => {
  * Legacy query string rendering. (generates q/qv syntax queries).
  * TODO: remove these converters when the api is modernized.
  */
-function buildLegacyQueryStringFrom(filters) {
-    const filterDict = getQueryDictFromFilters(filters);
-    const queryString = Object.entries(filterDict)
+function buildQueryStringFrom(filters) {
+    const queryString = Object.entries(filters)
         .map(([f, v]) => `q=${f}&qv=${v}`)
         .join("&");
     return queryString;
@@ -256,7 +254,7 @@ export async function updateContentFields(content, newFields = {}) {
  */
 export async function bulkUpdate(history, operation, filters, items = []) {
     const { id } = history;
-    const filterQuery = buildLegacyQueryStringFrom(filters);
+    const filterQuery = buildQueryStringFrom(filters);
     const url = `/histories/${id}/contents/bulk?${filterQuery}`;
     const payload = {
         operation,

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -47,19 +47,9 @@ function buildLegacyQueryStringFrom(filters) {
 
 function buildLegacyParam(fields = {}) {
     return Object.keys(fields).reduce((result, key) => {
-        result[key] = pythonBooleanFormat(fields[key]);
+        result[key] = fields[key];
         return result;
     }, {});
-}
-
-function pythonBooleanFormat(val) {
-    if (val === true) {
-        return "True";
-    }
-    if (val === false) {
-        return "False";
-    }
-    return val;
 }
 
 /**

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -36,15 +36,13 @@ const doResponse = (response) => {
 /**
  * Legacy query string rendering. (generates q/qv syntax queries).
  * TODO: remove these converters when the api is modernized.
- *
- * @param {Object} fields Object with parameters to pass to our dumb api
  */
-
-function buildLegacyQueryString(fields = {}) {
-    const badParams = buildLegacyParam(fields);
-    return Object.keys(badParams)
-        .map((key) => `q=${key}&qv=${badParams[key]}`)
+function buildLegacyQueryStringFrom(filters) {
+    const filterDict = getQueryDictFromFilters(filters);
+    const queryString = Object.entries(filterDict)
+        .map(([f, v]) => `q=${f}&qv=${v}`)
         .join("&");
+    return queryString;
 }
 
 function buildLegacyParam(fields = {}) {
@@ -62,14 +60,6 @@ function pythonBooleanFormat(val) {
         return "False";
     }
     return val;
-}
-
-function buildLegacyQueryStringFrom(filters) {
-    const filterDict = getQueryDictFromFilters(filters);
-    const queryString = Object.entries(filterDict)
-        .map(([f, v]) => `q=${f}&qv=${v}`)
-        .join("&");
-    return queryString;
 }
 
 /**
@@ -221,23 +211,6 @@ export async function setCurrentHistoryOnServer(history_id) {
 /**
  * Content Queries
  */
-
-/**
- * Generic content query function originally intended to help with bulk updates
- * so we don't have to go through the legacy /history endpoints and
- * can stay in the /api as much as possible.
- *
- * @param {*} history
- * @param {*} filterParams
- */
-export async function getAllContentByFilter(history, filterParams = {}) {
-    const { id } = history;
-    const strFilter = buildLegacyQueryString(filterParams);
-    const params = { v: "dev", view: "summary", keys: "file_size,accessible,creating_job,job_source_id" };
-    const url = `/histories/${id}/contents?${strFilter}`;
-    const response = await api.get(url, { params });
-    return doResponse(response);
-}
 
 /**
  * Given a content object, retrieve the detailed dataset or collection

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -43,13 +43,6 @@ function buildQueryStringFrom(filters) {
     return queryString;
 }
 
-function buildLegacyParam(fields = {}) {
-    return Object.keys(fields).reduce((result, key) => {
-        result[key] = fields[key];
-        return result;
-    }, {});
-}
-
 /**
  * Some of the current endpoints don't accept JSON, so we need to
  * do some massaging to send in old form post data.
@@ -201,19 +194,6 @@ export async function setCurrentHistoryOnServer(history_id) {
  */
 
 /**
- * Given a content object, retrieve the detailed dataset or collection
- * object by looking at the url prop of the content
- * @param {Object} content Content object
- * @param {Object} params key/value search parameters
- */
-export async function getContentDetails(content, params = {}) {
-    const { history_id, id, history_content_type } = content;
-    const url = `/histories/${history_id}/contents/${history_content_type}s/${id}`;
-    const response = await api.get(url, { params });
-    return doResponse(response);
-}
-
-/**
  * Deletes item from history
  *
  * @param {Object} content Content object
@@ -282,14 +262,6 @@ export async function createDatasetCollection(history, inputs = {}) {
     const payload = Object.assign({}, defaults, inputs);
     const url = `/histories/${history.id}/contents`;
     const response = await api.post(url, payload);
-    return doResponse(response);
-}
-
-export async function deleteDatasetCollection(collection, recursive = false, purge = false) {
-    const { history_id, id } = collection;
-    const url = `/histories/${history_id}/contents/dataset_collections/${id}`;
-    const params = buildLegacyParam({ recursive, purge });
-    const response = await api.delete(url, { params });
     return doResponse(response);
 }
 

--- a/client/src/components/providers/storeProviders.js
+++ b/client/src/components/providers/storeProviders.js
@@ -1,8 +1,8 @@
 // Simple dataset provider, looks at api for result, renders to slot prop
 import axios from "axios";
 import { prependPath } from "utils/redirect";
-import { mapCacheActions } from "vuex-cache";
 import { mapActions, mapGetters } from "vuex";
+import { mapCacheActions } from "vuex-cache";
 
 export const SimpleProviderMixin = {
     props: {
@@ -131,9 +131,9 @@ export const JobProvider = {
  * Provider component interface to the actual stores i.e. history items and collection elements stores.
  * @param {String} storeAction The store action is executed when the consuming component e.g. the history panel, changes the provider props.
  * @param {String} storeGetter The store getter passes its result to the slot of the corresponding provider.
- * @param {String} queryStatsGetter The query stats store getter passes its matches counts to the slot of the corresponding provider.
+ * @param {String} storeCountGetter The query stats store getter passes its matches counts to the slot of the corresponding provider.
  */
-export const StoreProvider = (storeAction, storeGetter, queryStatsGetter = undefined) => {
+export const StoreProvider = (storeAction, storeGetter, storeCountGetter = undefined) => {
     return {
         watch: {
             $attrs() {
@@ -150,15 +150,15 @@ export const StoreProvider = (storeAction, storeGetter, queryStatsGetter = undef
             this.load();
         },
         computed: {
-            ...mapGetters([storeGetter, queryStatsGetter]),
+            ...mapGetters([storeGetter, storeCountGetter]),
             attributes() {
                 return this.toCamelCase(this.$attrs);
             },
             result() {
                 return this[storeGetter](this.attributes);
             },
-            totalMatches() {
-                return queryStatsGetter ? this[queryStatsGetter]() : undefined;
+            count() {
+                return storeCountGetter ? this[storeCountGetter]() : undefined;
             },
         },
         render() {
@@ -166,7 +166,7 @@ export const StoreProvider = (storeAction, storeGetter, queryStatsGetter = undef
                 error: this.error,
                 loading: this.loading,
                 result: this.result,
-                totalMatches: this.totalMatches,
+                count: this.count,
             });
         },
         methods: {
@@ -196,4 +196,4 @@ export const StoreProvider = (storeAction, storeGetter, queryStatsGetter = undef
 
 export const DatasetProvider = StoreProvider("fetchDataset", "getDataset");
 export const CollectionElementsProvider = StoreProvider("fetchCollectionElements", "getCollectionElements");
-export const HistoryItemsProvider = StoreProvider("fetchHistoryItems", "getHistoryItems", "getQueryStats");
+export const HistoryItemsProvider = StoreProvider("fetchHistoryItems", "getHistoryItems", "getTotalMatchesCount");

--- a/client/src/components/providers/storeProviders.js
+++ b/client/src/components/providers/storeProviders.js
@@ -129,10 +129,11 @@ export const JobProvider = {
 
 /**
  * Provider component interface to the actual stores i.e. history items and collection elements stores.
- * @param {String} This store action is executed when the consuming component e.g. the history panel, changes the provider props.
- * @param {String} This store getter passes its result to the slot of the corresponding provider.
+ * @param {String} storeAction The store action is executed when the consuming component e.g. the history panel, changes the provider props.
+ * @param {String} storeGetter The store getter passes its result to the slot of the corresponding provider.
+ * @param {String} queryStatsGetter The query stats store getter passes its matches counts to the slot of the corresponding provider.
  */
-export const StoreProvider = (storeAction, storeGetter) => {
+export const StoreProvider = (storeAction, storeGetter, queryStatsGetter = undefined) => {
     return {
         watch: {
             $attrs() {
@@ -149,12 +150,15 @@ export const StoreProvider = (storeAction, storeGetter) => {
             this.load();
         },
         computed: {
-            ...mapGetters([storeGetter]),
+            ...mapGetters([storeGetter, queryStatsGetter]),
             attributes() {
                 return this.toCamelCase(this.$attrs);
             },
             result() {
                 return this[storeGetter](this.attributes);
+            },
+            totalMatches() {
+                return queryStatsGetter ? this[queryStatsGetter]() : undefined;
             },
         },
         render() {
@@ -162,6 +166,7 @@ export const StoreProvider = (storeAction, storeGetter) => {
                 error: this.error,
                 loading: this.loading,
                 result: this.result,
+                totalMatches: this.totalMatches,
             });
         },
         methods: {
@@ -191,4 +196,4 @@ export const StoreProvider = (storeAction, storeGetter) => {
 
 export const DatasetProvider = StoreProvider("fetchDataset", "getDataset");
 export const CollectionElementsProvider = StoreProvider("fetchCollectionElements", "getCollectionElements");
-export const HistoryItemsProvider = StoreProvider("fetchHistoryItems", "getHistoryItems");
+export const HistoryItemsProvider = StoreProvider("fetchHistoryItems", "getHistoryItems", "getQueryStats");

--- a/client/src/store/historyStore/historyItemsFiltering.js
+++ b/client/src/store/historyStore/historyItemsFiltering.js
@@ -10,22 +10,22 @@
  * Use quotations (') around values containing spaces.
  */
 
-/* Converts user input to backend compatible date. */
+/** Converts user input to backend compatible date. */
 function toDate(value) {
     return Date.parse(value) / 1000;
 }
 
-/* Converts user input for case-insensitive filtering. */
+/** Converts user input for case-insensitive filtering. */
 function toLower(value) {
     return String(value).toLowerCase();
 }
 
-/* Converts user input to python boolean. */
+/** Converts user input to python boolean. */
 function toBoolPython(value) {
     return toLower(value) == "true" ? "True" : "False";
 }
 
-/* Converts user input to lower case and strips quotation marks. */
+/** Converts user input to lower case and strips quotation marks. */
 function toLowerNoQuotes(value) {
     return toLower(value).replaceAll("'", "");
 }
@@ -90,7 +90,7 @@ function compare(attribute, variant, converter = null) {
     };
 }
 
-/* Valid filter fields and handlers which can be used for text searches. */
+/** Valid filter fields and handlers which can be used for text searches. */
 const validFilters = {
     create_time: compare("create_time", "le", toDate),
     create_time_ge: compare("create_time", "ge", toDate),
@@ -115,19 +115,19 @@ const validFilters = {
     update_time_lt: compare("update_time", "lt", toDate),
 };
 
-/* Default filters are set, unless explicitly specified by the user. */
+/** Default filters are set, unless explicitly specified by the user. */
 const defaultFilters = {
     deleted: false,
     visible: true,
 };
 
-/* Add comparison aliases i.e. '*>value' is converted to '*_gt=value' */
+/** Add comparison aliases i.e. '*>value' is converted to '*_gt=value' */
 const validAlias = [
     [">", "_gt"],
     ["<", "_lt"],
 ];
 
-/* Check the value of a particular filter. */
+/** Check the value of a particular filter. */
 export function checkFilter(filterText, filterName, filterValue) {
     const re = new RegExp(`${filterName}=(\\S+)`);
     const reMatch = re.exec(filterText);
@@ -135,7 +135,7 @@ export function checkFilter(filterText, filterName, filterValue) {
     return toLowerNoQuotes(testValue) == toLowerNoQuotes(filterValue);
 }
 
-/* Parses single text input into a dict of field->value pairs. */
+/** Parses single text input into a dict of field->value pairs. */
 export function getFilters(filterText) {
     const pairSplitRE = /[^\s']+(?:'[^']*'[^\s']*)*|(?:'[^']*'[^\s']*)+/g;
     const result = {};
@@ -177,10 +177,19 @@ export function getFilters(filterText) {
     return Object.entries(result);
 }
 
-/* Returns a dictionary with query key and values. */
+/** Returns a dictionary with query key and values.
+ * @param {String} filterText The raw filter text
+ */
 export function getQueryDict(filterText) {
-    const queryDict = {};
     const filters = getFilters(filterText);
+    return getQueryDictFromFilters(filters);
+}
+
+/** Returns a dictionary with query key and values.
+ * @param {*} filters An array of [key, value] pairs with filter keys and values.
+ */
+export function getQueryDictFromFilters(filters) {
+    const queryDict = {};
     for (const [key, value] of filters) {
         const query = validFilters[key].query;
         const converter = validFilters[key].converter;
@@ -189,7 +198,7 @@ export function getQueryDict(filterText) {
     return queryDict;
 }
 
-/* Test if an item passes all filters. */
+/** Test if an item passes all filters. */
 export function testFilters(filters, item) {
     for (const [key, filterValue] of filters) {
         const filterAttribute = validFilters[key].attribute;

--- a/client/src/store/historyStore/historyItemsFiltering.js
+++ b/client/src/store/historyStore/historyItemsFiltering.js
@@ -181,15 +181,8 @@ export function getFilters(filterText) {
  * @param {String} filterText The raw filter text
  */
 export function getQueryDict(filterText) {
-    const filters = getFilters(filterText);
-    return getQueryDictFromFilters(filters);
-}
-
-/** Returns a dictionary with query key and values.
- * @param {*} filters An array of [key, value] pairs with filter keys and values.
- */
-export function getQueryDictFromFilters(filters) {
     const queryDict = {};
+    const filters = getFilters(filterText);
     for (const [key, value] of filters) {
         const query = validFilters[key].query;
         const converter = validFilters[key].converter;

--- a/client/src/store/historyStore/historyItemsFiltering.js
+++ b/client/src/store/historyStore/historyItemsFiltering.js
@@ -20,9 +20,9 @@ function toLower(value) {
     return String(value).toLowerCase();
 }
 
-/** Converts user input to python boolean. */
-function toBoolPython(value) {
-    return toLower(value) == "true" ? "True" : "False";
+/** Converts user input to boolean. */
+function toBool(value) {
+    return toLower(value) == "true";
 }
 
 /** Converts user input to lower case and strips quotation marks. */
@@ -97,14 +97,14 @@ const validFilters = {
     create_time_gt: compare("create_time", "gt", toDate),
     create_time_le: compare("create_time", "le", toDate),
     create_time_lt: compare("create_time", "lt", toDate),
-    deleted: equals("deleted", "deleted", toBoolPython),
+    deleted: equals("deleted", "deleted", toBool),
     extension: equals("extension"),
     hid: equals("hid"),
     hid_ge: compare("hid", "ge"),
     hid_gt: compare("hid", "gt"),
     hid_le: compare("hid", "le"),
     hid_lt: compare("hid", "lt"),
-    visible: equals("visible", "visible", toBoolPython),
+    visible: equals("visible", "visible", toBool),
     name: contains("name"),
     state: equals("state"),
     tag: contains("tags", "tag"),

--- a/client/src/store/historyStore/historyItemsFiltering.test.js
+++ b/client/src/store/historyStore/historyItemsFiltering.test.js
@@ -55,8 +55,8 @@ describe("historyItemsFiltering", () => {
             expect(queryDict["state-eq"]).toBe("success");
             expect(queryDict["extension-eq"]).toBe("ext");
             expect(queryDict["tag"]).toBe("first");
-            expect(queryDict["deleted"]).toBe("False");
-            expect(queryDict["visible"]).toBe("True");
+            expect(queryDict["deleted"]).toBe(false);
+            expect(queryDict["visible"]).toBe(true);
         });
     });
     test("validate filtering of a history item", () => {

--- a/client/src/store/historyStore/historyItemsStore.js
+++ b/client/src/store/historyStore/historyItemsStore.js
@@ -15,7 +15,7 @@ const queue = new LastQueue();
 const state = {
     items: {},
     itemKey: "hid",
-    totalMatches: undefined,
+    totalMatchesCount: undefined,
 };
 
 const getters = {
@@ -35,8 +35,8 @@ const getters = {
             });
             return reverse(filtered);
         },
-    getQueryStats: (state) => () => {
-        return state.totalMatches;
+    getTotalMatchesCount: (state) => () => {
+        return state.totalMatchesCount;
     },
 };
 
@@ -69,7 +69,7 @@ const mutations = {
     },
     saveQueryStats: (state, { headers }) => {
         const totalMatches = headers["total_matches"];
-        state.totalMatches = Number(totalMatches);
+        state.totalMatchesCount = Number(totalMatches);
     },
 };
 

--- a/client/src/utils/url.js
+++ b/client/src/utils/url.js
@@ -4,9 +4,20 @@ import { rethrowSimple } from "utils/simple-error";
 
 export async function urlData({ url }) {
     try {
-        console.debug("Requesting data from: ", url);
         const { data } = await axios.get(`${getAppRoot()}${url}`);
         return data;
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}
+
+export async function urlDataWithHeaders({ url }) {
+    try {
+        const response = await axios.get(`${getAppRoot()}${url}`);
+        return {
+            data: response.data,
+            headers: response.headers,
+        };
     } catch (e) {
         rethrowSimple(e);
     }

--- a/client/src/utils/url.js
+++ b/client/src/utils/url.js
@@ -2,22 +2,11 @@ import axios from "axios";
 import { getAppRoot } from "onload/loadConfig";
 import { rethrowSimple } from "utils/simple-error";
 
-export async function urlData({ url }) {
+export async function urlData({ url, headers }) {
     try {
-        const { data } = await axios.get(`${getAppRoot()}${url}`);
+        headers = headers || {};
+        const { data } = await axios.get(`${getAppRoot()}${url}`, { headers });
         return data;
-    } catch (e) {
-        rethrowSimple(e);
-    }
-}
-
-export async function urlDataWithHeaders({ url }) {
-    try {
-        const response = await axios.get(`${getAppRoot()}${url}`);
-        return {
-            data: response.data,
-            headers: response.headers,
-        };
     } catch (e) {
         rethrowSimple(e);
     }

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -1252,9 +1252,9 @@ def parse_bool(bool_string: Union[str, bool]) -> bool:
     Parse a boolean from a string.
     """
     # Be strict here to remove complexity of options (but allow already parsed).
-    if bool_string in ("True", True):
+    if bool_string in ("True", "true", True):
         return True
-    if bool_string in ("False", False):
+    if bool_string in ("False", "false", False):
         return False
     raise ValueError(f"invalid boolean: {bool_string}")
 

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -1246,6 +1246,10 @@ class ModelFilterParser(HasAModelManager):
             return date_string
         raise ValueError("datetime strings must be in the ISO 8601 format and in the UTC")
 
+    def contains_non_orm_filter(self, filters: List[ParsedFilter]) -> bool:
+        """Whether the list of filters contains any non-orm filter."""
+        return any(filter.filter_type == "function" for filter in filters)
+
 
 def parse_bool(bool_string: Union[str, bool]) -> bool:
     """

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -53,7 +53,7 @@ from galaxy import (
     model,
 )
 from galaxy.model import tool_shed_install
-from galaxy.schema import FilterQueryParams
+from galaxy.schema import ValueFilterQueryParams
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import (
     BasicSharedApp,
@@ -1028,7 +1028,7 @@ class ModelFilterParser(HasAModelManager):
 
     def build_filter_params(
         self,
-        query_params: FilterQueryParams,
+        query_params: ValueFilterQueryParams,
         filter_attr_key: str = "q",
         filter_value_key: str = "qv",
         attr_op_split_char: str = "-",
@@ -1064,8 +1064,8 @@ class ModelFilterParser(HasAModelManager):
         #   (instead of relying on zip to shorten)
         return list(zip(attrs, ops, values))
 
-    def parse_query_filters(self, query_filters: FilterQueryParams):
-        """Convenience function to parse a FilterQueryParams object into a collection of filtering criteria."""
+    def parse_query_filters(self, query_filters: ValueFilterQueryParams):
+        """Convenience function to parse a ValueFilterQueryParams object into a collection of filtering criteria."""
         filter_params = self.build_filter_params(query_filters)
         return self.parse_filters(filter_params)
 

--- a/lib/galaxy/schema/__init__.py
+++ b/lib/galaxy/schema/__init__.py
@@ -22,7 +22,12 @@ class BootstrapAdminUser(BaseModel):
         return []
 
 
-class FilterQueryParams(BaseModel):
+class ValueFilterQueryParams(BaseModel):
+    """Allows filtering/querying elements by value like `q=<property>-<operator>&qv=<value>`
+
+    Multiple `q/qv` queries can be concatenated.
+    """
+
     q: Optional[Union[List[str], str]] = Field(
         default=None,
         title="Filter Query",
@@ -35,6 +40,11 @@ class FilterQueryParams(BaseModel):
         description="The value to filter by.",
         example="2015-01-29",
     )
+
+
+class PaginationQueryParams(BaseModel):
+    """Used to paginate a the request results by limiting and offsetting."""
+
     offset: Optional[int] = Field(
         default=0,
         ge=0,
@@ -47,6 +57,11 @@ class FilterQueryParams(BaseModel):
         title="Limit",
         description="The maximum number of items to return.",
     )
+
+
+class FilterQueryParams(ValueFilterQueryParams, PaginationQueryParams):
+    """Contains full filtering options to query elements, paginate and order them."""
+
     order: Optional[str] = Field(
         default=None,
         title="Order",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2493,6 +2493,14 @@ class HistoryContentsArchiveDryRunResult(BaseModel):
     __root__: List[List[str]]  # List[Tuple[str, str]]
 
 
+class HistoryContentStats(BaseModel):
+    total_matches: int = Field(
+        ...,
+        title="Total Matches",
+        description=("The total number of items that match the search query without any pagination"),
+    )
+
+
 class ContentsNearStats(BaseModel):
     """Stats used by the `contents_near` endpoint."""
 
@@ -2519,11 +2527,31 @@ class ContentsNearStats(BaseModel):
 
 
 class HistoryContentsResult(Model):
-    """Collection of history content items.
+    """List of history content items.
     Can contain different views and kinds of items.
     """
 
     __root__: List[AnyHistoryContentItem]
+
+
+class HistoryContentsWithStatsResult(BaseModel):
+    """Includes stats with items counting"""
+
+    stats: HistoryContentStats = Field(
+        ...,
+        title="Stats",
+        description=("Contains counting stats for the query."),
+    )
+    contents: List[AnyHistoryContentItem] = Field(
+        ...,
+        title="Contents",
+        description=(
+            "The items matching the search query. Only the items fitting in the current page limit will be returned."
+        ),
+    )
+
+    # This field is ignored and contains the content type associated with this model
+    __accept_type__ = "application/vnd.galaxy.history.contents.stats+json"
 
 
 class ContentsNearResult(BaseModel):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -820,20 +820,16 @@ class UpdateHistoryContentsBatchPayload(HistoryBase):
         }
 
 
-class HistoryContentBulkOperation(str, Enum):
+class HistoryContentItemOperation(str, Enum):
     hide = "hide"
     unhide = "unhide"
     delete = "delete"
     undelete = "undelete"
     purge = "purge"
-    build_dataset_list = "build_dataset_list"
-    build_dataset_pair = "build_dataset_pair"
-    build_list_of_pairs = "build_list_of_pairs"
-    build_collection_from_rules = "build_collection_from_rules"
 
 
 class HistoryContentBulkOperationPayload(Model):
-    operation: HistoryContentBulkOperation
+    operation: HistoryContentItemOperation
     items: Optional[List[HistoryContentItem]]
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -783,8 +783,8 @@ class HistoryBase(BaseModel):
         extra = Extra.allow  # Allow any other extra fields
 
 
-class UpdateContentItem(HistoryBase):
-    """Used for updating a particular HDA. All fields are optional."""
+class HistoryContentItem(Model):
+    """Identifies a dataset or collection contained in a History."""
 
     history_content_type: HistoryContentType = Field(
         ...,
@@ -792,6 +792,14 @@ class UpdateContentItem(HistoryBase):
         description="The type of this item.",
     )
     id: EncodedDatabaseIdField = EncodedEntityIdField
+
+
+class UpdateContentItem(HistoryContentItem):
+    """Used for updating a particular history item. All fields are optional."""
+
+    class Config:
+        use_enum_values = True  # When using .dict()
+        extra = Extra.allow  # Allow any other extra fields
 
 
 class UpdateHistoryContentsBatchPayload(HistoryBase):
@@ -810,6 +818,33 @@ class UpdateHistoryContentsBatchPayload(HistoryBase):
                 "visible": False,
             }
         }
+
+
+class HistoryContentBulkOperation(str, Enum):
+    hide = "hide"
+    unhide = "unhide"
+    delete = "delete"
+    undelete = "undelete"
+    purge = "purge"
+    build_dataset_list = "build_dataset_list"
+    build_dataset_pair = "build_dataset_pair"
+    build_list_of_pairs = "build_list_of_pairs"
+    build_collection_from_rules = "build_collection_from_rules"
+
+
+class HistoryContentBulkOperationPayload(Model):
+    operation: HistoryContentBulkOperation
+    items: Optional[List[HistoryContentItem]]
+
+
+class BulkOperationItemError(Model):
+    item: HistoryContentItem
+    error: str
+
+
+class HistoryContentBulkOperationResult(Model):
+    success_count: int
+    errors: List[BulkOperationItemError]
 
 
 class UpdateHistoryContentsPayload(HistoryBase):

--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -15,6 +15,7 @@ from fastapi import (
 from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
+    ValueFilterQueryParams,
 )
 from galaxy.schema.schema import UpdateDatasetPermissionsPayload
 
@@ -34,6 +35,20 @@ SerializationDefaultViewQueryParam: Optional[str] = Query(
     None,
     title="Default View",
     description="The item view that will be used in case no particular view was specified.",
+)
+
+FilterQueryQueryParam: Optional[List[str]] = Query(
+    default=None,
+    title="Filter Query",
+    description="Generally a property name to filter by followed by an (often optional) hyphen and operator string.",
+    example="create_time-gt",
+)
+
+FilterValueQueryParam: Optional[List[str]] = Query(
+    default=None,
+    title="Filter Value",
+    description="The value to filter by.",
+    example="2015-01-29",
 )
 
 
@@ -57,19 +72,23 @@ def query_serialization_params(
     return parse_serialization_params(view=view, keys=keys, default_view=default_view)
 
 
+def get_value_filter_query_params(
+    q: Optional[List[str]] = FilterQueryQueryParam,
+    qv: Optional[List[str]] = FilterValueQueryParam,
+) -> ValueFilterQueryParams:
+    """
+    This function is meant to be used as a Dependency.
+    See https://fastapi.tiangolo.com/tutorial/dependencies/#first-steps
+    """
+    return ValueFilterQueryParams(
+        q=q,
+        qv=qv,
+    )
+
+
 def get_filter_query_params(
-    q: Optional[List[str]] = Query(
-        default=None,
-        title="Filter Query",
-        description="Generally a property name to filter by followed by an (often optional) hyphen and operator string.",
-        example="create_time-gt",
-    ),
-    qv: Optional[List[str]] = Query(
-        default=None,
-        title="Filter Value",
-        description="The value to filter by.",
-        example="2015-01-29",
-    ),
+    q: Optional[List[str]] = FilterQueryQueryParam,
+    qv: Optional[List[str]] = FilterValueQueryParam,
     offset: Optional[int] = Query(
         default=0,
         ge=0,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -29,6 +29,7 @@ from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
+    ValueFilterQueryParams,
 )
 from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -49,6 +50,7 @@ from galaxy.schema.schema import (
 from galaxy.webapps.galaxy.api.common import (
     get_filter_query_params,
     get_update_permission_payload,
+    get_value_filter_query_params,
     query_serialization_params,
 )
 from galaxy.webapps.galaxy.services.history_contents import (
@@ -525,7 +527,7 @@ class FastAPIHistoryContents:
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        filter_query_params: FilterQueryParams = Depends(get_filter_query_params),
+        filter_query_params: ValueFilterQueryParams = Depends(get_value_filter_query_params),
         payload: HistoryContentBulkOperationPayload = Body(...),
     ) -> HistoryContentBulkOperationResult:
         """Executes an operation on a set of items contained in the given History.

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -312,11 +312,10 @@ class FastAPIHistoryContents:
         name="history_contents",
         summary="Returns the contents of the given history.",
         responses={
-            200: {"model": List[AnyHistoryContentItem]},
-            204: {
+            200: {
+                "model": List[AnyHistoryContentItem],
                 "description": (
-                    "When using `v=dev&view=count` instead of the contents"
-                    " a header with the `total_matches` of the search is returned"
+                    "When using `v=dev&view=count` the `total_matches` of the search is returned in the headers"
                 ),
                 "headers": {
                     "total_matches": {
@@ -342,9 +341,8 @@ class FastAPIHistoryContents:
         - The contents can be filtered and queried using the appropriate parameters.
         - The amount of information returned for each item can be customized.
 
-        When using the special serialization view `count`, instead of returning the items
-        that match the search, no content (204) is returned and the header value `total_matches`
-        will contain the number of items that match the search query.
+        When using the special serialization view `count`, the header value `total_matches`
+        will contain the number of items that match the search query without any pagination.
 
         **Note**: Anonymous users are allowed to get their current history contents.
         """

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -20,6 +20,7 @@ from fastapi import (
 )
 from starlette import status
 from starlette.responses import (
+    JSONResponse,
     Response,
     StreamingResponse,
 )
@@ -356,7 +357,8 @@ class FastAPIHistoryContents:
             filter_query_params,
         )
         if total_matches:
-            return Response(status_code=status.HTTP_204_NO_CONTENT, headers={"total_matches": f"{total_matches}"})
+            query_stats = {"total_matches": f"{total_matches}"}
+            return JSONResponse(items, headers=query_stats)
         return items
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -37,6 +37,8 @@ from galaxy.schema.schema import (
     DatasetAssociationRoles,
     DeleteHistoryContentPayload,
     DeleteHistoryContentResult,
+    HistoryContentBulkOperationPayload,
+    HistoryContentBulkOperationResult,
     HistoryContentsArchiveDryRunResult,
     HistoryContentsResult,
     HistoryContentType,
@@ -514,6 +516,23 @@ class FastAPIHistoryContents:
         """
         result = self.service.update_batch(trans, history_id, payload, serialization_params)
         return HistoryContentsResult.parse_obj(result)
+
+    @router.put(
+        "/api/histories/{history_id}/contents/bulk",
+        summary="Executes an operation on a set of items contained in the given History.",
+    )
+    def bulk_operation(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        filter_query_params: FilterQueryParams = Depends(get_filter_query_params),
+        payload: HistoryContentBulkOperationPayload = Body(...),
+    ) -> HistoryContentBulkOperationResult:
+        """Executes an operation on a set of items contained in the given History.
+
+        The items to be processed can be explicitly set or determined by a dynamic query.
+        """
+        return self.service.bulk_operation(trans, history_id, filter_query_params, payload)
 
     @router.put(
         "/api/histories/{history_id}/contents/{id}/validate",

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -188,6 +188,7 @@ class HistoriesContentsService(ServiceBase):
         history_manager: histories.HistoryManager,
         history_contents_manager: HistoryContentsManager,
         hda_manager: hdas.HDAManager,
+        hdca_manager: hdcas.HDCAManager,
         dataset_collection_manager: DatasetCollectionManager,
         ldda_manager: LibraryDatasetsManager,
         folder_manager: folders.FolderManager,
@@ -200,6 +201,7 @@ class HistoriesContentsService(ServiceBase):
         self.history_manager = history_manager
         self.history_contents_manager = history_contents_manager
         self.hda_manager = hda_manager
+        self.hdca_manager = hdca_manager
         self.dataset_collection_manager = dataset_collection_manager
         self.ldda_manager = ldda_manager
         self.folder_manager = folder_manager
@@ -207,7 +209,7 @@ class HistoriesContentsService(ServiceBase):
         self.hda_deserializer = hda_deserializer
         self.hdca_serializer = hdca_serializer
         self.history_contents_filters = history_contents_filters
-        self.item_operator = HistoryItemOperator(self.hda_manager, self.dataset_collection_manager)
+        self.item_operator = HistoryItemOperator(self.hda_manager, self.hdca_manager)
 
     def index(
         self,
@@ -1298,10 +1300,10 @@ class HistoryItemOperator:
     def __init__(
         self,
         hda_manager: hdas.HDAManager,
-        dataset_collection_manager: DatasetCollectionManager,
+        hdca_manager: hdcas.HDCAManager,
     ):
         self.hda_manager = hda_manager
-        self.dataset_collection_manager = dataset_collection_manager
+        self.hdca_manager = hdca_manager
         self.flush = False
         self._operation_map: Dict[HistoryContentItemOperation, ItemOperation] = {
             HistoryContentItemOperation.hide: lambda item: self._hide(item),
@@ -1317,7 +1319,7 @@ class HistoryItemOperator:
     def _get_item_manager(self, item: HistoryItemModel):
         if isinstance(item, HistoryDatasetAssociation):
             return self.hda_manager
-        return self.dataset_collection_manager
+        return self.hdca_manager
 
     def _hide(self, item: HistoryItemModel):
         item.visible = False

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -935,12 +935,13 @@ class HistoriesContentsService(ServiceBase):
         history = self._get_history(trans, history_id)
         filters = self.history_contents_filters.parse_query_filters(filter_query_params)
 
+        total_matches: Optional[int] = None
         if serialization_params.view == "count":
+            serialization_params.view = None
             total_matches = self.history_contents_manager.contents_count(
                 history,
                 filters=filters,
             )
-            return [], total_matches
 
         filter_query_params.order = filter_query_params.order or "hid-asc"
         order_by = self.build_order_by(self.history_contents_manager, filter_query_params.order)
@@ -960,7 +961,7 @@ class HistoriesContentsService(ServiceBase):
                 serialization_params=serialization_params,
             )
             for content in contents
-        ], None
+        ], total_matches
 
     def _serialize_legacy_content_item(
         self,

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -49,6 +49,7 @@ from galaxy.model.security import GalaxyRBACAgent
 from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
+    ValueFilterQueryParams,
 )
 from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -478,7 +479,7 @@ class HistoriesContentsService(ServiceBase):
         self,
         trans: ProvidesHistoryContext,
         history_id: EncodedDatabaseIdField,
-        filter_query_params: FilterQueryParams,
+        filter_query_params: ValueFilterQueryParams,
         payload: HistoryContentBulkOperationPayload,
     ) -> HistoryContentBulkOperationResult:
         history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
@@ -494,8 +495,6 @@ class HistoriesContentsService(ServiceBase):
             contents = self.history_contents_manager.contents(
                 history,
                 filters,
-                limit=filter_query_params.limit,
-                offset=filter_query_params.offset,
             )
         errors = self._apply_bulk_operation(contents, payload.operation)
         trans.sa_session.flush()

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1122,13 +1122,15 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             )
 
     def _test_index_total_matches(self, history_id: str, expected_total_matches: int, search_query: str = ""):
-        search_response = self._get(f"histories/{history_id}/contents?v=dev&view=count{search_query}")
+        headers = {"accept": "application/vnd.galaxy.history.contents.stats+json"}
+        search_response = self._get(f"histories/{history_id}/contents?v=dev{search_query}", headers=headers)
         self._assert_status_code_is(search_response, 200)
-        self._assert_total_matches_header_is(search_response, expected_total_matches)
+        self._assert_total_matches_is(search_response.json(), expected_total_matches)
 
-    def _assert_total_matches_header_is(self, response, expected_total_matches: int):
-        assert response.headers["total_matches"]
-        assert int(response.headers["total_matches"]) == expected_total_matches
+    def _assert_total_matches_is(self, response, expected_total_matches: int):
+        assert response["stats"]
+        assert response["stats"]["total_matches"]
+        assert response["stats"]["total_matches"] == expected_total_matches
 
     def _create_test_history_contents(self, history_id) -> Tuple[List[str], List[str], List[Any]]:
         """Creates 3 collections (pairs) and their corresponding datasets (6 in total)

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1123,7 +1123,7 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
 
     def _test_index_total_matches(self, history_id: str, expected_total_matches: int, search_query: str = ""):
         search_response = self._get(f"histories/{history_id}/contents?v=dev&view=count{search_query}")
-        self._assert_status_code_is(search_response, 204)
+        self._assert_status_code_is(search_response, 200)
         self._assert_total_matches_header_is(search_response, expected_total_matches)
 
     def _assert_total_matches_header_is(self, response, expected_total_matches: int):

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -998,12 +998,11 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             }
             expected_hidden_item_ids = list(map(lambda item: item["id"], payload["items"]))
             expected_hidden_item_count = len(expected_hidden_item_ids)
-            bulk_operation_result = self._put(f"histories/{history_id}/contents/bulk", data=payload, json=True).json()
+            bulk_operation_result = self._apply_bulk_operation(history_id, payload)
             history_contents = self._get_history_contents(history_id)
             hidden_items = self._get_hidden_items_from_history_contents(history_contents)
 
-            assert bulk_operation_result["success_count"] == expected_hidden_item_count
-            assert not bulk_operation_result["errors"]
+            self._assert_bulk_success(bulk_operation_result, expected_hidden_item_count)
             assert len(hidden_items) == expected_hidden_item_count
             for item in hidden_items:
                 assert item["id"] in expected_hidden_item_ids
@@ -1019,18 +1018,90 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             # Hide all collections using query
             payload = {"operation": "hide"}
             query = "q=history_content_type-eq&qv=dataset_collection"
-            bulk_operation_result = self._put(
-                f"histories/{history_id}/contents/bulk?{query}",
-                data=payload,
-                json=True,
-            ).json()
-
+            bulk_operation_result = self._apply_bulk_operation(history_id, payload, query)
             history_contents = self._get_history_contents(history_id)
             hidden_items = self._get_hidden_items_from_history_contents(history_contents)
-            assert bulk_operation_result["success_count"] == len(collection_ids)
+
+            self._assert_bulk_success(bulk_operation_result, len(collection_ids))
             assert len(hidden_items) == len(collection_ids)
             for item in hidden_items:
                 assert item["id"] in collection_ids
+
+    def test_bulk_operations(self):
+        with self.dataset_populator.test_history() as history_id:
+            datasets_ids, collection_ids, history_contents = self._create_test_history_contents(history_id)
+
+            # Hide all datasets using query
+            payload = {"operation": "hide"}
+            query = "q=history_content_type-eq&qv=dataset"
+            bulk_operation_result = self._apply_bulk_operation(history_id, payload, query)
+            history_contents = self._get_history_contents(history_id)
+            hidden_items = self._get_hidden_items_from_history_contents(history_contents)
+            self._assert_bulk_success(bulk_operation_result, len(datasets_ids))
+            assert len(hidden_items) == len(datasets_ids)
+
+            # Unhide datasets_ids[0] and datasets_ids[3]
+            payload = {
+                "operation": "unhide",
+                "items": [
+                    {
+                        "id": datasets_ids[0],
+                        "history_content_type": "dataset",
+                    },
+                    {
+                        "id": datasets_ids[3],
+                        "history_content_type": "dataset",
+                    },
+                ],
+            }
+            expected_unhidden_count = len(payload["items"])
+            bulk_operation_result = self._apply_bulk_operation(history_id, payload)
+            history_contents = self._get_history_contents(history_id)
+            self._assert_bulk_success(bulk_operation_result, expected_unhidden_count)
+            for item in history_contents:
+                if item["id"] in [datasets_ids[0], datasets_ids[3]]:
+                    assert item["visible"] is True
+
+            # Delete all hidden datasets (total dataset - 2 previously unhidden)
+            expected_hidden_item_count = len(datasets_ids) - expected_unhidden_count
+            payload = {"operation": "delete"}
+            query = "q=history_content_type-eq&qv=dataset&q=visible&qv=False"
+            bulk_operation_result = self._apply_bulk_operation(history_id, payload, query)
+            history_contents = self._get_history_contents(history_id)
+            hidden_items = self._get_hidden_items_from_history_contents(history_contents)
+            self._assert_bulk_success(bulk_operation_result, expected_hidden_item_count)
+            for item in hidden_items:
+                assert item["deleted"] is True
+
+            # Undelete all items in history
+            payload = {
+                "operation": "undelete",
+            }
+            bulk_operation_result = self._apply_bulk_operation(history_id, payload)
+            history_contents = self._get_history_contents(history_id)
+            self._assert_bulk_success(bulk_operation_result, len(history_contents))
+            for item in history_contents:
+                assert item["deleted"] is False
+
+            # Purge datasets_ids[0] and collection_ids[0]
+            payload = {
+                "operation": "purge",
+                "items": [
+                    {
+                        "id": datasets_ids[0],
+                        "history_content_type": "dataset",
+                    },
+                    {
+                        "id": collection_ids[0],
+                        "history_content_type": "dataset_collection",
+                    },
+                ],
+            }
+            expected_purged_count = len(payload["items"])
+            bulk_operation_result = self._apply_bulk_operation(history_id, payload)
+            history_contents = self._get_history_contents(history_id)
+            self._assert_bulk_success(bulk_operation_result, expected_purged_count)
+
 
     def _create_test_history_contents(self, history_id) -> Tuple[List[str], List[str], List[Any]]:
         """Creates 3 collections (pairs) and their corresponding datasets (6 in total)
@@ -1060,3 +1131,16 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
 
     def _get_hidden_items_from_history_contents(self, history_contents) -> List[Any]:
         return list(filter(lambda item: item["visible"] is False, history_contents))
+
+    def _apply_bulk_operation(self, history_id: str, payload, query: str = ""):
+        if query:
+            query = f"?{query}"
+        return self._put(
+            f"histories/{history_id}/contents/bulk{query}",
+            data=payload,
+            json=True,
+        ).json()
+
+    def _assert_bulk_success(self, bulk_operation_result, expected_success_count: int):
+        assert bulk_operation_result["success_count"] == expected_success_count, bulk_operation_result
+        assert not bulk_operation_result["errors"]

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -748,7 +748,7 @@ class HistoryFiltersTestCase(BaseTestCase):
             exceptions.RequestParameterInvalidException,
             self.filter_parser.parse_filters,
             [
-                ("deleted", "eq", "true"),
+                ("deleted", "eq", "wot"),
             ],
         )
 


### PR DESCRIPTION
Closes #13521

# Backend
 - New API route `PUT /api/histories/{history_id}/contents/bulk` that can apply an operation to multiple selected items in a History. The items to process can be explicitly set in the payload or selected by the filtering query parameters.

    ![Screenshot from 2022-03-18 16-28-33](https://user-images.githubusercontent.com/46503462/159032651-f7b417bc-3ed0-44c5-ac70-369a72d23f34.png)
 
 - The `GET /api/histories/{history_id}/contents` now accepts a custom media type (thanks to @mvdbeek) that returns an augmented response with the total number of matched items of the query. This `total_matches` value is critical to determine if we are trying to do a query-based selection or just selecting individual items when requesting a bulk operation from the client.
   
    ![customMediaType](https://user-images.githubusercontent.com/46503462/161790645-e9b261de-2e59-4d51-af93-0aa940fb9a70.gif)


  - Relaxed the parsing of boolean values in query parameters (https://github.com/galaxyproject/galaxy/pull/13555/commits/1397aa06449e6b722b93a7967c8b08e13f320e79) to accept also JSON style booleans ("true", "false") and not exclusively python style booleans ("True", "False")
---

# Frontend *(WIP)*
- [x] Update the history content selection system to support *query selection* in addition to just specific items.
- [x] Run `hide`, `unhide`, `delete`, `undelete` and `purge` operations in bulk over a search query or specific items selection.
- [x] Adapt history wide operations to use bulk operations endpoint
- [ ] Add error handling
- [x] Add client tests 

---

# Open questions
- [x] How do we handle collection building based on query selection?
  - *Discussed in chat*: We will enable collection building only for specific item selection (query selection not supported)

---

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
