### PR TITLE
Replace 2 uses of deprecated ``imp`` module

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -786,20 +786,6 @@ def in_directory(file, directory, local_path_module=os.path):
 
     local_path_module is used by Pulsar to check Windows paths while running on
     a POSIX-like system.
-
-    >>> base_dir = tempfile.mkdtemp()
-    >>> safe_dir = os.path.join(base_dir, "user")
-    >>> os.mkdir(safe_dir)
-    >>> good_file = os.path.join(safe_dir, "1")
-    >>> with open(good_file, "w") as f: _ = f.write("hello")
-    >>> in_directory(good_file, safe_dir)
-    True
-    >>> in_directory("/other/file/is/here.txt", safe_dir)
-    False
-    >>> unsafe_link = os.path.join(safe_dir, "2")
-    >>> os.symlink("/other/file/bad.fasta", unsafe_link)
-    >>> in_directory(unsafe_link, safe_dir)
-    False
     """
     if local_path_module != os.path:
         _safe_contains = importlib.import_module(f"galaxy.util.path.{local_path_module.__name__}").safe_contains

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -2,9 +2,10 @@
 """
 
 import errno
-import imp
+import importlib
 import logging
 import shlex
+import types
 from functools import partial
 from itertools import starmap
 from operator import getitem
@@ -424,7 +425,7 @@ def __splitext_ignore(path, ignore=None):
 # cross-platform support
 
 
-def _build_self(target, path_module):
+def _build_self(target: types.ModuleType, path_module: types.ModuleType) -> None:
     """Populate a module with the same exported functions as this module, but using the given os.path module.
 
     :type target: module
@@ -432,20 +433,8 @@ def _build_self(target, path_module):
     :type path_module: ``ntpath`` or ``posixpath`` module
     :param path_module: module implementing ``os.path`` API to use for path functions
     """
-    __copy_self().__set_fxns_on(target, path_module)
-
-
-def __copy_self(names=__name__, parent=None):
-    """Returns a copy of this module that can be modified without modifying `galaxy.util.path`` in ``sys.modules``."""
-    if isinstance(names, str):
-        names = iter(names.split("."))
-    try:
-        name = next(names)
-    except StopIteration:
-        return parent
-    path = parent and parent.__path__
-    parent = imp.load_module(name, *imp.find_module(name, path))
-    return __copy_self(names, parent)
+    self_copy = importlib.import_module(__name__)
+    self_copy.__set_fxns_on(target, path_module)
 
 
 def __set_fxns_on(target, path_module):

--- a/test/unit/util/test_paths.py
+++ b/test/unit/util/test_paths.py
@@ -1,0 +1,28 @@
+import ntpath
+import os
+import posixpath
+import tempfile
+
+from galaxy.util import in_directory
+
+
+def test_in_directory():
+    base_dir = tempfile.mkdtemp()
+    safe_dir = os.path.join(base_dir, "user")
+    os.mkdir(safe_dir)
+    good_file = os.path.join(safe_dir, "1")
+    with open(good_file, "w") as f:
+        f.write("hello")
+    assert in_directory(good_file, safe_dir)
+
+    assert not in_directory("/other/file/is/here.txt", safe_dir)
+
+    unsafe_link = os.path.join(safe_dir, "2")
+    os.symlink("/other/file/bad.fasta", unsafe_link)
+    assert not in_directory(unsafe_link, safe_dir)
+
+    # Test local_path_module parameter
+    if os.path == posixpath:
+        assert in_directory(good_file, safe_dir, local_path_module=ntpath)
+    elif os.path == ntpath:
+        assert in_directory(good_file, safe_dir, local_path_module=posixpath)


### PR DESCRIPTION
Also:
- Move doctests for `in_directory()` function to unit tests, add test for `local_path_module` parameter to exercise the posixpath/ntpath import code.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
