### PR TITLE
Allow users to view invocations only for a particular workflow.

### DIFF
--- a/client/src/components/Dataset/DatasetList.vue
+++ b/client/src/components/Dataset/DatasetList.vue
@@ -88,7 +88,7 @@ export default {
             sortDesc: true,
             loading: true,
             message: null,
-            messageVariant: null,
+            messageVariant: "danger",
             rows: [],
         };
     },
@@ -184,13 +184,8 @@ export default {
                 }
             }
         },
-        onSuccess(message) {
-            this.message = message;
-            this.messageVariant = "success";
-        },
         onError(message) {
             this.message = message;
-            this.messageVariant = "danger";
         },
     },
 };

--- a/client/src/components/FilesDialog/FilesDialog.test.js
+++ b/client/src/components/FilesDialog/FilesDialog.test.js
@@ -34,8 +34,7 @@ const api_paths_map = new Map([
     ["/api/remote_files?target=gxfiles://pdb-gzip/directory2&recursive=true", directory2RecursiveResponse],
     ["/api/remote_files?target=gxfiles://pdb-gzip/directory1/subdirectory1", subsubdirectoryResponse],
 ]);
-const initComponent = async (props) => {
-    const axiosMock = new MockAdapter(axios);
+const initComponent = async (props, axiosMock) => {
     const localVue = createLocalVue();
 
     localVue.use(BootstrapVue);
@@ -80,10 +79,16 @@ const initComponent = async (props) => {
 describe("FilesDialog, file mode", () => {
     let wrapper;
     let utils;
+    let axiosMock;
 
     beforeEach(async () => {
-        wrapper = await initComponent({ multiple: true });
+        axiosMock = new MockAdapter(axios);
+        wrapper = await initComponent({ multiple: true }, axiosMock);
         utils = new Utils(wrapper);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
     });
 
     it("should show the same number of items", async () => {
@@ -242,11 +247,18 @@ describe("FilesDialog, file mode", () => {
 describe("FilesDialog, directory mode", () => {
     let wrapper;
     let utils;
+    let axiosMock;
+
     const spyFinalize = jest.spyOn(FilesDialog.methods, "finalize");
 
     beforeEach(async () => {
-        wrapper = await initComponent({ multiple: false, mode: "directory" });
+        axiosMock = new MockAdapter(axios);
+        wrapper = await initComponent({ multiple: false, mode: "directory" }, axiosMock);
         utils = new Utils(wrapper);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
     });
 
     it("should render directories", async () => {

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -8,146 +8,132 @@ import { parseISO, formatDistanceToNow } from "date-fns";
 
 const localVue = getLocalVue();
 
-describe("Invocations.vue without invocations", () => {
+describe("Invocations.vue", () => {
     let axiosMock;
     let wrapper;
-    let propsData;
 
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
-        axiosMock.onAny().reply(200, [], { total_matches: "0" });
-        propsData = {
-            ownerGrid: false,
-        };
-        wrapper = mount(Invocations, {
-            propsData,
-            localVue,
-        });
     });
 
     afterEach(() => {
         axiosMock.restore();
     });
 
-    it("title should be shown", async () => {
-        expect(wrapper.find("#invocations-title").text()).toBe("Workflow Invocations");
-    });
+    describe(" with empty invocation list", () => {
+        beforeEach(async () => {
+            axiosMock.onAny().reply(200, [], { total_matches: "0" });
+            const propsData = {
+                ownerGrid: false,
+            };
+            wrapper = mount(Invocations, {
+                propsData,
+                localVue,
+            });
+        });
 
-    it("no invocations message should be shown when not loading", async () => {
-        expect(wrapper.find("#no-invocations").exists()).toBe(true);
-    });
-});
+        it("title should be shown", async () => {
+            expect(wrapper.find("#invocations-title").text()).toBe("Workflow Invocations");
+        });
 
-describe("Invocations.vue for a workflow invocations", () => {
-    let axiosMock;
-    let wrapper;
-    let propsData;
-
-    beforeEach(async () => {
-        axiosMock = new MockAdapter(axios);
-        axiosMock.onAny().reply(200, [], { total_matches: "0" });
-        propsData = {
-            ownerGrid: false,
-            storedWorkflowName: "My Workflow",
-            storedWorkflowId: "abcde145678",
-        };
-        wrapper = mount(Invocations, {
-            propsData,
-            localVue,
+        it("no invocations message should be shown when not loading", async () => {
+            expect(wrapper.find("#no-invocations").exists()).toBe(true);
         });
     });
 
-    afterEach(() => {
-        axiosMock.restore();
-    });
+    describe("for a workflow with an empty invocation list", () => {
+        beforeEach(async () => {
+            axiosMock.onAny().reply(200, [], { total_matches: "0" });
+            const propsData = {
+                ownerGrid: false,
+                storedWorkflowName: "My Workflow",
+                storedWorkflowId: "abcde145678",
+            };
+            wrapper = mount(Invocations, {
+                propsData,
+                localVue,
+            });
+        });
 
-    it("title should be shown", async () => {
-        expect(wrapper.find("#invocations-title").text()).toBe("Workflow Invocations for My Workflow");
-    });
+        it("title should be shown", async () => {
+            expect(wrapper.find("#invocations-title").text()).toBe("Workflow Invocations for My Workflow");
+        });
 
-    it("no invocations message should be shown when not loading", async () => {
-        expect(wrapper.find("#no-invocations").exists()).toBe(true);
-    });
-});
-
-describe("Invocations.vue with invocation", () => {
-    let wrapper;
-    let propsData;
-    let axiosMock;
-
-    beforeEach(async () => {
-        axiosMock = new MockAdapter(axios);
-        axiosMock
-            .onGet("/api/invocations", { params: { limit: 50, offset: 0, include_terminal: false } })
-            .reply(200, [mockInvocationData], { total_matches: "1" });
-        propsData = {
-            ownerGrid: false,
-            loading: false,
-        };
-        wrapper = mount(Invocations, {
-            propsData,
-            computed: {
-                getWorkflowNameByInstanceId: (state) => (id) => "workflow name",
-                getWorkflowByInstanceId: (state) => (id) => {
-                    return { id: "workflowId" };
-                },
-                getHistoryById: (state) => (id) => {
-                    return { id: "historyId" };
-                },
-                getHistoryNameById: () => () => "history name",
-            },
-            stubs: {
-                "workflow-invocation-state": {
-                    template: "<span/>",
-                },
-            },
-            localVue,
+        it("no invocations message should be shown when not loading", async () => {
+            expect(wrapper.find("#no-invocations").exists()).toBe(true);
         });
     });
 
-    afterEach(() => {
-        axiosMock.reset();
-    });
+    describe("with invocation", () => {
+        beforeEach(async () => {
+            axiosMock
+                .onGet("/api/invocations", { params: { limit: 50, offset: 0, include_terminal: false } })
+                .reply(200, [mockInvocationData], { total_matches: "1" });
+            const propsData = {
+                ownerGrid: false,
+                loading: false,
+            };
+            wrapper = mount(Invocations, {
+                propsData,
+                computed: {
+                    getWorkflowNameByInstanceId: (state) => (id) => "workflow name",
+                    getWorkflowByInstanceId: (state) => (id) => {
+                        return { id: "workflowId" };
+                    },
+                    getHistoryById: (state) => (id) => {
+                        return { id: "historyId" };
+                    },
+                    getHistoryNameById: () => () => "history name",
+                },
+                stubs: {
+                    "workflow-invocation-state": {
+                        template: "<span/>",
+                    },
+                },
+                localVue,
+            });
+        });
 
-    it("renders one row", async () => {
-        const rows = wrapper.findAll("tbody > tr").wrappers;
-        expect(rows.length).toBe(1);
-        const row = rows[0];
-        const columns = row.findAll("td");
-        expect(columns.at(1).text()).toBe("workflow name");
-        expect(columns.at(2).text()).toBe("history name");
-        expect(columns.at(3).text()).toBe(
-            formatDistanceToNow(parseISO(`${mockInvocationData.create_time}Z`), { addSuffix: true })
-        );
-        expect(columns.at(4).text()).toBe(
-            formatDistanceToNow(parseISO(`${mockInvocationData.update_time}Z`), { addSuffix: true })
-        );
-        expect(columns.at(5).text()).toBe("scheduled");
-        expect(columns.at(6).text()).toBe("");
-    });
+        it("renders one row", async () => {
+            const rows = wrapper.findAll("tbody > tr").wrappers;
+            expect(rows.length).toBe(1);
+            const row = rows[0];
+            const columns = row.findAll("td");
+            expect(columns.at(1).text()).toBe("workflow name");
+            expect(columns.at(2).text()).toBe("history name");
+            expect(columns.at(3).text()).toBe(
+                formatDistanceToNow(parseISO(`${mockInvocationData.create_time}Z`), { addSuffix: true })
+            );
+            expect(columns.at(4).text()).toBe(
+                formatDistanceToNow(parseISO(`${mockInvocationData.update_time}Z`), { addSuffix: true })
+            );
+            expect(columns.at(5).text()).toBe("scheduled");
+            expect(columns.at(6).text()).toBe("");
+        });
 
-    it("toggles detail rendering", async () => {
-        let rows = wrapper.findAll("tbody > tr").wrappers;
-        expect(rows.length).toBe(1);
-        await wrapper.find(".toggle-invocation-details").trigger("click");
-        rows = wrapper.findAll("tbody > tr").wrappers;
-        expect(rows.length).toBe(3);
-        await wrapper.find(".toggle-invocation-details").trigger("click");
-        rows = wrapper.findAll("tbody > tr").wrappers;
-        expect(rows.length).toBe(1);
-    });
+        it("toggles detail rendering", async () => {
+            let rows = wrapper.findAll("tbody > tr").wrappers;
+            expect(rows.length).toBe(1);
+            await wrapper.find(".toggle-invocation-details").trigger("click");
+            rows = wrapper.findAll("tbody > tr").wrappers;
+            expect(rows.length).toBe(3);
+            await wrapper.find(".toggle-invocation-details").trigger("click");
+            rows = wrapper.findAll("tbody > tr").wrappers;
+            expect(rows.length).toBe(1);
+        });
 
-    it("calls switchHistory", async () => {
-        const mockMethod = jest.fn();
-        wrapper.vm.switchHistory = mockMethod;
-        await wrapper.find("#switch-to-history").trigger("click");
-        expect(mockMethod).toHaveBeenCalled();
-    });
+        it("calls switchHistory", async () => {
+            const mockMethod = jest.fn();
+            wrapper.vm.switchHistory = mockMethod;
+            await wrapper.find("#switch-to-history").trigger("click");
+            expect(mockMethod).toHaveBeenCalled();
+        });
 
-    it("calls executeWorkflow", async () => {
-        const mockMethod = jest.fn();
-        wrapper.vm.executeWorkflow = mockMethod;
-        await wrapper.find("#run-workflow").trigger("click");
-        expect(mockMethod).toHaveBeenCalledWith("workflowId");
+        it("calls executeWorkflow", async () => {
+            const mockMethod = jest.fn();
+            wrapper.vm.executeWorkflow = mockMethod;
+            await wrapper.find("#run-workflow").trigger("click");
+            expect(mockMethod).toHaveBeenCalledWith("workflowId");
+        });
     });
 });

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -8,7 +8,7 @@ import { parseISO, formatDistanceToNow } from "date-fns";
 
 const localVue = getLocalVue();
 
-describe("Invocations.vue without invocation", () => {
+describe("Invocations.vue without invocations", () => {
     let axiosMock;
     let wrapper;
     let propsData;
@@ -31,6 +31,38 @@ describe("Invocations.vue without invocation", () => {
 
     it("title should be shown", async () => {
         expect(wrapper.find("#invocations-title").text()).toBe("Workflow Invocations");
+    });
+
+    it("no invocations message should be shown when not loading", async () => {
+        expect(wrapper.find("#no-invocations").exists()).toBe(true);
+    });
+});
+
+describe("Invocations.vue for a workflow invocations", () => {
+    let axiosMock;
+    let wrapper;
+    let propsData;
+
+    beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+        axiosMock.onAny().reply(200, [], { total_matches: "0" });
+        propsData = {
+            ownerGrid: false,
+            storedWorkflowName: "My Workflow",
+            storedWorkflowId: "abcde145678",
+        };
+        wrapper = mount(Invocations, {
+            propsData,
+            localVue,
+        });
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    it("title should be shown", async () => {
+        expect(wrapper.find("#invocations-title").text()).toBe("Workflow Invocations for My Workflow");
     });
 
     it("no invocations message should be shown when not loading", async () => {

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -26,7 +26,7 @@ describe("Invocations.vue without invocation", () => {
     });
 
     afterEach(() => {
-        axiosMock.reset();
+        axiosMock.restore();
     });
 
     it("title should be shown", async () => {

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -80,6 +80,7 @@
         </b-table>
         <b-pagination
             v-model="currentPage"
+            v-show="rows >= perPage"
             :per-page="perPage"
             :total-rows="rows"
             aria-controls="invocation-list-table"></b-pagination>

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="invocations-list">
         <h2 class="mb-3">
-            <span id="invocations-title">Workflow Invocations</span>
+            <span id="invocations-title">{{ title }}</span>
         </h2>
         <b-alert v-if="headerMessage" variant="info" show>
             {{ headerMessage }}
@@ -22,7 +22,7 @@
             <template v-slot:empty>
                 <loading-span v-if="loading" message="Loading workflow invocations" />
                 <b-alert v-else id="no-invocations" variant="info" show>
-                    {{ noInvocationsMessage }}
+                    {{ effectiveNoInvocationsMessage }}
                 </b-alert>
             </template>
             <template v-slot:row-details="row">
@@ -108,6 +108,8 @@ export default {
         headerMessage: { type: String, default: "" },
         ownerGrid: { type: Boolean, default: true },
         userId: { type: String, default: null },
+        storedWorkflowId: { type: String, default: null },
+        storedWorkflowName: { type: String, default: null },
     },
     data() {
         const fields = [
@@ -133,6 +135,20 @@ export default {
         apiUrl() {
             return `${getAppRoot()}api/invocations`;
         },
+        title() {
+            let title = `Workflow Invocations`;
+            if (this.storedWorkflowName) {
+                title += ` for ${this.storedWorkflowName}`;
+            }
+            return title;
+        },
+        effectiveNoInvocationsMessage() {
+            let message = this.noInvocationsMessage;
+            if (this.storedWorkflowName) {
+                message += ` for ${this.storedWorkflowName}`;
+            }
+            return message;
+        },
     },
     watch: {
         invocationItems: function (promise) {
@@ -157,6 +173,9 @@ export default {
         provider(ctx) {
             ctx.apiUrl = this.apiUrl;
             const extraParams = this.ownerGrid ? {} : { include_terminal: false };
+            if (this.storedWorkflowId) {
+                extraParams["workflow_id"] = this.storedWorkflowId;
+            }
             if (this.userId) {
                 extraParams["user_id"] = this.userId;
             }

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -7,7 +7,7 @@
             {{ headerMessage }}
         </b-alert>
         <b-table
-            id="invocation-list-table"
+            :id="tableId"
             v-model="invocationItemsModel"
             :fields="invocationFields"
             :items="provider"
@@ -20,7 +20,8 @@
             show-empty
             class="invocations-table">
             <template v-slot:empty>
-                <b-alert id="no-invocations" variant="info" show>
+                <loading-span v-if="loading" message="Loading workflow invocations" />
+                <b-alert v-else id="no-invocations" variant="info" show>
                     {{ noInvocationsMessage }}
                 </b-alert>
             </template>
@@ -81,9 +82,8 @@
         <b-pagination
             v-model="currentPage"
             v-show="rows >= perPage"
-            :per-page="perPage"
-            :total-rows="rows"
-            aria-controls="invocation-list-table"></b-pagination>
+            class="gx-invocations-grid-pager"
+            v-bind="paginationAttrs"></b-pagination>
     </div>
 </template>
 
@@ -95,12 +95,14 @@ import { WorkflowInvocationState } from "components/WorkflowInvocationState";
 import UtcDate from "components/UtcDate";
 import { mapCacheActions } from "vuex-cache";
 import { mapGetters } from "vuex";
+import paginationMixin from "./paginationMixin";
 
 export default {
     components: {
         UtcDate,
         WorkflowInvocationState,
     },
+    mixins: [paginationMixin],
     props: {
         noInvocationsMessage: { type: String, default: "No Workflow Invocations to display" },
         headerMessage: { type: String, default: "" },
@@ -118,13 +120,11 @@ export default {
             { key: "execute", label: "", class: "col-button" },
         ];
         return {
+            tableId: "invocation-list-table",
             invocationItems: [],
             invocationItemsModel: [],
             invocationFields: fields,
-            status: "",
-            currentPage: 1,
-            perPage: 50,
-            rows: 0,
+            perPage: this.rowsPerPage(50),
         };
     },
     computed: {
@@ -162,12 +162,6 @@ export default {
             }
             this.invocationItems = invocationsProvider(ctx, this.setRows, extraParams);
             return this.invocationItems;
-        },
-        refresh() {
-            this.$root.$emit("bv::refresh::table", "invocation-list-table");
-        },
-        setRows(data) {
-            this.rows = data.headers.total_matches;
         },
         swapRowDetails(row) {
             row.toggleDetails();

--- a/client/src/components/Workflow/StoredWorkflowInvocations.vue
+++ b/client/src/components/Workflow/StoredWorkflowInvocations.vue
@@ -1,0 +1,30 @@
+<template>
+    <CurrentUser v-slot="{ user }">
+        <StoredWorkflowDetailsProvider :storedWorkflowId="storedWorkflowId" v-slot="{ result: item, loading }">
+            <Invocations
+                v-if="!loading && user.id"
+                :user-id="user.id"
+                :stored-workflow-id="item.id"
+                :stored-workflow-name="item.name" />
+        </StoredWorkflowDetailsProvider>
+    </CurrentUser>
+</template>
+<script>
+import Invocations from "components/Workflow/Invocations";
+import CurrentUser from "components/providers/CurrentUser";
+import { StoredWorkflowDetailsProvider } from "components/providers/StoredWorkflowsProvider";
+
+export default {
+    props: {
+        storedWorkflowId: {
+            type: String,
+            required: true,
+        },
+    },
+    components: {
+        CurrentUser,
+        Invocations,
+        StoredWorkflowDetailsProvider,
+    },
+};
+</script>

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -41,6 +41,10 @@
                 <span class="fa fa-copy fa-fw mr-1" />
                 <span>Copy</span>
             </a>
+            <a class="dropdown-item" :href="urlInvocations">
+                <span class="fa fa-list fa-fw mr-1" />
+                <span>Invocations</span>
+            </a>
             <a class="dropdown-item" :href="urlDownload">
                 <span class="fa fa-download fa-fw mr-1" />
                 <span>Download</span>
@@ -102,6 +106,9 @@ export default {
         },
         urlView() {
             return `${getAppRoot()}workflow/display_by_id?id=${this.workflow.id}`;
+        },
+        urlInvocations() {
+            return `${getAppRoot()}workflows/${this.workflow.id}/invocations`;
         },
         urlViewShared() {
             return `${getAppRoot()}workflow/display_by_username_and_slug?username=${this.workflow.owner}&slug=${

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -189,10 +189,10 @@ export default {
         },
     },
     methods: {
-        provider(ctx) {
+        async provider(ctx) {
             ctx.apiUrl = this.apiUrl;
             const extraParams = { search: this.filter, skip_step_counts: true };
-            this.workflowItems = storedWorkflowsProvider(ctx, this.setRows, extraParams);
+            this.workflowItems = await storedWorkflowsProvider(ctx, this.setRows, extraParams);
             return this.workflowItems;
         },
         createWorkflow: function (workflow) {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -2,10 +2,7 @@
     <div>
         <div v-if="error" class="alert alert-danger" show>{{ error }}</div>
         <div v-else>
-            <span v-if="loading">
-                <font-awesome-icon icon="spinner" spin />
-                Loading workflows...
-            </span>
+            <loading-span v-if="loading" message="Loading workflows" />
             <div v-else>
                 <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
                 <b-row class="mb-3">
@@ -93,6 +90,7 @@ import { getAppRoot } from "onload/loadConfig";
 import { Services } from "./services";
 import Tags from "components/Common/Tags";
 import WorkflowDropdown from "./WorkflowDropdown";
+import LoadingSpan from "components/LoadingSpan";
 import UtcDate from "components/UtcDate";
 import { getGalaxyInstance } from "app";
 
@@ -101,6 +99,7 @@ library.add(faPlus, faUpload, faSpinner, faGlobe, faShareAlt, farStar, faStar);
 export default {
     components: {
         FontAwesomeIcon,
+        LoadingSpan,
         UtcDate,
         Tags,
         WorkflowDropdown,

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -193,7 +193,7 @@ export default {
     methods: {
         provider(ctx) {
             ctx.apiUrl = this.apiUrl;
-            const extraParams = { search: this.filter };
+            const extraParams = { search: this.filter, skip_step_counts: true };
             this.workflowItems = storedWorkflowsProvider(ctx, this.setRows, extraParams);
             return this.workflowItems;
         },

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -162,7 +162,7 @@ export default {
             titleRunWorkflow: _l("Run workflow"),
             workflowItemsModel: [],
             workflowItems: [],
-            perPage: this.rowsPerPage(20),
+            perPage: this.rowsPerPage(50),
         };
     },
     computed: {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -28,7 +28,7 @@
                 </b-col>
             </b-row>
             <b-table
-                id="workflow-table"
+                :id="tableId"
                 :fields="fields"
                 :items="provider"
                 v-model="workflowItemsModel"
@@ -87,9 +87,8 @@
             <b-pagination
                 v-model="currentPage"
                 v-show="rows >= perPage"
-                :per-page="perPage"
-                :total-rows="rows"
-                aria-controls="workflow-table"></b-pagination>
+                class="gx-workflows-grid-pager"
+                v-bind="paginationAttrs"></b-pagination>
         </div>
     </div>
 </template>
@@ -104,22 +103,23 @@ import { Services } from "./services";
 import { storedWorkflowsProvider } from "components/providers/StoredWorkflowsProvider";
 import Tags from "components/Common/Tags";
 import WorkflowDropdown from "./WorkflowDropdown";
-import LoadingSpan from "components/LoadingSpan";
 import UtcDate from "components/UtcDate";
 import { getGalaxyInstance } from "app";
+import paginationMixin from "./paginationMixin";
 
 library.add(faPlus, faUpload, faSpinner, faGlobe, faShareAlt, farStar, faStar);
 
 export default {
     components: {
         FontAwesomeIcon,
-        LoadingSpan,
         UtcDate,
         Tags,
         WorkflowDropdown,
     },
+    mixins: [paginationMixin],
     data() {
         return {
+            tableId: "workflow-table",
             error: null,
             fields: [
                 {
@@ -162,9 +162,7 @@ export default {
             titleRunWorkflow: _l("Run workflow"),
             workflowItemsModel: [],
             workflowItems: [],
-            currentPage: 1,
-            perPage: 20,
-            rows: 0,
+            perPage: this.rowsPerPage(20),
         };
     },
     computed: {
@@ -196,13 +194,6 @@ export default {
             const extraParams = { search: this.filter, skip_step_counts: true };
             this.workflowItems = storedWorkflowsProvider(ctx, this.setRows, extraParams);
             return this.workflowItems;
-        },
-        refresh() {
-            this.$root.$emit("bv::refresh::table", "workflow-table");
-        },
-        setRows(data) {
-            this.rows = data.headers.total_matches;
-            this.loading = false;
         },
         createWorkflow: function (workflow) {
             window.location = `${this.root}workflows/create`;

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -1,82 +1,80 @@
 <template>
     <div>
         <div v-if="error" class="alert alert-danger" show>{{ error }}</div>
+        <loading-span v-else-if="loading" message="Loading workflows" />
         <div v-else>
-            <loading-span v-if="loading" message="Loading workflows" />
-            <div v-else>
-                <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
-                <b-row class="mb-3">
-                    <b-col cols="6">
-                        <b-input
-                            id="workflow-search"
-                            v-model="filter"
-                            class="m-1"
-                            name="query"
-                            :placeholder="titleSearchWorkflows"
-                            autocomplete="off"
-                            type="text" />
-                    </b-col>
-                    <b-col>
-                        <span class="float-right">
-                            <b-button id="workflow-create" class="m-1" @click="createWorkflow">
-                                <font-awesome-icon icon="plus" />
-                                {{ titleCreate }}
-                            </b-button>
-                            <b-button id="workflow-import" class="m-1" @click="importWorkflow">
-                                <font-awesome-icon icon="upload" />
-                                {{ titleImport }}
-                            </b-button>
-                        </span>
-                    </b-col>
-                </b-row>
-                <b-table
-                    id="workflow-table"
-                    striped
-                    :fields="fields"
-                    :items="workflows"
-                    :filter="filter"
-                    @filtered="filtered">
-                    <template v-slot:cell(name)="row">
-                        <WorkflowDropdown
-                            :workflow="row.item"
-                            @onAdd="onAdd"
-                            @onRemove="onRemove"
-                            @onUpdate="onUpdate"
-                            @onSuccess="onSuccess"
-                            @onError="onError" />
-                    </template>
-                    <template v-slot:cell(tags)="row">
-                        <Tags :index="row.index" :tags="row.item.tags" @input="onTags" />
-                    </template>
-                    <template v-slot:cell(published)="row">
-                        <font-awesome-icon v-if="row.item.published" v-b-tooltip.hover title="Published" icon="globe" />
-                        <font-awesome-icon v-if="row.item.shared" v-b-tooltip.hover title="Shared" icon="share-alt" />
-                    </template>
-                    <template v-slot:cell(show_in_tool_panel)="row">
-                        <b-link v-if="row.item.show_in_tool_panel" @click="bookmarkWorkflow(row.item, false)">
-                            <font-awesome-icon :icon="['fas', 'star']" />
-                        </b-link>
-                        <b-link v-else @click="bookmarkWorkflow(row.item, true)">
-                            <font-awesome-icon :icon="['far', 'star']" />
-                        </b-link>
-                    </template>
-                    <template v-slot:cell(update_time)="data">
-                        <UtcDate :date="data.value" mode="elapsed" />
-                    </template>
-                    <template v-slot:cell(execute)="row">
-                        <b-button
-                            v-b-tooltip.hover.bottom
-                            :title="titleRunWorkflow"
-                            class="workflow-run btn-sm btn-primary fa fa-play"
-                            @click.stop="executeWorkflow(row.item)" />
-                    </template>
-                </b-table>
-                <div v-if="showNotFound">
-                    No matching entries found for: <span class="font-weight-bold">{{ filter }}</span
-                    >.
-                </div>
-                <div v-if="showNotAvailable">No workflows found. You may create or import new workflows.</div>
+            <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
+            <b-row class="mb-3">
+                <b-col cols="6">
+                    <b-input
+                        id="workflow-search"
+                        class="m-1"
+                        name="query"
+                        :placeholder="titleSearchWorkflows"
+                        autocomplete="off"
+                        type="text"
+                        v-model="filter" />
+                </b-col>
+                <b-col>
+                    <span class="float-right">
+                        <b-button id="workflow-create" class="m-1" @click="createWorkflow">
+                            <font-awesome-icon icon="plus" />
+                            {{ titleCreate }}
+                        </b-button>
+                        <b-button id="workflow-import" class="m-1" @click="importWorkflow">
+                            <font-awesome-icon icon="upload" />
+                            {{ titleImport }}
+                        </b-button>
+                    </span>
+                </b-col>
+            </b-row>
+            <b-table
+                id="workflow-table"
+                striped
+                :fields="fields"
+                :items="workflows"
+                :filter="filter"
+                @filtered="filtered">
+                <template v-slot:cell(name)="row">
+                    <WorkflowDropdown
+                        :workflow="row.item"
+                        @onAdd="onAdd"
+                        @onRemove="onRemove"
+                        @onUpdate="onUpdate"
+                        @onSuccess="onSuccess"
+                        @onError="onError" />
+                </template>
+                <template v-slot:cell(tags)="row">
+                    <Tags :index="row.index" :tags="row.item.tags" @input="onTags" />
+                </template>
+                <template v-slot:cell(published)="row">
+                    <font-awesome-icon v-if="row.item.published" v-b-tooltip.hover title="Published" icon="globe" />
+                    <font-awesome-icon v-if="row.item.shared" v-b-tooltip.hover title="Shared" icon="share-alt" />
+                </template>
+                <template v-slot:cell(show_in_tool_panel)="row">
+                    <b-link @click="bookmarkWorkflow(row.item, false)" v-if="row.item.show_in_tool_panel">
+                        <font-awesome-icon :icon="['fas', 'star']" />
+                    </b-link>
+                    <b-link @click="bookmarkWorkflow(row.item, true)" v-else>
+                        <font-awesome-icon :icon="['far', 'star']" />
+                    </b-link>
+                </template>
+                <template v-slot:cell(update_time)="data">
+                    <UtcDate :date="data.value" mode="elapsed" />
+                </template>
+                <template v-slot:cell(execute)="row">
+                    <b-button
+                        v-b-tooltip.hover.bottom
+                        :title="titleRunWorkflow"
+                        class="workflow-run btn-sm btn-primary fa fa-play"
+                        @click.stop="executeWorkflow(row.item)" />
+                </template>
+            </b-table>
+            <div v-if="showNotFound">
+                No matching entries found for: <span class="font-weight-bold">{{ this.filter }}</span
+                >.
             </div>
+            <div v-if="showNotAvailable">No workflows found. You may create or import new workflows.</div>
         </div>
     </div>
 </template>

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -86,6 +86,7 @@
             </b-table>
             <b-pagination
                 v-model="currentPage"
+                v-show="rows >= perPage"
                 :per-page="perPage"
                 :total-rows="rows"
                 aria-controls="workflow-table"></b-pagination>

--- a/client/src/components/Workflow/paginationMixin.js
+++ b/client/src/components/Workflow/paginationMixin.js
@@ -1,0 +1,43 @@
+import QueryStringParsing from "utils/query-string-parsing";
+import LoadingSpan from "components/LoadingSpan";
+
+export default {
+    components: { LoadingSpan },
+    data() {
+        return {
+            currentPage: 1,
+            perPage: 20,
+            rows: 0,
+            loading: true,
+        };
+    },
+    computed: {
+        paginationAttrs() {
+            return {
+                "next-class": "gx-grid-pager-next",
+                "prev-class": "gx-grid-pager-prev",
+                "first-class": "gx-grid-pager-first",
+                "last-class": "gx-grid-pager-last",
+                "page-class": "gx-grid-pager-page",
+                class: "gx-grid-pager",
+                size: "lg",
+                "aria-controls": this.tableId,
+                "per-page": this.perPage,
+                "total-rows": this.rows,
+            };
+        },
+    },
+    methods: {
+        refresh() {
+            this.$root.$emit("bv::refresh::table", this.tableId);
+        },
+        setRows(data) {
+            this.rows = data.headers.total_matches;
+            this.loading = false;
+        },
+        rowsPerPage(defaultPerPage) {
+            const queryRowsPerPage = QueryStringParsing.get("rows_per_page");
+            return queryRowsPerPage || defaultPerPage;
+        },
+    },
+};

--- a/client/src/components/providers/InvocationsProvider.js
+++ b/client/src/components/providers/InvocationsProvider.js
@@ -1,21 +1,9 @@
 import axios from "axios";
-import { snakeCase } from "snake-case";
+import { cleanPaginationParameters} from "./utils";
 
 export function invocationsProvider(ctx, callback, extraParams) {
     const { apiUrl, ...requestParams } = ctx;
-    const cleanParams = {};
-    Object.entries(requestParams).map(([key, val]) => {
-        if (key === "perPage") {
-            key = "limit";
-        }
-        if (val) {
-            cleanParams[snakeCase(key)] = val;
-        }
-    });
-    if (cleanParams.current_page && cleanParams.limit) {
-        cleanParams.offset = (cleanParams.current_page - 1) * cleanParams.limit;
-        delete cleanParams.current_page;
-    }
+    const cleanParams = cleanPaginationParameters(requestParams);
     const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });
 
     // Must return a promise that resolves to an array of items

--- a/client/src/components/providers/StoredWorkflowsProvider.js
+++ b/client/src/components/providers/StoredWorkflowsProvider.js
@@ -1,5 +1,8 @@
 import axios from "axios";
+import { getAppRoot } from "onload/loadConfig";
 import { cleanPaginationParameters } from "./utils";
+import { SingleQueryProvider } from "components/providers/SingleQueryProvider";
+import { rethrowSimple } from "utils/simple-error";
 
 export function storedWorkflowsProvider(ctx, callback, extraParams = {}) {
     const { apiUrl, ...requestParams } = ctx;
@@ -15,3 +18,15 @@ export function storedWorkflowsProvider(ctx, callback, extraParams = {}) {
         return items || [];
     });
 }
+
+async function storedWorkflowDetails({ storedWorkflowId }) {
+    const url = `${getAppRoot()}api/workflows/${storedWorkflowId}?instance=true`;
+    try {
+        const { data } = await axios.get(url);
+        return data;
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}
+
+export const StoredWorkflowDetailsProvider = SingleQueryProvider(storedWorkflowDetails);

--- a/client/src/components/providers/StoredWorkflowsProvider.js
+++ b/client/src/components/providers/StoredWorkflowsProvider.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { cleanPaginationParameters } from "./utils";
 
-export function invocationsProvider(ctx, callback, extraParams) {
+export function storedWorkflowsProvider(ctx, callback, extraParams = {}) {
     const { apiUrl, ...requestParams } = ctx;
     const cleanParams = cleanPaginationParameters(requestParams);
     const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });

--- a/client/src/components/providers/utils.js
+++ b/client/src/components/providers/utils.js
@@ -1,5 +1,25 @@
 import JOB_STATES_MODEL from "mvc/history/job-states-model";
+import { snakeCase } from "snake-case";
 
 export function stateIsTerminal(result) {
     return !JOB_STATES_MODEL.NON_TERMINAL_STATES.includes(result.state);
+}
+
+// Adapt bootstrap parameters to Galaxy API. Galaxy consumes snake case parameters
+// and generally uses limit instead of perPage/per_page as a name for this concept.
+export function cleanPaginationParameters(requestParams) {
+    const cleanParams = {};
+    Object.entries(requestParams).map(([key, val]) => {
+        if (key === "perPage") {
+            key = "limit";
+        }
+        if (val) {
+            cleanParams[snakeCase(key)] = val;
+        }
+    });
+    if (cleanParams.current_page && cleanParams.limit) {
+        cleanParams.offset = (cleanParams.current_page - 1) * cleanParams.limit;
+        delete cleanParams.current_page;
+    }
+    return cleanParams;
 }

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -38,6 +38,7 @@ import HistoryView from "components/HistoryView";
 import WorkflowInvocationReport from "components/Workflow/InvocationReport";
 import WorkflowRun from "components/Workflow/Run/WorkflowRun";
 import UserInvocations from "components/Workflow/UserInvocations";
+import StoredWorkflowInvocations from "components/Workflow/StoredWorkflowInvocations";
 import ToolsView from "components/ToolsView/ToolsView";
 import ToolsJson from "components/ToolsView/ToolsSchemaJson/ToolsJson";
 import HistoryList from "mvc/history/history-list";
@@ -90,6 +91,7 @@ export const getAnalysisRouter = (Galaxy) => {
             "(/)workflows/invocations/report": "show_workflow_invocation_report",
             // "(/)workflows/invocations/view_bco": "show_invocation_bco",
             "(/)workflows/list_published(/)": "show_workflows_published",
+            "(/)workflows(/)(:stored_workflow_id)(/)/invocations": "show_invocations_for_stored_workflow",
             "(/)workflows/create(/)": "show_workflows_create",
             "(/)histories(/)citations(/)": "show_history_citations",
             "(/)histories(/)rename(/)": "show_histories_rename",
@@ -246,6 +248,10 @@ export const getAnalysisRouter = (Galaxy) => {
 
         show_workflow_invocations: function () {
             this._display_vue_helper(UserInvocations, {});
+        },
+
+        show_invocations_for_stored_workflow: function (stored_workflow_id) {
+            this._display_vue_helper(StoredWorkflowInvocations, { storedWorkflowId: stored_workflow_id });
         },
 
         show_history_structure: function () {

--- a/client/src/store/historyStore/model/watchHistory.test.js
+++ b/client/src/store/historyStore/model/watchHistory.test.js
@@ -36,7 +36,6 @@ describe("watchHistory", () => {
 
     afterEach(() => {
         axiosMock.restore();
-        axiosMock.reset();
     });
 
     it("store initialization", async () => {

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -578,6 +578,7 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         self.queue_worker = self._register_singleton(GalaxyQueueWorker, GalaxyQueueWorker(self))
 
         self._configure_tool_shed_registry()
+        self._register_singleton(tool_shed_registry.Registry, self.tool_shed_registry)
 
         self.dependency_resolvers_view = self._register_singleton(
             DependencyResolversView, DependencyResolversView(self)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1063,6 +1063,7 @@ class WorkflowIndexPayload(Model):
         lt=1000,
     )
     offset: Optional[int] = Field(default=0, description="Number of workflows to skip")
+    search: Optional[str] = Field(default=None, title="Filter text", description="Freetext to search.")
 
 
 class InvocationSortByEnum(str, Enum):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1054,7 +1054,7 @@ class WorkflowIndexPayload(Model):
     show_published: Optional[bool] = None
     show_shared: Optional[bool] = None
     missing_tools: bool = False
-    sort_by: Optional[WorkflowSortByEnum] = Field(title="Sort By", description="Sort Worklfows by this attribute")
+    sort_by: Optional[WorkflowSortByEnum] = Field(title="Sort By", description="Sort workflows by this attribute")
     sort_desc: Optional[bool] = Field(
         title="Sort descending", description="Explicitly sort by descending if sort_by is specified."
     )

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1055,6 +1055,9 @@ class WorkflowIndexPayload(Model):
     show_shared: Optional[bool] = None
     missing_tools: bool = False
     sort_by: Optional[WorkflowSortByEnum] = Field(title="Sort By", description="Sort Worklfows by this attribute")
+    sort_desc: Optional[bool] = Field(
+        title="Sort descending", description="Explicitly sort by descending if sort_by is specified."
+    )
 
 
 class InvocationSortByEnum(str, Enum):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1047,6 +1047,14 @@ class SortByEnum(str, Enum):
     none = None
 
 
+class WorkflowIndexPayload(Model):
+    show_deleted: bool = False
+    show_hidden: bool = False
+    show_published: Optional[bool] = None
+    show_shared: Optional[bool] = None
+    missing_tools: bool = False
+
+
 class InvocationIndexPayload(Model):
     workflow_id: Optional[DecodedDatabaseIdField] = Field(
         title="Workflow ID", description="Return only invocations for this Workflow ID"

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1041,9 +1041,10 @@ class ExportHistoryArchivePayload(Model):
     )
 
 
-class SortByEnum(str, Enum):
+class WorkflowSortByEnum(str, Enum):
     create_time = "create_time"
     update_time = "update_time"
+    name = "name"
     none = None
 
 
@@ -1053,6 +1054,13 @@ class WorkflowIndexPayload(Model):
     show_published: Optional[bool] = None
     show_shared: Optional[bool] = None
     missing_tools: bool = False
+    sort_by: Optional[WorkflowSortByEnum] = Field(title="Sort By", description="Sort Worklfows by this attribute")
+
+
+class InvocationSortByEnum(str, Enum):
+    create_time = "create_time"
+    update_time = "update_time"
+    none = None
 
 
 class InvocationIndexPayload(Model):
@@ -1068,7 +1076,9 @@ class InvocationIndexPayload(Model):
     user_id: Optional[DecodedDatabaseIdField] = Field(
         title="User ID", description="Return invocations for this User ID"
     )
-    sort_by: Optional[SortByEnum] = Field(title="Sort By", description="Sort Workflow Invocations by this attribute")
+    sort_by: Optional[InvocationSortByEnum] = Field(
+        title="Sort By", description="Sort Workflow Invocations by this attribute"
+    )
     sort_desc: bool = Field(default=False, descritpion="Sort in descending order?")
     include_terminal: bool = Field(default=True, description="Set to false to only include terminal Invocations.")
     limit: Optional[int] = Field(

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1058,6 +1058,11 @@ class WorkflowIndexPayload(Model):
     sort_desc: Optional[bool] = Field(
         title="Sort descending", description="Explicitly sort by descending if sort_by is specified."
     )
+    limit: Optional[int] = Field(
+        default=None,
+        lt=1000,
+    )
+    offset: Optional[int] = Field(default=0, description="Number of workflows to skip")
 
 
 class InvocationSortByEnum(str, Enum):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1064,6 +1064,7 @@ class WorkflowIndexPayload(Model):
     )
     offset: Optional[int] = Field(default=0, description="Number of workflows to skip")
     search: Optional[str] = Field(default=None, title="Filter text", description="Freetext to search.")
+    skip_step_counts: bool = False
 
 
 class InvocationSortByEnum(str, Enum):

--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -19,6 +19,14 @@ class HasDriver:
     TimeoutException = TimeoutException
     driver: WebDriver
 
+    def re_get_with_query_params(self, params_str: str):
+        driver = self.driver
+        new_url = driver.current_url
+        if "?" not in new_url:
+            new_url += "?"
+        new_url += params_str
+        driver.get(new_url)
+
     def assert_xpath(self, xpath):
         assert self.driver.find_element_by_xpath(xpath)
 

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1197,11 +1197,9 @@ class NavigatesGalaxy(HasDriver):
         self.click_masthead_workflow()
 
     def workflow_index_table_elements(self):
-        self.wait_for_selector_visible("#workflow-table")
-        table_elements = self.driver.find_elements_by_css_selector(
-            "#workflow-table > tbody > tr:not(.b-table-empty-row, [style*='display: none'])"
-        )
-        return table_elements
+        workflows = self.components.workflows
+        workflows.workflow_table.wait_for_visible()
+        return workflows.workflow_rows.all()
 
     def workflow_index_table_row(self, workflow_index=0):
         return self.workflow_index_table_elements()[workflow_index]
@@ -1326,6 +1324,11 @@ class NavigatesGalaxy(HasDriver):
         inputs[1].send_keys(annotation)
         form_element.click()
         return name
+
+    def invocation_index_table_elements(self):
+        invocations = self.components.invocations
+        invocations.invocations_table.wait_for_visible()
+        return invocations.invocations_table_rows.all()
 
     def tool_open(self, tool_id, outer=False):
         if outer:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1199,7 +1199,7 @@ class NavigatesGalaxy(HasDriver):
     def workflow_index_table_elements(self):
         self.wait_for_selector_visible("#workflow-table")
         table_elements = self.driver.find_elements_by_css_selector(
-            "#workflow-table > tbody > tr:not([style*='display: none'])"
+            "#workflow-table > tbody > tr:not(.b-table-empty-row, [style*='display: none'])"
         )
         return table_elements
 

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -494,8 +494,16 @@ workflows:
     save_button: '#workflow-save-button'
     search_box: "#workflow-search"
     workflow_table: "#workflow-table"
+    workflow_rows: "#workflow-table > tbody > tr:not(.b-table-empty-row, [style*='display: none'])"
     external_link: '.workflow-external-link'
     trs_icon: '.workflow-trs-icon'
+    pager: '.gx-workflows-grid-pager'
+    pager_page: '.gx-workflows-grid-pager .gx-grid-pager-page [aria-posinset=${page}]'
+    pager_page_next: '.gx-workflows-grid-pager .gx-grid-pager-next button'
+    pager_page_first: '.gx-workflows-grid-pager .gx-grid-pager-first button'
+    pager_page_last: '.gx-workflows-grid-pager .gx-grid-pager-last button'
+    pager_page_previous: '.gx-workflows-grid-pager .gx-grid-pager-prev button'
+    pager_page_active: '.gx-workflows-grid-pager .gx-grid-pager-page.active button'
 
 trs_search:
   selectors:
@@ -631,7 +639,15 @@ workflow_show:
 invocations:
   selectors:
     invocations_table: '.invocations-list table'
-    invocations_table_rows: '.invocations-list table tbody tr'
+    invocations_table_rows: '.invocations-list table tbody tr:not(.b-table-empty-row, [style*="display: none"])'
+    pager: '.gx-invocations-grid-pager'
+    pager_page: '.gx-invocations-grid-pager .gx-grid-pager-page [aria-posinset=${page}]'
+    pager_page_next: '.gx-invocations-grid-pager .gx-grid-pager-next button'
+    pager_page_last: '.gx-invocations-grid-pager .gx-grid-pager-last button'
+    pager_page_first: '.gx-invocations-grid-pager .gx-grid-pager-first button'
+    pager_page_previous: '.gx-invocations-grid-pager .gx-grid-pager-prev button'
+    pager_page_active: '.gx-invocations-grid-pager .gx-grid-pager-page.active button'
+
     state_details: '.workflow-invocation-state-component'
     toggle_invocation_details: '.toggle-invocation-details'
     progress_steps_note: '.workflow-invocation-state-component .steps-progress .progressNote'

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1446,6 +1446,12 @@ SortByQueryParam: Optional[WorkflowSortByEnum] = Query(
     description="In unspecified, default ordering depends on other parameters but generally the user's own workflows appear first based on update time",
 )
 
+SortDescQueryParam: Optional[bool] = Query(
+    default=None,
+    title="Sort Descending",
+    description="Sort in descending order?",
+)
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -1465,6 +1471,7 @@ class FastAPIWorkflows:
         show_published: Optional[bool] = ShowPublishedQueryParam,
         show_shared: Optional[bool] = ShowSharedQueryParam,
         sort_by: Optional[WorkflowSortByEnum] = SortByQueryParam,
+        sort_desc: Optional[bool] = SortDescQueryParam,
     ) -> List[Dict[str, Any]]:
         """Return the sharing status of the item."""
         payload = WorkflowIndexPayload(
@@ -1474,6 +1481,7 @@ class FastAPIWorkflows:
             show_shared=show_shared,
             missing_tools=missing_tools,
             sort_by=sort_by,
+            sort_desc=sort_desc,
         )
         return self.service.index(trans, payload)
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -50,6 +50,7 @@ from galaxy.schema.schema import (
     ShareWithStatus,
     SharingStatus,
     WorkflowIndexPayload,
+    WorkflowSortByEnum,
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
@@ -1439,6 +1440,12 @@ ShowPublishedQueryParam: Optional[bool] = Query(default=None, title="Include pub
 
 ShowSharedQueryParam: Optional[bool] = Query(default=None, title="Include shared workflows.", description="")
 
+SortByQueryParam: Optional[WorkflowSortByEnum] = Query(
+    default=None,
+    title="Sort workflow index by this attribute",
+    description="In unspecified, default ordering depends on other parameters but generally the user's own workflows appear first based on update time",
+)
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -1457,6 +1464,7 @@ class FastAPIWorkflows:
         missing_tools: bool = MissingToolsQueryParam,
         show_published: Optional[bool] = ShowPublishedQueryParam,
         show_shared: Optional[bool] = ShowSharedQueryParam,
+        sort_by: Optional[WorkflowSortByEnum] = SortByQueryParam,
     ) -> List[Dict[str, Any]]:
         """Return the sharing status of the item."""
         payload = WorkflowIndexPayload(
@@ -1465,6 +1473,7 @@ class FastAPIWorkflows:
             show_deleted=show_deleted,
             show_shared=show_shared,
             missing_tools=missing_tools,
+            sort_by=sort_by,
         )
         return self.service.index(trans, payload)
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1466,6 +1466,12 @@ SearchQueryParameter: Optional[str] = Query(
     description="Free text used to filter the query. Currently this just filters by name but this shouldn't be considered part the API, the freetext search may search additional fields in different ways in the future.",
 )
 
+SkipStepCountsQueryParam: bool = Query(
+    default=False,
+    title="Skip step counts.",
+    description="Set this to true to skip joining workflow step counts and optimize the resulting index query. Response objects will not contain step counts.",
+)
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -1490,6 +1496,7 @@ class FastAPIWorkflows:
         limit: Optional[int] = LimitQueryParam,
         offset: Optional[int] = OffsetQueryParam,
         search: Optional[str] = SearchQueryParameter,
+        skip_step_counts: bool = SkipStepCountsQueryParam,
     ) -> List[Dict[str, Any]]:
         """Return the sharing status of the item."""
         payload = WorkflowIndexPayload(
@@ -1503,6 +1510,7 @@ class FastAPIWorkflows:
             limit=limit,
             offset=offset,
             search=search,
+            skip_step_counts=skip_step_counts,
         )
         workflows, total_matches = self.service.index(trans, payload, include_total_count=True)
         response.headers["total_matches"] = str(total_matches)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1460,6 +1460,12 @@ OffsetQueryParam: Optional[int] = Query(
     title="Number of workflows to skip in sorted query (to enable pagination).",
 )
 
+SearchQueryParameter: Optional[str] = Query(
+    default=None,
+    title="Search query.",
+    description="Free text used to filter the query. Currently this just filters by name but this shouldn't be considered part the API, the freetext search may search additional fields in different ways in the future.",
+)
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -1483,6 +1489,7 @@ class FastAPIWorkflows:
         sort_desc: Optional[bool] = SortDescQueryParam,
         limit: Optional[int] = LimitQueryParam,
         offset: Optional[int] = OffsetQueryParam,
+        search: Optional[str] = SearchQueryParameter,
     ) -> List[Dict[str, Any]]:
         """Return the sharing status of the item."""
         payload = WorkflowIndexPayload(
@@ -1495,6 +1502,7 @@ class FastAPIWorkflows:
             sort_desc=sort_desc,
             limit=limit,
             offset=offset,
+            search=search,
         )
         workflows, total_matches = self.service.index(trans, payload, include_total_count=True)
         response.headers["total_matches"] = str(total_matches)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -9,24 +9,20 @@ import os
 from typing import (
     Any,
     Dict,
+    List,
+    Optional,
 )
 
 import requests
 from fastapi import (
     Body,
     Path,
+    Query,
     Response,
     status,
 )
 from gxformat2._yaml import ordered_dump
 from markupsafe import escape
-from sqlalchemy import (
-    desc,
-    false,
-    or_,
-    true,
-)
-from sqlalchemy.orm import joinedload
 
 from galaxy import (
     exceptions,
@@ -53,6 +49,7 @@ from galaxy.schema.schema import (
     ShareWithPayload,
     ShareWithStatus,
     SharingStatus,
+    WorkflowIndexPayload,
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
@@ -92,25 +89,14 @@ router = Router(tags=["workflows"])
 
 
 class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, UsesAnnotations, SharableMixin):
+    service: WorkflowsService = depends(WorkflowsService)
+
     def __init__(self, app: StructuredApp):
         super().__init__(app)
         self.history_manager = app.history_manager
         self.workflow_manager = app.workflow_manager
         self.workflow_contents_manager = app.workflow_contents_manager
         self.tool_recommendations = recommendations.ToolRecommendations()
-
-    def __get_full_shed_url(self, url):
-        for shed_url in self.app.tool_shed_registry.tool_sheds.values():
-            if url in shed_url:
-                return shed_url
-        return None
-
-    @expose_api_anonymous_and_sessionless
-    def index(self, trans: ProvidesUserContext, **kwd):
-        """
-        GET /api/workflows
-        """
-        return self.get_workflows_list(trans, **kwd)
 
     @expose_api
     def get_workflow_menu(self, trans: ProvidesUserContext, **kwd):
@@ -120,7 +106,8 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         """
         user = trans.user
         ids_in_menu = [x.stored_workflow_id for x in user.stored_workflow_menu_entries]
-        return {"ids_in_menu": ids_in_menu, "workflows": self.get_workflows_list(trans, **kwd)}
+        workflows = self.get_workflows_list(trans, **kwd)
+        return {"ids_in_menu": ids_in_menu, "workflows": workflows}
 
     @expose_api
     def set_workflow_menu(self, trans: GalaxyWebTransaction, payload=None, **kwd):
@@ -194,91 +181,15 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         show_hidden = util.string_as_bool(show_hidden)
         show_deleted = util.string_as_bool(show_deleted)
         missing_tools = util.string_as_bool(missing_tools)
-        if show_shared is None:
-            show_shared = not show_hidden and not show_deleted
-        else:
-            show_shared = util.string_as_bool(show_shared)
-        if show_shared and show_deleted:
-            message = "show_shared and show_deleted cannot both be specified as true"
-            raise exceptions.RequestParameterInvalidException(message)
-        if show_shared and show_hidden:
-            message = "show_shared and show_hidden cannot both be specified as true"
-            raise exceptions.RequestParameterInvalidException(message)
-
-        rval = []
-        filters = [
-            model.StoredWorkflow.user == trans.user,
-        ]
-        user = trans.user
-        if user and show_shared:
-            filters.append(model.StoredWorkflowUserShareAssociation.user == user)
-
-        if show_published or user is None and show_published is None:
-            filters.append((model.StoredWorkflow.published == true()))
-
-        query = trans.sa_session.query(model.StoredWorkflow)
-        if show_shared:
-            query = query.outerjoin(model.StoredWorkflow.users_shared_with)
-
-        query = (
-            query.options(joinedload("annotations"))
-            .options(joinedload("latest_workflow").undefer("step_count").lazyload("steps"))
-            .options(joinedload("tags"))
+        show_shared = util.string_as_bool_or_none(show_shared)
+        payload = WorkflowIndexPayload(
+            show_published=show_published,
+            show_hidden=show_hidden,
+            show_deleted=show_deleted,
+            show_shared=show_shared,
+            missing_tools=missing_tools,
         )
-        query = query.filter(or_(*filters))
-        query = query.filter(model.StoredWorkflow.table.c.hidden == (true() if show_hidden else false()))
-        query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
-        if user:
-            query = query.order_by(desc(model.StoredWorkflow.user == user))
-        query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
-        for wf in query.all():
-            item = wf.to_dict(value_mapper={"id": trans.security.encode_id})
-            encoded_id = trans.security.encode_id(wf.id)
-            item["annotations"] = [x.annotation for x in wf.annotations]
-            item["url"] = url_for("workflow", id=encoded_id)
-            item["owner"] = wf.user.username
-            item["source_metadata"] = wf.latest_workflow.source_metadata
-            item["number_of_steps"] = wf.latest_workflow.step_count
-            item["show_in_tool_panel"] = False
-            if user is not None:
-                item["show_in_tool_panel"] = wf.show_in_tool_panel(user_id=user.id)
-            rval.append(item)
-        if missing_tools:
-            workflows_missing_tools = []
-            workflows = []
-            workflows_by_toolshed = dict()
-            for value in rval:
-                tools = self.workflow_contents_manager.get_all_tools(
-                    self.__get_stored_workflow(trans, value["id"]).latest_workflow
-                )
-                missing_tool_ids = [
-                    tool["tool_id"] for tool in tools if self.app.toolbox.is_missing_shed_tool(tool["tool_id"])
-                ]
-                if len(missing_tool_ids) > 0:
-                    value["missing_tools"] = missing_tool_ids
-                    workflows_missing_tools.append(value)
-            for workflow in workflows_missing_tools:
-                for tool_id in workflow["missing_tools"]:
-                    toolshed, _, owner, name, tool, version = tool_id.split("/")
-                    shed_url = self.__get_full_shed_url(toolshed)
-                    repo_identifier = "/".join((toolshed, owner, name))
-                    if repo_identifier not in workflows_by_toolshed:
-                        workflows_by_toolshed[repo_identifier] = dict(
-                            shed=shed_url.rstrip("/"),
-                            repository=name,
-                            owner=owner,
-                            tools=[tool_id],
-                            workflows=[workflow["name"]],
-                        )
-                    else:
-                        if tool_id not in workflows_by_toolshed[repo_identifier]["tools"]:
-                            workflows_by_toolshed[repo_identifier]["tools"].append(tool_id)
-                        if workflow["name"] not in workflows_by_toolshed[repo_identifier]["workflows"]:
-                            workflows_by_toolshed[repo_identifier]["workflows"].append(workflow["name"])
-            for repo_tag in workflows_by_toolshed:
-                workflows.append(workflows_by_toolshed[repo_tag])
-            return workflows
-        return rval
+        return self.service.index(trans, payload)
 
     @expose_api_anonymous_and_sessionless
     def show(self, trans: GalaxyWebTransaction, id, **kwd):
@@ -1510,10 +1421,52 @@ StoredWorkflowIDPathParam: EncodedDatabaseIdField = Path(
     ..., title="Stored Workflow ID", description="The encoded database identifier of the Stored Workflow."
 )
 
+DeletedQueryParam: bool = Query(
+    default=False, title="Display deleted", description="Whether to restrict result to deleted workflows."
+)
+
+HiddenQueryParam: bool = Query(
+    default=False, title="Display hidden", description="Whether to restrict result to hidden workflows."
+)
+
+MissingToolsQueryParam: bool = Query(
+    default=False,
+    title="Display missing tools",
+    description="Whether to include a list of missing tools per workflow entry",
+)
+
+ShowPublishedQueryParam: Optional[bool] = Query(default=None, title="Include published workflows.", description="")
+
+ShowSharedQueryParam: Optional[bool] = Query(default=None, title="Include shared workflows.", description="")
+
 
 @router.cbv
 class FastAPIWorkflows:
     service: WorkflowsService = depends(WorkflowsService)
+
+    @router.get(
+        "/api/workflows",
+        summary="Lists stored workflows viewable by the user.",
+        response_description="A list with summary stored workflow information per viewable entry.",
+    )
+    def index(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        show_deleted: bool = DeletedQueryParam,
+        show_hidden: bool = HiddenQueryParam,
+        missing_tools: bool = MissingToolsQueryParam,
+        show_published: Optional[bool] = ShowPublishedQueryParam,
+        show_shared: Optional[bool] = ShowSharedQueryParam,
+    ) -> List[Dict[str, Any]]:
+        """Return the sharing status of the item."""
+        payload = WorkflowIndexPayload(
+            show_published=show_published,
+            show_hidden=show_hidden,
+            show_deleted=show_deleted,
+            show_shared=show_shared,
+            missing_tools=missing_tools,
+        )
+        return self.service.index(trans, payload)
 
     @router.get(
         "/api/workflows/{id}/sharing",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -251,6 +251,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     webapp.add_client_route("/workflows/trs_search")
     webapp.add_client_route("/workflows/invocations")
     webapp.add_client_route("/workflows/sharing")
+    webapp.add_client_route("/workflows/{stored_workflow_id}/invocations")
     webapp.add_client_route("/workflows/invocations/report")
     # webapp.add_client_route('/workflows/invocations/view_bco')
     webapp.add_client_route("/custom_builds")

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -1,7 +1,30 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+)
+
+from sqlalchemy import (
+    desc,
+    false,
+    or_,
+    true,
+)
+from sqlalchemy.orm import joinedload
+
+from galaxy import (
+    exceptions,
+    model,
+    web,
+)
+from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.workflows import (
+    WorkflowContentsManager,
     WorkflowSerializer,
     WorkflowsManager,
 )
+from galaxy.schema.schema import WorkflowIndexPayload
+from galaxy.tool_shed.tool_shed_registry import Registry
 from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.sharable import ShareableService
 
@@ -10,8 +33,113 @@ class WorkflowsService(ServiceBase):
     def __init__(
         self,
         workflows_manager: WorkflowsManager,
+        workflow_contents_manager: WorkflowContentsManager,
         serializer: WorkflowSerializer,
+        tool_shed_registry: Registry,
     ):
         self._workflows_manager = workflows_manager
+        self._workflow_contents_manager = workflow_contents_manager
         self._serializer = serializer
         self.shareable_service = ShareableService(workflows_manager, serializer)
+        self._tool_shed_registry = tool_shed_registry
+
+    def index(
+        self,
+        trans: ProvidesUserContext,
+        payload: WorkflowIndexPayload,
+    ) -> List[Dict[str, Any]]:
+        show_published = payload.show_published
+        show_hidden = payload.show_hidden
+        show_deleted = payload.show_deleted
+        missing_tools = payload.missing_tools
+        show_shared = payload.show_shared
+
+        if show_shared is None:
+            show_shared = not show_hidden and not show_deleted
+
+        if show_shared and show_deleted:
+            message = "show_shared and show_deleted cannot both be specified as true"
+            raise exceptions.RequestParameterInvalidException(message)
+        if show_shared and show_hidden:
+            message = "show_shared and show_hidden cannot both be specified as true"
+            raise exceptions.RequestParameterInvalidException(message)
+
+        rval = []
+        filters = [
+            model.StoredWorkflow.user == trans.user,
+        ]
+        user = trans.user
+        if user and show_shared:
+            filters.append(model.StoredWorkflowUserShareAssociation.user == user)
+
+        if show_published or user is None and show_published is None:
+            filters.append((model.StoredWorkflow.published == true()))
+
+        query = trans.sa_session.query(model.StoredWorkflow)
+        if show_shared:
+            query = query.outerjoin(model.StoredWorkflow.users_shared_with)
+
+        query = (
+            query.options(joinedload("annotations"))
+            .options(joinedload("latest_workflow").undefer("step_count").lazyload("steps"))
+            .options(joinedload("tags"))
+        )
+        query = query.filter(or_(*filters))
+        query = query.filter(model.StoredWorkflow.table.c.hidden == (true() if show_hidden else false()))
+        query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
+        if user:
+            query = query.order_by(desc(model.StoredWorkflow.user == user))
+        query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
+        for wf in query.all():
+            item = wf.to_dict(value_mapper={"id": trans.security.encode_id})
+            encoded_id = trans.security.encode_id(wf.id)
+            item["annotations"] = [x.annotation for x in wf.annotations]
+            item["url"] = web.url_for("workflow", id=encoded_id)
+            item["owner"] = wf.user.username
+            item["source_metadata"] = wf.latest_workflow.source_metadata
+            item["number_of_steps"] = wf.latest_workflow.step_count
+            item["show_in_tool_panel"] = False
+            if user is not None:
+                item["show_in_tool_panel"] = wf.show_in_tool_panel(user_id=user.id)
+            rval.append(item)
+        if missing_tools:
+            workflows_missing_tools = []
+            workflows = []
+            workflows_by_toolshed = dict()
+            for value in rval:
+                stored_workflow = self._workflows_manager.get_stored_workflow(trans, value["id"], by_stored_id=True)
+                tools = self._workflow_contents_manager.get_all_tools(stored_workflow.latest_workflow)
+                missing_tool_ids = [
+                    tool["tool_id"] for tool in tools if trans.app.toolbox.is_missing_shed_tool(tool["tool_id"])
+                ]
+                if len(missing_tool_ids) > 0:
+                    value["missing_tools"] = missing_tool_ids
+                    workflows_missing_tools.append(value)
+            for workflow in workflows_missing_tools:
+                for tool_id in workflow["missing_tools"]:
+                    toolshed, _, owner, name, tool, version = tool_id.split("/")
+                    shed_url = self.__get_full_shed_url(toolshed)
+                    repo_identifier = "/".join((toolshed, owner, name))
+                    if repo_identifier not in workflows_by_toolshed:
+                        workflows_by_toolshed[repo_identifier] = dict(
+                            shed=shed_url.rstrip("/"),
+                            repository=name,
+                            owner=owner,
+                            tools=[tool_id],
+                            workflows=[workflow["name"]],
+                        )
+                    else:
+                        if tool_id not in workflows_by_toolshed[repo_identifier]["tools"]:
+                            workflows_by_toolshed[repo_identifier]["tools"].append(tool_id)
+                        if workflow["name"] not in workflows_by_toolshed[repo_identifier]["workflows"]:
+                            workflows_by_toolshed[repo_identifier]["workflows"].append(workflow["name"])
+            for repo_tag in workflows_by_toolshed:
+                workflows.append(workflows_by_toolshed[repo_tag])
+            return workflows
+        return rval
+
+    def __get_full_shed_url(self, url):
+        for shed_url in self._tool_shed_registry.tool_sheds.values():
+            if url in shed_url:
+                return shed_url
+        return None

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -87,9 +87,13 @@ class WorkflowsService(ServiceBase):
         query = query.filter(or_(*filters))
         query = query.filter(model.StoredWorkflow.table.c.hidden == (true() if show_hidden else false()))
         query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
-        if user:
-            query = query.order_by(desc(model.StoredWorkflow.user == user))
-        query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
+        if payload.sort_by is None:
+            if user:
+                query = query.order_by(desc(model.StoredWorkflow.user == user))
+            query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
+        else:
+            sort_column = getattr(model.StoredWorkflow, payload.sort_by)
+            query = query.order_by(sort_column)
         for wf in query.all():
             item = wf.to_dict(value_mapper={"id": trans.security.encode_id})
             encoded_id = trans.security.encode_id(wf.id)

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -93,6 +93,10 @@ class WorkflowsService(ServiceBase):
         query = query.filter(or_(*filters))
         query = query.filter(model.StoredWorkflow.table.c.hidden == (true() if show_hidden else false()))
         query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
+        if payload.search:
+            search_query = payload.search
+            for q in search_query.split():
+                query = query.filter(model.StoredWorkflow.name.like(f"%{q}%"))
         if include_total_count:
             total_matches = query.count()
         else:

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -1,3 +1,4 @@
+import logging
 from typing import (
     Any,
     Dict,
@@ -27,6 +28,8 @@ from galaxy.schema.schema import WorkflowIndexPayload
 from galaxy.tool_shed.tool_shed_registry import Registry
 from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.sharable import ShareableService
+
+log = logging.getLogger(__name__)
 
 
 class WorkflowsService(ServiceBase):
@@ -93,6 +96,8 @@ class WorkflowsService(ServiceBase):
             query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
         else:
             sort_column = getattr(model.StoredWorkflow, payload.sort_by)
+            if payload.sort_desc:
+                sort_column = sort_column.desc()
             query = query.order_by(sort_column)
         for wf in query.all():
             item = wf.to_dict(value_mapper={"id": trans.security.encode_id})

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -433,6 +433,14 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert my_workflow_id_1 in index_ids
         assert their_workflow_id_1 in index_ids
 
+    def test_index_search(self):
+        name1, name2 = self.dataset_populator.get_random_name(), self.dataset_populator.get_random_name()
+        workflow_id_1 = self.workflow_populator.simple_workflow(name1)
+        self.workflow_populator.simple_workflow(name2)
+        index_ids = self.workflow_populator.index_ids(search=name1)
+        assert len(index_ids) == 1
+        assert workflow_id_1 in index_ids
+
     def test_index_published(self):
         # published workflows are also the default of what is displayed for anonymous API requests
         # this is tested in test_anonymous_published.

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -395,8 +395,16 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         my_workflow_id_z = self.workflow_populator.simple_workflow("z_2")
         index_ids = self.workflow_populator.index_ids()
         assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
+        index_ids = self.workflow_populator.index_ids(sort_by="create_time", sort_desc=True)
+        assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
+        index_ids = self.workflow_populator.index_ids(sort_by="create_time", sort_desc=False)
+        assert index_ids.index(my_workflow_id_y) < index_ids.index(my_workflow_id_z)
         index_ids = self.workflow_populator.index_ids(sort_by="name")
         assert index_ids.index(my_workflow_id_y) < index_ids.index(my_workflow_id_z)
+        index_ids = self.workflow_populator.index_ids(sort_by="name", sort_desc=False)
+        assert index_ids.index(my_workflow_id_y) < index_ids.index(my_workflow_id_z)
+        index_ids = self.workflow_populator.index_ids(sort_by="name", sort_desc=True)
+        assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
 
     def test_show_shared(self):
         my_workflow_id_1 = self.workflow_populator.simple_workflow("mine_1")

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -415,7 +415,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert len(index_ids_offset) == 1
         assert index_ids[0] != index_ids_offset[0]
 
-    def test_show_shared(self):
+    def test_index_show_shared(self):
         my_workflow_id_1 = self.workflow_populator.simple_workflow("mine_1")
         my_email = self.dataset_populator.user_email()
         with self._different_user():
@@ -432,6 +432,16 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         index_ids = self.workflow_populator.index_ids(show_shared=True)
         assert my_workflow_id_1 in index_ids
         assert their_workflow_id_1 in index_ids
+
+    def test_index_skip_step_counts(self):
+        self.workflow_populator.simple_workflow("mine_1")
+        index = self.workflow_populator.index()
+        index_0 = index[0]
+        assert "number_of_steps" in index_0
+        assert index_0["number_of_steps"]
+        index = self.workflow_populator.index(skip_step_counts=True)
+        index_0 = index[0]
+        assert "number_of_steps" not in index_0
 
     def test_index_search(self):
         name1, name2 = self.dataset_populator.get_random_name(), self.dataset_populator.get_random_name()

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -406,6 +406,15 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         index_ids = self.workflow_populator.index_ids(sort_by="name", sort_desc=True)
         assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
 
+    def test_index_limit_and_offset(self):
+        self.workflow_populator.simple_workflow("y_1")
+        self.workflow_populator.simple_workflow("z_2")
+        index_ids = self.workflow_populator.index_ids(limit=1)
+        assert len(index_ids) == 1
+        index_ids_offset = self.workflow_populator.index_ids(limit=1, offset=1)
+        assert len(index_ids_offset) == 1
+        assert index_ids[0] != index_ids_offset[0]
+
     def test_show_shared(self):
         my_workflow_id_1 = self.workflow_populator.simple_workflow("mine_1")
         my_email = self.dataset_populator.user_email()

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -390,6 +390,14 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         # after an update to workflow 1, it now comes before workflow 2
         assert index_ids.index(my_workflow_id_1) < index_ids.index(my_workflow_id_2)
 
+    def test_index_sort_by(self):
+        my_workflow_id_y = self.workflow_populator.simple_workflow("y_1")
+        my_workflow_id_z = self.workflow_populator.simple_workflow("z_2")
+        index_ids = self.workflow_populator.index_ids()
+        assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
+        index_ids = self.workflow_populator.index_ids(sort_by="name")
+        assert index_ids.index(my_workflow_id_y) < index_ids.index(my_workflow_id_z)
+
     def test_show_shared(self):
         my_workflow_id_1 = self.workflow_populator.simple_workflow("mine_1")
         my_email = self.dataset_populator.user_email()

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1537,6 +1537,7 @@ class BaseWorkflowPopulator(BasePopulator):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         search: Optional[str] = None,
+        skip_step_counts: Optional[bool] = None,
     ):
         endpoint = "workflows?"
         if show_shared is not None:
@@ -1553,6 +1554,8 @@ class BaseWorkflowPopulator(BasePopulator):
             endpoint += f"offset={offset}&"
         if search is not None:
             endpoint += f"search={search}&"
+        if skip_step_counts is not None:
+            endpoint += f"skip_step_counts={skip_step_counts}&"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1529,23 +1529,36 @@ class BaseWorkflowPopulator(BasePopulator):
         time.sleep(0.5)
 
     def index(
-        self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None, sort_by: Optional[str] = None
+        self,
+        show_shared: Optional[bool] = None,
+        show_published: Optional[bool] = None,
+        sort_by: Optional[str] = None,
+        sort_desc: Optional[bool] = None,
     ):
         endpoint = "workflows?"
         if show_shared is not None:
-            endpoint += f"show_shared={show_shared}"
+            endpoint += f"show_shared={show_shared}&"
         if show_published is not None:
-            endpoint += f"show_published={show_published}"
+            endpoint += f"show_published={show_published}&"
         if sort_by is not None:
-            endpoint += f"sort_by={sort_by}"
+            endpoint += f"sort_by={sort_by}&"
+        if sort_desc is not None:
+            endpoint += f"sort_desc={sort_desc}&"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
 
     def index_ids(
-        self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None, sort_by: Optional[str] = None
+        self,
+        show_shared: Optional[bool] = None,
+        show_published: Optional[bool] = None,
+        sort_by: Optional[str] = None,
+        sort_desc: Optional[bool] = None,
     ):
-        return [w["id"] for w in self.index(show_shared=show_shared, show_published=show_published, sort_by=sort_by)]
+        workflows = self.index(
+            show_shared=show_shared, show_published=show_published, sort_by=sort_by, sort_desc=sort_desc
+        )
+        return [w["id"] for w in workflows]
 
     def share_with_user(self, workflow_id: str, user_id_or_email: str):
         data = {"user_ids": [user_id_or_email]}

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1528,18 +1528,24 @@ class BaseWorkflowPopulator(BasePopulator):
         self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=assert_ok)
         time.sleep(0.5)
 
-    def index(self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None):
+    def index(
+        self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None, sort_by: Optional[str] = None
+    ):
         endpoint = "workflows?"
         if show_shared is not None:
             endpoint += f"show_shared={show_shared}"
         if show_published is not None:
             endpoint += f"show_published={show_published}"
+        if sort_by is not None:
+            endpoint += f"sort_by={sort_by}"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
 
-    def index_ids(self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None):
-        return [w["id"] for w in self.index(show_shared=show_shared, show_published=show_published)]
+    def index_ids(
+        self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None, sort_by: Optional[str] = None
+    ):
+        return [w["id"] for w in self.index(show_shared=show_shared, show_published=show_published, sort_by=sort_by)]
 
     def share_with_user(self, workflow_id: str, user_id_or_email: str):
         data = {"user_ids": [user_id_or_email]}

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1534,6 +1534,8 @@ class BaseWorkflowPopulator(BasePopulator):
         show_published: Optional[bool] = None,
         sort_by: Optional[str] = None,
         sort_desc: Optional[bool] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ):
         endpoint = "workflows?"
         if show_shared is not None:
@@ -1544,6 +1546,10 @@ class BaseWorkflowPopulator(BasePopulator):
             endpoint += f"sort_by={sort_by}&"
         if sort_desc is not None:
             endpoint += f"sort_desc={sort_desc}&"
+        if limit is not None:
+            endpoint += f"limit={limit}&"
+        if offset is not None:
+            endpoint += f"offset={offset}&"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
@@ -1554,9 +1560,16 @@ class BaseWorkflowPopulator(BasePopulator):
         show_published: Optional[bool] = None,
         sort_by: Optional[str] = None,
         sort_desc: Optional[bool] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ):
         workflows = self.index(
-            show_shared=show_shared, show_published=show_published, sort_by=sort_by, sort_desc=sort_desc
+            show_shared=show_shared,
+            show_published=show_published,
+            sort_by=sort_by,
+            sort_desc=sort_desc,
+            limit=limit,
+            offset=offset,
         )
         return [w["id"] for w in workflows]
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1536,6 +1536,7 @@ class BaseWorkflowPopulator(BasePopulator):
         sort_desc: Optional[bool] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        search: Optional[str] = None,
     ):
         endpoint = "workflows?"
         if show_shared is not None:
@@ -1550,6 +1551,8 @@ class BaseWorkflowPopulator(BasePopulator):
             endpoint += f"limit={limit}&"
         if offset is not None:
             endpoint += f"offset={offset}&"
+        if search is not None:
+            endpoint += f"search={search}&"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
@@ -1562,6 +1565,7 @@ class BaseWorkflowPopulator(BasePopulator):
         sort_desc: Optional[bool] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        search: Optional[str] = None,
     ):
         workflows = self.index(
             show_shared=show_shared,
@@ -1570,6 +1574,7 @@ class BaseWorkflowPopulator(BasePopulator):
             sort_desc=sort_desc,
             limit=limit,
             offset=offset,
+            search=search,
         )
         return [w["id"] for w in workflows]
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1387,6 +1387,7 @@ class BaseWorkflowPopulator(BasePopulator):
         assert_ok=True,
         client_convert=None,
         round_trip_format_conversion=False,
+        invocations=1,
         raw_yaml=False,
     ):
         """High-level wrapper around workflow API, etc. to invoke format 2 workflows."""
@@ -1432,28 +1433,31 @@ class BaseWorkflowPopulator(BasePopulator):
             workflow_request["replacement_params"] = json.dumps(replacement_parameters)
         if has_uploads:
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        invocation_response = workflow_populator.invoke_workflow_raw(workflow_id, workflow_request)
-        api_asserts.assert_status_code_is(invocation_response, expected_response)
-        invocation = invocation_response.json()
-        if expected_response != 200:
-            assert not assert_ok
-            return invocation
-        invocation_id = invocation.get("id")
-        if invocation_id:
-            # Wait for workflow to become fully scheduled and then for all jobs
-            # complete.
-            if wait:
-                workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id, assert_ok=assert_ok)
-            jobs = self.dataset_populator.history_jobs(history_id)
-            return RunJobsSummary(
-                history_id=history_id,
-                workflow_id=workflow_id,
-                invocation_id=invocation_id,
-                inputs=inputs,
-                jobs=jobs,
-                invocation=invocation,
-                workflow_request=workflow_request,
-            )
+        assert invocations > 0
+        jobs = []
+        for _ in range(invocations):
+            invocation_response = workflow_populator.invoke_workflow_raw(workflow_id, workflow_request)
+            api_asserts.assert_status_code_is(invocation_response, expected_response)
+            invocation = invocation_response.json()
+            if expected_response != 200:
+                assert not assert_ok
+                return invocation
+            invocation_id = invocation.get("id")
+            if invocation_id:
+                # Wait for workflow to become fully scheduled and then for all jobs
+                # complete.
+                if wait:
+                    workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id, assert_ok=assert_ok)
+                jobs.extend(self.dataset_populator.history_jobs(history_id))
+        return RunJobsSummary(
+            history_id=history_id,
+            workflow_id=workflow_id,
+            invocation_id=invocation_id,
+            inputs=inputs,
+            jobs=jobs,
+            invocation=invocation,
+            workflow_request=workflow_request,
+        )
 
     def dump_workflow(self, workflow_id, style=None):
         raw_workflow = self.download_workflow(workflow_id, style=style)

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -552,6 +552,26 @@ class UsesWorkflowAssertions(NavigatesGalaxyMixin):
         self.workflow_import_submit_url(url)
 
 
+class TestsGalaxyPagers(GalaxyTestSeleniumContext):
+    @retry_assertion_during_transitions
+    def _assert_current_page_is(self, component, expected_page: int):
+        component.pager.wait_for_visible()
+        page_from_pager = component.pager_page_active.wait_for_present().text
+        assert int(page_from_pager) == expected_page
+
+    def _next_page(self, component):
+        component.pager_page_next.wait_for_and_click()
+
+    def _previous_page(self, component):
+        component.pager_page_previous.wait_for_and_click()
+
+    def _last_page(self, component):
+        component.pager_page_last.wait_for_and_click()
+
+    def _first_page(self, component):
+        component.pager_page_first.wait_for_and_click()
+
+
 class RunsWorkflows(GalaxyTestSeleniumContext):
     def workflow_upload_yaml_with_random_name(self, content: str, **kwds) -> str:
         name = self._get_random_name()

--- a/lib/galaxy_test/selenium/test_invocation_grid.py
+++ b/lib/galaxy_test/selenium/test_invocation_grid.py
@@ -1,0 +1,50 @@
+from galaxy_test.base.workflow_fixtures import WORKFLOW_RENAME_ON_INPUT
+from .framework import (
+    retry_assertion_during_transitions,
+    selenium_test,
+    SeleniumTestCase,
+    TestsGalaxyPagers,
+)
+
+
+class InvocationGridSeleniumTestCase(SeleniumTestCase, TestsGalaxyPagers):
+
+    ensure_registered = True
+
+    @selenium_test
+    def test_grid(self):
+        gx_selenium_context = self
+        history_id = gx_selenium_context.dataset_populator.new_history()
+        gx_selenium_context.workflow_populator.run_workflow(
+            WORKFLOW_RENAME_ON_INPUT,
+            history_id=history_id,
+            assert_ok=True,
+            wait=True,
+            invocations=2,
+        )
+        gx_selenium_context.navigate_to_invocations()
+        self._assert_showing_n_invocations(2)
+
+        # by default the pager only appears when there are too many invocations
+        # for one page - so verify it is absent and then swap to showing just
+        # one invocation per page.
+        invocations = gx_selenium_context.components.invocations
+        invocations.pager.wait_for_absent_or_hidden()
+        self.re_get_with_query_params("rows_per_page=1")
+        self._assert_showing_n_invocations(1)
+        invocations.pager.wait_for_visible()
+        self.screenshot("invocations_paginated_first_page")
+        self._next_page(invocations)
+        self._assert_current_page_is(invocations, 2)
+        self.screenshot("invocations_paginated_next_page")
+        self._previous_page(invocations)
+        self._assert_current_page_is(invocations, 1)
+        self._last_page(invocations)
+        self._assert_current_page_is(invocations, 2)
+        self.screenshot("invocations_paginated_last_page")
+        self._first_page(invocations)
+        self._assert_current_page_is(invocations, 1)
+
+    @retry_assertion_during_transitions
+    def _assert_showing_n_invocations(self, n):
+        self.assertEqual(len(self.invocation_index_table_elements()), n)

--- a/lib/galaxy_test/selenium/test_workflow_invocation_details.py
+++ b/lib/galaxy_test/selenium/test_workflow_invocation_details.py
@@ -28,8 +28,8 @@ class WorkflowInvocationDetailsTestCase(SeleniumTestCase):
             assert len(invocation_rows) > 0
             return invocation_rows[0]
 
-        first_row = assert_has_row()
-        print(first_row)
+        assert_has_row()
+
         invocations.state_details.assert_absent()
         invocations.toggle_invocation_details.wait_for_visible()
         details = invocations.toggle_invocation_details.all()[0]

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -3,11 +3,12 @@ from .framework import (
     retry_assertion_during_transitions,
     selenium_test,
     SeleniumTestCase,
+    TestsGalaxyPagers,
     UsesWorkflowAssertions,
 )
 
 
-class WorkflowManagementTestCase(SeleniumTestCase, UsesWorkflowAssertions):
+class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers, UsesWorkflowAssertions):
 
     ensure_registered = True
 
@@ -94,3 +95,37 @@ class WorkflowManagementTestCase(SeleniumTestCase, UsesWorkflowAssertions):
 
         self.workflow_index_search_for("searchforthis")
         self._assert_showing_n_workflows(1)
+
+    @selenium_test
+    def test_pagination(self):
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_open()
+
+        self._assert_showing_n_workflows(4)
+
+        # by default the pager only appears when there are too many workflows
+        # for one page - so verify it is absent and then swap to showing just
+        # one workflow per page.
+        workflows = self.components.workflows
+        workflows.pager.wait_for_absent_or_hidden()
+        self.re_get_with_query_params("rows_per_page=1")
+        self._assert_showing_n_workflows(1)
+        self.screenshot("workflows_paginated_first_page")
+        self._assert_current_page_is(workflows, 1)
+        self._next_page(workflows)
+        self._assert_current_page_is(workflows, 2)
+        self.screenshot("workflows_paginated_next_page")
+        self._previous_page(workflows)
+        self._assert_current_page_is(workflows, 1)
+        self._last_page(workflows)
+        self._assert_current_page_is(workflows, 4)
+        self.screenshot("workflows_paginated_last_page")
+        self._first_page(workflows)
+        self._assert_current_page_is(workflows, 1)


### PR DESCRIPTION
Builds on grid enhancements from #13183.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run a workflow several times.
  2. Click the workflow in the grid view and go down to the new "Invocations" option.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
