### PR TITLE
[22.01] Fix error when getting destinations by tag

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -784,7 +784,7 @@ class JobConfiguration(ConfiguresHandlers):
         Destinations are not deepcopied, so they should not be passed to
         anything which might modify them.
         """
-        return self.destinations.get(id_or_tag, None)
+        return self.destinations.get(id_or_tag, [])
 
     def get_job_runner_plugins(self, handler_id):
         """Load all configured job runner plugins

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -13,7 +13,13 @@ import sys
 import time
 import traceback
 from json import loads
-from typing import Any, Dict, List, TYPE_CHECKING
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    TYPE_CHECKING,
+)
 
 import packaging.version
 import yaml
@@ -773,7 +779,7 @@ class JobConfiguration(ConfiguresHandlers):
             id_or_tag = self.default_destination_id
         return copy.deepcopy(self._get_single_item(self.destinations[id_or_tag]))
 
-    def get_destinations(self, id_or_tag):
+    def get_destinations(self, id_or_tag) -> Iterable[JobDestination]:
         """Given a destination ID or tag, return all JobDestinations matching the provided ID or tag
 
         :param id_or_tag: A destination ID or tag.

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -27,6 +27,7 @@ from galaxy.webhooks import WebhooksRegistry
 from galaxy.workflow.trs_proxy import TrsProxy
 
 if TYPE_CHECKING:
+    from galaxy.jobs import JobConfiguration
     from galaxy.tools.data import ToolDataTableManager
 
 
@@ -83,7 +84,7 @@ class MinimalManagerApp(MinimalApp):
     role_manager: Any  # 'galaxy.managers.roles.RoleManager'
     installed_repository_manager: Any  # 'galaxy.tool_shed.galaxy_install.installed_repository_manager.InstalledRepositoryManager'
     user_manager: Any
-    job_config: Any  # 'galaxy.jobs.JobConfiguration'
+    job_config: "JobConfiguration"
     job_manager: Any  # galaxy.jobs.manager.JobManager
 
     @property
@@ -138,7 +139,7 @@ class StructuredApp(MinimalManagerApp):
     installed_repository_manager: Any  # 'galaxy.tool_shed.galaxy_install.installed_repository_manager.InstalledRepositoryManager'
     workflow_scheduling_manager: Any  # 'galaxy.workflow.scheduling_manager.WorkflowSchedulingManager'
     interactivetool_manager: Any
-    job_config: Any  # 'galaxy.jobs.JobConfiguration'
+    job_config: "JobConfiguration"
     job_manager: Any  # galaxy.jobs.manager.JobManager
     user_manager: Any
     api_keys_manager: Any  # 'galaxy.managers.api_keys.ApiKeyManager'


### PR DESCRIPTION
While trying to tag dynamic destination (based on user info) from our sorting hat, we got this error:

```
Traceback (most recent call last):
  File "/galaxy/server/lib/galaxy/jobs/handler.py", line 436, in __handle_waiting_jobs
    job_state = self.__check_job_state(job)
  File "/galaxy/server/lib/galaxy/jobs/handler.py", line 575, in __check_job_state
    state, job_destination = self.__verify_job_ready(job, job_wrapper)
  File "/galaxy/server/lib/galaxy/jobs/handler.py", line 617, in __verify_job_ready
    state = self.__check_user_jobs(job, job_wrapper)
  File "/galaxy/server/lib/galaxy/jobs/handler.py", line 796, in __check_user_jobs
    for id in [d.id for d in self.app.job_config.get_destinations(tag)]:
TypeError: 'NoneType' object is not iterable
```
We had the error because the tag is only used on dynamic destinations on our instance => get_destinations returns `None`

This PR fixes it by returning an empty array when no static destination has the asked tag.

## How to test the changes?

- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows (not super easy sorry):
  1. Create a dynamic destination with a specific tag
  2. Add a tag specific limit in job conf (like `destination_user_concurrent_jobs`)
  3. Check that jobs are properly submitted without error

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
