### PR TITLE
[WIP] Make selenium workflow row check more robust.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1196,11 +1196,12 @@ class NavigatesGalaxy(HasDriver):
         return table_elements
 
     def workflow_index_table_row(self, workflow_index=0):
-        return self.workflow_index_table_elements()[workflow_index]
+        workflows = self.components.workflows
+        return workflows.workflow_row(index=workflow_index + 1).wait_for_visible()
 
     @retry_during_transitions
     def workflow_index_column_text(self, column_index, workflow_index=0):
-        row_element = self.workflow_index_table_row()
+        row_element = self.workflow_index_table_row(workflow_index=workflow_index)
         columns = row_element.find_elements_by_css_selector("td")
         return columns[column_index].text
 

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -494,6 +494,8 @@ workflows:
     save_button: '#workflow-save-button'
     search_box: "#workflow-search"
     workflow_table: "#workflow-table"
+    workflow_rows: "#workflow-table > tbody > tr:not(.b-table-empty-row, [style*='display: none'])"
+    workflow_row: "#workflow-table > tbody > tr:not(.b-table-empty-row, [style*='display: none'])[aria-rowindex='${index}']"
     external_link: '.workflow-external-link'
     trs_icon: '.workflow-trs-icon'
 


### PR DESCRIPTION
Should prevent transient errors like : https://github.com/galaxyproject/galaxy/runs/6131099888?check_suite_focus=true. I assume what is happening is the table is available but the row is not yet rendered/computed - waiting for the actual row would prevent this category of race conditions.


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
