### PR TITLE
Check if column exists before executing upgrade/downgrade operations in select revisions

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
@@ -31,5 +31,4 @@ def upgrade():
 
 
 def downgrade():
-    if column_exists(table_name, column_name):
-        drop_column(table_name, column_name)
+    drop_column(table_name, column_name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
@@ -10,8 +10,8 @@ from sqlalchemy import Column
 
 from galaxy.model.custom_types import JSONType
 from galaxy.model.migrations.util import (
+    column_exists,
     drop_column,
-    ignore_add_column_error,
 )
 
 # revision identifiers, used by Alembic.
@@ -20,12 +20,16 @@ down_revision = "e7b6dcb09efd"
 branch_labels = None
 depends_on = None
 
+# database object names user in this revision
+table_name = "workflow"
+column_name = "source_metadata"
+
 
 def upgrade():
-    table, column = "workflow", "source_metadata"
-    with ignore_add_column_error(table, column):
-        op.add_column(table, Column(column, JSONType))
+    if not column_exists(table_name, column_name):
+        op.add_column(table_name, Column(column_name, JSONType))
 
 
 def downgrade():
-    drop_column("workflow", "source_metadata")
+    if column_exists(table_name, column_name):
+        drop_column(table_name, column_name)

--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -1,38 +1,18 @@
 import logging
-from contextlib import contextmanager
 
 from alembic import op
-from sqlalchemy.exc import (
-    OperationalError,
-    ProgrammingError,
-)
+from sqlalchemy import inspect
 
 log = logging.getLogger(__name__)
 
 
-def drop_column(table, column):
-    with op.batch_alter_table(table) as batch_op:
-        batch_op.drop_column(column)
+def drop_column(table_name, column_name):
+    with op.batch_alter_table(table_name) as batch_op:
+        batch_op.drop_column(column_name)
 
 
-@contextmanager
-def ignore_add_column_error(table, column):
-    """
-    Use this context manager to wrap statements in upgrade/downgrade functions
-    in revision files when a statement may cause an error that may be safely
-    ignored. For example, in revision b182f655505f, if an upgrade operation is
-    executed on a database that has been previoiusly upgraded via SQLAlchemy
-    Migrate to version 181, a subsequent upgrade to Alembic may cause such as
-    error. For more details, see https://github.com/galaxyproject/galaxy/issues/13528.
-
-    We are checking for 2 different error types: OperationalError is raised
-    for SQLite, ProgrammingError is raised for PostgreSQL.
-    """
-    statement = f"ALTER TABLE {table} ADD COLUMN {column}"
-    try:
-        yield
-    except (ProgrammingError, OperationalError) as e:
-        if e.statement.startswith(statement):
-            log.error(f"Ignoring error: {e}")
-        else:
-            raise e
+def column_exists(table_name, column_name):
+    bind = op.get_context().bind
+    insp = inspect(bind)
+    columns = insp.get_columns(table_name)
+    return any(c["name"] == column_name for c in columns)


### PR DESCRIPTION
Fixes #13617 and replaces #13595 (because we don't need to silence those errors anymore).

I intentionally did not move this check into the utils module where it could be applied to all such schema modifications by default: I think that while it is justified for edge cases like `source_metadata` (and any schema edits prior to 22.05), it would be safer to fail fast in all other cases.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
1. Make sure galaxy is up-to-date (current dev branch: source_metadata column should exist in workflow table)
2. Delete rows from alembic_version table
3. Run manage_db.sh upgrade, observe no error happening. If you run these steps on the current dev branch, #13617 will happen.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
