### PR TITLE
Report resolution cache miss for galaxy.tool_util.deps.container_reso…

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -79,6 +79,7 @@ def _namespace_has_repo_name(namespace, repo_name, resolution_cache):
             return repo_name in resolution_cache.get(cache_key)
         except KeyError:
             pass
+    log.debug("Resolution cache miss: " + cache_key)
     next_page = None
     repo_names = []
     repos_headers = {"Accept-encoding": "gzip", "Accept": "application/json"}

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -79,7 +79,7 @@ def _namespace_has_repo_name(namespace, repo_name, resolution_cache):
             return repo_name in resolution_cache.get(cache_key)
         except KeyError:
             pass
-    log.debug("Resolution cache miss: " + cache_key)
+    log.debug("Querying " + QUAY_REPOSITORY_API_ENDPOINT + " for repos within " + namespace)
     next_page = None
     repo_names = []
     repos_headers = {"Accept-encoding": "gzip", "Accept": "application/json"}

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -79,7 +79,7 @@ def _namespace_has_repo_name(namespace, repo_name, resolution_cache):
             return repo_name in resolution_cache.get(cache_key)
         except KeyError:
             pass
-    log.debug("Querying " + QUAY_REPOSITORY_API_ENDPOINT + " for repos within " + namespace)
+    log.debug(f"Querying {QUAY_REPOSITORY_API_ENDPOINT} for repos within {namespace}")
     next_page = None
     repo_names = []
     repos_headers = {"Accept-encoding": "gzip", "Accept": "application/json"}


### PR DESCRIPTION
…lvers.mulled.util:namespace_repo_names

This is important to detect if Galaxy is hammering quay.io for any reason.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Configure mulled container resolution
  2. Execute any biocontainer tools
  3. Check debug log for multiple misses.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
