### PR TITLE
Handle missing error response in failed upload

### DIFF
--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -15,7 +15,7 @@ function submitPayload(payload, cnf) {
             cnf.success(response.data);
         })
         .catch((error) => {
-            cnf.error(error.response.data.err_msg);
+            cnf.error(error.response?.data.err_msg || "Request failed.");
         });
 }
 


### PR DESCRIPTION
Fixes #13589. This PR allows the upload queue to continue if an individual upload fails without proper server error response details. Error details can be missing if e.g. the connection itself fails.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
