### PR TITLE
Fix histories API index filter query params

### DIFF
--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 from pydantic import Field
 
@@ -90,17 +89,4 @@ def ModelClassField(class_name: str) -> str:
         title="Model class",
         description="The name of the database model class.",
         const=True,  # Make this field constant
-    )
-
-
-def OrderParamField(default_order: str) -> Optional[str]:
-    return Field(
-        default=default_order,
-        title="Order",
-        description=(
-            "String containing one of the valid ordering attributes followed (optionally) "
-            "by '-asc' or '-dsc' for ascending and descending order respectively. "
-            "Orders can be stacked as a comma-separated list of values."
-        ),
-        example="name-dsc,create_time",
     )

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -127,7 +127,7 @@ class HistoriesService(ServiceBase):
             filters += [model.History.user == current_user]
         # and any sent in from the query string
         filters += self.filters.parse_filters(filter_params)
-        order_by = self.build_order_by(self.manager, filter_query_params.order or DEFAULT_ORDER_BY)
+        order_by = self._build_order_by(filter_query_params.order)
 
         histories = self.manager.list(
             filters=filters, order_by=order_by, limit=filter_query_params.limit, offset=filter_query_params.offset
@@ -349,7 +349,7 @@ class HistoriesService(ServiceBase):
         """
         current_user = trans.user
         filters = self.filters.parse_query_filters(filter_query_params)
-        order_by = self.build_order_by(self.manager, filter_query_params.order or DEFAULT_ORDER_BY)
+        order_by = self._build_order_by(filter_query_params.order)
         histories = self.manager.list_shared_with(
             current_user,
             filters=filters,
@@ -373,7 +373,7 @@ class HistoriesService(ServiceBase):
         Return all histories that are published. The results can be filtered.
         """
         filters = self.filters.parse_query_filters(filter_query_params)
-        order_by = self.build_order_by(self.manager, filter_query_params.order or DEFAULT_ORDER_BY)
+        order_by = self._build_order_by(filter_query_params.order)
         histories = self.manager.list_published(
             filters=filters,
             order_by=order_by,
@@ -552,3 +552,6 @@ class HistoriesService(ServiceBase):
             history, user=trans.user, trans=trans, **serialization_params.dict()
         )
         return serialized_history
+
+    def _build_order_by(self, order: Optional[str]):
+        return self.build_order_by(self.manager, order or DEFAULT_ORDER_BY)

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -56,6 +56,8 @@ from galaxy.webapps.galaxy.services.sharable import ShareableService
 
 log = logging.getLogger(__name__)
 
+DEFAULT_ORDER_BY = "create_time-dsc"
+
 
 class HistoriesService(ServiceBase):
     """Common interface/service logic for interactions with histories in the context of the API.
@@ -125,7 +127,7 @@ class HistoriesService(ServiceBase):
             filters += [model.History.user == current_user]
         # and any sent in from the query string
         filters += self.filters.parse_filters(filter_params)
-        order_by = self.build_order_by(self.manager, filter_query_params.order)
+        order_by = self.build_order_by(self.manager, filter_query_params.order or DEFAULT_ORDER_BY)
 
         histories = self.manager.list(
             filters=filters, order_by=order_by, limit=filter_query_params.limit, offset=filter_query_params.offset
@@ -347,7 +349,7 @@ class HistoriesService(ServiceBase):
         """
         current_user = trans.user
         filters = self.filters.parse_query_filters(filter_query_params)
-        order_by = self.build_order_by(self.manager, filter_query_params.order)
+        order_by = self.build_order_by(self.manager, filter_query_params.order or DEFAULT_ORDER_BY)
         histories = self.manager.list_shared_with(
             current_user,
             filters=filters,
@@ -371,7 +373,7 @@ class HistoriesService(ServiceBase):
         Return all histories that are published. The results can be filtered.
         """
         filters = self.filters.parse_query_filters(filter_query_params)
-        order_by = self.build_order_by(self.manager, filter_query_params.order)
+        order_by = self.build_order_by(self.manager, filter_query_params.order or DEFAULT_ORDER_BY)
         histories = self.manager.list_published(
             filters=filters,
             order_by=order_by,

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -93,7 +93,7 @@ class HistoriesApiTestCase(ApiTestCase, BaseHistories):
         assert index_response[1]["id"] == slightly_older_history_id
 
     def test_index_query(self):
-        expected_history_name = "TestHistoryThatMatchQuery"
+        expected_history_name = f"TestHistoryThatMatchQuery_{uuid4()}"
         self._create_history(expected_history_name)["id"]
         self._create_history("TestHistoryThatDoesNotMatchQuery")
         query = f"?q=name&qv={expected_history_name}"

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -92,6 +92,15 @@ class HistoriesApiTestCase(ApiTestCase, BaseHistories):
         assert index_response[0]["id"] == newer_history_id
         assert index_response[1]["id"] == slightly_older_history_id
 
+    def test_index_query(self):
+        expected_history_name = "TestHistoryThatMatchQuery"
+        self._create_history(expected_history_name)["id"]
+        self._create_history("TestHistoryThatDoesNotMatchQuery")
+        query = f"?q=name&qv={expected_history_name}"
+        index_response = self._get(f"histories{query}").json()
+        assert len(index_response) == 1
+        assert index_response[0]["name"] == expected_history_name
+
     def test_delete(self):
         # Setup a history and ensure it is in the index
         history_id = self._create_history("TestHistoryForDelete")["id"]

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -94,9 +94,22 @@ class HistoriesApiTestCase(ApiTestCase, BaseHistories):
 
     def test_index_query(self):
         expected_history_name = f"TestHistoryThatMatchQuery_{uuid4()}"
-        self._create_history(expected_history_name)["id"]
+        expected_history_id = self._create_history(expected_history_name)["id"]
         self._create_history("TestHistoryThatDoesNotMatchQuery")
+        # Filter by name
         query = f"?q=name&qv={expected_history_name}"
+        index_response = self._get(f"histories{query}").json()
+        assert len(index_response) == 1
+        assert index_response[0]["name"] == expected_history_name
+
+        # Filter by name and deleted
+        query = f"?q=name&qv={expected_history_name}&q=deleted&qv=True"
+        index_response = self._get(f"histories{query}").json()
+        assert len(index_response) == 0  # Not deleted yet
+
+        # Delete the history
+        self._delete(f"histories/{expected_history_id}")
+        # Now it should match the query
         index_response = self._get(f"histories{query}").json()
         assert len(index_response) == 1
         assert index_response[0]["name"] == expected_history_name


### PR DESCRIPTION
The filtering query parameters for histories were not properly parsed by the pydantic model as a dependency because they need to be parsed in a custom way for compatibility with the current API.

I've included a small API test since, apparently, we only test these filtering parameters in BioBlend.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
