### PR TITLE
[22.01] Correct data fetch API call in the client.

### DIFF
--- a/client/src/components/Upload/helpers.js
+++ b/client/src/components/Upload/helpers.js
@@ -60,13 +60,27 @@ export function uploadModelsToPayload(items, history_id, composite = false) {
                 default:
                     console.error("Unknown file_mode", item);
             }
-            return {
-                src: src,
-                url: url,
-                paste_content: pasteContent,
-                name: fileName,
-                ...elem,
-            };
+            if (src == "pasted") {
+                return {
+                    src: src,
+                    paste_content: pasteContent,
+                    name: fileName,
+                    ...elem,
+                };
+            } else if (src == "url") {
+                return {
+                    src: src,
+                    name: fileName,
+                    url: url,
+                    ...elem,
+                };
+            } else {
+                return {
+                    src: src,
+                    name: fileName,
+                    ...elem,
+                };
+            }
         })
         .filter((item) => item)
         .flat();

--- a/lib/galaxy/webapps/galaxy/api/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/api/_fetch_util.py
@@ -93,6 +93,14 @@ def validate_and_normalize_targets(trans, payload):
             raise RequestParameterInvalidException("in_place cannot be set in the upload request")
 
         src = item["src"]
+        if src == "pasted":
+            if item.get("url") is not None:
+                raise RequestParameterInvalidException("Cannot specify a 'url' when fetching data with pasted content 'src'")
+            if "paste_content" not in item:
+                raise RequestParameterInvalidException("src of type 'pasted' requires paste_content field")
+        else:
+            if "paste_content" in item:
+                raise RequestParameterInvalidException("'paste_content' field can only be specified with src of type 'pasted'")
 
         # Check link_data_only can only be set for certain src types and certain elements_from types.
         _handle_invalid_link_data_only_elements_type(item)


### PR DESCRIPTION
More defensive backend to prevent these errors.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Upload content via pasting data and verify it no longer renders as if a URL was pasted.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
