### PR TITLE
Add support for gulp build process to use a configurable directory

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -95,8 +95,8 @@ function buildPlugins(callback, forceRebuild) {
         glob(buildModule, {}, (er, files) => {
             files.map((file) => {
                 let skipBuild = false;
-                const pluginDir = file.slice(0, -12);
-                const pluginName = path.dirname(file).split(path.sep).pop();
+                const pluginDir = path.dirname(file)
+                const pluginName = pluginDir.split(path.sep).pop();
 
                 const hashFilePath = path.join(
                     pluginDir,

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -34,7 +34,7 @@ const DIST_PLUGIN_BUILD_IDS = ["new_user"];
 const PLUGIN_BUILD_IDS = Array.prototype.concat(DIST_PLUGIN_BUILD_IDS, STATIC_PLUGIN_BUILD_IDS);
 
 const PATHS = {
-    pluginBaseDir: process.env.GALAXY_PLUGIN_DIR || "../config/plugins/",
+    pluginBaseDir: process.env.GALAXY_PLUGIN_PATH || "../config/plugins/",
     nodeModules: "./node_modules",
     stagedLibraries: {
         // This is a stepping stone towards having all this staged

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -34,7 +34,6 @@ const DIST_PLUGIN_BUILD_IDS = ["new_user"];
 const PLUGIN_BUILD_IDS = Array.prototype.concat(DIST_PLUGIN_BUILD_IDS, STATIC_PLUGIN_BUILD_IDS);
 
 const PATHS = {
-    pluginBaseDir: process.env.GALAXY_PLUGIN_PATH || "../config/plugins/",
     nodeModules: "./node_modules",
     stagedLibraries: {
         // This is a stepping stone towards having all this staged
@@ -50,6 +49,11 @@ const PATHS = {
         underscore: ["underscore.js", "underscore.js"],
     },
 };
+
+PATHS.pluginBaseDir =
+    (process.env.GALAXY_PLUGIN_PATH && process.env.GALAXY_PLUGIN_PATH !== "None"
+        ? process.env.GALAXY_PLUGIN_PATH
+        : undefined) || "../config/plugins/";
 
 PATHS.pluginDirs = [
     path.join(PATHS.pluginBaseDir, "{visualizations,welcome_page}/*/static/**/*"),
@@ -95,7 +99,7 @@ function buildPlugins(callback, forceRebuild) {
         glob(buildModule, {}, (er, files) => {
             files.map((file) => {
                 let skipBuild = false;
-                const pluginDir = path.dirname(file)
+                const pluginDir = path.dirname(file);
                 const pluginName = pluginDir.split(path.sep).pop();
 
                 const hashFilePath = path.join(

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -31,6 +31,8 @@ const STATIC_PLUGIN_BUILD_IDS = [
     "venn",
 ];
 
+const PLUGIN_BASE_DIR = process.env.GALAXY_PLUGIN_DIR || "../config/plugins/";
+
 const DIST_PLUGIN_BUILD_IDS = ["new_user"];
 
 const PLUGIN_BUILD_IDS = Array.prototype.concat(DIST_PLUGIN_BUILD_IDS, STATIC_PLUGIN_BUILD_IDS);
@@ -38,11 +40,11 @@ const PLUGIN_BUILD_IDS = Array.prototype.concat(DIST_PLUGIN_BUILD_IDS, STATIC_PL
 const PATHS = {
     nodeModules: "./node_modules",
     pluginDirs: [
-        "../config/plugins/{visualizations,welcome_page}/*/static/**/*",
-        "../config/plugins/{visualizations,welcome_page}/*/*/static/**/*",
+        path.join(PLUGIN_BASE_DIR, "{visualizations,welcome_page}/*/static/**/*"),
+        path.join(PLUGIN_BASE_DIR, "{visualizations,welcome_page}/*/*/static/**/*"),
     ],
     pluginBuildModules: [
-        `../config/plugins/{visualizations,welcome_page}/{${PLUGIN_BUILD_IDS.join(",")}}/package.json`,
+        path.join(PLUGIN_BASE_DIR, `{visualizations,welcome_page}/{${PLUGIN_BUILD_IDS.join(",")}}/package.json`),
     ],
     stagedLibraries: {
         // This is a stepping stone towards having all this staged
@@ -90,8 +92,8 @@ function buildPlugins(callback, forceRebuild) {
     /*
      * Walk pluginBuildModules glob and attempt to build modules.
      * */
-    PATHS.pluginBuildModules.map((build_module) => {
-        glob(build_module, {}, (er, files) => {
+    PATHS.pluginBuildModules.map((buildModule) => {
+        glob(buildModule, {}, (er, files) => {
             files.map((file) => {
                 let skipBuild = false;
                 const f = path.join(process.cwd(), file).slice(0, -12);
@@ -102,7 +104,7 @@ function buildPlugins(callback, forceRebuild) {
                     "plugin_build_hash.txt"
                 );
 
-                if (!!forceRebuild) {
+                if (forceRebuild) {
                     skipBuild = false;
                 } else {
                     if (fs.existsSync(hashFilePath)) {
@@ -163,7 +165,7 @@ const pluginsRebuild = series(forceBuildPlugins, cleanPlugins, stagePlugins);
 
 function watchPlugins() {
     const BUILD_PLUGIN_WATCH_GLOB = [
-        `../config/plugins/{visualizations,welcome_page}/{${PLUGIN_BUILD_IDS.join(",")}}/**/*`,
+        path.join(PLUGIN_BASE_DIR, `{visualizations,welcome_page}/{${PLUGIN_BUILD_IDS.join(",")}}/**/*`),
     ];
     watch(BUILD_PLUGIN_WATCH_GLOB, { queue: false }, plugins);
 }

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -255,6 +255,10 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
     else
         echo "WARNING: Galaxy client build needed but there is no virtualenv enabled. Build may fail."
     fi
+    # We need galaxy config here, ensure it's set.
+    set_galaxy_config_file_var
+    # Set plugin path
+    GALAXY_PLUGIN_PATH=$(python scripts/config_parse.py --setting=plugin_path --config-file="$GALAXY_CONFIG_FILE")
     # Build client
     cd client
     if yarn install $YARN_INSTALL_OPTS; then

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -262,7 +262,7 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
     # Build client
     cd client
     if yarn install $YARN_INSTALL_OPTS; then
-        if ! yarn run build-production-maps; then
+        if ! (export GALAXY_PLUGIN_PATH="$GALAXY_PLUGIN_PATH"; yarn run build-production-maps;) then
             echo "ERROR: Galaxy client build failed. See ./client/README.md for more information, including how to get help."
             exit 1
         fi

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -198,6 +198,23 @@ if [ $FETCH_WHEELS -eq 1 ]; then
     fi
 fi
 
+# Install node if not installed
+if [ -n "$VIRTUAL_ENV" ]; then
+    if ! in_venv "$(command -v node)" || [ "$(node --version)" != "v${NODE_VERSION}" ]; then
+        echo "Installing node into $VIRTUAL_ENV with nodeenv."
+        if [ -d "${VIRTUAL_ENV}/lib/node_modules" ]; then
+            echo "Removing old ${VIRTUAL_ENV}/lib/node_modules directory."
+            rm -rf "${VIRTUAL_ENV}/lib/node_modules"
+        fi
+        nodeenv -n "$NODE_VERSION" -p
+    fi
+elif [ -n "$CONDA_DEFAULT_ENV" ] && [ -n "$CONDA_EXE" ]; then
+    if ! in_conda_env "$(command -v node)"; then
+        echo "Installing node into '$CONDA_DEFAULT_ENV' Conda environment with conda."
+        $CONDA_EXE install --yes --override-channels --channel conda-forge --channel defaults --name "$CONDA_DEFAULT_ENV" nodejs="$NODE_VERSION"
+    fi
+fi
+
 # Check client build state.
 if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
     if [ -f static/client_build_hash.txt ]; then
@@ -220,23 +237,6 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
     fi
 else
     echo "The Galaxy client build is being skipped due to the SKIP_CLIENT_BUILD environment variable."
-fi
-
-# Install node if not installed
-if [ -n "$VIRTUAL_ENV" ]; then
-    if ! in_venv "$(command -v node)" || [ "$(node --version)" != "v${NODE_VERSION}" ]; then
-        echo "Installing node into $VIRTUAL_ENV with nodeenv."
-        if [ -d "${VIRTUAL_ENV}/lib/node_modules" ]; then
-            echo "Removing old ${VIRTUAL_ENV}/lib/node_modules directory."
-            rm -rf "${VIRTUAL_ENV}/lib/node_modules"
-        fi
-        nodeenv -n "$NODE_VERSION" -p
-    fi
-elif [ -n "$CONDA_DEFAULT_ENV" ] && [ -n "$CONDA_EXE" ]; then
-    if ! in_conda_env "$(command -v node)"; then
-        echo "Installing node into '$CONDA_DEFAULT_ENV' Conda environment with conda."
-        $CONDA_EXE install --yes --override-channels --channel conda-forge --channel defaults --name "$CONDA_DEFAULT_ENV" nodejs="$NODE_VERSION"
-    fi
 fi
 
 # Build client if necessary.

--- a/scripts/config_parse.py
+++ b/scripts/config_parse.py
@@ -11,15 +11,16 @@ from galaxy.config import GalaxyAppConfiguration
 def main(config, setting):
     # Use explicit config, then env, then guess.
     config = config or os.environ.get("GALAXY_CONFIG_FILE", "config/galaxy.yml")
-    gx_config = GalaxyAppConfiguration(**yaml.safe_load(open(config))['galaxy'])
-    if setting:
-        print(gx_config.get(setting))
-    else:
-        pprint.pprint(gx_config.config_dict)
+    if config and os.path.exists(config):
+        gx_config = GalaxyAppConfiguration(**yaml.safe_load(open(config))["galaxy"])
+        if setting:
+            print(gx_config.get(setting))
+        else:
+            pprint.pprint(gx_config.config_dict)
 
 
 if __name__ == "__main__":
-    arg_parser = argparse.ArgumentParser()
+    arg_parser = argparse.ArgumentParser(description="Fetch values from Galaxy config, or print all set values.")
     # add optional 'setting' argument
     arg_parser.add_argument("-s", "--setting", default=None, help="setting")
     arg_parser.add_argument(

--- a/scripts/config_parse.py
+++ b/scripts/config_parse.py
@@ -1,8 +1,9 @@
-import yaml
-import sys
-import os
 import argparse
+import os
 import pprint
+import sys
+
+import yaml
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "lib")))
 from galaxy.config import GalaxyAppConfiguration

--- a/scripts/config_parse.py
+++ b/scripts/config_parse.py
@@ -1,0 +1,29 @@
+import yaml
+import sys
+import os
+import argparse
+import pprint
+
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "lib")))
+from galaxy.config import GalaxyAppConfiguration
+
+
+def main(config, setting):
+    # Use explicit config, then env, then guess.
+    config = config or os.environ.get("GALAXY_CONFIG_FILE", "config/galaxy.yml")
+    gx_config = GalaxyAppConfiguration(**yaml.safe_load(open(config))['galaxy'])
+    if setting:
+        print(gx_config.get(setting))
+    else:
+        pprint.pprint(gx_config.config_dict)
+
+
+if __name__ == "__main__":
+    arg_parser = argparse.ArgumentParser()
+    # add optional 'setting' argument
+    arg_parser.add_argument("-s", "--setting", default=None, help="setting")
+    arg_parser.add_argument(
+        "-c", "--config-file", default=None, help="Galaxy config file (defaults to config/galaxy.ini)"
+    )
+    args = arg_parser.parse_args()
+    main(args.config_file, args.setting)


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/13620.  

This adds support for an env var specifying plugin dir (or use the default otherwise) to the gulp build scripts.  It also adjusts startup (anything using `common_startup.sh` to attempt to derive this value when set and pass it along.

Deployers who don't use common_startup but do have a custom plugin location can set the env var in ansible/etc as appropriate.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
