### PR TITLE
Use API link to download datasets

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -96,7 +96,7 @@ export default {
     },
     computed: {
         downloadUrl() {
-            return prependPath(`datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
+            return prependPath(`api/datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
         },
         showDownloads() {
             return !this.item.purged && ["ok", "failed_metadata", "error"].includes(this.item.state);

--- a/client/src/mvc/dataset/dataset-model.js
+++ b/client/src/mvc/dataset/dataset-model.js
@@ -74,7 +74,7 @@ var DatasetAssociation = Backbone.Model.extend(BASE_MVC.LoggableMixin).extend(
                     purge: `datasets/${id}/purge_async`,
                     display: `datasets/${id}/display/?preview=True`,
                     edit: `datasets/edit?dataset_id=${id}`,
-                    download: `datasets/${id}/display${this._downloadQueryParameters()}`,
+                    download: `api/datasets/${id}/display${this._downloadQueryParameters()}`,
                     report_error: `dataset/errors?id=${id}`,
                     rerun: `tool_runner/rerun?id=${id}`,
                     show_params: `datasets/${id}/details`,

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -195,9 +195,14 @@ class FastAPIDatasets:
         return self.service.extra_files(trans, history_content_id)
 
     @router.get(
+        "/api/datasets/{history_content_id}/display",
+        summary="Displays (preview) or downloads dataset content.",
+        response_class=StreamingResponse,
+    )
+    @router.get(
         "/api/histories/{history_id}/contents/{history_content_id}/display",
         name="history_contents_display",
-        summary="Displays dataset (preview) content.",
+        summary="Displays (preview) or downloads dataset content.",
         tags=["histories"],
         response_class=StreamingResponse,
     )
@@ -205,7 +210,10 @@ class FastAPIDatasets:
         self,
         request: Request,
         trans=DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: Optional[EncodedDatabaseIdField] = Query(
+            default=None,
+            description="The encoded database identifier of the History.",
+        ),
         history_content_id: EncodedDatabaseIdField = DatasetIDPathParam,
         preview: bool = Query(
             default=False,
@@ -234,10 +242,10 @@ class FastAPIDatasets:
             ),
         ),
     ):
-        """Streams the preview contents of a dataset to be displayed in a browser."""
+        """Streams the dataset for download or the contents preview to be displayed in a browser."""
         extra_params = get_query_parameters_from_request_excluding(request, {"preview", "filename", "to_ext", "raw"})
         display_data, headers = self.service.display(
-            trans, history_content_id, history_id, preview, filename, to_ext, raw, **extra_params
+            trans, history_content_id, preview, filename, to_ext, raw, **extra_params
         )
         return StreamingResponse(display_data, headers=headers)
 

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -411,7 +411,6 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         self,
         trans: ProvidesHistoryContext,
         history_content_id: EncodedDatabaseIdField,
-        history_id: EncodedDatabaseIdField,
         preview: bool = False,
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,
@@ -443,9 +442,6 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         except galaxy_exceptions.MessageException:
             raise
         except Exception as e:
-            log.exception(
-                "Server error getting display data for dataset (%s) from history (%s)", history_content_id, history_id
-            )
             raise galaxy_exceptions.InternalServerError(f"Could not get display data for dataset: {util.unicodify(e)}")
         return rval, headers
 


### PR DESCRIPTION
Fixes #13679

Since the `history_id` in `/api/histories/{history_id}/contents/{history_content_id}/display` is only really used in the path for consistency with other *history contents* endpoint, I made it optional, removed the parameter from the service and added a route alias for `/api/datasets/{history_content_id}/display`.

Now the download links in both legacy and new history use the API link.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
