### PR TITLE
[22.01] Do not store toolbox on ToolPanelViewSearch

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -230,7 +230,7 @@ class ConfiguresGalaxyMixin:
 
     def reindex_tool_search(self):
         # Call this when tools are added or removed.
-        self.toolbox_search.build_index(tool_cache=self.tool_cache)
+        self.toolbox_search.build_index(tool_cache=self.tool_cache, toolbox=self.toolbox)
         self.tool_cache.reset_status()
 
     def _set_enabled_container_types(self):

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -63,7 +63,7 @@ class ToolBoxSearch:
         for panel_view in toolbox.panel_views():
             panel_view_id = panel_view.id
             panel_index_dir = os.path.join(index_dir, panel_view_id)
-            panel_searches[panel_view_id] = ToolPanelViewSearch(toolbox, panel_view_id, panel_index_dir, index_help=index_help)
+            panel_searches[panel_view_id] = ToolPanelViewSearch(panel_view_id, panel_index_dir, index_help=index_help)
         self.panel_searches = panel_searches
         # We keep track of how many times the tool index has been rebuilt.
         # We start at -1, so that after the first index the count is at 0,
@@ -71,10 +71,10 @@ class ToolBoxSearch:
         # reindexing if the index count is equal to the toolbox reload count.
         self.index_count = -1
 
-    def build_index(self, tool_cache, index_help: bool = True) -> None:
+    def build_index(self, tool_cache, toolbox, index_help: bool = True) -> None:
         self.index_count += 1
         for panel_search in self.panel_searches.values():
-            panel_search.build_index(tool_cache, index_help=index_help)
+            panel_search.build_index(tool_cache, toolbox, index_help=index_help)
 
     def search(self, *args, **kwd) -> List[str]:
         panel_view = kwd.pop("panel_view")
@@ -90,7 +90,7 @@ class ToolPanelViewSearch:
     the Whoosh search library.
     """
 
-    def __init__(self, toolbox, panel_view_id: str, index_dir: str, index_help: bool = True):
+    def __init__(self, panel_view_id: str, index_dir: str, index_help: bool = True):
         self.schema = Schema(id=ID(stored=True, unique=True),
                              old_id=ID,
                              stub=KEYWORD,
@@ -101,14 +101,13 @@ class ToolPanelViewSearch:
                              labels=KEYWORD)
         self.rex = analysis.RegexTokenizer()
         self.index_dir = index_dir
-        self.toolbox = toolbox
         self.panel_view_id = panel_view_id
         self.index = self._index_setup()
 
     def _index_setup(self) -> index.Index:
         return get_or_create_index(index_dir=self.index_dir, schema=self.schema)
 
-    def build_index(self, tool_cache, index_help: bool = True) -> None:
+    def build_index(self, tool_cache, toolbox, index_help: bool = True) -> None:
         """
         Prepare search index for tools loaded in toolbox.
         Use `tool_cache` to determine which tools need indexing and which tools should be expired.
@@ -132,8 +131,8 @@ class ToolPanelViewSearch:
             for tool_id in tool_ids_to_remove:
                 writer.delete_by_term('id', tool_id)
             for tool_id in tool_cache._new_tool_ids - indexed_tool_ids:
-                tool = self.toolbox.get_tool(tool_id)
-                if tool and tool.is_latest_version and self.toolbox.panel_has_tool(tool, self.panel_view_id):
+                tool = toolbox.get_tool(tool_id)
+                if tool and tool.is_latest_version and toolbox.panel_has_tool(tool, self.panel_view_id):
                     if tool.hidden:
                         # we check if there is an older tool we can return
                         if tool.lineage:


### PR DESCRIPTION
For issue #13775 

Updated tools have been disappearing from tool search results until the next time galaxy is restarted. The `ToolPanelViewSearch` has `self.toolbox` assigned in `__init__` and this is not updated when `app.toolbox` is updated for a new tool. The out of date `self.toolbox` is used in the `build_index` function.

This change is passing `app.toolbox` to `ToolBoxSearch.build_index` and passing it from there to `ToolPanelViewSearch.build_index` so that the newly installed tool can be found in the toolbox when the search index is updated.  This is the only place where `ToolPanelViewSearch.toolbox` is used so `ToolPanelViewSearch` does not need `self.toolbox`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
