### PR TITLE
Fixes for sharing component error handling.

### DIFF
--- a/client/src/components/Sharing/ErrorMessage.vue
+++ b/client/src/components/Sharing/ErrorMessage.vue
@@ -1,0 +1,31 @@
+<template>
+    <span>
+        <span v-for="(part, index) in parts" :key="index">
+            {{ part }}
+            <a v-if="index < parts.length - 1" :href="link" class="require-login-link"> logged in </a>
+        </span>
+    </span>
+</template>
+
+<script>
+export default {
+    props: {
+        message: {
+            type: String,
+            required: true,
+        },
+        root: {
+            type: String,
+            required: true,
+        },
+    },
+    computed: {
+        link() {
+            return `${this.root}login?redirect=${encodeURIComponent(window.location)}`;
+        },
+        parts() {
+            return this.message.split("logged in");
+        },
+    },
+};
+</script>

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -244,6 +244,9 @@ class NavigatesGalaxy(HasDriver):
     def go_to_workflow_sharing(self, workflow_id: str) -> None:
         self.driver.get(self.build_url(f"workflow/sharing?id={workflow_id}"))
 
+    def go_to_history_sharing(self, history_id: str) -> None:
+        self.driver.get(self.build_url(f"histories/sharing?id={history_id}"))
+
     def switch_to_main_panel(self):
         self.driver.switch_to.frame(GALAXY_MAIN_FRAME_ID)
 
@@ -584,19 +587,9 @@ class NavigatesGalaxy(HasDriver):
         return "".join(random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(len))
 
     def submit_login(self, email, password=None, assert_valid=True, retries=0):
-        if password is None:
-            password = self.default_password
-        login_info = {
-            "login": email,
-            "password": password,
-        }
         self.components.masthead.register_or_login.wait_for_and_click()
         self.sleep_for(WAIT_TYPES.UX_RENDER)
-        form = self.wait_for_visible(self.navigation.login.selectors.form)
-        self.fill(form, login_info)
-        self.snapshot("logging-in")
-        self.wait_for_and_click(self.navigation.login.selectors.submit)
-        self.snapshot("login-submitted")
+        self.fill_login_and_submit(email, password=password)
         if assert_valid:
             try:
                 self.wait_for_logged_in()
@@ -607,6 +600,19 @@ class NavigatesGalaxy(HasDriver):
                 else:
                     raise
             self.snapshot("logged-in")
+
+    def fill_login_and_submit(self, email, password=None):
+        if password is None:
+            password = self.default_password
+        login_info = {
+            "login": email,
+            "password": password,
+        }
+        form = self.wait_for_visible(self.navigation.login.selectors.form)
+        self.fill(form, login_info)
+        self.snapshot("logging-in")
+        self.wait_for_and_click(self.navigation.login.selectors.submit)
+        self.snapshot("login-submitted")
 
     def register(self, email=None, password=None, username=None, confirm=None, assert_valid=True):
         if email is None:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -233,13 +233,16 @@ class NavigatesGalaxy(HasDriver):
         self.get()
         self.components.masthead._.wait_for_visible()
 
-    def trs_search(self) -> None:
+    def go_to_trs_search(self) -> None:
         self.driver.get(self.build_url("workflows/trs_search"))
         self.components.masthead._.wait_for_visible()
 
-    def trs_by_id(self) -> None:
+    def go_to_trs_by_id(self) -> None:
         self.driver.get(self.build_url("workflows/trs_import"))
         self.components.masthead._.wait_for_visible()
+
+    def go_to_workflow_sharing(self, workflow_id: str) -> None:
+        self.driver.get(self.build_url(f"workflow/sharing?id={workflow_id}"))
 
     def switch_to_main_panel(self):
         self.driver.switch_to.frame(GALAXY_MAIN_FRAME_ID)

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -26,6 +26,7 @@ _:  # global stuff
       info: '.alert-info'
       donelarge: '.donemessagelarge'
       infolarge: '.infomessagelarge'
+      require_login: 'a.require-login-link'
 
 masthead:
 

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -89,7 +89,8 @@ def require_login(verb="perform this action", use_panels=False):
                     redirect_url = f"{redirect_url}?{query_string}"
                 href = url_for(controller="login", redirect=redirect_url)
                 return trans.show_error_message(
-                    f'You must be <a target="galaxy_main" href="{href}">logged in</a> to {verb}.', use_panels=use_panels
+                    f'You must be <a target="galaxy_main" href="{href}" class="require-login-link">logged in</a> to {verb}.',
+                    use_panels=use_panels,
                 )
 
         return decorator

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -367,7 +367,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         )
 
     @web.expose
-    @web.require_login("Share or export Galaxy workflows")
+    @web.require_login("share or export Galaxy workflows")
     def sharing(self, trans, id, **kwargs):
         """Handle workflow sharing."""
         session = trans.sa_session

--- a/lib/galaxy_test/selenium/test_history_sharing.py
+++ b/lib/galaxy_test/selenium/test_history_sharing.py
@@ -120,3 +120,20 @@ class HistorySharingTestCase(SeleniumTestCase):
 
             xpath = f'//span[contains(text(), "{user_email}")]'
             self.wait_for_xpath_visible(xpath)
+
+
+class HistoryRequiresLoginSeleniumTestCase(SeleniumTestCase):
+
+    ensure_registered = True
+
+    @selenium_test
+    def test_share_history_login_redirect(self):
+        user_email = self.get_logged_in_user()["email"]
+        history_id = self.current_history_id()
+        self.logout()
+        self.go_to_history_sharing(history_id)
+        self.assert_error_message(contains="Must be logged in to manage Galaxy items")
+        self.components._.messages.require_login.wait_for_and_click()
+        self.fill_login_and_submit(user_email)
+        self.wait_for_logged_in()
+        self.wait_for_selector(".make-accessible")

--- a/lib/galaxy_test/selenium/test_workflow_sharing.py
+++ b/lib/galaxy_test/selenium/test_workflow_sharing.py
@@ -15,15 +15,10 @@ class WorkflowSharingTestCase(SeleniumTestCase):
         workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
         self.logout()
         self.go_to_workflow_sharing(workflow_id)
-        modal = self.components._.messages.error.wait_for_present()
-        assert modal.text == "You must be logged in to Share or export Galaxy workflows."
-        login_link = modal.find_element_by_tag_name("a")
-        assert login_link.text == "logged in"
+        self.assert_error_message(contains="You must be logged in to share or export Galaxy workflows.")
         self.sleep_for(self.wait_types.UX_RENDER)
-        login_link.click()
-        form = self.wait_for_visible(self.navigation.login.selectors.form)
-        self.fill(form, {"login": user_email, "password": self.default_password})
-        self.wait_for_and_click(self.navigation.login.selectors.submit)
+        self.components._.messages.require_login.wait_for_and_click()
+        self.fill_login_and_submit(user_email)
         self.wait_for_logged_in()
         accessible_via_link_button = self.wait_for_selector(".make-accessible")
         accessible_via_link_button.click()

--- a/lib/galaxy_test/selenium/test_workflow_sharing.py
+++ b/lib/galaxy_test/selenium/test_workflow_sharing.py
@@ -14,8 +14,7 @@ class WorkflowSharingTestCase(SeleniumTestCase):
         user_email = self.get_logged_in_user()["email"]
         workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
         self.logout()
-        sharing_url = f"workflow/sharing?id={workflow_id}"
-        self.get(sharing_url)
+        self.go_to_workflow_sharing(workflow_id)
         modal = self.components._.messages.error.wait_for_present()
         assert modal.text == "You must be logged in to Share or export Galaxy workflows."
         login_link = modal.find_element_by_tag_name("a")

--- a/test/integration_selenium/test_trs_import.py
+++ b/test/integration_selenium/test_trs_import.py
@@ -60,7 +60,7 @@ class TrsImportTestCase(SeleniumIntegrationTestCase):
         self.assert_workflow_imported(WORKFLOW_NAME)
 
     def test_import_by_search_dockstore(self):
-        self.trs_search()
+        self.go_to_trs_search()
         self.components.trs_search.search.wait_for_and_send_keys("This is the documentation for the workflow.")
         self.components.trs_search.search_result(
             workflow_name="galaxy-workflow-dockstore-example-1"
@@ -71,7 +71,7 @@ class TrsImportTestCase(SeleniumIntegrationTestCase):
         self.assert_workflow_imported("Test Workflow")
 
     def test_import_by_organization_search_dockstore(self):
-        self.trs_search()
+        self.go_to_trs_search()
         self.components.trs_search.search.wait_for_and_send_keys("organization: iwc-workflows")
         self.components.trs_search.search_result(workflow_name=TRS_NAME).wait_for_and_click()
         self.components.trs_search.import_version(version="v0.4").wait_for_and_click()
@@ -82,7 +82,7 @@ class TrsImportTestCase(SeleniumIntegrationTestCase):
         self.screenshot("workflow_imported_via_dockstore_search")
 
     def test_import_by_search_workflowhub(self):
-        self.trs_search()
+        self.go_to_trs_search()
         self.components.trs_search.select_server_button.wait_for_and_click()
         self.components.trs_search.select_server(server="workflowhub").wait_for_and_click()
         self.components.trs_search.search.wait_for_and_send_keys(WORKFLOW_NAME)
@@ -99,7 +99,7 @@ class TrsImportTestCase(SeleniumIntegrationTestCase):
         self._import_by_id(TRS_ID_WORKFLOWHUB, server="workflowhub")
 
     def _import_by_id(self, trs_id, server):
-        self.trs_by_id()
+        self.go_to_trs_by_id()
         self.components.trs_import.select_server_button.wait_for_and_click()
         self.components.trs_import.select_server(server=server).wait_for_and_click()
         self.components.trs_import.input.wait_for_and_send_keys(trs_id)


### PR DESCRIPTION
I want to convert the workflow sharing component over to the Vue - to reduce mako, reuse the Vue component, provide a common look and feel, exercise the new workflow sharing APIs from (https://github.com/galaxyproject/galaxy/pull/13719).

In setting up tests for that - I noticed bugs in both the newer Vue component (errors never shown) and older mako error handling (casing of exception). This fixes error handling across those components and fixes the bugs in both. It also adds a history test to match the existing workflow sharing test of login redirect, etc... 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
