### PR TITLE
Expose TRS id of imported workflows in the UI

### DIFF
--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -10,13 +10,13 @@
             <span>{{ workflow.name }}</span>
         </b-link>
         <font-awesome-icon
-            v-if="workflow.source_metadata?.trs_tool_id"
+            v-if="sourceType.includes('trs')"
             v-b-tooltip.hover
             :title="`Imported from TRS ID (version ${workflow.source_metadata.trs_version_id})`"
             icon="check"
             style="color: green" />
         <font-awesome-icon
-            v-if="workflow.source_metadata?.url"
+            v-if="sourceType == 'url'"
             v-b-tooltip.hover
             :title="`Imported from ${workflow.source_metadata.url}`"
             icon="link" />
@@ -122,6 +122,15 @@ export default {
             } else {
                 // TODO: add WorkflowHub
                 return null;
+            }
+        },
+        sourceType() {
+            if (this.workflow.source_metadata?.url) {
+                return "url";
+            } else if (this.workflow.source_metadata?.trs_server) {
+                return `trs_${this.workflow.source_metadata?.trs_server}`;
+            } else {
+                return "";
             }
         },
     },

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -10,11 +10,16 @@
             <span>{{ workflow.name }}</span>
         </b-link>
         <font-awesome-icon
-            v-if="workflow.source_metadata && workflow.source_metadata.trs_tool_id"
+            v-if="workflow.source_metadata?.trs_tool_id"
             v-b-tooltip.hover
-            :title="'Imported from TRS ID (version ' + workflow.source_metadata.trs_version_id + ')'"
+            :title="`Imported from TRS ID (version ${workflow.source_metadata.trs_version_id})`"
             icon="check"
             style="color: green" />
+        <font-awesome-icon
+            v-if="workflow.source_metadata?.url"
+            v-b-tooltip.hover
+            :title="`Imported from ${workflow.source_metadata.url}`"
+            icon="link" />
         <p v-if="workflow.description">{{ workflow.description }}</p>
         <div v-if="workflow.shared" class="dropdown-menu" aria-labelledby="workflow-dropdown">
             <a class="dropdown-item" href="#" @click.prevent="onCopy">
@@ -51,12 +56,9 @@
                 <span class="fa fa-eye fa-fw mr-1" />
                 <span>View</span>
             </a>
-            <a
-                v-if="workflow.source_metadata && workflow.source_metadata.trs_server == 'dockstore'"
-                class="dropdown-item"
-                :href="urlDockstore">
-                <span class="fa fa-cube fa-fw mr-1" />
-                <span>View on Dockstore</span>
+            <a v-if="sourceLabel" class="dropdown-item" :href="sourceUrl">
+                <span class="fa fa-globe fa-fw mr-1" />
+                <span>{{ sourceLabel }}</span>
             </a>
             <a class="dropdown-item" href="#" @click.prevent="onDelete">
                 <span class="fa fa-trash fa-fw mr-1" />
@@ -98,10 +100,27 @@ export default {
                 this.workflow.slug
             }`;
         },
-        urlDockstore() {
-            if (this.workflow.source_metadata && this.workflow.source_metadata.trs_tool_id) {
-                return `https://dockstore.org/workflows${this.workflow.source_metadata.trs_tool_id.slice(9)}`;
+        sourceUrl() {
+            if (this.workflow.source_metadata?.url) {
+                return this.workflow.source_metadata.url;
+            } else if (this.workflow.source_metadata?.trs_server) {
+                if (this.workflow.source_metadata?.trs_server == "dockstore") {
+                    return `https://dockstore.org/workflows${this.workflow.source_metadata.trs_tool_id.slice(9)}`;
+                } else {
+                    // TODO: add WorkflowHub
+                    return null;
+                }
             } else {
+                return null;
+            }
+        },
+        sourceLabel() {
+            if (this.workflow.source_metadata?.url) {
+                return "View external link";
+            } else if (this.workflow.source_metadata?.trs_server == "dockstore") {
+                return "View on Dockstore";
+            } else {
+                // TODO: add WorkflowHub
                 return null;
             }
         },

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -9,6 +9,12 @@
             <font-awesome-icon icon="caret-down" />
             <span>{{ workflow.name }}</span>
         </b-link>
+        <font-awesome-icon
+            v-if="workflow.source_metadata && workflow.source_metadata.trs_tool_id"
+            v-b-tooltip.hover
+            :title="'Imported from TRS ID (version ' + workflow.source_metadata.trs_version_id + ')'"
+            icon="check"
+            style="color: green" />
         <p v-if="workflow.description">{{ workflow.description }}</p>
         <div v-if="workflow.shared" class="dropdown-menu" aria-labelledby="workflow-dropdown">
             <a class="dropdown-item" href="#" @click.prevent="onCopy">
@@ -44,6 +50,13 @@
             <a class="dropdown-item" :href="urlView">
                 <span class="fa fa-eye fa-fw mr-1" />
                 <span>View</span>
+            </a>
+            <a
+                v-if="workflow.source_metadata && workflow.source_metadata.trs_server == 'dockstore'"
+                class="dropdown-item"
+                :href="urlDockstore">
+                <span class="fa fa-cube fa-fw mr-1" />
+                <span>View on Dockstore</span>
             </a>
             <a class="dropdown-item" href="#" @click.prevent="onDelete">
                 <span class="fa fa-trash fa-fw mr-1" />
@@ -84,6 +97,13 @@ export default {
             return `${getAppRoot()}workflow/display_by_username_and_slug?username=${this.workflow.owner}&slug=${
                 this.workflow.slug
             }`;
+        },
+        urlDockstore() {
+            if (this.workflow.source_metadata && this.workflow.source_metadata.trs_tool_id) {
+                return `https://dockstore.org/workflows${this.workflow.source_metadata.trs_tool_id.slice(9)}`;
+            } else {
+                return null;
+            }
         },
     },
     created() {

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1295,6 +1295,7 @@ class WorkflowContentsManager(UsesAnnotations):
         item["annotation"] = self.get_item_annotation_str(sa_session, stored.user, stored)
         item["license"] = workflow.license
         item["creator"] = workflow.creator_metadata
+        item["source_metadata"] = workflow.source_metadata
         steps = {}
         steps_to_order_index = {}
         for step in workflow.steps:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -180,6 +180,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
             item["annotations"] = [x.annotation for x in wf.annotations]
             item["url"] = url_for("workflow", id=encoded_id)
             item["owner"] = wf.user.username
+            item["source_metadata"] = wf.latest_workflow.source_metadata
             item["number_of_steps"] = wf.latest_workflow.step_count
             item["show_in_tool_panel"] = False
             if user is not None:
@@ -360,10 +361,12 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
                     trs_server = payload.get("trs_server")
                     trs_tool_id = payload.get("trs_tool_id")
                     trs_version_id = payload.get("trs_version_id")
+                    import_source = None
                     archive_data = self.app.trs_proxy.get_version_descriptor(trs_server, trs_tool_id, trs_version_id)
                 else:
                     try:
                         archive_data = requests.get(archive_source, timeout=util.DEFAULT_SOCKET_TIMEOUT).text
+                        import_source = "URL"
                     except Exception:
                         raise exceptions.MessageException(f"Failed to open URL '{escape(archive_source)}'.")
             elif hasattr(archive_file, "file"):
@@ -371,11 +374,12 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
                 uploaded_file_name = uploaded_file.name
                 if os.path.getsize(os.path.abspath(uploaded_file_name)) > 0:
                     archive_data = util.unicodify(uploaded_file.read())
+                    import_source = "uploaded file"
                 else:
                     raise exceptions.MessageException("You attempted to upload an empty file.")
             else:
                 raise exceptions.MessageException("Please provide a URL or file.")
-            return self.__api_import_from_archive(trans, archive_data, "uploaded file", payload=payload)
+            return self.__api_import_from_archive(trans, archive_data, import_source, payload=payload)
 
         if "from_history_id" in payload:
             from_history_id = payload.get("from_history_id")

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -19,7 +19,7 @@ class WorkflowManagementTestCase(SeleniumTestCase):
         assert len(table_elements) == 1
 
         new_workflow = table_elements[0].find_element_by_css_selector(".workflow-dropdown")
-        assert "TestWorkflow1 (imported from uploaded file)" in new_workflow.text, new_workflow.text
+        assert "TestWorkflow1 (imported from URL)" in new_workflow.text, new_workflow.text
 
     @selenium_test
     def test_view(self):


### PR DESCRIPTION
Follow-on to #13376 to partially expose the information about workflow provenance in the UI - we discussed this briefly in the workflows WG meeting.

Any alternative ideas how I can do this better are welcome, here are a couple of screenshots:

![image](https://user-images.githubusercontent.com/32272674/159726585-d18df2b9-c72e-4c96-96bc-37e72ee849c2.png)
![image](https://user-images.githubusercontent.com/32272674/159727211-9dde8514-5374-49b3-95f2-09a358c83d7c.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Import a workflow by TRS id (e.g. `#workflow/github.com/iwc-workflows/sars-cov-2-consensus-from-variation/COVID-19-CONSENSUS-CONSTRUCTION` from Dockstore) and check the UI matches the screenshots above.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
