### PR TITLE
Feature for #13517: Workflow Editor - Scroll Wheel Zoom feature

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -53,7 +53,18 @@
                     </div>
                 </div>
                 <div id="workflow-canvas" class="unified-panel-body workflow-canvas">
-                    <ZoomControl :zoom-level="zoomLevel" @onZoom="onZoom" />
+                    <ZoomControl v-if="!checkWheeled" :zoom-level="zoomLevel" @onZoom="onZoom" />
+                    <b-button
+                        v-else
+                        class="reset-wheel"
+                        @click="resetWheel"
+                        variant="light"
+                        title="Show Zoom Buttons"
+                        size="sm"
+                        aria-label="Show Zoom Buttons"
+                        v-b-tooltip.hover>
+                        Zoom Controls
+                    </b-button>
                     <div id="canvas-viewport">
                         <div ref="canvas" id="canvas-container">
                             <WorkflowNode
@@ -260,6 +271,8 @@ export default {
             messageIsError: false,
             version: this.initialVersion,
             showInPanel: "attributes",
+            isWheeled: false,
+            canvasManager: null,
         };
     },
     computed: {
@@ -277,6 +290,12 @@ export default {
         },
         hasActiveNodeTool() {
             return this.activeNode && this.activeNode.type == "tool";
+        },
+        checkWheeled() {
+            if (this.canvasManager != null) {
+                return this.canvasManager.isWheeled;
+            }
+            return this.isWheeled;
         },
     },
     created() {
@@ -528,6 +547,10 @@ export default {
         onZoom(zoomLevel) {
             this.zoomLevel = this.canvasManager.setZoom(zoomLevel);
         },
+        resetWheel() {
+            this.zoomLevel = this.canvasManager.zoomLevel;
+            this.canvasManager.isWheeled = false;
+        },
         onSave(hideProgress = false) {
             !hideProgress && this.onWorkflowMessage("Saving workflow...", "progress");
             return saveWorkflow(this)
@@ -637,5 +660,12 @@ export default {
 <style scoped>
 .workflow-markdown-editor {
     right: 0px !important;
+}
+.reset-wheel {
+    position: absolute;
+    left: 1rem;
+    bottom: 1rem;
+    cursor: pointer;
+    z-index: 1002;
 }
 </style>

--- a/client/src/components/Workflow/Editor/ZoomControl.test.js
+++ b/client/src/components/Workflow/Editor/ZoomControl.test.js
@@ -18,7 +18,7 @@ describe("ZoomControl", () => {
         await buttons.at(0).trigger("click");
         expect(wrapper.emitted().onZoom[0][0]).toBe(9);
         await buttons.at(1).trigger("click");
-        expect(wrapper.emitted().onZoom[1][0]).toBe(10);
+        expect(wrapper.emitted().onZoom[1][0]).toBe(7);
         await buttons.at(2).trigger("click");
         expect(wrapper.emitted().onZoom[2][0]).toBe(11);
     });

--- a/client/src/components/Workflow/Editor/ZoomControl.vue
+++ b/client/src/components/Workflow/Editor/ZoomControl.vue
@@ -33,7 +33,7 @@
 <script>
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
-import { zoomLevels } from "./modules/canvas";
+import { zoomLevels, defaultZoomLevel } from "./modules/canvas";
 
 Vue.use(BootstrapVue);
 
@@ -46,7 +46,7 @@ export default {
     },
     data() {
         return {
-            zoomDefault: this.zoomLevel,
+            zoomDefault: defaultZoomLevel,
         };
     },
     computed: {

--- a/client/src/components/Workflow/Editor/modules/canvas.js
+++ b/client/src/components/Workflow/Editor/modules/canvas.js
@@ -103,8 +103,11 @@ class CanvasManager {
         this.init_drag();
         // Initialize Copy & Paste events
         this.init_copy_paste();
+        this.init_scroll_zoom();
+        this.isWheeled = false;
     }
     setZoom(zoomLevel) {
+        this.isWheeled = false;
         this.zoomLevel = Math.min(Math.max(0, zoomLevel), zoomLevels.length - 1);
         this.canvasZoom = zoomLevels[this.zoomLevel];
         // Set CSS transform to appropriate zoom level
@@ -117,6 +120,41 @@ class CanvasManager {
         this._fitCanvasToNodes();
         this.drawOverview();
         return this.zoomLevel;
+    }
+    init_scroll_zoom() {
+        /*
+            The scroll_zoom event binding allows for the functionality of zooming in
+            using the mouse scroll wheel.
+        */
+        // Zooming within canvas background
+        document.getElementById("workflow-canvas").addEventListener("wheel", (e) => {
+            this.isWheeled = true;
+            e.preventDefault();
+            var zoomScale = this.canvasZoom;
+            zoomScale += e.deltaY * -0.001;
+            // // Get value within range of zoom/scale levels (0.25 - 4)
+            zoomScale = Math.min(Math.max(0.25, zoomScale), 4);
+            // Find index (zoomLevel) for the zoom value (canvasZoom)
+            let zoomIndex = 0;
+            while (zoomLevels[zoomIndex] < zoomScale) {
+                zoomIndex++;
+            }
+            // Tried to use setZoom() function but it requires zoomLevel as input
+            // i.e.: won't allow for smooth zooming (will only allow 15 levels
+            // of zoom like in ZoomControl)
+            // this.setZoom(i);
+            this.zoomLevel = zoomIndex;
+            this.canvasZoom = zoomScale;
+            // Set CSS transform to appropriate zoom level
+            this.cv.css("transform-origin", "top left");
+            this.cv.css("transform", "scale(" + this.canvasZoom + ")");
+            // Modify canvas size to account for scale
+            this.cv.css("width", `${100 / this.canvasZoom}%`);
+            this.cv.css("height", `${100 / this.canvasZoom}%`);
+            // Update canvas size
+            this._fitCanvasToNodes();
+            this.drawOverview();
+        });
     }
     move(x, y) {
         x = Math.min(x, this.cv.width() / 2);


### PR DESCRIPTION
# Workflow Editor - Scroll Wheel Zoom feature
As mentioned in https://github.com/galaxyproject/galaxy/issues/13525 , adding the ability to zoom in/out in the workflow editor canvas would be a really convenient feature when moving a multitude of tools around a large canvas. Therefore, by adding an `init_scroll_zoom()` function to the `canvas.js`, and making appropriate additions to the `Index.vue` of the `Workflow/Editor`, I added the scroll to zoom feature (that works not only with mouse wheels but also track pads).
This is a demonstration of the feature (03/28):

https://user-images.githubusercontent.com/78516064/160508029-9c4b8f73-2bbe-4aba-8ddc-1bae20175fba.mov


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
