### PR TITLE
Two small fixes to testing infrastructure.

### DIFF
--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -630,6 +630,7 @@ class BaseDatasetPopulator(BasePopulator):
         return details_response.json()
 
     def get_history_collection_details(self, history_id: str, **kwds) -> dict:
+        kwds["history_content_type"] = "dataset_collection"
         hdca_id = self.__history_content_id(history_id, **kwds)
         details_response = self._get_contents_request(history_id, f"/dataset_collections/{hdca_id}")
         assert details_response.status_code == 200, details_response.content
@@ -664,7 +665,9 @@ class BaseDatasetPopulator(BasePopulator):
             history_content_id = kwds["dataset"]["id"]
         else:
             hid = kwds.get("hid", None)  # If not hid, just grab last dataset
-            history_contents = self._get_contents_request(history_id).json()
+            contents_request = self._get_contents_request(history_id)
+            contents_request.raise_for_status()
+            history_contents = contents_request.json()
             if hid:
                 history_content_id = None
                 for history_item in history_contents:

--- a/lib/galaxy_test/base/testcase.py
+++ b/lib/galaxy_test/base/testcase.py
@@ -35,7 +35,9 @@ class FunctionalTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.history_id = os.environ.get("GALAXY_TEST_HISTORY_ID", None)
         self.host, self.port, self.url = target_url_parts()
-        server_wrapper = self._test_driver and self._test_driver.server_wrappers[0]
+        server_wrapper = (
+            self._test_driver and self._test_driver.server_wrappers and self._test_driver.server_wrappers[0]
+        )
         if server_wrapper:
             self.host = server_wrapper.host
             self.port = server_wrapper.port


### PR DESCRIPTION
Running tests on external Galaxy servers broke recently and there is a fix for that as well a small tweak to make fetching data about collections more robust that would have caught a bug I was working on downstream a lot faster.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Start a stock, default dev Galaxy server on localhost:8080
  2. ``GALAXY_TEST_EXTERNAL=http://localhost:8080/ pytest lib/galaxy_test/selenium/test_workflow_management.py::WorkflowManagementTestCase::test_view``

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
