### PR TITLE
[22.01] linter: allow setting output format with actions

### DIFF
--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -63,6 +63,8 @@ def __check_format(node, lint_ctx, allow_ext=False):
         lint_ctx.warn(f"Tool {node.tag} output '{node.attrib.get('name', 'with missing name')}' should use either format_source or format/ext", node=node)
     if "format_source" in node.attrib:
         return True
+    if node.find(".//action[@type='format']") is not None:
+        return True
     # if allowed (e.g. for discover_datasets), ext takes precedence over format
     fmt = None
     if allow_ext:

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -442,6 +442,25 @@ OUTPUTS_COLLECTION_FORMAT_SOURCE = """
 </tool>
 """
 
+# check that setting format with actions is supported
+OUTPUTS_FORMAT_ACTION = """
+<tool>
+    <outputs>
+        <data name="output">
+            <actions>
+                <conditional name="library.type">
+                    <when value="paired">
+                        <action type="format">
+                            <option type="from_param" name="library.input_2" param_attribute="ext" />
+                        </action>
+                    </when>
+                </conditional>
+            </actions>
+        </data>
+    </outputs>
+</tool>
+"""
+
 # check that linter does not complain about missing format if from_tool_provided_metadata is used
 OUTPUTS_DISCOVER_TOOL_PROVIDED_METADATA = """
 <tool>
@@ -1099,6 +1118,15 @@ def test_outputs_collection_format_source(lint_ctx):
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert len(lint_ctx.warn_messages) == 1
+    assert not lint_ctx.error_messages
+
+
+def test_outputs_format_action(lint_ctx):
+    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_ACTION)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
+    assert len(lint_ctx.info_messages) == 1
+    assert not lint_ctx.valid_messages
+    assert not lint_ctx.warn_messages
     assert not lint_ctx.error_messages
 
 


### PR DESCRIPTION
Ideally one would force `ftype` for outputs in tests if the format is set dynamic (discovered, action, ...)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
