### PR TITLE
Fix workflow index API boolean parameters.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -161,6 +161,10 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         :param  missing_tools:       if True, include a list of missing tools per workflow
         :type   missing_tools:       boolean
         """
+        show_published = util.string_as_bool(show_published)
+        show_hidden = util.string_as_bool(show_hidden)
+        show_deleted = util.string_as_bool(show_deleted)
+        missing_tools = util.string_as_bool(missing_tools)
         rval = []
         filter1 = model.StoredWorkflow.user == trans.user
         user = trans.user

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -309,6 +309,8 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert not [w for w in workflow_index if w["id"] == workflow_id]
         workflow_index = self._get("workflows?show_deleted=true").json()
         assert [w for w in workflow_index if w["id"] == workflow_id]
+        workflow_index = self._get("workflows?show_deleted=false").json()
+        assert not [w for w in workflow_index if w["id"] == workflow_id]
 
     def test_index_hidden(self):
         workflow_id = self.workflow_populator.simple_workflow("test_delete")
@@ -322,6 +324,8 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert not [w for w in workflow_index if w["id"] == workflow_id]
         workflow_index = self._get("workflows?show_hidden=true").json()
         assert [w for w in workflow_index if w["id"] == workflow_id]
+        workflow_index = self._get("workflows?show_hidden=false").json()
+        assert not [w for w in workflow_index if w["id"] == workflow_id]
 
     def test_upload(self):
         self.__test_upload(use_deprecated_route=False)


### PR DESCRIPTION
I want to merge the two queries so I can do pagination/sorting/limits/etc... but the API needs to be consistent first I think and trying to do that made me realize this is broken.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
