### PR TITLE
Limit tool parameter value to show only 20 lines with overflow scrolling

### DIFF
--- a/client/src/components/JobParameters/JobParameters.vue
+++ b/client/src/components/JobParameters/JobParameters.vue
@@ -18,7 +18,7 @@
                         <td v-if="Array.isArray(parameter.value)">
                             <JobParametersArrayValue :parameter_value="parameter.value" />
                         </td>
-                        <td v-else>
+                        <td v-else class="tool-parameter-value">
                             {{ parameter.value }}
                         </td>
                         <td v-if="anyNotes">
@@ -138,3 +138,13 @@ export default {
     },
 };
 </script>
+
+<style scoped>
+.tool-parameter-value {
+    overflow: auto;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 20;
+    -webkit-box-orient: vertical;
+}
+</style>


### PR DESCRIPTION
Fixes #13452
Display content for tool parameter values limited to 20 lines and with overflow scrolling (I think this is a better option than using expand button)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Use the issue `To Reproduce` steps

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
