### PR TITLE
Rework workflow index API for more consistency between deleted/hidden and showing shared workflows.

### DIFF
--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -327,6 +327,22 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         workflow_index = self._get("workflows?show_hidden=false").json()
         assert not [w for w in workflow_index if w["id"] == workflow_id]
 
+    def test_index_parameter_invalid_combinations(self):
+        # these can all be called by themselves and return 200...
+        response = self._get("workflows?show_hidden=true")
+        self._assert_status_code_is(response, 200)
+        response = self._get("workflows?show_deleted=true")
+        self._assert_status_code_is(response, 200)
+        response = self._get("workflows?show_shared=true")
+        self._assert_status_code_is(response, 200)
+        # but showing shared workflows along with deleted or hidden results in an error
+        response = self._get("workflows?show_hidden=true&show_shared=true")
+        self._assert_status_code_is(response, 400)
+        self._assert_error_code_is(response, error_codes.error_codes_by_name["USER_REQUEST_INVALID_PARAMETER"])
+        response = self._get("workflows?show_deleted=true&show_shared=true")
+        self._assert_status_code_is(response, 400)
+        self._assert_error_code_is(response, error_codes.error_codes_by_name["USER_REQUEST_INVALID_PARAMETER"])
+
     def test_upload(self):
         self.__test_upload(use_deprecated_route=False)
 


### PR DESCRIPTION
So currently is show_deleted is true - you'll also non-deleted workflows that are shared with you but not your own non-deleted workflows. Likewise, regardless of show_hidden - you always get the same bunch of shared workflows. Also, none of that is documented in tests or the docstring.

This tries to fix that up a bit by making showing shared workflows a parameterized boolean that defaults in a consistent, safe way with the parameters show_deleted and show_hidden. It will default to true if those are false and to false if either of those are true - so it always builds a consistent set of workflows. It also gives very explicit and tested
 errors if invalid combinations are requested (e.g. explicitly asking for deleted workflows shared with you for instance).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
