### PR TITLE
New History: Break item's name to fit and show completely

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -215,7 +215,7 @@ export default {
 }
 .content-item {
     .name {
-        word-wrap: break-word;
+        word-break: break-all;
     }
 }
 .detail-animation-wrapper {


### PR DESCRIPTION
Fixes #13603

![Screen Shot 2022-03-24 at 00 43 40](https://user-images.githubusercontent.com/8046843/159787548-53472fd1-1dee-4801-ab4b-7fa88af40551.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create a history item with a long name

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
