### PR TITLE
Focus cursor in text box after clearing search term

### DIFF
--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -2,6 +2,7 @@
     <b-input-group>
         <b-input
             class="search-query"
+            id="tool-input"
             size="sm"
             autocomplete="off"
             v-model="queryInput"
@@ -14,7 +15,7 @@
                 class="search-clear"
                 size="sm"
                 :title="titleClear | l"
-                @click="setQuery('')"
+                @click="clearBox"
                 data-description="reset query">
                 <icon v-if="loading" icon="spinner" spin />
                 <icon v-else icon="times" />
@@ -77,6 +78,10 @@ export default {
                 this.queryCurrent = this.queryInput = queryNew;
                 this.$emit("change", this.queryCurrent);
             }
+        },
+        clearBox() {
+            this.setQuery('');
+            document.getElementById("tool-input").focus();
         },
     },
 };

--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -80,7 +80,7 @@ export default {
             }
         },
         clearBox() {
-            this.setQuery('');
+            this.setQuery("");
             document.getElementById("tool-input").focus();
         },
     },

--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -2,7 +2,7 @@
     <b-input-group>
         <b-input
             class="search-query"
-            id="tool-input"
+            ref="toolInput"
             size="sm"
             autocomplete="off"
             v-model="queryInput"
@@ -81,7 +81,7 @@ export default {
         },
         clearBox() {
             this.setQuery("");
-            document.getElementById("tool-input").focus();
+            this.$refs.toolInput.focus();
         },
     },
 };


### PR DESCRIPTION
This is an enhancement for the issue: https://github.com/galaxyproject/galaxy/issues/13354
Previously, when clicking the clear button for the search box, the cursor would not be focused in the text box. Now it is focused. Demonstrated below:

https://user-images.githubusercontent.com/78516064/161633957-04c2073f-4e40-4838-8f50-61a49f98facc.mov


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
