### PR TITLE
Add format source to the Extract dataset tool output

### DIFF
--- a/lib/galaxy/tools/extract_dataset.xml
+++ b/lib/galaxy/tools/extract_dataset.xml
@@ -1,6 +1,6 @@
 <tool id="__EXTRACT_DATASET__"
       name="Extract dataset"
-      version="1.0.1"
+      version="1.0.2"
       tool_type="extract_element">
   <description></description>
   <type class="ExtractDatasetCollectionTool" module="galaxy.tools" />
@@ -36,7 +36,7 @@
     </conditional>
   </inputs>
   <outputs>
-    <data name="output" label="${on_string} (extracted element)" />
+    <data name="output" label="${on_string} (extracted element)" format_source="input" />
   </outputs>
   <help><![CDATA[
 
@@ -50,7 +50,18 @@ Extracts datasets from a collection based on either position or identifier.
 Description
 ===========
 
-The tool allow extracting datasets based on position (**The first dataset** and **Select by index** options) or name (**Select by element identifier** option). This tool effectively collapses the inner-most collection into a dataset. For nested collections (e.g a list of lists of lists: outer:middle:inner, extracting the inner dataset element) a new list is created where the selected element takes the position of the inner-most collection (so outer:middle, where middle is not a collection but the inner dataset element).
+The tool allow extracting datasets based on position (**The first dataset** and
+**Select by index** options) or name (**Select by element identifier** option)
+from a collection or a pair.
+
+If applied to nested collection, e.g. collection of pairs or collection of pairs,
+then the tool will be applied (in separate jobs) on the contained lists and
+produce a list. 
+That is, this tool effectively transforms the inner-most collection into a dataset. For
+nested collections (e.g a list of lists of lists: outer:middle:inner, where inner is a
+dataset element) a new list is created where the selected element
+takes the position of the inner-most collection (so outer:middle, where middle
+is not a collection but the inner dataset element).
 
 .. class:: warningmark 
 


### PR DESCRIPTION
the tool already produces outputs of the correct format (i.e. the format of the inputs), but
the outputs can not be be connected to downstream tools in the workflow editor. 

This is now possible, but I don't understand why I can connect even if I do not set the
format of the input node. (So I have an input paired node, feed it into the extract dataset tool, 
and connect it to a downstream tool .. then I would expect to be able to do so only if I set
the format of the paired input node).


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
