### PR TITLE
Rework admin job tables into reusable Galaxy job table component.

### DIFF
--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -16,106 +16,94 @@
         </p>
         <h3>Job Control</h3>
         <job-lock />
-        <b-alert v-if="loading" variant="info" show> Waiting for data </b-alert>
-        <div v-else>
-            <h3>Job Details</h3>
-            <b-row>
-                <b-col class="col-sm-4">
+        <h3>Job Details</h3>
+        <b-row>
+            <b-col class="col-sm-4">
+                <b-form-group
+                    label="Filters"
+                    label-for="show-all-running"
+                    description="Select whether or not to use the cutoff, or show all jobs.">
+                    <b-form-checkbox id="show-all-running" v-model="showAllRunning" switch @change="update">
+                        {{ showAllRunning ? "Showing all currently running jobs" : "Time cutoff applied to query" }}
+                    </b-form-checkbox>
+                </b-form-group>
+                <b-form name="jobs" @submit.prevent="onRefresh">
                     <b-form-group
-                        label="Filters"
-                        label-for="show-all-running"
-                        description="Select whether or not to use the cutoff, or show all jobs.">
-                        <b-form-checkbox id="show-all-running" v-model="showAllRunning" switch @change="update">
-                            {{ showAllRunning ? "Showing all currently running jobs" : "Time cutoff applied to query" }}
-                        </b-form-checkbox>
-                    </b-form-group>
-                    <b-form name="jobs" @submit.prevent="onRefresh">
-                        <b-form-group
-                            id="cutoff"
-                            label="Cutoff time period"
-                            :disabled="showAllRunning"
-                            description="in minutes">
-                            <b-input-group>
-                                <b-form-input id="cutoff" type="number" v-model="cutoffMin"> </b-form-input>
-                                <b-input-group-append>
-                                    <b-btn type="submit">Refresh</b-btn>
-                                </b-input-group-append>
-                            </b-input-group>
-                        </b-form-group>
-                    </b-form>
-                    <b-form-group
-                        label="Filter Jobs"
-                        label-for="filter-regex"
-                        description="by strings or regular expressions">
-                        <b-input-group id="filter-regex">
-                            <b-form-input
-                                v-model="filter"
-                                placeholder="Type to Search"
-                                @keyup.esc.native="filter = ''" />
-                            <b-input-group-append>
-                                <b-btn :disabled="!filter" @click="filter = ''">Clear (esc)</b-btn>
-                            </b-input-group-append>
-                        </b-input-group>
-                    </b-form-group>
-                </b-col>
-            </b-row>
-            <transition name="fade">
-                <b-form v-if="unfinishedJobs.length && selectedStopJobIds.length" @submit.prevent="onStopJobs">
-                    <b-form-group label="Stop Selected Jobs" description="Stop message will be displayed to the user">
+                        id="cutoff"
+                        label="Cutoff time period"
+                        :disabled="showAllRunning"
+                        description="in minutes">
                         <b-input-group>
-                            <b-form-input id="stop-message" v-model="stopMessage" placeholder="Stop message" required>
-                            </b-form-input>
+                            <b-form-input id="cutoff" type="number" v-model="cutoffMin"> </b-form-input>
                             <b-input-group-append>
-                                <b-btn type="submit">Submit</b-btn>
+                                <b-btn type="submit">Refresh</b-btn>
                             </b-input-group-append>
                         </b-input-group>
                     </b-form-group>
                 </b-form>
-            </transition>
-            <h4>Unfinished Jobs</h4>
-            <b-alert v-if="!unfinishedJobs.length" variant="secondary" show>
-                There are no unfinished jobs<template v-if="!showAllRunning">
-                    to show with current cutoff time of {{ cutoffMin }} minutes</template
-                >.
-            </b-alert>
-            <jobs-table
-                v-else
-                v-model="jobsItemsModel"
-                :fields="unfinishedJobFields"
-                :items="unfinishedJobs"
-                :filter="filter"
-                :tableCaption="runningTableCaption"
-                :busy="busy">
-                <template v-slot:head(selected)>
-                    <b-form-checkbox
-                        v-model="allSelected"
-                        :indeterminate="indeterminate"
-                        @change="toggleAll"></b-form-checkbox>
-                </template>
-                <template v-slot:cell(selected)="data">
-                    <b-form-checkbox
-                        v-model="selectedStopJobIds"
-                        :checked="allSelected"
-                        :key="data.index"
-                        :value="data.item['id']"></b-form-checkbox>
-                </template>
-            </jobs-table>
-
-            <template v-if="!showAllRunning">
-                <h4>Finished Jobs</h4>
-                <b-alert v-if="!finishedJobs.length" variant="secondary" show>
-                    There are no recently finished jobs to show with current cutoff time of {{ cutoffMin }} minutes.
-                </b-alert>
-                <jobs-table
-                    v-else
-                    :table-caption="finishedTableCaption"
-                    :fields="finishedJobFields"
-                    :items="finishedJobs"
-                    :filter="filter"
-                    :busy="busy">
-                </jobs-table>
+                <b-form-group
+                    label="Filter Jobs"
+                    label-for="filter-regex"
+                    description="by strings or regular expressions">
+                    <b-input-group id="filter-regex">
+                        <b-form-input v-model="filter" placeholder="Type to Search" @keyup.esc.native="filter = ''" />
+                        <b-input-group-append>
+                            <b-btn :disabled="!filter" @click="filter = ''">Clear (esc)</b-btn>
+                        </b-input-group-append>
+                    </b-input-group>
+                </b-form-group>
+            </b-col>
+        </b-row>
+        <transition name="fade">
+            <b-form v-if="unfinishedJobs.length && selectedStopJobIds.length" @submit.prevent="onStopJobs">
+                <b-form-group label="Stop Selected Jobs" description="Stop message will be displayed to the user">
+                    <b-input-group>
+                        <b-form-input id="stop-message" v-model="stopMessage" placeholder="Stop message" required>
+                        </b-form-input>
+                        <b-input-group-append>
+                            <b-btn type="submit">Submit</b-btn>
+                        </b-input-group-append>
+                    </b-input-group>
+                </b-form-group>
+            </b-form>
+        </transition>
+        <h4>Unfinished Jobs</h4>
+        <jobs-table
+            v-model="jobsItemsModel"
+            :fields="unfinishedJobFields"
+            :items="unfinishedJobs"
+            :filter="filter"
+            :tableCaption="runningTableCaption"
+            :noItemsMessage="runningNoJobsMessage"
+            :loading="loading"
+            :busy="busy">
+            <template v-slot:head(selected)>
+                <b-form-checkbox
+                    v-model="allSelected"
+                    :indeterminate="indeterminate"
+                    @change="toggleAll"></b-form-checkbox>
             </template>
-        </div>
+            <template v-slot:cell(selected)="data">
+                <b-form-checkbox
+                    v-model="selectedStopJobIds"
+                    :checked="allSelected"
+                    :key="data.index"
+                    :value="data.item['id']"></b-form-checkbox>
+            </template>
+        </jobs-table>
+
+        <template v-if="!showAllRunning">
+            <h4>Finished Jobs</h4>
+            <jobs-table
+                :table-caption="finishedTableCaption"
+                :fields="finishedJobFields"
+                :items="finishedJobs"
+                :filter="filter"
+                :noItemsMessage="finishedNoJobsMessage"
+                :loading="loading"
+                :busy="busy">
+            </jobs-table>
+        </template>
     </div>
 </template>
 
@@ -194,6 +182,17 @@ export default {
         },
         runningTableCaption() {
             return `These jobs are unfinished and have had their state updated in the previous ${this.cutoffMin} minutes. For currently running jobs, the "Last Update" column should indicate the runtime so far.`;
+        },
+        finishedNoJobsMessage() {
+            return `There are no recently finished jobs to show with current cutoff time of ${this.cutoffMin} minutes.`;
+        },
+        runningNoJobsMessage() {
+            let message = `There are no unfinished jobs`;
+            if (!this.showAllRunning) {
+                message += ` to show with current cutoff time of ${this.cutoffMin} minutes`;
+            }
+            message += ".";
+            return message;
         },
     },
     methods: {

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <h2 id="jobs-title">Jobs</h2>
-        <b-alert v-if="this.message" :variant="galaxyKwdToBootstrap(status)" show>
+        <b-alert v-if="this.message" :variant="status" show>
             {{ message }}
         </b-alert>
         <p>
@@ -126,6 +126,7 @@ import JobsTable from "components/admin/JobsTable";
 import JobLock from "./JobLock";
 import JOB_STATES_MODEL from "mvc/history/job-states-model";
 import { commonJobFields } from "./JobFields";
+import { errorMessageAsString } from "utils/simple-error";
 
 function cancelJob(jobId, message) {
     const url = `${getAppRoot()}api/jobs/${jobId}`;
@@ -153,7 +154,7 @@ export default {
             stopMessage: "",
             filter: "",
             message: "",
-            status: "",
+            status: "info",
             loading: true,
             busy: true,
             cutoffMin: 5,
@@ -212,14 +213,13 @@ export default {
                 .get(`${getAppRoot()}api/jobs?${params}`)
                 .then((response) => {
                     this.jobs = response.data;
-                    this.message = response.data.message;
-                    this.status = response.data.status;
                     this.loading = false;
                     this.busy = false;
+                    this.status = "info";
                 })
                 .catch((error) => {
-                    this.message = error.response.data.err_msg;
-                    this.status = "error";
+                    this.message = errorMessageAsString(error);
+                    this.status = "danger";
                     console.log(error.response);
                 });
         },
@@ -235,23 +235,6 @@ export default {
         },
         toggleAll(checked) {
             this.selectedStopJobIds = checked ? this.jobsItemsModel.reduce((acc, j) => [...acc, j["id"]], []) : [];
-        },
-        galaxyKwdToBootstrap(status) {
-            let variant = "info";
-            if (status !== "") {
-                variant = status;
-            }
-            const galaxyKwdToBoostrapDict = {
-                done: "success",
-                info: "info",
-                warning: "warning",
-                error: "danger",
-            };
-            if (variant in galaxyKwdToBoostrapDict) {
-                return galaxyKwdToBoostrapDict[variant];
-            } else {
-                return variant;
-            }
         },
     },
     created() {

--- a/client/src/components/admin/JobsTable.vue
+++ b/client/src/components/admin/JobsTable.vue
@@ -10,9 +10,16 @@
             caption-top
             @row-clicked="toggleDetails"
             v-model="innerValue"
-            :busy="busy">
+            :busy="busy"
+            show-empty>
             <template v-slot:table-caption>
                 {{ tableCaption }}
+            </template>
+            <template v-slot:empty>
+                <LoadingSpan v-if="loading" message="Loading jobs" />
+                <b-alert v-else class="no-jobs" variant="info" show>
+                    {{ noItemsMessage }}
+                </b-alert>
             </template>
             <template v-slot:cell(update_time)="data">
                 <utc-date :date="data.value" mode="elapsed" />
@@ -33,9 +40,10 @@
 <script>
 import UtcDate from "components/UtcDate";
 import JobDetails from "components/JobInformation/JobDetails";
+import LoadingSpan from "components/LoadingSpan";
 
 export default {
-    components: { UtcDate, JobDetails },
+    components: { UtcDate, JobDetails, LoadingSpan },
     props: {
         tableCaption: {
             type: String,
@@ -54,6 +62,14 @@ export default {
         busy: {
             type: Boolean,
             required: true,
+        },
+        loading: {
+            type: Boolean,
+            default: false,
+        },
+        noItemsMessage: {
+            type: String,
+            default: "No jobs to display.",
         },
         value: {},
     },

--- a/client/src/components/admin/JobsTable.vue
+++ b/client/src/components/admin/JobsTable.vue
@@ -1,0 +1,119 @@
+<template>
+    <div>
+        <b-table
+            :fields="fields"
+            :items="items"
+            :filter="filter"
+            hover
+            responsive
+            striped
+            caption-top
+            @row-clicked="toggleDetails"
+            v-model="innerValue"
+            :busy="busy">
+            <template v-slot:table-caption>
+                {{ tableCaption }}
+            </template>
+            <template v-slot:cell(update_time)="data">
+                <utc-date :date="data.value" mode="elapsed" />
+            </template>
+            <template v-slot:row-details="row">
+                <job-details :job="row.item" />
+            </template>
+            <template v-for="(index, name) in $slots" v-slot:[name]>
+                <slot :name="name" />
+            </template>
+            <template v-for="(index, name) in $scopedSlots" v-slot:[name]="data">
+                <slot :name="name" v-bind="data"></slot>
+            </template>
+        </b-table>
+    </div>
+</template>
+
+<script>
+import UtcDate from "components/UtcDate";
+import JobDetails from "components/JobInformation/JobDetails";
+
+export default {
+    components: { UtcDate, JobDetails },
+    props: {
+        tableCaption: {
+            type: String,
+            required: true,
+        },
+        fields: {
+            required: true,
+        },
+        items: {
+            required: true,
+        },
+        filter: {
+            type: String,
+            required: true,
+        },
+        busy: {
+            type: Boolean,
+            required: true,
+        },
+        value: {},
+    },
+    data() {
+        return {
+            innerValue: this.value,
+        };
+    },
+    watch: {
+        innerValue(newVal) {
+            this.$emit("input", newVal);
+        },
+        items(newVal) {
+            this.setCellVariants(newVal);
+        },
+    },
+    created() {
+        this.setCellVariants(this.items);
+    },
+    methods: {
+        setCellVariants(items) {
+            items.forEach((item) => {
+                item._cellVariants = { state: this.translateState(item.state) };
+            });
+        },
+        toggleDetails(item) {
+            this.$set(item, "_showDetails", !item._showDetails);
+        },
+        translateState(state) {
+            const translateDict = {
+                ok: "success",
+                error: "danger",
+                new: "primary",
+                queued: "secondary",
+                running: "info",
+                upload: "dark",
+            };
+            return translateDict[state] || "primary";
+        },
+    },
+};
+</script>
+
+<style>
+/* Can not be scoped because of command line tdClass */
+.break-word {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.info-frame-container {
+    overflow: hidden;
+    padding-top: 100%;
+    position: relative;
+}
+.info-frame-container iframe {
+    border: 0;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
+</style>


### PR DESCRIPTION
In addition to allowing reuse, this reduces duplication in the existing admin code a bit and aligns state handling and such with other places in the codebase. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run some long running jobs as admin, go into Admin -> Jobs to see the components.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
