### PR TITLE
Fix bug to enable alembic's stamp command: revision can be a list of revisions

### DIFF
--- a/lib/galaxy/model/migrations/alembic/env.py
+++ b/lib/galaxy/model/migrations/alembic/env.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import (
     Callable,
@@ -17,6 +18,7 @@ from galaxy.model.migrations import (
 
 config = context.config
 target_metadata = None  # Not implemented: used for autogenerate, which we don't use here.
+log = logging.getLogger(__name__)
 
 
 def run_migrations_offline() -> None:
@@ -47,7 +49,14 @@ def _run_migrations_invoked_via_script(run_migrations: Callable[[str], None]) ->
     if _process_cmd_current(urls):
         return  # we're done
 
-    revision_str = config.cmd_opts.revision  # type: ignore[union-attr]
+    try:
+        revision_str = config.cmd_opts.revision  # type: ignore[union-attr]
+    except AttributeError:
+        revision_str = config.cmd_opts.revisions  # type: ignore[union-attr]
+        if revision_str:
+            if len(revision_str) > 1:
+                log.error("Please run the commmand for one revision at a time")
+            revision_str = revision_str[0]  # type: ignore[union-attr]
 
     if revision_str.startswith(f"{GXY}@"):
         url = urls[GXY]


### PR DESCRIPTION
This is a bug fix that offers a (sort of partial) fix for #13617 

When running `./run_alembic.sh stamp gxy@REVISION-ID-GOES-HERE`, the revision string is passed to Alembic's Config as a list `revisions`, not a string `revision` (as it does for other commands). This requires more work (both use cases should be available), but for now the code will log an error if multiple revision identifiers are passed, prompting the user to submit one revisions at a time (which is not something that would happen with our setup in any case). This should be sufficient to address the referenced issue: running the stamp command is a reasonable workaround (see issue for context and more detail).


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
