### PR TITLE
Adjust tours and tour tests to new history

### DIFF
--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -91,8 +91,6 @@ steps:
       element: '.center-panel'
       intro: "Your tool is loaded into the main Galaxy page and ready for use."
       position: "right"
-      #backdropContainer: 'background'
-      #backdrop: true
 
     - title: "Tool parameters"
       element: '.center-panel .portlet-content'
@@ -120,44 +118,39 @@ steps:
               grey this means you are queued and need to wait until your tool can be started. If your dataset turns into red, an error has occurred. Please report the bug to the Galaxy team with the bug report button."
       position: "left"
 
-    - title: "Rename history"
-      element: "#current-history-panel > div.controls > div.title > div"
-      intro: "Name your history here and press enter."
-      position: "left"
-      preclick:
-        - "#current-history-panel > div.controls > div.title > div"
-
     - title: "View dataset"
-      element: "#current-history-panel .fa-eye:eq(0)"
+      element: "#current-history-panel div.content-item button[title='Display']"
       intro: "View your dataset by clicking the eye button."
       position: "left"
-      #preclick:
-      #  - "#current-history-panel .fa-eye:eq(0)"
 
     - title: "Rename dataset"
-      element: "#current-history-panel .fa-pencil:eq(0)"
+      element: "#current-history-panel div.content-item button[title='Edit attributes']"
       intro: "Rename your dataset by clicking the pencil button."
-      position: "left"
-      #preclick:
-      #  - "#current-history-panel .fa-pencil:eq(0)"
-
-    - title: "Remove dataset"
-      element: "#current-history-panel .fa-times:eq(0)"
-      intro: "Delete your dataset by clicking the x-button."
       position: "left"
 
     - title: "Dataset information"
-      element: "div.title-bar.clear:eq(0)"
+      element: "div.content-item .content-title"
+      intro: "This is your dataset. You can get more informations and options like different visualizations by clicking on it."
+      position: "left"
+      postclick:
+        - "div.content-item .content-title"
+
+    - title: "Remove dataset"
+      element: "#current-history-panel div.content-item button[title='Delete']"
+      intro: "Delete your dataset by clicking the trash-button."
+      position: "left"
+
+    - title: "Dataset information"
+      element: "#current-history-panel div.content-item button[title='Dataset Details']"
       intro: "Clicking on your dataset provides you with more information regarding your dataset (e.g. filetype or size)."
       position: "left"
       preclick:
-        - "div.title-bar.clear:eq(0)"
+        - "#current-history-panel div.content-item button[title='Dataset Details']"
 
     - title: "Re-run tool"
-      element: "#current-history-panel .fa-redo:first"
+      element: "#current-history-panel div.content-item button[title='Run Job Again']"
       intro: "By clicking the reload button, you can re-run your tool again (e.g. with different parameters or on another dataset)."
       position: "left"
-
 
     - title: "Panel collapse"
       element: "#left > div.unified-panel-footer > div.panel-collapse.left"

--- a/config/plugins/tours/core.history.yaml
+++ b/config/plugins/tours/core.history.yaml
@@ -30,7 +30,7 @@ steps:
       position: "top"
 
     - title: "Insert URLs"
-      element: ".upload-text-content:first"
+      element: ".upload-text-content"
       intro: "URLs separated by a line break are automatically downloaded by Galaxy."
       position: "bottom"
       textinsert: |
@@ -51,87 +51,77 @@ steps:
       position: "left"
 
     - title: "Dataset information"
-      element: "div.title-bar.clear:eq(0)"
+      element: "div.content-item .content-title"
       intro: "This is one of your uploaded datasets. You can get more informations and options like different visualizations by clicking on it."
       position: "left"
       postclick:
-        - "div.title-bar.clear:eq(0)"
+        - "div.content-item .content-title"
 
     - title: "Metadata"
-      element: "#current-history-panel > ul.list-items > div:nth-child(1) > div.details > div.summary > div.datatype > label"
+      element: "#current-history-panel div.content-item span.datatype"
       intro: "Galaxy has assigned a datatype to your dataset during upload, which you can see here."
       position: "left"
 
-    - element: "#current-history-panel > ul.list-items > div:nth-child(1) > div.details > div.actions.clear > div.left > a.download-btn.icon-btn"
+    - element: "#current-history-panel div.content-item button[title='Download']"
       title: "Download your dataset"
       intro: "You can download every dataset by using the floppy disc symbol."
       position: "left"
 
-    - element: "#current-history-panel > ul.list-items > div:nth-child(1) > div.details > div.actions.clear > div.left > a.icon-btn.params-btn"
+    - element: "#current-history-panel div.content-item button[title='Dataset Details']"
       title: "Even more information"
       intro: "Get an overview of all metadata associated with your dataset by using the Information symbol."
       position: "left"
       preclick:
-        - "#current-history-panel > ul.list-items > div:nth-child(1) > div.details > div.actions.clear > div.left > a.icon-btn.params-btn"
+        - "#current-history-panel div.content-item button[title='Dataset Details']"
 
-    - element: "#current-history-panel > ul.list-items > div:nth-child(1) > div.primary-actions > a.icon-btn.display-btn"
+    - element: "#current-history-panel div.content-item button[title='Display']"
       title: "Inspect your data"
       intro: "The eye symbol can be used to look at your data."
       position: "left"
       preclick:
-        - "#current-history-panel > ul.list-items > div:nth-child(1) > div.primary-actions > a.icon-btn.display-btn"
+        - "#current-history-panel div.content-item button[title='Display']"
 
-    - element: "#current-history-panel > ul.list-items > div:nth-child(1) > div.primary-actions > a.icon-btn.edit-btn"
+    - element: "#current-history-panel div.content-item button[title='Edit attributes']"
       title: "Edit metadata"
       intro: "With the pencil button you can edit metadata attributes of your dataset, like the associated filetype or the dataset name."
       position: "left"
       preclick:
-        - "#current-history-panel > ul.list-items > div:nth-child(1) > div.primary-actions > a.icon-btn.edit-btn"
+        - "#current-history-panel div.content-item button[title='Edit attributes']"
 
-    - element: "#current-history-panel > ul.list-items > div:nth-child(1) > div.primary-actions > a.icon-btn.delete-btn"
+    - element: "#current-history-panel div.content-item button[title='Delete']"
       title: "Remove datasets"
       intro: "You can remove a dataset from the history with the cross symbol."
       position: "left"
       postclick:
-        - "#current-history-panel > ul.list-items > div:nth-child(1) > div.primary-actions > a.icon-btn.delete-btn"
+        - "#current-history-panel div.content-item button[title='Delete']"
 
-    - element: "#current-history-panel > .controls > .subtitle .toggle-deleted-link"
-      title: "Include all deleted datasets"
-      intro: "By default your history will hide all deleted datasets from you. You can visualize them by toggling this button."
+    - element: "#current-history-panel input[data-description='filter text input']"
+      title: "Filter your datasets"
+      intro: "By default your history will hide all deleted datasets from you. You can visualize them by filtering."
+      textinsert: "deleted=true"
       position: "bottom"
-      postclick:
-        - "#current-history-panel > .controls > .subtitle .toggle-deleted-link"
 
-    - element: "#current-history-panel > ul.list-items > div:nth-child(1) > div.warnings > div > a.undelete-link"
+    - element: "#current-history-panel div.content-item button[title='Undelete']"
       title: "Undeleting a dataset"
       intro: |
             Galaxy datasets are only marked as deleted and can be recovered by clicking this link.
             Please note that datasets marked as deleted can be purged by your administrator at any time.
       position: "bottom"
       postclick:
-        - "#current-history-panel > ul.list-items > div:nth-child(1) > div.warnings > div > a.undelete-link"
+        - "#current-history-panel div.content-item button[title='Undelete']"
 
-    - element: "#current-history-panel > div.controls > div.title > div"
-      title: "Change your History name"
-      intro: "You can change the history name clicking on the title."
-      position: "bottom"
-      preclick:
-        - "#current-history-panel > div.controls > div.title > div"
-
-    - element: "#current-history-panel > div.controls > div.search > div > input"
+    - element: "#current-history-panel [data-description='filter text input']"
       title: "Search your History"
       intro: "You can filter your history by typing your search term in here. Galaxy supports more advanced filters that can be seen here."
       position: "left"
       textinsert: "WWFSMD"
-      preclick:
-        - "#current-history-panel > div.controls > div.search > div > input"
 
-    - element: "#history-options-button"
+    - element: "#current-history-panel [title='Show history options']"
       title: "History Options"
       intro: "In the History menu you will find a lot more useful History options."
       position: "left"
       postclick:
-        - "#history-options-button"
+        - "#current-history-panel [title='Show history options']"
 
     - title: "Enjoy your Galaxy Histories"
       intro: "Thanks for taking this tour! Happy research with Galaxy!"

--- a/config/plugins/tours/core.scratchbook.yaml
+++ b/config/plugins/tours/core.scratchbook.yaml
@@ -21,7 +21,7 @@ steps:
       postclick:
         - "#btn-new"
 
-    - element: ".upload-text-content:first"
+    - element: ".upload-text-content"
       intro: "...and paste content into the text area field."
       position: "top"
       textinsert: |
@@ -34,17 +34,17 @@ steps:
         7 0.000 0.000
         8 0.000 0.000
 
-    - element: ".upload-settings:first"
+    - element: ".upload-settings"
       intro: "Now, we may further configure the upload content."
       position: "right"
       postclick:
-        - ".upload-settings:first"
+        - ".upload-settings"
 
-    - element: ".upload-space_to_tab:first"
+    - element: ".upload-space_to_tab"
       intro: "...by specifying that all spaces in our table should be converted into tabs."
       position: "left"
       postclick:
-        - ".upload-space_to_tab:first"
+        - ".upload-space_to_tab"
 
     - element: "#btn-start"
       intro: "Upload the data into your Galaxy history."
@@ -68,11 +68,11 @@ steps:
       intro: "This is your history. It contains all datasets you are currently working with including our uploaded table."
       position: "left"
 
-    - element: "#current-history-panel .fa-eye:first"
+    - element: "#current-history-panel div.content-item button[title='Display']"
       intro: "Clicking the eye-icon usually displays a dataset in the center panel."
       position: "left"
       postclick:
-        - "#current-history-panel .fa-eye:first"
+        - "#current-history-panel div.content-item button[title='Display']"
 
     - element: "#frame-0"
       intro: "However while in Scratchbook mode, the dataset will be shown as resizable window."

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1423,12 +1423,6 @@ class NavigatesGalaxy(HasDriver):
             option_component = option_label_or_component
             option_component.wait_for_and_click()
 
-    def use_legacy_history(self):
-        if self.is_beta_history():
-            self.components.history_panel.histories_operation_menu.wait_for_and_click()
-            self.components.history_panel.options_use_legacy_history.wait_for_and_click()
-            self.components.history_panel.legacy.wait_for_present()
-
     def use_beta_history(self):
         if not self.is_beta_history():
             self.click_history_option(self.components.history_panel.options_use_beta_history)
@@ -1728,10 +1722,7 @@ class NavigatesGalaxy(HasDriver):
         sleep_on_steps = sleep_on_steps or {}
         if tour_callback is None:
             tour_callback = NullTourCallback()
-
         self.home()
-        self.use_legacy_history()
-
         with open(path) as f:
             tour_dict = yaml.safe_load(f)
         steps = tour_dict["steps"]

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -272,7 +272,7 @@ history_panel:
     options_show_history_structure:
       type: xpath
       selector: '//a[contains(text(), "Show Structure")]'
-    options_show_export_history_to_file: 'a[title="Export History to File"]'
+    options_show_export_history_to_file: 'a[data-description="export to file"]'
     options_use_beta_history:
       type: xpath
       selector: '//a[text()="Use Beta History Panel"]'

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -22,7 +22,6 @@ class HistoryImportExportFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestC
 
     @selenium_test
     def test_history_import_export(self):
-        self.use_legacy_history()
         email = self.get_logged_in_user()["email"]
         user_ftp_dir = os.path.join(self.ftp_dir(), email)
         os.makedirs(user_ftp_dir)


### PR DESCRIPTION
Resolves #13723. This PR removes the final occurrence of the `use_legacy_history` selenium test transition helper for tour and the history export tests. The history renaming steps have been removed from the tours since that feature is not available for anonymous users. Selectors have been modified such that they comply with regular `document.querySelector` arguments and not relying on jQuery/Sizzle for now.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
