### PR TITLE
Revert 4f3ad45 (double quoting fix)

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -7,7 +7,6 @@ from typing import (
     AsyncGenerator,
     Callable,
     cast,
-    Dict,
     Optional,
     Type,
     TypeVar,
@@ -330,7 +329,6 @@ def as_form(cls: Type[BaseModel]):
     ]
 
     async def _as_form(**data):
-        data = sanitize_data(data)
         return cls(**data)
 
     sig = inspect.signature(_as_form)
@@ -346,11 +344,3 @@ async def try_get_request_body_as_json(request: Request) -> Optional[Any]:
         body = await request.json()
         return body
     return None
-
-
-def sanitize_data(data: Dict[str, Any]) -> Dict[str, Any]:
-    """Removes possible double quoting on string values"""
-    for k, v in data.items():
-        if isinstance(v, str):
-            data[k] = v.replace('"', "").replace("'", "")
-    return data


### PR DESCRIPTION
This hack is no longer needed as the source of the double quoting issue was external and fixed directly in BioBlend.
Thanks @nsoranzo!

xref https://github.com/galaxyproject/galaxy/pull/13717#issuecomment-1098350191

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
