### PR TITLE
[21.09] Add missing pin for rich, dependency of refgenconf 0.12.0

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -201,6 +201,7 @@ requests==2.25.1; (python_version >= "2.7" and python_full_version < "3.0.0") or
 requestsexceptions==1.4.0; python_version >= "3.6"
 responses==0.13.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 rfc3986==1.4.0; python_version >= "3.6"
+rich==10.9.0
 routes==2.5.1
 rsa==4.7.2; python_version >= "3.5" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 ruamel.yaml.clib==0.2.2; platform_python_implementation == "CPython" and python_version < "3.8" and python_version >= "3.6"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -169,6 +169,7 @@ requests-toolbelt==0.9.1; python_version >= "3.6"
 requests==2.25.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 requestsexceptions==1.4.0; python_version >= "3.6"
 rfc3986==1.4.0; python_version >= "3.6"
+rich==10.9.0
 routes==2.5.1
 rsa==4.7.2; python_version >= "3.5" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 ruamel.yaml.clib==0.2.2; platform_python_implementation == "CPython" and python_version < "3.8" and python_version >= "3.6"


### PR DESCRIPTION
Pinning to the version that was current when https://github.com/galaxyproject/galaxy/pull/12435 was merged to fix the following [traceback](https://github.com/galaxyproject/galaxy/runs/5817904497?check_suite_focus=true) with rich 12.1.0:

```
2022-04-04T14:16:19.5073158Z   File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/tools/data/__init__.py", line 21, in <module>
2022-04-04T14:16:19.5073535Z     import refgenconf
2022-04-04T14:16:19.5074393Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/refgenconf/__init__.py", line 6, in <module>
2022-04-04T14:16:19.5074853Z     from .populator import looper_refgenie_populate
2022-04-04T14:16:19.5075535Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/refgenconf/populator.py", line 9, in <module>
2022-04-04T14:16:19.5075970Z     from . import refgenconf
2022-04-04T14:16:19.5076607Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/refgenconf/refgenconf.py", line 27, in <module>
2022-04-04T14:16:19.5077091Z     from rich.progress import BarColumn, Progress, TextColumn
2022-04-04T14:16:19.5077768Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/rich/progress.py", line 43, in <module>
2022-04-04T14:16:19.5078272Z     from .console import Console, JustifyMethod, RenderableType, Group
2022-04-04T14:16:19.5078956Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/rich/console.py", line 46, in <module>
2022-04-04T14:16:19.5079437Z     from ._log_render import FormatTimeCallable, LogRender
2022-04-04T14:16:19.5080105Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/rich/_log_render.py", line 5, in <module>
2022-04-04T14:16:19.5124479Z     from .text import Text, TextType
2022-04-04T14:16:19.5130069Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/rich/text.py", line 5, in <module>
2022-04-04T14:16:19.5134858Z     from rich.emoji import EmojiVariant
2022-04-04T14:16:19.5139847Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/rich/emoji.py", line 4, in <module>
2022-04-04T14:16:19.5144648Z     from .jupyter import JupyterMixin
2022-04-04T14:16:19.5147478Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/rich/jupyter.py", line 4, in <module>
2022-04-04T14:16:19.5150060Z     from .segment import Segment
2022-04-04T14:16:19.5152862Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/rich/segment.py", line 19, in <module>
2022-04-04T14:16:19.5155442Z     from .cells import (
2022-04-04T14:16:19.5158112Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/rich/cells.py", line 6, in <module>
2022-04-04T14:16:19.5159612Z     from ._lru_cache import LRUCache
2022-04-04T14:16:19.5161691Z   File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/rich/_lru_cache.py", line 8, in <module>
2022-04-04T14:16:19.5163233Z     from typing_extensions import OrderedDict
2022-04-04T14:16:19.5165289Z ImportError: cannot import name 'OrderedDict' from 'typing_extensions' (/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/typing_extensions.py)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
