### PR TITLE
[21.09] Backport job error message fix

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -337,7 +337,7 @@ export default {
                     if (genericError) {
                         this.showError = true;
                         this.errorTitle = "Job submission failed.";
-                        this.errorContent = this.jobDef;
+                        this.errorContent = jobDef;
                     }
                 }
             );

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -16,7 +16,10 @@
                     />
                     <Webhook v-if="showSuccess" type="tool" :tool-id="jobDef.tool_id" />
                     <b-modal v-model="showError" size="sm" :title="errorTitle | l" scrollable ok-only>
-                        <b-alert show variant="danger">
+                        <b-alert v-if="errorMessage" show variant="danger">
+                            {{ errorMessage }}
+                        </b-alert>
+                        <b-alert show variant="warning">
                             The server could not complete this request. Please verify your parameter settings, retry
                             submission and contact the Galaxy Team if this error persists. A transcript of the submitted
                             data is shown below.
@@ -155,6 +158,7 @@ export default {
             remapAllowed: false,
             errorTitle: null,
             errorContent: null,
+            errorMessage: "",
             messageShow: false,
             messageVariant: "",
             messageText: "",
@@ -324,6 +328,7 @@ export default {
                     document.querySelector(".center-panel").scrollTop = 0;
                 },
                 (e) => {
+                    this.errorMessage = e?.response?.data?.err_msg;
                     this.showExecuting = false;
                     let genericError = true;
                     const errorData = e && e.response && e.response.data && e.response.data.err_data;


### PR DESCRIPTION
This is a partial backport from #13628 including only the part for fixing the display of tool error messages.

It may help determine what failed in #13607

Before these changes when the request fails the information displayed is:

![Screenshot from 2022-04-13 18-31-58](https://user-images.githubusercontent.com/46503462/163227777-4535f5fa-565b-433e-aef2-40ad3d2340fa.png)


After the changes:

![Screenshot from 2022-04-13 18-20-54](https://user-images.githubusercontent.com/46503462/163227283-4956f6d1-1a90-4706-96eb-40213a9bc92f.png)


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
