### PR TITLE
[22.01] Write to exit code file before running metadata script

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -106,7 +106,6 @@ def build_command(
         # xref https://github.com/galaxyproject/galaxy/issues/3289
         commands_builder.prepend_command(PREPARE_DIRS)
 
-    for_pulsar = 'script_directory' in remote_command_params
     __handle_remote_command_line_building(commands_builder, job_wrapper, for_pulsar=for_pulsar)
 
     container_monitor_command = job_wrapper.container_monitor_command(container)

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -289,12 +289,9 @@ tee -a stderr.log < "$err" >&2 &""",
         self.append_command(f"> '{stdout_file}' 2> '{stderr_file}'",
                             sep="")
 
-    def capture_return_code(self, exit_code_path=None):
-        if not self.return_code_captured:
-            self.return_code_captured = True
-            self.append_command(CAPTURE_RETURN_CODE)
-            if exit_code_path:
-                self.append_command(f"echo $return_code > {exit_code_path}")
+    def capture_return_code(self, exit_code_path):
+        self.append_command(CAPTURE_RETURN_CODE)
+        self.append_command(f"echo $return_code > {exit_code_path}")
 
     def build(self):
         if self.return_code_captured:

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -110,13 +110,13 @@ def build_command(
     if container_monitor_command:
         commands_builder.prepend_command(container_monitor_command)
 
+    if stdout_file and stderr_file:
+        commands_builder.capture_stdout_stderr(stdout_file, stderr_file)
+
     working_directory = remote_job_directory or job_wrapper.working_directory
     commands_builder.capture_return_code(default_exit_code_file(working_directory, job_wrapper.job_id))
     if include_work_dir_outputs:
         __handle_work_dir_outputs(commands_builder, job_wrapper, runner, remote_command_params)
-
-    if stdout_file and stderr_file:
-        commands_builder.capture_stdout_stderr(stdout_file, stderr_file)
 
     if include_metadata and job_wrapper.requires_setting_metadata:
         working_directory = remote_job_directory or job_wrapper.working_directory

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -293,6 +293,7 @@ tee -a stderr.log < "$err" >&2 &""",
     def capture_return_code(self, exit_code_path):
         self.append_command(CAPTURE_RETURN_CODE)
         self.append_command(f"echo $return_code > {exit_code_path}")
+        self.return_code_captured = True
 
     def build(self):
         if self.return_code_captured:

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -91,6 +91,10 @@ def build_command(
         else:
             commands_builder = CommandsBuilder(externalized_commands)
 
+    for_pulsar = 'script_directory' in remote_command_params
+    if not for_pulsar:
+        commands_builder.capture_stdout_stderr('../outputs/tool_stdout', '../outputs/tool_stderr')
+
     # Don't need to create a separate tool working directory for Pulsar
     # jobs - that is handled by Pulsar.
     if create_tool_working_directory:
@@ -162,10 +166,6 @@ def __externalize_commands(job_wrapper, shell, commands_builder, remote_command_
     for_pulsar = 'script_directory' in remote_command_params
     if for_pulsar:
         commands = f"{shell} {join(remote_command_params['script_directory'], script_name)}"
-    else:
-        cb = CommandsBuilder(commands)
-        cb.capture_stdout_stderr('../outputs/tool_stdout', '../outputs/tool_stderr')
-        commands = cb.build()
     log.info(f"Built script [{local_container_script}] for tool command [{tool_commands}]")
     return commands
 

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -6,6 +6,7 @@ from os.path import (
 )
 
 from galaxy import util
+from galaxy.job_execution.output_collect import default_exit_code_file
 from galaxy.jobs.runners.util.job_script import (
     INTEGRITY_INJECTION,
     write_script,
@@ -110,7 +111,7 @@ def build_command(
         commands_builder.prepend_command(container_monitor_command)
 
     working_directory = remote_job_directory or job_wrapper.working_directory
-    commands_builder.capture_return_code(join(working_directory, f"galaxy_{job_wrapper.job_id}.ec"))
+    commands_builder.capture_return_code(default_exit_code_file(working_directory, job_wrapper.job_id))
     if include_work_dir_outputs:
         __handle_work_dir_outputs(commands_builder, job_wrapper, runner, remote_command_params)
 

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -282,14 +282,14 @@ class CommandsBuilder:
         self.append_command("; ".join(c for c in commands if c))
 
     def capture_stdout_stderr(self, stdout_file, stderr_file):
-        self.prepend_command("""out="${TMPDIR:-/tmp}/out.$$" err="${TMPDIR:-/tmp}/err.$$"
-mkfifo "$out" "$err"
-trap 'rm "$out" "$err"' EXIT
-tee -a stdout.log < "$out" &
-tee -a stderr.log < "$err" >&2 &""",
-                             sep="")
-        self.append_command(f"> '{stdout_file}' 2> '{stderr_file}'",
-                            sep="")
+        self.prepend_command(
+            f"""out="${{TMPDIR:-/tmp}}/out.$$" err="${{TMPDIR:-/tmp}}/err.$$"
+mkfifo "$__out" "$__err"
+trap 'rm "$__out" "$__err"' EXIT
+tee -a '{stdout_file}' < "$__out" &
+tee -a '{stderr_file}' < "$__err" >&2 &""",
+            sep="")
+        self.append_command('> "$__out" 2> "$__err"', sep="")
 
     def capture_return_code(self, exit_code_path):
         self.append_command(CAPTURE_RETURN_CODE)

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -114,7 +114,7 @@ def build_command(
 
     if stdout_file and stderr_file:
         commands_builder.capture_stdout_stderr(stdout_file, stderr_file)
-    commands_builder.capture_return_code()
+    commands_builder.capture_return_code(job_wrapper.job_id)
 
     if include_metadata and job_wrapper.requires_setting_metadata:
         working_directory = remote_job_directory or job_wrapper.working_directory
@@ -290,10 +290,12 @@ tee -a stderr.log < "$err" >&2 &""",
         self.append_command(f"> '{stdout_file}' 2> '{stderr_file}'",
                             sep="")
 
-    def capture_return_code(self):
+    def capture_return_code(self, job_id=None):
         if not self.return_code_captured:
             self.return_code_captured = True
             self.append_command(CAPTURE_RETURN_CODE)
+            if job_id:
+                self.append_command(f"echo $return_code > galaxy_{job_id}.ec")
 
     def build(self):
         if self.return_code_captured:

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -93,6 +93,9 @@ def build_command(
         else:
             commands_builder = CommandsBuilder(externalized_commands)
 
+    if stdout_file and stderr_file:
+        commands_builder.capture_stdout_stderr(stdout_file, stderr_file)
+
     # Don't need to create a separate tool working directory for Pulsar
     # jobs - that is handled by Pulsar.
     if create_tool_working_directory:
@@ -110,11 +113,9 @@ def build_command(
     if container_monitor_command:
         commands_builder.prepend_command(container_monitor_command)
 
-    if stdout_file and stderr_file:
-        commands_builder.capture_stdout_stderr(stdout_file, stderr_file)
-
     working_directory = remote_job_directory or job_wrapper.working_directory
     commands_builder.capture_return_code(default_exit_code_file(working_directory, job_wrapper.job_id))
+
     if include_work_dir_outputs:
         __handle_work_dir_outputs(commands_builder, job_wrapper, runner, remote_command_params)
 

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -11,6 +11,7 @@ from galaxy.jobs.runners.util.job_script import (
     INTEGRITY_INJECTION,
     write_script,
 )
+from galaxy.tool_util.deps.container_classes import TRAP_KILL_CONTAINER
 
 log = getLogger(__name__)
 
@@ -278,10 +279,15 @@ class CommandsBuilder:
         self.append_command("; ".join(c for c in commands if c))
 
     def capture_stdout_stderr(self, stdout_file, stderr_file):
+        trap_command = """trap 'rm "$__out" "$__err"' EXIT"""
+        if TRAP_KILL_CONTAINER in self.commands:
+            # We need to replace the container kill trap with one that removes the named pipes and kills the container
+            self.commands = self.commands.replace(TRAP_KILL_CONTAINER, "")
+            trap_command = """trap 'rm "$__out" "$__err"; _on_exit' EXIT"""
         self.prepend_command(
             f"""__out="${{TMPDIR:-.}}/out.$$" __err="${{TMPDIR:-.}}/err.$$"
 mkfifo "$__out" "$__err"
-trap 'rm "$__out" "$__err"' EXIT
+{trap_command}
 tee -a '{stdout_file}' < "$__out" &
 tee -a '{stderr_file}' < "$__err" >&2 &""",
             sep="")

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -218,15 +218,14 @@ class BaseJobRunner:
         """
         raise NotImplementedError()
 
-    def prepare_job(self,
-                    job_wrapper,
-                    include_metadata=False,
-                    include_work_dir_outputs=True,
-                    modify_command_for_container=True,
-                    stdout_file=None,
-                    stderr_file=None):
-        """Some sanity checks that all runners' queue_job() methods are likely to want to do
-        """
+    def prepare_job(
+        self,
+        job_wrapper,
+        include_metadata=False,
+        include_work_dir_outputs=True,
+        modify_command_for_container=True,
+    ):
+        """Some sanity checks that all runners' queue_job() methods are likely to want to do"""
         job_id = job_wrapper.get_id_tag()
         job_state = job_wrapper.get_state()
         job_wrapper.is_ready = False
@@ -251,8 +250,6 @@ class BaseJobRunner:
                 include_metadata=include_metadata,
                 include_work_dir_outputs=include_work_dir_outputs,
                 modify_command_for_container=modify_command_for_container,
-                stdout_file=stdout_file,
-                stderr_file=stderr_file,
             )
         except Exception as e:
             log.exception("(%s) Failure preparing job", job_id)
@@ -280,8 +277,7 @@ class BaseJobRunner:
                            include_metadata=False,
                            include_work_dir_outputs=True,
                            modify_command_for_container=True,
-                           stdout_file=None,
-                           stderr_file=None):
+                           ):
         container = self._find_container(job_wrapper)
         if not container and job_wrapper.requires_containerization:
             raise Exception("Failed to find a container when required, contact Galaxy admin.")
@@ -292,8 +288,6 @@ class BaseJobRunner:
             include_work_dir_outputs=include_work_dir_outputs,
             modify_command_for_container=modify_command_for_container,
             container=container,
-            stdout_file=stdout_file,
-            stderr_file=stderr_file,
         )
 
     def get_work_dir_outputs(self, job_wrapper, job_working_directory=None, tool_working_directory=None):

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -139,12 +139,17 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         ajs = AsynchronousJobState(files_dir=job_wrapper.working_directory,
                                    job_wrapper=job_wrapper,
                                    job_destination=job_wrapper.job_destination)
+        # Kubernetes doesn't really produce meaningful "job stdout", but file needs to be present
+        with open(ajs.output_file, 'w'):
+            pass
+        with open(ajs.error_file, 'w'):
+            pass
 
-        if not self.prepare_job(job_wrapper,
-                                include_metadata=False,
-                                modify_command_for_container=False,
-                                stdout_file=ajs.output_file,
-                                stderr_file=ajs.error_file):
+        if not self.prepare_job(
+            job_wrapper,
+            include_metadata=False,
+            modify_command_for_container=False,
+        ):
             return
 
         script = self.get_job_file(job_wrapper, exit_code_path=ajs.exit_code_file, shell=job_wrapper.shell, galaxy_virtual_env=None)

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -40,5 +40,4 @@ cd $working_directory
 $memory_statement
 $instrument_pre_commands
 $command
-echo $? > $exit_code_path
 $instrument_post_commands

--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -70,8 +70,6 @@ def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):
     >>> script = job_script(working_directory='wd', command='uptime', exit_code_path='ec')
     >>> '\\nuptime\\n' in script
     True
-    >>> 'echo $? > ec' in script
-    True
     >>> 'GALAXY_LIB="None"' in script
     True
     >>> script.startswith('#!/bin/sh\\n#PBS -test\\n')

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -26,6 +26,7 @@ log = getLogger(__name__)
 
 DOCKER_CONTAINER_TYPE = "docker"
 SINGULARITY_CONTAINER_TYPE = "singularity"
+TRAP_KILL_CONTAINER = "trap _on_exit EXIT"
 
 LOAD_CACHED_IMAGE_COMMAND_TEMPLATE = r'''
 python << EOF
@@ -343,7 +344,7 @@ class DockerContainer(Container, HasDockerLikeVolumes):
 _on_exit() {{
   {kill_command} &> /dev/null
 }}
-trap _on_exit 0
+{TRAP_KILL_CONTAINER}
 {cache_command}
 {run_command}"""
 

--- a/test/functional/tools/job_properties.xml
+++ b/test/functional/tools/job_properties.xml
@@ -9,11 +9,13 @@
     echo 'The bool is really true' 1>&2 &&
     echo 'This is a line of text.' > '$out_file1' &&
     cp '$out_file1' '$one' &&
-    cp '$out_file1' '$two'
+    cp '$out_file1' '$two' &&
+    sleep $sleepsecs
 #else
     echo 'The bool is not true' &&
     echo 'The bool is very not true' 1>&2 &&
     echo 'This is a different line of text.' > '$out_file1' &&
+    sleep $sleepsecs &&
     sh -c 'exit 2'
 #end if
 #if $failbool
@@ -23,6 +25,7 @@
 #end if
     ]]></command>
     <inputs>
+        <param name="sleepsecs" type="integer" value="0" label="Sleep this many seconds"/>
         <param name="thebool" type="boolean" label="The boolean property" />
         <param name="failbool" type="boolean" label="The failure property" checked="false" />
     </inputs>

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -302,19 +302,31 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
     @skip_without_tool('job_properties')
     def test_exit_code_127(self):
         inputs = {
-            'failbool': True
+            'failbool': True,
+            'sleepsecs': 20,
         }
         running_response = self.dataset_populator.run_tool_raw(
             "job_properties",
             inputs,
             self.history_id,
         )
+        time.sleep(10)
+        # check that logs are also available in job logs
+        app = self._app
+        sa_session = app.model.context.current
+        job = sa_session.query(app.model.Job).get(app.security.decode_id(running_response.json()['jobs'][0]['id']))
+        external_id = job.job_runner_external_id
+        output = unicodify(subprocess.check_output(["kubectl", "logs", "-l" f"job-name={external_id}"]))
+        EXPECTED_STDOUT = "The bool is not true"
+        EXPECTED_STDERR = "The bool is very not true"
+        assert EXPECTED_STDOUT in output
+        assert EXPECTED_STDERR in output
+        # Wait for job to finish, then fetch details via Galaxy API
         result = self.dataset_populator.wait_for_tool_run(run_response=running_response, history_id=self.history_id, assert_ok=False).json()
         details = self.dataset_populator.get_job_details(result['jobs'][0]['id'], full=True).json()
-
         assert details['state'] == 'error', details
-        assert details['stdout'].strip() == 'The bool is not true', details
-        assert details['stderr'].strip() == 'The bool is very not true', details
+        assert details['stdout'].strip() == EXPECTED_STDOUT, details
+        assert details['stderr'].strip() == EXPECTED_STDERR, details
         assert details['exit_code'] == 127, details
 
     @skip_without_tool('Count1')

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -52,10 +52,11 @@ class TestCommandFactory(TestCase):
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
         self.__assert_command_is(self._surround_command(
-            "{} {}/tool_script.sh > ../outputs/tool_stdout 2> ../outputs/tool_stderr".format(
+            "{} {}/tool_script.sh > ../outputs/tool_stdout 2> ../outputs/tool_stderr{}".format(
                 self.job_wrapper.shell,
                 self.job_wrapper.working_directory,
-            ) + RETURN_CODE_CAPTURE))
+                RETURN_CODE_CAPTURE,
+            )))
         self.__assert_tool_script_is(f"#!/bin/sh\n{dep_commands[0]}; {MOCK_COMMAND_LINE}")
 
     def test_remote_dependency_resolution(self):
@@ -68,13 +69,13 @@ class TestCommandFactory(TestCase):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(self._surround_command(f"{dep_commands[0]}; {MOCK_COMMAND_LINE}" + RETURN_CODE_CAPTURE),
+        self.__assert_command_is(self._surround_command(f"{dep_commands[0]}; {MOCK_COMMAND_LINE}{RETURN_CODE_CAPTURE}"),
                                  remote_command_params=dict(dependency_resolution="local"))
 
     def test_task_prepare_inputs(self):
         self.include_work_dir_outputs = False
         self.job_wrapper.prepare_input_files_cmds = ["/opt/split1", "/opt/split2"]
-        self.__assert_command_is(self._surround_command(f"/opt/split1; /opt/split2; {MOCK_COMMAND_LINE}" + RETURN_CODE_CAPTURE))
+        self.__assert_command_is(self._surround_command(f"/opt/split1; /opt/split2; {MOCK_COMMAND_LINE}{RETURN_CODE_CAPTURE}"))
 
     def test_workdir_outputs(self):
         self.include_work_dir_outputs = True

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -39,6 +39,10 @@ class TestCommandFactory(TestCase):
         self.include_work_dir_outputs = False
         self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"))
 
+    def test_exit_code_file_appended(self):
+        self.job_wrapper.job_id = 1
+        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?; echo $return_code > galaxy_1.ec"))
+
     def test_shell_commands(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
@@ -189,6 +193,7 @@ class MockJobWrapper:
         )
         self.shell = "/bin/sh"
         self.use_metadata_binary = False
+        self.job_id = None
 
     def get_command_line(self):
         return self.command_line

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -44,7 +44,7 @@ class TestCommandFactory(TestCase):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(self._surround_command(f"{dep_commands[0]}; {MOCK_COMMAND_LINE}" + RETURN_CODE_CAPTURE))
+        self.__assert_command_is(self._surround_command(f"{dep_commands[0]}; {MOCK_COMMAND_LINE}{RETURN_CODE_CAPTURE}"))
 
     def test_shell_commands_external(self):
         self.job_wrapper.commands_in_new_shell = True

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -38,7 +38,7 @@ class TestCommandFactory(TestCase):
 
     def test_simplest_command(self):
         self.include_work_dir_outputs = False
-        self.__assert_command_is(self._surround_command(MOCK_COMMAND_LINE + RETURN_CODE_CAPTURE))
+        self.__assert_command_is(self._surround_command(f"{MOCK_COMMAND_LINE}{RETURN_CODE_CAPTURE}"))
 
     def test_shell_commands(self):
         self.include_work_dir_outputs = False

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -18,10 +18,10 @@ TEST_FILES_PATH = "file_path"
 RETURN_CODE_CAPTURE = "; return_code=$?; echo $return_code > galaxy_1.ec"
 CP_WORK_DIR_OUTPUTS = '; \nif [ -f "foo" ] ; then cp "foo" "bar" ; fi'
 TEE_LOG = """out="${TMPDIR:-/tmp}/out.$$" err="${TMPDIR:-/tmp}/err.$$"
-mkfifo "$out" "$err"
-trap 'rm "$out" "$err"' EXIT
-tee -a stdout.log < "$out" &
-tee -a stderr.log < "$err" >&2 & """
+mkfifo "$__out" "$__err"
+trap 'rm "$__out" "$__err"' EXIT
+tee -a '/stdout' < "$__out" &
+tee -a '/stderr' < "$__err" >&2 & """
 
 
 class TestCommandFactory(TestCase):
@@ -51,7 +51,7 @@ class TestCommandFactory(TestCase):
         stderr_file = "/stderr"
         stdout_file = "/stdout"
         self.__assert_command_is(self._surround_command(
-            f"{TEE_LOG}{MOCK_COMMAND_LINE} > '{stdout_file}' 2> '{stderr_file}'{RETURN_CODE_CAPTURE}"),
+            f'{TEE_LOG}{MOCK_COMMAND_LINE} > "$__out" 2> "$__err"{RETURN_CODE_CAPTURE}'),
             stderr_file=stderr_file,
             stdout_file=stdout_file
         )
@@ -61,7 +61,7 @@ class TestCommandFactory(TestCase):
         stderr_file = "/stderr"
         stdout_file = "/stdout"
         self.__assert_command_is(self._surround_command(
-            f"{TEE_LOG}{MOCK_COMMAND_LINE} > '{stdout_file}' 2> '{stderr_file}'{RETURN_CODE_CAPTURE}{CP_WORK_DIR_OUTPUTS}"),
+            f'{TEE_LOG}{MOCK_COMMAND_LINE} > "$__out" 2> "$__err"{RETURN_CODE_CAPTURE}{CP_WORK_DIR_OUTPUTS}'),
             stderr_file=stderr_file,
             stdout_file=stdout_file
         )

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -17,11 +17,11 @@ TEST_METADATA_LINE = "set_metadata_and_stuff.sh"
 TEST_FILES_PATH = "file_path"
 RETURN_CODE_CAPTURE = "; return_code=$?; echo $return_code > galaxy_1.ec"
 CP_WORK_DIR_OUTPUTS = '; \nif [ -f "foo" ] ; then cp "foo" "bar" ; fi'
-TEE_LOG = """out="${TMPDIR:-/tmp}/out.$$" err="${TMPDIR:-/tmp}/err.$$"
+TEE_LOG = """__out="${TMPDIR:-.}/out.$$" __err="${TMPDIR:-.}/err.$$"
 mkfifo "$__out" "$__err"
 trap 'rm "$__out" "$__err"' EXIT
-tee -a '/stdout' < "$__out" &
-tee -a '/stderr' < "$__err" >&2 & """
+tee -a '../outputs/tool_stdout' < "$__out" &
+tee -a '../outputs/tool_stderr' < "$__err" >&2 & """
 
 
 class TestCommandFactory(TestCase):
@@ -46,26 +46,6 @@ class TestCommandFactory(TestCase):
         self.include_work_dir_outputs = False
         self.__assert_command_is(self._surround_command(f"{MOCK_COMMAND_LINE}{RETURN_CODE_CAPTURE}"))
 
-    def test_stdout_stderr_capture_simple(self):
-        self.include_work_dir_outputs = False
-        stderr_file = "/stderr"
-        stdout_file = "/stdout"
-        self.__assert_command_is(self._surround_command(
-            f'{TEE_LOG}{MOCK_COMMAND_LINE} > "$__out" 2> "$__err"{RETURN_CODE_CAPTURE}'),
-            stderr_file=stderr_file,
-            stdout_file=stdout_file
-        )
-
-    def test_stdout_stderr_capture_with_work_dir_outputs(self):
-        self.workdir_outputs = [("foo", "bar")]
-        stderr_file = "/stderr"
-        stdout_file = "/stdout"
-        self.__assert_command_is(self._surround_command(
-            f'{TEE_LOG}{MOCK_COMMAND_LINE} > "$__out" 2> "$__err"{RETURN_CODE_CAPTURE}{CP_WORK_DIR_OUTPUTS}'),
-            stderr_file=stderr_file,
-            stdout_file=stdout_file
-        )
-
     def test_shell_commands(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
@@ -78,7 +58,8 @@ class TestCommandFactory(TestCase):
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
         self.__assert_command_is(self._surround_command(
-            "{} {}/tool_script.sh > ../outputs/tool_stdout 2> ../outputs/tool_stderr{}".format(
+            '{}{} {}/tool_script.sh > "$__out" 2> "$__err"{}'.format(
+                TEE_LOG,
                 self.job_wrapper.shell,
                 self.job_wrapper.working_directory,
                 RETURN_CODE_CAPTURE,

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -15,6 +15,7 @@ from galaxy.util.bunch import Bunch
 MOCK_COMMAND_LINE = "/opt/galaxy/tools/bowtie /mnt/galaxyData/files/000/input000.dat"
 TEST_METADATA_LINE = "set_metadata_and_stuff.sh"
 TEST_FILES_PATH = "file_path"
+RETURN_CODE_CAPTURE = "; return_code=$?; echo $return_code > galaxy_1.ec"
 
 
 class TestCommandFactory(TestCase):
@@ -37,63 +38,59 @@ class TestCommandFactory(TestCase):
 
     def test_simplest_command(self):
         self.include_work_dir_outputs = False
-        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"))
-
-    def test_exit_code_file_appended(self):
-        self.job_wrapper.job_id = 1
-        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?; echo $return_code > galaxy_1.ec"))
+        self.__assert_command_is(self._surround_command(MOCK_COMMAND_LINE + RETURN_CODE_CAPTURE))
 
     def test_shell_commands(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surround_command(f"{dep_commands[0]}; {MOCK_COMMAND_LINE}; return_code=$?"))
+        self.__assert_command_is(self._surround_command(f"{dep_commands[0]}; {MOCK_COMMAND_LINE}" + RETURN_CODE_CAPTURE))
 
     def test_shell_commands_external(self):
         self.job_wrapper.commands_in_new_shell = True
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surround_command(
-            "{} {}/tool_script.sh > ../outputs/tool_stdout 2> ../outputs/tool_stderr; return_code=$?".format(
+        self.__assert_command_is(self._surround_command(
+            "{} {}/tool_script.sh > ../outputs/tool_stdout 2> ../outputs/tool_stderr".format(
                 self.job_wrapper.shell,
                 self.job_wrapper.working_directory,
-            )))
+            ) + RETURN_CODE_CAPTURE))
         self.__assert_tool_script_is(f"#!/bin/sh\n{dep_commands[0]}; {MOCK_COMMAND_LINE}")
 
     def test_remote_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"), remote_command_params=dict(dependency_resolution="remote"))
+        self.__assert_command_is(self._surround_command(MOCK_COMMAND_LINE + RETURN_CODE_CAPTURE), remote_command_params=dict(dependency_resolution="remote"))
 
     def test_explicit_local_dependency_resolution(self):
         self.include_work_dir_outputs = False
         dep_commands = [". /opt/galaxy/tools/bowtie/default/env.sh"]
         self.job_wrapper.dependency_shell_commands = dep_commands
-        self.__assert_command_is(_surround_command(f"{dep_commands[0]}; {MOCK_COMMAND_LINE}; return_code=$?"),
+        self.__assert_command_is(self._surround_command(f"{dep_commands[0]}; {MOCK_COMMAND_LINE}" + RETURN_CODE_CAPTURE),
                                  remote_command_params=dict(dependency_resolution="local"))
 
     def test_task_prepare_inputs(self):
         self.include_work_dir_outputs = False
         self.job_wrapper.prepare_input_files_cmds = ["/opt/split1", "/opt/split2"]
-        self.__assert_command_is(_surround_command("/opt/split1; /opt/split2; %s; return_code=$?") % MOCK_COMMAND_LINE)
+        self.__assert_command_is(self._surround_command(f"/opt/split1; /opt/split2; {MOCK_COMMAND_LINE}" + RETURN_CODE_CAPTURE))
 
     def test_workdir_outputs(self):
         self.include_work_dir_outputs = True
         self.workdir_outputs = [("foo", "bar")]
-        self.__assert_command_is(_surround_command('%s; return_code=$?; \nif [ -f "foo" ] ; then cp "foo" "bar" ; fi' % MOCK_COMMAND_LINE))
+        self.__assert_command_is(self._surround_command(f'{MOCK_COMMAND_LINE}{RETURN_CODE_CAPTURE}; \nif [ -f "foo" ] ; then cp "foo" "bar" ; fi'))
 
     def test_workdir_outputs_with_glob(self):
         self.include_work_dir_outputs = True
         self.workdir_outputs = [("foo*bar", "foo_x_bar")]
-        self.__assert_command_is(_surround_command(
-            '%s; return_code=$?; \nif [ -f "foo"*"bar" ] ; then cp "foo"*"bar" "foo_x_bar" ; fi' % MOCK_COMMAND_LINE))
+        self.__assert_command_is(self._surround_command(
+            f'{MOCK_COMMAND_LINE}{RETURN_CODE_CAPTURE}; \nif [ -f "foo"*"bar" ] ; then cp "foo"*"bar" "foo_x_bar" ; fi'))
 
     def test_set_metadata_skipped_if_unneeded(self):
         self.include_metadata = True
         self.include_work_dir_outputs = False
-        self.__assert_command_is(_surround_command(MOCK_COMMAND_LINE + "; return_code=$?"))
+        self.__assert_command_is(self._surround_command(MOCK_COMMAND_LINE + RETURN_CODE_CAPTURE))
 
     def test_set_metadata(self):
         self._test_set_metadata()
@@ -106,7 +103,7 @@ class TestCommandFactory(TestCase):
         self.include_metadata = True
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = TEST_METADATA_LINE
-        expected_command = _surround_command(f"{MOCK_COMMAND_LINE}; return_code=$?; cd '{self.job_dir}'; {SETUP_GALAXY_FOR_METADATA}{TEST_METADATA_LINE}")
+        expected_command = self._surround_command(f"{MOCK_COMMAND_LINE}{RETURN_CODE_CAPTURE}; cd '{self.job_dir}'; {SETUP_GALAXY_FOR_METADATA}{TEST_METADATA_LINE}")
         self.__assert_command_is(expected_command)
 
     def test_empty_metadata(self):
@@ -117,7 +114,7 @@ class TestCommandFactory(TestCase):
         self.include_work_dir_outputs = False
         self.job_wrapper.metadata_line = ' '
         # Empty metadata command do not touch command line.
-        expected_command = _surround_command(f"{MOCK_COMMAND_LINE}; return_code=$?; cd '{self.job_dir}'")
+        expected_command = self._surround_command(f"{MOCK_COMMAND_LINE}{RETURN_CODE_CAPTURE}; cd '{self.job_dir}'")
         self.__assert_command_is(expected_command)
 
     def test_metadata_kwd_defaults(self):
@@ -170,9 +167,9 @@ class TestCommandFactory(TestCase):
         )
         return build_command(**kwds)
 
-
-def _surround_command(command):
-    return f'''{PREPARE_DIRS}; {command}; sh -c "exit $return_code"'''
+    def _surround_command(self, command):
+        command = command.replace("galaxy_1.ec", os.path.join(self.job_wrapper.working_directory, "galaxy_1.ec"), 1)
+        return f'''{PREPARE_DIRS}; {command}; sh -c "exit $return_code"'''
 
 
 class MockJobWrapper:
@@ -193,7 +190,7 @@ class MockJobWrapper:
         )
         self.shell = "/bin/sh"
         self.use_metadata_binary = False
-        self.job_id = None
+        self.job_id = 1
 
     def get_command_line(self):
         return self.command_line

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -10,6 +10,7 @@ from galaxy.jobs.command_factory import (
     PREPARE_DIRS,
     SETUP_GALAXY_FOR_METADATA,
 )
+from galaxy.tool_util.deps.container_classes import TRAP_KILL_CONTAINER
 from galaxy.util.bunch import Bunch
 
 MOCK_COMMAND_LINE = "/opt/galaxy/tools/bowtie /mnt/galaxyData/files/000/input000.dat"
@@ -47,6 +48,15 @@ class TestCommandFactory(TestCase):
     def test_simplest_command(self):
         self.include_work_dir_outputs = False
         self.__assert_command_is(self._surround_command(MOCK_COMMAND_LINE))
+
+    def test_kill_trap_replaced(self):
+        self.include_work_dir_outputs = False
+        self.job_wrapper.command_line = f"{TRAP_KILL_CONTAINER}{MOCK_COMMAND_LINE}"
+        expected_command_line = self._surround_command(MOCK_COMMAND_LINE).replace(
+            """trap 'rm "$__out" "$__err"' EXIT""",
+            """trap 'rm "$__out" "$__err"; _on_exit' EXIT"""
+        )
+        self.__assert_command_is(expected_command_line)
 
     def test_shell_commands(self):
         self.include_work_dir_outputs = False


### PR DESCRIPTION
We need the exit code in the metadata script to figure out the correct
job messages. This would fix
```
FAILED test/functional/test_toolbox_pytest.py::test_tool[unicode_stream_test_2]
FAILED test/functional/test_toolbox_pytest.py::test_tool[strict_shell_test
FAILED test/functional/test_toolbox_pytest.py::test_tool[detect_errors_test_1]
FAILED test/functional/test_toolbox_pytest.py::test_tool[detect_errors_test_2]
FAILED test/functional/test_toolbox_pytest.py::test_tool[detect_errors_test_3]
FAILED test/functional/test_toolbox_pytest.py::test_tool[detect_errors_test_5]
FAILED test/functional/test_toolbox_pytest.py::test_tool[detect_errors_test_9]
FAILED test/functional/test_toolbox_pytest.py::test_tool[detect_errors_test_10]
FAILED test/functional/test_toolbox_pytest.py::test_tool[collection_creates_list_fail_test_1]
```
that are broken when using `metadata_strategy: extended` (https://github.com/galaxyproject/galaxy/issues/13551).
This broke in https://github.com/galaxyproject/galaxy/pull/12459 because we started importing the job back in in extended metadata mode. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
