### PR TITLE
Add optional dependency on total-perspective-vortex

### DIFF
--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -805,7 +805,7 @@
             <param id="type">python</param>
             <param id="function">map_tool_to_destination</param>
             <param id="rules_module">vortex.rules</param>
-            <param id="vortex_config_files">https://github.com/galaxyproject/total-perspective-vortex/blob/bf8ec46c672ed5a7ba2471d9b514cef15995bf3f/tests/fixtures/mapping-rules.yml</param>
+            <param id="vortex_config_files">https://raw.githubusercontent.com/galaxyproject/total-perspective-vortex/main/tests/fixtures/mapping-sample.yml</param>
         </destination>
         <destination id="docker_dispatch" runner="dynamic">
             <!-- Follow dynamic destination type will send all tool's that

--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -798,6 +798,15 @@
             <!-- Pick next available server and resubmit if an unknown error occurs -->
             <resubmit condition="unknown_error and attempt &lt;= 3" destination="galaxycloudrunner" />
         </destination>
+        <destination id="vortex_dispatcher" runner="dynamic">
+            <!-- Demonstrates how to use total-perspective-vortex, which enables dynamic destination
+            selection for entities (Tools, Users, Groups) based on a configurable yaml file.
+            See: https://total-perspective-vortex.readthedocs.io/ for documentation. -->
+            <param id="type">python</param>
+            <param id="function">map_tool_to_destination</param>
+            <param id="rules_module">vortex.rules</param>
+            <param id="vortex_config_files">https://github.com/galaxyproject/total-perspective-vortex/blob/bf8ec46c672ed5a7ba2471d9b514cef15995bf3f/tests/fixtures/mapping-rules.yml</param>
+        </destination>
         <destination id="docker_dispatch" runner="dynamic">
             <!-- Follow dynamic destination type will send all tool's that
             support docker to static destination defined by

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -50,8 +50,10 @@ class ConditionalDependencies:
             for runner in runners.values():
                 if "load" in runner:
                     self.job_runners.append(runner.get("load"))
-                if "rules_module" in runner:
-                    self.job_rule_modules.append(runner.get("rules_module"))
+            environments = job_conf_dict.get("execution", {}).get("environments", {})
+            for env in environments.values():
+                if "rules_module" in env:
+                    self.job_rule_modules.append(env.get("rules_module"))
 
         if "job_config" in self.config:
             load_job_config_dict(self.config.get("job_config"))
@@ -187,6 +189,9 @@ class ConditionalDependencies:
             or "galaxy.jobs.runners.slurm:SlurmJobRunner" in self.job_runners
             or "galaxy.jobs.runners.univa:UnivaJobRunner" in self.job_runners
         )
+
+    def check_galaxycloudrunner(self):
+        return "galaxycloudrunner.rules" in self.job_rule_modules
 
     def check_total_perspective_vortex(self):
         return "vortex.rules" in self.job_rule_modules

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -188,8 +188,8 @@ class ConditionalDependencies:
             or "galaxy.jobs.runners.univa:UnivaJobRunner" in self.job_runners
         )
 
-    def check_galaxycloudrunner(self):
-        return "galaxycloudrunner.rules" in self.job_rule_modules
+    def check_total_perspective_vortex(self):
+        return "vortex.rules" in self.job_rule_modules
 
     def check_pbs_python(self):
         return "galaxy.jobs.runners.pbs:PBSJobRunner" in self.job_runners

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -12,6 +12,7 @@ python-ldap==3.4.0
 python-pam
 galaxycloudrunner
 pkce
+total-perspective-vortex
 
 # For file sources plugins
 fs.webdavfs>=0.4.2  # type: webdav

--- a/test/unit/app/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/app/jobs/job_conf.sample_advanced.yml
@@ -757,8 +757,8 @@ execution:
       function: map_tool_to_destination
       rules_module: vortex.rules
       vortex_config_files:
-        - https://github.com/galaxyproject/total-perspective-vortex/blob/bf8ec46c672ed5a7ba2471d9b514cef15995bf3f/tests/fixtures/mapping-rules.yml
-        - config/vortex_rules_local.yml
+        - https://raw.githubusercontent.com/galaxyproject/total-perspective-vortex/main/tests/fixtures/mapping-sample.yml
+        # - config/vortex_rules_local.yml
 
     docker_dispatch:
       runner: dynamic

--- a/test/unit/app/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/app/jobs/job_conf.sample_advanced.yml
@@ -748,6 +748,17 @@ execution:
       fallback_destination: local
       # Pick next available server and resubmit if an unknown error occurs
       # resubmit: {condition: 'unknown_error and attempt <= 3', environment: galaxycloudrunner}
+    vortex_dispatcher:
+      runner: dynamic
+      # Demonstrates how to use total-perspective-vortex, which enables dynamic destination
+      # selection for entities (Tools, Users, Groups) based on a configurable yaml file.
+      # See: https://total-perspective-vortex.readthedocs.io/ for documentation.
+      type: python
+      function: map_tool_to_destination
+      rules_module: vortex.rules
+      vortex_config_files:
+        - https://github.com/galaxyproject/total-perspective-vortex/blob/bf8ec46c672ed5a7ba2471d9b514cef15995bf3f/tests/fixtures/mapping-rules.yml
+        - config/vortex_rules_local.yml
 
     docker_dispatch:
       runner: dynamic


### PR DESCRIPTION
This PR adds [total-perspective-vortex](https://github.com/galaxyproject/total-perspective-vortex) (TPV) as an optional dependency.

TPV provides an installable set of dynamic rules that can route entities (Tools, Users, Roles) to appropriate job destinations based on a configurable yaml file. TPV also provides pluggable meta-scheduling capabilities, and a centralizable database of rules that can be shared by multiple Galaxy instances. It is meant to be a successor to Galaxy's dynamic tool destinations.

TPV is in production in Galaxy-Australia, and we've seen a significant increase in throughput (2x) due to better scheduling and utilization of Pulsar nodes.

More information: [http://total-perspective-vortex.readthedocs.org](http://total-perspective-vortex.readthedocs.org/en/latest/?badge=latest)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
