### PR TITLE
Workflow index API fix and testing

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -174,7 +174,10 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         """
         Displays a collection of workflows.
 
-        :param  show_published:      if True, show also published workflows
+        :param  show_published:      Optional boolean to include published workflows
+                                     If unspecified this behavior depends on whether the request
+                                     is coming from an authenticated session. The default is true
+                                     for annonymous API requests and false otherwise.
         :type   show_published:      boolean
         :param  show_hidden:         if True, show hidden workflows
         :type   show_hidden:         boolean

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -190,7 +190,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         :param  missing_tools:       if True, include a list of missing tools per workflow
         :type   missing_tools:       boolean
         """
-        show_published = util.string_as_bool(show_published)
+        show_published = util.string_as_bool_or_none(show_published)
         show_hidden = util.string_as_bool(show_hidden)
         show_deleted = util.string_as_bool(show_deleted)
         missing_tools = util.string_as_bool(missing_tools)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1438,6 +1438,19 @@ class BaseWorkflowPopulator(BasePopulator):
         self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=assert_ok)
         time.sleep(0.5)
 
+    def index(self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None):
+        endpoint = "workflows?"
+        if show_shared is not None:
+            endpoint += f"show_shared={show_shared}"
+        if show_published is not None:
+            endpoint += f"show_published={show_published}"
+        response = self._get(endpoint)
+        api_asserts.assert_status_code_is_ok(response)
+        return response.json()
+
+    def index_ids(self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None):
+        return [w["id"] for w in self.index(show_shared=show_shared, show_published=show_published)]
+
     def share_with_user(self, workflow_id: str, user_id_or_email: str):
         data = {"user_ids": [user_id_or_email]}
         response = self._put(f"workflows/{workflow_id}/share_with_users", data, json=True)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1438,6 +1438,11 @@ class BaseWorkflowPopulator(BasePopulator):
         self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=assert_ok)
         time.sleep(0.5)
 
+    def share_with_user(self, workflow_id: str, user_id_or_email: str):
+        data = {"user_ids": [user_id_or_email]}
+        response = self._put(f"workflows/{workflow_id}/share_with_users", data, json=True)
+        api_asserts.assert_status_code_is_ok(response)
+
 
 class RunJobsSummary(NamedTuple):
     history_id: str


### PR DESCRIPTION
I introduced a bug (or at least an unintended behavior change) around published workflows and anonymous API requests against the index API in #13698. This fixes that, updates the docs to clarify the behavior, and introduces a bunch of new tests for this API.

All this testing is important because I swap these things to FastAPI, a merged index query, and a service layer into #13725.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
