### PR TITLE
[22.01] Fix slow download of large files

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -2,6 +2,7 @@
 API operations on the contents of a history dataset.
 """
 import logging
+from io import IOBase
 from typing import (
     Any,
     cast,
@@ -248,7 +249,13 @@ class FastAPIDatasets:
     ):
         """Streams the preview contents of a dataset to be displayed in a browser."""
         extra_params = get_query_parameters_from_request_excluding(request, {"preview", "filename", "to_ext", "raw"})
-        display_data, headers = self.service.display(trans, history_content_id, history_id, preview, filename, to_ext, raw, **extra_params)
+        display_data, headers = self.service.display(
+            trans, history_content_id, history_id, preview, filename, to_ext, raw, **extra_params
+        )
+        if isinstance(display_data, IOBase):
+            file_name = getattr(display_data, "name", None)
+            if file_name:
+                return FileResponse(file_name, headers=headers)
         return StreamingResponse(display_data, headers=headers)
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -469,7 +469,9 @@ class FastAPIHistoryContents:
         while maintaining approximate collection structure.
         """
         archive = self.service.get_dataset_collection_archive_for_download(trans, id)
-        return StreamingResponse(archive.get_iterator(), headers=archive.get_headers())
+        if archive.upstream_mod_zip:
+            return StreamingResponse(archive.response(), headers=archive.get_headers())
+        return StreamingResponse(archive.get_iterator(), headers=archive.get_headers(), media_type="application/zip")
 
     @router.post(
         '/api/histories/{history_id}/contents/{type}s',


### PR DESCRIPTION
There's a 9.6 MB Sequences file being downloaded in composite_data_outputs test, and that stalls for a few minutes in the tests.

This also means we can use the add_send_file_header middleware to offload the download completely.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
