### PR TITLE
Fix config file generation if name and filename are given

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -513,13 +513,13 @@ class ToolEvaluator:
             config_text, is_template = self.__build_config_file_text(content)
             # If a particular filename was forced by the config use it
             directory = ensure_configs_directory(self.local_working_directory)
+            with tempfile.NamedTemporaryFile(dir=directory, delete=False) as temp:
+                config_filename = temp.name
             if filename is not None:
-                # Explicit filename was requested, needs to be placed in tool working directory
+                # Explicit filename was requested, this is implemented as symbolic link
+                # to the actual config file that is placed in tool working directory
                 directory = os.path.join(self.local_working_directory, "working")
-                config_filename = os.path.join(directory, filename)
-            else:
-                with tempfile.NamedTemporaryFile(dir=directory, delete=False) as temp:
-                    config_filename = temp.name
+                os.symlink(config_filename, os.path.join(directory, filename))
             self.__write_workdir_file(config_filename, config_text, param_dict, is_template=is_template)
             self.__register_extra_file(name, config_filename)
             config_filenames.append(config_filename)

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -519,7 +519,7 @@ class ToolEvaluator:
                 # Explicit filename was requested, this is implemented as symbolic link
                 # to the actual config file that is placed in tool working directory
                 directory = os.path.join(self.local_working_directory, "working")
-                os.symlink(config_filename, os.path.join(directory, filename))
+                os.link(config_filename, os.path.join(directory, filename))
             self.__write_workdir_file(config_filename, config_text, param_dict, is_template=is_template)
             self.__register_extra_file(name, config_filename)
             config_filenames.append(config_filename)

--- a/test/functional/tools/exit_code_oom.xml
+++ b/test/functional/tools/exit_code_oom.xml
@@ -1,6 +1,10 @@
 <tool id="exit_code_oom" name="exit_code_oom" version="0.1.1" profile="16.04">
     <!-- tool errors out with identified OOM error if less than 10MB are allocated. -->
     <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
+## test if the config file is accessible via the file name and the cheetah variable
+[[ -f hi.txt ]] || (>&2 echo 'configfile hi.text is missing'; exit 1) &&
+[[ -f '$hi_name' ]] || (>&2 echo 'configfile \$hi_name is missing'; exit 1) &&
+##
 mv hi.txt '$out_file1' &&
 echo "\$GALAXY_MEMORY_MB" &&
 : \${GALAXY_MEMORY_MB:=20} &&
@@ -13,7 +17,7 @@ fi
     ]]></command>
     <configfiles>
         <!-- also tests that configfiles are placed in working dir and that this works on resubmission as well -->
-        <configfile filename="hi.txt">Hello</configfile>
+        <configfile name="hi_name" filename="hi.txt">Hello</configfile>
     </configfiles>
     <inputs>
         <param name="input" type="integer" label="Dummy" value="6" />


### PR DESCRIPTION
always create the config file in `job_directory/configs/` and
if `filename` is given create a ~sym~ _hard_ link to the actual config file

fixes https://github.com/galaxyproject/galaxy/issues/13586

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
