### PR TITLE
Adjustments to hidden/deleted history links

### DIFF
--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -58,7 +58,7 @@ export default {
         isDataset: { type: Boolean, required: true },
         isDeleted: { type: Boolean, required: true },
         isHistoryItem: { type: Boolean, required: true },
-        isPurged: { type: Boolean, required: true },
+        isPurged: { type: Boolean, default: false },
         isVisible: { type: Boolean, required: true },
         state: { type: String, default: "" },
     },

--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -1,0 +1,68 @@
+<template>
+    <div v-if="history.size" class="history-size my-1 d-flex justify-content-between">
+        <b-button
+            title="Access Dashboard"
+            variant="link"
+            size="sm"
+            class="rounded-0 text-decoration-none"
+            @click="onDashboard">
+            <icon icon="database" />
+            <span>{{ history.size | niceFileSize }}</span>
+        </b-button>
+        <b-button-group>
+            <b-button
+                title="Show active"
+                variant="link"
+                size="sm"
+                class="rounded-0 text-decoration-none"
+                @click="setFilter('')">
+                <span class="fa fa-map-marker" />
+                <span>{{ history.contents_active.active }}</span>
+            </b-button>
+            <b-button
+                v-if="history.contents_active.deleted"
+                title="Show deleted"
+                variant="link"
+                size="sm"
+                class="rounded-0 text-decoration-none"
+                @click="setFilter('deleted=true')">
+                <icon icon="trash" />
+                <span>{{ history.contents_active.deleted }}</span>
+            </b-button>
+            <b-button
+                v-if="history.contents_active.hidden"
+                title="Show hidden"
+                variant="link"
+                size="sm"
+                class="rounded-0 text-decoration-none"
+                @click="setFilter('visible=false')">
+                <icon icon="lock" />
+                <span>{{ history.contents_active.hidden }}</span>
+            </b-button>
+        </b-button-group>
+    </div>
+</template>
+
+<script>
+import { backboneRoute } from "components/plugins/legacyNavigation";
+import prettyBytes from "pretty-bytes";
+
+export default {
+    filters: {
+        niceFileSize(rawSize = 0) {
+            return prettyBytes(rawSize);
+        },
+    },
+    props: {
+        history: { type: Object, required: true },
+    },
+    methods: {
+        onDashboard() {
+            backboneRoute("/storage");
+        },
+        setFilter(newFilterText) {
+            this.$emit("update:filter-text", newFilterText);
+        },
+    },
+};
+</script>

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -5,50 +5,6 @@
         :tags="history.tags"
         :writeable="writeable"
         @save="onSave">
-        <template v-slot:header>
-            <div v-if="history.size" class="history-size my-1 w-100 d-flex justify-content-between">
-                <b-button
-                    title="Access Dashboard"
-                    variant="link"
-                    size="sm"
-                    class="text-decoration-none"
-                    @click="onDashboard">
-                    <icon icon="database" />
-                    <span>{{ history.size | niceFileSize }}</span>
-                </b-button>
-                <b-button-group>
-                    <b-button
-                        title="Show active"
-                        variant="link"
-                        size="sm"
-                        class="text-decoration-none"
-                        @click="setFilter('')">
-                        <span class="fa fa-map-marker" />
-                        <span>{{ history.contents_active.active }}</span>
-                    </b-button>
-                    <b-button
-                        v-if="history.contents_active.deleted"
-                        title="Show deleted"
-                        variant="link"
-                        size="sm"
-                        class="text-decoration-none"
-                        @click="setFilter('deleted=true')">
-                        <icon icon="trash" />
-                        <span>{{ history.contents_active.deleted }}</span>
-                    </b-button>
-                    <b-button
-                        v-if="history.contents_active.hidden"
-                        title="Show hidden"
-                        variant="link"
-                        size="sm"
-                        class="text-decoration-none"
-                        @click="setFilter('visible=false')">
-                        <icon icon="lock" />
-                        <span>{{ history.contents_active.hidden }}</span>
-                    </b-button>
-                </b-button-group>
-            </div>
-        </template>
         <template v-slot:name>
             <h3 data-description="name display" class="my-2" v-short="history.name || 'History'" />
         </template>
@@ -56,8 +12,6 @@
 </template>
 
 <script>
-import { backboneRoute } from "components/plugins/legacyNavigation";
-import prettyBytes from "pretty-bytes";
 import short from "components/directives/v-short";
 import Details from "components/History/Layout/Details";
 
@@ -68,25 +22,14 @@ export default {
     directives: {
         short,
     },
-    filters: {
-        niceFileSize(rawSize = 0) {
-            return prettyBytes(rawSize);
-        },
-    },
     props: {
         history: { type: Object, required: true },
         writeable: { type: Boolean, default: true },
     },
     methods: {
-        onDashboard() {
-            backboneRoute("/storage");
-        },
         onSave(newDetails) {
             const id = this.history.id;
-            this.$emit("updateHistory", { ...newDetails, id });
-        },
-        setFilter(newFilterText) {
-            this.$emit("update:filter-text", newFilterText);
+            this.$emit("update:history", { ...newDetails, id });
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -5,30 +5,58 @@
         :tags="history.tags"
         :writeable="writeable"
         @save="onSave">
+        <template v-slot:header>
+            <nav v-if="history.size" class="history-size my-1 w-100 d-flex justify-content-between">
+                <b-button
+                    title="Access Dashboard"
+                    variant="link"
+                    size="sm"
+                    class="text-decoration-none"
+                    @click="onDashboard">
+                    <icon icon="database" />
+                    <span>{{ history.size | niceFileSize }}</span>
+                </b-button>
+                <b-button-group>
+                    <b-button
+                        title="Show active"
+                        variant="link"
+                        size="sm"
+                        class="text-decoration-none"
+                        @click="setFilter('')">
+                        <icon icon="star" />
+                        <span>{{ history.contents_active.active }}</span>
+                    </b-button>
+                    <b-button
+                        v-if="history.contents_active.deleted"
+                        title="Show deleted"
+                        variant="link"
+                        size="sm"
+                        class="text-decoration-none"
+                        @click="setFilter('deleted=true')">
+                        <icon icon="trash" />
+                        <span>{{ history.contents_active.deleted }}</span>
+                    </b-button>
+                    <b-button
+                        v-if="history.contents_active.hidden"
+                        title="Show hidden"
+                        variant="link"
+                        size="sm"
+                        class="text-decoration-none"
+                        @click="setFilter('visible=false')">
+                        <icon icon="lock" />
+                        <span>{{ history.contents_active.hidden }}</span>
+                    </b-button>
+                </b-button-group>
+            </nav>
+        </template>
         <template v-slot:name>
-            <h3 data-description="name display" v-short="history.name || 'History'" />
-            <h5 class="history-size mt-1">
-                <span v-if="history.size">
-                    <div>{{ history.size | niceFileSize }}</div>
-                    <div class="dataCounts">
-                        <a href="javascript:void(0)" @click="filterText('')"
-                            >{{ history.contents_active.active }} active,
-                        </a>
-                        <a href="javascript:void(0)" @click="filterText('deleted=true')"
-                            >{{ history.contents_active.deleted }} deleted,
-                        </a>
-                        <a href="javascript:void(0)" @click="filterText('visible=false')"
-                            >{{ history.contents_active.hidden }} hidden</a
-                        >
-                    </div>
-                </span>
-                <span v-else v-localize>(empty)</span>
-            </h5>
+            <h3 data-description="name display" class="my-2" v-short="history.name || 'History'" />
         </template>
     </Details>
 </template>
 
 <script>
+import { backboneRoute } from "components/plugins/legacyNavigation";
 import prettyBytes from "pretty-bytes";
 import short from "components/directives/v-short";
 import Details from "components/History/Layout/Details";
@@ -50,18 +78,16 @@ export default {
         writeable: { type: Boolean, default: true },
     },
     methods: {
+        onDashboard() {
+            backboneRoute("/storage");
+        },
         onSave(newDetails) {
             const id = this.history.id;
             this.$emit("updateHistory", { ...newDetails, id });
         },
-        filterText(newFilterText) {
-            this.$emit("detailsFilter", newFilterText);
+        setFilter(newFilterText) {
+            this.$emit("update:filter-text", newFilterText);
         },
     },
 };
 </script>
-<style>
-.dataCounts a {
-    color: inherit;
-}
-</style>

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -6,7 +6,7 @@
         :writeable="writeable"
         @save="onSave">
         <template v-slot:header>
-            <nav v-if="history.size" class="history-size my-1 w-100 d-flex justify-content-between">
+            <div v-if="history.size" class="history-size my-1 w-100 d-flex justify-content-between">
                 <b-button
                     title="Access Dashboard"
                     variant="link"
@@ -47,7 +47,7 @@
                         <span>{{ history.contents_active.hidden }}</span>
                     </b-button>
                 </b-button-group>
-            </nav>
+            </div>
         </template>
         <template v-slot:name>
             <h3 data-description="name display" class="my-2" v-short="history.name || 'History'" />

--- a/client/src/components/History/CurrentHistory/HistoryDetails.vue
+++ b/client/src/components/History/CurrentHistory/HistoryDetails.vue
@@ -23,7 +23,7 @@
                         size="sm"
                         class="text-decoration-none"
                         @click="setFilter('')">
-                        <icon icon="star" />
+                        <span class="fa fa-map-marker" />
                         <span>{{ history.contents_active.active }}</span>
                     </b-button>
                     <b-button

--- a/client/src/components/History/CurrentHistory/HistoryMessages.vue
+++ b/client/src/components/History/CurrentHistory/HistoryMessages.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="hasMessages">
+    <div v-if="hasMessages" class="mx-3 my-2">
         <b-alert :show="history.isDeleted" variant="warning">
             {{ "This history has been deleted" | localize }}
         </b-alert>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -32,7 +32,7 @@
                         :filter-text.sync="filterText"
                         :show-advanced.sync="showAdvanced" />
                     <section v-if="!showAdvanced">
-                        <HistoryDetails :history="history" @detailsFilter="onDetailsFilter" v-on="$listeners" />
+                        <HistoryDetails :history="history" :filter-text.sync="filterText" v-on="$listeners" />
                         <HistoryMessages class="m-2" :history="history" />
                         <HistoryOperations
                             :history="history"
@@ -198,9 +198,6 @@ export default {
         },
         setInvisible(item) {
             Vue.set(this.invisible, item.hid, true);
-        },
-        onDetailsFilter(newFilterText) {
-            this.filterText = newFilterText;
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -32,8 +32,9 @@
                         :filter-text.sync="filterText"
                         :show-advanced.sync="showAdvanced" />
                     <section v-if="!showAdvanced">
-                        <HistoryDetails :history="history" :filter-text.sync="filterText" v-on="$listeners" />
-                        <HistoryMessages class="m-2" :history="history" />
+                        <HistoryDetails :history="history" @update:history="$emit('updateHistory', $event)" />
+                        <HistoryMessages :history="history" />
+                        <HistoryCounter :history="history" :filter-text.sync="filterText" />
                         <HistoryOperations
                             :history="history"
                             :show-selection="showSelection"
@@ -110,6 +111,7 @@ import { deleteContent, updateContentFields } from "components/History/model/que
 import ExpandedItems from "components/History/Content/ExpandedItems";
 import SelectedItems from "components/History/Content/SelectedItems";
 import Listing from "components/History/Layout/Listing";
+import HistoryCounter from "./HistoryCounter";
 import HistoryOperations from "./HistoryOperations/Index";
 import HistoryDetails from "./HistoryDetails";
 import HistoryEmpty from "./HistoryEmpty";
@@ -122,6 +124,7 @@ export default {
     components: {
         ContentItem,
         ExpandedItems,
+        HistoryCounter,
         HistoryMessages,
         HistoryDetails,
         HistoryEmpty,

--- a/client/src/components/History/Layout/Details.vue
+++ b/client/src/components/History/Layout/Details.vue
@@ -1,6 +1,5 @@
 <template>
     <section class="m-3 details" data-description="edit details">
-        <slot name="header" />
         <b-button
             v-if="!currentUser.isAnonymous && writeable"
             class="edit-button ml-1 float-right"

--- a/client/src/components/History/Layout/Details.vue
+++ b/client/src/components/History/Layout/Details.vue
@@ -1,5 +1,6 @@
 <template>
     <section class="m-3 details" data-description="edit details">
+        <slot name="header" />
         <b-button
             v-if="!currentUser.isAnonymous && writeable"
             class="edit-button ml-1 float-right"

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -298,7 +298,6 @@ history_panel:
   text:
     tooltip_name: 'Rename history...'
     new_name: 'Unnamed history'
-    new_size: '(empty)'
 
 
 history_structure:

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -388,16 +388,10 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin):
     def assert_initial_history_panel_state_correct(self):
         # Move into a TestsHistoryPanel mixin
         unnamed_name = self.components.history_panel.new_name.text
-
         name_element = self.history_panel_name_element()
+
         assert name_element.is_displayed()
         assert unnamed_name in name_element.text
-
-        initial_size_str = self.components.history_panel.new_size.text
-        size_selector = self.components.history_panel.size
-        size_text = size_selector.wait_for_text()
-
-        assert initial_size_str in size_text, f"{initial_size_str} not in {size_text}"
 
         self.components.history_panel.empty_message.wait_for_visible()
 


### PR DESCRIPTION
This PR combines the size display with the item count links for a more consistent behavior and appearance. Also increases the visibility of the new storage dashboard which is now accessible by clicking on the history storage size.

<span>
before:<img width="284" alt="image" src="https://user-images.githubusercontent.com/2105447/165022009-21d4a394-4ab0-4fad-a88b-fba5b1e2cdfb.png">
after:<img width="289" alt="image" src="https://user-images.githubusercontent.com/2105447/165147343-4eb730d7-7e50-47cb-b5d4-72c0bce1ff1d.png">
</span>

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
