### PR TITLE
Decode / encode database ids within pydantic models

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -88,7 +88,7 @@ class LibraryActions:
     Mixin for controllers that provide library functionality.
     """
 
-    def _upload_dataset(self, trans, folder_id: str, replace_dataset: Optional[LibraryDataset] = None, **kwd):
+    def _upload_dataset(self, trans, folder_id: int, replace_dataset: Optional[LibraryDataset] = None, **kwd):
         # Set up the traditional tool state/params
         cntrller = "api"
         tool_id = "upload1"

--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -302,13 +302,11 @@ class LibraryActions:
             trans.sa_session.flush()
         return uploaded_dataset
 
-    def _create_folder(self, trans, parent_id, library_id, **kwd):
+    def _create_folder(self, trans, parent_id: int, library_id: int, **kwd):
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
         try:
-            parent_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(
-                trans.security.decode_id(parent_id)
-            )
+            parent_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(parent_id)
         except Exception:
             parent_folder = None
         # Check the library which actually contains the user-supplied parent folder, not the user-supplied

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -152,14 +152,14 @@ def encode_with_security(security: IdEncodingHelper, id: Any):
     return security.encode_id(id)
 
 
-def get_object(trans, id, class_name, check_ownership=False, check_accessible=False, deleted=None):
+def get_object(trans, id: Union[str, int], class_name, check_ownership=False, check_accessible=False, deleted=None):
     """
     Convenience method to get a model object with the specified checks. This is
     a generic method for dealing with objects uniformly from the older
     controller mixin code - however whenever possible the managers for a
     particular model should be used to load objects.
     """
-    decoded_id = decode_id(trans.app, id)
+    decoded_id = decode_id(trans.app, id) if isinstance(id, str) else id
     try:
         item_class = get_class(class_name)
         assert item_class is not None

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -311,7 +311,9 @@ class DatasetCollectionManager:
         dataset_collection.collection_type = collection_type
         return dataset_collection
 
-    def get_converters_for_collection(self, trans, id, datatypes_registry: Registry, instance_type="history"):
+    def get_converters_for_collection(
+        self, trans, id: int, datatypes_registry: Registry, instance_type: str = "history"
+    ):
         dataset_collection_instance = self.get_dataset_collection_instance(
             trans, id=id, instance_type=instance_type, check_ownership=True
         )
@@ -432,13 +434,13 @@ class DatasetCollectionManager:
         changed = self._set_from_dict(trans, dataset_collection_instance, payload)
         return changed
 
-    def copy(self, trans, parent, source, encoded_source_id, copy_elements=False, dataset_instance_attributes=None):
+    def copy(self, trans, parent, source: str, source_id: int, copy_elements=False, dataset_instance_attributes=None):
         """
         PRECONDITION: security checks on ability to add to parent occurred
         during load.
         """
         assert source == "hdca"  # for now
-        source_hdca = self.__get_history_collection_instance(trans, encoded_source_id)
+        source_hdca = self.__get_history_collection_instance(trans, source_id)
         copy_kwds = {}
         if copy_elements:
             copy_kwds["element_destination"] = parent  # e.g. a history
@@ -594,8 +596,8 @@ class DatasetCollectionManager:
             src_type = element_identifier.get("src", "hda")
         except AttributeError:
             raise MessageException(f"Dataset collection element definition ({element_identifier}) not dictionary-like.")
-        encoded_id = element_identifier.get("id")
-        if not src_type or not encoded_id:
+        src_id = element_identifier.get("id")
+        if not src_type or not src_id:
             message_template = "Problem decoding element identifier %s - must contain a 'src' and a 'id'."
             message = message_template % element_identifier
             raise RequestParameterInvalidException(message)
@@ -605,8 +607,7 @@ class DatasetCollectionManager:
         if tags:
             tag_str = ",".join(str(_) for _ in tags)
         if src_type == "hda":
-            decoded_id = int(trans.app.security.decode_id(encoded_id))
-            hda = self.hda_manager.get_accessible(decoded_id, trans.user)
+            hda = self.hda_manager.get_accessible(src_id, trans.user)
             if copy_elements:
                 element = self.hda_manager.copy(hda, history=history or trans.history, hide_copy=True, flush=False)
             else:
@@ -617,14 +618,14 @@ class DatasetCollectionManager:
                 hda.visible = False
             self.tag_handler.apply_item_tags(user=trans.user, item=element, tags_str=tag_str, flush=False)
         elif src_type == "ldda":
-            element = self.ldda_manager.get(trans, encoded_id, check_accessible=True)
+            element = self.ldda_manager.get(trans, src_id, check_accessible=True)
             element = element.to_history_dataset_association(
                 history or trans.history, add_to_history=True, visible=not hide_source_items
             )
             self.tag_handler.apply_item_tags(user=trans.user, item=element, tags_str=tag_str, flush=False)
         elif src_type == "hdca":
             # TODO: Option to copy? Force copy? Copy or allow if not owned?
-            element = self.__get_history_collection_instance(trans, encoded_id).collection
+            element = self.__get_history_collection_instance(trans, src_id).collection
         # TODO: ldca.
         else:
             raise RequestParameterInvalidException(f"Unknown src_type parameter supplied '{src_type}'.")
@@ -637,17 +638,12 @@ class DatasetCollectionManager:
         """
         return MatchingCollections.for_collections(collections_to_match, self.collection_type_descriptions)
 
-    def get_dataset_collection_instance(self, trans, instance_type, id, **kwds):
+    def get_dataset_collection_instance(self, trans, instance_type: str, id: int, **kwds):
         """ """
         if instance_type == "history":
             return self.__get_history_collection_instance(trans, id, **kwds)
         elif instance_type == "library":
             return self.__get_library_collection_instance(trans, id, **kwds)
-
-    def get_dataset_collection(self, trans, encoded_id):
-        collection_id = int(trans.app.security.decode_id(encoded_id))
-        collection = trans.sa_session.query(trans.app.model.DatasetCollection).get(collection_id)
-        return collection
 
     def apply_rules(self, hdca, rule_set, handle_dataset):
         hdca_collection = hdca.collection
@@ -749,13 +745,12 @@ class DatasetCollectionManager:
 
         return data, sources
 
-    def __get_history_collection_instance(self, trans, id, check_ownership=False, check_accessible=True):
-        instance_id = int(trans.app.security.decode_id(id))
+    def __get_history_collection_instance(self, trans, instance_id: int, check_ownership=False, check_accessible=True):
         collection_instance = trans.sa_session.query(trans.app.model.HistoryDatasetCollectionAssociation).get(
             instance_id
         )
         if not collection_instance:
-            raise RequestParameterInvalidException(f"History dataset collection association {id} not found")
+            raise RequestParameterInvalidException("History dataset collection association not found")
         history = getattr(trans, "history", collection_instance.history)
         if check_ownership:
             self.history_manager.error_unless_owner(collection_instance.history, trans.user, current_history=history)
@@ -765,12 +760,11 @@ class DatasetCollectionManager:
             )
         return collection_instance
 
-    def __get_library_collection_instance(self, trans, id, check_ownership=False, check_accessible=True):
+    def __get_library_collection_instance(self, trans, instance_id: int, check_ownership=False, check_accessible=True):
         if check_ownership:
             raise NotImplementedError(
                 "Functionality (getting library dataset collection with ownership check) unimplemented."
             )
-        instance_id = int(trans.security.decode_id(id))
         collection_instance = trans.sa_session.query(trans.app.model.LibraryDatasetCollectionAssociation).get(
             instance_id
         )

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -10,7 +10,6 @@ import os
 import sys
 from typing import (
     Any,
-    cast,
     Dict,
     List,
 )
@@ -19,7 +18,6 @@ from galaxy.managers import base
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.markdown_util import weasyprint_available
 from galaxy.schema import SerializationParams
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.structured_app import StructuredApp
 from galaxy.web.framework.base import server_starttime
 
@@ -62,11 +60,11 @@ class ConfigurationManager:
 
     def decode_id(
         self,
-        encoded_id: EncodedDatabaseIdField,
+        encoded_id: str,
     ) -> Dict[str, int]:
         # Handle the special case for library folders
-        if (len(encoded_id) % 16 == 1) and encoded_id.startswith("F"):
-            encoded_id = cast(EncodedDatabaseIdField, encoded_id[1:])
+        if len(encoded_id) % 16 == 1 and encoded_id.startswith("F"):
+            encoded_id = encoded_id[1:]
         decoded_id = self._app.security.decode_id(encoded_id)
         return {"decoded_id": decoded_id}
 

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -447,16 +447,8 @@ class DatasetAssociationManager(base.ModelManager, secured.AccessibleManagerMixi
                 raise exceptions.InternalServerError("An error occurred and the dataset is NOT private.")
         elif action == "set_permissions":
 
-            def to_role_id(encoded_role_id):
-                role_id = base.decode_id(self.app, encoded_role_id)
-                return role_id
-
             def parameters_roles_or_none(role_type):
-                encoded_role_ids = kwd.get(role_type, kwd.get(f"{role_type}_ids[]", None))
-                if encoded_role_ids is not None:
-                    return list(map(to_role_id, encoded_role_ids))
-                else:
-                    return None
+                return kwd.get(role_type, kwd.get(f"{role_type}_ids[]"))
 
             access_roles = parameters_roles_or_none("access")
             manage_roles = parameters_roles_or_none("manage")

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -28,7 +28,7 @@ class FolderManager:
     Interface/service object for interacting with folders.
     """
 
-    def get(self, trans, decoded_folder_id, check_manageable=False, check_accessible=True):
+    def get(self, trans, decoded_folder_id: int, check_manageable=False, check_accessible=True):
         """
         Get the folder from the DB.
 

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -6,9 +6,7 @@ from typing import (
 
 from galaxy import model
 from galaxy.exceptions import ObjectNotFound
-from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesAppContext
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
@@ -20,14 +18,14 @@ class GroupRolesManager:
     def __init__(self, app: MinimalManagerApp) -> None:
         self._app = app
 
-    def index(self, trans: ProvidesAppContext, group_id: EncodedDatabaseIdField):
+    def index(self, trans: ProvidesAppContext, group_id: int):
         """
         Returns a collection roles associated with the given group.
         """
         group = self._get_group(trans, group_id)
         return group.roles
 
-    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
+    def show(self, trans: ProvidesAppContext, id: int, group_id: int):
         """
         Returns information about a group role.
         """
@@ -39,7 +37,7 @@ class GroupRolesManager:
             raise ObjectNotFound(f"Role {role.name} not in group {group.name}")
         return role
 
-    def update(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
+    def update(self, trans: ProvidesAppContext, id: int, group_id: int):
         """
         Adds a role to a group if it is not already associated.
         """
@@ -51,7 +49,7 @@ class GroupRolesManager:
             self._add_role_to_group(trans, group, role)
         return role
 
-    def delete(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
+    def delete(self, trans: ProvidesAppContext, id: int, group_id: int):
         """
         Removes a role from a group.
         """
@@ -64,18 +62,16 @@ class GroupRolesManager:
         self._remove_role_from_group(trans, group_role)
         return role
 
-    def _get_group(self, trans: ProvidesAppContext, encoded_group_id: EncodedDatabaseIdField) -> Any:
-        decoded_group_id = decode_id(self._app, encoded_group_id)
-        group = trans.sa_session.query(model.Group).get(decoded_group_id)
+    def _get_group(self, trans: ProvidesAppContext, group_id: int) -> Any:
+        group = trans.sa_session.query(model.Group).get(group_id)
         if not group:
-            raise ObjectNotFound(f"Group with id {encoded_group_id} was not found.")
+            raise ObjectNotFound("Group not found.")
         return group
 
-    def _get_role(self, trans: ProvidesAppContext, encoded_role_id: EncodedDatabaseIdField) -> model.Role:
-        decoded_role_id = decode_id(self._app, encoded_role_id)
-        role = trans.sa_session.query(model.Role).get(decoded_role_id)
+    def _get_role(self, trans: ProvidesAppContext, role_id: int) -> model.Role:
+        role = trans.sa_session.query(model.Role).get(role_id)
         if not role:
-            raise ObjectNotFound(f"Role with id {encoded_role_id} was not found.")
+            raise ObjectNotFound("Role not found.")
         return role
 
     def _get_group_role(

--- a/lib/galaxy/managers/groups.py
+++ b/lib/galaxy/managers/groups.py
@@ -1,20 +1,18 @@
-from typing import (
-    Any,
-    Dict,
-    List,
-)
+from typing import List
 
 from sqlalchemy import false
 
 from galaxy import model
 from galaxy.exceptions import (
     Conflict,
-    ObjectAttributeMissingException,
     ObjectNotFound,
 )
-from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesAppContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.schema import (
+    GroupDefinitionModel,
+    GroupUpdateModel,
+)
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.web import url_for
 
@@ -37,21 +35,17 @@ class GroupsManager:
             rval.append(item)
         return rval
 
-    def create(self, trans: ProvidesAppContext, payload: Dict[str, Any]):
+    def create(self, trans: ProvidesAppContext, group_model: GroupDefinitionModel):
         """
         Creates a new group.
         """
-        name = payload.get("name", None)
-        if name is None:
-            raise ObjectAttributeMissingException("Missing required name")
+        name = group_model.name
         self._check_duplicated_group_name(trans, name)
 
         group = model.Group(name=name)
         trans.sa_session.add(group)
-        encoded_user_ids = payload.get("user_ids", [])
-        users = self._get_users_by_encoded_ids(trans, encoded_user_ids)
-        encoded_role_ids = payload.get("role_ids", [])
-        roles = self._get_roles_by_encoded_ids(trans, encoded_role_ids)
+        users = self._get_users_by_ids(trans, group_model.user_ids)
+        roles = self._get_roles_by_ids(trans, group_model.role_ids)
         trans.app.security_agent.set_entity_group_associations(groups=[group], roles=roles, users=users)
         trans.sa_session.flush()
 
@@ -60,63 +54,48 @@ class GroupsManager:
         item["url"] = url_for("group", id=encoded_id)
         return [item]
 
-    def show(self, trans: ProvidesAppContext, encoded_id: EncodedDatabaseIdField):
+    def show(self, trans: ProvidesAppContext, group_id: int):
         """
         Displays information about a group.
         """
-        group = self._get_group(trans, encoded_id)
+        group = self._get_group(trans, group_id)
         item = group.to_dict(view="element", value_mapper={"id": trans.security.encode_id})
-        item["url"] = url_for("group", id=encoded_id)
-        item["users_url"] = url_for("group_users", group_id=encoded_id)
-        item["roles_url"] = url_for("group_roles", group_id=encoded_id)
+        item["url"] = url_for("group", id=item["id"])
+        item["users_url"] = url_for("group_users", group_id=item["id"])
+        item["roles_url"] = url_for("group_roles", group_id=item["id"])
         return item
 
-    def update(self, trans: ProvidesAppContext, encoded_id: EncodedDatabaseIdField, payload: Dict[str, Any]):
+    def update(self, trans: ProvidesAppContext, group_id: int, group_model: GroupUpdateModel):
         """
         Modifies a group.
         """
-        group = self._get_group(trans, encoded_id)
-        name = payload.get("name", None)
+        group = self._get_group(trans, group_id)
+        name = group_model.name
         if name:
             self._check_duplicated_group_name(trans, name)
             group.name = name
             trans.sa_session.add(group)
-        encoded_user_ids = payload.get("user_ids", [])
-        users = self._get_users_by_encoded_ids(trans, encoded_user_ids)
-        encoded_role_ids = payload.get("role_ids", [])
-        roles = self._get_roles_by_encoded_ids(trans, encoded_role_ids)
+        users = self._get_users_by_ids(trans, group_model.user_ids)
+        roles = self._get_roles_by_ids(trans, group_model.role_ids)
         trans.app.security_agent.set_entity_group_associations(
             groups=[group], roles=roles, users=users, delete_existing_assocs=False
         )
         trans.sa_session.flush()
 
-    def _decode_id(self, encoded_id: EncodedDatabaseIdField) -> int:
-        return decode_id(self._app, encoded_id)
-
-    def _decode_ids(self, encoded_ids: List[EncodedDatabaseIdField]) -> List[int]:
-        return [self._decode_id(encoded_id) for encoded_id in encoded_ids]
-
     def _check_duplicated_group_name(self, trans: ProvidesAppContext, group_name: str) -> None:
         if trans.sa_session.query(model.Group).filter(model.Group.name == group_name).first():
             raise Conflict(f"A group with name '{group_name}' already exists")
 
-    def _get_group(self, trans: ProvidesAppContext, encoded_id: EncodedDatabaseIdField) -> model.Group:
-        decoded_group_id = self._decode_id(encoded_id)
-        group = trans.sa_session.query(model.Group).get(decoded_group_id)
+    def _get_group(self, trans: ProvidesAppContext, group_id: int) -> model.Group:
+        group = trans.sa_session.query(model.Group).get(group_id)
         if group is None:
-            raise ObjectNotFound(f"Group with id {encoded_id} was not found.")
+            raise ObjectNotFound("Group not found.")
         return group
 
-    def _get_users_by_encoded_ids(
-        self, trans: ProvidesAppContext, encoded_user_ids: List[EncodedDatabaseIdField]
-    ) -> List[model.User]:
-        decoded_user_ids = self._decode_ids(encoded_user_ids)
-        users = trans.sa_session.query(model.User).filter(model.User.table.c.id.in_(decoded_user_ids)).all()
+    def _get_users_by_ids(self, trans: ProvidesAppContext, user_ids: List[DecodedDatabaseIdField]) -> List[model.User]:
+        users = trans.sa_session.query(model.User).filter(model.User.table.c.id.in_(user_ids)).all()
         return users
 
-    def _get_roles_by_encoded_ids(
-        self, trans: ProvidesAppContext, encoded_role_ids: List[EncodedDatabaseIdField]
-    ) -> List[model.Role]:
-        decoded_role_ids = self._decode_ids(encoded_role_ids)
-        roles = trans.sa_session.query(model.Role).filter(model.Role.id.in_(decoded_role_ids)).all()
+    def _get_roles_by_ids(self, trans: ProvidesAppContext, role_ids: List[DecodedDatabaseIdField]) -> List[model.Role]:
+        roles = trans.sa_session.query(model.Role).filter(model.Role.id.in_(role_ids)).all()
         return roles

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -11,6 +11,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Union,
 )
 
 from sqlalchemy import (
@@ -32,9 +33,11 @@ from galaxy.managers.base import (
     SortableManager,
 )
 from galaxy.schema.schema import (
-    HDABasicInfo,
-    ShareHistoryExtra,
+    HDABasicInfoResponse,
+    ShareHistoryExtraResponse,
+    ShareWithExtraResponse,
 )
+from galaxy.schema.types import LatestLiteral
 from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
@@ -254,9 +257,9 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
 
     def get_sharing_extra_information(
         self, trans, item, users: Set[model.User], errors: Set[str], option: Optional[sharable.SharingOptions] = None
-    ) -> Optional[sharable.ShareWithExtra]:
+    ) -> Optional[ShareWithExtraResponse]:
         """Returns optional extra information about the datasets of the history that can be accessed by the users."""
-        extra = ShareHistoryExtra()
+        extra = ShareHistoryExtraResponse()
         history = cast(model.History, item)
         if history.empty:
             errors.add("You cannot share an empty history.")
@@ -291,7 +294,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
                         trans.app.security_agent.make_dataset_public(hda.dataset)
                 else:
                     hda_id = trans.security.encode_id(hda.id)
-                    hda_info = HDABasicInfo(id=hda_id, name=hda.name)
+                    hda_info = HDABasicInfoResponse(id=hda_id, name=hda.name)
                     if owner_can_manage_dataset:
                         can_change_dict[hda_id] = hda_info
                     else:
@@ -341,18 +344,21 @@ class HistoryExportView:
     def __init__(self, app: MinimalManagerApp):
         self.app = app
 
-    def get_exports(self, trans, history_id):
+    def get_exports(self, trans, history_id: int):
         history = self._history(trans, history_id)
         matching_exports = history.exports
         return [self.serialize(trans, history_id, e) for e in matching_exports]
 
-    def serialize(self, trans, history_id, jeha):
+    def serialize(self, trans, history_id: int, jeha):
         rval = jeha.to_dict()
         encoded_jeha_id = trans.security.encode_id(jeha.id)
-        api_url = trans.url_builder("history_archive_download", id=history_id, jeha_id=encoded_jeha_id)
-        external_url = trans.url_builder("history_archive_download", id=history_id, jeha_id="latest", qualified=True)
+        encoded_history_id = trans.security.encode_id(history_id)
+        api_url = trans.url_builder("history_archive_download", id=encoded_history_id, jeha_id=encoded_jeha_id)
+        external_url = trans.url_builder(
+            "history_archive_download", id=encoded_history_id, jeha_id="latest", qualified=True
+        )
         external_permanent_url = trans.url_builder(
-            "history_archive_download", id=history_id, jeha_id=encoded_jeha_id, qualified=True
+            "history_archive_download", id=encoded_history_id, jeha_id=encoded_jeha_id, qualified=True
         )
         rval["download_url"] = api_url
         rval["external_download_latest_url"] = external_url
@@ -360,12 +366,11 @@ class HistoryExportView:
         rval = trans.security.encode_all_ids(rval)
         return rval
 
-    def get_ready_jeha(self, trans, history_id, jeha_id="latest"):
+    def get_ready_jeha(self, trans, history_id, jeha_id: Union[int, LatestLiteral] = "latest"):
         history = self._history(trans, history_id)
         matching_exports = history.exports
         if jeha_id != "latest":
-            decoded_jeha_id = trans.security.decode_id(jeha_id)
-            matching_exports = [e for e in matching_exports if e.id == decoded_jeha_id]
+            matching_exports = [e for e in matching_exports if e.id == jeha_id]
         if len(matching_exports) == 0:
             raise glx_exceptions.ObjectNotFound("Failed to find target history export")
 
@@ -375,11 +380,9 @@ class HistoryExportView:
 
         return jeha
 
-    def _history(self, trans, history_id):
+    def _history(self, trans, history_id: Optional[int] = None) -> model.History:
         if history_id is not None:
-            history = self.app.history_manager.get_accessible(
-                trans.security.decode_id(history_id), trans.user, current_history=trans.history
-            )
+            history = self.app.history_manager.get_accessible(history_id, trans.user, current_history=trans.history)
         else:
             history = trans.history
         return history

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -75,7 +75,7 @@ class JobManager:
         )
         return self.job_lock()
 
-    def get_accessible_job(self, trans, decoded_job_id):
+    def get_accessible_job(self, trans, decoded_job_id: int):
         job = trans.sa_session.query(trans.app.model.Job).filter(trans.app.model.Job.id == decoded_job_id).first()
         if job is None:
             raise ObjectNotFound()

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -32,7 +32,7 @@ class LibraryManager:
     Interface/service object for interacting with libraries.
     """
 
-    def get(self, trans, decoded_library_id, check_accessible=True):
+    def get(self, trans, decoded_library_id: int, check_accessible: bool = True):
         """
         Get the library from the DB.
 
@@ -238,9 +238,7 @@ class LibraryManager:
         allowed_library_add_ids = prefetched_ids.get("allowed_library_add_ids", None) if prefetched_ids else None
         allowed_library_modify_ids = prefetched_ids.get("allowed_library_modify_ids", None) if prefetched_ids else None
         allowed_library_manage_ids = prefetched_ids.get("allowed_library_manage_ids", None) if prefetched_ids else None
-        library_dict = library.to_dict(
-            view="element", value_mapper={"id": trans.security.encode_id, "root_folder_id": trans.security.encode_id}
-        )
+        library_dict = library.to_dict(view="element")
         library_dict["public"] = False if (restricted_library_ids and library.id in restricted_library_ids) else True
         library_dict["create_time_pretty"] = pretty_print_time_interval(library.create_time, precise=True)
         if not trans.user_is_admin:

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -28,7 +28,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         self.app = app
         self.tag_handler = tags.GalaxyTagHandler(app.model.context)
 
-    def get(self, trans, decoded_library_dataset_id, check_accessible=True):
+    def get(self, trans, decoded_library_dataset_id: int, check_accessible=True):
         """
         Get the library dataset from the DB.
 

--- a/lib/galaxy/managers/quotas.py
+++ b/lib/galaxy/managers/quotas.py
@@ -23,7 +23,6 @@ from galaxy.quota._schema import (
     DefaultQuotaValues,
     QuotaOperation,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.structured_app import StructuredApp
 
 log = logging.getLogger(__name__)
@@ -257,5 +256,5 @@ class QuotaManager:
         message += ", ".join(names)
         return message
 
-    def get_quota(self, trans, id: EncodedDatabaseIdField, deleted: Optional[bool] = None) -> model.Quota:
+    def get_quota(self, trans, id: int, deleted: Optional[bool] = None) -> model.Quota:
         return base.get_object(trans, id, "Quota", check_ownership=False, check_accessible=False, deleted=deleted)

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -28,7 +28,7 @@ class RoleManager(base.ModelManager):
     user_assoc = model.UserRoleAssociation
     group_assoc = model.GroupRoleAssociation
 
-    def get(self, trans: ProvidesUserContext, decoded_role_id):
+    def get(self, trans: ProvidesUserContext, decoded_role_id: int):
         """
         Method loads the role from the DB based on the given role id.
 
@@ -74,8 +74,8 @@ class RoleManager(base.ModelManager):
 
         role = Role(name=name, description=description, type=role_type)
         trans.sa_session.add(role)
-        users = [trans.sa_session.query(model.User).get(trans.security.decode_id(i)) for i in user_ids]
-        groups = [trans.sa_session.query(model.Group).get(trans.security.decode_id(i)) for i in group_ids]
+        users = [trans.sa_session.query(model.User).get(user_id) for user_id in user_ids]
+        groups = [trans.sa_session.query(model.Group).get(group_id) for group_id in group_ids]
 
         # Create the UserRoleAssociations
         for user in users:

--- a/lib/galaxy/managers/secured.py
+++ b/lib/galaxy/managers/secured.py
@@ -32,7 +32,7 @@ class AccessibleManagerMixin:
         # override in subclasses
         raise exceptions.NotImplemented("Abstract interface Method")
 
-    def get_accessible(self, id, user, **kwargs):
+    def get_accessible(self, id: int, user, **kwargs):
         """
         Return the item with the given id if it's accessible to user,
         otherwise raise an error.
@@ -98,7 +98,7 @@ class OwnableManagerMixin:
         # override in subclasses
         raise exceptions.NotImplemented("Abstract interface Method")
 
-    def get_owned(self, id, user, **kwargs):
+    def get_owned(self, id: int, user, **kwargs):
         """
         Return the item with the given id if owned by the user,
         otherwise raise an error.

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -37,7 +37,7 @@ from galaxy.model import (
 )
 from galaxy.model.tags import GalaxyTagHandler
 from galaxy.schema.schema import (
-    ShareWithExtra,
+    ShareWithExtraResponse,
     SharingOptions,
 )
 from galaxy.structured_app import MinimalManagerApp
@@ -243,7 +243,7 @@ class SharableModelManager(
 
     def get_sharing_extra_information(
         self, trans, item, users: Set[User], errors: Set[str], option: Optional[SharingOptions] = None
-    ) -> Optional[ShareWithExtra]:
+    ) -> Optional[ShareWithExtraResponse]:
         """Returns optional extra information about the shareability of the given item.
 
         This function should be overridden in the particular manager class that wants
@@ -564,6 +564,5 @@ __all__ = (
     "SharableModelManager",
     "SharableModelSerializer",
     "SharingOptions",
-    "ShareWithExtra",
     "SlugBuilder",
 )

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -9,7 +9,7 @@ from pydantic import (
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import ItemTagAssociation
 from galaxy.model.tags import GalaxyTagHandlerSession
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import TagCollection
 
 taggable_item_names = {item: item for item in ItemTagAssociation.associated_item_names}
@@ -19,7 +19,7 @@ TaggableItemClass = Enum("TaggableItemClass", taggable_item_names)  # type: igno
 
 
 class ItemTagsPayload(BaseModel):
-    item_id: EncodedDatabaseIdField = Field(
+    item_id: DecodedDatabaseIdField = Field(
         ...,  # This field is required
         title="Item ID",
         description="The `encoded identifier` of the item whose tags will be updated.",
@@ -59,8 +59,7 @@ class TagsManager:
         Get an item based on type and id.
         """
         tag_handler = GalaxyTagHandlerSession(trans.sa_session)
-        id = trans.security.decode_id(payload.item_id)
         item_class_name = str(payload.item_class)
         item_class = tag_handler.item_tag_assoc_info[item_class_name].item_class
-        item = trans.sa_session.query(item_class).filter(item_class.id == id).first()
+        item = trans.sa_session.query(item_class).filter(item_class.id == payload.item_id).first()
         return item

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -90,19 +90,19 @@ class WorkflowsManager:
                     trans.app.model.Workflow.uuid == workflow_uuid,
                 )
             )
-        elif by_stored_id:
-            workflow_id = decode_id(self.app, workflow_id)
-            workflow_query = trans.sa_session.query(trans.app.model.StoredWorkflow).filter(
-                trans.app.model.StoredWorkflow.id == workflow_id
-            )
         else:
-            workflow_id = decode_id(self.app, workflow_id)
-            workflow_query = trans.sa_session.query(trans.app.model.StoredWorkflow).filter(
-                and_(
-                    trans.app.model.StoredWorkflow.id == trans.app.model.Workflow.stored_workflow_id,
-                    trans.app.model.Workflow.id == workflow_id,
+            workflow_id = workflow_id if isinstance(workflow_id, int) else decode_id(self.app, workflow_id)
+            if by_stored_id:
+                workflow_query = trans.sa_session.query(trans.app.model.StoredWorkflow).filter(
+                    trans.app.model.StoredWorkflow.id == workflow_id
                 )
-            )
+            else:
+                workflow_query = trans.sa_session.query(trans.app.model.StoredWorkflow).filter(
+                    and_(
+                        trans.app.model.StoredWorkflow.id == trans.app.model.Workflow.stored_workflow_id,
+                        trans.app.model.Workflow.id == workflow_id,
+                    )
+                )
         stored_workflow = workflow_query.options(
             joinedload("annotations"),
             joinedload("tags"),

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -197,7 +197,7 @@ class WorkflowsManager:
 
         return True
 
-    def get_invocation(self, trans, decoded_invocation_id, eager=False):
+    def get_invocation(self, trans, decoded_invocation_id: int, eager=False):
         q = trans.sa_session.query(self.app.model.WorkflowInvocation)
         if eager:
             q = q.options(
@@ -215,9 +215,8 @@ class WorkflowsManager:
         self.check_security(trans, workflow_invocation, check_ownership=True, check_accessible=False)
         return workflow_invocation
 
-    def get_invocation_report(self, trans, invocation_id, **kwd):
-        decoded_workflow_invocation_id = trans.security.decode_id(invocation_id)
-        workflow_invocation = self.get_invocation(trans, decoded_workflow_invocation_id)
+    def get_invocation_report(self, trans, invocation_id: int, **kwd):
+        workflow_invocation = self.get_invocation(trans, invocation_id)
         generator_plugin_type = kwd.get("generator_plugin_type")
         runtime_report_config_json = kwd.get("runtime_report_config_json")
         invocation_markdown = kwd.get("invocation_markdown", None)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4757,15 +4757,6 @@ class Library(Base, Dictifiable, HasName, Serializable):
         serialization_options.attach_identifier(id_encoder, self, rval)
         return rval
 
-    def to_dict(self, view="collection", value_mapper=None):
-        """
-        We prepend an F to folders.
-        """
-        rval = super().to_dict(view=view, value_mapper=value_mapper)
-        if "root_folder_id" in rval:
-            rval["root_folder_id"] = f"F{str(rval['root_folder_id'])}"
-        return rval
-
     def get_active_folders(self, folder, folders=None):
         # TODO: should we make sure the library is not deleted?
         def sort_by_attr(seq, attr):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -220,7 +220,7 @@ def recalculate_user_disk_usage(app, **kwargs):
     user_id = kwargs.get("user_id", None)
     sa_session = app.model.context
     if user_id:
-        user = sa_session.query(app.model.User).get(app.security.decode_id(user_id))
+        user = sa_session.query(app.model.User).get(user_id)
         if user:
             user.calculate_and_set_disk_usage()
         else:

--- a/lib/galaxy/quota/_schema.py
+++ b/lib/galaxy/quota/_schema.py
@@ -15,7 +15,7 @@ from galaxy.schema.fields import (
 )
 from galaxy.schema.schema import (
     GroupModel,
-    UserModel,
+    UserResponseModel,
 )
 
 QUOTA_MODEL_CLASS_NAME = "Quota"
@@ -82,7 +82,7 @@ class DefaultQuota(BaseModel):  # TODO: should this replace lib.galaxy.model.Def
 
 class UserQuota(BaseModel):
     model_class: str = ModelClassField(USER_QUOTA_ASSOCIATION_MODEL_CLASS_NAME)
-    user: UserModel = Field(
+    user: UserResponseModel = Field(
         ...,
         title="User",
         description="Information about a user associated with a quota.",
@@ -98,7 +98,7 @@ class GroupQuota(BaseModel):
     )
 
 
-class QuotaBase(BaseModel):
+class QuotaBaseResponse(BaseModel):
     """Base model containing common fields for Quotas."""
 
     model_class: str = ModelClassField(QUOTA_MODEL_CLASS_NAME)
@@ -110,7 +110,7 @@ class QuotaBase(BaseModel):
     name: str = QuotaNameField
 
 
-class QuotaSummary(QuotaBase):
+class QuotaSummaryResponse(QuotaBaseResponse):
     """Contains basic information about a Quota"""
 
     url: str = Field(
@@ -122,13 +122,13 @@ class QuotaSummary(QuotaBase):
 
 
 class QuotaSummaryList(BaseModel):
-    __root__: List[QuotaSummary] = Field(
+    __root__: List[QuotaSummaryResponse] = Field(
         default=[],
         title="List with summary information of Quotas.",
     )
 
 
-class QuotaDetails(QuotaBase):
+class QuotaDetailsResponse(QuotaBaseResponse):
     description: str = QuotaDescriptionField
     bytes: int = Field(
         ...,
@@ -158,7 +158,7 @@ class QuotaDetails(QuotaBase):
     )
 
 
-class CreateQuotaResult(QuotaSummary):
+class CreateQuotaResult(QuotaSummaryResponse):
     message: str = Field(
         ...,
         title="Message",

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -37,6 +37,7 @@ from galaxy.webhooks import WebhooksRegistry
 from galaxy.workflow.trs_proxy import TrsProxy
 
 if TYPE_CHECKING:
+    import galaxy.managers.workflows
     from galaxy.tools.data import ToolDataTableManager
 
 
@@ -86,8 +87,8 @@ class MinimalManagerApp(MinimalApp):
     dataset_collection_manager: Any  # 'galaxy.managers.collections.DatasetCollectionManager'
     history_manager: Any  # 'galaxy.managers.histories.HistoryManager'
     hda_manager: Any  # 'galaxy.managers.hdas.HDAManager'
-    workflow_manager: Any  # 'galaxy.managers.workflows.WorkflowsManager'
-    workflow_contents_manager: Any  # 'galaxy.managers.workflows.WorkflowContentsManager'
+    workflow_manager: "galaxy.managers.workflows.WorkflowsManager"
+    workflow_contents_manager: "galaxy.managers.workflows.WorkflowContentsManager"
     library_folder_manager: Any  # 'galaxy.managers.folders.FolderManager'
     library_manager: Any  # 'galaxy.managers.libraries.LibraryManager'
     role_manager: Any  # 'galaxy.managers.roles.RoleManager'
@@ -132,8 +133,8 @@ class StructuredApp(MinimalManagerApp):
     queue_worker: Any  # 'galaxy.queue_worker.GalaxyQueueWorker'
     history_manager: Any  # 'galaxy.managers.histories.HistoryManager'
     hda_manager: Any  # 'galaxy.managers.hdas.HDAManager'
-    workflow_manager: Any  # 'galaxy.managers.workflows.WorkflowsManager'
-    workflow_contents_manager: Any  # 'galaxy.managers.workflows.WorkflowContentsManager'
+    workflow_manager: "galaxy.managers.workflows.WorkflowsManager"
+    workflow_contents_manager: "galaxy.managers.workflows.WorkflowContentsManager"
     library_folder_manager: Any  # 'galaxy.managers.folders.FolderManager'
     library_manager: Any  # 'galaxy.managers.libraries.LibraryManager'
     role_manager: Any  # 'galaxy.managers.roles.RoleManager'

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -174,7 +174,7 @@ class LibraryParams:
 
 
 def handle_library_params(
-    trans, params, folder_id: str, replace_dataset: Optional[LibraryDataset] = None
+    trans, params, folder_id: int, replace_dataset: Optional[LibraryDataset] = None
 ) -> LibraryParams:
     # FIXME: the received params has already been parsed by util.Params() by the time it reaches here,
     # so no complex objects remain.  This is not good because it does not allow for those objects to be
@@ -183,7 +183,7 @@ def handle_library_params(
     # See if we have any template field contents
     template_field_contents = {}
     template_id = params.get("template_id", None)
-    folder = trans.sa_session.query(LibraryFolder).get(trans.security.decode_id(folder_id))
+    folder = trans.sa_session.query(LibraryFolder).get(folder_id)
     # We are inheriting the folder's info_association, so we may have received inherited contents or we may have redirected
     # here after the user entered template contents ( due to errors ).
     template: Optional[FormDefinition] = None

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -619,13 +619,13 @@ class UsesVisualizationMixin(UsesLibraryMixinItems):
 
     slug_builder = SlugBuilder()
 
-    def get_visualization(self, trans, id, check_ownership=True, check_accessible=False):
+    def get_visualization(self, trans, id: int, check_ownership=True, check_accessible=False):
         """
         Get a Visualization from the database by id, verifying ownership.
         """
         # Load workflow from database
         try:
-            visualization = trans.sa_session.query(trans.model.Visualization).get(trans.security.decode_id(id))
+            visualization = trans.sa_session.query(trans.model.Visualization).get(id)
         except TypeError:
             visualization = None
         if not visualization:
@@ -1393,7 +1393,7 @@ class SharableMixin:
         """Returns item content in HTML format."""
         raise NotImplementedError()
 
-    def get_item(self, trans, id):
+    def get_item(self, trans, id: str):
         """Return item based on id."""
         raise NotImplementedError()
 

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -4,6 +4,7 @@ Contains functionality needed in every web interface
 import logging
 from typing import (
     Any,
+    Callable,
     Optional,
 )
 
@@ -406,7 +407,10 @@ class SharableItemSecurityMixin:
 
 
 class UsesLibraryMixinItems(SharableItemSecurityMixin):
-    def get_library_folder(self, trans, id, check_ownership=False, check_accessible=True):
+
+    get_object: Callable
+
+    def get_library_folder(self, trans, id: int, check_ownership=False, check_accessible=True):
         return self.get_object(trans, id, "LibraryFolder", check_ownership=False, check_accessible=check_accessible)
 
     def get_library_dataset_dataset_association(self, trans, id, check_ownership=False, check_accessible=True):
@@ -454,7 +458,7 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
             # Slight misuse of ItemOwnershipException?
             raise exceptions.ItemOwnershipException("User cannot add to library item.")
 
-    def _copy_hdca_to_library_folder(self, trans, hda_manager, from_hdca_id, folder_id, ldda_message=""):
+    def _copy_hdca_to_library_folder(self, trans, hda_manager, from_hdca_id: int, folder_id: int, ldda_message=""):
         """
         Fetches the collection identified by `from_hcda_id` and dispatches individual collection elements to
         _copy_hda_to_library_folder
@@ -480,7 +484,7 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
         ]
 
     def _copy_hda_to_library_folder(
-        self, trans, hda_manager, from_hda_id, folder_id, ldda_message="", element_identifier=None
+        self, trans, hda_manager, from_hda_id: int, folder_id: int, ldda_message="", element_identifier=None
     ):
         """
         Copies hda ``from_hda_id`` to library folder ``folder_id``, optionally
@@ -490,7 +494,6 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
         in its payload.
         """
         log.debug(f"_copy_hda_to_library_folder: {str((from_hda_id, folder_id, ldda_message))}")
-        # PRECONDITION: folder_id has already been altered to remove the folder prefix ('F')
         # TODO: allow name and other, editable ldda attrs?
         if ldda_message:
             ldda_message = sanitize_html(ldda_message)

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -39,7 +39,6 @@ from galaxy import (
 from galaxy.exceptions import (
     AdminRequiredException,
     UserCannotRunAsException,
-    UserInvalidRunAsException,
 )
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.users import UserManager
@@ -129,11 +128,7 @@ def get_api_user(
     user = user_manager.by_api_key(api_key=api_key)
     if run_as:
         if user_manager.user_can_do_run_as(user):
-            try:
-                decoded_run_as_id = security.decode_id(run_as)
-            except Exception:
-                raise UserInvalidRunAsException
-            return user_manager.by_id(decoded_run_as_id)
+            return user_manager.by_id(run_as)
         else:
             raise UserCannotRunAsException
     return user

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -44,7 +44,7 @@ from galaxy.exceptions import (
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.users import UserManager
 from galaxy.model import User
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import StructuredApp
 from galaxy.web.framework.decorators import require_admin_message
@@ -114,7 +114,7 @@ def get_api_user(
     user_manager: UserManager = depends(UserManager),
     key: Optional[str] = Query(None),
     x_api_key: Optional[str] = Header(None),
-    run_as: Optional[EncodedDatabaseIdField] = Header(
+    run_as: Optional[DecodedDatabaseIdField] = Header(
         default=None,
         title="Run as User",
         description=(

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -97,7 +97,7 @@ class FastAPIConfiguration:
         summary="Decode a given id",
         response_description="Decoded id",
     )
-    def decode_id(self, encoded_id: DecodedDatabaseIdField = EncodedIdPathParam) -> Dict[str, DecodedDatabaseIdField]:
+    def decode_id(self, encoded_id: DecodedDatabaseIdField = EncodedIdPathParam) -> Dict[str, int]:
         """Decode a given id."""
         return {"decoded_id": encoded_id}
 

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -8,16 +8,16 @@ from fastapi import (
 )
 
 from galaxy.managers.context import ProvidesHistoryContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
-    AnyHDCA,
+    AnyHDCAResponse,
     CreateNewCollectionPayload,
     DatasetCollectionInstanceType,
-    HDCADetailed,
+    HDCADetailedResponse,
 )
 from galaxy.webapps.galaxy.services.dataset_collections import (
     DatasetCollectionAttributesResult,
-    DatasetCollectionContentElements,
+    DatasetCollectionContentElementsResponse,
     DatasetCollectionsService,
     SuitableConverters,
     UpdateCollectionAttributePayload,
@@ -32,7 +32,7 @@ log = getLogger(__name__)
 
 router = Router(tags=["dataset collections"])
 
-DatasetCollectionIdPathParam: EncodedDatabaseIdField = Path(
+DatasetCollectionIdPathParam: DecodedDatabaseIdField = Path(
     ..., description="The encoded identifier of the dataset collection."
 )
 
@@ -54,7 +54,7 @@ class FastAPIDatasetCollections:
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         payload: CreateNewCollectionPayload = Body(...),
-    ) -> HDCADetailed:
+    ) -> HDCADetailedResponse:
         return self.service.create(trans, payload)
 
     @router.post(
@@ -64,7 +64,7 @@ class FastAPIDatasetCollections:
     def copy(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = Path(..., description="The ID of the dataset collection to copy."),
+        id: DecodedDatabaseIdField = Path(..., description="The ID of the dataset collection to copy."),
         payload: UpdateCollectionAttributePayload = Body(...),
     ):
         self.service.copy(trans, id, payload)
@@ -76,7 +76,7 @@ class FastAPIDatasetCollections:
     def attributes(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
+        id: DecodedDatabaseIdField = DatasetCollectionIdPathParam,
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
     ) -> DatasetCollectionAttributesResult:
         return self.service.attributes(trans, id, instance_type)
@@ -88,7 +88,7 @@ class FastAPIDatasetCollections:
     def suitable_converters(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
+        id: DecodedDatabaseIdField = DatasetCollectionIdPathParam,
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
     ) -> SuitableConverters:
         return self.service.suitable_converters(trans, id, instance_type)
@@ -100,9 +100,9 @@ class FastAPIDatasetCollections:
     def show(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
+        id: DecodedDatabaseIdField = DatasetCollectionIdPathParam,
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
-    ) -> AnyHDCA:
+    ) -> AnyHDCAResponse:
         return self.service.show(trans, id, instance_type)
 
     @router.get(
@@ -113,8 +113,8 @@ class FastAPIDatasetCollections:
     def contents(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        hdca_id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
-        parent_id: EncodedDatabaseIdField = Path(
+        hdca_id: DecodedDatabaseIdField = DatasetCollectionIdPathParam,
+        parent_id: DecodedDatabaseIdField = Path(
             ...,
             description="Parent collection ID describing what collection the contents belongs to.",
         ),
@@ -127,5 +127,5 @@ class FastAPIDatasetCollections:
             default=None,
             description="The number of content elements that will be skipped before returning.",
         ),
-    ) -> DatasetCollectionContentElements:
+    ) -> DatasetCollectionContentElementsResponse:
         return self.service.contents(trans, hdca_id, parent_id, instance_type, limit, offset)

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -14,12 +14,12 @@ from fastapi import (
 )
 
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     CreateLibraryFolderPayload,
-    LibraryAvailablePermissions,
-    LibraryFolderCurrentPermissions,
-    LibraryFolderDetails,
+    LibraryAvailablePermissionsResponse,
+    LibraryFolderCurrentPermissionsResponse,
+    LibraryFolderDetailsResponse,
     LibraryFolderPermissionAction,
     LibraryFolderPermissionsPayload,
     LibraryPermissionScope,
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
 
 router = Router(tags=["folders"])
 
-FolderIdPathParam: EncodedDatabaseIdField = Path(
+FolderIdPathParam: DecodedDatabaseIdField = Path(
     ..., title="Folder ID", description="The encoded identifier of the library folder."
 )
 
@@ -56,8 +56,8 @@ class FastAPILibraryFolders:
     def show(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
-    ) -> LibraryFolderDetails:
+        id: DecodedDatabaseIdField = FolderIdPathParam,
+    ) -> LibraryFolderDetailsResponse:
         """Returns detailed information about the library folder with the given ID."""
         return self.service.show(trans, id)
 
@@ -68,9 +68,9 @@ class FastAPILibraryFolders:
     def create(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: DecodedDatabaseIdField = FolderIdPathParam,
         payload: CreateLibraryFolderPayload = Body(...),
-    ) -> LibraryFolderDetails:
+    ) -> LibraryFolderDetailsResponse:
         """Returns detailed information about the newly created library folder."""
         return self.service.create(trans, id, payload)
 
@@ -82,9 +82,9 @@ class FastAPILibraryFolders:
     def update(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: DecodedDatabaseIdField = FolderIdPathParam,
         payload: UpdateLibraryFolderPayload = Body(...),
-    ) -> LibraryFolderDetails:
+    ) -> LibraryFolderDetailsResponse:
         """Updates the information of an existing library folder."""
         return self.service.update(trans, id, payload)
 
@@ -95,9 +95,9 @@ class FastAPILibraryFolders:
     def delete(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: DecodedDatabaseIdField = FolderIdPathParam,
         undelete: Optional[bool] = UndeleteQueryParam,
-    ) -> LibraryFolderDetails:
+    ) -> LibraryFolderDetailsResponse:
         """Marks the specified library folder as deleted (or undeleted)."""
         return self.service.delete(trans, id, undelete)
 
@@ -108,7 +108,7 @@ class FastAPILibraryFolders:
     def get_permissions(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: DecodedDatabaseIdField = FolderIdPathParam,
         scope: Optional[LibraryPermissionScope] = Query(
             None,
             title="Scope",
@@ -123,7 +123,7 @@ class FastAPILibraryFolders:
         q: Optional[str] = Query(
             None, title="Query", description="Optional search text to retrieve only the roles matching this query."
         ),
-    ) -> Union[LibraryFolderCurrentPermissions, LibraryAvailablePermissions]:
+    ) -> Union[LibraryFolderCurrentPermissionsResponse, LibraryAvailablePermissionsResponse]:
         """Gets the current or available permissions of a particular library.
         The results can be paginated and additionally filtered by a query."""
         return self.service.get_permissions(
@@ -142,7 +142,7 @@ class FastAPILibraryFolders:
     def set_permissions(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: DecodedDatabaseIdField = FolderIdPathParam,
         action: Optional[LibraryFolderPermissionAction] = Query(
             default=None,
             title="Action",
@@ -152,7 +152,7 @@ class FastAPILibraryFolders:
             ),
         ),
         payload: LibraryFolderPermissionsPayload = Body(...),
-    ) -> LibraryFolderCurrentPermissions:
+    ) -> LibraryFolderCurrentPermissionsResponse:
         """Sets the permissions to manage a library folder."""
         payload_dict = payload.dict(by_alias=True)
         if isinstance(payload, LibraryFolderPermissionsPayload) and action is not None:

--- a/lib/galaxy/webapps/galaxy/api/group_users.py
+++ b/lib/galaxy/webapps/galaxy/api/group_users.py
@@ -5,7 +5,7 @@ import logging
 
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.group_users import GroupUsersManager
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.web import (
     expose_api,
     require_admin,
@@ -19,40 +19,47 @@ log = logging.getLogger(__name__)
 
 
 class GroupUsersAPIController(BaseGalaxyAPIController):
-    manager = depends(GroupUsersManager)
+    manager: GroupUsersManager = depends(GroupUsersManager)
 
     @require_admin
     @expose_api
-    def index(self, trans: ProvidesAppContext, group_id: EncodedDatabaseIdField, **kwd):
+    def index(self, trans: ProvidesAppContext, group_id: DecodedDatabaseIdField, **kwd):
         """
         GET /api/groups/{encoded_group_id}/users
         Displays a collection (list) of groups.
         """
+        group_id = self.decode_id(group_id)
         return self.manager.index(trans, group_id)
 
     @require_admin
     @expose_api
-    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField, **kwd):
+    def show(self, trans: ProvidesAppContext, id: DecodedDatabaseIdField, group_id: DecodedDatabaseIdField, **kwd):
         """
         GET /api/groups/{encoded_group_id}/users/{encoded_user_id}
         Displays information about a group user.
         """
+        id = self.decode_id(id)
+        group_id = self.decode_id(group_id)
         return self.manager.show(trans, id, group_id)
 
     @require_admin
     @expose_api
-    def update(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField, **kwd):
+    def update(self, trans: ProvidesAppContext, id: DecodedDatabaseIdField, group_id: DecodedDatabaseIdField, **kwd):
         """
         PUT /api/groups/{encoded_group_id}/users/{encoded_user_id}
         Adds a user to a group
         """
+        id = self.decode_id(id)
+        group_id = self.decode_id(group_id)
         return self.manager.update(trans, id, group_id)
 
     @require_admin
     @expose_api
-    def delete(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField, **kwd):
+    def delete(self, trans: ProvidesAppContext, id: DecodedDatabaseIdField, group_id: DecodedDatabaseIdField, **kwd):
         """
         DELETE /api/groups/{encoded_group_id}/users/{encoded_user_id}
         Removes a user from a group
         """
+        id = self.decode_id(id)
+        group_id = self.decode_id(group_id)
         return self.manager.delete(trans, id, group_id)

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -9,7 +9,11 @@ from typing import (
 
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.groups import GroupsManager
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.schema import (
+    GroupDefinitionModel,
+    GroupUpdateModel,
+)
 from galaxy.web import (
     expose_api,
     require_admin,
@@ -23,7 +27,7 @@ log = logging.getLogger(__name__)
 
 
 class GroupAPIController(BaseGalaxyAPIController):
-    manager = depends(GroupsManager)
+    manager: GroupsManager = depends(GroupsManager)
 
     @expose_api
     @require_admin
@@ -41,22 +45,24 @@ class GroupAPIController(BaseGalaxyAPIController):
         POST /api/groups
         Creates a new group.
         """
-        return self.manager.create(trans, payload)
+        return self.manager.create(trans, GroupDefinitionModel(**payload))
 
     @expose_api
     @require_admin
-    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, **kwd):
+    def show(self, trans: ProvidesAppContext, id: DecodedDatabaseIdField, **kwd):
         """
         GET /api/groups/{encoded_group_id}
         Displays information about a group.
         """
+        id = self.decode_id(id)
         return self.manager.show(trans, id)
 
     @expose_api
     @require_admin
-    def update(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, payload: Dict[str, Any], **kwd):
+    def update(self, trans: ProvidesAppContext, id: DecodedDatabaseIdField, payload: Dict[str, Any], **kwd):
         """
         PUT /api/groups/{encoded_group_id}
         Modifies a group.
         """
-        self.manager.update(trans, id, payload)
+        id = self.decode_id(id)
+        self.manager.update(trans, id, GroupUpdateModel(**payload))

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -358,13 +358,11 @@ class FastAPIHistoryContents:
         "/api/histories/{history_id}/contents/{type}s/{id}",
         name="history_content_typed",
         summary="Return detailed information about a specific HDA or HDCA with the given `ID` within a history.",
-        response_model_exclude_unset=True,
     )
     @router.get(
         "/api/histories/{history_id}/contents/{id}",
         name="history_content",
         summary="Return detailed information about an HDA within a history.",
-        response_model_exclude_unset=True,
         deprecated=True,
     )
     def show(
@@ -452,12 +450,10 @@ class FastAPIHistoryContents:
     @router.post(
         "/api/histories/{history_id}/contents/{type}s",
         summary="Create a new `HDA` or `HDCA` in the given History.",
-        response_model_exclude_unset=True,
     )
     @router.post(
         "/api/histories/{history_id}/contents",
         summary="Create a new `HDA` or `HDCA` in the given History.",
-        response_model_exclude_unset=True,
         deprecated=True,
     )
     def create(
@@ -531,12 +527,10 @@ class FastAPIHistoryContents:
     @router.put(
         "/api/histories/{history_id}/contents/{type}s/{id}",
         summary="Updates the values for the history content item with the given ``ID``.",
-        response_model_exclude_unset=True,
     )
     @router.put(
         "/api/histories/{history_id}/contents/{id}",
         summary="Updates the values for the history content item with the given ``ID``.",
-        response_model_exclude_unset=True,
         deprecated=True,
     )
     def update(

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -27,7 +27,7 @@ from galaxy.managers.jobs import (
     summarize_job_parameters,
     view_show_job,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.web import (
     expose_api,
     expose_api_anonymous,
@@ -53,10 +53,10 @@ class FastAPIJobs:
     job_search: JobSearch = depends(JobSearch)
     hda_manager: hdas.HDAManager = depends(hdas.HDAManager)
 
-    @router.get("/api/jobs/{id}")
+    @router.get("/api/jobs/{job_id}")
     def show(
         self,
-        id: EncodedDatabaseIdField,
+        job_id: DecodedDatabaseIdField,
         trans: ProvidesUserContext = DependsOnTrans,
         full: typing.Optional[bool] = False,
     ) -> typing.Dict:
@@ -67,8 +67,7 @@ class FastAPIJobs:
         - id: ID of job to return
         - full: Return extra information ?
         """
-        id = trans.app.security.decode_id(id)
-        job = self.job_manager.get_accessible_job(trans, id)
+        job = self.job_manager.get_accessible_job(trans, job_id)
         return view_show_job(trans, job, bool(full))
 
 

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -14,19 +14,19 @@ from fastapi import (
 )
 
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     CreateLibraryPayload,
     DeleteLibraryPayload,
     LegacyLibraryPermissionsPayload,
-    LibraryAvailablePermissions,
-    LibraryCurrentPermissions,
-    LibraryLegacySummary,
+    LibraryAvailablePermissionsResponse,
+    LibraryCurrentPermissionsResponse,
+    LibraryLegacySummaryResponse,
     LibraryPermissionAction,
     LibraryPermissionScope,
     LibraryPermissionsPayload,
-    LibrarySummary,
-    LibrarySummaryList,
+    LibrarySummaryListResponse,
+    LibrarySummaryResponse,
     UpdateLibraryPayload,
 )
 from galaxy.webapps.galaxy.services.libraries import LibrariesService
@@ -44,7 +44,7 @@ DeletedQueryParam: Optional[bool] = Query(
     default=None, title="Display deleted", description="Whether to include deleted libraries in the result."
 )
 
-LibraryIdPathParam: EncodedDatabaseIdField = Path(
+LibraryIdPathParam: DecodedDatabaseIdField = Path(
     ..., title="Library ID", description="The encoded identifier of the Library."
 )
 
@@ -65,7 +65,7 @@ class FastAPILibraries:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         deleted: Optional[bool] = DeletedQueryParam,
-    ) -> LibrarySummaryList:
+    ) -> LibrarySummaryListResponse:
         """Returns a list of summary data for all libraries."""
         return self.service.index(trans, deleted)
 
@@ -76,7 +76,7 @@ class FastAPILibraries:
     def index_deleted(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-    ) -> LibrarySummaryList:
+    ) -> LibrarySummaryListResponse:
         """Returns a list of summary data for all libraries marked as deleted."""
         return self.service.index(trans, True)
 
@@ -87,8 +87,8 @@ class FastAPILibraries:
     def show(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
-    ) -> LibrarySummary:
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
+    ) -> LibrarySummaryResponse:
         """Returns summary information about a particular library."""
         return self.service.show(trans, id)
 
@@ -101,7 +101,7 @@ class FastAPILibraries:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         payload: CreateLibraryPayload = Body(...),
-    ) -> LibrarySummary:
+    ) -> LibrarySummaryResponse:
         """Creates a new library and returns its summary information. Currently, only admin users can create libraries."""
         return self.service.create(trans, payload)
 
@@ -112,9 +112,9 @@ class FastAPILibraries:
     def update(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
         payload: UpdateLibraryPayload = Body(...),
-    ) -> LibrarySummary:
+    ) -> LibrarySummaryResponse:
         """
         Updates the information of an existing library.
         """
@@ -128,10 +128,10 @@ class FastAPILibraries:
     def delete(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
         undelete: Optional[bool] = UndeleteQueryParam,
         payload: Optional[DeleteLibraryPayload] = Body(default=None),
-    ) -> LibrarySummary:
+    ) -> LibrarySummaryResponse:
         """Marks the specified library as deleted (or undeleted).
         Currently, only admin users can delete or restore libraries."""
         if payload:
@@ -145,7 +145,7 @@ class FastAPILibraries:
     def get_permissions(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
         scope: Optional[LibraryPermissionScope] = Query(
             None,
             title="Scope",
@@ -165,7 +165,7 @@ class FastAPILibraries:
         q: Optional[str] = Query(
             None, title="Query", description="Optional search text to retrieve only the roles matching this query."
         ),
-    ) -> Union[LibraryCurrentPermissions, LibraryAvailablePermissions]:
+    ) -> Union[LibraryCurrentPermissionsResponse, LibraryAvailablePermissionsResponse]:
         """Gets the current or available permissions of a particular library.
         The results can be paginated and additionally filtered by a query."""
         return self.service.get_permissions(
@@ -185,7 +185,7 @@ class FastAPILibraries:
     def set_permissions(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
         action: Optional[LibraryPermissionAction] = Query(
             default=None,
             title="Action",
@@ -195,7 +195,7 @@ class FastAPILibraries:
             LibraryPermissionsPayload,
             LegacyLibraryPermissionsPayload,
         ] = Body(...),
-    ) -> Union[LibraryLegacySummary, LibraryCurrentPermissions]:  # Old legacy response
+    ) -> Union[LibraryLegacySummaryResponse, LibraryCurrentPermissionsResponse]:  # Old legacy response
         """Sets the permissions to access and manipulate a library."""
         payload_dict = payload.dict(by_alias=True)
         if isinstance(payload, LibraryPermissionsPayload) and action is not None:

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -334,7 +334,7 @@ class LibraryContentsController(
                 )
             return rval
 
-    def _upload_library_dataset(self, trans, library_id, folder_id, **kwd):
+    def _upload_library_dataset(self, trans, library_id: int, folder_id: int, **kwd):
         replace_id = kwd.get("replace_id", None)
         replace_dataset: Optional[LibraryDataset] = None
         upload_option = kwd.get("upload_option", "upload_file")
@@ -347,7 +347,7 @@ class LibraryContentsController(
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
         if replace_id not in ["", None, "None"]:
-            replace_dataset = trans.sa_session.query(LibraryDataset).get(trans.security.decode_id(replace_id))
+            replace_dataset = trans.sa_session.query(LibraryDataset).get(replace_id)
             self._check_access(trans, is_admin, replace_dataset, current_user_roles)
             self._check_modify(trans, is_admin, replace_dataset, current_user_roles)
             library = replace_dataset.folder.parent_library
@@ -357,7 +357,7 @@ class LibraryContentsController(
             if not last_used_build:
                 last_used_build = replace_dataset.library_dataset_dataset_association.dbkey
         else:
-            folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(trans.security.decode_id(folder_id))
+            folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(folder_id)
             self._check_access(trans, is_admin, folder, current_user_roles)
             self._check_add(trans, is_admin, folder, current_user_roles)
             library = folder.parent_library
@@ -377,7 +377,7 @@ class LibraryContentsController(
             return 400, message
         else:
             created_outputs_dict = self._upload_dataset(
-                trans, folder_id=trans.security.encode_id(folder.id), replace_dataset=replace_dataset, **kwd
+                trans, folder_id=folder.id, replace_dataset=replace_dataset, **kwd
             )
             if created_outputs_dict:
                 if type(created_outputs_dict) == str:

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -258,10 +258,10 @@ class LibraryContentsController(
             raise exceptions.RequestParameterMissingException("Missing required 'folder_id' parameter.")
         folder_id = payload.pop("folder_id")
         _, folder_id = self._decode_library_content_id(folder_id)
+        folder_id = trans.security.decode_id(folder_id)
         # security is checked in the downstream controller
         parent = self.get_library_folder(trans, folder_id, check_ownership=False, check_accessible=False)
         # The rest of the security happens in the library_common controller.
-        real_folder_id = trans.security.encode_id(parent.id)
 
         payload["tag_using_filenames"] = util.string_as_bool(payload.get("tag_using_filenames", None))
         payload["tags"] = util.listify(payload.get("tags", None))
@@ -276,11 +276,11 @@ class LibraryContentsController(
         if create_type == "file":
             if from_hda_id:
                 return self._copy_hda_to_library_folder(
-                    trans, self.hda_manager, self.decode_id(from_hda_id), real_folder_id, ldda_message
+                    trans, self.hda_manager, self.decode_id(from_hda_id), folder_id, ldda_message
                 )
             if from_hdca_id:
                 return self._copy_hdca_to_library_folder(
-                    trans, self.hda_manager, self.decode_id(from_hdca_id), real_folder_id, ldda_message
+                    trans, self.hda_manager, self.decode_id(from_hdca_id), folder_id, ldda_message
                 )
 
         # check for extended metadata, store it and pop it out of the param
@@ -289,9 +289,9 @@ class LibraryContentsController(
 
         # Now create the desired content object, either file or folder.
         if create_type == "file":
-            status, output = self._upload_library_dataset(trans, library_id, real_folder_id, **payload)
+            status, output = self._upload_library_dataset(trans, library_id, folder_id, **payload)
         elif create_type == "folder":
-            status, output = self._create_folder(trans, real_folder_id, library_id, **payload)
+            status, output = self._create_folder(trans, folder_id, library_id, **payload)
         elif create_type == "collection":
             # Not delegating to library_common, so need to check access to parent
             # folder here.

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -335,7 +335,6 @@ class LibraryContentsController(
             return rval
 
     def _upload_library_dataset(self, trans, library_id: int, folder_id: int, **kwd):
-        replace_id = kwd.get("replace_id", None)
         replace_dataset: Optional[LibraryDataset] = None
         upload_option = kwd.get("upload_option", "upload_file")
         dbkey = kwd.get("dbkey", "?")
@@ -346,21 +345,10 @@ class LibraryContentsController(
         roles = kwd.get("roles", "")
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
-        if replace_id not in ["", None, "None"]:
-            replace_dataset = trans.sa_session.query(LibraryDataset).get(replace_id)
-            self._check_access(trans, is_admin, replace_dataset, current_user_roles)
-            self._check_modify(trans, is_admin, replace_dataset, current_user_roles)
-            library = replace_dataset.folder.parent_library
-            folder = replace_dataset.folder
-            # The name is stored - by the time the new ldda is created, replace_dataset.name
-            # will point to the new ldda, not the one it's replacing.
-            if not last_used_build:
-                last_used_build = replace_dataset.library_dataset_dataset_association.dbkey
-        else:
-            folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(folder_id)
-            self._check_access(trans, is_admin, folder, current_user_roles)
-            self._check_add(trans, is_admin, folder, current_user_roles)
-            library = folder.parent_library
+        folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(folder_id)
+        self._check_access(trans, is_admin, folder, current_user_roles)
+        self._check_add(trans, is_admin, folder, current_user_roles)
+        library = folder.parent_library
         if folder and last_used_build in ["None", None, "?"]:
             last_used_build = folder.genome_build
         error = False

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -527,7 +527,7 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
         for input in tool.inputs.values():
             if input.type == "upload_dataset":
                 dataset_upload_inputs.append(input)
-        library_bunch = upload_common.handle_library_params(trans, {}, trans.security.encode_id(folder.id))
+        library_bunch = upload_common.handle_library_params(trans, {}, folder.id)
         abspath_datasets = []
         kwd["filesystem_paths"] = path
         if source in ["importdir_folder"]:

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -14,16 +14,16 @@ from fastapi import (
 from starlette.responses import StreamingResponse
 
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     CreatePagePayload,
-    PageDetails,
-    PageSummary,
-    PageSummaryList,
+    PageDetailsResponse,
+    PageSummaryListResponse,
+    PageSummaryResponse,
     SetSlugPayload,
     ShareWithPayload,
-    ShareWithStatus,
-    SharingStatus,
+    ShareWithStatusResponse,
+    SharingStatusResponse,
 )
 from galaxy.webapps.galaxy.services.pages import PagesService
 from . import (
@@ -40,7 +40,7 @@ DeletedQueryParam: bool = Query(
     default=False, title="Display deleted", description="Whether to include deleted pages in the result."
 )
 
-PageIdPathParam: EncodedDatabaseIdField = Path(
+PageIdPathParam: DecodedDatabaseIdField = Path(
     ..., title="Page ID", description="The encoded database identifier of the Page."  # Required
 )
 
@@ -58,7 +58,7 @@ class FastAPIPages:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         deleted: bool = DeletedQueryParam,
-    ) -> PageSummaryList:
+    ) -> PageSummaryListResponse:
         """Get a list with summary information of all Pages available to the user."""
         return self.service.index(trans, deleted)
 
@@ -71,7 +71,7 @@ class FastAPIPages:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         payload: CreatePagePayload = Body(...),
-    ) -> PageSummary:
+    ) -> PageSummaryResponse:
         """Get a list with details of all Pages available to the user."""
         return self.service.create(trans, payload)
 
@@ -83,7 +83,7 @@ class FastAPIPages:
     async def delete(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ):
         """Marks the Page with the given ID as deleted."""
         self.service.delete(trans, id)
@@ -104,7 +104,7 @@ class FastAPIPages:
     async def show_pdf(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ):
         """Return a PDF document of the last revision of the Page.
 
@@ -121,8 +121,8 @@ class FastAPIPages:
     async def show(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
-    ) -> PageDetails:
+        id: DecodedDatabaseIdField = PageIdPathParam,
+    ) -> PageDetailsResponse:
         """Return summary information about a specific Page and the content of the last revision."""
         return self.service.show(trans, id)
 
@@ -133,8 +133,8 @@ class FastAPIPages:
     def sharing(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
-    ) -> SharingStatus:
+        id: DecodedDatabaseIdField = PageIdPathParam,
+    ) -> SharingStatusResponse:
         """Return the sharing status of the item."""
         return self.service.shareable_service.sharing(trans, id)
 
@@ -145,8 +145,8 @@ class FastAPIPages:
     def enable_link_access(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
-    ) -> SharingStatus:
+        id: DecodedDatabaseIdField = PageIdPathParam,
+    ) -> SharingStatusResponse:
         """Makes this item accessible by a URL link and return the current sharing status."""
         return self.service.shareable_service.enable_link_access(trans, id)
 
@@ -157,8 +157,8 @@ class FastAPIPages:
     def disable_link_access(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
-    ) -> SharingStatus:
+        id: DecodedDatabaseIdField = PageIdPathParam,
+    ) -> SharingStatusResponse:
         """Makes this item inaccessible by a URL link and return the current sharing status."""
         return self.service.shareable_service.disable_link_access(trans, id)
 
@@ -169,8 +169,8 @@ class FastAPIPages:
     def publish(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
-    ) -> SharingStatus:
+        id: DecodedDatabaseIdField = PageIdPathParam,
+    ) -> SharingStatusResponse:
         """Makes this item publicly available by a URL link and return the current sharing status."""
         return self.service.shareable_service.publish(trans, id)
 
@@ -181,8 +181,8 @@ class FastAPIPages:
     def unpublish(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
-    ) -> SharingStatus:
+        id: DecodedDatabaseIdField = PageIdPathParam,
+    ) -> SharingStatusResponse:
         """Removes this item from the published list and return the current sharing status."""
         return self.service.shareable_service.unpublish(trans, id)
 
@@ -193,9 +193,9 @@ class FastAPIPages:
     def share_with_users(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
         payload: ShareWithPayload = Body(...),
-    ) -> ShareWithStatus:
+    ) -> ShareWithStatusResponse:
         """Shares this item with specific users and return the current sharing status."""
         return self.service.shareable_service.share_with_users(trans, id, payload)
 
@@ -207,7 +207,7 @@ class FastAPIPages:
     def set_slug(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
         payload: SetSlugPayload = Body(...),
     ):
         """Sets a new slug to access this item by URL. The new slug must be unique."""

--- a/lib/galaxy/webapps/galaxy/api/quotas.py
+++ b/lib/galaxy/webapps/galaxy/api/quotas.py
@@ -11,11 +11,11 @@ from galaxy.quota._schema import (
     CreateQuotaParams,
     CreateQuotaResult,
     DeleteQuotaPayload,
-    QuotaDetails,
+    QuotaDetailsResponse,
     QuotaSummaryList,
     UpdateQuotaParams,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.webapps.galaxy.services.quotas import QuotasService
 from . import (
     depends,
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 router = Router(tags=["quotas"])
 
 
-QuotaIdPathParam: EncodedDatabaseIdField = Path(
+QuotaIdPathParam: DecodedDatabaseIdField = Path(
     ..., title="Quota ID", description="The encoded identifier of the Quota."  # Required
 )
 
@@ -68,8 +68,8 @@ class FastAPIQuota:
         require_admin=True,
     )
     def show(
-        self, trans: ProvidesUserContext = DependsOnTrans, id: EncodedDatabaseIdField = QuotaIdPathParam
-    ) -> QuotaDetails:
+        self, trans: ProvidesUserContext = DependsOnTrans, id: DecodedDatabaseIdField = QuotaIdPathParam
+    ) -> QuotaDetailsResponse:
         """Displays details on a particular active quota."""
         return self.service.show(trans, id)
 
@@ -81,8 +81,8 @@ class FastAPIQuota:
     def show_deleted(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = QuotaIdPathParam,
-    ) -> QuotaDetails:
+        id: DecodedDatabaseIdField = QuotaIdPathParam,
+    ) -> QuotaDetailsResponse:
         """Displays details on a particular quota that has been deleted."""
         return self.service.show(trans, id, deleted=True)
 
@@ -107,7 +107,7 @@ class FastAPIQuota:
     def update(
         self,
         payload: UpdateQuotaParams,
-        id: EncodedDatabaseIdField = QuotaIdPathParam,
+        id: DecodedDatabaseIdField = QuotaIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> str:
         """Updates an existing quota."""
@@ -120,7 +120,7 @@ class FastAPIQuota:
     )
     def delete(
         self,
-        id: EncodedDatabaseIdField = QuotaIdPathParam,
+        id: DecodedDatabaseIdField = QuotaIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
         payload: DeleteQuotaPayload = Body(None),  # Optional
     ) -> str:
@@ -134,7 +134,7 @@ class FastAPIQuota:
     )
     def undelete(
         self,
-        id: EncodedDatabaseIdField = QuotaIdPathParam,
+        id: DecodedDatabaseIdField = QuotaIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> str:
         """Restores a previously deleted quota."""

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -485,13 +485,13 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
             decoded_id = self.decode_id(history_id)
             target_history = self.history_manager.get_owned(decoded_id, trans.user, current_history=trans.history)
         else:
+            decoded_input_id = trans.app.security.decode_id(input_id)
             if input_src == "hdca":
                 target_history = self.hdca_manager.get_dataset_collection_instance(
-                    trans, instance_type="history", id=input_id
+                    trans, instance_type="history", id=decoded_input_id
                 ).history
             elif input_src == "hda":
-                decoded_id = trans.app.security.decode_id(input_id)
-                target_history = self.hda_manager.get_accessible(decoded_id, trans.user).history
+                target_history = self.hda_manager.get_accessible(decoded_input_id, trans.user).history
                 self.history_manager.error_unless_owner(target_history, trans.user, current_history=trans.history)
             else:
                 raise exceptions.RequestParameterInvalidException("Must run conversion on either hdca or hda.")

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -990,7 +990,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         Get JSON summarizing invocation for reporting.
         """
         kwd["format"] = "json"
-        return self.workflow_manager.get_invocation_report(trans, invocation_id, **kwd)
+        return self.workflow_manager.get_invocation_report(trans, self.decode_id(invocation_id), **kwd)
 
     @expose_api_raw
     def show_invocation_report_pdf(self, trans: GalaxyWebTransaction, invocation_id, **kwd):
@@ -1002,7 +1002,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         """
         kwd["format"] = "pdf"
         trans.response.set_content_type("application/pdf")
-        return self.workflow_manager.get_invocation_report(trans, invocation_id, **kwd)
+        return self.workflow_manager.get_invocation_report(trans, self.decode_id(invocation_id), **kwd)
 
     def _generate_invocation_bco(self, trans: GalaxyWebTransaction, invocation_id, **kwd):
         decoded_workflow_invocation_id = self.decode_id(invocation_id)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -895,9 +895,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         invocation_payload = InvocationIndexPayload(**kwd)
         workflow_id = invocation_payload.workflow_id
         if invocation_payload.instance:
-            invocation_payload.workflow_id = self.__get_stored_workflow(
-                trans, trans.security.encode_id(workflow_id), instance=True
-            ).id
+            invocation_payload.workflow_id = self.__get_stored_workflow(trans, workflow_id, instance=True).id
         if invocation_payload.history_id:
             # access check
             self.history_manager.get_accessible(

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -203,7 +203,10 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             raise RequestParameterInvalidException("Invalid request parameter 'hdca' encountered.")
         hdca_id = kwd.get("hdca_id", None)
         if hdca_id:
-            hdca = self.app.dataset_collection_manager.get_dataset_collection_instance(trans, "history", hdca_id)
+            decoded_hdca_id = trans.security.decode_id(hdca_id)
+            hdca = self.app.dataset_collection_manager.get_dataset_collection_instance(
+                trans, "history", decoded_hdca_id
+            )
             del kwd["hdca_id"]
             kwd["hdca"] = hdca
         # Ensure offset is an integer before passing through to datatypes.

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -969,7 +969,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         self.set_as_current(trans, id=hist_id)
         return trans.response.send_redirect(url_for("/"))
 
-    def get_item(self, trans, id):
+    def get_item(self, trans, id: str):
         return self.history_manager.get_owned(self.decode_id(id), trans.user, current_history=trans.history)
         # TODO: override of base ui controller?
 

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -702,7 +702,7 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
         else:
             return self.security_check(trans, page, check_ownership, check_accessible)
 
-    def get_item(self, trans, id):
+    def get_item(self, trans, id: str):
         return self.get_page(trans, id)
 
     def _get_embedded_history_html(self, trans, decoded_id):
@@ -737,7 +737,7 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
         """
         Returns html suitable for embedding visualizations in another page.
         """
-        visualization = self.get_visualization(trans, encoded_id, False, True)
+        visualization = self.get_visualization(trans, trans.security.decode_id(encoded_id), False, True)
         visualization.annotation = self.get_item_annotation_str(trans.sa_session, visualization.user, visualization)
         if not visualization:
             return None
@@ -749,11 +749,10 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
             # if a registry visualization, load a version into an iframe :(
             # TODO: simplest path from A to B but not optimal - will be difficult to do reg visualizations any other way
             # TODO: this will load the visualization twice (once above, once when the iframe src calls 'saved')
-            encoded_visualization_id = trans.security.encode_id(visualization.id)
             return trans.fill_template(
                 "visualization/embed_in_frame.mako",
                 item=visualization,
-                encoded_visualization_id=encoded_visualization_id,
+                encoded_visualization_id=encoded_id,
                 content_only=True,
             )
 

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm import (
 )
 
 from galaxy import (
-    exceptions,
     model,
     util,
     web,
@@ -28,6 +27,7 @@ from galaxy.managers.pages import (
 from galaxy.managers.sharable import SlugBuilder
 from galaxy.managers.workflows import WorkflowsManager
 from galaxy.model.item_attrs import UsesItemRatings
+from galaxy.schema.schema import CreatePagePayload
 from galaxy.structured_app import StructuredApp
 from galaxy.util import unicodify
 from galaxy.util.sanitize_html import sanitize_html
@@ -408,7 +408,7 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
             {"username": p.page.user.username, "slug": p.page.slug, "title": p.page.title} for p in shared_by_others
         ]
 
-    @web.legacy_expose_api
+    @web.expose_api
     @web.require_login("create pages")
     def create(self, trans, payload=None, **kwd):
         """
@@ -425,7 +425,9 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
                 invocation_id = kwd.get("invocation_id")
                 form_title = f"{form_title} from Invocation Report"
                 slug = f"invocation-report-{invocation_id}"
-                invocation_report = self.workflow_manager.get_invocation_report(trans, invocation_id)
+                invocation_report = self.workflow_manager.get_invocation_report(
+                    trans, trans.security.decode_id(invocation_id)
+                )
                 title = invocation_report.get("title")
                 content = invocation_report.get("markdown")
                 content_format_hide = True
@@ -467,10 +469,7 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
                 ],
             }
         else:
-            try:
-                page = self.page_manager.create(trans, payload)
-            except exceptions.MessageException as e:
-                return self.message_exception(trans, unicodify(e))
+            page = self.page_manager.create(trans, CreatePagePayload(**payload))
             return {"message": "Page '%s' successfully created." % page.title, "status": "success"}
 
     @web.legacy_expose_api

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -260,11 +260,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
 
                 recalculate_user_disk_usage.delay(user_id=trans.user.id)
             else:
-                send_local_control_task(
-                    trans.app,
-                    "recalculate_user_disk_usage",
-                    kwargs={"user_id": trans.security.encode_id(trans.user.id)},
-                )
+                send_local_control_task(trans.app, "recalculate_user_disk_usage", kwargs={"user_id": trans.user.id})
         # Since logging an event requires a session, we'll log prior to ending the session
         trans.log_event("User logged out")
         trans.handle_user_logout(logout_all=logout_all)

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -402,7 +402,7 @@ class VisualizationController(
     @web.expose
     @web.require_login()
     def copy(self, trans, id, **kwargs):
-        visualization = self.get_visualization(trans, id, check_ownership=False)
+        visualization = self.get_visualization(trans, self.decode_id(id), check_ownership=False)
         user = trans.get_user()
         owner = visualization.user == user
         new_title = f"Copy of '{visualization.title}'"
@@ -422,9 +422,9 @@ class VisualizationController(
 
     @web.expose
     @web.require_login("use Galaxy visualizations")
-    def set_accessible_async(self, trans, id=None, accessible=False):
+    def set_accessible_async(self, trans, id, accessible=False):
         """Set visualization's importable attribute and slug."""
-        visualization = self.get_visualization(trans, id)
+        visualization = self.get_visualization(trans, self.decode_id(id))
 
         # Only set if importable value would change; this prevents a change in the update_time unless attribute really changed.
         importable = accessible in ["True", "true", "t", "T"]
@@ -443,7 +443,7 @@ class VisualizationController(
     def rate_async(self, trans, id, rating):
         """Rate a visualization asynchronously and return updated community data."""
 
-        visualization = self.get_visualization(trans, id, check_ownership=False, check_accessible=True)
+        visualization = self.get_visualization(trans, self.decode_id(id), check_ownership=False, check_accessible=True)
         if not visualization:
             return trans.show_error_message("The specified visualization does not exist.")
 
@@ -465,7 +465,7 @@ class VisualizationController(
 
         # Do import.
         session = trans.sa_session
-        visualization = self.get_visualization(trans, id, check_ownership=False)
+        visualization = self.get_visualization(trans, self.decode_id(id), check_ownership=False)
         if visualization.importable is False:
             return trans.show_error_message(
                 f"The owner of this visualization has disabled imports via this link.<br>You can {referer_message}",
@@ -554,7 +554,7 @@ class VisualizationController(
     @web.require_login("get item name and link")
     def get_name_and_link_async(self, trans, id=None):
         """Returns visualization's name and link."""
-        visualization = self.get_visualization(trans, id, check_ownership=False, check_accessible=True)
+        visualization = self.get_visualization(trans, self.decode_id(id), check_ownership=False, check_accessible=True)
 
         if self.slug_builder.create_item_slug(trans.sa_session, visualization):
             trans.sa_session.flush()
@@ -574,7 +574,7 @@ class VisualizationController(
         """Returns item content in HTML format."""
 
         # Get visualization, making sure it's accessible.
-        visualization = self.get_visualization(trans, id, check_ownership=False, check_accessible=True)
+        visualization = self.get_visualization(trans, self.decode_id(id), check_ownership=False, check_accessible=True)
         if visualization is None:
             raise web.httpexceptions.HTTPNotFound()
 
@@ -613,7 +613,7 @@ class VisualizationController(
         if not id:
             return self.message_exception(trans, "No visualization id received for editing.")
         trans_user = trans.get_user()
-        v = self.get_visualization(trans, id, check_ownership=True)
+        v = self.get_visualization(trans, self.decode_id(id), check_ownership=True)
         if trans.request.method == "GET":
             if v.slug is None:
                 self.slug_builder.create_item_slug(trans.sa_session, v)
@@ -730,7 +730,7 @@ class VisualizationController(
         # check the id and load the saved visualization
         if id is None:
             return HTTPBadRequest("A valid visualization id is required to load a visualization")
-        visualization = self.get_visualization(trans, id, check_ownership=False, check_accessible=True)
+        visualization = self.get_visualization(trans, self.decode_id(id), check_ownership=False, check_accessible=True)
 
         # re-add title to kwargs for passing to render
         if title:
@@ -761,7 +761,7 @@ class VisualizationController(
         # TODO: would be easier if this returned the visualization directly
         # check security if posting to existing visualization
         if id is not None:
-            self.get_visualization(trans, id, check_ownership=True, check_accessible=False)
+            self.get_visualization(trans, self.decode_id(id), check_ownership=True, check_accessible=False)
             # ??: on not owner: error raised, but not returned (status = 200)
         # TODO: there's no security check in save visualization (if passed an id)
         returned = self.save_visualization(trans, config, type, id, title)
@@ -804,7 +804,7 @@ class VisualizationController(
             app["default_dbkey"] = dbkey
         else:
             # load saved visualization
-            vis = self.get_visualization(trans, id, check_ownership=False, check_accessible=True)
+            vis = self.get_visualization(trans, self.decode_id(id), check_ownership=False, check_accessible=True)
             app["viz_config"] = self.get_visualization_config(trans, vis)
 
         # backup id
@@ -837,7 +837,7 @@ class VisualizationController(
         # Get/create vis.
         if id:
             # Display existing viz.
-            vis = self.get_visualization(trans, id, check_ownership=False, check_accessible=True)
+            vis = self.get_visualization(trans, self.decode_id(id), check_ownership=False, check_accessible=True)
             dbkey = vis.dbkey
         else:
             # Create new viz.
@@ -897,7 +897,7 @@ class VisualizationController(
 
         if id:
             # Loading a shared visualization.
-            viz = self.get_visualization(trans, id)
+            viz = self.get_visualization(trans, self.decode_id(id))
             viz_config = self.get_visualization_config(trans, viz)
             decoded_id = self.decode_id(viz_config["dataset_id"])
             dataset = self.hda_manager.get_owned(decoded_id, trans.user, current_history=trans.history)
@@ -914,8 +914,8 @@ class VisualizationController(
 
         return trans.fill_template_mako("visualization/sweepster.mako", config=viz_config)
 
-    def get_item(self, trans, id):
-        return self.get_visualization(trans, id)
+    def get_item(self, trans, id: str):
+        return self.get_visualization(trans, self.decode_id(id))
 
     @web.expose
     def phyloviz(self, trans, id=None, dataset_id=None, tree_index=0, **kwargs):
@@ -924,7 +924,7 @@ class VisualizationController(
 
         # if id, then this is a saved visualization; get its config and the dataset_id from there
         if id:
-            visualization = self.get_visualization(trans, id)
+            visualization = self.get_visualization(trans, self.decode_id(id))
             config = self.get_visualization_config(trans, visualization)
             dataset_id = config.get("dataset_id", None)
 

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -973,7 +973,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
                 )
             )
 
-    def get_item(self, trans, id):
+    def get_item(self, trans, id: str):
         return self.get_stored_workflow(trans, id)
 
     def _workflow_to_svg_canvas(self, trans, stored):

--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -14,7 +14,6 @@ from galaxy.managers.base import (
 )
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import User
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.security.idencoding import IdEncodingHelper
 
 
@@ -33,15 +32,15 @@ class ServiceBase:
     def __init__(self, security: IdEncodingHelper):
         self.security = security
 
-    def decode_id(self, id: EncodedDatabaseIdField) -> int:
+    def decode_id(self, id: str) -> int:
         """Decodes a previously encoded database ID."""
         return decode_with_security(self.security, id)
 
-    def encode_id(self, id: int) -> EncodedDatabaseIdField:
+    def encode_id(self, id: int) -> str:
         """Encodes a raw database ID."""
         return encode_with_security(self.security, id)
 
-    def decode_ids(self, ids: List[EncodedDatabaseIdField]) -> List[int]:
+    def decode_ids(self, ids: List[str]) -> List[int]:
         """
         Decodes all encoded IDs in the given list.
         """

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -113,7 +113,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
             history = self.history_manager.get_owned(payload.history_id, trans.user, current_history=trans.history)
             create_params["parent"] = history
             create_params["history"] = history
-        elif payload.instance_type == DatasetCollectionInstanceType.library:
+        elif payload.instance_type == DatasetCollectionInstanceType.library and payload.folder_id:
             library_folder = self.get_library_folder(trans, payload.folder_id, check_accessible=True)
             self.check_user_can_add_to_library_item(trans, library_folder, check_accessible=False)
             create_params["parent"] = library_folder

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -42,11 +42,11 @@ from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
-    AnyHDA,
-    AnyHistoryContentItem,
-    DatasetAssociationRoles,
+    AnyHDAResponse,
+    AnyHistoryContentItemResponse,
+    DatasetAssociationRolesResponse,
     DatasetSourceType,
     Model,
     UpdateDatasetPermissionsPayload,
@@ -105,13 +105,6 @@ class DatasetInheritanceChainEntry(Model):
     )
 
 
-class DatasetInheritanceChain(Model):
-    __root__: List[DatasetInheritanceChainEntry] = Field(
-        default=[],
-        title="Dataset inheritance chain",
-    )
-
-
 class ExtraFilesEntryClass(str, Enum):
     Directory = "Directory"
     File = "File"
@@ -142,7 +135,7 @@ class DatasetTextContentDetails(Model):
 class ConvertedDatasetsMap(BaseModel):
     """Map of `file extension` -> `converted dataset encoded id`"""
 
-    __root__: Dict[str, EncodedDatabaseIdField]  # extension -> dataset ID
+    __root__: Dict[str, DecodedDatabaseIdField]  # extension -> dataset ID
 
     class Config:
         schema_extra = {
@@ -203,10 +196,10 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def index(
         self,
         trans: ProvidesHistoryContext,
-        history_id: Optional[EncodedDatabaseIdField],
+        history_id: Optional[DecodedDatabaseIdField],
         serialization_params: SerializationParams,
         filter_query_params: FilterQueryParams,
-    ) -> List[AnyHistoryContentItem]:
+    ) -> List[AnyHistoryContentItemResponse]:
         """
         Search datasets or collections using a query system and returns a list
         containing summary of dataset or dataset_collection information.
@@ -217,7 +210,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         order_by = self.build_order_by(self.history_contents_manager, filter_query_params.order or "create_time-dsc")
         container = None
         if history_id:
-            container = self.history_manager.get_accessible(self.decode_id(history_id), user)
+            container = self.history_manager.get_accessible(history_id, user)
         contents = self.history_contents_manager.contents(
             container=container,
             filters=filters,
@@ -236,7 +229,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def show(
         self,
         trans: ProvidesHistoryContext,
-        dataset_id: EncodedDatabaseIdField,
+        dataset_id: int,
         hda_ldda: DatasetSourceType,
         serialization_params: SerializationParams,
         data_type: Optional[RequestDataType] = None,
@@ -245,8 +238,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         """
         Displays information about and/or content of a dataset.
         """
-        decoded_dataset_id = self.decode_id(dataset_id)
-        dataset = self.dataset_manager_by_type[hda_ldda].get_accessible(decoded_dataset_id, trans.user)
+        dataset = self.dataset_manager_by_type[hda_ldda].get_accessible(dataset_id, trans.user)
 
         # Use data type to return particular type of data.
         rval: Any
@@ -285,15 +277,14 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def show_storage(
         self,
         trans: ProvidesHistoryContext,
-        dataset_id: EncodedDatabaseIdField,
+        dataset_id: int,
         hda_ldda: DatasetSourceType = DatasetSourceType.hda,
     ) -> DatasetStorageDetails:
         """
         Display user-facing storage details related to the objectstore a
         dataset resides in.
         """
-        decoded_dataset_id = self.decode_id(dataset_id)
-        dataset_instance = self.dataset_manager_by_type[hda_ldda].get_accessible(decoded_dataset_id, trans.user)
+        dataset_instance = self.dataset_manager_by_type[hda_ldda].get_accessible(dataset_id, trans.user)
         dataset = dataset_instance.dataset
         object_store = trans.app.object_store
         object_store_id = dataset.object_store_id
@@ -316,49 +307,46 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def show_inheritance_chain(
         self,
         trans: ProvidesHistoryContext,
-        dataset_id: EncodedDatabaseIdField,
+        dataset_id: int,
         hda_ldda: DatasetSourceType = DatasetSourceType.hda,
-    ) -> DatasetInheritanceChain:
+    ) -> List[DatasetInheritanceChainEntry]:
         """
         Display inheritance chain for the given dataset.
         """
-        decoded_dataset_id = self.decode_id(dataset_id)
-        dataset_instance = self.dataset_manager_by_type[hda_ldda].get_accessible(decoded_dataset_id, trans.user)
+        dataset_instance = self.dataset_manager_by_type[hda_ldda].get_accessible(dataset_id, trans.user)
         inherit_chain = dataset_instance.source_dataset_chain
         result = []
         for dep in inherit_chain:
             result.append(DatasetInheritanceChainEntry(name=f"{dep[0].name}", dep=dep[1]))
 
-        return DatasetInheritanceChain(__root__=result)
+        return result
 
     def update_permissions(
         self,
         trans: ProvidesHistoryContext,
-        dataset_id: EncodedDatabaseIdField,
+        dataset_id: int,
         payload: UpdateDatasetPermissionsPayload,
         hda_ldda: DatasetSourceType = DatasetSourceType.hda,
-    ) -> DatasetAssociationRoles:
+    ) -> DatasetAssociationRolesResponse:
         """
         Updates permissions of a dataset.
         """
         self.check_user_is_authenticated(trans)
-        decoded_dataset_id = self.decode_id(dataset_id)
         payload_dict = payload.dict(by_alias=True)
         dataset_manager = self.dataset_manager_by_type[hda_ldda]
-        dataset = dataset_manager.get_accessible(decoded_dataset_id, trans.user)
+        dataset = dataset_manager.get_accessible(dataset_id, trans.user)
         dataset_manager.update_permissions(trans, dataset, **payload_dict)
         return dataset_manager.serialize_dataset_association_roles(trans, dataset)
 
     def extra_files(
         self,
         trans: ProvidesHistoryContext,
-        history_content_id: EncodedDatabaseIdField,
+        history_content_id: int,
     ):
         """
         Generate list of extra files.
         """
-        decoded_content_id = self.decode_id(history_content_id)
-        hda = self.hda_manager.get_accessible(decoded_content_id, trans.user)
+        hda = self.hda_manager.get_accessible(history_content_id, trans.user)
         extra_files_path = hda.extra_files_path
         rval = []
         for root, directories, files in safe_walk(extra_files_path):
@@ -374,8 +362,8 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def display(
         self,
         trans: ProvidesHistoryContext,
-        history_content_id: EncodedDatabaseIdField,
-        history_id: EncodedDatabaseIdField,
+        history_content_id: int,
+        history_id: int,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,
@@ -389,11 +377,10 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         some point in the future without warning. Generally, data should be processed by its
         datatype prior to display (the defult if raw is unspecified or explicitly false.
         """
-        decoded_content_id = self.decode_id(history_content_id)
         headers = {}
         rval: Any = ""
         try:
-            hda = self.hda_manager.get_accessible(decoded_content_id, trans.user)
+            hda = self.hda_manager.get_accessible(history_content_id, trans.user)
             if raw:
                 if filename and filename != "index":
                     object_store = trans.app.object_store
@@ -416,12 +403,11 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def get_content_as_text(
         self,
         trans: ProvidesHistoryContext,
-        dataset_id: EncodedDatabaseIdField,
+        dataset_id: int,
     ) -> DatasetTextContentDetails:
         """Returns dataset content as Text."""
         user = self.get_authenticated_user(trans)
-        decoded_id = self.decode_id(dataset_id)
-        hda = self.hda_manager.get_accessible(decoded_id, user)
+        hda = self.hda_manager.get_accessible(dataset_id, user)
         hda = self.hda_manager.error_if_uploading(hda)
         truncated, dataset_data = self.hda_manager.text_data(hda, preview=True)
         item_url = web.url_for(
@@ -440,8 +426,8 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def get_metadata_file(
         self,
         trans: ProvidesHistoryContext,
-        history_content_id: EncodedDatabaseIdField,
-        metadata_file: str,
+        history_content_id: int,
+        metadata_file: Optional[str] = None,
         open_file: bool = False,
     ):
         """
@@ -450,8 +436,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         The `open_file` parameter determines if we return the path of the file or the opened file handle.
         TODO: Remove the `open_file` parameter when removing the associated legacy endpoint.
         """
-        decoded_content_id = self.decode_id(history_content_id)
-        hda = self.hda_manager.get_accessible(decoded_content_id, trans.user)
+        hda = self.hda_manager.get_accessible(history_content_id, trans.user)
         file_ext = hda.metadata.spec.get(metadata_file).get("file_ext", metadata_file)
         fname = "".join(c in util.FILENAME_VALID_CHARS and c or "_" for c in hda.name)[0:150]
         headers = {}
@@ -465,15 +450,14 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def converted_ext(
         self,
         trans: ProvidesHistoryContext,
-        dataset_id: EncodedDatabaseIdField,
+        dataset_id: int,
         ext: str,
         serialization_params: SerializationParams,
-    ) -> AnyHDA:
+    ) -> AnyHDAResponse:
         """
         Return information about datasets made by converting this dataset to a new format
         """
-        decoded_id = self.decode_id(dataset_id)
-        hda = self.hda_manager.get_accessible(decoded_id, trans.user)
+        hda = self.hda_manager.get_accessible(dataset_id, trans.user)
         serialization_params.default_view = "detailed"
         converted = self._get_or_create_converted(trans, hda, ext)
         return self.hda_serializer.serialize_to_view(
@@ -483,14 +467,13 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     def converted(
         self,
         trans: ProvidesHistoryContext,
-        dataset_id: EncodedDatabaseIdField,
+        dataset_id: int,
     ) -> ConvertedDatasetsMap:
         """
         Return a `file extension` -> `converted dataset encoded id` map
         with all the existing converted datasets associated with this instance.
         """
-        decoded_id = self.decode_id(dataset_id)
-        hda = self.hda_manager.get_accessible(decoded_id, trans.user)
+        hda = self.hda_manager.get_accessible(dataset_id, trans.user)
         return self.hda_serializer.serialize_converted_datasets(hda, "converted")
 
     def _get_or_create_converted(self, trans, original: model.DatasetInstance, target_ext: str):

--- a/lib/galaxy/webapps/galaxy/services/library_folders.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folders.py
@@ -168,7 +168,7 @@ class LibraryFoldersService(ServiceBase):
             valid_add_roles = []
             invalid_add_roles_names = []
             for role_id in new_add_roles_ids:
-                role = self.role_manager.get(trans, trans.security.decode_id(role_id, object_name="role"))
+                role = self.role_manager.get(trans, role_id)
                 #  Check whether role is in the set of allowed roles
                 valid_roles, total_roles = trans.app.security_agent.get_valid_roles(trans, folder)
                 if role in valid_roles:
@@ -184,13 +184,13 @@ class LibraryFoldersService(ServiceBase):
             valid_manage_roles = []
             invalid_manage_roles_names = []
             for role_id in new_manage_roles_ids:
-                role = self.role_manager.get(trans, trans.security.decode_id(role_id, object_name="role"))
+                role = self.role_manager.get(trans, role_id)
                 #  Check whether role is in the set of allowed roles
                 valid_roles, total_roles = trans.app.security_agent.get_valid_roles(trans, folder)
                 if role in valid_roles:
                     valid_manage_roles.append(role)
                 else:
-                    invalid_manage_roles_names.append(role_id)
+                    invalid_manage_roles_names.append(trans.security.encode_id(role_id))
             if len(invalid_manage_roles_names) > 0:
                 log.warning(
                     f"The following roles could not be added to the manage folder permission: {str(invalid_manage_roles_names)}"
@@ -200,13 +200,13 @@ class LibraryFoldersService(ServiceBase):
             valid_modify_roles = []
             invalid_modify_roles_names = []
             for role_id in new_modify_roles_ids:
-                role = self.role_manager.get(trans, trans.security.decode_id(role_id, object_name="role"))
+                role = self.role_manager.get(trans, role_id)
                 #  Check whether role is in the set of allowed roles
                 valid_roles, total_roles = trans.app.security_agent.get_valid_roles(trans, folder)
                 if role in valid_roles:
                     valid_modify_roles.append(role)
                 else:
-                    invalid_modify_roles_names.append(role_id)
+                    invalid_modify_roles_names.append(trans.security.encode_id(role_id))
             if len(invalid_modify_roles_names) > 0:
                 log.warning(
                     f"The following roles could not be added to the modify folder permission: {str(invalid_modify_roles_names)}"

--- a/lib/galaxy/webapps/galaxy/services/library_folders.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folders.py
@@ -12,12 +12,11 @@ from galaxy.exceptions import (
 )
 from galaxy.managers.folders import FolderManager
 from galaxy.managers.roles import RoleManager
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import (
     CreateLibraryFolderPayload,
-    LibraryAvailablePermissions,
-    LibraryFolderCurrentPermissions,
-    LibraryFolderDetails,
+    LibraryAvailablePermissionsResponse,
+    LibraryFolderCurrentPermissionsResponse,
+    LibraryFolderDetailsResponse,
     LibraryPermissionScope,
     UpdateLibraryFolderPayload,
 )
@@ -38,7 +37,7 @@ class LibraryFoldersService(ServiceBase):
         self.folder_manager = folder_manager
         self.role_manager = role_manager
 
-    def show(self, trans, id: EncodedDatabaseIdField) -> LibraryFolderDetails:
+    def show(self, trans, id: int) -> LibraryFolderDetailsResponse:
         """
         Displays information about a folder.
 
@@ -48,19 +47,16 @@ class LibraryFoldersService(ServiceBase):
         :returns:   dictionary including details of the folder
         :rtype:     dict
         """
-        folder_id = self.folder_manager.cut_and_decode(trans, id)
-        folder = self.folder_manager.get(trans, folder_id, check_manageable=False, check_accessible=True)
+        folder = self.folder_manager.get(trans, id, check_manageable=False, check_accessible=True)
         return_dict = self.folder_manager.get_folder_dict(trans, folder)
-        return LibraryFolderDetails.parse_obj(return_dict)
+        return LibraryFolderDetailsResponse.parse_obj(return_dict)
 
-    def create(
-        self, trans, encoded_parent_folder_id: EncodedDatabaseIdField, payload: CreateLibraryFolderPayload
-    ) -> LibraryFolderDetails:
+    def create(self, trans, folder_id: int, payload: CreateLibraryFolderPayload) -> LibraryFolderDetailsResponse:
         """
         Create a new folder object underneath the one specified in the parameters.
 
-        :param  encoded_parent_folder_id:      (required) the parent folder's id
-        :type   encoded_parent_folder_id:      an encoded id string (should be prefixed by 'F')
+        :param  folder_id:      (required) the parent folder's id
+        :type   folder_id:      an encoded id string (should be prefixed by 'F')
         :param   payload: dictionary structure containing:
 
             :param  name:                          (required) the name of the new folder
@@ -73,26 +69,25 @@ class LibraryFoldersService(ServiceBase):
         :rtype:     dictionary
         :raises: RequestParameterMissingException
         """
-        decoded_parent_folder_id = self.folder_manager.cut_and_decode(trans, encoded_parent_folder_id)
-        parent_folder = self.folder_manager.get(trans, decoded_parent_folder_id)
+        parent_folder = self.folder_manager.get(trans, folder_id)
         new_folder = self.folder_manager.create(trans, parent_folder.id, payload.name, payload.description)
         return_dict = self.folder_manager.get_folder_dict(trans, new_folder)
-        return LibraryFolderDetails.parse_obj(return_dict)
+        return LibraryFolderDetailsResponse.parse_obj(return_dict)
 
     def get_permissions(
         self,
         trans,
-        encoded_folder_id: EncodedDatabaseIdField,
+        folder_id: int,
         scope: Optional[LibraryPermissionScope] = LibraryPermissionScope.current,
         page: Optional[int] = 1,
         page_limit: Optional[int] = 10,
         query: Optional[str] = None,
-    ) -> Union[LibraryFolderCurrentPermissions, LibraryAvailablePermissions]:
+    ) -> Union[LibraryFolderCurrentPermissionsResponse, LibraryAvailablePermissionsResponse]:
         """
         Load all permissions for the given folder id and return it.
 
-        :param  encoded_folder_id:     the encoded id of the folder
-        :type   encoded_folder_id:     an encoded id string
+        :param  folder_id:     the encoded id of the folder
+        :type   folder_id:     an encoded id string
 
         :param  scope:      either 'current' or 'available'
         :type   scope:      string
@@ -104,8 +99,7 @@ class LibraryFoldersService(ServiceBase):
         """
         current_user_roles = trans.get_current_user_roles()
         is_admin = trans.user_is_admin
-        decoded_folder_id = self.folder_manager.cut_and_decode(trans, encoded_folder_id)
-        folder = self.folder_manager.get(trans, decoded_folder_id)
+        folder = self.folder_manager.get(trans, folder_id)
 
         if not (is_admin or trans.app.security_agent.can_manage_library_item(current_user_roles, folder)):
             raise InsufficientPermissionsException(
@@ -114,7 +108,7 @@ class LibraryFoldersService(ServiceBase):
 
         if scope is None or scope == LibraryPermissionScope.current:
             current_permissions = self.folder_manager.get_current_roles(trans, folder)
-            return LibraryFolderCurrentPermissions.parse_obj(current_permissions)
+            return LibraryFolderCurrentPermissionsResponse.parse_obj(current_permissions)
         #  Return roles that are available to select.
         elif scope == LibraryPermissionScope.available:
             roles, total_roles = trans.app.security_agent.get_valid_roles(trans, folder, query, page, page_limit)
@@ -122,20 +116,20 @@ class LibraryFoldersService(ServiceBase):
             for role in roles:
                 role_id = trans.security.encode_id(role.id)
                 return_roles.append(dict(id=role_id, name=role.name, type=role.type))
-            return LibraryAvailablePermissions(roles=return_roles, page=page, page_limit=page_limit, total=total_roles)
+            return LibraryAvailablePermissionsResponse(
+                roles=return_roles, page=page, page_limit=page_limit, total=total_roles
+            )
         else:
             raise RequestParameterInvalidException(
                 "The value of 'scope' parameter is invalid. Allowed values: current, available"
             )
 
-    def set_permissions(
-        self, trans, encoded_folder_id: EncodedDatabaseIdField, payload: dict
-    ) -> LibraryFolderCurrentPermissions:
+    def set_permissions(self, trans, folder_id: int, payload: dict) -> LibraryFolderCurrentPermissionsResponse:
         """
         Set permissions of the given folder to the given role ids.
 
-        :param  encoded_folder_id:      the encoded id of the folder to set the permissions of
-        :type   encoded_folder_id:      an encoded id string
+        :param  folder_id:      the encoded id of the folder to set the permissions of
+        :type   folder_id:      an encoded id string
         :param   payload: dictionary structure containing:
 
             :param  action:            (required) describes what action should be performed
@@ -155,8 +149,7 @@ class LibraryFoldersService(ServiceBase):
 
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
-        decoded_folder_id = self.folder_manager.cut_and_decode(trans, encoded_folder_id)
-        folder = self.folder_manager.get(trans, decoded_folder_id)
+        folder = self.folder_manager.get(trans, folder_id)
         if not (is_admin or trans.app.security_agent.can_manage_library_item(current_user_roles, folder)):
             raise InsufficientPermissionsException(
                 "You do not have proper permission to modify permissions of this folder."
@@ -229,21 +222,19 @@ class LibraryFoldersService(ServiceBase):
                 'The mandatory parameter "action" has an invalid value.' 'Allowed values are: "set_permissions"'
             )
         current_permissions = self.folder_manager.get_current_roles(trans, folder)
-        return LibraryFolderCurrentPermissions.parse_obj(current_permissions)
+        return LibraryFolderCurrentPermissionsResponse.parse_obj(current_permissions)
 
-    def delete(
-        self, trans, encoded_folder_id: EncodedDatabaseIdField, undelete: Optional[bool] = False
-    ) -> LibraryFolderDetails:
+    def delete(self, trans, folder_id: int, undelete: Optional[bool] = False) -> LibraryFolderDetailsResponse:
         """
-        DELETE /api/folders/{encoded_folder_id}
+        DELETE /api/folders/{folder_id}
 
         Mark the folder with the given ``encoded_folder_id`` as `deleted`
         (or remove the `deleted` mark if the `undelete` param is true).
 
         .. note:: Currently, only admin users can un/delete folders.
 
-        :param  encoded_folder_id:     the encoded id of the folder to un/delete
-        :type   encoded_folder_id:     an encoded id string
+        :param  folder_id:     the encoded id of the folder to un/delete
+        :type   folder_id:     an encoded id string
 
         :param  undelete:    (optional) flag specifying whether the item should be deleted or undeleted, defaults to false:
         :type   undelete:    bool
@@ -252,22 +243,20 @@ class LibraryFoldersService(ServiceBase):
         :rtype:     dictionary
 
         """
-        folder = self.folder_manager.get(trans, self.folder_manager.cut_and_decode(trans, encoded_folder_id), True)
+        folder = self.folder_manager.get(trans, folder_id, True)
         folder = self.folder_manager.delete(trans, folder, undelete)
         folder_dict = self.folder_manager.get_folder_dict(trans, folder)
-        return LibraryFolderDetails.parse_obj(folder_dict)
+        return LibraryFolderDetailsResponse.parse_obj(folder_dict)
 
-    def update(
-        self, trans, encoded_folder_id: EncodedDatabaseIdField, payload: UpdateLibraryFolderPayload
-    ) -> LibraryFolderDetails:
+    def update(self, trans, folder_id: int, payload: UpdateLibraryFolderPayload) -> LibraryFolderDetailsResponse:
         """
          Update the folder defined by an ``encoded_folder_id``
          with the data in the payload.
 
         .. note:: Currently, only admin users can update library folders. Also the folder must not be `deleted`.
 
-         :param  id:      the encoded id of the folder
-         :type   id:      an encoded id string
+         :param  folder_id:      the encoded id of the folder
+         :type   folder_id:      an encoded id string
 
          :param  payload: (required) dictionary structure containing::
              'name':         new folder's name, cannot be empty
@@ -279,8 +268,7 @@ class LibraryFoldersService(ServiceBase):
 
          :raises: RequestParameterMissingException
         """
-        decoded_folder_id = self.folder_manager.cut_and_decode(trans, encoded_folder_id)
-        folder = self.folder_manager.get(trans, decoded_folder_id)
+        folder = self.folder_manager.get(trans, folder_id)
         updated_folder = self.folder_manager.update(trans, folder, payload.name, payload.description)
         folder_dict = self.folder_manager.get_folder_dict(trans, updated_folder)
-        return LibraryFolderDetails.parse_obj(folder_dict)
+        return LibraryFolderDetailsResponse.parse_obj(folder_dict)

--- a/lib/galaxy/webapps/galaxy/services/pages.py
+++ b/lib/galaxy/webapps/galaxy/services/pages.py
@@ -76,11 +76,11 @@ class PagesService(ServiceBase):
 
         return PageSummaryListResponse.parse_obj(out)
 
-    def create(self, trans, payload: CreatePagePayload) -> PageSummaryResponse:
+    def create(self, trans, payload: CreatePagePayload, *args, **kwargs) -> PageSummaryResponse:
         """
         Create a page and return Page summary
         """
-        page = self.manager.create(trans, payload.dict())
+        page = self.manager.create(trans, payload)
         rval = trans.security.encode_all_ids(page.to_dict(), recursive=True)
         rval["content"] = page.latest_revision.content
         self.manager.rewrite_content_for_export(trans, rval)

--- a/lib/galaxy/webapps/galaxy/services/pages.py
+++ b/lib/galaxy/webapps/galaxy/services/pages.py
@@ -11,13 +11,12 @@ from galaxy.managers.pages import (
     PageSerializer,
 )
 from galaxy.schema import PdfDocumentType
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import (
     CreatePagePayload,
     PageContentFormat,
-    PageDetails,
-    PageSummary,
-    PageSummaryList,
+    PageDetailsResponse,
+    PageSummaryListResponse,
+    PageSummaryResponse,
 )
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.webapps.galaxy.services.base import ServiceBase
@@ -44,7 +43,7 @@ class PagesService(ServiceBase):
         self.serializer = serializer
         self.shareable_service = ShareableService(self.manager, self.serializer)
 
-    def index(self, trans, deleted: bool = False) -> PageSummaryList:
+    def index(self, trans, deleted: bool = False) -> PageSummaryListResponse:
         """Return a list of Pages viewable by the user
 
         :param deleted: Display deleted pages
@@ -75,9 +74,9 @@ class PagesService(ServiceBase):
             for row in r:
                 out.append(trans.security.encode_all_ids(row.to_dict(), recursive=True))
 
-        return PageSummaryList.parse_obj(out)
+        return PageSummaryListResponse.parse_obj(out)
 
-    def create(self, trans, payload: CreatePagePayload) -> PageSummary:
+    def create(self, trans, payload: CreatePagePayload) -> PageSummaryResponse:
         """
         Create a page and return Page summary
         """
@@ -85,9 +84,9 @@ class PagesService(ServiceBase):
         rval = trans.security.encode_all_ids(page.to_dict(), recursive=True)
         rval["content"] = page.latest_revision.content
         self.manager.rewrite_content_for_export(trans, rval)
-        return PageSummary.parse_obj(rval)
+        return PageSummaryResponse.parse_obj(rval)
 
-    def delete(self, trans, id: EncodedDatabaseIdField):
+    def delete(self, trans, id: int):
         """
         Deletes a page (or marks it as deleted)
         """
@@ -97,7 +96,7 @@ class PagesService(ServiceBase):
         page.deleted = True
         trans.sa_session.flush()
 
-    def show(self, trans, id: EncodedDatabaseIdField) -> PageDetails:
+    def show(self, trans, id: int) -> PageDetailsResponse:
         """View a page summary and the content of the latest revision
 
         :param  id:    ID of page to be displayed
@@ -110,9 +109,9 @@ class PagesService(ServiceBase):
         rval["content"] = page.latest_revision.content
         rval["content_format"] = page.latest_revision.content_format
         self.manager.rewrite_content_for_export(trans, rval)
-        return PageDetails.parse_obj(rval)
+        return PageDetailsResponse.parse_obj(rval)
 
-    def show_pdf(self, trans, id: EncodedDatabaseIdField):
+    def show_pdf(self, trans, id: int):
         """
         View a page summary and the content of the latest revision as PDF.
 

--- a/lib/galaxy/webapps/galaxy/services/sharable.py
+++ b/lib/galaxy/webapps/galaxy/services/sharable.py
@@ -119,24 +119,18 @@ class ShareableService:
         send_to_users: Set[User] = set()
         send_to_err: Set[str] = set()
         for email_or_id in set(emails_or_ids):
-            email_or_id = email_or_id.strip()
-            if not email_or_id:
-                continue
-
             send_to_user = None
-            if "@" in email_or_id:
-                email_address = email_or_id
+            if isinstance(email_or_id, int):
+                send_to_user = self.manager.user_manager.by_id(email_or_id)
+                if send_to_user.deleted:
+                    send_to_user = None
+            else:
+                email_address = email_or_id.strip()
+                if not email_address:
+                    continue
                 send_to_user = self.manager.user_manager.by_email(
                     email_address, filters=[User.table.c.deleted == false()]
                 )
-            else:
-                try:
-                    decoded_user_id = trans.security.decode_id(email_or_id)
-                    send_to_user = self.manager.user_manager.by_id(decoded_user_id)
-                    if send_to_user.deleted:
-                        send_to_user = None
-                except exceptions.MalformedId:
-                    send_to_user = None
 
             if not send_to_user:
                 send_to_err.add(f"{email_or_id} is not a valid Galaxy user.")

--- a/lib/galaxy/webapps/galaxy/services/sharable.py
+++ b/lib/galaxy/webapps/galaxy/services/sharable.py
@@ -15,13 +15,12 @@ from galaxy.managers.sharable import (
     SharableModelSerializer,
 )
 from galaxy.model import User
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import (
     SetSlugPayload,
     ShareWithPayload,
-    ShareWithStatus,
+    ShareWithStatusResponse,
     SharingOptions,
-    SharingStatus,
+    SharingStatusResponse,
 )
 
 log = logging.getLogger(__name__)
@@ -40,16 +39,16 @@ class ShareableService:
         self.manager = manager
         self.serializer = serializer
 
-    def set_slug(self, trans, id: EncodedDatabaseIdField, payload: SetSlugPayload):
+    def set_slug(self, trans, id: int, payload: SetSlugPayload):
         item = self._get_item_by_id(trans, id)
         self.manager.set_slug(item, payload.new_slug, trans.user)
 
-    def sharing(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def sharing(self, trans, id: int) -> SharingStatusResponse:
         """Gets the current sharing status of the item with the given id."""
         item = self._get_item_by_id(trans, id)
         return self._get_sharing_status(trans, item)
 
-    def enable_link_access(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def enable_link_access(self, trans, id: int) -> SharingStatusResponse:
         """Makes this item accessible by link.
         If this item contains other elements they will be publicly accessible too.
         """
@@ -58,12 +57,12 @@ class ShareableService:
         self.manager.make_importable(item)
         return self._get_sharing_status(trans, item)
 
-    def disable_link_access(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def disable_link_access(self, trans, id: int) -> SharingStatusResponse:
         item = self._get_item_by_id(trans, id)
         self.manager.make_non_importable(item)
         return self._get_sharing_status(trans, item)
 
-    def publish(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def publish(self, trans, id: int) -> SharingStatusResponse:
         """Makes this item publicly accessible.
         If this item contains other elements they will be publicly accessible too.
         """
@@ -72,17 +71,17 @@ class ShareableService:
         self.manager.publish(item)
         return self._get_sharing_status(trans, item)
 
-    def unpublish(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def unpublish(self, trans, id: int) -> SharingStatusResponse:
         item = self._get_item_by_id(trans, id)
         self.manager.unpublish(item)
         return self._get_sharing_status(trans, item)
 
-    def share_with_users(self, trans, id: EncodedDatabaseIdField, payload: ShareWithPayload) -> ShareWithStatus:
+    def share_with_users(self, trans, id: int, payload: ShareWithPayload) -> ShareWithStatusResponse:
         item = self._get_item_by_id(trans, id)
         users, errors = self._get_users(trans, payload.user_ids)
         extra = self._share_with_options(trans, item, users, errors, payload.share_option)
         base_status = self._get_sharing_status(trans, item)
-        status = ShareWithStatus.parse_obj(base_status)
+        status = ShareWithStatusResponse.parse_obj(base_status)
         status.extra = extra
         status.errors.extend(errors)
         return status
@@ -101,7 +100,7 @@ class ShareableService:
             extra = None
         return extra
 
-    def _get_item_by_id(self, trans, id: EncodedDatabaseIdField):
+    def _get_item_by_id(self, trans, id: int):
         class_name = self.manager.model_class.__name__
         item = base.get_object(trans, id, class_name, check_ownership=True, check_accessible=True, deleted=False)
         return item
@@ -112,7 +111,7 @@ class ShareableService:
             {"id": self.manager.app.security.encode_id(a.user.id), "email": a.user.email}
             for a in item.users_shared_with
         ]
-        return SharingStatus.parse_obj(status)
+        return SharingStatusResponse.parse_obj(status)
 
     def _get_users(self, trans, emails_or_ids: Optional[List] = None) -> Tuple[Set[User], Set[str]]:
         if emails_or_ids is None:

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -35,5 +35,5 @@ class UsersService(ServiceBase):
             send_local_control_task(
                 trans.app,
                 "recalculate_user_disk_usage",
-                kwargs={"user_id": self.encode_id(trans.user.id)},
+                kwargs={"user_id": trans.user.id},
             )

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -365,7 +365,9 @@ def build_workflow_run_configs(trans, workflow, payload):
                     )
                     content = history.add_dataset(dataset)
                 elif input_source == "hdca":
-                    content = app.dataset_collection_manager.get_dataset_collection_instance(trans, "history", input_id)
+                    content = app.dataset_collection_manager.get_dataset_collection_instance(
+                        trans, "history", trans.security.decode_id(input_id)
+                    )
                 else:
                     raise exceptions.RequestParameterInvalidException(
                         f"Unknown workflow input source '{input_source}' specified."

--- a/lib/tool_shed/managers/groups.py
+++ b/lib/tool_shed/managers/groups.py
@@ -2,6 +2,7 @@
 Manager and Serializer for TS groups.
 """
 import logging
+from typing import Optional
 
 from sqlalchemy import (
     false,
@@ -33,7 +34,7 @@ class GroupManager:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def get(self, trans, decoded_group_id=None, name=None):
+    def get(self, trans, decoded_group_id: Optional[int] = None, name: Optional[str] = None):
         """
         Get the group from the DB based on its ID or name.
 

--- a/test/unit/app/managers/base.py
+++ b/test/unit/app/managers/base.py
@@ -126,8 +126,7 @@ class CreatesCollectionsMixin:
             #    src = 'collection'#?
             # elif isinstance( element, model.LibraryDatasetDatasetAssociation ):
             #    src = 'ldda'#?
-            encoded_id = self.trans.security.encode_id(element.id)
-            identifier_list.append(dict(src=src, name=element.name, id=encoded_id))
+            identifier_list.append(dict(src=src, name=element.name, id=element.id))
         return identifier_list
 
 


### PR DESCRIPTION
For this to work we need to discriminate response models from incoming
models. This lets us move a large part of the id encoding and decoding
business out of the managers and service layer.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
