### PR TITLE
Process pasted content with tus

### DIFF
--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -19,17 +19,18 @@ function submitPayload(payload, cnf) {
         });
 }
 
-function tusUpload(data, index, tusEndpoint, cnf) {
+function tusUpload(uploadables, index, data, tusEndpoint, cnf) {
+    // uploadables must be an array of files or blobs with a name property
     const startTime = performance.now();
     const chunkSize = cnf.chunkSize;
-    const file = data.files[index];
-    if (!file) {
-        // We've uploaded all files, delete files from data and submit fetch payload
+    const uploadable = uploadables[index];
+    if (!uploadable) {
+        // We've uploaded all files or blobs; delete files from data and submit fetch payload
         delete data["files"];
         return submitPayload(data, cnf);
     }
-    console.debug(`Starting chunked upload for ${file.name} [chunkSize=${chunkSize}].`);
-    const upload = new tus.Upload(file, {
+    console.debug(`Starting chunked upload for ${uploadable.name} [chunkSize=${chunkSize}].`);
+    const upload = new tus.Upload(uploadable, {
         endpoint: tusEndpoint,
         chunkSize: chunkSize,
         metadata: data.payload,
@@ -44,13 +45,13 @@ function tusUpload(data, index, tusEndpoint, cnf) {
         },
         onSuccess: function () {
             console.log(
-                `Upload of ${upload.file.name} to ${upload.url} took ${(performance.now() - startTime) / 1000} seconds`
+                `Upload of ${uploadable.name} to ${upload.url} took ${(performance.now() - startTime) / 1000} seconds`
             );
             data[`files_${index}|file_data`] = {
                 session_id: upload.url.split("/").at(-1),
-                name: upload.file.name,
+                name: uploadable.name,
             };
-            tusUpload(data, index + 1, tusEndpoint, cnf);
+            tusUpload(uploadables, index + 1, data, tusEndpoint, cnf);
         },
     });
     // Check if there are any previous uploads to continue.
@@ -60,7 +61,6 @@ function tusUpload(data, index, tusEndpoint, cnf) {
             console.log("previous Upload", previousUploads);
             upload.resumeFromPreviousUpload(previousUploads[0]);
         }
-
         // Start the upload
         upload.start();
     });
@@ -91,12 +91,30 @@ export function submitUpload(config) {
         cnf.error(data.error_message);
         return;
     }
-    if (!data.files.length) {
-        // No files attached, don't need to use TUS uploader
-        return submitPayload(data, cnf);
-    }
     const tusEndpoint = `${getAppRoot()}api/upload/resumable_upload/`;
-    tusUpload(data, 0, tusEndpoint, cnf);
+
+    if (isPasted(data)) {
+        if (data.targets.length && data.targets[0].elements.length) {
+            const pasted = data.targets[0].elements[0];
+            if (isUrl(pasted)) {
+                return submitPayload(data, cnf);
+            } else {
+                const blob = new Blob([pasted.paste_content]);
+                blob.name = data.targets[0].elements[0].name || "default";
+                return tusUpload([blob], 0, data, tusEndpoint, cnf);
+            }
+        }
+    } else {
+        return tusUpload(data.files, 0, data, tusEndpoint, cnf);
+    }
+}
+
+function isPasted(data) {
+    return !data.files.length;
+}
+
+function isUrl(pasted_item) {
+    return pasted_item.src == "url";
 }
 
 (($) => {


### PR DESCRIPTION
This fixes #13558 and #13610, or so I hope.

This does not include any new tests. I've tested it manually by uploading multiple files and multiple pasted items - both non-url and url content at the same time (from the same data upload modal).



(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Upload multiple data in same modal: files, pasted content items, pasted urls. Do upload, then check data; verify that all datasets uploaded correctly and the issue described in #13558 is no longer present.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
