### PR TITLE
Update mypy to 0.942 and fix new mypy errors

### DIFF
--- a/lib/galaxy/celery/_serialization.py
+++ b/lib/galaxy/celery/_serialization.py
@@ -36,7 +36,7 @@ def schema_decoder(obj):
             ), f"Invalid class str {clazz_str}"
             module_name, class_name = clazz_str.rsplit(".", 1)
             module = import_module(module_name)
-            clazz = getattr(module, class_name, None)
+            clazz = getattr(module, class_name)
             obj = clazz(**obj["__object__"])
             return obj
 

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -19,7 +19,6 @@ from typing import Optional
 import h5py
 import numpy as np
 import pysam
-import pysam.bcftools
 from bx.seq.twobit import (
     TWOBIT_MAGIC_NUMBER,
     TWOBIT_MAGIC_NUMBER_SWAP,

--- a/lib/galaxy/datatypes/converters/cram_to_bam.py
+++ b/lib/galaxy/datatypes/converters/cram_to_bam.py
@@ -7,7 +7,7 @@ usage: %prog in_file out_file
 import optparse
 import os
 
-import pysam
+from pysam import sort  # type: ignore[attr-defined]
 
 
 def main():
@@ -16,7 +16,7 @@ def main():
     (options, args) = parser.parse_args()
     input_fname, output_fname = args
     slots = os.getenv("GALAXY_SLOTS", 1)
-    pysam.sort(f"-@{slots}", "-o", output_fname, "-O", "bam", "-T", ".", input_fname)
+    sort(f"-@{slots}", "-o", output_fname, "-O", "bam", "-T", ".", input_fname)
 
 
 if __name__ == "__main__":

--- a/lib/galaxy/dependencies/lint-requirements.txt
+++ b/lib/galaxy/dependencies/lint-requirements.txt
@@ -1,6 +1,6 @@
 flake8
 flake8-bugbear
-mypy==0.910
+mypy
 types-bleach
 types-boto
 types-contextvars

--- a/lib/galaxy/dependencies/pinned-lint-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-lint-requirements.txt
@@ -3,12 +3,12 @@ flake8==4.0.1
 flake8-bugbear==22.3.23
 importlib-metadata==4.2.0
 mccabe==0.6.1
-mypy==0.910
+mypy==0.942
 mypy-extensions==0.4.3
 pycodestyle==2.8.0
 pyflakes==2.4.0
-toml==0.10.2
-typed-ast==1.4.3
+tomli==2.0.1
+typed-ast==1.5.2
 types-bleach==4.1.5
 types-boto==2.49.10
 types-contextvars==2.4.4
@@ -20,7 +20,7 @@ types-paramiko==2.8.17
 types-pkg-resources==0.1.3
 types-python-dateutil==2.8.10
 types-PyYAML==6.0.5
-types-requests==2.27.14
+types-requests==2.27.15
 types-six==1.16.12
 types-urllib3==1.26.11
 typing_extensions==4.1.1

--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -1,11 +1,7 @@
-import inspect
 import re
 from typing import Optional
 
-from pydantic import (
-    BaseModel,
-    Field,
-)
+from pydantic import Field
 
 from galaxy.security.idencoding import IdEncodingHelper
 
@@ -108,23 +104,3 @@ def OrderParamField(default_order: str) -> Optional[str]:
         ),
         example="name-dsc,create_time",
     )
-
-
-def optional(*fields):
-    """Decorator function used to modify a pydantic model's fields to all be optional.
-    Alternatively, you can  also pass the field names that should be made optional as arguments
-    to the decorator.
-    Taken from https://github.com/samuelcolvin/pydantic/issues/1223#issuecomment-775363074
-    """
-
-    def dec(_cls):
-        for field in fields:
-            _cls.__fields__[field].required = False
-        return _cls
-
-    if fields and inspect.isclass(fields[0]) and issubclass(fields[0], BaseModel):
-        cls = fields[0]
-        fields = cls.__fields__
-        return dec(cls)
-
-    return dec

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -12,6 +12,7 @@ import urllib.parse
 from collections import namedtuple
 from typing import (
     Any,
+    BinaryIO,
     List,
     Optional,
 )
@@ -61,6 +62,7 @@ def output_properties(
 ) -> OutputPropertiesType:
     checksum = hashlib.sha1()
     properties: OutputPropertiesType = {"class": "File", "checksum": "", "size": 0}
+    f: BinaryIO
     if path is not None:
         properties["path"] = path
         f = open(path, "rb")

--- a/lib/galaxy/util/compression_utils.py
+++ b/lib/galaxy/util/compression_utils.py
@@ -107,6 +107,7 @@ def get_fileobj_raw(
         fh: Union[gzip.GzipFile, bz2.BZ2File, IO[bytes]] = gzip.GzipFile(filename, mode)
         compressed_format = "gzip"
     elif "bz2" in compressed_formats and is_bz2(filename):
+        mode = cast(Literal["a", "ab", "r", "rb", "w", "wb", "x", "xb"], mode)
         fh = bz2.BZ2File(filename, mode)
         compressed_format = "bz2"
     elif "zip" in compressed_formats and zipfile.is_zipfile(filename):
@@ -115,7 +116,7 @@ def get_fileobj_raw(
         # since it always opens files in binary mode.
         # For emulating text mode, we will be returning the binary fh in a
         # TextIOWrapper.
-        zf_mode = mode.replace("b", "")
+        zf_mode = cast(Literal["r", "w"], mode.replace("b", ""))
         with zipfile.ZipFile(filename, zf_mode) as zh:
             fh = zh.open(zh.namelist()[0], zf_mode)
         compressed_format = "zip"
@@ -311,6 +312,7 @@ class CompressedFile:
         return tarfile.open(filepath, mode, errorlevel=0)
 
     def open_zip(self, filepath: str, mode: str) -> zipfile.ZipFile:
+        mode = cast(Literal["a", "r", "w", "x"], mode)
         return zipfile.ZipFile(filepath, mode)
 
     def zipfile_ok(self, path_to_archive: str) -> bool:

--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -139,11 +139,7 @@ class NicerConfigParser(ConfigParser):
     def __init__(self, filename, *args, **kw):
         ConfigParser.__init__(self, *args, **kw)
         self.filename = filename
-        if hasattr(self, "_interpolation"):
-            self._interpolation = self.InterpolateWrapper(self._interpolation)
-
-    read_file = getattr(ConfigParser, "read_file", ConfigParser.readfp)
-    read_file.__doc__ = ""
+        self._interpolation = self.InterpolateWrapper(self._interpolation)
 
     def defaults(self):
         """Return the defaults, with their values interpolated (with the
@@ -156,20 +152,7 @@ class NicerConfigParser(ConfigParser):
             defaults[key] = self.get("DEFAULT", key) or val
         return defaults
 
-    def _interpolate(self, section, option, rawval, vars):
-        # Python < 3.2
-        try:
-            return ConfigParser._interpolate(self, section, option, rawval, vars)
-        except Exception:
-            e = sys.exc_info()[1]
-            args = list(e.args)
-            args[0] = f"Error in file {self.filename}: {e}"
-            e.args = tuple(args)
-            e.message = args[0]
-            raise
-
     class InterpolateWrapper:
-        # Python >= 3.2
         def __init__(self, original):
             self._original = original
 

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -88,7 +88,7 @@ def depends(dep_type: Type[T]) -> T:
     def _do_resolve(request: Request):
         return get_app().resolve(dep_type)
 
-    return GalaxyTypeDepends(_do_resolve, dep_type)
+    return cast(T, GalaxyTypeDepends(_do_resolve, dep_type))
 
 
 def get_session_manager(app: StructuredApp = DependsOnApp) -> GalaxySessionManager:

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1898,7 +1898,7 @@ class ToolModule(WorkflowModule):
                         replacement = dataset_instance
                         temp = iteration_elements[prefixed_name]
                         if hasattr(temp, "element_identifier") and temp.element_identifier:
-                            replacement.element_identifier = temp.element_identifier  # type: ignore[attr-defined]
+                            replacement.element_identifier = temp.element_identifier  # type: ignore[union-attr]
                     else:
                         # If collection - just use element model object.
                         replacement = iteration_elements[prefixed_name]

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -933,6 +933,8 @@ class GalaxyTestDriver(TestDriver):
 
         self.testing_shed_tools = getattr(config_object, "testing_shed_tools", False)
 
+        default_tool_conf: Optional[str]
+        datatypes_conf_override: Optional[str]
         if getattr(config_object, "framework_tool_and_types", False):
             default_tool_conf = FRAMEWORK_SAMPLE_TOOLS_CONF
             datatypes_conf_override = FRAMEWORK_DATATYPES_CONF
@@ -976,8 +978,8 @@ class GalaxyTestDriver(TestDriver):
                 if callable(galaxy_config):
                     galaxy_config = galaxy_config()
                 if galaxy_config is None:
-                    setup_galaxy_config_kwds = dict(
-                        allow_path_paste=getattr(config_object, "allow_path_paste", False),
+                    galaxy_config = setup_galaxy_config(
+                        galaxy_db_path,
                         use_test_file_dir=not self.testing_shed_tools,
                         default_install_db_merged=True,
                         default_tool_conf=self.default_tool_conf,
@@ -988,8 +990,8 @@ class GalaxyTestDriver(TestDriver):
                         conda_auto_install=getattr(config_object, "conda_auto_install", False),
                         use_shared_connection_for_amqp=getattr(config_object, "use_shared_connection_for_amqp", False),
                         allow_tool_conf_override=self.allow_tool_conf_override,
+                        allow_path_paste=getattr(config_object, "allow_path_paste", False),
                     )
-                    galaxy_config = setup_galaxy_config(galaxy_db_path, **setup_galaxy_config_kwds)
 
                     isolate_galaxy_config = getattr(config_object, "isolate_galaxy_config", False)
                     if isolate_galaxy_config:

--- a/lib/tool_shed/tools/tool_validator.py
+++ b/lib/tool_shed/tools/tool_validator.py
@@ -89,12 +89,9 @@ class ToolValidator(GalaxyToolValidator):
                         # 'ncbi_blastp_wrapper.xml' was moved to 'tools/ncbi_blast_plus/ncbi_blastp_wrapper.xml',
                         # so keep looking for the file until we find the new location.
                         continue
-                    fh = tempfile.NamedTemporaryFile("wb", prefix="tmp-toolshed-gltcrfrm")
-                    tmp_filename = fh.name
-                    fh.close()
-                    fh = open(tmp_filename, "wb")
-                    fh.write(fctx.data())
-                    fh.close()
+                    with tempfile.NamedTemporaryFile("wb", prefix="tmp-toolshed-gltcrfrm", delete=False) as fh:
+                        tmp_filename = fh.name
+                        fh.write(fctx.data())
                     return tmp_filename
         return None
 

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -2,7 +2,7 @@ galaxy-files
 galaxy-objectstore
 galaxy-sequence-utils
 galaxy-util[template]
-alembic==1.7.4; python_version >= "3.6"
+alembic
 bdbag
 bx-python
 contextvars; python_version >= "3.6" and python_version < "3.7"

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -13,7 +13,7 @@ numpy
 parsley
 pycryptodome
 pydantic
-pysam<0.19  # Seemingly inaccurate type definitions - CI breaks on this
+pysam
 social-auth-core[openidconnect]==4.0.3
 SQLAlchemy>=1.4.25,<2
 tifffile<=2020.9.3  # Last version compatible with python 3.6

--- a/test/unit/data/datatypes/test_bam.py
+++ b/test/unit/data/datatypes/test_bam.py
@@ -1,4 +1,7 @@
-import pysam
+from pysam import (  # type: ignore[attr-defined]
+    AlignmentFile,
+    view,
+)
 
 from galaxy.datatypes.binary import Bam
 from .util import (
@@ -11,8 +14,8 @@ from .util import (
 def test_merge_bam():
     with get_input_files("1.bam", "1.bam") as input_files, get_tmp_path() as outpath:
         Bam.merge(input_files, outpath)
-        alignment_count_output = int(pysam.view("-c", outpath).strip())
-        alignment_count_input = int(pysam.view("-c", input_files[0]).strip()) * 2
+        alignment_count_output = int(view("-c", outpath).strip())
+        alignment_count_input = int(view("-c", input_files[0]).strip()) * 2
         assert alignment_count_input == alignment_count_output
 
 
@@ -43,9 +46,7 @@ def test_set_meta_presorted():
     with get_dataset("1.bam") as dataset:
         b.set_meta(dataset=dataset)
         assert dataset.metadata.sort_order == "coordinate"
-        bam_file = pysam.AlignmentFile(
-            dataset.file_name, mode="rb", index_filename=dataset.metadata.bam_index.file_name
-        )
+        bam_file = AlignmentFile(dataset.file_name, mode="rb", index_filename=dataset.metadata.bam_index.file_name)
         assert bam_file.has_index() is True
 
 


### PR DESCRIPTION
Also:
- Reverts https://github.com/galaxyproject/galaxy/pull/13644
- Remove unused `optional()` decorator function that had an annotation issue.
- Unpin alembic in galaxy-data package

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
