### PR TITLE
Fix download collection button in history panel.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -431,16 +431,26 @@ class FastAPIHistoryContents:
         summary="Download the content of a dataset collection as a `zip` archive.",
         response_class=StreamingResponse,
     )
+    def download_history_dataset_collection(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        id: EncodedDatabaseIdField = HistoryHDCAIDPathParam,
+    ):
+        """Download the content of a history dataset collection as a `zip` archive
+        while maintaining approximate collection structure.
+        """
+        archive = self.service.get_dataset_collection_archive_for_download(trans, id)
+        return StreamingResponse(archive.get_iterator(), headers=archive.get_headers())
+
     @router.get(
-        "/api/dataset_collection/{id}/download",
+        "/api/dataset_collections/{id}/download",
         summary="Download the content of a dataset collection as a `zip` archive.",
         response_class=StreamingResponse,
-        tags=["dataset collections"],
     )
     def download_dataset_collection(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
         id: EncodedDatabaseIdField = HistoryHDCAIDPathParam,
     ):
         """Download the content of a history dataset collection as a `zip` archive

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -431,18 +431,6 @@ class FastAPIHistoryContents:
         summary="Download the content of a dataset collection as a `zip` archive.",
         response_class=StreamingResponse,
     )
-    def download_history_dataset_collection(
-        self,
-        trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryHDCAIDPathParam,
-    ):
-        """Download the content of a history dataset collection as a `zip` archive
-        while maintaining approximate collection structure.
-        """
-        archive = self.service.get_dataset_collection_archive_for_download(trans, id)
-        return StreamingResponse(archive.get_iterator(), headers=archive.get_headers())
-
     @router.get(
         "/api/dataset_collections/{id}/download",
         summary="Download the content of a dataset collection as a `zip` archive.",
@@ -451,6 +439,10 @@ class FastAPIHistoryContents:
     def download_dataset_collection(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: Optional[EncodedDatabaseIdField] = Query(
+            default=None,
+            description="The encoded database identifier of the History.",
+        ),
         id: EncodedDatabaseIdField = HistoryHDCAIDPathParam,
     ):
         """Download the content of a history dataset collection as a `zip` archive

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -435,6 +435,7 @@ class FastAPIHistoryContents:
         "/api/dataset_collections/{id}/download",
         summary="Download the content of a dataset collection as a `zip` archive.",
         response_class=StreamingResponse,
+        tags=["dataset collections"],
     )
     def download_dataset_collection(
         self,


### PR DESCRIPTION
Downloading collections from the classic history panel seems broken in dev. I assume the FastAPI endpoint was broken-ish and then we dropped the WSGI backups and the functionality broke.

I needed to drop the tags in order to not get a 404 and I needed a signature with history_id in it in order to not get a validation error. So this is probably not the best way - just the fastest? @davelopez any ideas?

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Download a collection from the History Panel Classic. 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
