### PR TITLE
Fix package CI for pysam errors.

### DIFF
--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -13,7 +13,7 @@ numpy
 parsley
 pycryptodome
 pydantic
-pysam
+pysam<0.19  # Seemingly inaccurate type definitions - CI breaks on this
 social-auth-core[openidconnect]==4.0.3
 SQLAlchemy>=1.4.25,<2
 tifffile<=2020.9.3  # Last version compatible with python 3.6


### PR DESCRIPTION
Fix CircleCI for now? Pin pysam since 0.19.0 seems to have incomplete type definitions.

Failed build example: https://app.circleci.com/pipelines/github/galaxyproject/galaxy/22088/workflows/f9d6b681-da6d-4e0e-9867-baeb1fc73968/jobs/167487

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
