### PR TITLE
Fix David URL

### DIFF
--- a/tools/phenotype_association/linkToDavid.pl
+++ b/tools/phenotype_association/linkToDavid.pl
@@ -39,8 +39,8 @@ if (scalar @gene > 400) {
    print "ERROR David only allows 400 genes submitted via a link\n";
    exit 1;
 }
- 
-my $link = 'http://david.abcc.ncifcrf.gov/api.jsp?type=TYPE&ids=GENELIST&tool=summary';
+
+my $link = 'http://david.ncifcrf.gov/api.jsp?type=TYPE&ids=GENELIST&tool=summary';
 
 my $g = join(",", @gene);
 $link =~ s/GENELIST/$g/;


### PR DESCRIPTION
Currently david fails, the DNS entry seems to no longer exist. Removing the abcc from the DNS entry makes it work again.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run david
  2. It fails due to missing dns
  3. with this change, now it works

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
