### PR TITLE
Separate content item options into component

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -49,7 +49,7 @@
                     @display="onDisplay"
                     @edit="onEdit"
                     @undelete="$emit('undelete')"
-                    @unhide="$emit('delete')" />
+                    @unhide="$emit('unhide')" />
             </div>
         </div>
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
@@ -62,10 +62,10 @@
 <script>
 import { backboneRoute, useGalaxy, iframeRedirect } from "components/plugins/legacyNavigation";
 import { Nametag } from "components/Nametags";
+import { STATES } from "./model/states";
 import CollectionDescription from "./Collection/CollectionDescription";
 import ContentOptions from "./ContentOptions";
 import DatasetDetails from "./Dataset/DatasetDetails";
-import STATES from "./contentStates";
 
 export default {
     components: {
@@ -76,10 +76,10 @@ export default {
     },
     props: {
         expandDataset: { type: Boolean, required: true },
-        item: { type: Object, required: true },
         id: { type: Number, required: true },
         isDataset: { type: Boolean, default: true },
         isHistoryItem: { type: Boolean, default: true },
+        item: { type: Object, required: true },
         name: { type: String, required: true },
         selected: { type: Boolean, default: false },
         selectable: { type: Boolean, default: false },

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -1,0 +1,92 @@
+<template>
+    <span class="align-self-start btn-group">
+        <b-button
+            v-if="isDataset"
+            :disabled="displayDisabled"
+            :title="displayButtonTitle"
+            class="px-1"
+            size="sm"
+            variant="link"
+            @click.stop="$emit('display')">
+            <icon icon="eye" />
+        </b-button>
+        <b-button
+            v-if="isHistoryItem"
+            :disabled="editDisabled"
+            :title="editButtonTitle"
+            class="px-1"
+            size="sm"
+            variant="link"
+            @click.stop="$emit('edit')">
+            <icon icon="pen" />
+        </b-button>
+        <b-button
+            v-if="isHistoryItem && !isDeleted"
+            class="px-1"
+            title="Delete"
+            size="sm"
+            variant="link"
+            :disabled="isPurged"
+            @click.stop="$emit('delete')">
+            <icon icon="trash" />
+        </b-button>
+        <b-button
+            v-if="isHistoryItem && isDeleted"
+            class="px-1"
+            title="Undelete"
+            size="sm"
+            variant="link"
+            :disabled="isPurged"
+            @click.stop="$emit('undelete')">
+            <icon icon="trash-restore" />
+        </b-button>
+        <b-button
+            v-if="isHistoryItem && !isVisible"
+            class="px-1"
+            title="Unhide"
+            size="sm"
+            variant="link"
+            @click.stop="$emit('unhide')">
+            <icon icon="unlock" />
+        </b-button>
+    </span>
+</template>
+
+<script>
+export default {
+    props: {
+        isDataset: { type: Boolean, required: true },
+        isDeleted: { type: Boolean, required: true },
+        isHistoryItem: { type: Boolean, required: true },
+        isPurged: { type: Boolean, required: true },
+        isVisible: { type: Boolean, required: true },
+        state: { type: String, default: "" },
+    },
+    computed: {
+        displayButtonTitle() {
+            if (this.isPurged) {
+                return "Cannot display datasets removed from disk.";
+            }
+            if (this.displayDisabled) {
+                return "This dataset is not yet viewable.";
+            }
+            return "Display";
+        },
+        displayDisabled() {
+            return this.isPurged || ["discarded", "new", "upload"].includes(this.state);
+        },
+        editButtonTitle() {
+            if (this.isPurged) {
+                return "Cannot edit attributes of datasets removed from disk.";
+            }
+            if (this.editDisabled) {
+                return "This dataset is not yet editable.";
+            }
+            return "Edit Attributes";
+        },
+        editDisabled() {
+            return this.isPurged || ["discarded", "new", "upload", "queued", "running", "waiting"].includes(this.state);
+        },
+    },
+};
+</script>

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -82,7 +82,7 @@ export default {
             if (this.editDisabled) {
                 return "This dataset is not yet editable.";
             }
-            return "Edit Attributes";
+            return "Edit attributes";
         },
         editDisabled() {
             return this.isPurged || ["discarded", "new", "upload", "queued", "running", "waiting"].includes(this.state);

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script>
-import STATES from "components/History/Content/contentStates";
+import { STATES } from "components/History/Content/model/states";
 import { DatasetProvider } from "components/providers/storeProviders";
 import DatasetActions from "./DatasetActions";
 

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -13,7 +13,7 @@
                     </span>
                     <span v-if="result.genome_build" class="dbkey">
                         <label class="prompt" v-localize>database</label>
-                        <b-link class="value" @click.stop="$emit('edit', dataset)" data-label="Database/Build">{{
+                        <b-link class="value" @click.stop="$emit('edit')" data-label="Database/Build">{{
                             result.genome_build
                         }}</b-link>
                     </span>

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -2,7 +2,7 @@
     Client representation of state and state messages. See: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/model/__init__.py#L3292
     for a list of available states.
 */
-export default {
+export const STATES = {
     /** deleted while uploading */
     discarded: {
         status: "danger",

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -26,8 +26,8 @@
                                     :item="item.object"
                                     :id="item.element_index"
                                     :name="item.element_identifier"
-                                    :is-dataset="item.element_type == 'hda'"
                                     :expand-dataset="isExpanded(item)"
+                                    :is-dataset="item.element_type == 'hda'"
                                     :is-history-item="false"
                                     @update:expand-dataset="setExpanded(item, $event)"
                                     @view-collection="onViewSubCollection" />

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -82,7 +82,7 @@
                                         :id="item.hid"
                                         :name="item.name"
                                         :expand-dataset="isExpanded(item)"
-                                        :is-dataset="item.history_content_type == 'dataset'"
+                                        :is-dataset="isDataset(item)"
                                         :selected="isSelected(item)"
                                         :selectable="showSelection"
                                         @update:expand-dataset="setExpanded(item, $event)"
@@ -173,17 +173,20 @@ export default {
         hasMatches(payload) {
             return !!payload && payload.length > 0;
         },
-        onScroll(offset) {
-            this.offset = offset;
+        isDataset(item) {
+            return item.history_content_type == "dataset";
+        },
+        onDelete(item) {
+            this.setInvisible(item);
+            deleteContent(item);
         },
         onHideSelection(selectedItems) {
             selectedItems.forEach((item) => {
                 this.setInvisible(item);
             });
         },
-        onDelete(item) {
-            this.setInvisible(item);
-            deleteContent(item);
+        onScroll(offset) {
+            this.offset = offset;
         },
         onUndelete(item) {
             this.setInvisible(item);

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -88,9 +88,9 @@
                                         @update:expand-dataset="setExpanded(item, $event)"
                                         @update:selected="setSelected(item, $event)"
                                         @view-collection="$emit('view-collection', item)"
-                                        @delete="onDelete"
-                                        @undelete="onUndelete"
-                                        @unhide="onUnhide" />
+                                        @delete="onDelete(item)"
+                                        @undelete="onUndelete(item)"
+                                        @unhide="onUnhide(item)" />
                                 </template>
                             </Listing>
                         </div>

--- a/client/src/components/History/adapters/HistoryPanelProxy.js
+++ b/client/src/components/History/adapters/HistoryPanelProxy.js
@@ -2,7 +2,6 @@
  * This is an adapter for the History component. It's required since the previous
  * history provided the same interface for other components.
  */
-import $ from "jquery";
 import Backbone from "backbone";
 import store from "store";
 import { getGalaxyInstance } from "app";
@@ -94,10 +93,12 @@ export class HistoryPanelProxy {
     }
     render() {
         const container = document.createElement("div");
-        $("#right > .unified-panel-header").remove();
-        $("#right > .unified-panel-controls").remove();
-        $("#right > .unified-panel-body").remove();
-        $("#right").addClass("beta").prepend(container);
+        document.querySelector("#right > .unified-panel-header").remove();
+        document.querySelector("#right > .unified-panel-controls").remove();
+        document.querySelector("#right > .unified-panel-body").remove();
+        const parent = document.querySelector("#right");
+        parent.classList.add("beta");
+        parent.prepend(container);
         const mountFn = mountVueComponent(HistoryIndex);
         mountFn({}, container);
     }

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -8,16 +8,6 @@
 import axios from "axios";
 import { prependPath } from "utils/redirect";
 
-// #region setup & utils
-
-/**
- * Prefix axios with configured path prefix and /api
- */
-
-const api = axios.create({
-    baseURL: prependPath("/api"),
-});
-
 /**
  * Generic json getter
  * @param {*} response
@@ -58,8 +48,8 @@ export async function deleteContent(content, deleteParams = {}) {
     const defaults = { purge: false, recursive: false };
     const params = Object.assign({}, defaults, deleteParams);
     const { history_id, history_content_type, id } = content;
-    const url = `/histories/${history_id}/contents/${history_content_type}s/${id}`;
-    const response = await api.delete(url, { params });
+    const url = `api/histories/${history_id}/contents/${history_content_type}s/${id}`;
+    const response = await axios.delete(prependPath(url), { params });
     return doResponse(response);
 }
 
@@ -70,8 +60,8 @@ export async function deleteContent(content, deleteParams = {}) {
  */
 export async function updateContentFields(content, newFields = {}) {
     const { history_id, id, history_content_type: type } = content;
-    const url = `/histories/${history_id}/contents/${type}s/${id}`;
-    const response = await api.put(url, newFields);
+    const url = `api/histories/${history_id}/contents/${type}s/${id}`;
+    const response = await axios.put(prependPath(url), newFields);
     return doResponse(response);
 }
 
@@ -89,12 +79,12 @@ export async function updateContentFields(content, newFields = {}) {
 export async function bulkUpdate(history, operation, filters, items = []) {
     const { id } = history;
     const filterQuery = buildQueryStringFrom(filters);
-    const url = `/histories/${id}/contents/bulk?${filterQuery}`;
+    const url = `api/histories/${id}/contents/bulk?${filterQuery}`;
     const payload = {
         operation,
         items,
     };
-    const response = await api.put(url, payload);
+    const response = await axios.put(prependPath(url), payload);
     console.debug(`Submitted request to ${operation} selected content in bulk.`, response);
     return doResponse(response);
 }
@@ -114,40 +104,7 @@ export async function createDatasetCollection(history, inputs = {}) {
     };
 
     const payload = Object.assign({}, defaults, inputs);
-    const url = `/histories/${history.id}/contents`;
-    const response = await api.post(url, payload);
+    const url = `api/histories/${history.id}/contents`;
+    const response = await axios.post(prependPath(url), payload);
     return doResponse(response);
-}
-
-/**
- * Job Queries
- */
-const jobStash = new Map();
-const toolStash = new Map();
-
-async function loadJobById(jobId) {
-    if (!jobStash.has(jobId)) {
-        const url = `/jobs/${jobId}?full=false`;
-        const response = await api.get(url);
-        const job = response.data;
-        jobStash.set(jobId, job);
-    }
-    return jobStash.get(jobId);
-}
-
-async function loadToolForJob(job) {
-    const { tool_id, history_id } = job;
-    const key = `${tool_id}-${history_id}`;
-    if (!toolStash.has(key)) {
-        const url = `/tools/${tool_id}/build?history_id=${history_id}`;
-        const response = await api.get(url);
-        const tool = response.data;
-        toolStash.set(key, tool);
-    }
-    return toolStash.get(key);
-}
-
-export async function loadToolFromJob(jobId) {
-    const job = await loadJobById(jobId);
-    return await loadToolForJob(job);
 }

--- a/client/src/components/Tour/TourStep.vue
+++ b/client/src/components/Tour/TourStep.vue
@@ -2,8 +2,8 @@
     <div
         class="tour-element"
         :class="{ 'tour-element-sticky': !targetElement, 'tour-has-title': !!step.title }"
-        :id="'tour-element-' + hash"
-        :ref="'tour-element-' + hash">
+        :id="id"
+        :ref="id">
         <div v-if="step.title" class="tour-header">
             <div class="tour-title" v-html="step.title"></div>
         </div>
@@ -43,15 +43,15 @@ export default {
     },
     data() {
         return {
-            hash: sum(this.step.target),
-            targetElement: document.querySelector(this.step.target),
+            id: `tour-element-${sum(this.step.element)}`,
+            targetElement: document.querySelector(this.step.element),
         };
     },
     methods: {
         createStep() {
             if (this.targetElement) {
                 this.targetElement.scrollIntoView({ behavior: "smooth" });
-                createPopper(this.targetElement, this.$refs["tour-element-" + this.hash], {
+                createPopper(this.targetElement, this.$refs[this.id], {
                     modifiers: [
                         {
                             name: "preventOverflow",

--- a/client/src/components/Tour/TourStep.vue
+++ b/client/src/components/Tour/TourStep.vue
@@ -2,8 +2,7 @@
     <div
         class="tour-element"
         :class="{ 'tour-element-sticky': !targetElement, 'tour-has-title': !!step.title }"
-        :id="id"
-        :ref="id">
+        ref="tour-element">
         <div v-if="step.title" class="tour-header">
             <div class="tour-title" v-html="step.title"></div>
         </div>
@@ -27,7 +26,6 @@
 
 <script>
 import { createPopper } from "@popperjs/core";
-import sum from "hash-sum";
 
 export default {
     props: {
@@ -41,17 +39,19 @@ export default {
             type: Boolean,
         },
     },
-    data() {
-        return {
-            id: `tour-element-${sum(this.step.element)}`,
-            targetElement: document.querySelector(this.step.element),
-        };
+    computed: {
+        targetElement() {
+            if (this.step.element) {
+                return document.querySelector(this.step.element);
+            }
+            return null;
+        },
     },
     methods: {
         createStep() {
             if (this.targetElement) {
                 this.targetElement.scrollIntoView({ behavior: "smooth" });
-                createPopper(this.targetElement, this.$refs[this.id], {
+                createPopper(this.targetElement, this.$refs["tour-element"], {
                     modifiers: [
                         {
                             name: "preventOverflow",


### PR DESCRIPTION
Requires #13778. Contains only refactoring and clean-up. Removes jQuery from History proxy panel and separates content item options from content items. Also contains additional tour error handlers and fixes. Should be applied before enhancing the content item components like e.g. in #13740.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
