### PR TITLE
Drop use_legacy from tests

### DIFF
--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -16,6 +16,7 @@ env:
   GALAXY_TEST_SELENIUM_RETRIES: 1
   YARN_INSTALL_OPTS: --frozen-lockfile
   GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
+  GALAXY_CONFIG_USE_LEGACY_HISTORY: 'true'
   GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT: '1'
 concurrency:
   group: integration-selenium-${{ github.ref }}

--- a/.github/workflows/integration_selenium_beta.yaml
+++ b/.github/workflows/integration_selenium_beta.yaml
@@ -1,4 +1,4 @@
-name: Selenium tests (beta history panel)
+name: Integration Selenium (beta history panel)
 on:
   push:
     paths-ignore:
@@ -10,16 +10,15 @@ on:
     # Run at midnight UTC every Tuesday
     - cron: '0 0 * * 2'
 env:
-  GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
+  GALAXY_SKIP_CLIENT_BUILD: '0'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_TEST_SELENIUM_RETRIES: 1
-  GALAXY_TEST_SELENIUM_BETA_HISTORY: 1
-  GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
   YARN_INSTALL_OPTS: --frozen-lockfile
   GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
+  GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT: '1'
 concurrency:
-  group: selenium-beta-${{ github.ref }}
+  group: integration-selenium-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   test:
@@ -27,10 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
-      fail-fast: false
       matrix:
         python-version: ['3.7']
-        chunk: [0, 1, 2]
     services:
       postgres:
         image: postgres:13
@@ -45,6 +42,8 @@ jobs:
         run: |
           echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
           echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
+      - name: Prune unused docker image, volumes and containers
+        run: docker system prune -a -f
       - uses: actions/checkout@v2
         with:
           path: 'galaxy root'
@@ -64,25 +63,25 @@ jobs:
         uses: actions/cache@v2
         with:
           path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-selenium-beta
+          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-integration-selenium
       - uses: mvdbeek/gha-yarn-cache@master
         with:
           yarn-lock-file: 'galaxy root/client/yarn.lock'
       - uses: nanasess/setup-chromedriver@master
       - name: Run tests
-        run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
+        run: ./run_tests.sh --coverage -integration test/integration_selenium
         working-directory: 'galaxy root'
       - uses: codecov/codecov-action@v2
         with:
-          flags: selenium-beta-history
+          flags: integration-selenium
           working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: Selenium beta history panel test results (${{ matrix.python-version }}, ${{ matrix.chunk }})
-          path: 'galaxy root/run_selenium_tests.html'
+          name: Integration Selenium test results (${{ matrix.python-version }})
+          path: 'galaxy root/run_integration_tests.html'
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: Selenium beta history panel debug info (${{ matrix.python-version }}, ${{ matrix.chunk }})
+          name: Integration Selenium debug info (${{ matrix.python-version }})
           path: 'galaxy root/database/test_errors'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -11,6 +11,7 @@ on:
     - cron: '0 0 * * 2'
 env:
   GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
+  GALAXY_CONFIG_USE_LEGACY_HISTORY: 'true'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_TEST_SELENIUM_RETRIES: 1

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1702,7 +1702,6 @@ class NavigatesGalaxy(HasDriver):
             tour_callback = NullTourCallback()
 
         self.home()
-        self.use_legacy_history()
 
         with open(path) as f:
             tour_dict = yaml.safe_load(f)

--- a/lib/galaxy_test/selenium/test_anon_history.py
+++ b/lib/galaxy_test/selenium/test_anon_history.py
@@ -8,7 +8,6 @@ class AnonymousHistoriesTestCase(SeleniumTestCase):
     @selenium_test
     def test_anon_history_landing(self):
         self.home()
-        self.use_legacy_history()
         self.assert_initial_history_panel_state_correct()
 
         # Anonymous users can annotate or tag, these components should be absent.
@@ -42,7 +41,6 @@ class AnonymousHistoriesTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_clean_anon_history_after_logout(self):
-        self.use_legacy_history()
         self._upload_file_anonymous_then_register_user()
         self.logout_if_needed()
         # Give Galaxy the chance to load a new empty history for that now

--- a/lib/galaxy_test/selenium/test_custom_builds.py
+++ b/lib/galaxy_test/selenium/test_custom_builds.py
@@ -9,7 +9,6 @@ class CustomBuildsTestcase(SharedStateSeleniumTestCase):
     @selenium_test
     def test_build_add(self):
         self._login()
-        self.use_legacy_history()
         self.navigate_to_custom_builds_page()
 
         self.add_custom_build(self.build_name1, self.build_key1)
@@ -18,7 +17,6 @@ class CustomBuildsTestcase(SharedStateSeleniumTestCase):
     @selenium_test
     def test_build_delete(self):
         self._login()
-        self.use_legacy_history()
         self.navigate_to_custom_builds_page()
 
         self.add_custom_build(self.build_name2, self.build_key2)

--- a/lib/galaxy_test/selenium/test_history_options.py
+++ b/lib/galaxy_test/selenium/test_history_options.py
@@ -9,7 +9,6 @@ class HistoryOptionsTestCase(SeleniumTestCase):
     def test_options(self):
         self.register()
         self.perform_upload(self.get_filename("1.txt"))
-        self.use_legacy_history()
         self.click_history_options()
 
         menu_selector = self.navigation.history_panel.selectors.options_menu

--- a/lib/galaxy_test/selenium/test_history_sharing.py
+++ b/lib/galaxy_test/selenium/test_history_sharing.py
@@ -10,7 +10,6 @@ VALID_LOGIN_RETRIES = 3
 class HistorySharingTestCase(SeleniumTestCase):
     @selenium_test
     def test_sharing_valid(self):
-        self.use_legacy_history()
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history()
         self.submit_login(user2_email, retries=VALID_LOGIN_RETRIES)
         response = self.api_get(f"histories/{history_id}", raw=True)
@@ -18,7 +17,6 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_sharing_valid_by_id(self):
-        self.use_legacy_history()
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history(share_by_id=True)
         self.submit_login(user2_email, retries=VALID_LOGIN_RETRIES)
         response = self.api_get(f"histories/{history_id}", raw=True)
@@ -26,7 +24,6 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_unsharing(self):
-        self.use_legacy_history()
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history()
         self.submit_login(user1_email, retries=VALID_LOGIN_RETRIES)
         self.navigate_to_history_share_page()
@@ -60,7 +57,6 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_sharing_with_invalid_user(self):
-        self.use_legacy_history()
         user1_email = self._get_random_email()
         self.register(user1_email)
         self.share_history_with_user(user_email="invalid_user@test.com")
@@ -68,7 +64,6 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_sharing_with_self(self):
-        self.use_legacy_history()
         user1_email = self._get_random_email()
         self.register(user1_email)
         self.share_history_with_user(user_email=user1_email)

--- a/lib/galaxy_test/selenium/test_library_to_collections.py
+++ b/lib/galaxy_test/selenium/test_library_to_collections.py
@@ -55,7 +55,6 @@ class LibraryToCollectionsTestCase(SeleniumTestCase, UsesLibraryAssertions):
 
     def collection_export(self, is_new_history=False, collection_option=None):
         random_name = self._get_random_name()
-        self.use_legacy_history()
         self.prepare_library_for_data_export(["1.bam", "1.bed"], random_name if is_new_history else None)
         self.components.libraries.folder.export_to_history_options.wait_for_and_click()
 
@@ -70,7 +69,6 @@ class LibraryToCollectionsTestCase(SeleniumTestCase, UsesLibraryAssertions):
             assert self.history_panel_name_element().text == random_name
 
     def list_of_pairs_export(self, is_new_history=False):
-        self.use_legacy_history()
         history_name = self._get_random_name()
         self.prepare_library_for_data_export(
             ["bam_from_sam.bam", "asian_chars_1.txt", "1.bam", "1.bed"], history_name if is_new_history else None

--- a/lib/galaxy_test/selenium/test_navigates_galaxy.py
+++ b/lib/galaxy_test/selenium/test_navigates_galaxy.py
@@ -15,7 +15,6 @@ class NavigatesGalaxySeleniumTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_click_error(self):
-        self.use_legacy_history()
         self.home()
         self.upload_start_click()
         # Open the details, verify they are open and do a refresh.

--- a/lib/galaxy_test/selenium/test_published_histories_grid.py
+++ b/lib/galaxy_test/selenium/test_published_histories_grid.py
@@ -159,7 +159,6 @@ class HistoryGridTestCase(SharedStateSeleniumTestCase):
         self.sleep_for(self.wait_types.UX_RENDER)
 
     def setup_shared_state(self):
-        self.use_legacy_history()
         tag1 = self._get_random_name(len=5)
         tag2 = self._get_random_name(len=5)
         tag3 = self._get_random_name(len=5)

--- a/lib/galaxy_test/selenium/test_tool_describing_tours.py
+++ b/lib/galaxy_test/selenium/test_tool_describing_tours.py
@@ -34,7 +34,6 @@ class ToolDescribingToursTestCase(SeleniumTestCase):
     def test_generate_tour_with_data(self):
         """Ensure a tour with data populates history."""
         self._ensure_tdt_available()
-        self.use_legacy_history()
         self.tool_open("md5sum")
 
         self.tool_form_generate_tour()

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -89,7 +89,6 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_rerun(self):
-        self.use_legacy_history()
         self._run_environment_test_tool()
         self.history_panel_wait_for_hid_ok(1)
         self.hda_click_primary_action_button(1, "rerun")

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -13,7 +13,6 @@ from .framework import (
 class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
     def test_upload_simplest(self):
-        self.use_legacy_history()
         self.perform_upload(self.get_filename("1.sam"))
 
         self.history_panel_wait_for_hid_ok(1)
@@ -64,7 +63,6 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_upload_list(self):
-        self.use_legacy_history()
         self.upload_list([self.get_filename("1.tabular")], name="Test List")
         self.history_panel_wait_for_hid_ok(2)
         # Make sure modals disappeared - both List creator (TODO: upload).
@@ -77,7 +75,6 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_upload_pair(self):
-        self.use_legacy_history()
         self.upload_list([self.get_filename("1.tabular"), self.get_filename("2.tabular")], name="Test Pair")
         self.history_panel_wait_for_hid_ok(3)
         # Make sure modals disappeared - both collection creator (TODO: upload).
@@ -107,7 +104,6 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_upload_paired_list(self):
-        self.use_legacy_history()
         self.upload_paired_list(
             [self.get_filename("1.tabular"), self.get_filename("2.tabular")], name="Test Paired List"
         )

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -22,7 +22,6 @@ class HistoryImportExportFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestC
 
     @selenium_test
     def test_history_import_export(self):
-        self.use_legacy_history()
         email = self.get_logged_in_user()["email"]
         user_ftp_dir = os.path.join(self.ftp_dir(), email)
         os.makedirs(user_ftp_dir)


### PR DESCRIPTION
If you can't use the new history to setup sharing or do re-runs, that is
a major issue that needs to be resolved before the release. Just
sprinkling in `use_legacy_history` does not help and just obscures the
actual work that still needs to be done.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
