### PR TITLE
Unquote url before using it

### DIFF
--- a/lib/galaxy/model/migrations/__init__.py
+++ b/lib/galaxy/model/migrations/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import urllib.parse
 from typing import (
     cast,
     Dict,
@@ -497,7 +498,8 @@ def get_last_sqlalchemymigrate_version(model: ModelId) -> int:
 
 
 def get_url_string(engine: Engine) -> str:
-    return engine.url.render_as_string(hide_password=False)
+    db_url = engine.url.render_as_string(hide_password=False)
+    return urllib.parse.unquote(db_url)
 
 
 def get_alembic_manager(engine: Engine) -> AlembicManager:


### PR DESCRIPTION
When the `database_connection` uses the unix domain socket format specifying the host as a keyword argument: 
`postgresql//user:password@/dbname?host=/var/lib/postgresql` 
or omitting the user:
`postgresql///dbname?host=/var/lib/postgresql`
the value of the `host` argument is url-encoded.

In the migrations module, we access the `database_connection` value programmatically via the Engine object. The way to do that is to use the `Engine.render_as_string` method. However, while this works for all other formats, the format above, being url-encoded, leads to an error raised by python's configparser: `ValueError: invalid interpolation syntax`. 

Ref: https://docs.sqlalchemy.org/en/14/core/engines.html?highlight=engine%20configuration#database-urls and 
https://docs.sqlalchemy.org/en/14/dialects/postgresql.html?highlight=unix%20domain%20socket#unix-domain-connections

This PR resolves this issue.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
