### PR TITLE
Fix sorting of recursively discovered datasets

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -603,10 +603,9 @@ def walk_over_extra_files(target_dir, extra_file_collector, job_working_director
                     new_parent_paths = parent_paths[:]
                     new_parent_paths.append(filename)
                     # The current directory is already validated, so use that as the next job_working_directory when recursing
-                    for match in walk_over_extra_files(
+                    matches.extend(walk_over_extra_files(
                         filename, extra_file_collector, directory, matchable, parent_paths=new_parent_paths
-                    ):
-                        yield match
+                    ))
             else:
                 match = extra_file_collector.match(matchable, filename, path=path, parent_paths=parent_paths)
                 if match:

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -592,26 +592,29 @@ def walk_over_extra_files(target_dir, extra_file_collector, job_working_director
     match the given collector's match criteria. If the collector has the
     recurse flag enabled, will also recursively descend into child folders.
     """
-    matches = []
     parent_paths = parent_paths or []
-    directory = discover_target_directory(target_dir, job_working_directory)
-    if os.path.isdir(directory):
-        for filename in os.listdir(directory):
-            path = os.path.join(directory, filename)
-            if os.path.isdir(path):
-                if extra_file_collector.recurse:
-                    new_parent_paths = parent_paths[:]
-                    new_parent_paths.append(filename)
-                    # The current directory is already validated, so use that as the next job_working_directory when recursing
-                    matches.extend(walk_over_extra_files(
-                        filename, extra_file_collector, directory, matchable, parent_paths=new_parent_paths
-                    ))
-            else:
-                match = extra_file_collector.match(matchable, filename, path=path, parent_paths=parent_paths)
-                if match:
-                    matches.append(match)
 
-    for match in extra_file_collector.sort(matches):
+    def _walk(target_dir, extra_file_collector, job_working_directory, matchable, parent_paths):
+        directory = discover_target_directory(target_dir, job_working_directory)
+        if os.path.isdir(directory):
+            for filename in os.listdir(directory):
+                path = os.path.join(directory, filename)
+                if os.path.isdir(path):
+                    if extra_file_collector.recurse:
+                        new_parent_paths = parent_paths[:]
+                        new_parent_paths.append(filename)
+                        # The current directory is already validated, so use that as the next job_working_directory when recursing
+                        yield from _walk(
+                            filename, extra_file_collector, directory, matchable, parent_paths=new_parent_paths
+                        )
+                else:
+                    match = extra_file_collector.match(matchable, filename, path=path, parent_paths=parent_paths)
+                    if match:
+                        yield match
+
+    for match in extra_file_collector.sort(
+        _walk(target_dir, extra_file_collector, job_working_directory, matchable, parent_paths)
+    ):
         yield match
 
 

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -994,7 +994,7 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
                 try:
                     i = generated_sort_order[i:].index(identifier) + 1
                 except ValueError:
-                    message = f"Output collection '{name}': identifier '{element_identifier}' found out of order, expected order of {expected_sort_order} for the tool generated collection elements {eo_ids}"
+                    message = f"Output collection '{name}': identifier '{identifier}' found out of order, expected order of {expected_sort_order} for the tool generated collection elements {eo_ids}"
                     raise AssertionError(message)
 
     verify_elements(data_collection["elements"], output_collection_def.element_tests)

--- a/test/functional/tools/multi_output_recurse.xml
+++ b/test/functional/tools/multi_output_recurse.xml
@@ -1,4 +1,4 @@
-<tool id="multi_output_recurse" name="multi_output_recurse" version="0.1.0" profile="18.01">
+<tool id="multi_output_recurse" name="multi_output_recurse" version="0.1.0" profile="21.09">
   <command><![CDATA[
     echo "Hello" > '$report';
     mkdir subdir1;

--- a/test/functional/tools/multi_output_recurse_collection.xml
+++ b/test/functional/tools/multi_output_recurse_collection.xml
@@ -1,0 +1,57 @@
+<!--essentially the same as multi_output_recurse_collection, but:
+  - test collection and generated order in the collection
+-->
+<tool id="multi_output_recurse_collection" name="multi_output_recurse_collection" version="0.1.0" profile="22.01">
+  <macros>
+    <xml name="outelem" tokens="number" token_path="">
+      <element name="@PATH@@NUMBER@" ftype="txt">
+        <assert_contents>
+          <has_text text="@NUMBER@"/>
+        </assert_contents>
+      </element>
+    </xml>
+  </macros>
+  <command><![CDATA[
+    mkdir 1;
+    echo "3" > 1/3.txt;
+    echo "4" > 1/4.txt;
+    mkdir 2;
+    echo "1" > 2/1.txt;
+    echo "2" > 2/2.txt;
+    mkdir 3;
+    echo "5" > 3/5.txt;
+    mkdir 3/1;
+    echo "0" > 3/1/0.txt;
+    ]]></command>
+  <inputs>
+    <param type="boolean" name="match_relative"/>
+  </inputs>
+  <outputs>
+    <collection type="list" name="output">
+      <discover_datasets directory="./" recurse="true" pattern="__designation_and_ext__"/>
+    </collection>
+    <collection type="list" name="output_relative">
+      <discover_datasets directory="./" recurse="true" pattern="__designation_and_ext__" match_relative_path="true"/>
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <output_collection name="output" count="6">
+        <expand macro="outelem" number="0"/>
+        <expand macro="outelem" number="1"/>
+        <expand macro="outelem" number="2"/>
+        <expand macro="outelem" number="3"/>
+        <expand macro="outelem" number="4"/>
+        <expand macro="outelem" number="5"/>
+      </output_collection>
+      <output_collection name="output_relative" count="6">
+        <expand macro="outelem" path="1/" number="3"/>
+        <expand macro="outelem" path="1/" number="4"/>
+        <expand macro="outelem" path="2/" number="1"/>
+        <expand macro="outelem" path="2/" number="2"/>
+        <expand macro="outelem" path="3/" number="5"/>
+        <expand macro="outelem" path="3/1/" number="0"/>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -28,6 +28,7 @@
   <tool file="multi_output_assign_primary.xml" />
   <tool file="multi_output_assign_primary_ext_dbkey.xml" />
   <tool file="multi_output_recurse.xml" />
+  <tool file="multi_output_recurse_collection.xml" />
   <tool file="tool_provided_metadata_1.xml" />
   <tool file="tool_provided_metadata_2.xml" />
   <tool file="tool_provided_metadata_3.xml" />


### PR DESCRIPTION
So far only top level files were subject to sorting. Consider the following directory:

```
- 0
  |\ 4.txt
   \ 3.txt
- 1
  |\ 1.txt
   \ 2.txt
- 5.txt
- 6.txt
```

Would have resulted the following problems

- the order of 1.txt - 4.txt is only subject to `os.listdir` and bypasses the sorting of discovered elements
  -  since the output of `os.listdir` _is in arbitrary order_ (https://docs.python.org/3.8/library/os.html#os.listdir) we could get any permutation of the elements in 0 and 1 and within 0 and 1 (ie 1234, 2134, 1243, 3412, 3421, 4312)
- the datasets 1.txt - 4.txt are before 5.txt and 6.txt, because the yield for recursive elements has been called first

In addition the PR fixes a minor bug in the output of the order verification.

As far as I see this is broken since recursive discovery has been introduced in 18.01 (https://github.com/galaxyproject/galaxy/pull/5240) so we should backport this, but I was unsure how far.

Should fix the problem in the recent OpenMS wrapper generation https://github.com/galaxyproteomics/tools-galaxyp/pull/653#issuecomment-1090468894

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
