### PR TITLE
Add pre-commit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ test/unit/**.log
 .vscode
 client/**/jsconfig.json
 vetur.config.js
+.pre-commit-config.yaml
 
 # Chrom len files
 *.len

--- a/.pre-commit-config.yaml.sample
+++ b/.pre-commit-config.yaml.sample
@@ -31,6 +31,16 @@ repos:
     rev: 0.14.0
     hooks:
       - id: check-github-workflows
+  - repo: local
+    hooks:
+    -   id: eslint
+        name: client eslint
+        language: system
+        files: ^client/
+        entry: make client-eslint-precommit
+        'types': [javascript]
+        require_serial: false
+        minimum_pre_commit_version: '0'
 #  - repo: https://github.com/pycqa/isort
 #    rev: 5.10.1
 #    hooks:

--- a/.pre-commit-config.yaml.sample
+++ b/.pre-commit-config.yaml.sample
@@ -1,0 +1,38 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.1.0
+    hooks:
+    - id: black
+      language_version: python3.7
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.6.0 # Use the sha or tag you want to point at
+    hooks:
+      - id: prettier
+        types: [file]
+        types_or: [javascript, jsx, ts, tsx, vue]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0  # Use the ref you want to point at
+    hooks:
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      - id: end-of-file-fixer
+  - repo: git://github.com/detailyang/pre-commit-shell
+    rev: v1.0.6
+    hooks:
+    - id: shell-lint
+      args: [--format=json]
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.14.0
+    hooks:
+      - id: check-github-workflows
+#  - repo: https://github.com/pycqa/isort
+#    rev: 5.10.1
+#    hooks:
+#      - id: isort
+#        name: isort (python)

--- a/.pre-commit-config.yaml.sample
+++ b/.pre-commit-config.yaml.sample
@@ -38,9 +38,9 @@ repos:
         language: system
         files: ^client/
         entry: make client-eslint-precommit
-        'types': [javascript]
-        require_serial: false
-        minimum_pre_commit_version: '0'
+        types: [file]
+        types_or: [javascript, jsx, ts, tsx, vue]
+        pass_filenames: false
 #  - repo: https://github.com/pycqa/isort
 #    rev: 5.10.1
 #    hooks:

--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,9 @@ client-dev-server: node-deps ## Starts a webpack dev server for client developme
 client-test: node-deps  ## Run JS unit tests
 	cd client && yarn run test
 
+client-eslint-precommit: node-deps # Client linting for pre-commit hook; skips glob input and takes specific paths
+	cd client && yarn run eslint-precommit
+
 client-eslint: node-deps # Run client linting
 	cd client && yarn run eslint
 

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "extends": [
         "eslint:recommended",
         "plugin:vue/strongly-recommended"
@@ -13,7 +14,7 @@
     },
     "parserOptions": {
         "parser": "@babel/eslint-parser",
-        "sourceType": "module"
+        "babelOptions": { "configFile": "./babel.config.json" }
     },
     "rules": {
         // Standard rules

--- a/client/package.json
+++ b/client/package.json
@@ -119,8 +119,8 @@
     "jest": "jest --config tests/jest/jest.config.js",
     "jest-watch": "jest --config tests/jest/jest.config.js --watch",
     "qunit": "karma start tests/karma/karma.config.qunit.js",
-    "eslint-precommit": "eslint -c .eslintrc.json",
-    "eslint": "eslint -c .eslintrc.json src --ext .js,.vue"
+    "eslint-precommit": "eslint -c .eslintrc.json --quiet --ext .js,.vue src",
+    "eslint": "eslint -c .eslintrc.json --ext .js,.vue src"
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",

--- a/client/package.json
+++ b/client/package.json
@@ -119,6 +119,7 @@
     "jest": "jest --config tests/jest/jest.config.js",
     "jest-watch": "jest --config tests/jest/jest.config.js --watch",
     "qunit": "karma start tests/karma/karma.config.qunit.js",
+    "eslint-precommit": "eslint -c .eslintrc.json",
     "eslint": "eslint -c .eslintrc.json src --ext .js,.vue"
   },
   "devDependencies": {


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) is a nice utility that automates
setting up pre-commit hooks. You can use this with multiple tools, but
for now I've only set it up for black. If you choose to use pre-commit
(you don't have to!) you do `pre-commit install` once and then black
will run for each commit.

We could also just put the file under .gitignore if developers want
to set up their own custom config file, but I suppose having one for
everyone is probably nice?

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
