### PR TITLE
[22.01] Fix model discovery unit tests

### DIFF
--- a/lib/galaxy/model/unittest_utils/data_app.py
+++ b/lib/galaxy/model/unittest_utils/data_app.py
@@ -13,6 +13,7 @@ from galaxy import model, objectstore
 from galaxy.datatypes import registry
 from galaxy.model.mapping import GalaxyModelMapping, init
 from galaxy.model.security import GalaxyRBACAgent
+from galaxy.model.tags import GalaxyTagHandler
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util.bunch import Bunch
 
@@ -75,6 +76,7 @@ class GalaxyDataTestApp():
         self.object_store = objectstore.build_object_store_from_config(self.config)
         self.model = init("/tmp", self.config.database_connection, create_tables=True, object_store=self.object_store)
         self.security_agent = self.model.security_agent
+        self.tag_handler = GalaxyTagHandler(self.model.context)
         self.init_datatypes()
 
     def init_datatypes(self):


### PR DESCRIPTION
that I broke when merging https://github.com/galaxyproject/galaxy/pull/13552 forward.

Fix:

```
app = <galaxy.model.unittest_utils.data_app.GalaxyDataTestApp object at 0x7f0e00dd3640>, target = '/tmp/tmpyj5d8268', work_directory = '/tmp/tmp_a7e191v'

    def _import_directory_to_history(app, target, work_directory):
        sa_session = app.model.context

        u = model.User(email="collection@example.com", password="password")
        import_history = model.History(name="Test History for Import", user=u)

        sa_session = app.model.context
        sa_session.add_all([u, import_history])
        sa_session.flush()

        assert len(import_history.datasets) == 0

        import_options = store.ImportOptions(allow_dataset_object_edit=True)
>       import_model_store = store.get_import_model_store_for_directory(target, app=app, user=u, import_options=import_options, tag_handler=app.tag_handler.create_tag_handler_session())
E       AttributeError: 'GalaxyDataTestApp' object has no attribute 'tag_handler'

test/unit/data/model/test_model_discovery.py:235: AttributeError
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
