### PR TITLE
Misc fixes

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -10,7 +10,7 @@ from galaxy.util.custom_logging import get_logger
 log = get_logger(__name__)
 
 
-@galaxy_task(ignore_result=True, action="recalcuate a user's disk usage")
+@galaxy_task(ignore_result=True, action="recalculate a user's disk usage")
 def recalculate_user_disk_usage(session: galaxy_scoped_session, user_id=None):
     if user_id:
         user = session.query(model.User).get(user_id)

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -133,7 +133,7 @@ class RegexValidator(Validator):
 
     def __init__(self, message, expression, negate):
         if message is None:
-            message = f"Value '%s' does {'not ' if negate == 'false' else ''}match regular expression '{expression}'"
+            message = f"Value '%s' does {'not ' if negate == 'false' else ''}match regular expression '{expression.replace('%', '%%')}'"
         super().__init__(message, negate)
         # Compile later. RE objects used to not be thread safe. Not sure about
         # the sre module.

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -323,7 +323,7 @@ class CwlPopulator:
             # workflows as well, and then make it the default. Or decide they are safe.
             "allow_tool_state_corrections": True,
         }
-        invocation_id = self.workflow_populator.invoke_workflow(
+        invocation_id = self.workflow_populator.invoke_workflow_and_assert_ok(
             workflow_id, history_id=history_id, inputs=job, request=request, inputs_by="name"
         )
         return CwlWorkflowRun(self.dataset_populator, self.workflow_populator, history_id, workflow_id, invocation_id)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1213,7 +1213,7 @@ class BaseWorkflowPopulator(BasePopulator):
     def wait_for_invocation(
         self, workflow_id: str, invocation_id: str, timeout: timeout_type = DEFAULT_TIMEOUT, assert_ok: bool = True
     ):
-        url = f"workflows/{workflow_id}/usage/{invocation_id}"
+        url = f"invocations/{invocation_id}"
 
         def workflow_state():
             return self._get(url)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -269,161 +269,6 @@ class CwlWorkflowRun(CwlRun):
         self.workflow_populator.wait_for_invocation_and_jobs(self.history_id, self.workflow_id, self.invocation_id)
 
 
-class CwlPopulator:
-    def __init__(self, dataset_populator, workflow_populator):
-        self.dataset_populator = dataset_populator
-        self.workflow_populator = workflow_populator
-
-    def get_conformance_test(self, version, doc):
-        for test in conformance_tests_gen(os.path.join(CWL_TOOL_DIRECTORY, str(version))):
-            if test.get("doc") == doc:
-                return test
-        raise Exception(f"doc [{doc}] not found")
-
-    def _run_cwl_tool_job(
-        self,
-        tool_id: str,
-        job: dict,
-        history_id: str,
-        assert_ok: bool = True,
-    ):
-        galaxy_tool_id: Optional[str] = tool_id
-        tool_uuid = None
-
-        if os.path.exists(tool_id):
-            raw_tool_id = os.path.basename(tool_id)
-            index = self.dataset_populator._get("tools", data=dict(in_panel=False))
-            tools = index.json()
-            # In panels by default, so flatten out sections...
-            tool_ids = [itemgetter("id")(_) for _ in tools]
-            if raw_tool_id in tool_ids:
-                galaxy_tool_id = raw_tool_id
-            else:
-                dynamic_tool = self.dataset_populator.create_tool_from_path(tool_id)
-                galaxy_tool_id = None
-                tool_uuid = dynamic_tool["uuid"]
-
-        run_response = self.dataset_populator.run_tool_raw(galaxy_tool_id, job, history_id, tool_uuid=tool_uuid)
-        if assert_ok:
-            run_response.raise_for_status()
-        return CwlToolRun(self.dataset_populator, history_id, run_response)
-
-    def _run_cwl_workflow_job(
-        self,
-        workflow_path: str,
-        job: dict,
-        history_id: str,
-        assert_ok: bool = True,
-    ):
-        workflow_path, object_id = urllib.parse.urldefrag(workflow_path)
-        workflow_id = self.workflow_populator.import_workflow_from_path(workflow_path, object_id)
-
-        request = {
-            # TODO: rework tool state corrections so more of these are valid in Galaxy
-            # workflows as well, and then make it the default. Or decide they are safe.
-            "allow_tool_state_corrections": True,
-        }
-        invocation_id = self.workflow_populator.invoke_workflow_and_assert_ok(
-            workflow_id, history_id=history_id, inputs=job, request=request, inputs_by="name"
-        )
-        return CwlWorkflowRun(self.dataset_populator, self.workflow_populator, history_id, workflow_id, invocation_id)
-
-    def run_cwl_job(
-        self,
-        artifact: str,
-        job_path: Optional[str] = None,
-        job: Optional[Dict] = None,
-        test_data_directory: Optional[str] = None,
-        history_id: Optional[str] = None,
-        assert_ok=True,
-    ):
-        """
-        :param artifact: CWL tool id, or (absolute or relative) path to a CWL
-          tool or workflow file
-        """
-        if history_id is None:
-            history_id = self.dataset_populator.new_history()
-        artifact_without_id = artifact.split("#", 1)[0]
-        if not os.path.exists(artifact_without_id):
-            # Assume it's a tool id
-            tool_or_workflow = "tool"
-        else:
-            tool_or_workflow = guess_artifact_type(artifact)
-        if job_path and not os.path.exists(job_path):
-            raise ValueError(f"job_path [{job_path}] does not exist")
-        if test_data_directory is None and job_path is not None:
-            test_data_directory = os.path.dirname(job_path)
-        if job_path is not None:
-            assert job is None
-            with open(job_path) as f:
-                if job_path.endswith(".yml") or job_path.endswith(".yaml"):
-                    job = yaml.safe_load(f)
-                else:
-                    job = json.load(f)
-        elif job is None:
-            job = {}
-        _, datasets_uploaded = stage_inputs(
-            self.dataset_populator.galaxy_interactor,
-            history_id,
-            job,
-            use_fetch_api=False,
-            tool_or_workflow=tool_or_workflow,
-            job_dir=test_data_directory,
-        )
-        if datasets_uploaded:
-            self.dataset_populator.wait_for_history(history_id=history_id, assert_ok=True)
-        if tool_or_workflow == "tool":
-            run_object = self._run_cwl_tool_job(
-                artifact,
-                job,
-                history_id,
-                assert_ok=assert_ok,
-            )
-        else:
-            run_object = self._run_cwl_workflow_job(
-                artifact,
-                job,
-                history_id,
-                assert_ok=assert_ok,
-            )
-        if assert_ok:
-            try:
-                run_object.wait()
-            except Exception:
-                self.dataset_populator._summarize_history(history_id)
-                raise
-        return run_object
-
-    def run_conformance_test(self, version, doc):
-        test = self.get_conformance_test(version, doc)
-        directory = test["directory"]
-        artifact = os.path.join(directory, test["tool"])
-        job_path = test.get("job")
-        if job_path is not None:
-            job_path = os.path.join(directory, job_path)
-        should_fail = test.get("should_fail", False)
-        try:
-            run = self.run_cwl_job(artifact, job_path=job_path)
-        except Exception:
-            # Should fail so this is good!
-            if should_fail:
-                return True
-            raise
-
-        if should_fail:
-            self.dataset_populator._summarize_history(run.history_id)
-            raise Exception("Expected run to fail but it didn't.")
-
-        expected_outputs = test["output"]
-        try:
-            for key, value in expected_outputs.items():
-                actual_output = run.get_output_as_object(key)
-                cwltest.compare(value, actual_output)
-        except Exception:
-            self.dataset_populator._summarize_history(run.history_id)
-            raise
-
-
 class BasePopulator(metaclass=ABCMeta):
 
     galaxy_interactor: ApiTestInteractor
@@ -707,7 +552,7 @@ class BaseDatasetPopulator(BasePopulator):
         response.raise_for_status()
         return response.json()
 
-    def run_tool_payload(self, tool_id: str, inputs: dict, history_id: str, **kwds) -> dict:
+    def run_tool_payload(self, tool_id: Optional[str], inputs: dict, history_id: str, **kwds) -> dict:
         # Remove files_%d|file_data parameters from inputs dict and attach
         # as __files dictionary.
         for key, value in list(inputs.items()):
@@ -724,7 +569,7 @@ class BaseDatasetPopulator(BasePopulator):
         response.raise_for_status()
         return response.json()
 
-    def run_tool_raw(self, tool_id: str, inputs: dict, history_id: str, **kwds) -> Response:
+    def run_tool_raw(self, tool_id: Optional[str], inputs: dict, history_id: str, **kwds) -> Response:
         payload = self.run_tool_payload(tool_id, inputs, history_id, **kwds)
         return self.tools_post(payload)
 
@@ -1687,6 +1532,161 @@ class WorkflowPopulator(GalaxyInteractorHttpMixin, BaseWorkflowPopulator, Import
         if output_name is not None:
             link = f"{str(link)}/{output_name}"
         return {"$link": link}
+
+
+class CwlPopulator:
+    def __init__(self, dataset_populator: DatasetPopulator, workflow_populator: WorkflowPopulator):
+        self.dataset_populator = dataset_populator
+        self.workflow_populator = workflow_populator
+
+    def get_conformance_test(self, version: str, doc: str):
+        for test in conformance_tests_gen(os.path.join(CWL_TOOL_DIRECTORY, version)):
+            if test.get("doc") == doc:
+                return test
+        raise Exception(f"doc [{doc}] not found")
+
+    def _run_cwl_tool_job(
+        self,
+        tool_id: str,
+        job: dict,
+        history_id: str,
+        assert_ok: bool = True,
+    ):
+        galaxy_tool_id: Optional[str] = tool_id
+        tool_uuid = None
+
+        if os.path.exists(tool_id):
+            raw_tool_id = os.path.basename(tool_id)
+            index = self.dataset_populator._get("tools", data=dict(in_panel=False))
+            tools = index.json()
+            # In panels by default, so flatten out sections...
+            tool_ids = [itemgetter("id")(_) for _ in tools]
+            if raw_tool_id in tool_ids:
+                galaxy_tool_id = raw_tool_id
+            else:
+                dynamic_tool = self.dataset_populator.create_tool_from_path(tool_id)
+                galaxy_tool_id = None
+                tool_uuid = dynamic_tool["uuid"]
+
+        run_response = self.dataset_populator.run_tool_raw(galaxy_tool_id, job, history_id, tool_uuid=tool_uuid)
+        if assert_ok:
+            run_response.raise_for_status()
+        return CwlToolRun(self.dataset_populator, history_id, run_response)
+
+    def _run_cwl_workflow_job(
+        self,
+        workflow_path: str,
+        job: dict,
+        history_id: str,
+        assert_ok: bool = True,
+    ):
+        workflow_path, object_id = urllib.parse.urldefrag(workflow_path)
+        workflow_id = self.workflow_populator.import_workflow_from_path(workflow_path, object_id)
+
+        request = {
+            # TODO: rework tool state corrections so more of these are valid in Galaxy
+            # workflows as well, and then make it the default. Or decide they are safe.
+            "allow_tool_state_corrections": True,
+        }
+        invocation_id = self.workflow_populator.invoke_workflow_and_assert_ok(
+            workflow_id, history_id=history_id, inputs=job, request=request, inputs_by="name"
+        )
+        return CwlWorkflowRun(self.dataset_populator, self.workflow_populator, history_id, workflow_id, invocation_id)
+
+    def run_cwl_job(
+        self,
+        artifact: str,
+        job_path: Optional[str] = None,
+        job: Optional[Dict] = None,
+        test_data_directory: Optional[str] = None,
+        history_id: Optional[str] = None,
+        assert_ok=True,
+    ):
+        """
+        :param artifact: CWL tool id, or (absolute or relative) path to a CWL
+          tool or workflow file
+        """
+        if history_id is None:
+            history_id = self.dataset_populator.new_history()
+        artifact_without_id = artifact.split("#", 1)[0]
+        if not os.path.exists(artifact_without_id):
+            # Assume it's a tool id
+            tool_or_workflow = "tool"
+        else:
+            tool_or_workflow = guess_artifact_type(artifact)
+        if job_path and not os.path.exists(job_path):
+            raise ValueError(f"job_path [{job_path}] does not exist")
+        if test_data_directory is None and job_path is not None:
+            test_data_directory = os.path.dirname(job_path)
+        if job_path is not None:
+            assert job is None
+            with open(job_path) as f:
+                if job_path.endswith(".yml") or job_path.endswith(".yaml"):
+                    job = yaml.safe_load(f)
+                else:
+                    job = json.load(f)
+        elif job is None:
+            job = {}
+        _, datasets_uploaded = stage_inputs(
+            self.dataset_populator.galaxy_interactor,
+            history_id,
+            job,
+            use_fetch_api=False,
+            tool_or_workflow=tool_or_workflow,
+            job_dir=test_data_directory,
+        )
+        if datasets_uploaded:
+            self.dataset_populator.wait_for_history(history_id=history_id, assert_ok=True)
+        if tool_or_workflow == "tool":
+            run_object = self._run_cwl_tool_job(
+                artifact,
+                job,
+                history_id,
+                assert_ok=assert_ok,
+            )
+        else:
+            run_object = self._run_cwl_workflow_job(
+                artifact,
+                job,
+                history_id,
+                assert_ok=assert_ok,
+            )
+        if assert_ok:
+            try:
+                run_object.wait()
+            except Exception:
+                self.dataset_populator._summarize_history(history_id)
+                raise
+        return run_object
+
+    def run_conformance_test(self, version: str, doc: str):
+        test = self.get_conformance_test(version, doc)
+        directory = test["directory"]
+        artifact = os.path.join(directory, test["tool"])
+        job_path = test.get("job")
+        if job_path is not None:
+            job_path = os.path.join(directory, job_path)
+        should_fail = test.get("should_fail", False)
+        try:
+            run = self.run_cwl_job(artifact, job_path=job_path)
+        except Exception:
+            # Should fail so this is good!
+            if should_fail:
+                return True
+            raise
+
+        if should_fail:
+            self.dataset_populator._summarize_history(run.history_id)
+            raise Exception("Expected run to fail but it didn't.")
+
+        expected_outputs = test["output"]
+        try:
+            for key, value in expected_outputs.items():
+                actual_output = run.get_output_as_object(key)
+                cwltest.compare(value, actual_output)
+        except Exception:
+            self.dataset_populator._summarize_history(run.history_id)
+            raise
 
 
 class LibraryPopulator:

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -514,8 +514,7 @@ def wait_for_http_server(host, port, prefix=None, sleep_amount=0.1, sleep_tries=
                 raise
         time.sleep(sleep_amount)
     else:
-        template = "Test HTTP server on host %s and port %s did not return '200 OK' after 10 tries"
-        message = template % (host, port)
+        message = f"Test HTTP server on host {host} and port {port} did not return '200 OK' after {sleep_tries} tries"
         raise Exception(message)
 
 

--- a/packages/app/gxupload_0
+++ b/packages/app/gxupload_0
@@ -1,2 +1,0 @@
-sample data
-hello world

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -57,10 +57,6 @@ parse_common_args() {
                 add_pid_arg=1
                 shift
                 ;;
-            --wait)
-                wait_arg_set=1
-                shift
-                ;;
             "")
                 break
                 ;;


### PR DESCRIPTION
- Replace `invoke_workflow()` call with `invoke_workflow_and_assert_ok()`. Follow-up on commit 18891f3791b475e6c81569d9349a6fa8a8c62d50 .
- Replace use of deprecated API endpoint in `BaseWorkflowPopulator.wait_for_invocation()`.
- More type annotations for `CwlPopulator`.
- Fix error message for `RegexValidator`.
- Remove file added by mistake in commit 9690680ec7256d979b8b11eb7d5f343a691c93f3 .
- Remove `--wait` startup option. Follow-up on https://github.com/galaxyproject/galaxy/pull/13071 .

See individual commits for more details.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
