### PR TITLE
[22.01] Fix FormElement: doesn't populate options for parameters

### DIFF
--- a/client/src/components/Form/Elements/parameters.test.js
+++ b/client/src/components/Form/Elements/parameters.test.js
@@ -1,0 +1,43 @@
+import Ui from "mvc/ui/ui-misc";
+import ParameterFactory from "./parameters";
+
+jest.mock("app");
+jest.mock("mvc/ui/ui-misc", () => ({
+    TextSelect: jest.fn(() => {
+        return {
+            value: jest.fn(),
+        };
+    }),
+    Input: jest.fn(() => {
+        return {
+            value: jest.fn(),
+        };
+    }),
+}));
+
+describe("ParameterFactory", () => {
+    it("should create a TEXT parameter input when no type is specified", async () => {
+        const input = {
+            id: "type-less parameter",
+            type: "",
+            value: "initial_value",
+        };
+        const parameter = new ParameterFactory();
+        parameter.create(input);
+        expect(Ui.Input).toHaveBeenCalled();
+        expect(Ui.TextSelect).not.toHaveBeenCalled();
+    });
+
+    it("should create a SELECT parameter input when no type is specified and the input has options", async () => {
+        const input = {
+            id: "type-less parameter with options",
+            type: "",
+            value: "initial_value",
+            options: [("Option A", "a"), ("Option B", "b")],
+        };
+        const parameter = new ParameterFactory();
+        parameter.create(input);
+        expect(Ui.TextSelect).toHaveBeenCalled();
+        expect(Ui.Input).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -74,7 +74,7 @@ export default {
         },
         type: {
             type: String,
-            default: "text",
+            default: "",
         },
         value: {
             default: null,


### PR DESCRIPTION
Fixes #13597

Remove `text` as the default type for Form input elements, otherwise when the form input defines `options` they won't be rendered as a select and will be forced to a regular text field.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #13597

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
