### PR TITLE
Add Number of Hidden/Deleted Datasets to History Details

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -8,7 +8,10 @@
         <template v-slot:name>
             <h3 data-description="name display" v-short="history.name || 'History'" />
             <h5 class="history-size mt-1">
-                <span v-if="history.size">{{ history.size | niceFileSize }}</span>
+                <span v-if="history.size">
+                    <div>{{ history.size | niceFileSize }}</div>
+                    <div>{{ shownCount }} shown, {{ hiddenCount }} hidden</div>
+                </span>
                 <span v-else v-localize>(empty)</span>
             </h5>
         </template>
@@ -17,6 +20,7 @@
 
 <script>
 import prettyBytes from "pretty-bytes";
+import store from "store";
 import short from "components/directives/v-short";
 import Details from "components/History/Layout/Details";
 
@@ -35,6 +39,14 @@ export default {
     props: {
         history: { type: Object, required: true },
         writeable: { type: Boolean, default: true },
+    },
+    computed: {
+        shownCount() {
+            return (store.getters.getHistoryItems({ historyId: this.history.id, filterText: "" })).length;
+        },
+        hiddenCount() {
+            return (store.getters.getHistoryItems({ historyId: this.history.id, filterText: "visible=false" })).length;
+        },
     },
     methods: {
         onSave(newDetails) {

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -10,7 +10,9 @@
             <h5 class="history-size mt-1">
                 <span v-if="history.size">
                     <div>{{ history.size | niceFileSize }}</div>
-                    <div>{{ history.contents_active["active"] }} shown, {{ history.contents_active["hidden"] }} hidden</div>
+                    <div>
+                        {{ history.contents_active["active"] }} shown, {{ history.contents_active["hidden"] }} hidden
+                    </div>
                 </span>
                 <span v-else v-localize>(empty)</span>
             </h5>

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -10,8 +10,10 @@
             <h5 class="history-size mt-1">
                 <span v-if="history.size">
                     <div>{{ history.size | niceFileSize }}</div>
-                    <div>
-                        {{ history.contents_active["active"] }} shown, {{ history.contents_active["hidden"] }} hidden
+                    <div class="dataCounts">
+                        <a href="javascript:void(0)" @click="filterText('')">{{ history.contents_active.active }} active, </a>
+                        <a href="javascript:void(0)" @click="filterText('deleted=true')">{{ history.contents_active.deleted }} deleted, </a>
+                        <a href="javascript:void(0)" @click="filterText('visible=false')">{{ history.contents_active.hidden }} hidden</a>
                     </div>
                 </span>
                 <span v-else v-localize>(empty)</span>
@@ -46,6 +48,14 @@ export default {
             const id = this.history.id;
             this.$emit("updateHistory", { ...newDetails, id });
         },
+        filterText(newFilterText) {
+            this.$emit("detailsFilter",newFilterText);
+        },
     },
 };
 </script>
+<style>
+.dataCounts a {
+    color: inherit;
+}
+</style>

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -11,9 +11,15 @@
                 <span v-if="history.size">
                     <div>{{ history.size | niceFileSize }}</div>
                     <div class="dataCounts">
-                        <a href="javascript:void(0)" @click="filterText('')">{{ history.contents_active.active }} active, </a>
-                        <a href="javascript:void(0)" @click="filterText('deleted=true')">{{ history.contents_active.deleted }} deleted, </a>
-                        <a href="javascript:void(0)" @click="filterText('visible=false')">{{ history.contents_active.hidden }} hidden</a>
+                        <a href="javascript:void(0)" @click="filterText('')"
+                            >{{ history.contents_active.active }} active,
+                        </a>
+                        <a href="javascript:void(0)" @click="filterText('deleted=true')"
+                            >{{ history.contents_active.deleted }} deleted,
+                        </a>
+                        <a href="javascript:void(0)" @click="filterText('visible=false')"
+                            >{{ history.contents_active.hidden }} hidden</a
+                        >
                     </div>
                 </span>
                 <span v-else v-localize>(empty)</span>
@@ -49,7 +55,7 @@ export default {
             this.$emit("updateHistory", { ...newDetails, id });
         },
         filterText(newFilterText) {
-            this.$emit("detailsFilter",newFilterText);
+            this.$emit("detailsFilter", newFilterText);
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -42,10 +42,10 @@ export default {
     },
     computed: {
         shownCount() {
-            return (store.getters.getHistoryItems({ historyId: this.history.id, filterText: "" })).length;
+            return store.getters.getHistoryItems({ historyId: this.history.id, filterText: "" }).length;
         },
         hiddenCount() {
-            return (store.getters.getHistoryItems({ historyId: this.history.id, filterText: "visible=false" })).length;
+            return store.getters.getHistoryItems({ historyId: this.history.id, filterText: "visible=false" }).length;
         },
     },
     methods: {

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -10,7 +10,7 @@
             <h5 class="history-size mt-1">
                 <span v-if="history.size">
                     <div>{{ history.size | niceFileSize }}</div>
-                    <div>{{ shownCount }} shown, {{ hiddenCount }} hidden</div>
+                    <div>{{ history.contents_active["active"] }} shown, {{ history.contents_active["hidden"] }} hidden</div>
                 </span>
                 <span v-else v-localize>(empty)</span>
             </h5>
@@ -20,7 +20,6 @@
 
 <script>
 import prettyBytes from "pretty-bytes";
-import store from "store";
 import short from "components/directives/v-short";
 import Details from "components/History/Layout/Details";
 
@@ -39,14 +38,6 @@ export default {
     props: {
         history: { type: Object, required: true },
         writeable: { type: Boolean, default: true },
-    },
-    computed: {
-        shownCount() {
-            return store.getters.getHistoryItems({ historyId: this.history.id, filterText: "" }).length;
-        },
-        hiddenCount() {
-            return store.getters.getHistoryItems({ historyId: this.history.id, filterText: "visible=false" }).length;
-        },
     },
     methods: {
         onSave(newDetails) {

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -32,7 +32,7 @@
                         :filter-text.sync="filterText"
                         :show-advanced.sync="showAdvanced" />
                     <section v-if="!showAdvanced">
-                        <HistoryDetails :history="history" v-on="$listeners" />
+                        <HistoryDetails :history="history" @detailsFilter="onDetailsFilter" v-on="$listeners" />
                         <HistoryMessages class="m-2" :history="history" />
                         <HistoryOperations
                             :history="history"
@@ -198,6 +198,9 @@ export default {
         },
         setInvisible(item) {
             Vue.set(this.invisible, item.hid, true);
+        },
+        onDetailsFilter(newFilterText) {
+            this.filterText = newFilterText;
         },
     },
 };

--- a/client/src/store/historyStore/model/queries.js
+++ b/client/src/store/historyStore/model/queries.js
@@ -40,7 +40,7 @@ function formData(fields = {}) {
  */
 const stdHistoryParams = {
     view: "summary",
-    keys: "size",
+    keys: "size,contents_active",
 };
 
 /**


### PR DESCRIPTION
As requested in https://github.com/galaxyproject/galaxy/issues/12493, the Beta History needs to show how many datasets are shown/hidden. I have added that information:

![image](https://user-images.githubusercontent.com/78516064/163886087-a8914519-c5aa-40bb-a52a-b02d7133e873.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
