### PR TITLE
Miscellaneous Histories API fixes

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -7,6 +7,7 @@ from typing import (
     AsyncGenerator,
     Callable,
     cast,
+    Dict,
     Optional,
     Type,
     TypeVar,
@@ -329,6 +330,7 @@ def as_form(cls: Type[BaseModel]):
     ]
 
     async def _as_form(**data):
+        data = sanitize_data(data)
         return cls(**data)
 
     sig = inspect.signature(_as_form)
@@ -344,3 +346,11 @@ async def try_get_request_body_as_json(request: Request) -> Optional[Any]:
         body = await request.json()
         return body
     return None
+
+
+def sanitize_data(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Removes possible double quoting on string values"""
+    for k, v in data.items():
+        if isinstance(v, str):
+            data[k] = v.replace('"', "").replace("'", "")
+    return data

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -803,6 +803,10 @@ class HistoryContentsApiTestCase(ApiTestCase):
         assert len(contents_response) == expected_num_datasets
         contents_response = self._get(f"histories/{history_id}/contents?types=dataset_collection").json()
         assert len(contents_response) == expected_num_collections
+        contents_response = self._get(f"histories/{history_id}/contents?types=dataset,dataset_collection").json()
+        assert len(contents_response) == expected_num_datasets + expected_num_collections
+        contents_response = self._get(f"histories/{history_id}/contents?types=dataset&types=dataset_collection").json()
+        assert len(contents_response) == expected_num_datasets + expected_num_collections
 
     def test_elements_datatypes_field(self):
         history_id = self.dataset_populator.new_history()


### PR DESCRIPTION
This fixes a couple more issues detected by BioBlend tests with the modernized histories API endpoints.

- Fix legacy support for the `types` parameter as a list of strings (`?types=dataset&types=dataset_collection`) or a comma-separated list (`?types=dataset,dataset_collection`)
- Fix a weird case in the import histories endpoint where the string typed parameters in the payload (as form-data) could contain extra quotations resulting in failing the model validation. Surprisingly this behavior cannot be reproduced by our [API tests](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy_test/api/test_histories.py#L304) but was reproduced by [BioBlend tests](https://github.com/galaxyproject/bioblend/runs/5977464941?check_suite_focus=true#step:10:1553)

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
