### PR TITLE
Highlight Inputs for a given dataset/collection in the history

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -23,6 +23,23 @@
                             :icon="['far', 'square']"
                             @click.stop="$emit('update:selected', true)" />
                     </span>
+                    <span v-if="highlight == 'input'" v-b-tooltip.hover title="Input" @click.stop="toggleHighlights">
+                        <span class="text-info fa fa-arrow-circle-up fa-fw" />
+                    </span>
+                    <span
+                        v-else-if="highlight == 'noInputs'"
+                        v-b-tooltip.hover
+                        title="No Inputs for this item"
+                        @click.stop="toggleHighlights">
+                        <span class="text-info fa fa-minus-circle fa-fw" />
+                    </span>
+                    <span
+                        v-else-if="highlight == 'output'"
+                        v-b-tooltip.hover
+                        title="Inputs highlighted for this item"
+                        @click.stop="toggleHighlights">
+                        <span class="fa fa-check-circle fa-fw" />
+                    </span>
                     <span v-if="hasStateIcon">
                         <icon fixed-width :icon="contentState.icon" :spin="contentState.spin" />
                     </span>
@@ -60,7 +77,12 @@
             @input="onTags" />
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
         <div class="detail-animation-wrapper" :class="expandDataset ? '' : 'collapsed'">
-            <DatasetDetails v-if="expandDataset" :dataset="item" @edit="onEdit" />
+            <DatasetDetails
+                v-if="expandDataset"
+                :dataset="item"
+                :show-highlight="isHistoryItem && isHistPanel"
+                @edit="onEdit"
+                @toggleHighlights="toggleHighlights" />
         </div>
     </div>
 </template>
@@ -84,9 +106,11 @@ export default {
     },
     props: {
         expandDataset: { type: Boolean, required: true },
+        highlight: { type: String, default: null },
         id: { type: Number, required: true },
         isDataset: { type: Boolean, default: true },
         isHistoryItem: { type: Boolean, default: true },
+        isHistPanel: { type: Boolean, default: false },
         item: { type: Object, required: true },
         name: { type: String, required: true },
         selected: { type: Boolean, default: false },
@@ -167,6 +191,9 @@ export default {
         },
         onTagClick(tag) {
             this.$emit("tag-click", tag.label);
+        },
+        toggleHighlights() {
+            this.$emit("toggleHighlights", this.item);
         },
     },
 };

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -24,21 +24,21 @@
                             @click.stop="$emit('update:selected', true)" />
                     </span>
                     <span v-if="highlight == 'input'" v-b-tooltip.hover title="Input" @click.stop="toggleHighlights">
-                        <span class="text-info fa fa-arrow-circle-up fa-fw" />
+                        <font-awesome-icon class="text-info" icon="arrow-circle-up" />
                     </span>
                     <span
                         v-else-if="highlight == 'noInputs'"
                         v-b-tooltip.hover
                         title="No Inputs for this item"
                         @click.stop="toggleHighlights">
-                        <span class="text-info fa fa-minus-circle fa-fw" />
+                        <font-awesome-icon icon="minus-circle" />
                     </span>
                     <span
                         v-else-if="highlight == 'output'"
                         v-b-tooltip.hover
                         title="Inputs highlighted for this item"
                         @click.stop="toggleHighlights">
-                        <span class="fa fa-check-circle fa-fw" />
+                        <font-awesome-icon icon="check-circle" />
                     </span>
                     <span v-if="hasStateIcon">
                         <icon fixed-width :icon="contentState.icon" :spin="contentState.spin" />
@@ -96,6 +96,11 @@ import ContentOptions from "./ContentOptions";
 import DatasetDetails from "./Dataset/DatasetDetails";
 import { updateContentFields } from "components/History/model/queries";
 import { JobStateSummary } from "./Collection/JobStateSummary";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faArrowCircleUp, faMinusCircle, faCheckCircle } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faArrowCircleUp, faMinusCircle, faCheckCircle);
 
 export default {
     components: {
@@ -103,6 +108,7 @@ export default {
         ContentOptions,
         DatasetDetails,
         StatelessTags,
+        FontAwesomeIcon,
     },
     props: {
         expandDataset: { type: Boolean, required: true },

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -50,6 +50,15 @@
                     @click.stop="onVisualize">
                     <span class="fa fa-bar-chart-o" />
                 </b-button>
+                <b-button
+                    v-if="showHighlight"
+                    class="px-1"
+                    title="Show Inputs for this item"
+                    size="sm"
+                    variant="link"
+                    @click.stop="onHighlight">
+                    <span class="fa fa-sitemap" />
+                </b-button>
                 <b-button v-if="showRerun" class="px-1" title="Help" size="sm" variant="link" @click.stop="onRerun">
                     <span class="fa fa-question" />
                 </b-button>
@@ -68,6 +77,7 @@ export default {
     mixins: [legacyNavigationMixin],
     props: {
         item: { type: Object, required: true },
+        showHighlight: { type: Boolean, default: false },
     },
     computed: {
         downloadUrl() {
@@ -124,6 +134,9 @@ export default {
             if (!this.iframeAdd(redirectParams)) {
                 this.backboneRoute(path);
             }
+        },
+        onHighlight() {
+            this.$emit("toggleHighlights");
         },
     },
 };

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -21,7 +21,7 @@
                         <span class="value">{{ result.misc_info }}</span>
                     </div>
                 </div>
-                <DatasetActions :item="result" />
+                <DatasetActions :item="result" :show-highlight="showHighlight" @toggleHighlights="toggleHighlights" />
                 <pre v-if="result.peek" class="dataset-peek p-1" v-html="result.peek" />
             </div>
         </div>
@@ -40,10 +40,16 @@ export default {
     },
     props: {
         dataset: { type: Object, required: true },
+        showHighlight: { type: Boolean, default: false },
     },
     computed: {
         stateText() {
             return STATES[this.dataset.state] && STATES[this.dataset.state].text;
+        },
+    },
+    methods: {
+        toggleHighlights() {
+            this.$emit("toggleHighlights");
         },
     },
 };

--- a/client/src/components/History/Content/model/highlights.js
+++ b/client/src/components/History/Content/model/highlights.js
@@ -1,6 +1,8 @@
 /**
  * Specifies highlighted items in the history listing. The `highlight` property is passed to
  * the content item component and can be used to modify its appearance.
+ * TO DO: Consider case where parameter history is different and hence inputs cannot be seen
+ *        in the current panel.
  */
 import axios from "axios";
 import { prependPath } from "utils/redirect";
@@ -35,7 +37,7 @@ function getKey(details) {
 }
 
 /** Returns highlighting details */
-export async function getHighlights(item) {
+export async function getHighlights(item, itemKey) {
     const highlights = {};
     const { outputs, parameters } = await getDatasetParameters(item.id, item.job_source_id);
     deepeach(parameters, (details) => {
@@ -47,8 +49,19 @@ export async function getHighlights(item) {
     deepeach(outputs, (details) => {
         const key = getKey(details);
         if (key) {
-            highlights[key] = "output";
+            // some other item created this item (e.g.: inheritance)
+            if (key != itemKey) {
+                highlights[itemKey] = "output";
+                highlights[key] = "input";
+            } else {
+                highlights[key] = "output";
+            }
         }
     });
+    // highlights only has item itself as an output (i.e.: no inputs)
+    if (highlights[itemKey] === "output" && Object.keys(highlights).length == 1) {
+        highlights[itemKey] = "noInputs";
+    }
+    // TO DO: Consider case where a job created multiple items (all highlights are outputs)
     return highlights;
 }

--- a/client/src/components/History/Content/model/highlights.js
+++ b/client/src/components/History/Content/model/highlights.js
@@ -1,0 +1,54 @@
+/**
+ * Specifies highlighted items in the history listing. The `highlight` property is passed to
+ * the content item component and can be used to modify its appearance.
+ */
+import axios from "axios";
+import { prependPath } from "utils/redirect";
+import { deepeach } from "utils/utils";
+import { LastQueue } from "utils/promise-queue";
+
+// add promise queue
+const lastQueue = new LastQueue(300);
+
+/** Local cache for parameter requests */
+const paramStash = new Map();
+
+/** Performs request to obtain dataset parameters */
+async function getDatasetParameters(datasetId, jobId) {
+    if (!paramStash.has(datasetId)) {
+        const url = jobId
+            ? `api/jobs/${jobId}/parameters_display`
+            : `api/datasets/${datasetId}/parameters_display?hda_ldda=hda`;
+        const { data } = await lastQueue.enqueue(axios.get, prependPath(url));
+        paramStash.set(datasetId, data);
+    }
+    return paramStash.get(datasetId);
+}
+
+/** Returns item key */
+function getKey(details) {
+    if (details.id && details.src) {
+        const historyContentType = details.src == "hda" ? "dataset" : "dataset_collection";
+        return `${details.id}-${historyContentType}`;
+    }
+    return null;
+}
+
+/** Returns highlighting details */
+export async function getHighlights(item) {
+    const highlights = {};
+    const { outputs, parameters } = await getDatasetParameters(item.id, item.job_source_id);
+    deepeach(parameters, (details) => {
+        const key = getKey(details);
+        if (key) {
+            highlights[key] = "input";
+        }
+    });
+    deepeach(outputs, (details) => {
+        const key = getKey(details);
+        if (key) {
+            highlights[key] = "output";
+        }
+    });
+    return highlights;
+}

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -96,10 +96,13 @@
                                         :name="item.name"
                                         :expand-dataset="isExpanded(item)"
                                         :is-dataset="isDataset(item)"
+                                        is-hist-panel
+                                        :highlight="getHighlight(item)"
                                         :selected="isSelected(item)"
                                         :selectable="showSelection"
                                         @tag-click="onTagClick"
                                         @tag-change="onTagChange"
+                                        @toggleHighlights="toggleHighlights"
                                         @update:expand-dataset="setExpanded(item, $event)"
                                         @update:selected="setSelected(item, $event)"
                                         @view-collection="$emit('view-collection', item)"
@@ -122,6 +125,7 @@ import { HistoryItemsProvider } from "components/providers/storeProviders";
 import LoadingSpan from "components/LoadingSpan";
 import ContentItem from "components/History/Content/ContentItem";
 import { deleteContent, updateContentFields } from "components/History/model/queries";
+import { getHighlights } from "components/History/Content/model/highlights";
 import ExpandedItems from "components/History/Content/ExpandedItems";
 import SelectedItems from "components/History/Content/SelectedItems";
 import Listing from "components/History/Layout/Listing";
@@ -161,6 +165,8 @@ export default {
     data() {
         return {
             filterText: "",
+            highlights: {},
+            highlightsKey: null,
             invisible: {},
             offset: 0,
             showAdvanced: false,
@@ -195,14 +201,27 @@ export default {
         queryKey() {
             this.invisible = {};
             this.offset = 0;
+            this.resetHighlights();
         },
         historyId(newVal, oldVal) {
             if (newVal !== oldVal) {
                 this.operationRunning = null;
+                this.resetHighlights();
             }
         },
     },
     methods: {
+        getHighlight(item) {
+            const key = this.getItemKey(item);
+            if (this.highlights[key] == "output" && Object.keys(this.highlights).length == 1) {
+                return "noInputs";
+            } else {
+                return this.highlights[key];
+            }
+        },
+        getItemKey(item) {
+            return `${item.id}-${item.history_content_type}`;
+        },
         hasMatches(items) {
             return !!items && items.length > 0;
         },
@@ -245,6 +264,19 @@ export default {
         onOperationError(error) {
             console.debug("OPERATION ERROR", error);
             this.operationError = error;
+        },
+        async toggleHighlights(item) {
+            const key = this.getItemKey(item);
+            if (this.highlightsKey != key) {
+                this.highlightsKey = key;
+                this.highlights = await getHighlights(item);
+            } else {
+                this.resetHighlights();
+            }
+        },
+        resetHighlights() {
+            this.highlights = {};
+            this.highlightsKey = null;
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -213,8 +213,22 @@ export default {
     methods: {
         getHighlight(item) {
             const key = this.getItemKey(item);
-            if (this.highlights[key] == "output" && Object.keys(this.highlights).length == 1) {
-                return "noInputs";
+            // the current item has one item in its parameters (i.e.: outputs)
+            if (Object.keys(this.highlights).length == 1) {
+                // parameters has itself as an output (i.e.: no inputs)
+                if (key == this.highlightsKey && this.highlights[key] == "output") {
+                    return "noInputs";
+                }
+                // parameters has another item as output but not current one
+                // (i.e.: the current one is an output)
+                else if (key == this.highlightsKey) {
+                    return "output";
+                }
+                // parameters has another item as output but not current one
+                // (i.e.: must be the item that created it/it was copied from)
+                else if (this.highlights[key] == "output") {
+                    return "input";
+                }
             } else {
                 return this.highlights[key];
             }

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -212,26 +212,7 @@ export default {
     },
     methods: {
         getHighlight(item) {
-            const key = this.getItemKey(item);
-            // the current item has one item in its parameters (i.e.: outputs)
-            if (Object.keys(this.highlights).length == 1) {
-                // parameters has itself as an output (i.e.: no inputs)
-                if (key == this.highlightsKey && this.highlights[key] == "output") {
-                    return "noInputs";
-                }
-                // parameters has another item as output but not current one
-                // (i.e.: the current one is an output)
-                else if (key == this.highlightsKey) {
-                    return "output";
-                }
-                // parameters has another item as output but not current one
-                // (i.e.: must be the item that created it/it was copied from)
-                else if (this.highlights[key] == "output") {
-                    return "input";
-                }
-            } else {
-                return this.highlights[key];
-            }
+            return this.highlights[this.getItemKey(item)];
         },
         getItemKey(item) {
             return `${item.id}-${item.history_content_type}`;
@@ -283,7 +264,7 @@ export default {
             const key = this.getItemKey(item);
             if (this.highlightsKey != key) {
                 this.highlightsKey = key;
-                this.highlights = await getHighlights(item);
+                this.highlights = await getHighlights(item, key);
             } else {
                 this.resetHighlights();
             }


### PR DESCRIPTION
A feature was requested (Fixes https://github.com/galaxyproject/galaxy/issues/13632) that would highlight the inputs for a given dataset in the history. @guerler and I have implemented an input highlight feature, that is triggered by clicking on a newly added `DatasetActions` button. These inputs are obtained through an api that only checks if there is a job that made the dataset.

https://user-images.githubusercontent.com/78516064/172516642-32d596b6-946c-429f-9245-5c99ead57db5.mov


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
