### PR TITLE
Properly initialize chart settings for new visualizations

### DIFF
--- a/client/src/mvc/visualization/chart/chart-client.js
+++ b/client/src/mvc/visualization/chart/chart-client.js
@@ -42,7 +42,6 @@ export default Backbone.View.extend({
             .done((dataset) => {
                 this.dataset = dataset;
                 this.chart.load();
-                this.chart.trigger("redraw");
             })
             .fail((response) => {
                 const message = response.responseJSON && response.responseJSON.err_msg;

--- a/client/src/mvc/visualization/chart/components/model.js
+++ b/client/src/mvc/visualization/chart/components/model.js
@@ -22,8 +22,7 @@ export default Backbone.Model.extend({
         this.visualization_name = viz_options.visualization_name;
         this.dataset_id = viz_options.dataset_id;
         this.chart_dict = viz_options.chart_dict;
-        console.debug("model::initialize() - Initialized with configuration:");
-        console.debug(viz_options);
+        console.debug("model::initialize() - Initialized with configuration:", viz_options);
     },
 
     reset: function () {
@@ -103,7 +102,7 @@ export default Backbone.Model.extend({
                     console.debug("model::save() - Unrecognized response. Saving may have failed.");
                 }
             })
-            .fail(function (response) {
+            .fail(function () {
                 if (options.error) {
                     options.error();
                 }
@@ -113,26 +112,23 @@ export default Backbone.Model.extend({
     },
 
     /** Load nested models/collections from packed dictionary */
-    load: function (chart_parsed) {
-        var d = chart_parsed || this.chart_dict;
-        if (d) {
-            console.debug("model::load() - Attempting to load with configuration:");
-            console.debug(d);
-        }
+    load: function () {
         this.reset();
+        var d = this.chart_dict;
         if (d && d.attributes) {
+            console.debug("model::load() - Loading saved visualization.", d);
             this.set(d.attributes);
             this.state("ok", "Loading saved visualization...");
             this.settings.set(d.settings);
             this.groups.reset();
             this.groups.add(d.groups);
             this.set("modified", false);
-            this.trigger("load");
-            console.debug("model::load() - Loading chart model " + d.attributes.type + ".");
+            this.trigger("refresh");
+            console.debug("model::load() - Loading chart model.");
             return true;
         } else {
             this.set("modified", true);
-            this.trigger("load");
+            this.trigger("refresh");
             console.debug("model::load() - Visualization attributes unavailable.");
             return false;
         }

--- a/client/src/mvc/visualization/chart/views/editor.js
+++ b/client/src/mvc/visualization/chart/views/editor.js
@@ -46,7 +46,7 @@ export default Backbone.View.extend({
         this.setElement("<div class='charts-editor'/>");
         this.$el.append(this.description.$el);
         this.$el.append(this.tabs.$el);
-        this.listenTo(this.chart, "load", () => {
+        this.listenTo(this.chart, "refresh", () => {
             this.title.value(this.chart.get("title"));
         });
     },

--- a/client/src/mvc/visualization/chart/views/settings.js
+++ b/client/src/mvc/visualization/chart/views/settings.js
@@ -10,7 +10,7 @@ export default Backbone.View.extend({
         var self = this;
         this.chart = app.chart;
         this.setElement("<div/>");
-        this.listenTo(this.chart, "load", function () {
+        this.listenTo(this.chart, "refresh", function () {
             self.render();
         });
     },
@@ -23,6 +23,8 @@ export default Backbone.View.extend({
                 var model_value = self.chart.settings.get(name);
                 if (model_value !== undefined && !input.hidden) {
                     input.value = model_value;
+                } else {
+                    self.chart.settings.set(name, input.value);
                 }
             });
             const instance = appendVueComponent(this.$el, FormDisplay, {
@@ -33,5 +35,6 @@ export default Backbone.View.extend({
                 this.chart.trigger("redraw");
             });
         }
+        this.chart.trigger("redraw");
     },
 });


### PR DESCRIPTION
This PR fixes the initialization of newly created charts visualizations. We should consider to rewrite these components in Vue, which would allow us to build tests and also extend the tests to visualizations itself.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

- Select a dataset from the history e.g. a tabular or pdb file
- Click on the visualization icon and create a bar diagram or a ngl view
- Notice that the initial rendering fails until a setting a changed and the visualization properly renders. 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
