### PR TITLE
Raise a more appropriate error when there's no version table

### DIFF
--- a/lib/galaxy/model/migrations/scripts.py
+++ b/lib/galaxy/model/migrations/scripts.py
@@ -21,6 +21,7 @@ from galaxy.model.migrations import (
     DatabaseStateCache,
     GXY,
     IncorrectVersionError,
+    NoVersionTableError,
     SQLALCHEMYMIGRATE_LAST_VERSION_GXY,
     TSI,
 )
@@ -238,7 +239,9 @@ class LegacyManageDb:
             version = self._get_gxy_alembic_db_version(engine)
             if not version:
                 version = self._get_gxy_sam_db_version(engine)
-                if version != SQLALCHEMYMIGRATE_LAST_VERSION_GXY:
+                if version is None:
+                    raise NoVersionTableError(GXY)
+                elif version != SQLALCHEMYMIGRATE_LAST_VERSION_GXY:
                     raise IncorrectVersionError(GXY, SQLALCHEMYMIGRATE_LAST_VERSION_GXY)
             return version
         finally:

--- a/test/unit/data/model/migrations/test_migrations.py
+++ b/test/unit/data/model/migrations/test_migrations.py
@@ -899,23 +899,24 @@ def _setup_db_state1(db_url, metadata):
 # state 2
 @pytest.fixture
 def db_state2_gxy(url_factory, metadata_state2_gxy):  # noqa F811
-    yield from _setup_db_state2(url_factory(), metadata_state2_gxy)
+    yield from _setup_db_state2(url_factory(), metadata_state2_gxy, SQLALCHEMYMIGRATE_LAST_VERSION_GXY)
 
 
 @pytest.fixture
 def db_state2_tsi(url_factory, metadata_state2_tsi):  # noqa F811
-    yield from _setup_db_state2(url_factory(), metadata_state2_tsi)
+    yield from _setup_db_state2(url_factory(), metadata_state2_tsi, SQLALCHEMYMIGRATE_LAST_VERSION_TSI)
 
 
 @pytest.fixture
 def db_state2_combined(url_factory, metadata_state2_combined):  # noqa F811
-    yield from _setup_db_state2(url_factory(), metadata_state2_combined)
+    yield from _setup_db_state2(url_factory(), metadata_state2_combined, SQLALCHEMYMIGRATE_LAST_VERSION_GXY)
 
 
-def _setup_db_state2(db_url, metadata):
+def _setup_db_state2(db_url, metadata, last_version):
     with create_and_drop_database(db_url):
         with disposing_engine(db_url) as engine:
             load_metadata(metadata, engine)
+            load_sqlalchemymigrate_version(db_url, last_version - 1)
             yield db_url
 
 


### PR DESCRIPTION
Triggered *only* by the database task in the ansible galaxy role (which calls `scripts/manage_db.py version` directly, bypassing the `manage_db.sh` shell script)

This is for a better solution to https://github.com/galaxyproject/ansible-galaxy/pull/151


(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
