### PR TITLE
More robust is_beta_history() testing check.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1435,7 +1435,16 @@ class NavigatesGalaxy(HasDriver):
             self.components.history_panel.beta.wait_for_present()
 
     def is_beta_history(self):
-        return not self.components.history_panel.beta.is_absent
+        old_panel = self.components.history_panel.beta.is_absent
+        new_panel = self.components.history_panel.new_history_button.is_absent
+        if old_panel and new_panel:
+            # both absent, let page render a bit...
+            self.sleep_for(self.wait_types.UX_RENDER)
+        else:
+            return new_panel
+
+        old_panel = self.components.history_panel.beta.is_absent
+        return not old_panel
 
     # avoids problematic ID and classes on markup
     def beta_history_element(self, attribute_value, attribute_name="data-description", scope=".history-index"):


### PR DESCRIPTION
Given error on https://github.com/galaxyproject/galaxy/runs/6068791674?check_suite_focus=true, I assume what happened is the beta history panel wasn't on the page so the test tried to act on the old history panel but the test was against the beta history panel.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
