### PR TITLE
Fix thread accumulation in testing

### DIFF
--- a/lib/galaxy/web_stack/gunicorn_config.py
+++ b/lib/galaxy/web_stack/gunicorn_config.py
@@ -1,11 +1,8 @@
 """
 Gunicorn config file based on https://gist.github.com/hynek/ba655c8756924a5febc5285c712a7946
 """
-import logging
 import os
 import sys
-
-log = logging.getLogger(__name__)
 
 
 def on_starting(server):

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -174,6 +174,7 @@ def initialize_fast_app(gx_wsgi_webapp, gx_app):
     include_all_package_routers(app, "galaxy.webapps.galaxy.api")
     include_legacy_openapi(app, gx_app)
     wsgi_handler = WSGIMiddleware(gx_wsgi_webapp)
+    gx_app.haltables.append(("WSGI Middleware threadpool", wsgi_handler.executor.shutdown))
     app.mount("/", wsgi_handler)
     if gx_app.config.galaxy_url_prefix != "/":
         parent_app = FastAPI()

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -743,7 +743,8 @@ class EmbeddedServerWrapper(ServerWrapper):
             self._app.shutdown()
             log.info(f"Application {self.name} stopped.")
 
-        log.info(f"{threading.active_count()} active after stopping embedded server")
+        thread_count = threading.active_count()
+        log.info(f"{thread_count} active after stopping embedded server")
 
 
 class GravityServerWrapper(ServerWrapper):
@@ -845,7 +846,7 @@ def launch_server(app_factory, webapp_factory, prefix=DEFAULT_CONFIG_PREFIX, gal
     if name == "galaxy":
         asgi_app = init_galaxy_fast_app(wsgi_webapp, app)
     elif name == "tool_shed":
-        asgi_app = init_tool_shed_fast_app(wsgi_webapp)
+        asgi_app = init_tool_shed_fast_app(wsgi_webapp, app)
     else:
         raise NotImplementedError(f"Launching {name} not implemented")
 
@@ -885,6 +886,11 @@ class TestDriver:
     def stop_servers(self):
         for server_wrapper in self.server_wrappers:
             server_wrapper.stop()
+        active_count = threading.active_count()
+        if active_count > 10:
+            raise Exception(
+                f"{active_count} active threads after stopping embedded server. Have all threads been shut down?"
+            )
         self.server_wrappers = []
 
     def mkdtemp(self):

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -886,6 +886,8 @@ class TestDriver:
     def stop_servers(self):
         for server_wrapper in self.server_wrappers:
             server_wrapper.stop()
+        for th in threading.enumerate():
+            log.debug(f"After stopping all servers thread {th} is alive.")
         active_count = threading.active_count()
         if active_count > 10:
             raise Exception(

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -889,7 +889,9 @@ class TestDriver:
         for th in threading.enumerate():
             log.debug(f"After stopping all servers thread {th} is alive.")
         active_count = threading.active_count()
-        if active_count > 10:
+        if active_count > 100:
+            # For an unknown reason running iRODS tests results in application threads not shutting down immediately,
+            # but if we've accumulated over 100 active threads something else is wrong that needs to be fixed.
             raise Exception(
                 f"{active_count} active threads after stopping embedded server. Have all threads been shut down?"
             )

--- a/lib/tool_shed/webapp/app.py
+++ b/lib/tool_shed/webapp/app.py
@@ -11,7 +11,10 @@ import tool_shed.repository_registry
 import tool_shed.repository_types.registry
 import tool_shed.webapp.model
 from galaxy import auth
-from galaxy.app import SentryClientMixin
+from galaxy.app import (
+    HaltableContainer,
+    SentryClientMixin,
+)
 from galaxy.config import configure_logging
 from galaxy.managers.api_keys import ApiKeyManager
 from galaxy.managers.citations import CitationsManager
@@ -33,7 +36,7 @@ from . import config
 log = logging.getLogger(__name__)
 
 
-class UniverseApplication(BasicSharedApp, SentryClientMixin):
+class UniverseApplication(BasicSharedApp, SentryClientMixin, HaltableContainer):
     """Encapsulates the state of a Universe application"""
 
     def __init__(self, **kwd) -> None:
@@ -104,6 +107,3 @@ class UniverseApplication(BasicSharedApp, SentryClientMixin):
         #  used for cachebusting -- refactor this into a *SINGLE* UniverseApplication base.
         self.server_starttime = int(time.time())
         log.debug("Tool shed hgweb.config file is: %s", self.hgweb_config_manager.hgweb_config)
-
-    def shutdown(self):
-        pass

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -48,7 +48,14 @@ def add_ui_controllers(webapp, app):
                     webapp.add_ui_controller(name, T(app))
 
 
-def app_factory(global_conf, load_app_kwds=None, **kwargs):
+def app_factory(*args, **kwargs):
+    """
+    Return a wsgi application serving the root object
+    """
+    return app_pair(*args, **kwargs)[0]
+
+
+def app_pair(global_conf, load_app_kwds=None, **kwargs):
     """Return a wsgi application serving the root object"""
     # Create the Galaxy tool shed application unless passed in
     load_app_kwds = load_app_kwds or {}
@@ -207,7 +214,7 @@ def app_factory(global_conf, load_app_kwds=None, **kwargs):
         webapp = wrap_in_middleware(webapp, global_conf, app.application_stack, **kwargs)
     if asbool(kwargs.get("static_enabled", True)):
         webapp = wrap_if_allowed(webapp, app.application_stack, build_url_map, args=(global_conf,), kwargs=kwargs)
-    return webapp
+    return webapp, app
 
 
 def wrap_in_middleware(app, global_conf, application_stack, **local_conf):

--- a/lib/tool_shed/webapp/fast_app.py
+++ b/lib/tool_shed/webapp/fast_app.py
@@ -8,7 +8,7 @@ from galaxy.webapps.base.api import (
 )
 
 
-def initialize_fast_app(gx_webapp):
+def initialize_fast_app(gx_webapp, tool_shed_app):
     app = FastAPI(
         title="Galaxy Tool Shed API",
         description=("This API allows you to manage the Tool Shed repositories."),
@@ -18,6 +18,7 @@ def initialize_fast_app(gx_webapp):
     add_request_id_middleware(app)
     include_all_package_routers(app, "tool_shed.webapp.api")
     wsgi_handler = WSGIMiddleware(gx_webapp)
+    tool_shed_app.haltables.append(("WSGI Middleware threadpool", wsgi_handler.executor.shutdown))
     app.mount("/", wsgi_handler)
     return app
 

--- a/lib/tool_shed/webapp/fast_factory.py
+++ b/lib/tool_shed/webapp/fast_factory.py
@@ -38,7 +38,7 @@ from galaxy.main_config import (
     WebappConfigResolver,
     WebappSetupProps,
 )
-from tool_shed.webapp.buildapp import app_factory
+from tool_shed.webapp.buildapp import app_pair
 from tool_shed.webapp.config import TOOLSHED_APP_NAME
 from .fast_app import initialize_fast_app
 
@@ -51,7 +51,7 @@ def factory():
     )
     config_provider = WebappConfigResolver(props)
     config = config_provider.resolve_config()
-    gx_webapp = app_factory(
+    gx_webapp, app = app_pair(
         global_conf=config.global_conf, load_app_kwds=config.load_app_kwds, wsgi_preflight=config.wsgi_preflight
     )
-    return initialize_fast_app(gx_webapp)
+    return initialize_fast_app(gx_webapp, app)


### PR DESCRIPTION
a2wsgi's WSGIMiddleWare starts a threadpool that we need to shut down when we restart the instance during tests

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
