### PR TITLE
Improve matching reliability, add test cases

### DIFF
--- a/client/src/store/historyStore/historyItemsFiltering.js
+++ b/client/src/store/historyStore/historyItemsFiltering.js
@@ -24,10 +24,10 @@ function toLower(value) {
  * @param {*} attribute of the content item
  * @param {*} query parameter if the attribute does not match the server query key
  */
-function equals(attribute, query = null) {
+function equals(attribute) {
     return {
         attribute,
-        query: query || `${attribute}-eq`,
+        query: `${attribute}-eq`,
         handler: (v, q) => {
             return toLower(v) == toLower(q);
         },
@@ -38,10 +38,10 @@ function equals(attribute, query = null) {
  * Checks if a query value is part of the item value
  * @param {*} attribute of the content item
  */
-function contains(attribute) {
+function contains(attribute, query = null) {
     return {
         attribute,
-        query: `${attribute}-contains`,
+        query: query || `${attribute}-contains`,
         handler: (v, q) => {
             return toLower(v).includes(toLower(q));
         },
@@ -93,7 +93,7 @@ const validFilters = {
     hid_lt: compare("hid", "lt"),
     name: contains("name"),
     state: equals("state"),
-    tag: equals("tags", "tag"),
+    tag: contains("tags", "tag"),
     update_time: compare("update_time", "le", toDate),
     update_time_ge: compare("update_time", "ge", toDate),
     update_time_gt: compare("update_time", "gt", toDate),
@@ -102,31 +102,35 @@ const validFilters = {
 };
 
 /* Add comparison aliases i.e. '*>value' is converted to '*_gt=value' */
-const validAlias = { _gt: ">", _lt: "<" };
+const validAlias = { ">": "_gt", "<": "_lt" };
 
 /* Parses single text input into a dict of field->value pairs. */
 export function getFilters(filterText) {
-    const pairSplitRE = /(\S+=".*")|(\S+='.*')|(\S+=\S+)/g;
+    const pairSplitRE = /(\S+".*?")|(\S+'.*?')|(\S+)/g;
     const scrubQuotesRE = /'|"/g;
     const result = {};
     if (filterText.length == 0) {
         return [];
     }
-    Object.entries(validAlias).forEach(([suffix, alias]) => {
-        filterText = filterText.replaceAll(alias, `${suffix}=`);
-    });
-    let matches = filterText.match(pairSplitRE);
-    if (!matches && filterText.length > 0 && !filterText.includes("=")) {
-        matches = [`name=${filterText}`];
-    }
+    const matches = filterText.match(pairSplitRE);
+    let hasMatches = false;
     if (matches) {
         matches.forEach((pair) => {
+            Object.entries(validAlias).forEach(([alias, suffix]) => {
+                pair = pair.replace(alias, `${suffix}=`);
+            });
             const [field, value] = pair.split("=");
-            const normalizedField = field.replaceAll("-", "_");
-            if (validFilters[normalizedField]) {
-                result[normalizedField] = value.replace(scrubQuotesRE, "");
+            if (field && value) {
+                const normalizedField = field.replaceAll("-", "_");
+                if (validFilters[normalizedField]) {
+                    result[normalizedField] = value.replace(scrubQuotesRE, "");
+                    hasMatches = true;
+                }
             }
         });
+    }
+    if (!hasMatches) {
+        result["name"] = filterText;
     }
     return Object.entries(result);
 }

--- a/client/src/store/historyStore/historyItemsFiltering.test.js
+++ b/client/src/store/historyStore/historyItemsFiltering.test.js
@@ -2,7 +2,7 @@ import { getFilters, getQueryDict, testFilters } from "./historyItemsFiltering";
 
 const filterTexts = [
     "name='name of item' hid>10 hid<100 create-time>'2021-01-01' update-time<\"2022-01-01\" state=success extension=ext tag=first",
-    "name='name of item' hid>10 hid<100 create_time>\"2021-01-01\" update_time-lt='2022-01-01' state=success extension=ext tag=first",
+    "name='name of item' hid_gt=10 hid-lt=100 create_time-gt=\"2021-01-01\" update_time-lt='2022-01-01' state=success extension=ext tag=first",
 ];
 describe("historyItemsFiltering", () => {
     test("parse default filter", () => {

--- a/client/src/store/historyStore/historyItemsFiltering.test.js
+++ b/client/src/store/historyStore/historyItemsFiltering.test.js
@@ -62,7 +62,7 @@ describe("historyItemsFiltering", () => {
             expect(testFilters(filters, { ...item, hid: 10 })).toBe(false);
             expect(testFilters(filters, { ...item, hid: 100 })).toBe(false);
             expect(testFilters(filters, { ...item, hid: 99 })).toBe(true);
-            expect(testFilters(filters, { ...item, status: "error" })).toBe(true);
+            expect(testFilters(filters, { ...item, state: "error" })).toBe(false);
             expect(testFilters(filters, { ...item, create_time: "2021-01-01" })).toBe(false);
             expect(testFilters(filters, { ...item, create_time: "2021-01-02" })).toBe(true);
             expect(testFilters(filters, { ...item, update_time: "2022-01-01" })).toBe(false);

--- a/client/src/store/historyStore/historyItemsFiltering.test.js
+++ b/client/src/store/historyStore/historyItemsFiltering.test.js
@@ -1,0 +1,74 @@
+import { getFilters, getQueryDict, testFilters } from "./historyItemsFiltering";
+
+const filterTexts = [
+    "name='name of item' hid>10 hid<100 create-time>'2021-01-01' update-time<\"2022-01-01\" state=success extension=ext tag=first",
+    "name='name of item' hid>10 hid<100 create_time>\"2021-01-01\" update_time-lt='2022-01-01' state=success extension=ext tag=first",
+];
+describe("historyItemsFiltering", () => {
+    test("parse default filter", () => {
+        const filters = getFilters("name of item");
+        expect(filters[0][0]).toBe("name");
+        expect(filters[0][1]).toBe("name of item");
+        const queryDict = getQueryDict("name of item");
+        expect(queryDict["name-contains"]).toBe("name of item");
+    });
+    test("parse filter text as entries", () => {
+        filterTexts.forEach((filterText) => {
+            const filters = getFilters(filterText);
+            expect(filters[0][0]).toBe("name");
+            expect(filters[0][1]).toBe("name of item");
+            expect(filters[1][0]).toBe("hid_gt");
+            expect(filters[1][1]).toBe("10");
+            expect(filters[2][0]).toBe("hid_lt");
+            expect(filters[2][1]).toBe("100");
+            expect(filters[3][0]).toBe("create_time_gt");
+            expect(filters[3][1]).toBe("2021-01-01");
+            expect(filters[4][0]).toBe("update_time_lt");
+            expect(filters[4][1]).toBe("2022-01-01");
+            expect(filters[5][0]).toBe("state");
+            expect(filters[5][1]).toBe("success");
+            expect(filters[6][0]).toBe("extension");
+            expect(filters[6][1]).toBe("ext");
+            expect(filters[7][0]).toBe("tag");
+            expect(filters[7][1]).toBe("first");
+        });
+    });
+    test("parse filter text as query dictionary", () => {
+        filterTexts.forEach((filterText) => {
+            const queryDict = getQueryDict(filterText);
+            expect(queryDict["name-contains"]).toBe("name of item");
+            expect(queryDict["hid-gt"]).toBe("10");
+            expect(queryDict["hid-lt"]).toBe("100");
+            expect(queryDict["create_time-gt"]).toBe(1609459200);
+            expect(queryDict["update_time-lt"]).toBe(1640995200);
+            expect(queryDict["state-eq"]).toBe("success");
+            expect(queryDict["extension-eq"]).toBe("ext");
+            expect(queryDict["tag"]).toBe("first");
+        });
+    });
+    test("validate filtering of a history item", () => {
+        filterTexts.forEach((filterText) => {
+            const filters = getFilters(filterText);
+            const item = {
+                name: "contains the name of item.",
+                hid: 11,
+                create_time: "2021-06-01",
+                update_time: "2021-06-01",
+                state: "success",
+                extension: "ext",
+                tags: ["first", "second"],
+            };
+            expect(testFilters(filters, { ...item })).toBe(true);
+            expect(testFilters(filters, { ...item, hid: 10 })).toBe(false);
+            expect(testFilters(filters, { ...item, hid: 100 })).toBe(false);
+            expect(testFilters(filters, { ...item, hid: 99 })).toBe(true);
+            expect(testFilters(filters, { ...item, status: "error" })).toBe(true);
+            expect(testFilters(filters, { ...item, create_time: "2021-01-01" })).toBe(false);
+            expect(testFilters(filters, { ...item, create_time: "2021-01-02" })).toBe(true);
+            expect(testFilters(filters, { ...item, update_time: "2022-01-01" })).toBe(false);
+            expect(testFilters(filters, { ...item, update_time: "2021-12-31" })).toBe(true);
+            expect(testFilters(filters, { ...item, status: "error" })).toBe(true);
+            expect(testFilters(filters, { ...item, tags: ["second"] })).toBe(false);
+        });
+    });
+});

--- a/client/src/store/historyStore/historyItemsFiltering.test.js
+++ b/client/src/store/historyStore/historyItemsFiltering.test.js
@@ -67,7 +67,6 @@ describe("historyItemsFiltering", () => {
             expect(testFilters(filters, { ...item, create_time: "2021-01-02" })).toBe(true);
             expect(testFilters(filters, { ...item, update_time: "2022-01-01" })).toBe(false);
             expect(testFilters(filters, { ...item, update_time: "2021-12-31" })).toBe(true);
-            expect(testFilters(filters, { ...item, status: "error" })).toBe(true);
             expect(testFilters(filters, { ...item, tags: ["second"] })).toBe(false);
         });
     });


### PR DESCRIPTION
Follow-up for #13591. Adds query filtering tests and improves matching reliability.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
