### PR TITLE
Disable implicitly attaching HDAs to histories.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2458,7 +2458,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     published = Column(Boolean, index=True, default=False)
 
     datasets = relationship(
-        "HistoryDatasetAssociation", back_populates="history", order_by=lambda: asc(HistoryDatasetAssociation.hid)  # type: ignore[has-type]
+        "HistoryDatasetAssociation", back_populates="history", cascade_backrefs=False, order_by=lambda: asc(HistoryDatasetAssociation.hid)  # type: ignore[has-type]
     )
     exports = relationship(
         "JobExportHistoryArchive",
@@ -4324,7 +4324,6 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         DatasetInstance.__init__(self, sa_session=sa_session, **kwd)
         self.hid = hid
         # Relationships
-        add_object_to_object_session(self, history)
         self.history = history
         self.copied_from_history_dataset_association = copied_from_history_dataset_association
         self.copied_from_library_dataset_dataset_association = copied_from_library_dataset_dataset_association
@@ -9566,7 +9565,7 @@ mapper_registry.map_imperatively(
         _metadata=deferred(HistoryDatasetAssociation.table.c._metadata),
         dependent_jobs=relationship(JobToInputDatasetAssociation, back_populates="dataset"),
         creating_job_associations=relationship(JobToOutputDatasetAssociation, back_populates="dataset"),
-        history=relationship(History, back_populates="datasets"),
+        history=relationship(History, back_populates="datasets", cascade_backrefs=False),
         implicitly_converted_datasets=relationship(
             ImplicitlyConvertedDatasetAssociation,
             primaryjoin=(lambda: ImplicitlyConvertedDatasetAssociation.hda_parent_id == HistoryDatasetAssociation.id),

--- a/test/unit/data/model/mapping/test_model_mapping.py
+++ b/test/unit/data/model/mapping/test_model_mapping.py
@@ -1548,6 +1548,18 @@ class TestHistoryDatasetAssociation(BaseTest):
 
         delete_from_database(session, [copied_from_hda, parent])
 
+    def test_detached_histories(
+        self,
+        session,
+        history,
+    ):
+        hda = model.HistoryDatasetAssociation(create_dataset=False)
+        assert hda not in session
+        session.add(history)
+        assert history in session
+        hda.history = history
+        assert hda not in session
+
     def test_relationships(
         self,
         session,


### PR DESCRIPTION
This is bad and we should be explicit about it... if we want it to happen gotta make sure it has an HID and such.

@mvdbeek believes we have sufficient test coverage... let's see what breaks. Prevents needing arbitrary hacks in deferred data branch if this works.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
