### PR TITLE
Implement more useful workflow tagging

### DIFF
--- a/client/src/components/Common/Tags.vue
+++ b/client/src/components/Common/Tags.vue
@@ -1,5 +1,5 @@
 <template>
-    <StatelessTags :value="tags" @input="onInput" />
+    <StatelessTags :value="tags" @input="onInput" @tag-click="onTagClick" />
 </template>
 <script>
 import StatelessTags from "components/Tags/StatelessTags";
@@ -18,6 +18,9 @@ export default {
     methods: {
         onInput(tags) {
             this.$emit("input", tags, this.index);
+        },
+        onTagClick(tag) {
+            this.$emit("tag-click", tag);
         },
     },
 };

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -247,7 +247,7 @@ export default {
                 });
         },
         onTagClick: function (tag) {
-            const tagFilter = `tag:${tag.text}`;
+            const tagFilter = `tag:'${tag.text}'`;
             const initialFilter = this.filter;
             if (initialFilter.length === 0) {
                 this.filter = tagFilter;

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -59,7 +59,7 @@
                         @onError="onError" />
                 </template>
                 <template v-slot:cell(tags)="row">
-                    <Tags :index="row.index" :tags="row.item.tags" @input="onTags" />
+                    <Tags :index="row.index" :tags="row.item.tags" @input="onTags" @tag-click="onTagClick" />
                 </template>
                 <template v-slot:cell(published)="row">
                     <font-awesome-icon v-if="row.item.published" v-b-tooltip.hover title="Published" icon="globe" />
@@ -245,6 +245,15 @@ export default {
                 .catch((error) => {
                     this.onError(error);
                 });
+        },
+        onTagClick: function (tag) {
+            const tagFilter = `tag:${tag.text}`;
+            const initialFilter = this.filter;
+            if (initialFilter.length === 0) {
+                this.filter = tagFilter;
+            } else if (initialFilter.indexOf(tagFilter) < 0) {
+                this.filter = `${tagFilter} ${initialFilter}`;
+            }
         },
         onAdd: function (workflow) {
             if (this.currentPage == 1) {

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1259,15 +1259,36 @@ class NavigatesGalaxy(HasDriver):
         tag_display = workflow_row_element.find_element_by_css_selector(".tags-display")
         tag_display.click()
 
+    def workflow_index_add_tag(self, tag: str, workflow_index: int = 0):
+        self.workflow_index_click_tag_display(workflow_index=workflow_index)
+        self.tagging_add([tag])
+
     @retry_during_transitions
     def workflow_index_tags(self, workflow_index=0):
-        workflow_row_element = self.workflow_index_table_row(workflow_index)
-        tag_display = workflow_row_element.find_element_by_css_selector(".tags-display")
-        tag_spans = tag_display.find_elements_by_css_selector(".tag-name")
+        tag_spans = self.workflow_index_tag_elements(workflow_index=workflow_index)
         tags = []
         for tag_span in tag_spans:
             tags.append(tag_span.text)
         return tags
+
+    @retry_during_transitions
+    def workflow_index_tag_elements(self, workflow_index=0):
+        workflow_row_element = self.workflow_index_table_row(workflow_index)
+        tag_display = workflow_row_element.find_element_by_css_selector(".tags-display")
+        tag_spans = tag_display.find_elements_by_css_selector(".tag-name")
+        return tag_spans
+
+    @retry_during_transitions
+    def workflow_index_click_tag(self, tag, workflow_index=0):
+        tag_spans = self.workflow_index_tag_elements(workflow_index=workflow_index)
+        clicked = False
+        for tag_span in tag_spans:
+            if tag_span.text == tag:
+                tag_span.click()
+                clicked = True
+                break
+        if not clicked:
+            raise KeyError(f"Failed to find tag {tag} on workflow with index {workflow_index}")
 
     def workflow_import_submit_url(self, url):
         form_button = self.wait_for_selector_visible("#workflow-import-button")

--- a/lib/galaxy/util/search.py
+++ b/lib/galaxy/util/search.py
@@ -1,7 +1,17 @@
 import re
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+KeyedQueryT = Tuple[str, str]
 
 
-def parse_filters(search_term, filters):
+def parse_filters(
+    search_term: str, filters: Optional[Dict[str, str]] = None
+) -> Tuple[Optional[List[KeyedQueryT]], Optional[str]]:
     """Support github-like filters for narrowing the results.
 
     Order of chunks does not matter, only recognized filter names are allowed.
@@ -16,6 +26,7 @@ def parse_filters(search_term, filters):
     allow_terms = []
     search_term_without_filters = None
     search_space = search_term.replace('"', "'")
+    filters = filters or {}
     filter_keys = "|".join(list(filters.keys()))
     pattern = rf"({filter_keys}):(?:\s+)?([\w-]+|\'.*?\')"
     reserved = re.compile(pattern)

--- a/lib/galaxy/util/search.py
+++ b/lib/galaxy/util/search.py
@@ -2,16 +2,18 @@ import re
 from typing import (
     Dict,
     List,
+    NamedTuple,
     Optional,
     Tuple,
+    Union,
 )
 
 KeyedQueryT = Tuple[str, str]
+ParseFilterResultT = Tuple[Optional[List["FilteredTerm"]], Optional[str]]
+QUOTE_PATTERN = re.compile(r"\'(.*?)\'")
 
 
-def parse_filters(
-    search_term: str, filters: Optional[Dict[str, str]] = None
-) -> Tuple[Optional[List[KeyedQueryT]], Optional[str]]:
+def parse_filters(search_term: str, filters: Optional[Dict[str, str]] = None) -> ParseFilterResultT:
     """Support github-like filters for narrowing the results.
 
     Order of chunks does not matter, only recognized filter names are allowed.
@@ -23,22 +25,89 @@ def parse_filters(
     :returns search_term_without_filters: str that represents user's
         search phrase without the filters
     """
-    allow_terms = []
-    search_term_without_filters = None
+    return parse_filters_structured(search_term, filters, preserve_quotes=False).simple_result
+
+
+def parse_filters_structured(
+    search_term: str,
+    filters: Optional[Dict[str, str]] = None,
+    preserve_quotes: bool = True,
+) -> "ParsedSearch":
     search_space = search_term.replace('"', "'")
     filters = filters or {}
     filter_keys = "|".join(list(filters.keys()))
     pattern = rf"({filter_keys}):(?:\s+)?([\w-]+|\'.*?\')"
     reserved = re.compile(pattern)
+    parsed_search = ParsedSearch()
     while True:
         match = reserved.search(search_space)
         if match is None:
-            search_term_without_filters = " ".join(search_space.split())
-            break
-        first_group = match.groups()[0]
-        if first_group in filters:
-            filter_as = filters[first_group]
-            allow_terms.append((filter_as, match.groups()[1].strip().replace("'", "")))
-        search_space = search_space[0 : match.start()] + search_space[match.end() :]
-    allow_query = allow_terms if len(allow_terms) > 0 else None
-    return allow_query, search_term_without_filters
+            match = QUOTE_PATTERN.search(search_space)
+            if match is None:
+                parsed_search.add_unfiltered_text_terms(search_space)
+                break
+            group = match.groups()[0].strip()
+            parsed_search.add_unfiltered_text_terms(search_space[0 : match.start()])
+            parsed_search.add_unfiltered_text(group, True)
+        else:
+            first_group = match.groups()[0]
+            if first_group in filters:
+                filter_as = filters[first_group]
+                group = match.groups()[1].strip()
+                quoted = preserve_quotes and group.startswith("'")
+                parsed_search.add_keyed_term(filter_as, group.replace("'", ""), quoted)
+            parsed_search.add_unfiltered_text_terms(search_space[0 : match.start()])
+        search_space = search_space[match.end() :]
+    return parsed_search
+
+
+class RawTextTerm(NamedTuple):
+    text: str
+    quoted: bool
+
+
+class FilteredTerm(NamedTuple):
+    filter: str
+    text: str
+    quoted: bool
+
+
+TermT = Union[RawTextTerm, FilteredTerm]
+
+
+class ParsedSearch:
+    terms: List[TermT]
+    text_terms: List[RawTextTerm]
+    filter_terms: List[FilteredTerm]
+
+    def __init__(self):
+        self.terms = []
+        self.text_terms = []
+        self.filter_terms = []
+
+    def add_unfiltered_text_terms(self, text: str):
+        for part in text.split():
+            self.add_unfiltered_text(part, False)
+
+    def add_unfiltered_text(self, text: str, quoted: bool = False):
+        text = text.strip()
+        if not text:
+            return
+        term = RawTextTerm(text.strip(), quoted)
+        self.terms.append(term)
+        self.text_terms.append(term)
+
+    def add_keyed_term(self, key: str, text: str, quoted: bool):
+        term = FilteredTerm(key, text, quoted)
+        self.terms.append(term)
+        self.filter_terms.append(term)
+
+    @property
+    def simple_result(self) -> ParseFilterResultT:
+        return None if len(self.filter_terms) == 0 else self.filter_terms, " ".join([t.text for t in self.text_terms])
+
+
+__all__ = (
+    "parse_filters",
+    "parse_filters_structured",
+)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1460,10 +1460,10 @@ OffsetQueryParam: Optional[int] = Query(
     title="Number of workflows to skip in sorted query (to enable pagination).",
 )
 
-SearchQueryParameter: Optional[str] = Query(
+SearchQueryParam: Optional[str] = Query(
     default=None,
     title="Search query.",
-    description="Free text used to filter the query. Currently this just filters by name but this shouldn't be considered part the API, the freetext search may search additional fields in different ways in the future.",
+    description="Free text used to filter the query. Filters on a name and tags, Github-style tags can be used to be more specific. Free-text search is case-insensitive.",
 )
 
 SkipStepCountsQueryParam: bool = Query(
@@ -1495,7 +1495,7 @@ class FastAPIWorkflows:
         sort_desc: Optional[bool] = SortDescQueryParam,
         limit: Optional[int] = LimitQueryParam,
         offset: Optional[int] = OffsetQueryParam,
-        search: Optional[str] = SearchQueryParameter,
+        search: Optional[str] = SearchQueryParam,
         skip_step_counts: bool = SkipStepCountsQueryParam,
     ) -> List[Dict[str, Any]]:
         """Return the sharing status of the item."""

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -120,8 +120,8 @@ class WorkflowsService(ServiceBase):
                     key, value = term_text.rsplit(":", 1)
                     if not quoted:
                         return and_(
-                            model.StoredWorkflowTagAssociation.user_tname == key,
-                            model.StoredWorkflowTagAssociation.user_value.like(f"%{value}%"),
+                            model.StoredWorkflowTagAssociation.user_tname.ilike(key),
+                            model.StoredWorkflowTagAssociation.user_value.ilike(f"%{value}%"),
                         )
                     else:
                         return and_(
@@ -130,13 +130,13 @@ class WorkflowsService(ServiceBase):
                         )
                 else:
                     if not quoted:
-                        return model.StoredWorkflowTagAssociation.user_tname.like(f"%{term_text}%")
+                        return model.StoredWorkflowTagAssociation.user_tname.ilike(f"%{term_text}%")
                     else:
                         return model.StoredWorkflowTagAssociation.user_tname == term_text
 
             def name_filter(text, quoted):
                 if not quoted:
-                    filter = model.StoredWorkflow.name.like(f"%{text}%")
+                    filter = model.StoredWorkflow.name.ilike(f"%{text}%")
                 else:
                     filter = model.StoredWorkflow.name == text
                 return filter

--- a/lib/galaxy/workflow/trs_proxy.py
+++ b/lib/galaxy/workflow/trs_proxy.py
@@ -43,7 +43,7 @@ def parse_search_kwds(search_query):
         query_kwd["description"] = (description_term,)
 
     if keyed_terms is not None:
-        for (key, value) in keyed_terms:
+        for (key, value, _) in keyed_terms:
             query_kwd[key] = value
     return query_kwd
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -493,6 +493,21 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         index_ids = self.workflow_populator.index_ids(search="tag:moocowatag")
         assert workflow_id_1 in index_ids
 
+    def test_search_casing(self):
+        name1, name2 = (
+            self.dataset_populator.get_random_name().upper(),
+            self.dataset_populator.get_random_name().upper(),
+        )
+        workflow_id_1 = self.workflow_populator.simple_workflow(name1)
+        self.workflow_populator.simple_workflow(name2)
+        self.workflow_populator.set_tags(workflow_id_1, ["searchcasingtag", "searchcasinganothertag"])
+        index_ids = self.workflow_populator.index_ids(search=name1.lower())
+        assert len(index_ids) == 1
+        assert workflow_id_1 in index_ids
+        index_ids = self.workflow_populator.index_ids(search="SEARCHCASINGTAG")
+        assert len(index_ids) == 1
+        assert workflow_id_1 in index_ids
+
     def test_index_search_tags_exact(self):
         name1, name2 = self.dataset_populator.get_random_name(), self.dataset_populator.get_random_name()
         workflow_id_1 = self.workflow_populator.simple_workflow(name1)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -451,6 +451,32 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert len(index_ids) == 1
         assert workflow_id_1 in index_ids
 
+    def test_index_search_name(self):
+        name1, name2 = self.dataset_populator.get_random_name(), self.dataset_populator.get_random_name()
+        workflow_id_1 = self.workflow_populator.simple_workflow(name1)
+        self.workflow_populator.simple_workflow(name2)
+        self.workflow_populator.set_tags(workflow_id_1, [name2])
+        index_ids = self.workflow_populator.index_ids(search=name2)
+        # one found by tag and one found by name...
+        assert len(index_ids) == 2
+        assert workflow_id_1 in index_ids
+
+        index_ids = self.workflow_populator.index_ids(search=f"name:{name2}")
+        assert len(index_ids) == 1
+        assert workflow_id_1 not in index_ids
+
+    def test_index_search_tags(self):
+        name1, name2 = self.dataset_populator.get_random_name(), self.dataset_populator.get_random_name()
+        workflow_id_1 = self.workflow_populator.simple_workflow(name1)
+        self.workflow_populator.simple_workflow(name2)
+        index_ids = self.workflow_populator.index_ids(search="moocowatag")
+        assert len(index_ids) == 0
+        self.workflow_populator.set_tags(workflow_id_1, ["moocowatag", "moocowanothertag"])
+        index_ids = self.workflow_populator.index_ids(search="moocowatag")
+        assert workflow_id_1 in index_ids
+        index_ids = self.workflow_populator.index_ids(search="tag:moocowatag")
+        assert workflow_id_1 in index_ids
+
     def test_index_published(self):
         # published workflows are also the default of what is displayed for anonymous API requests
         # this is tested in test_anonymous_published.

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -596,16 +596,16 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
 
     def test_update_tags(self):
         workflow_object = self.workflow_populator.load_workflow(name="test_import")
-        upload_response = self.__test_upload(workflow=workflow_object)
-        workflow = upload_response.json()
-        workflow["tags"] = ["a_tag", "b_tag"]
-        update_response = self._update_workflow(workflow["id"], workflow).json()
+        workflow_id = self.__test_upload(workflow=workflow_object).json()["id"]
+        update_payload = {}
+        update_payload["tags"] = ["a_tag", "b_tag"]
+        update_response = self._update_workflow(workflow_id, update_payload).json()
         assert update_response["tags"] == ["a_tag", "b_tag"]
-        del workflow["tags"]
-        update_response = self._update_workflow(workflow["id"], workflow).json()
+        del update_payload["tags"]
+        update_response = self._update_workflow(workflow_id, update_payload).json()
         assert update_response["tags"] == ["a_tag", "b_tag"]
-        workflow["tags"] = []
-        update_response = self._update_workflow(workflow["id"], workflow).json()
+        update_payload["tags"] = []
+        update_response = self._update_workflow(workflow_id, update_payload).json()
         assert update_response["tags"] == []
 
     def test_update_name(self):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1348,6 +1348,11 @@ class BaseWorkflowPopulator(BasePopulator):
         else:
             return ordered_load(response.text)
 
+    def set_tags(self, workflow_id: str, tags: List[str]) -> None:
+        update_payload = {"tags": tags}
+        response = self.update_workflow(workflow_id, update_payload)
+        response.raise_for_status()
+
     def update_workflow(self, workflow_id: str, workflow_object: dict) -> Response:
         data = dict(workflow=workflow_object)
         raw_url = f"workflows/{workflow_id}"

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -99,7 +99,8 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers, UsesWorkfl
         self._assert_showing_n_workflows(4)
 
         self.workflow_index_click_tag("mytag", workflow_index=3)
-        self._assert_showing_n_workflows(3)
+        self._assert_showing_n_workflows(2)
+        self.screenshot("workflow_manage_search_by_tag_exact")
 
     @selenium_test
     def test_index_search(self):

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -69,8 +69,7 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers, UsesWorkfl
         self.workflow_index_open()
         self._workflow_import_from_url()
 
-        self.workflow_index_click_tag_display()
-        self.tagging_add(["cooltag"])
+        self.workflow_index_add_tag("cooltag")
 
         @retry_assertion_during_transitions
         def check_tags():
@@ -78,6 +77,29 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers, UsesWorkfl
 
         check_tags()
         self.screenshot("workflow_manage_tags")
+
+    @selenium_test
+    def test_tag_filtering(self):
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_add_tag("mytag")
+        self._workflow_import_from_url()
+        self.workflow_index_add_tag("mytag")
+        self._workflow_import_from_url()
+        self.workflow_index_add_tag("mytaglonger")
+        self._workflow_import_from_url()
+
+        self.workflow_index_search_for("mytag")
+        self._assert_showing_n_workflows(3)
+        self.screenshot("workflow_manage_search_by_tag_freetext")
+        self.workflow_index_search_for("thisisnotatag")
+        self._assert_showing_n_workflows(0)
+
+        self.workflow_index_search_for()
+        self._assert_showing_n_workflows(4)
+
+        self.workflow_index_click_tag("mytag", workflow_index=3)
+        self._assert_showing_n_workflows(3)
 
     @selenium_test
     def test_index_search(self):

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -97,6 +97,32 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers, UsesWorkfl
         self._assert_showing_n_workflows(1)
 
     @selenium_test
+    def test_index_search_filters(self):
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_rename("searchforthis")
+        self._assert_showing_n_workflows(1)
+
+        self.workflow_index_search_for("name:doesnotmatch")
+        self._assert_showing_n_workflows(0)
+        self.screenshot("workflow_manage_search_no_matches")
+
+        self.workflow_index_search_for()
+        self._assert_showing_n_workflows(1)
+
+        self.workflow_index_search_for("name:searchforthis")
+        self._assert_showing_n_workflows(1)
+        self.screenshot("workflow_manage_search_name_filter")
+
+        self.workflow_index_search_for("n:searchforthis")
+        self._assert_showing_n_workflows(1)
+        self.screenshot("workflow_manage_search_name_alias")
+
+        self.workflow_index_search_for("n:doesnotmatch")
+        self._assert_showing_n_workflows(0)
+        self.screenshot("workflow_manage_search_name_alias")
+
+    @selenium_test
     def test_pagination(self):
         self.workflow_index_open()
         self._workflow_import_from_url()

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -102,6 +102,10 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers, UsesWorkfl
         self._assert_showing_n_workflows(2)
         self.screenshot("workflow_manage_search_by_tag_exact")
 
+        self.workflow_index_search_for()
+        self._assert_showing_n_workflows(4)
+        self.workflow_index_search_for("MyTaG")
+
     @selenium_test
     def test_index_search(self):
         self.workflow_index_open()

--- a/lib/tool_shed/webapp/search/repo_search.py
+++ b/lib/tool_shed/webapp/search/repo_search.py
@@ -209,6 +209,6 @@ class RepoSearch:
         }
         allow_query, search_term_without_filters = parse_filters(search_term, filters)
         allow_query = (
-            And([Term(t, v) for (t, v) in allow_query] if len(allow_query) > 0 else None) if allow_query else None
+            And([Term(t, v) for (t, v, _) in allow_query] if len(allow_query) > 0 else None) if allow_query else None
         )
         return allow_query, search_term_without_filters

--- a/test/unit/util/test_search.py
+++ b/test/unit/util/test_search.py
@@ -1,4 +1,7 @@
-from galaxy.util.search import parse_filters
+from galaxy.util.search import (
+    parse_filters,
+    parse_filters_structured,
+)
 
 
 def test_parse_filters():
@@ -7,26 +10,87 @@ def test_parse_filters():
     assert result[1] == "moo cow"
 
     result = parse_filters("moo:mooterm cow", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "mooterm"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "mooterm"
     assert result[1] == "cow"
 
     result = parse_filters("moo:'moo term' cow", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "moo term"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "moo term"
     assert result[1] == "cow"
 
     result = parse_filters("""moo:"moo term" cow""", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "moo term"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "moo term"
     assert result[1] == "cow"
 
     result = parse_filters("cow moo:'moo term'", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "moo term"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "moo term"
     assert result[1] == "cow"
 
     result = parse_filters("cow moo:'moo term' other side", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "moo term"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "moo term"
     assert result[1] == "cow other side"
+
+
+def test_parse_filters_structured():
+    result = parse_filters_structured("cow moo:moo other side", {"moo": "mookey"}, preserve_quotes=True)
+    filters = result.filter_terms
+    assert filters
+    assert filters[0].quoted is False
+    text_terms = result.text_terms
+    assert len(text_terms) == 3
+    assert text_terms[0].text == "cow"
+    assert text_terms[0].quoted is False
+    assert text_terms[1].text == "other"
+    assert text_terms[1].quoted is False
+    assert text_terms[2].text == "side"
+    assert text_terms[2].quoted is False
+
+    result = parse_filters_structured("cow moo:'moo' other side", {"moo": "mookey"}, preserve_quotes=True)
+    filters = result.filter_terms
+    assert filters
+    assert filters[0].quoted is True
+    text_terms = result.text_terms
+    assert len(text_terms) == 3
+    assert text_terms[0].text == "cow"
+    assert text_terms[0].quoted is False
+    assert text_terms[1].text == "other"
+    assert text_terms[1].quoted is False
+    assert text_terms[2].text == "side"
+    assert text_terms[2].quoted is False
+
+    result = parse_filters_structured("""cow moo:"moo" other side""", {"moo": "mookey"}, preserve_quotes=True)
+    filters = result.filter_terms
+    assert filters
+    assert filters[0].quoted is True
+
+    result = parse_filters_structured("cow moo:'moo term' other side", {"moo": "mookey"}, preserve_quotes=True)
+    filters = result.filter_terms
+    assert filters
+    assert filters[0].filter == "mookey"
+    assert filters[0].text == "moo term"
+    assert filters[0].quoted is True
+    assert " ".join(t.text for t in result.text_terms) == "cow other side"
+
+    result = parse_filters_structured("cow 'other side' foo", {"moo": "mookey"}, preserve_quotes=True)
+    text_terms = result.text_terms
+    assert len(text_terms) == 3
+    assert text_terms[0].text == "cow"
+    assert text_terms[0].quoted is False
+    assert text_terms[1].text == "other side"
+    assert text_terms[1].quoted is True
+    assert text_terms[2].text == "foo"
+    assert text_terms[2].quoted is False

--- a/test/unit/util/test_search.py
+++ b/test/unit/util/test_search.py
@@ -1,0 +1,32 @@
+from galaxy.util.search import parse_filters
+
+
+def test_parse_filters():
+    result = parse_filters("moo cow", {})
+    assert result[0] is None
+    assert result[1] == "moo cow"
+
+    result = parse_filters("moo:mooterm cow", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "mooterm"
+    assert result[1] == "cow"
+
+    result = parse_filters("moo:'moo term' cow", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "moo term"
+    assert result[1] == "cow"
+
+    result = parse_filters("""moo:"moo term" cow""", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "moo term"
+    assert result[1] == "cow"
+
+    result = parse_filters("cow moo:'moo term'", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "moo term"
+    assert result[1] == "cow"
+
+    result = parse_filters("cow moo:'moo term' other side", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "moo term"
+    assert result[1] == "cow other side"


### PR DESCRIPTION
Extends the workflow index search and pagination functionality added in #13725 to enhance tag functionality. 

- By default now free search terms are also searched against workflow tags.
- Github-style "search tags" as used with the tool shed repository search and TRS searching can no be used for "stored workflow tags" and names - to restrict search terms.
- The workflow tags in the grid themselves can now be clicked and the query textbox will reactively update to include a "search tag" to search by the  "workflow tag".

A grid with tagged workflows:

<img width="1189" alt="Screen Shot 2022-04-21 at 3 47 14 PM" src="https://user-images.githubusercontent.com/216771/164541117-4705aaba-796f-416d-837e-a53857e90131.png">

Once a tag is clicked on:

<img width="1197" alt="Screen Shot 2022-04-21 at 3 47 21 PM" src="https://user-images.githubusercontent.com/216771/164541120-516f8490-c080-45bf-b2fc-09da70278ee3.png">

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  1. Search workflows by tag.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
