### PR TITLE
Allow setting a workflow as (un)importable via the API

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6571,8 +6571,26 @@ class StoredWorkflow(Base, HasTags, Dictifiable, RepresentById):
     # returns a list of users that workflow is shared with.
     users_shared_with_dot_users = association_proxy("users_shared_with", "user")
 
-    dict_collection_visible_keys = ["id", "name", "create_time", "update_time", "published", "deleted", "hidden"]
-    dict_element_visible_keys = ["id", "name", "create_time", "update_time", "published", "deleted", "hidden"]
+    dict_collection_visible_keys = [
+        "id",
+        "name",
+        "create_time",
+        "update_time",
+        "published",
+        "importable",
+        "deleted",
+        "hidden",
+    ]
+    dict_element_visible_keys = [
+        "id",
+        "name",
+        "create_time",
+        "update_time",
+        "published",
+        "importable",
+        "deleted",
+        "hidden",
+    ]
 
     def __init__(
         self,

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -583,6 +583,10 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
                 stored_workflow.published = workflow_dict["published"]
                 trans.sa_session.flush()
 
+            if "importable" in workflow_dict and stored_workflow.importable != workflow_dict["importable"]:
+                stored_workflow.importable = workflow_dict["importable"]
+                trans.sa_session.flush()
+
             if "annotation" in workflow_dict and not steps_updated:
                 newAnnotation = sanitize_html(workflow_dict["annotation"])
                 self.add_item_annotation(trans.sa_session, trans.user, stored_workflow, newAnnotation)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5034,10 +5034,15 @@ input_c:
         workflow_id = self.workflow_populator.simple_workflow("dummy")
         response = self._show_workflow(workflow_id)
         assert not response["published"]
+        assert not response["importable"]
         published_worklow = self._put(f"workflows/{workflow_id}", data={"published": True}, json=True).json()
         assert published_worklow["published"]
+        importable_worklow = self._put(f"workflows/{workflow_id}", data={"importable": True}, json=True).json()
+        assert importable_worklow["importable"]
         unpublished_worklow = self._put(f"workflows/{workflow_id}", data={"published": False}, json=True).json()
         assert not unpublished_worklow["published"]
+        unimportable_worklow = self._put(f"workflows/{workflow_id}", data={"importable": False}, json=True).json()
+        assert not unimportable_worklow["importable"]
 
     def test_workflow_from_path_requires_admin(self):
         # There are two ways to import workflows from paths, just verify both require an admin.


### PR DESCRIPTION
Fix for #10683 (came across it again today).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
