### PR TITLE
[22.01] Attach dataset source in model store imports

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -264,8 +264,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         if attribute in dataset_attrs["dataset"]:
                             setattr(dataset_instance.dataset, attribute, dataset_attrs["dataset"][attribute])
                     self._attach_dataset_hashes(dataset_attrs["dataset"], dataset_instance)
-                    # TODO: Once we have a test...
-                    #    self._attach_dataset_sources(dataset_attrs["dataset"], dataset_instance)
+                    self._attach_dataset_sources(dataset_attrs["dataset"], dataset_instance)
                     if 'id' in dataset_attrs["dataset"] and self.import_options.allow_edit:
                         dataset_instance.dataset.id = dataset_attrs["dataset"]['id']
                     if job:

--- a/test/integration_selenium/test_dataset_details_source_transforms.py
+++ b/test/integration_selenium/test_dataset_details_source_transforms.py
@@ -80,3 +80,11 @@ class DatasetSourceTransformSeleniumIntegrationTestCase(PosixFileSourceSetup, Se
     def setUp(self):
         super().setUp()
         self._write_file_fixtures()
+
+
+class DatasetSourceTransformInModelStoreSeleniumIntegrationTestCase(DatasetSourceTransformSeleniumIntegrationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["metadata_strategy"] = "extended"


### PR DESCRIPTION
Fixes
```
FAILED test/integration_selenium/test_dataset_details_source_transforms.py::DatasetSourceTransformSeleniumIntegrationTestCase::test_displaying_source_transformations_grooming
FAILED test/integration_selenium/test_dataset_details_source_transforms.py::DatasetSourceTransformSeleniumIntegrationTestCase::test_displaying_source_transformations_posixlines
FAILED test/integration_selenium/test_dataset_details_source_transforms.py::DatasetSourceTransformSeleniumIntegrationTestCase::test_displaying_source_transformations_spaces_to_tabs
```

xref: https://github.com/galaxyproject/galaxy/issues/13551

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
