### PR TITLE
[21.09] Fix collection population error handling

### DIFF
--- a/client/src/components/JobStates/CollectionJobStates.vue
+++ b/client/src/components/JobStates/CollectionJobStates.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="!jobSourceType || jobSourceType == 'Job' || isTerminal">
+    <div v-if="!jobSourceType || jobSourceType == 'Job' || (isTerminal && !isErrored)">
         {{ simpleDescription }}
     </div>
     <div v-else-if="!jobStatesSummary || !jobStatesSummary.hasDetails()">
@@ -52,6 +52,9 @@ export default {
             return DC_VIEW.collectionDescription(this.collection);
         },
         errorDescription() {
+            if (this.isPopulationFailed) {
+                return `${this.collection.get("populated_state_message")}`;
+            }
             var jobCount = this.jobCount;
             var errorCount = this.jobStatesSummary.numInError();
             return `a ${this.collectionTypeDescription} with ${errorCount} / ${jobCount} jobs in error`;

--- a/client/src/components/JobStates/mixin.js
+++ b/client/src/components/JobStates/mixin.js
@@ -7,6 +7,9 @@ export default {
         isErrored() {
             return this.jobStatesSummary && this.jobStatesSummary.errored();
         },
+        isPopulationFailed() {
+            return this.jobStatesSummary && this.jobStatesSummary.populationFailed();
+        },
         isTerminal() {
             return this.jobStatesSummary && this.jobStatesSummary.terminal();
         },

--- a/client/src/mvc/collection/collection-model.js
+++ b/client/src/mvc/collection/collection-model.js
@@ -252,6 +252,15 @@ var DatasetCollection = Backbone.Model.extend(BASE_MVC.LoggableMixin)
                     _.extend(element, {
                         parent_hdca_id: parentHdcaId,
                     });
+
+                    // Warning: MEGA-hack ahead...
+                    if (!element.element_type && !element.object) {
+                        // The DCE has to be in error state... so we simulate it
+                        _.extend(element, {
+                            element_type: "hda",
+                            object: { state: "error" },
+                        });
+                    }
                 });
                 this.elements = new collectionClass(elements);
                 //this.debug( 'collectionClass:', this.collectionClass + '', this.elements );

--- a/client/src/mvc/collection/collection-view.js
+++ b/client/src/mvc/collection/collection-view.js
@@ -62,11 +62,16 @@ var CollectionView = _super.extend(
         },
 
         handleWarning: function ($newRender) {
+            var $warns = $newRender.find(".elements-warning");
+            if (this.model.get("populated_state") === "failed") {
+                var error = _l(`${this.model.get("populated_state_message")}`);
+                $warns.html(`<div class="errormessagesmall">${error}</div>`);
+                return;
+            }
             var viewLength = this.views.length;
             var elementCount = this.model.get("element_count");
             if (elementCount && elementCount !== viewLength) {
                 var warning = _l(`displaying only ${viewLength} of ${elementCount} items`);
-                var $warns = $newRender.find(".elements-warning");
                 $warns.html(`<div class="warningmessagesmall">${warning}</div>`);
             }
         },

--- a/client/src/mvc/history/job-states-model.js
+++ b/client/src/mvc/history/job-states-model.js
@@ -7,6 +7,7 @@ var UPDATE_DELAY = 2000;
 var NON_TERMINAL_STATES = ["new", "queued", "running", "waiting"];
 var ERROR_STATES = ["error", "deleted"];
 var TERMINAL_STATES = ["ok"].concat(ERROR_STATES);
+const POPULATED_STATE_FAILED = "failed";
 /** Fetch state on add or just wait for polling to start. */
 var FETCH_STATE_ON_ADD = false;
 var BATCH_FETCH_STATE = true;
@@ -27,7 +28,7 @@ var JobStatesSummary = Backbone.Model.extend({
     },
 
     errored: function () {
-        return this.get("populated_state") === "error" || this.anyWithStates(ERROR_STATES);
+        return this.get("populated_state") === POPULATED_STATE_FAILED || this.anyWithStates(ERROR_STATES);
     },
 
     states: function () {

--- a/client/src/mvc/history/job-states-model.js
+++ b/client/src/mvc/history/job-states-model.js
@@ -27,8 +27,12 @@ var JobStatesSummary = Backbone.Model.extend({
         return !this.hasDetails() || this.get("populated_state") == "new";
     },
 
+    populationFailed: function () {
+        return this.get("populated_state") === POPULATED_STATE_FAILED;
+    },
+
     errored: function () {
-        return this.get("populated_state") === POPULATED_STATE_FAILED || this.anyWithStates(ERROR_STATES);
+        return this.populationFailed() || this.anyWithStates(ERROR_STATES);
     },
 
     states: function () {


### PR DESCRIPTION
Fixes #13607

This is a naive attempt at fixing the display of failed collections produced by a tool run.
I'm not very comfortable with Backbone, so maybe there are smarter ways of fixing this?

Before the changes:

![collectionErrorBefore](https://user-images.githubusercontent.com/46503462/163453650-6c98f59c-1750-47e6-a74c-58e4dd8a71db.gif)


After the changes:

![collectionErrorAfter](https://user-images.githubusercontent.com/46503462/163453489-4ce5ea5b-84c9-43f1-8e1b-38d28826a377.gif)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow the steps on #13607

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
