### PR TITLE
Wrap update statement in revision to silence safe error

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
@@ -9,7 +9,10 @@ from alembic import op
 from sqlalchemy import Column
 
 from galaxy.model.custom_types import JSONType
-from galaxy.model.migrations.util import drop_column
+from galaxy.model.migrations.util import (
+    drop_column,
+    ignore_add_column_error,
+)
 
 # revision identifiers, used by Alembic.
 revision = "b182f655505f"
@@ -19,7 +22,9 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column("workflow", Column("source_metadata", JSONType))
+    table, column = "workflow", "source_metadata"
+    with ignore_add_column_error(table, column):
+        op.add_column(table, Column(column, JSONType))
 
 
 def downgrade():

--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -1,6 +1,38 @@
+import logging
+from contextlib import contextmanager
+
 from alembic import op
+from sqlalchemy.exc import (
+    OperationalError,
+    ProgrammingError,
+)
+
+log = logging.getLogger(__name__)
 
 
 def drop_column(table, column):
     with op.batch_alter_table(table) as batch_op:
         batch_op.drop_column(column)
+
+
+@contextmanager
+def ignore_add_column_error(table, column):
+    """
+    Use this context manager to wrap statements in upgrade/downgrade functions
+    in revision files when a statement may cause an error that may be safely
+    ignored. For example, in revision b182f655505f, if an upgrade operation is
+    executed on a database that has been previoiusly upgraded via SQLAlchemy
+    Migrate to version 181, a subsequent upgrade to Alembic may cause such as
+    error. For more details, see https://github.com/galaxyproject/galaxy/issues/13528.
+
+    We are checking for 2 different error types: OperationalError is raised
+    for SQLite, ProgrammingError is raised for PostgreSQL.
+    """
+    statement = f"ALTER TABLE {table} ADD COLUMN {column}"
+    try:
+        yield
+    except (ProgrammingError, OperationalError) as e:
+        if e.statement.startswith(statement):
+            log.error(f"Ignoring error: {e}")
+        else:
+            raise e


### PR DESCRIPTION
This provides a utility that can be used to silence database migration errors that can be safely ignored. Most likely, this will apply to development contexts only. The new context manager can wrap statements in upgrade/downgrade functions in revision files. For example, in revision b182f655505f (which is in this PR), if an upgrade operation is executed on a database that has been previously upgraded via SQLAlchemy Migrate to version 181, a subsequent upgrade to Alembic may cause such as error, complaining about a duplicate column (which has been previously added). For more details, see https://github.com/galaxyproject/galaxy/issues/13528. 

I've considered silencing such errors by default (wrapping all statements in the upgrade/downgrade functions), but this doesn't feel safe at all. The revision in the PR is a good candidate because it happened during the very brief transition period from SQLAlchemy Migrate to Alembic. We can revisit this, should similar errors become a nuisance. For example, if the `alembic_revision` table is corrupted in any way, trying to rerun any revision would (rightfully) lead to such an error. However, in that case, a better solution would be to examine the database to verify that it's up-to-date and then manually insert the correct revision identifiers into the version table.

NOTE: We are checking for 2 different error types: OperationalError is raised for SQLite, ProgrammingError is raised for PostgreSQL. We're checking the specific statement, so that we don't miss any other errors (or accidentally wrap a different statement).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
