### PR TITLE
Improve error handling for CLI job runner.

### DIFF
--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -104,8 +104,8 @@ class ShellJobRunner(AsynchronousJobRunner):
             return
         # Some job runners return something like 'Submitted batch job XXXX'
         # Strip and split to get job ID.
-        submit_stdout_pieces = stdout.strip().split()
-        external_job_id = submit_stdout_pieces and submit_stdout_pieces[-1]
+        submit_stdout = stdout.strip()
+        external_job_id = submit_stdout and submit_stdout.split()[-1]
         if not external_job_id:
             log.error(f"({galaxy_id_tag}) submission did not return a job identifier, failing job")
             job_wrapper.fail("failure submitting job")

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -104,7 +104,8 @@ class ShellJobRunner(AsynchronousJobRunner):
             return
         # Some job runners return something like 'Submitted batch job XXXX'
         # Strip and split to get job ID.
-        external_job_id = stdout.strip().split()[-1]
+        submit_stdout_pieces = stdout.strip().split()
+        external_job_id = submit_stdout_pieces and submit_stdout_pieces[-1]
         if not external_job_id:
             log.error(f"({galaxy_id_tag}) submission did not return a job identifier, failing job")
             job_wrapper.fail("failure submitting job")


### PR DESCRIPTION
Saw this in the logs for a failed test. I'm sure the test would still have failed but at least we'd be handling things in the error path we're meant to.

```
ERROR    galaxy.jobs.runners:__init__.py:149 (1) Unhandled exception calling queue_job
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/runners/__init__.py", line 146, in run_next
    method(arg)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/runners/cli.py", line 107, in queue_job
    external_job_id = stdout.strip().split()[-1]
IndexError: list index out of range
DEBUG    galaxy.jobs.runners.cli:cli.py:249 (1/None) Terminated at user's request
```

https://github.com/galaxyproject/galaxy/runs/6068791433?check_suite_focus=true

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
