### PR TITLE
[22.01] Fix toolshed style loading

### DIFF
--- a/lib/tool_shed/webapp/templates/base.mako
+++ b/lib/tool_shed/webapp/templates/base.mako
@@ -44,7 +44,7 @@
 ## Default stylesheets
 <%def name="stylesheets()">
     ${h.css('bootstrap-tour')}
-    ${h.css('base')}
+    ${h.dist_css('base')}
 </%def>
 
 ## Default javascripts

--- a/lib/tool_shed/webapp/templates/base/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/base/base_panels.mako
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML>
 <%namespace name="galaxy_client" file="/galaxy_client_app.mako" />
 
+
 <%
     self.has_left_panel = hasattr( self, 'left_panel' )
     self.has_right_panel = hasattr( self, 'right_panel' )
@@ -21,6 +22,8 @@
     <!--- base/base_panels.mako stylesheets() -->
     ${h.css(
         'bootstrap-tour',
+    )}
+    ${h.dist_css(
         'base'
     )}
 </%def>
@@ -117,7 +120,7 @@
 
 ## Document
 <html>
-    <!--base_panels.mako-->
+    <!-- toolshed webapp base_panels.mako-->
     ${self.init()}
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
@@ -137,7 +140,9 @@
         ## relative href for site root
         <link rel="index" href="${ h.url_for( '/' ) }"/>
 
+        <!-- stylesheets -->
         ${self.stylesheets()}
+        <!-- stylesheets -->
 
         ## Normally, we'd put all the javascripts at the bottom of the <body>
         ## but during this transitional period we need access to the config

--- a/lib/tool_shed/webapp/templates/base/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/base/base_panels.mako
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <%namespace name="galaxy_client" file="/galaxy_client_app.mako" />
 
-
 <%
     self.has_left_panel = hasattr( self, 'left_panel' )
     self.has_right_panel = hasattr( self, 'right_panel' )
@@ -140,9 +139,7 @@
         ## relative href for site root
         <link rel="index" href="${ h.url_for( '/' ) }"/>
 
-        <!-- stylesheets -->
         ${self.stylesheets()}
-        <!-- stylesheets -->
 
         ## Normally, we'd put all the javascripts at the bottom of the <body>
         ## but during this transitional period we need access to the config

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/index.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/index.mako
@@ -2,9 +2,6 @@
 <%namespace file="/message.mako" import="render_msg" />
 
 <%def name="stylesheets()">
-    ## Include "base.css" for styling tool menu and forms (details)
-    ${h.css( "base" )}
-
     ## But make sure styles for the layout take precedence
     ${parent.stylesheets()}
 


### PR DESCRIPTION
Load a local toolshed, observe fontawesome icons loading (or not).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
