### PR TITLE
Porting undocumented API: '/api/groups/{encoded_group_id}/users' to FastAPI

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1980,6 +1980,25 @@ class GroupRoleListModel(BaseModel):
     __root__: List[GroupRoleModel]
 
 
+# Users -----------------------------------------------------------------
+
+UserIdField = Field(title="ID", description="Encoded ID of the user")
+UserEmailField = Field(title="Email", description="Email of the user")
+UserDescriptionField = Field(title="Description", description="Description of the user")
+
+# Group_Users -----------------------------------------------------------------
+
+
+class GroupUserModel(BaseModel):
+    id: EncodedDatabaseIdField = UserIdField
+    email: str = UserEmailField
+    url: RelativeUrl = RelativeUrlField
+
+
+class GroupUserListModel(BaseModel):
+    __root__: List[GroupUserModel]
+
+
 # Libraries -----------------------------------------------------------------
 
 

--- a/lib/galaxy/webapps/galaxy/api/group_users.py
+++ b/lib/galaxy/webapps/galaxy/api/group_users.py
@@ -3,56 +3,105 @@ API operations on Group objects.
 """
 import logging
 
+from fastapi import Path
+
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.group_users import GroupUsersManager
 from galaxy.schema.fields import EncodedDatabaseIdField
-from galaxy.web import (
-    expose_api,
-    require_admin,
+from galaxy.schema.schema import (
+    GroupUserListModel,
+    GroupUserModel,
 )
 from . import (
-    BaseGalaxyAPIController,
     depends,
+    DependsOnTrans,
+    Router,
 )
 
 log = logging.getLogger(__name__)
 
+router = Router(tags=["group_users"])
 
-class GroupUsersAPIController(BaseGalaxyAPIController):
-    manager = depends(GroupUsersManager)
+GroupIDParam: EncodedDatabaseIdField = Path(..., title="GroupID", description="The ID of the group")
 
-    @require_admin
-    @expose_api
-    def index(self, trans: ProvidesAppContext, group_id: EncodedDatabaseIdField, **kwd):
+UserIDParam: EncodedDatabaseIdField = Path(..., title="UserID", description="The ID of the user")
+
+
+def group_user_to_model(trans, encoded_group_id, user):
+    encoded_user_id = trans.security.encode_id(user.id)
+    url = trans.url_builder("group_user", group_id=encoded_group_id, id=encoded_user_id)
+    return GroupUserModel(id=encoded_user_id, email=user.email, url=url)
+
+
+@router.cbv
+class FastAPIGroupUsers:
+    manager: GroupUsersManager = depends(GroupUsersManager)
+
+    @router.get("/api/groups/{group_id}/users", require_admin=True, summary="Displays a collection (list) of groups.")
+    def index(
+        self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam
+    ) -> GroupUserListModel:
         """
         GET /api/groups/{encoded_group_id}/users
         Displays a collection (list) of groups.
         """
-        return self.manager.index(trans, group_id)
+        group_users = self.manager.index(trans, group_id)
+        return GroupUserListModel(__root__=[group_user_to_model(trans, group_id, gr) for gr in group_users])
 
-    @require_admin
-    @expose_api
-    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField, **kwd):
+    @router.get(
+        "/api/groups/{group_id}/user/{id}",
+        alias="/api/groups/{group_id}/users/{id}",
+        name="group_user",
+        require_admin=True,
+        summary="Displays information about a group user.",
+    )
+    def show(
+        self,
+        trans: ProvidesAppContext = DependsOnTrans,
+        group_id: EncodedDatabaseIdField = GroupIDParam,
+        id: EncodedDatabaseIdField = UserIDParam,
+    ) -> GroupUserModel:
         """
         GET /api/groups/{encoded_group_id}/users/{encoded_user_id}
         Displays information about a group user.
         """
-        return self.manager.show(trans, id, group_id)
+        user = self.manager.show(trans, id, group_id)
+        return group_user_to_model(trans, group_id, user)
 
-    @require_admin
-    @expose_api
-    def update(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField, **kwd):
+    @router.put(
+        "/api/groups/{group_id}/users/{user_id}",
+        alias="/api/groups/{group_id}/user/{user_id}",
+        require_admin=True,
+        summary="Adds a user to a group",
+    )
+    def update(
+        self,
+        trans: ProvidesAppContext = DependsOnTrans,
+        group_id: EncodedDatabaseIdField = GroupIDParam,
+        user_id: EncodedDatabaseIdField = UserIDParam,
+    ) -> GroupUserModel:
         """
         PUT /api/groups/{encoded_group_id}/users/{encoded_user_id}
         Adds a user to a group
         """
-        return self.manager.update(trans, id, group_id)
+        user = self.manager.update(trans, user_id, group_id)
+        return group_user_to_model(trans, group_id, user)
 
-    @require_admin
-    @expose_api
-    def delete(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField, **kwd):
+    @router.delete(
+        "/api/groups/{group_id}/user/{user_id}",
+        alias="/api/groups/{group_id}/users/{user_id}",
+        require_admin=True,
+        summary="Removes a user from a group",
+    )
+    def delete(
+        self,
+        trans: ProvidesAppContext = DependsOnTrans,
+        group_id: EncodedDatabaseIdField = GroupIDParam,
+        user_id: EncodedDatabaseIdField = UserIDParam,
+    ) -> GroupUserModel:
         """
         DELETE /api/groups/{encoded_group_id}/users/{encoded_user_id}
         Removes a user from a group
         """
-        return self.manager.delete(trans, id, group_id)
+        user = self.manager.delete(trans, user_id, group_id)
+        return group_user_to_model(trans, group_id, user)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -285,14 +285,6 @@ def postfork_setup():
 def populate_api_routes(webapp, app):
     webapp.add_api_controllers("galaxy.webapps.galaxy.api", app)
 
-    webapp.mapper.resource(
-        "user",
-        "users",
-        controller="group_users",
-        name_prefix="group_",
-        path_prefix="/api/groups/{group_id}",
-        parent_resources=dict(member_name="group", collection_name="groups"),
-    )
     _add_item_tags_controller(
         webapp, name_prefix="history_content_", path_prefix="/api/histories/{history_id}/contents/{history_content_id}"
     )

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -45,6 +45,10 @@ api_tags_metadata = [
         "name": "group_roles",
         "description": "Operations with group roles.",
     },
+    {
+        "name": "group_users",
+        "description": "Operations with group users.",
+    },
     {"name": "histories"},
     {"name": "libraries"},
     {"name": "folders"},


### PR DESCRIPTION
- Adding the implementation for Porting the undocumented /api/groups/{encoded_group_id}/users i.e. group_users APIs to FastAPI. 
- Adding a Wrapping FastAPI method with an additional alias keyword and require_admin handling in Router class present in lib/galaxy/webapps/galaxy/api/__init__.py
- Updated lib/galaxy/managers/group_users.py Update and Delete functions, as returned userId was being encoded twice.
 
**Testing** 
- Unit tests present in lib/galaxy_test/api/test_group_users.py are successfully passing.
- Additonally, porting of the APIs can be verified at http://localhost:8080/api/docs#/group_users