### PR TITLE
SelectionStatus component/test fixes

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.test.js
@@ -1,4 +1,4 @@
-import { mount } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "jest/helpers";
 import HistorySelectionStatus from "./SelectionStatus.vue";
@@ -17,7 +17,7 @@ const SOMETHING_SELECTED = {
 };
 
 async function mountHistorySelectionStatusWith(props) {
-    const wrapper = mount(HistorySelectionStatus, { propsData: props }, localVue);
+    const wrapper = shallowMount(HistorySelectionStatus, { propsData: props }, localVue);
     await flushPromises();
     return wrapper;
 }

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionStatus.vue
@@ -10,9 +10,15 @@
 </template>
 
 <script>
+import { BButton, BButtonGroup } from "bootstrap-vue";
+
 export default {
     props: {
         selectionSize: { type: Number, required: true },
+    },
+    components: {
+        "b-button": BButton,
+        "b-button-group": BButtonGroup,
     },
     computed: {
         /** @returns {Boolean} */


### PR DESCRIPTION
Minor tweaks to SelectionStatus test and component.  Shallowmounts for the test and explicitly registers components used so testing is happier.

When testing (without this), you see the following:

```
  console.error
    [Vue warn]: Unknown custom element: <b-button-group> - did you register the component correctly? For recursive components, make sure to provide the "name" option.

    found in

    ---> <Anonymous>
           <Root>

      at warn (node_modules/vue/dist/vue.runtime.common.dev.js:621:15)
      at createElm (node_modules/vue/dist/vue.runtime.common.dev.js:5962:11)
      at VueComponent.patch [as __patch__] (node_modules/vue/dist/vue.runtime.common.dev.js:6499:7)
      at VueComponent.Vue._update (node_modules/vue/dist/vue.runtime.common.dev.js:3948:19)
      at VueComponent.updateComponent (node_modules/vue/dist/vue.runtime.common.dev.js:4069:10)
      at Watcher.get (node_modules/vue/dist/vue.runtime.common.dev.js:4481:25)
      at new Watcher (node_modules/vue/dist/vue.runtime.common.dev.js:4470:12)
      at mountComponent (node_modules/vue/dist/vue.runtime.common.dev.js:4076:3)
      at VueComponent.Object.<anonymous>.Vue.$mount (node_modules/vue/dist/vue.runtime.common.dev.js:8436:10)
      at init (node_modules/vue/dist/vue.runtime.common.dev.js:3131:13)
      at createComponent (node_modules/vue/dist/vue.runtime.common.dev.js:6002:9)
      at createElm (node_modules/vue/dist/vue.runtime.common.dev.js:5949:9)
      at VueComponent.patch [as __patch__] (node_modules/vue/dist/vue.runtime.common.dev.js:6499:7)

```

## How to test the changes?
(Select all options that apply)
- [x]  This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
