### PR TITLE
Respect conda channels in mulled docker container building 

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -30,6 +30,7 @@ from ..mulled.mulled_build import (
 )
 from ..mulled.mulled_build_tool import requirements_to_mulled_targets
 from ..mulled.util import (
+    default_mulled_conda_channels_from_env,
     mulled_tags_for,
     split_tag,
     v1_image_name,
@@ -647,10 +648,12 @@ class BuildMulledDockerContainerResolver(CliContainerResolver):
         self.auto_install = string_as_bool(auto_install)
         self._mulled_kwds = {
             "namespace": namespace,
-            "channels": self._get_config_option("mulled_channels", DEFAULT_CHANNELS),
             "hash_func": self.hash_func,
             "command": "build-and-test",
         }
+        self._mulled_kwds["channels"] = default_mulled_conda_channels_from_env() or self._get_config_option(
+            "mulled_channels", DEFAULT_CHANNELS
+        )
         self.auto_init = self._get_config_option("involucro_auto_init", True)
 
     def resolve(self, enabled_container_types, tool_info, install=False, **kwds):

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -154,8 +154,8 @@ def get_conda_hits_for_targets(targets, conda_context):
     return [r for r in search_results if r]
 
 
-def base_image_for_targets(targets, conda_context=None):
-    hits = get_conda_hits_for_targets(targets, conda_context or CondaInDockerContext())
+def base_image_for_targets(targets, conda_context):
+    hits = get_conda_hits_for_targets(targets, conda_context)
     for hit in hits:
         try:
             tarball = get_file_from_recipe_url(hit["url"])
@@ -267,7 +267,8 @@ def mull_targets(
     elif DEST_BASE_IMAGE:
         dest_base_image = DEST_BASE_IMAGE
     elif determine_base_image:
-        dest_base_image = base_image_for_targets(targets)
+        conda_context = CondaInDockerContext(ensure_channels=channels)
+        dest_base_image = base_image_for_targets(targets, conda_context)
 
     if dest_base_image:
         involucro_args.extend(["-set", f"DEST_BASE_IMAGE={dest_base_image}"])

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -244,7 +244,7 @@ def mull_targets(
     for channel in channels:
         if channel.startswith("file://"):
             bind_path = channel[7:]
-            binds.append(f"/{bind_path}:/{bind_path}")
+            binds.append(f"{bind_path}:{bind_path}")
 
     channels = ",".join(channels)
     target_str = ",".join(map(conda_build_target_str, targets))
@@ -344,7 +344,7 @@ class CondaInDockerContext(CondaContext):
             for channel in ensure_channels:
                 if channel.startswith("file://"):
                     bind_path = channel[7:]
-                    binds.extend(["-v", f"/{bind_path}:/{bind_path}"])
+                    binds.extend(["-v", f"{bind_path}:{bind_path}"])
             conda_exec = docker_command_list("run", binds + [conda_image, "conda"])
         super().__init__(
             conda_prefix=conda_prefix,

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -3,6 +3,7 @@
 import collections
 import hashlib
 import logging
+import os
 import re
 import sys
 import tarfile
@@ -18,6 +19,13 @@ QUAY_REPOSITORY_API_ENDPOINT = "https://quay.io/api/v1/repository"
 BUILD_NUMBER_REGEX = re.compile(r"\d+$")
 PARSED_TAG = collections.namedtuple("PARSED_TAG", "tag version build_string build_number")
 MULLED_SOCKET_TIMEOUT = 12
+
+
+def default_mulled_conda_channels_from_env():
+    if "DEFAULT_MULLED_CONDA_CHANNELS" in os.environ:
+        return os.environ["DEFAULT_MULLED_CONDA_CHANNELS"].split(",")
+    else:
+        return None
 
 
 def create_repository(namespace, repo_name, oauth_token):

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -3,6 +3,7 @@ import pytest
 from galaxy.tool_util.deps.mulled.mulled_build import (
     base_image_for_targets,
     build_target,
+    CondaInDockerContext,
     DEFAULT_BASE_IMAGE,
     DEFAULT_EXTENDED_BASE_IMAGE,
     mull_targets,
@@ -22,7 +23,8 @@ from ..util import external_dependency_management
 @external_dependency_management
 def test_base_image_for_targets(target, version, base_image):
     target = build_target(target, version=version)
-    assert base_image_for_targets([target]) == base_image
+    conda_context = CondaInDockerContext()
+    assert base_image_for_targets([target], conda_context) == base_image
 
 
 @external_dependency_management


### PR DESCRIPTION
DEFAULT_MULLED_CONDA_CHANNELS is now respected when building mulled docker containers.

In addition the change to CondaInDockerContext allows to use local packages.

Ideally planemo users would be able to set the channels via a command line option, but I could not find a way. Also this should be done for singularity container building?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
