### PR TITLE
Potential fix for certain kind of transient Selenium library errors.

### DIFF
--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -219,6 +219,10 @@ class HasDriver:
         )
 
 
+def execetion_indicates_click_intercepted(exception):
+    return "click intercepted" in str(exception)
+
+
 def exception_indicates_not_clickable(exception):
     return "not clickable" in str(exception)
 
@@ -228,6 +232,7 @@ def exception_indicates_stale_element(exception):
 
 
 __all__ = (
+    "execetion_indicates_click_intercepted",
     "exception_indicates_not_clickable",
     "exception_indicates_stale_element",
     "HasDriver",

--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -219,7 +219,7 @@ class HasDriver:
         )
 
 
-def execetion_indicates_click_intercepted(exception):
+def exception_indicates_click_intercepted(exception):
     return "click intercepted" in str(exception)
 
 
@@ -232,7 +232,7 @@ def exception_indicates_stale_element(exception):
 
 
 __all__ = (
-    "execetion_indicates_click_intercepted",
+    "exception_indicates_click_intercepted",
     "exception_indicates_not_clickable",
     "exception_indicates_stale_element",
     "HasDriver",

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -36,6 +36,7 @@ from .data import load_root_component
 from .has_driver import (
     exception_indicates_not_clickable,
     exception_indicates_stale_element,
+    execetion_indicates_click_intercepted,
     HasDriver,
     TimeoutException,
 )
@@ -98,7 +99,11 @@ def exception_seems_to_indicate_transition(e):
     StaleElement exceptions (a DOM element grabbed at one step is no longer available)
     and "not clickable" exceptions (so perhaps a popup modal is blocking a click).
     """
-    return exception_indicates_stale_element(e) or exception_indicates_not_clickable(e)
+    return (
+        exception_indicates_stale_element(e)
+        or exception_indicates_not_clickable(e)
+        or execetion_indicates_click_intercepted(e)
+    )
 
 
 def retry_call_during_transitions(

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -34,9 +34,9 @@ from .components import (
 )
 from .data import load_root_component
 from .has_driver import (
+    exception_indicates_click_intercepted,
     exception_indicates_not_clickable,
     exception_indicates_stale_element,
-    execetion_indicates_click_intercepted,
     HasDriver,
     TimeoutException,
 )
@@ -102,7 +102,7 @@ def exception_seems_to_indicate_transition(e):
     return (
         exception_indicates_stale_element(e)
         or exception_indicates_not_clickable(e)
-        or execetion_indicates_click_intercepted(e)
+        or exception_indicates_click_intercepted(e)
     )
 
 

--- a/test/integration_selenium/test_user_library_permissions.py
+++ b/test/integration_selenium/test_user_library_permissions.py
@@ -107,6 +107,6 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
 
     @retry_assertion_during_transitions
     def select_add_items_permission_option(self, option_text):
-        el = self.components.libraries.add_items_permission_option.wait_for_visible()
+        el = self.components.libraries.add_items_permission_option.wait_for_clickable()
         assert option_text == el.text
         el.click()


### PR DESCRIPTION
select_add_items_permission_option failed unexpectedly in a Selenium test https://github.com/galaxyproject/galaxy/runs/6130989843?check_suite_focus=true with this in the stack trace:

```
>       raise exception_class(message, screen, stacktrace)
E       selenium.common.exceptions.ElementClickInterceptedException: Message: element click intercepted: Element <ul class="multiselect__content" style="display: inline-block;">...</ul> is not clickable at point (324, 547). Other element would receive the click: <div data-v-5b55ce08="" class="col">...</div>
E         (Session info: headless chrome=100.0.4896.75)
```

I think this means something was preventing it from being clickable - presumably a toastr message or something. This attempts to fix that issue two ways - by making the retry decorator a little more aggressive and by ensuring the element is in fact clickable before clicking it.


## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
