### PR TITLE
Fix bug in setting check_migrate_databases config value

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -768,7 +768,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self.version_minor = VERSION_MINOR
 
         # Database related configuration
-        self.check_migrate_databases = kwargs.get("check_migrate_databases", True)
+        self.check_migrate_databases = string_as_bool(kwargs.get("check_migrate_databases", True))
         if not self.database_connection:  # Provide default if not supplied by user
             db_path = self._in_data_dir("universe.sqlite")
             self.database_connection = f"sqlite:///{db_path}?isolation_level=IMMEDIATE"


### PR DESCRIPTION
This fixes a bug, and enables running Galaxy with the `GALAXY_CONFIG_CHECK_MIGRATE_DATABASES=0` prefix. With this set to 0 (or anything other than 1/true/yes/on, as that's what our `string_as_bool` interprets as `True`), the migrations system will be  bypassed on startup.

This setting may come in handy during development, when you are moving between database versions, specifically across the point where Galaxy transitioned from SQLAlchemy Migrate to Alembic, and you are confident that the database is in the state you need it to be in. This is not a safe setting and should :skull_and_crossbones: **NEVER** :skull_and_crossbones: be used in production, because it does not check the database state.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
