### PR TITLE
Fix mypy error on bool expressions

### DIFF
--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -14,7 +14,6 @@ from typing import (
 from pyparsing import (
     alphanums,
     CaselessKeyword,
-    Forward,
     infixNotation,
     Keyword,
     opAssoc,
@@ -136,7 +135,7 @@ class BooleanExpressionEvaluator:
         action.evaluator = evaluator
         boolOperand = TRUE | FALSE | Word(token_format or DEFAULT_TOKEN_FORMAT)
         boolOperand.setParseAction(action)
-        self.boolExpr: Forward = infixNotation(
+        self.boolExpr = infixNotation(
             boolOperand,
             [
                 (NOT_OP, 1, opAssoc.RIGHT, BoolNot),

--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -135,7 +135,7 @@ class BooleanExpressionEvaluator:
         action.evaluator = evaluator
         boolOperand = TRUE | FALSE | Word(token_format or DEFAULT_TOKEN_FORMAT)
         boolOperand.setParseAction(action)
-        self.boolExpr = infixNotation(
+        self.boolExpr: ParserElement = infixNotation(
             boolOperand,
             [
                 (NOT_OP, 1, opAssoc.RIGHT, BoolNot),


### PR DESCRIPTION
This will hopefully get rid of the mypy error in `test_galaxy_packages` on dev.
```sh
+ make mypy
mypy galaxy tests
galaxy/util/bool_expressions.py:139: error: Incompatible types in assignment
(expression has type "ParserElement", variable has type "Forward")  [assignment]
            self.boolExpr: Forward = infixNotation(
                                     ^
Found 1 error in 1 file (checked 80 source files)
make: *** [Makefile:96: mypy] Error 1
```

I'm a bit confused though with which version of mypy are we using across tests. If I run `tox -e mypy` I don't catch this error, but a different one shows instead...
```sh
(.venv) davelopez@davelopez:~/dev/galaxy$ tox -e mypy
mypy installed: attrs==21.4.0,flake8==4.0.1,flake8-bugbear==21.11.29,flake8-import-order==0.18.1,importlib-metadata==4.2.0,mccabe==0.6.1,mypy==0.910,mypy-extensions==0.4.3,pycodestyle==2.8.0,pyflakes==2.4.0,toml==0.10.2,typed-ast==1.4.3,types-bleach==4.1.4,types-boto==2.49.5,types-contextvars==2.4.1,types-cryptography==3.3.11,types-dataclasses==0.6.3,types-docutils==0.17.3,types-enum34==1.1.2,types-ipaddress==1.0.2,types-Markdown==3.3.11,types-paramiko==2.8.7,types-pkg-resources==0.1.3,types-python-dateutil==2.8.5,types-PyYAML==6.0.2,types-requests==2.27.2,types-six==1.16.8,typing_extensions==4.0.1,zipp==3.7.0
mypy run-test-pre: PYTHONHASHSEED='3439307142'
mypy run-test: commands[0] | mypy test lib
lib/galaxy/workflow/modules.py:1901: error: "Dataset" has no attribute "element_identifier"  [attr-defined]
                                replacement.element_identifier = temp.element_identifier  # type: ignore[union-attr]
                                ^
Found 1 error in 1 file (checked 1429 source files)
```

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
