### PR TITLE
Add EOF to pasted content when EOF is missing

### DIFF
--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -91,12 +91,33 @@ export function submitUpload(config) {
         cnf.error(data.error_message);
         return;
     }
-    if (!data.files.length) {
-        // No files attached, don't need to use TUS uploader
-        return submitPayload(data, cnf);
+
+    if (isPasted(data)) {
+        if (data.targets.length && data.targets[0].elements.length) {
+            const pasted_item = data.targets[0].elements[0];
+            if (!isUrl(pasted_item)) {
+                ensureEOF(pasted_item);
+            }
+            // No files attached, don't need to use TUS uploader
+            return submitPayload(data, cnf);
+        }
     }
     const tusEndpoint = `${getAppRoot()}api/upload/resumable_upload/`;
     tusUpload(data, 0, tusEndpoint, cnf);
+}
+
+function isPasted(data) {
+    return !data.files.length;
+}
+
+function isUrl(pasted_item) {
+    return pasted_item.src == "url";
+}
+
+function ensureEOF(pasted_item) {
+    if (pasted_item.paste_content && !pasted_item.paste_content.endsWith("\n")) {
+        pasted_item.paste_content += "\n";
+    }
 }
 
 (($) => {


### PR DESCRIPTION
This fixes #13558.
While this is the first step towards #13610, I'm submitting it as a separate PR to verify this step is correct. In particular:

1. Is this logic correct? I assume if the content is pasted (`!data.files.length`), then the following ***must*** be true: `data.targets.length > 0` and `data.targets[0].elements.length > 0`. Or is there a case when either one is 0? (in which case this would break)
2. There's always one element: `data.targets[0].elements[0]`: when I paste more than 1 item, that code is executed more than once, but each time it's 1 element. Is this correct?
3. Do we want to accept empty pastes? (i.e., nothing pasted - we can still upload that as an empty dataset). Or should we validate and prevent the api call?
4. If we do validate and want to display an error, how do we do it? (i.e., is there a specific error class we throw, and what should the UI look like?
5. Somewhat related: currently, the logic for checking if pasted content is a url is this (I think): if the first line is a url, assume the same for all subsequent lines, submit to the api and let it handle error cases (e.g. if one of the lines is not a url); otherwise, treat it as pasted data. My question is, if the first line is a url, would it make sense to check each line on the client *before* hitting the api?
6. My JavaScript is rusty - please let me know if I'm writing Python in JavaScript (or doing something worse) :laughing: 


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
