### PR TITLE
Add a tooltip w/ version_minor in the galaxy help menu

### DIFF
--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -37,6 +37,7 @@
             <b-dropdown-item
                 v-else-if="item.hidden !== true"
                 :href="formatUrl(item.url)"
+                :title="item.tooltip ? item.tooltip : false"
                 :key="`item-${idx}`"
                 :target="item.target || '_parent'"
                 role="menuitem"

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -208,6 +208,7 @@ export function fetchMenu(options = {}) {
                 title: _l("Galaxy Version: " + Galaxy.config.version_major),
                 url: versionUserDocumentationUrl,
                 target: "_blank",
+                tooltip: `${options.version_major} ${options.version_minor}`,
             },
             {
                 title: _l("Terms and Conditions"),


### PR DESCRIPTION
Closes https://github.com/galaxyproject/galaxy/issues/13574

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Hover over version in help menu.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
