### PR TITLE
Workaround to numeric sorting in the local portion of tool versions if they are galaxy "build" numbers

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1099,7 +1099,10 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
     def version_object(self):
         version = self.version
         version_split = version.split("+", 1)
-        if len(version_split) == 2 and version_split[1].startswith("galaxy") and version_split[1] != "galaxy":
+        if (len(version_split) == 2
+                and version_split[1].startswith("galaxy")
+                and version_split[1] != "galaxy"
+                and version_split[1][6] != "."):
             # Per PEP-440 this would be sorted lexicographically if not separated by a '.', this forces a numeric sort
             # if the characters after 'galaxy' are an integer, otherwise the outcome will be the same.
             version_split[1] = "galaxy." + version_split[1][6:]

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1097,7 +1097,14 @@ class Tool(UsesDictVisibleKeys, ToolParameterBundle):
 
     @property
     def version_object(self):
-        return parse_version(self.version)
+        version = self.version
+        version_split = version.split("+", 1)
+        if len(version_split) == 2 and version_split[1].startswith("galaxy") and version_split[1] != "galaxy":
+            # Per PEP-440 this would be sorted lexicographically if not separated by a '.', this forces a numeric sort
+            # if the characters after 'galaxy' are an integer, otherwise the outcome will be the same.
+            version_split[1] = "galaxy." + version_split[1][6:]
+            version = "+".join(version_split)
+        return packaging.version.parse(version)
 
     @property
     def sa_session(self):


### PR DESCRIPTION
On usegalaxy.org, we have installed a few different "+galaxyN" versions of Circos 0.69.8, including +galaxy1, +galaxy7, and +galaxy10. The version that shows up in the tool panel is +galaxy7, although +galaxy10 is selectable from the tool form version dropdown. This is because of the PEP-440 rules regarding sorting of the [local version identifier](https://peps.python.org/pep-0440/#local-version-identifiers).

This change causes local version identifiers of the format `^\+galaxy(.+)$` to be converted to `+galaxy.(\1)` so that if the stuff after `+galaxy` is an integer, it will sort numerically instead of lexicographically.

WIP/Draft because @nsoranzo kindly offered to take a look at the proper handling of tool lineages.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
