### PR TITLE
Simplify some selenium upload tests to respect either history properly.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -485,8 +485,7 @@ class NavigatesGalaxy(HasDriver):
         self.wait_for_visible(self.navigation.history_panel.selectors.search, wait_type=WAIT_TYPES.DATABASE_OPERATION)
 
     def history_panel_wait_for_hid_hidden(self, hid, multi_history_panel=False):
-        history_item = self.hid_to_history_item(hid)
-        history_item_selector = self.history_panel_item_component(history_item, multi_history_panel=multi_history_panel)
+        history_item_selector = self.history_panel_item_component(hid=hid, multi_history_panel=multi_history_panel)
         self.wait_for_absent_or_hidden(history_item_selector, wait_type=WAIT_TYPES.JOB_COMPLETION)
         return history_item_selector
 

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -63,7 +63,6 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_upload_list(self):
-        self.use_legacy_history()
         self.upload_list([self.get_filename("1.tabular")], name="Test List")
         self.history_panel_wait_for_hid_ok(2)
         # Make sure modals disappeared - both List creator (TODO: upload).
@@ -76,7 +75,6 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_upload_pair(self):
-        self.use_legacy_history()
         self.upload_list([self.get_filename("1.tabular"), self.get_filename("2.tabular")], name="Test Pair")
         self.history_panel_wait_for_hid_ok(3)
         # Make sure modals disappeared - both collection creator (TODO: upload).

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -13,7 +13,6 @@ from .framework import (
 class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
     def test_upload_simplest(self):
-        self.use_legacy_history()
         self.perform_upload(self.get_filename("1.sam"))
 
         self.history_panel_wait_for_hid_ok(1)


### PR DESCRIPTION

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
