### PR TITLE
Converge testing and classes for history options across new and old history panel.

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -32,6 +32,7 @@
                     toggle-class="text-decoration-none"
                     v-b-tooltip.bottom.hover
                     title="Show history options"
+                    menu-class="history-options-button-menu"
                     data-description="history options">
                     <b-dropdown-text>
                         <div v-if="historiesLoading">

--- a/client/src/entry/panels/history-panel.js
+++ b/client/src/entry/panels/history-panel.js
@@ -67,6 +67,7 @@ const HistoryPanel = Backbone.View.extend({
             target: "galaxy_main",
             icon: "fa fa-cog",
             href: `${this.root}root/history_options`,
+            description: "history options",
         });
         panelHeaderButtons.push(this.buttonOptions);
 

--- a/client/src/mvc/ui/popup-menu.js
+++ b/client/src/mvc/ui/popup-menu.js
@@ -66,7 +66,7 @@ const PopupMenu = Backbone.View.extend({
     },
 
     template: function (id, options) {
-        return `<div id="${id}-menu" class="dropdown-menu">
+        return `<div id="${id}-menu" class="dropdown-menu ${id}-menu">
                     ${this._templateOptions(options)}
                 </div>`;
     },

--- a/client/src/mvc/ui/ui-buttons.js
+++ b/client/src/mvc/ui/ui-buttons.js
@@ -130,6 +130,7 @@ var ButtonLink = Button.extend({
                 title: options.title,
                 target: options.target || "_top",
                 disabled: options.disabled,
+                "data-description": options.description,
             })
             .css("display", options.visible ? "inline-block" : "none")
             .tooltip({ placement: "bottom" })

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -260,14 +260,14 @@ history_panel:
 
     annotation_done: '.details .history-annotation .annotation button'
 
-    options_button: '#history-options-button'
+    options_button: '[data-description="history options"]'
     options_button_icon: '.details .menu-expand-button'
-    options_button_icon_beta: '[data-description="history options"]'
+    options_button_icon_beta: '[data-description="history options"] button'
     options_button_copy_datasets_beta: '.copy-datasets-menu-item'
-    options_menu: '#history-options-button-menu'
+    options_menu: '.history-options-button-menu'
     options_menu_item:
       type: sizzle
-      selector: '#history-options-button-menu > a:contains("${option_label}")'
+      selector: '.history-options-button-menu > a:contains("${option_label}")'
 
     options_show_history_structure:
       type: xpath

--- a/lib/galaxy_test/selenium/test_history_options.py
+++ b/lib/galaxy_test/selenium/test_history_options.py
@@ -9,14 +9,19 @@ class HistoryOptionsTestCase(SeleniumTestCase):
     def test_options(self):
         self.register()
         self.perform_upload(self.get_filename("1.txt"))
-        self.use_legacy_history()
-        self.click_history_options()
-
         menu_selector = self.navigation.history_panel.selectors.options_menu
-        self.wait_for_visible(menu_selector)
+        self.wait_for_absent_or_hidden(menu_selector)
 
-        # Click away closes history options
-        self.click_center()
+        self.click_history_options()
+        component = self.wait_for_visible(menu_selector)
+        self.screenshot("history_options")
+        # TODO: clicking in center iframe dimisses old menu but not new one,
+        # sending escape dismisses the new menu and not old one. Sync this behavior.
+        if self.is_beta_history():
+            self.send_escape(component)
+        else:
+            # Click away closes history options
+            self.click_center()
 
         self.wait_for_absent_or_hidden(menu_selector)
 


### PR DESCRIPTION
Add TODO for different behavior between menus.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
