### PR TITLE
[22.01] Update supervisor config when starting galaxy via run.sh

### DIFF
--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -220,6 +220,7 @@ find_server() {
             run_server="galaxyctl"
             server_args="$gravity_args"
         else
+            galaxyctl update --force
             run_server="galaxy"
             server_args=
         fi


### PR DESCRIPTION
Fixes https://help.galaxyproject.org/t/galaxy-release-22-01-local-installation/7821?u=mvdbeek.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
