### PR TITLE
Add workflow_dispatch option api/integration/framework/selenium tests

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -13,6 +13,18 @@ on:
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository to fetch code from'
+        default: "galaxyproject/galaxy"
+        required: true
+      ref:
+        description: 'Branch, tag or SHA to checkout'
+        default: ""
+      env_vars:
+        description: 'The environment variables to set'
+        required: false
 env:
   GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT: '1'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
@@ -42,8 +54,18 @@ jobs:
         run: |
           echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
           echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
+      - if: github.event_name == 'workflow_dispatch'
+        run:
+          echo "${{ github.event.inputs.env_vars }}" | tr " " "\n" >> $GITHUB_ENV
       - uses: actions/checkout@v2
+        if: github.event_name != 'workflow_dispatch'
         with:
+          path: 'galaxy root'
+      - uses: actions/checkout@v2
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
           path: 'galaxy root'
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -11,6 +11,18 @@ on:
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository to fetch code from'
+        default: "galaxyproject/galaxy"
+        required: true
+      ref:
+        description: 'Branch, tag or SHA to checkout'
+        default: ""
+      env_vars:
+        description: 'The environment variables to set'
+        required: false
 env:
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
 concurrency:
@@ -28,8 +40,18 @@ jobs:
       run: |
         echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
         echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
+    - if: github.event_name == 'workflow_dispatch'
+      run:
+        echo "${{ github.event.inputs.env_vars }}" | tr " " "\n" >> $GITHUB_ENV
     - uses: actions/checkout@v2
+      if: github.event_name != 'workflow_dispatch'
       with:
+        path: 'galaxy root'
+    - uses: actions/checkout@v2
+      if: github.event_name == 'workflow_dispatch'
+      with:
+        repository: ${{ github.event.inputs.repository }}
+        ref: ${{ github.event.inputs.ref }}
         path: 'galaxy root'
     - name: Clone galaxyproject/galaxy-test-data
       uses: actions/checkout@v2

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -13,6 +13,18 @@ on:
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository to fetch code from'
+        default: "galaxyproject/galaxy"
+        required: true
+      ref:
+        description: 'Branch, tag or SHA to checkout'
+        default: ""
+      env_vars:
+        description: 'The environment variables to set'
+        required: false
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
@@ -40,8 +52,18 @@ jobs:
         run: |
           echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
           echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
+      - if: github.event_name == 'workflow_dispatch'
+        run:
+          echo "${{ github.event.inputs.env_vars }}" | tr " " "\n" >> $GITHUB_ENV
       - uses: actions/checkout@v2
+        if: github.event_name != 'workflow_dispatch'
         with:
+          path: 'galaxy root'
+      - uses: actions/checkout@v2
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
           path: 'galaxy root'
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -13,6 +13,18 @@ on:
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository to fetch code from'
+        default: "galaxyproject/galaxy"
+        required: true
+      ref:
+        description: 'Branch, tag or SHA to checkout'
+        default: ""
+      env_vars:
+        description: 'The environment variables to set'
+        required: false
 env:
   GALAXY_TEST_AMQP_URL: 'amqp://localhost:5672//'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
@@ -49,6 +61,9 @@ jobs:
           echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
           # Skip outputs_to_working_directory: true in integration tests, doesn't work with pulsar
           # echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
+      - if: github.event_name == 'workflow_dispatch'
+        run:
+          echo "${{ github.event.inputs.env_vars }}" | tr " " "\n" >> $GITHUB_ENV
       - name: Prune unused docker image, volumes and containers
         run: docker system prune -a -f
       - name: Clean dotnet folder for space
@@ -64,7 +79,14 @@ jobs:
         run: |
           kubectl get pods
       - uses: actions/checkout@v2
+        if: github.event_name != 'workflow_dispatch'
         with:
+          path: 'galaxy root'
+      - uses: actions/checkout@v2
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
           path: 'galaxy root'
       - uses: actions/setup-python@v1
         with:

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -66,6 +66,9 @@ jobs:
           repository: ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
           path: 'galaxy root'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Prune unused docker image, volumes and containers
         run: docker system prune -a -f
       - name: Get full Python version

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -9,6 +9,18 @@ on:
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository to fetch code from'
+        default: "galaxyproject/galaxy"
+        required: true
+      ref:
+        description: 'Branch, tag or SHA to checkout'
+        default: ""
+      env_vars:
+        description: 'The environment variables to set'
+        required: false
 env:
   GALAXY_SKIP_CLIENT_BUILD: '0'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
@@ -41,14 +53,21 @@ jobs:
         run: |
           echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
           echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
-      - name: Prune unused docker image, volumes and containers
-        run: docker system prune -a -f
+      - if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "${{ github.event.inputs.env_vars }}" | tr " " "\n" >> $GITHUB_ENV
       - uses: actions/checkout@v2
+        if: github.event_name != 'workflow_dispatch'
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v2
+        if: github.event_name == 'workflow_dispatch'
         with:
-          python-version: ${{ matrix.python-version }}
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+          path: 'galaxy root'
+      - name: Prune unused docker image, volumes and containers
+        run: docker system prune -a -f
       - name: Get full Python version
         id: full-python-version
         shell: bash

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -9,6 +9,18 @@ on:
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository to fetch code from'
+        default: "galaxyproject/galaxy"
+        required: true
+      ref:
+        description: 'Branch, tag or SHA to checkout'
+        default: ""
+      env_vars:
+        description: 'The environment variables to set'
+        required: false
 env:
   GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
@@ -43,8 +55,18 @@ jobs:
         run: |
           echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
           echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
+      - if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "${{ github.event.inputs.env_vars }}" | tr " " "\n" >> $GITHUB_ENV
       - uses: actions/checkout@v2
+        if: github.event_name != 'workflow_dispatch'
         with:
+          path: 'galaxy root'
+      - uses: actions/checkout@v2
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
           path: 'galaxy root'
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -9,6 +9,18 @@ on:
   schedule:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository to fetch code from'
+        default: "galaxyproject/galaxy"
+        required: true
+      ref:
+        description: 'Branch, tag or SHA to checkout'
+        default: ""
+      env_vars:
+        description: 'The environment variables to set'
+        required: false
 env:
   GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
@@ -44,8 +56,18 @@ jobs:
         run: |
           echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
           echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
+      - if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "${{ github.event.inputs.env_vars }}" | tr " " "\n" >> $GITHUB_ENV
       - uses: actions/checkout@v2
+        if: github.event_name != 'workflow_dispatch'
         with:
+          path: 'galaxy root'
+      - uses: actions/checkout@v2
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          repository: ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
           path: 'galaxy root'
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Including the ability to set environment variables, which we can use to
test some more esoteric options on a one-off basis.

<img width="940" alt="Screenshot 2022-03-17 at 12 51 48" src="https://user-images.githubusercontent.com/6804901/158802881-9a8c4d73-58db-48d5-8451-0d229078bc7a.png">


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
