### PR TITLE
Add nonce mismatch hint to exception msg

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -277,7 +277,7 @@ class CustosAuthnz(IdentityProvider):
         trans.set_cookie("", name=NONCE_COOKIE_NAME, age=-1)
         nonce_cookie_hash = self._hash_nonce(nonce_cookie)
         if nonce_hash != nonce_cookie_hash:
-            raise Exception("Nonce mismatch!")
+            raise Exception("Nonce mismatch. Check that configured redirect_uri matches the URL you are using.")
 
     def _load_config_for_cilogon(self):
         # Set cilogon endpoints


### PR DESCRIPTION
The existing exception was not very informative as to why a mismatch might happen. I've run into this in the past, hence offer a possible reason for the exception.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
