### PR TITLE
[22.01] Fix allow admin to use private datasets

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -330,7 +330,7 @@ export default {
                     if (genericError) {
                         this.showError = true;
                         this.errorTitle = "Job submission failed.";
-                        this.errorContent = this.jobDef;
+                        this.errorContent = jobDef;
                     }
                 }
             );

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -15,7 +15,10 @@
                         :tool-name="toolName" />
                     <Webhook v-if="showSuccess" type="tool" :tool-id="jobDef.tool_id" />
                     <b-modal v-model="showError" size="sm" :title="errorTitle | l" scrollable ok-only>
-                        <b-alert show variant="danger">
+                        <b-alert v-if="errorMessage" show variant="danger">
+                            {{ errorMessage }}
+                        </b-alert>
+                        <b-alert show variant="warning">
                             The server could not complete this request. Please verify your parameter settings, retry
                             submission and contact the Galaxy Team if this error persists. A transcript of the submitted
                             data is shown below.
@@ -147,6 +150,7 @@ export default {
             remapAllowed: false,
             errorTitle: null,
             errorContent: null,
+            errorMessage: "",
             messageShow: false,
             messageVariant: "",
             messageText: "",
@@ -317,6 +321,7 @@ export default {
                     document.querySelector(".center-panel").scrollTop = 0;
                 },
                 (e) => {
+                    this.errorMessage = e?.response?.data?.err_msg;
                     this.showExecuting = false;
                     let genericError = true;
                     const errorData = e && e.response && e.response.data && e.response.data.err_data;

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -97,13 +97,13 @@ class DefaultToolAction(ToolAction):
                 # fetch dataset details for this input from the database.
                 if collection_info and collection_info.is_mapped_over(input_name):
                     action_tuples = collection_info.map_over_action_tuples(input_name)
-                    if not trans.app.security_agent.can_access_datasets(current_user_roles, action_tuples):
+                    if not trans.user_is_admin and not trans.app.security_agent.can_access_datasets(current_user_roles, action_tuples):
                         raise ItemAccessibilityException("User does not have permission to use a dataset provided for input.")
                     for action, role_id in action_tuples:
                         record_permission(action, role_id)
                 else:
-                    if not trans.app.security_agent.can_access_dataset(current_user_roles, data.dataset):
-                        raise ItemAccessibilityException(f"User does not have permission to use a dataset ({data.id}) provided for input.")
+                    if not trans.user_is_admin and not trans.app.security_agent.can_access_dataset(current_user_roles, data.dataset):
+                        raise ItemAccessibilityException(f"User does not have permission to use dataset ({data.name}) provided for input.")
                     permissions = trans.app.security_agent.get_permissions(data.dataset)
                     for action, roles in permissions.items():
                         for role in roles:
@@ -169,7 +169,7 @@ class DefaultToolAction(ToolAction):
                     collection = value.collection
 
                 action_tuples = collection.dataset_action_tuples
-                if not trans.app.security_agent.can_access_datasets(current_user_roles, action_tuples):
+                if not trans.user_is_admin and not trans.app.security_agent.can_access_datasets(current_user_roles, action_tuples):
                     raise ItemAccessibilityException("User does not have permission to use a dataset provided for input.")
                 for action, role_id in action_tuples:
                     record_permission(action, role_id)

--- a/test/unit/app/tools/test_actions.py
+++ b/test/unit/app/tools/test_actions.py
@@ -243,6 +243,7 @@ class MockTrans:
         self.sa_session = self.app.model.context
         self.model = app.model
         self._user_is_active = True
+        self.user_is_admin = False
 
     def get_user_is_active(self):
         # NOTE: the real user_is_active also checks whether activation is enabled in the config


### PR DESCRIPTION
Fixes #13627

Also fixes some minor errors when displaying failed jobs in the UI:
- If the job submission returns an error message in the response, it is now more prominently displayed
- The job definition object was not being correctly displayed in case of an error (it was always `{}`)
- Changed the fixed text message style for failed jobs to warning (so the real error is highlighted)
- Replaced the unencoded dataset ID with the dataset name in the error message.

![Screenshot from 2022-03-28 15-35-30](https://user-images.githubusercontent.com/46503462/160425615-ae56dcfe-87e1-459d-aa94-a628a5f13926.png)

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Log in with a normal user
  - Create a History with some datasets
  - Make sure the datasets are private by using the `Make private` option in the History
  - Copy the encoded ID of the History
  - Log in as an admin
  - Go to http://127.0.0.1:8080/histories/view?id=<history_encoded_id>
  - Import the History
  - Run any tool using one of the datasets
  - Observe the tool runs successfully

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
