### PR TITLE
[WIP] Even more improved workflow tag filtering.

### DIFF
--- a/client/src/components/Common/Tags.vue
+++ b/client/src/components/Common/Tags.vue
@@ -1,5 +1,5 @@
 <template>
-    <StatelessTags :value="tags" @input="onInput" />
+    <StatelessTags :value="tags" @input="onInput" @tag-click="onTagClick" />
 </template>
 <script>
 import StatelessTags from "components/Tags/StatelessTags";
@@ -18,6 +18,9 @@ export default {
     methods: {
         onInput(tags) {
             this.$emit("input", tags, this.index);
+        },
+        onTagClick(tag) {
+            this.$emit("tag-click", tag);
         },
     },
 };

--- a/client/src/components/Dataset/DatasetList.vue
+++ b/client/src/components/Dataset/DatasetList.vue
@@ -88,7 +88,7 @@ export default {
             sortDesc: true,
             loading: true,
             message: null,
-            messageVariant: null,
+            messageVariant: "danger",
             rows: [],
         };
     },
@@ -184,13 +184,8 @@ export default {
                 }
             }
         },
-        onSuccess(message) {
-            this.message = message;
-            this.messageVariant = "success";
-        },
         onError(message) {
             this.message = message;
-            this.messageVariant = "danger";
         },
     },
 };

--- a/client/src/components/FilesDialog/FilesDialog.test.js
+++ b/client/src/components/FilesDialog/FilesDialog.test.js
@@ -34,8 +34,7 @@ const api_paths_map = new Map([
     ["/api/remote_files?target=gxfiles://pdb-gzip/directory2&recursive=true", directory2RecursiveResponse],
     ["/api/remote_files?target=gxfiles://pdb-gzip/directory1/subdirectory1", subsubdirectoryResponse],
 ]);
-const initComponent = async (props) => {
-    const axiosMock = new MockAdapter(axios);
+const initComponent = async (props, axiosMock) => {
     const localVue = createLocalVue();
 
     localVue.use(BootstrapVue);
@@ -80,10 +79,16 @@ const initComponent = async (props) => {
 describe("FilesDialog, file mode", () => {
     let wrapper;
     let utils;
+    let axiosMock;
 
     beforeEach(async () => {
-        wrapper = await initComponent({ multiple: true });
+        axiosMock = new MockAdapter(axios);
+        wrapper = await initComponent({ multiple: true }, axiosMock);
         utils = new Utils(wrapper);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
     });
 
     it("should show the same number of items", async () => {
@@ -242,11 +247,18 @@ describe("FilesDialog, file mode", () => {
 describe("FilesDialog, directory mode", () => {
     let wrapper;
     let utils;
+    let axiosMock;
+
     const spyFinalize = jest.spyOn(FilesDialog.methods, "finalize");
 
     beforeEach(async () => {
-        wrapper = await initComponent({ multiple: false, mode: "directory" });
+        axiosMock = new MockAdapter(axios);
+        wrapper = await initComponent({ multiple: false, mode: "directory" }, axiosMock);
         utils = new Utils(wrapper);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
     });
 
     it("should render directories", async () => {

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -26,7 +26,7 @@ describe("Invocations.vue without invocation", () => {
     });
 
     afterEach(() => {
-        axiosMock.reset();
+        axiosMock.restore();
     });
 
     it("title should be shown", async () => {

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -80,6 +80,7 @@
         </b-table>
         <b-pagination
             v-model="currentPage"
+            v-show="rows >= perPage"
             :per-page="perPage"
             :total-rows="rows"
             aria-controls="invocation-list-table"></b-pagination>

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -2,10 +2,7 @@
     <div>
         <div v-if="error" class="alert alert-danger" show>{{ error }}</div>
         <div v-else>
-            <span v-if="loading">
-                <font-awesome-icon icon="spinner" spin />
-                Loading workflows...
-            </span>
+            <loading-span v-if="loading" message="Loading workflows" />
             <div v-else>
                 <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
                 <b-row class="mb-3">
@@ -93,6 +90,7 @@ import { getAppRoot } from "onload/loadConfig";
 import { Services } from "./services";
 import Tags from "components/Common/Tags";
 import WorkflowDropdown from "./WorkflowDropdown";
+import LoadingSpan from "components/LoadingSpan";
 import UtcDate from "components/UtcDate";
 import { getGalaxyInstance } from "app";
 
@@ -101,6 +99,7 @@ library.add(faPlus, faUpload, faSpinner, faGlobe, faShareAlt, farStar, faStar);
 export default {
     components: {
         FontAwesomeIcon,
+        LoadingSpan,
         UtcDate,
         Tags,
         WorkflowDropdown,

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -193,7 +193,7 @@ export default {
     methods: {
         provider(ctx) {
             ctx.apiUrl = this.apiUrl;
-            const extraParams = { search: this.filter };
+            const extraParams = { search: this.filter, skip_step_counts: true };
             this.workflowItems = storedWorkflowsProvider(ctx, this.setRows, extraParams);
             return this.workflowItems;
         },

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -247,7 +247,7 @@ export default {
                 });
         },
         onTagClick: function (tag) {
-            const tagFilter = `tag:${tag.text}`;
+            const tagFilter = `tag:'${tag.text}'`;
             const initialFilter = this.filter;
             if (initialFilter.length === 0) {
                 this.filter = tagFilter;

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -28,7 +28,7 @@
                 </b-col>
             </b-row>
             <b-table
-                id="workflow-table"
+                :id="tableId"
                 :fields="fields"
                 :items="provider"
                 v-model="workflowItemsModel"
@@ -87,9 +87,8 @@
             <b-pagination
                 v-model="currentPage"
                 v-show="rows >= perPage"
-                :per-page="perPage"
-                :total-rows="rows"
-                aria-controls="workflow-table"></b-pagination>
+                class="gx-workflows-grid-pager"
+                v-bind="paginationAttrs"></b-pagination>
         </div>
     </div>
 </template>
@@ -104,22 +103,23 @@ import { Services } from "./services";
 import { storedWorkflowsProvider } from "components/providers/StoredWorkflowsProvider";
 import Tags from "components/Common/Tags";
 import WorkflowDropdown from "./WorkflowDropdown";
-import LoadingSpan from "components/LoadingSpan";
 import UtcDate from "components/UtcDate";
 import { getGalaxyInstance } from "app";
+import paginationMixin from "./paginationMixin";
 
 library.add(faPlus, faUpload, faSpinner, faGlobe, faShareAlt, farStar, faStar);
 
 export default {
     components: {
         FontAwesomeIcon,
-        LoadingSpan,
         UtcDate,
         Tags,
         WorkflowDropdown,
     },
+    mixins: [paginationMixin],
     data() {
         return {
+            tableId: "workflow-table",
             error: null,
             fields: [
                 {
@@ -162,9 +162,7 @@ export default {
             titleRunWorkflow: _l("Run workflow"),
             workflowItemsModel: [],
             workflowItems: [],
-            currentPage: 1,
-            perPage: 20,
-            rows: 0,
+            perPage: this.rowsPerPage(20),
         };
     },
     computed: {
@@ -196,13 +194,6 @@ export default {
             const extraParams = { search: this.filter, skip_step_counts: true };
             this.workflowItems = storedWorkflowsProvider(ctx, this.setRows, extraParams);
             return this.workflowItems;
-        },
-        refresh() {
-            this.$root.$emit("bv::refresh::table", "workflow-table");
-        },
-        setRows(data) {
-            this.rows = data.headers.total_matches;
-            this.loading = false;
         },
         createWorkflow: function (workflow) {
             window.location = `${this.root}workflows/create`;

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -1,82 +1,80 @@
 <template>
     <div>
         <div v-if="error" class="alert alert-danger" show>{{ error }}</div>
+        <loading-span v-else-if="loading" message="Loading workflows" />
         <div v-else>
-            <loading-span v-if="loading" message="Loading workflows" />
-            <div v-else>
-                <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
-                <b-row class="mb-3">
-                    <b-col cols="6">
-                        <b-input
-                            id="workflow-search"
-                            class="m-1"
-                            name="query"
-                            :placeholder="titleSearchWorkflows"
-                            autocomplete="off"
-                            type="text"
-                            v-model="filter" />
-                    </b-col>
-                    <b-col>
-                        <span class="float-right">
-                            <b-button id="workflow-create" class="m-1" @click="createWorkflow">
-                                <font-awesome-icon icon="plus" />
-                                {{ titleCreate }}
-                            </b-button>
-                            <b-button id="workflow-import" class="m-1" @click="importWorkflow">
-                                <font-awesome-icon icon="upload" />
-                                {{ titleImport }}
-                            </b-button>
-                        </span>
-                    </b-col>
-                </b-row>
-                <b-table
-                    id="workflow-table"
-                    striped
-                    :fields="fields"
-                    :items="workflows"
-                    :filter="filter"
-                    @filtered="filtered">
-                    <template v-slot:cell(name)="row">
-                        <WorkflowDropdown
-                            :workflow="row.item"
-                            @onAdd="onAdd"
-                            @onRemove="onRemove"
-                            @onUpdate="onUpdate"
-                            @onSuccess="onSuccess"
-                            @onError="onError" />
-                    </template>
-                    <template v-slot:cell(tags)="row">
-                        <Tags :index="row.index" :tags="row.item.tags" @input="onTags" />
-                    </template>
-                    <template v-slot:cell(published)="row">
-                        <font-awesome-icon v-if="row.item.published" v-b-tooltip.hover title="Published" icon="globe" />
-                        <font-awesome-icon v-if="row.item.shared" v-b-tooltip.hover title="Shared" icon="share-alt" />
-                    </template>
-                    <template v-slot:cell(show_in_tool_panel)="row">
-                        <b-link @click="bookmarkWorkflow(row.item, false)" v-if="row.item.show_in_tool_panel">
-                            <font-awesome-icon :icon="['fas', 'star']" />
-                        </b-link>
-                        <b-link @click="bookmarkWorkflow(row.item, true)" v-else>
-                            <font-awesome-icon :icon="['far', 'star']" />
-                        </b-link>
-                    </template>
-                    <template v-slot:cell(update_time)="data">
-                        <UtcDate :date="data.value" mode="elapsed" />
-                    </template>
-                    <template v-slot:cell(execute)="row">
-                        <b-button
-                            v-b-tooltip.hover.bottom
-                            :title="titleRunWorkflow"
-                            class="workflow-run btn-sm btn-primary fa fa-play"
-                            @click.stop="executeWorkflow(row.item)" />
-                    </template>
-                </b-table>
-                <div v-if="showNotFound">
-                    No matching entries found for: <span class="font-weight-bold">{{ this.filter }}</span
-                    >.
-                </div>
-                <div v-if="showNotAvailable">No workflows found. You may create or import new workflows.</div>
+            <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
+            <b-row class="mb-3">
+                <b-col cols="6">
+                    <b-input
+                        id="workflow-search"
+                        class="m-1"
+                        name="query"
+                        :placeholder="titleSearchWorkflows"
+                        autocomplete="off"
+                        type="text"
+                        v-model="filter" />
+                </b-col>
+                <b-col>
+                    <span class="float-right">
+                        <b-button id="workflow-create" class="m-1" @click="createWorkflow">
+                            <font-awesome-icon icon="plus" />
+                            {{ titleCreate }}
+                        </b-button>
+                        <b-button id="workflow-import" class="m-1" @click="importWorkflow">
+                            <font-awesome-icon icon="upload" />
+                            {{ titleImport }}
+                        </b-button>
+                    </span>
+                </b-col>
+            </b-row>
+            <b-table
+                id="workflow-table"
+                striped
+                :fields="fields"
+                :items="workflows"
+                :filter="filter"
+                @filtered="filtered">
+                <template v-slot:cell(name)="row">
+                    <WorkflowDropdown
+                        :workflow="row.item"
+                        @onAdd="onAdd"
+                        @onRemove="onRemove"
+                        @onUpdate="onUpdate"
+                        @onSuccess="onSuccess"
+                        @onError="onError" />
+                </template>
+                <template v-slot:cell(tags)="row">
+                    <Tags :index="row.index" :tags="row.item.tags" @input="onTags" />
+                </template>
+                <template v-slot:cell(published)="row">
+                    <font-awesome-icon v-if="row.item.published" v-b-tooltip.hover title="Published" icon="globe" />
+                    <font-awesome-icon v-if="row.item.shared" v-b-tooltip.hover title="Shared" icon="share-alt" />
+                </template>
+                <template v-slot:cell(show_in_tool_panel)="row">
+                    <b-link @click="bookmarkWorkflow(row.item, false)" v-if="row.item.show_in_tool_panel">
+                        <font-awesome-icon :icon="['fas', 'star']" />
+                    </b-link>
+                    <b-link @click="bookmarkWorkflow(row.item, true)" v-else>
+                        <font-awesome-icon :icon="['far', 'star']" />
+                    </b-link>
+                </template>
+                <template v-slot:cell(update_time)="data">
+                    <UtcDate :date="data.value" mode="elapsed" />
+                </template>
+                <template v-slot:cell(execute)="row">
+                    <b-button
+                        v-b-tooltip.hover.bottom
+                        :title="titleRunWorkflow"
+                        class="workflow-run btn-sm btn-primary fa fa-play"
+                        @click.stop="executeWorkflow(row.item)" />
+                </template>
+            </b-table>
+            <div v-if="showNotFound">
+                No matching entries found for: <span class="font-weight-bold">{{ this.filter }}</span
+                >.
             </div>
+            <div v-if="showNotAvailable">No workflows found. You may create or import new workflows.</div>
         </div>
     </div>
 </template>

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -59,7 +59,7 @@
                         @onError="onError" />
                 </template>
                 <template v-slot:cell(tags)="row">
-                    <Tags :index="row.index" :tags="row.item.tags" @input="onTags" />
+                    <Tags :index="row.index" :tags="row.item.tags" @input="onTags" @tag-click="onTagClick" />
                 </template>
                 <template v-slot:cell(published)="row">
                     <font-awesome-icon v-if="row.item.published" v-b-tooltip.hover title="Published" icon="globe" />
@@ -245,6 +245,15 @@ export default {
                 .catch((error) => {
                     this.onError(error);
                 });
+        },
+        onTagClick: function (tag) {
+            const tagFilter = `tag:${tag.text}`;
+            const initialFilter = this.filter;
+            if (initialFilter.length === 0) {
+                this.filter = tagFilter;
+            } else if (initialFilter.indexOf(tagFilter) < 0) {
+                this.filter = `${tagFilter} ${initialFilter}`;
+            }
         },
         onAdd: function (workflow) {
             if (this.currentPage == 1) {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -86,6 +86,7 @@
             </b-table>
             <b-pagination
                 v-model="currentPage"
+                v-show="rows >= perPage"
                 :per-page="perPage"
                 :total-rows="rows"
                 aria-controls="workflow-table"></b-pagination>

--- a/client/src/components/Workflow/paginationMixin.js
+++ b/client/src/components/Workflow/paginationMixin.js
@@ -1,0 +1,43 @@
+import QueryStringParsing from "utils/query-string-parsing";
+import LoadingSpan from "components/LoadingSpan";
+
+export default {
+    components: { LoadingSpan },
+    data() {
+        return {
+            currentPage: 1,
+            perPage: 20,
+            rows: 0,
+            loading: true,
+        };
+    },
+    computed: {
+        paginationAttrs() {
+            return {
+                "next-class": "gx-grid-pager-next",
+                "prev-class": "gx-grid-pager-prev",
+                "first-class": "gx-grid-pager-first",
+                "last-class": "gx-grid-pager-last",
+                "page-class": "gx-grid-pager-page",
+                class: "gx-grid-pager",
+                size: "lg",
+                "aria-controls": this.tableId,
+                "per-page": this.perPage,
+                "total-rows": this.rows,
+            };
+        },
+    },
+    methods: {
+        refresh() {
+            this.$root.$emit("bv::refresh::table", this.tableId);
+        },
+        setRows(data) {
+            this.rows = data.headers.total_matches;
+            this.loading = false;
+        },
+        rowsPerPage(defaultPerPage) {
+            const queryRowsPerPage = QueryStringParsing.get("rows_per_page");
+            return queryRowsPerPage || defaultPerPage;
+        },
+    },
+};

--- a/client/src/components/providers/InvocationsProvider.js
+++ b/client/src/components/providers/InvocationsProvider.js
@@ -1,21 +1,9 @@
 import axios from "axios";
-import { snakeCase } from "snake-case";
+import { cleanPaginationParameters} from "./utils";
 
 export function invocationsProvider(ctx, callback, extraParams) {
     const { apiUrl, ...requestParams } = ctx;
-    const cleanParams = {};
-    Object.entries(requestParams).map(([key, val]) => {
-        if (key === "perPage") {
-            key = "limit";
-        }
-        if (val) {
-            cleanParams[snakeCase(key)] = val;
-        }
-    });
-    if (cleanParams.current_page && cleanParams.limit) {
-        cleanParams.offset = (cleanParams.current_page - 1) * cleanParams.limit;
-        delete cleanParams.current_page;
-    }
+    const cleanParams = cleanPaginationParameters(requestParams);
     const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });
 
     // Must return a promise that resolves to an array of items

--- a/client/src/components/providers/StoredWorkflowsProvider.js
+++ b/client/src/components/providers/StoredWorkflowsProvider.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { cleanPaginationParameters } from "./utils";
 
-export function invocationsProvider(ctx, callback, extraParams) {
+export function storedWorkflowsProvider(ctx, callback, extraParams = {}) {
     const { apiUrl, ...requestParams } = ctx;
     const cleanParams = cleanPaginationParameters(requestParams);
     const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });

--- a/client/src/components/providers/utils.js
+++ b/client/src/components/providers/utils.js
@@ -1,5 +1,25 @@
 import JOB_STATES_MODEL from "mvc/history/job-states-model";
+import { snakeCase } from "snake-case";
 
 export function stateIsTerminal(result) {
     return !JOB_STATES_MODEL.NON_TERMINAL_STATES.includes(result.state);
+}
+
+// Adapt bootstrap parameters to Galaxy API. Galaxy consumes snake case parameters
+// and generally uses limit instead of perPage/per_page as a name for this concept.
+export function cleanPaginationParameters(requestParams) {
+    const cleanParams = {};
+    Object.entries(requestParams).map(([key, val]) => {
+        if (key === "perPage") {
+            key = "limit";
+        }
+        if (val) {
+            cleanParams[snakeCase(key)] = val;
+        }
+    });
+    if (cleanParams.current_page && cleanParams.limit) {
+        cleanParams.offset = (cleanParams.current_page - 1) * cleanParams.limit;
+        delete cleanParams.current_page;
+    }
+    return cleanParams;
 }

--- a/client/src/store/historyStore/model/watchHistory.test.js
+++ b/client/src/store/historyStore/model/watchHistory.test.js
@@ -36,7 +36,6 @@ describe("watchHistory", () => {
 
     afterEach(() => {
         axiosMock.restore();
-        axiosMock.reset();
     });
 
     it("store initialization", async () => {

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -577,6 +577,7 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         self.queue_worker = self._register_singleton(GalaxyQueueWorker, GalaxyQueueWorker(self))
 
         self._configure_tool_shed_registry()
+        self._register_singleton(tool_shed_registry.Registry, self.tool_shed_registry)
 
         self.dependency_resolvers_view = self._register_singleton(
             DependencyResolversView, DependencyResolversView(self)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1063,6 +1063,7 @@ class WorkflowIndexPayload(Model):
         lt=1000,
     )
     offset: Optional[int] = Field(default=0, description="Number of workflows to skip")
+    search: Optional[str] = Field(default=None, title="Filter text", description="Freetext to search.")
 
 
 class InvocationSortByEnum(str, Enum):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1055,6 +1055,9 @@ class WorkflowIndexPayload(Model):
     show_shared: Optional[bool] = None
     missing_tools: bool = False
     sort_by: Optional[WorkflowSortByEnum] = Field(title="Sort By", description="Sort Worklfows by this attribute")
+    sort_desc: Optional[bool] = Field(
+        title="Sort descending", description="Explicitly sort by descending if sort_by is specified."
+    )
 
 
 class InvocationSortByEnum(str, Enum):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1047,6 +1047,14 @@ class SortByEnum(str, Enum):
     none = None
 
 
+class WorkflowIndexPayload(Model):
+    show_deleted: bool = False
+    show_hidden: bool = False
+    show_published: Optional[bool] = None
+    show_shared: Optional[bool] = None
+    missing_tools: bool = False
+
+
 class InvocationIndexPayload(Model):
     workflow_id: Optional[DecodedDatabaseIdField] = Field(
         title="Workflow ID", description="Return only invocations for this Workflow ID"

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1041,9 +1041,10 @@ class ExportHistoryArchivePayload(Model):
     )
 
 
-class SortByEnum(str, Enum):
+class WorkflowSortByEnum(str, Enum):
     create_time = "create_time"
     update_time = "update_time"
+    name = "name"
     none = None
 
 
@@ -1053,6 +1054,13 @@ class WorkflowIndexPayload(Model):
     show_published: Optional[bool] = None
     show_shared: Optional[bool] = None
     missing_tools: bool = False
+    sort_by: Optional[WorkflowSortByEnum] = Field(title="Sort By", description="Sort Worklfows by this attribute")
+
+
+class InvocationSortByEnum(str, Enum):
+    create_time = "create_time"
+    update_time = "update_time"
+    none = None
 
 
 class InvocationIndexPayload(Model):
@@ -1068,7 +1076,9 @@ class InvocationIndexPayload(Model):
     user_id: Optional[DecodedDatabaseIdField] = Field(
         title="User ID", description="Return invocations for this User ID"
     )
-    sort_by: Optional[SortByEnum] = Field(title="Sort By", description="Sort Workflow Invocations by this attribute")
+    sort_by: Optional[InvocationSortByEnum] = Field(
+        title="Sort By", description="Sort Workflow Invocations by this attribute"
+    )
     sort_desc: bool = Field(default=False, descritpion="Sort in descending order?")
     include_terminal: bool = Field(default=True, description="Set to false to only include terminal Invocations.")
     limit: Optional[int] = Field(

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1058,6 +1058,11 @@ class WorkflowIndexPayload(Model):
     sort_desc: Optional[bool] = Field(
         title="Sort descending", description="Explicitly sort by descending if sort_by is specified."
     )
+    limit: Optional[int] = Field(
+        default=None,
+        lt=1000,
+    )
+    offset: Optional[int] = Field(default=0, description="Number of workflows to skip")
 
 
 class InvocationSortByEnum(str, Enum):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1064,6 +1064,7 @@ class WorkflowIndexPayload(Model):
     )
     offset: Optional[int] = Field(default=0, description="Number of workflows to skip")
     search: Optional[str] = Field(default=None, title="Filter text", description="Freetext to search.")
+    skip_step_counts: bool = False
 
 
 class InvocationSortByEnum(str, Enum):

--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -19,6 +19,14 @@ class HasDriver:
     TimeoutException = TimeoutException
     driver: WebDriver
 
+    def re_get_with_query_params(self, params_str: str):
+        driver = self.driver
+        new_url = driver.current_url
+        if "?" not in new_url:
+            new_url += "?"
+        new_url += params_str
+        driver.get(new_url)
+
     def assert_xpath(self, xpath):
         assert self.driver.find_element_by_xpath(xpath)
 

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1251,15 +1251,36 @@ class NavigatesGalaxy(HasDriver):
         tag_display = workflow_row_element.find_element_by_css_selector(".tags-display")
         tag_display.click()
 
+    def workflow_index_add_tag(self, tag: str, workflow_index: int = 0):
+        self.workflow_index_click_tag_display(workflow_index=workflow_index)
+        self.tagging_add([tag])
+
     @retry_during_transitions
     def workflow_index_tags(self, workflow_index=0):
-        workflow_row_element = self.workflow_index_table_row(workflow_index)
-        tag_display = workflow_row_element.find_element_by_css_selector(".tags-display")
-        tag_spans = tag_display.find_elements_by_css_selector(".tag-name")
+        tag_spans = self.workflow_index_tag_elements(workflow_index=workflow_index)
         tags = []
         for tag_span in tag_spans:
             tags.append(tag_span.text)
         return tags
+
+    @retry_during_transitions
+    def workflow_index_tag_elements(self, workflow_index=0):
+        workflow_row_element = self.workflow_index_table_row(workflow_index)
+        tag_display = workflow_row_element.find_element_by_css_selector(".tags-display")
+        tag_spans = tag_display.find_elements_by_css_selector(".tag-name")
+        return tag_spans
+
+    @retry_during_transitions
+    def workflow_index_click_tag(self, tag, workflow_index=0):
+        tag_spans = self.workflow_index_tag_elements(workflow_index=workflow_index)
+        clicked = False
+        for tag_span in tag_spans:
+            if tag_span.text == tag:
+                tag_span.click()
+                clicked = True
+                break
+        if not clicked:
+            raise KeyError(f"Failed to find tag {tag} on workflow with index {workflow_index}")
 
     def workflow_import_submit_url(self, url):
         form_button = self.wait_for_selector_visible("#workflow-import-button")

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1189,11 +1189,9 @@ class NavigatesGalaxy(HasDriver):
         self.click_masthead_workflow()
 
     def workflow_index_table_elements(self):
-        self.wait_for_selector_visible("#workflow-table")
-        table_elements = self.driver.find_elements_by_css_selector(
-            "#workflow-table > tbody > tr:not(.b-table-empty-row, [style*='display: none'])"
-        )
-        return table_elements
+        workflows = self.components.workflows
+        workflows.workflow_table.wait_for_visible()
+        return workflows.workflow_rows.all()
 
     def workflow_index_table_row(self, workflow_index=0):
         return self.workflow_index_table_elements()[workflow_index]
@@ -1318,6 +1316,11 @@ class NavigatesGalaxy(HasDriver):
         inputs[1].send_keys(annotation)
         form_element.click()
         return name
+
+    def invocation_index_table_elements(self):
+        invocations = self.components.invocations
+        invocations.invocations_table.wait_for_visible()
+        return invocations.invocations_table_rows.all()
 
     def tool_open(self, tool_id, outer=False):
         if outer:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1191,7 +1191,7 @@ class NavigatesGalaxy(HasDriver):
     def workflow_index_table_elements(self):
         self.wait_for_selector_visible("#workflow-table")
         table_elements = self.driver.find_elements_by_css_selector(
-            "#workflow-table > tbody > tr:not([style*='display: none'])"
+            "#workflow-table > tbody > tr:not(.b-table-empty-row, [style*='display: none'])"
         )
         return table_elements
 

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -494,8 +494,16 @@ workflows:
     save_button: '#workflow-save-button'
     search_box: "#workflow-search"
     workflow_table: "#workflow-table"
+    workflow_rows: "#workflow-table > tbody > tr:not(.b-table-empty-row, [style*='display: none'])"
     external_link: '.workflow-external-link'
     trs_icon: '.workflow-trs-icon'
+    pager: '.gx-workflows-grid-pager'
+    pager_page: '.gx-workflows-grid-pager .gx-grid-pager-page [aria-posinset=${page}]'
+    pager_page_next: '.gx-workflows-grid-pager .gx-grid-pager-next button'
+    pager_page_first: '.gx-workflows-grid-pager .gx-grid-pager-first button'
+    pager_page_last: '.gx-workflows-grid-pager .gx-grid-pager-last button'
+    pager_page_previous: '.gx-workflows-grid-pager .gx-grid-pager-prev button'
+    pager_page_active: '.gx-workflows-grid-pager .gx-grid-pager-page.active button'
 
 trs_search:
   selectors:
@@ -631,7 +639,15 @@ workflow_show:
 invocations:
   selectors:
     invocations_table: '.invocations-list table'
-    invocations_table_rows: '.invocations-list table tbody tr'
+    invocations_table_rows: '.invocations-list table tbody tr:not(.b-table-empty-row, [style*="display: none"])'
+    pager: '.gx-invocations-grid-pager'
+    pager_page: '.gx-invocations-grid-pager .gx-grid-pager-page [aria-posinset=${page}]'
+    pager_page_next: '.gx-invocations-grid-pager .gx-grid-pager-next button'
+    pager_page_last: '.gx-invocations-grid-pager .gx-grid-pager-last button'
+    pager_page_first: '.gx-invocations-grid-pager .gx-grid-pager-first button'
+    pager_page_previous: '.gx-invocations-grid-pager .gx-grid-pager-prev button'
+    pager_page_active: '.gx-invocations-grid-pager .gx-grid-pager-page.active button'
+
     state_details: '.workflow-invocation-state-component'
     toggle_invocation_details: '.toggle-invocation-details'
     progress_steps_note: '.workflow-invocation-state-component .steps-progress .progressNote'

--- a/lib/galaxy/util/search.py
+++ b/lib/galaxy/util/search.py
@@ -1,7 +1,17 @@
 import re
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+KeyedQueryT = Tuple[str, str]
 
 
-def parse_filters(search_term, filters):
+def parse_filters(
+    search_term: str, filters: Optional[Dict[str, str]] = None
+) -> Tuple[Optional[List[KeyedQueryT]], Optional[str]]:
     """Support github-like filters for narrowing the results.
 
     Order of chunks does not matter, only recognized filter names are allowed.
@@ -16,6 +26,7 @@ def parse_filters(search_term, filters):
     allow_terms = []
     search_term_without_filters = None
     search_space = search_term.replace('"', "'")
+    filters = filters or {}
     filter_keys = "|".join(list(filters.keys()))
     pattern = rf"({filter_keys}):(?:\s+)?([\w-]+|\'.*?\')"
     reserved = re.compile(pattern)

--- a/lib/galaxy/util/search.py
+++ b/lib/galaxy/util/search.py
@@ -2,16 +2,18 @@ import re
 from typing import (
     Dict,
     List,
+    NamedTuple,
     Optional,
     Tuple,
+    Union,
 )
 
 KeyedQueryT = Tuple[str, str]
+ParseFilterResultT = Tuple[Optional[List["FilteredTerm"]], Optional[str]]
+QUOTE_PATTERN = re.compile(r"\'(.*?)\'")
 
 
-def parse_filters(
-    search_term: str, filters: Optional[Dict[str, str]] = None
-) -> Tuple[Optional[List[KeyedQueryT]], Optional[str]]:
+def parse_filters(search_term: str, filters: Optional[Dict[str, str]] = None) -> ParseFilterResultT:
     """Support github-like filters for narrowing the results.
 
     Order of chunks does not matter, only recognized filter names are allowed.
@@ -23,22 +25,89 @@ def parse_filters(
     :returns search_term_without_filters: str that represents user's
         search phrase without the filters
     """
-    allow_terms = []
-    search_term_without_filters = None
+    return parse_filters_structured(search_term, filters, preserve_quotes=False).simple_result
+
+
+def parse_filters_structured(
+    search_term: str,
+    filters: Optional[Dict[str, str]] = None,
+    preserve_quotes: bool = True,
+) -> "ParsedSearch":
     search_space = search_term.replace('"', "'")
     filters = filters or {}
     filter_keys = "|".join(list(filters.keys()))
     pattern = rf"({filter_keys}):(?:\s+)?([\w-]+|\'.*?\')"
     reserved = re.compile(pattern)
+    parsed_search = ParsedSearch()
     while True:
         match = reserved.search(search_space)
         if match is None:
-            search_term_without_filters = " ".join(search_space.split())
-            break
-        first_group = match.groups()[0]
-        if first_group in filters:
-            filter_as = filters[first_group]
-            allow_terms.append((filter_as, match.groups()[1].strip().replace("'", "")))
-        search_space = search_space[0 : match.start()] + search_space[match.end() :]
-    allow_query = allow_terms if len(allow_terms) > 0 else None
-    return allow_query, search_term_without_filters
+            match = QUOTE_PATTERN.search(search_space)
+            if match is None:
+                parsed_search.add_unfiltered_text_terms(search_space)
+                break
+            group = match.groups()[0].strip()
+            parsed_search.add_unfiltered_text_terms(search_space[0 : match.start()])
+            parsed_search.add_unfiltered_text(group, True)
+        else:
+            first_group = match.groups()[0]
+            if first_group in filters:
+                filter_as = filters[first_group]
+                group = match.groups()[1].strip()
+                quoted = preserve_quotes and group.startswith("'")
+                parsed_search.add_keyed_term(filter_as, group.replace("'", ""), quoted)
+            parsed_search.add_unfiltered_text_terms(search_space[0 : match.start()])
+        search_space = search_space[match.end() :]
+    return parsed_search
+
+
+class RawTextTerm(NamedTuple):
+    text: str
+    quoted: bool
+
+
+class FilteredTerm(NamedTuple):
+    filter: str
+    text: str
+    quoted: bool
+
+
+TermT = Union[RawTextTerm, FilteredTerm]
+
+
+class ParsedSearch:
+    terms: List[TermT]
+    text_terms: List[RawTextTerm]
+    filter_terms: List[FilteredTerm]
+
+    def __init__(self):
+        self.terms = []
+        self.text_terms = []
+        self.filter_terms = []
+
+    def add_unfiltered_text_terms(self, text: str):
+        for part in text.split():
+            self.add_unfiltered_text(part, False)
+
+    def add_unfiltered_text(self, text: str, quoted: bool = False):
+        text = text.strip()
+        if not text:
+            return
+        term = RawTextTerm(text.strip(), quoted)
+        self.terms.append(term)
+        self.text_terms.append(term)
+
+    def add_keyed_term(self, key: str, text: str, quoted: bool):
+        term = FilteredTerm(key, text, quoted)
+        self.terms.append(term)
+        self.filter_terms.append(term)
+
+    @property
+    def simple_result(self) -> ParseFilterResultT:
+        return None if len(self.filter_terms) == 0 else self.filter_terms, " ".join([t.text for t in self.text_terms])
+
+
+__all__ = (
+    "parse_filters",
+    "parse_filters_structured",
+)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1446,6 +1446,12 @@ SortByQueryParam: Optional[WorkflowSortByEnum] = Query(
     description="In unspecified, default ordering depends on other parameters but generally the user's own workflows appear first based on update time",
 )
 
+SortDescQueryParam: Optional[bool] = Query(
+    default=None,
+    title="Sort Descending",
+    description="Sort in descending order?",
+)
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -1465,6 +1471,7 @@ class FastAPIWorkflows:
         show_published: Optional[bool] = ShowPublishedQueryParam,
         show_shared: Optional[bool] = ShowSharedQueryParam,
         sort_by: Optional[WorkflowSortByEnum] = SortByQueryParam,
+        sort_desc: Optional[bool] = SortDescQueryParam,
     ) -> List[Dict[str, Any]]:
         """Return the sharing status of the item."""
         payload = WorkflowIndexPayload(
@@ -1474,6 +1481,7 @@ class FastAPIWorkflows:
             show_shared=show_shared,
             missing_tools=missing_tools,
             sort_by=sort_by,
+            sort_desc=sort_desc,
         )
         return self.service.index(trans, payload)
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -50,6 +50,7 @@ from galaxy.schema.schema import (
     ShareWithStatus,
     SharingStatus,
     WorkflowIndexPayload,
+    WorkflowSortByEnum,
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
@@ -1439,6 +1440,12 @@ ShowPublishedQueryParam: Optional[bool] = Query(default=None, title="Include pub
 
 ShowSharedQueryParam: Optional[bool] = Query(default=None, title="Include shared workflows.", description="")
 
+SortByQueryParam: Optional[WorkflowSortByEnum] = Query(
+    default=None,
+    title="Sort workflow index by this attribute",
+    description="In unspecified, default ordering depends on other parameters but generally the user's own workflows appear first based on update time",
+)
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -1457,6 +1464,7 @@ class FastAPIWorkflows:
         missing_tools: bool = MissingToolsQueryParam,
         show_published: Optional[bool] = ShowPublishedQueryParam,
         show_shared: Optional[bool] = ShowSharedQueryParam,
+        sort_by: Optional[WorkflowSortByEnum] = SortByQueryParam,
     ) -> List[Dict[str, Any]]:
         """Return the sharing status of the item."""
         payload = WorkflowIndexPayload(
@@ -1465,6 +1473,7 @@ class FastAPIWorkflows:
             show_deleted=show_deleted,
             show_shared=show_shared,
             missing_tools=missing_tools,
+            sort_by=sort_by,
         )
         return self.service.index(trans, payload)
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1466,6 +1466,12 @@ SearchQueryParameter: Optional[str] = Query(
     description="Free text used to filter the query. Currently this just filters by name but this shouldn't be considered part the API, the freetext search may search additional fields in different ways in the future.",
 )
 
+SkipStepCountsQueryParam: bool = Query(
+    default=False,
+    title="Skip step counts.",
+    description="Set this to true to skip joining workflow step counts and optimize the resulting index query. Response objects will not contain step counts.",
+)
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -1490,6 +1496,7 @@ class FastAPIWorkflows:
         limit: Optional[int] = LimitQueryParam,
         offset: Optional[int] = OffsetQueryParam,
         search: Optional[str] = SearchQueryParameter,
+        skip_step_counts: bool = SkipStepCountsQueryParam,
     ) -> List[Dict[str, Any]]:
         """Return the sharing status of the item."""
         payload = WorkflowIndexPayload(
@@ -1503,6 +1510,7 @@ class FastAPIWorkflows:
             limit=limit,
             offset=offset,
             search=search,
+            skip_step_counts=skip_step_counts,
         )
         workflows, total_matches = self.service.index(trans, payload, include_total_count=True)
         response.headers["total_matches"] = str(total_matches)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1460,6 +1460,12 @@ OffsetQueryParam: Optional[int] = Query(
     title="Number of workflows to skip in sorted query (to enable pagination).",
 )
 
+SearchQueryParameter: Optional[str] = Query(
+    default=None,
+    title="Search query.",
+    description="Free text used to filter the query. Currently this just filters by name but this shouldn't be considered part the API, the freetext search may search additional fields in different ways in the future.",
+)
+
 
 @router.cbv
 class FastAPIWorkflows:
@@ -1483,6 +1489,7 @@ class FastAPIWorkflows:
         sort_desc: Optional[bool] = SortDescQueryParam,
         limit: Optional[int] = LimitQueryParam,
         offset: Optional[int] = OffsetQueryParam,
+        search: Optional[str] = SearchQueryParameter,
     ) -> List[Dict[str, Any]]:
         """Return the sharing status of the item."""
         payload = WorkflowIndexPayload(
@@ -1495,6 +1502,7 @@ class FastAPIWorkflows:
             sort_desc=sort_desc,
             limit=limit,
             offset=offset,
+            search=search,
         )
         workflows, total_matches = self.service.index(trans, payload, include_total_count=True)
         response.headers["total_matches"] = str(total_matches)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -9,24 +9,20 @@ import os
 from typing import (
     Any,
     Dict,
+    List,
+    Optional,
 )
 
 import requests
 from fastapi import (
     Body,
     Path,
+    Query,
     Response,
     status,
 )
 from gxformat2._yaml import ordered_dump
 from markupsafe import escape
-from sqlalchemy import (
-    desc,
-    false,
-    or_,
-    true,
-)
-from sqlalchemy.orm import joinedload
 
 from galaxy import (
     exceptions,
@@ -53,6 +49,7 @@ from galaxy.schema.schema import (
     ShareWithPayload,
     ShareWithStatus,
     SharingStatus,
+    WorkflowIndexPayload,
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
@@ -92,25 +89,14 @@ router = Router(tags=["workflows"])
 
 
 class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, UsesAnnotations, SharableMixin):
+    service: WorkflowsService = depends(WorkflowsService)
+
     def __init__(self, app: StructuredApp):
         super().__init__(app)
         self.history_manager = app.history_manager
         self.workflow_manager = app.workflow_manager
         self.workflow_contents_manager = app.workflow_contents_manager
         self.tool_recommendations = recommendations.ToolRecommendations()
-
-    def __get_full_shed_url(self, url):
-        for shed_url in self.app.tool_shed_registry.tool_sheds.values():
-            if url in shed_url:
-                return shed_url
-        return None
-
-    @expose_api_anonymous_and_sessionless
-    def index(self, trans: ProvidesUserContext, **kwd):
-        """
-        GET /api/workflows
-        """
-        return self.get_workflows_list(trans, **kwd)
 
     @expose_api
     def get_workflow_menu(self, trans: ProvidesUserContext, **kwd):
@@ -120,7 +106,8 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         """
         user = trans.user
         ids_in_menu = [x.stored_workflow_id for x in user.stored_workflow_menu_entries]
-        return {"ids_in_menu": ids_in_menu, "workflows": self.get_workflows_list(trans, **kwd)}
+        workflows = self.get_workflows_list(trans, **kwd)
+        return {"ids_in_menu": ids_in_menu, "workflows": workflows}
 
     @expose_api
     def set_workflow_menu(self, trans: GalaxyWebTransaction, payload=None, **kwd):
@@ -194,91 +181,15 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         show_hidden = util.string_as_bool(show_hidden)
         show_deleted = util.string_as_bool(show_deleted)
         missing_tools = util.string_as_bool(missing_tools)
-        if show_shared is None:
-            show_shared = not show_hidden and not show_deleted
-        else:
-            show_shared = util.string_as_bool(show_shared)
-        if show_shared and show_deleted:
-            message = "show_shared and show_deleted cannot both be specified as true"
-            raise exceptions.RequestParameterInvalidException(message)
-        if show_shared and show_hidden:
-            message = "show_shared and show_hidden cannot both be specified as true"
-            raise exceptions.RequestParameterInvalidException(message)
-
-        rval = []
-        filters = [
-            model.StoredWorkflow.user == trans.user,
-        ]
-        user = trans.user
-        if user and show_shared:
-            filters.append(model.StoredWorkflowUserShareAssociation.user == user)
-
-        if show_published or user is None and show_published is None:
-            filters.append((model.StoredWorkflow.published == true()))
-
-        query = trans.sa_session.query(model.StoredWorkflow)
-        if show_shared:
-            query = query.outerjoin(model.StoredWorkflow.users_shared_with)
-
-        query = (
-            query.options(joinedload("annotations"))
-            .options(joinedload("latest_workflow").undefer("step_count").lazyload("steps"))
-            .options(joinedload("tags"))
+        show_shared = util.string_as_bool_or_none(show_shared)
+        payload = WorkflowIndexPayload(
+            show_published=show_published,
+            show_hidden=show_hidden,
+            show_deleted=show_deleted,
+            show_shared=show_shared,
+            missing_tools=missing_tools,
         )
-        query = query.filter(or_(*filters))
-        query = query.filter(model.StoredWorkflow.table.c.hidden == (true() if show_hidden else false()))
-        query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
-        if user:
-            query = query.order_by(desc(model.StoredWorkflow.user == user))
-        query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
-        for wf in query.all():
-            item = wf.to_dict(value_mapper={"id": trans.security.encode_id})
-            encoded_id = trans.security.encode_id(wf.id)
-            item["annotations"] = [x.annotation for x in wf.annotations]
-            item["url"] = url_for("workflow", id=encoded_id)
-            item["owner"] = wf.user.username
-            item["source_metadata"] = wf.latest_workflow.source_metadata
-            item["number_of_steps"] = wf.latest_workflow.step_count
-            item["show_in_tool_panel"] = False
-            if user is not None:
-                item["show_in_tool_panel"] = wf.show_in_tool_panel(user_id=user.id)
-            rval.append(item)
-        if missing_tools:
-            workflows_missing_tools = []
-            workflows = []
-            workflows_by_toolshed = dict()
-            for value in rval:
-                tools = self.workflow_contents_manager.get_all_tools(
-                    self.__get_stored_workflow(trans, value["id"]).latest_workflow
-                )
-                missing_tool_ids = [
-                    tool["tool_id"] for tool in tools if self.app.toolbox.is_missing_shed_tool(tool["tool_id"])
-                ]
-                if len(missing_tool_ids) > 0:
-                    value["missing_tools"] = missing_tool_ids
-                    workflows_missing_tools.append(value)
-            for workflow in workflows_missing_tools:
-                for tool_id in workflow["missing_tools"]:
-                    toolshed, _, owner, name, tool, version = tool_id.split("/")
-                    shed_url = self.__get_full_shed_url(toolshed)
-                    repo_identifier = "/".join((toolshed, owner, name))
-                    if repo_identifier not in workflows_by_toolshed:
-                        workflows_by_toolshed[repo_identifier] = dict(
-                            shed=shed_url.rstrip("/"),
-                            repository=name,
-                            owner=owner,
-                            tools=[tool_id],
-                            workflows=[workflow["name"]],
-                        )
-                    else:
-                        if tool_id not in workflows_by_toolshed[repo_identifier]["tools"]:
-                            workflows_by_toolshed[repo_identifier]["tools"].append(tool_id)
-                        if workflow["name"] not in workflows_by_toolshed[repo_identifier]["workflows"]:
-                            workflows_by_toolshed[repo_identifier]["workflows"].append(workflow["name"])
-            for repo_tag in workflows_by_toolshed:
-                workflows.append(workflows_by_toolshed[repo_tag])
-            return workflows
-        return rval
+        return self.service.index(trans, payload)
 
     @expose_api_anonymous_and_sessionless
     def show(self, trans: GalaxyWebTransaction, id, **kwd):
@@ -1510,10 +1421,52 @@ StoredWorkflowIDPathParam: EncodedDatabaseIdField = Path(
     ..., title="Stored Workflow ID", description="The encoded database identifier of the Stored Workflow."
 )
 
+DeletedQueryParam: bool = Query(
+    default=False, title="Display deleted", description="Whether to restrict result to deleted workflows."
+)
+
+HiddenQueryParam: bool = Query(
+    default=False, title="Display hidden", description="Whether to restrict result to hidden workflows."
+)
+
+MissingToolsQueryParam: bool = Query(
+    default=False,
+    title="Display missing tools",
+    description="Whether to include a list of missing tools per workflow entry",
+)
+
+ShowPublishedQueryParam: Optional[bool] = Query(default=None, title="Include published workflows.", description="")
+
+ShowSharedQueryParam: Optional[bool] = Query(default=None, title="Include shared workflows.", description="")
+
 
 @router.cbv
 class FastAPIWorkflows:
     service: WorkflowsService = depends(WorkflowsService)
+
+    @router.get(
+        "/api/workflows",
+        summary="Lists stored workflows viewable by the user.",
+        response_description="A list with summary stored workflow information per viewable entry.",
+    )
+    def index(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        show_deleted: bool = DeletedQueryParam,
+        show_hidden: bool = HiddenQueryParam,
+        missing_tools: bool = MissingToolsQueryParam,
+        show_published: Optional[bool] = ShowPublishedQueryParam,
+        show_shared: Optional[bool] = ShowSharedQueryParam,
+    ) -> List[Dict[str, Any]]:
+        """Return the sharing status of the item."""
+        payload = WorkflowIndexPayload(
+            show_published=show_published,
+            show_hidden=show_hidden,
+            show_deleted=show_deleted,
+            show_shared=show_shared,
+            missing_tools=missing_tools,
+        )
+        return self.service.index(trans, payload)
 
     @router.get(
         "/api/workflows/{id}/sharing",

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -1,7 +1,30 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+)
+
+from sqlalchemy import (
+    desc,
+    false,
+    or_,
+    true,
+)
+from sqlalchemy.orm import joinedload
+
+from galaxy import (
+    exceptions,
+    model,
+    web,
+)
+from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.workflows import (
+    WorkflowContentsManager,
     WorkflowSerializer,
     WorkflowsManager,
 )
+from galaxy.schema.schema import WorkflowIndexPayload
+from galaxy.tool_shed.tool_shed_registry import Registry
 from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.sharable import ShareableService
 
@@ -10,8 +33,113 @@ class WorkflowsService(ServiceBase):
     def __init__(
         self,
         workflows_manager: WorkflowsManager,
+        workflow_contents_manager: WorkflowContentsManager,
         serializer: WorkflowSerializer,
+        tool_shed_registry: Registry,
     ):
         self._workflows_manager = workflows_manager
+        self._workflow_contents_manager = workflow_contents_manager
         self._serializer = serializer
         self.shareable_service = ShareableService(workflows_manager, serializer)
+        self._tool_shed_registry = tool_shed_registry
+
+    def index(
+        self,
+        trans: ProvidesUserContext,
+        payload: WorkflowIndexPayload,
+    ) -> List[Dict[str, Any]]:
+        show_published = payload.show_published
+        show_hidden = payload.show_hidden
+        show_deleted = payload.show_deleted
+        missing_tools = payload.missing_tools
+        show_shared = payload.show_shared
+
+        if show_shared is None:
+            show_shared = not show_hidden and not show_deleted
+
+        if show_shared and show_deleted:
+            message = "show_shared and show_deleted cannot both be specified as true"
+            raise exceptions.RequestParameterInvalidException(message)
+        if show_shared and show_hidden:
+            message = "show_shared and show_hidden cannot both be specified as true"
+            raise exceptions.RequestParameterInvalidException(message)
+
+        rval = []
+        filters = [
+            model.StoredWorkflow.user == trans.user,
+        ]
+        user = trans.user
+        if user and show_shared:
+            filters.append(model.StoredWorkflowUserShareAssociation.user == user)
+
+        if show_published or user is None and show_published is None:
+            filters.append((model.StoredWorkflow.published == true()))
+
+        query = trans.sa_session.query(model.StoredWorkflow)
+        if show_shared:
+            query = query.outerjoin(model.StoredWorkflow.users_shared_with)
+
+        query = (
+            query.options(joinedload("annotations"))
+            .options(joinedload("latest_workflow").undefer("step_count").lazyload("steps"))
+            .options(joinedload("tags"))
+        )
+        query = query.filter(or_(*filters))
+        query = query.filter(model.StoredWorkflow.table.c.hidden == (true() if show_hidden else false()))
+        query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
+        if user:
+            query = query.order_by(desc(model.StoredWorkflow.user == user))
+        query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
+        for wf in query.all():
+            item = wf.to_dict(value_mapper={"id": trans.security.encode_id})
+            encoded_id = trans.security.encode_id(wf.id)
+            item["annotations"] = [x.annotation for x in wf.annotations]
+            item["url"] = web.url_for("workflow", id=encoded_id)
+            item["owner"] = wf.user.username
+            item["source_metadata"] = wf.latest_workflow.source_metadata
+            item["number_of_steps"] = wf.latest_workflow.step_count
+            item["show_in_tool_panel"] = False
+            if user is not None:
+                item["show_in_tool_panel"] = wf.show_in_tool_panel(user_id=user.id)
+            rval.append(item)
+        if missing_tools:
+            workflows_missing_tools = []
+            workflows = []
+            workflows_by_toolshed = dict()
+            for value in rval:
+                stored_workflow = self._workflows_manager.get_stored_workflow(trans, value["id"], by_stored_id=True)
+                tools = self._workflow_contents_manager.get_all_tools(stored_workflow.latest_workflow)
+                missing_tool_ids = [
+                    tool["tool_id"] for tool in tools if trans.app.toolbox.is_missing_shed_tool(tool["tool_id"])
+                ]
+                if len(missing_tool_ids) > 0:
+                    value["missing_tools"] = missing_tool_ids
+                    workflows_missing_tools.append(value)
+            for workflow in workflows_missing_tools:
+                for tool_id in workflow["missing_tools"]:
+                    toolshed, _, owner, name, tool, version = tool_id.split("/")
+                    shed_url = self.__get_full_shed_url(toolshed)
+                    repo_identifier = "/".join((toolshed, owner, name))
+                    if repo_identifier not in workflows_by_toolshed:
+                        workflows_by_toolshed[repo_identifier] = dict(
+                            shed=shed_url.rstrip("/"),
+                            repository=name,
+                            owner=owner,
+                            tools=[tool_id],
+                            workflows=[workflow["name"]],
+                        )
+                    else:
+                        if tool_id not in workflows_by_toolshed[repo_identifier]["tools"]:
+                            workflows_by_toolshed[repo_identifier]["tools"].append(tool_id)
+                        if workflow["name"] not in workflows_by_toolshed[repo_identifier]["workflows"]:
+                            workflows_by_toolshed[repo_identifier]["workflows"].append(workflow["name"])
+            for repo_tag in workflows_by_toolshed:
+                workflows.append(workflows_by_toolshed[repo_tag])
+            return workflows
+        return rval
+
+    def __get_full_shed_url(self, url):
+        for shed_url in self._tool_shed_registry.tool_sheds.values():
+            if url in shed_url:
+                return shed_url
+        return None

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -87,9 +87,13 @@ class WorkflowsService(ServiceBase):
         query = query.filter(or_(*filters))
         query = query.filter(model.StoredWorkflow.table.c.hidden == (true() if show_hidden else false()))
         query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
-        if user:
-            query = query.order_by(desc(model.StoredWorkflow.user == user))
-        query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
+        if payload.sort_by is None:
+            if user:
+                query = query.order_by(desc(model.StoredWorkflow.user == user))
+            query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
+        else:
+            sort_column = getattr(model.StoredWorkflow, payload.sort_by)
+            query = query.order_by(sort_column)
         for wf in query.all():
             item = wf.to_dict(value_mapper={"id": trans.security.encode_id})
             encoded_id = trans.security.encode_id(wf.id)

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -93,6 +93,10 @@ class WorkflowsService(ServiceBase):
         query = query.filter(or_(*filters))
         query = query.filter(model.StoredWorkflow.table.c.hidden == (true() if show_hidden else false()))
         query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
+        if payload.search:
+            search_query = payload.search
+            for q in search_query.split():
+                query = query.filter(model.StoredWorkflow.name.like(f"%{q}%"))
         if include_total_count:
             total_matches = query.count()
         else:

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -1,3 +1,4 @@
+import logging
 from typing import (
     Any,
     Dict,
@@ -27,6 +28,8 @@ from galaxy.schema.schema import WorkflowIndexPayload
 from galaxy.tool_shed.tool_shed_registry import Registry
 from galaxy.webapps.galaxy.services.base import ServiceBase
 from galaxy.webapps.galaxy.services.sharable import ShareableService
+
+log = logging.getLogger(__name__)
 
 
 class WorkflowsService(ServiceBase):
@@ -93,6 +96,8 @@ class WorkflowsService(ServiceBase):
             query = query.order_by(desc(model.StoredWorkflow.table.c.update_time))
         else:
             sort_column = getattr(model.StoredWorkflow, payload.sort_by)
+            if payload.sort_desc:
+                sort_column = sort_column.desc()
             query = query.order_by(sort_column)
         for wf in query.all():
             item = wf.to_dict(value_mapper={"id": trans.security.encode_id})

--- a/lib/galaxy/workflow/trs_proxy.py
+++ b/lib/galaxy/workflow/trs_proxy.py
@@ -43,7 +43,7 @@ def parse_search_kwds(search_query):
         query_kwd["description"] = (description_term,)
 
     if keyed_terms is not None:
-        for (key, value) in keyed_terms:
+        for (key, value, _) in keyed_terms:
             query_kwd[key] = value
     return query_kwd
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -433,6 +433,14 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert my_workflow_id_1 in index_ids
         assert their_workflow_id_1 in index_ids
 
+    def test_index_search(self):
+        name1, name2 = self.dataset_populator.get_random_name(), self.dataset_populator.get_random_name()
+        workflow_id_1 = self.workflow_populator.simple_workflow(name1)
+        self.workflow_populator.simple_workflow(name2)
+        index_ids = self.workflow_populator.index_ids(search=name1)
+        assert len(index_ids) == 1
+        assert workflow_id_1 in index_ids
+
     def test_index_published(self):
         # published workflows are also the default of what is displayed for anonymous API requests
         # this is tested in test_anonymous_published.

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -395,8 +395,16 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         my_workflow_id_z = self.workflow_populator.simple_workflow("z_2")
         index_ids = self.workflow_populator.index_ids()
         assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
+        index_ids = self.workflow_populator.index_ids(sort_by="create_time", sort_desc=True)
+        assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
+        index_ids = self.workflow_populator.index_ids(sort_by="create_time", sort_desc=False)
+        assert index_ids.index(my_workflow_id_y) < index_ids.index(my_workflow_id_z)
         index_ids = self.workflow_populator.index_ids(sort_by="name")
         assert index_ids.index(my_workflow_id_y) < index_ids.index(my_workflow_id_z)
+        index_ids = self.workflow_populator.index_ids(sort_by="name", sort_desc=False)
+        assert index_ids.index(my_workflow_id_y) < index_ids.index(my_workflow_id_z)
+        index_ids = self.workflow_populator.index_ids(sort_by="name", sort_desc=True)
+        assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
 
     def test_show_shared(self):
         my_workflow_id_1 = self.workflow_populator.simple_workflow("mine_1")

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -415,7 +415,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert len(index_ids_offset) == 1
         assert index_ids[0] != index_ids_offset[0]
 
-    def test_show_shared(self):
+    def test_index_show_shared(self):
         my_workflow_id_1 = self.workflow_populator.simple_workflow("mine_1")
         my_email = self.dataset_populator.user_email()
         with self._different_user():
@@ -432,6 +432,16 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         index_ids = self.workflow_populator.index_ids(show_shared=True)
         assert my_workflow_id_1 in index_ids
         assert their_workflow_id_1 in index_ids
+
+    def test_index_skip_step_counts(self):
+        self.workflow_populator.simple_workflow("mine_1")
+        index = self.workflow_populator.index()
+        index_0 = index[0]
+        assert "number_of_steps" in index_0
+        assert index_0["number_of_steps"]
+        index = self.workflow_populator.index(skip_step_counts=True)
+        index_0 = index[0]
+        assert "number_of_steps" not in index_0
 
     def test_index_search(self):
         name1, name2 = self.dataset_populator.get_random_name(), self.dataset_populator.get_random_name()

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -406,6 +406,15 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         index_ids = self.workflow_populator.index_ids(sort_by="name", sort_desc=True)
         assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
 
+    def test_index_limit_and_offset(self):
+        self.workflow_populator.simple_workflow("y_1")
+        self.workflow_populator.simple_workflow("z_2")
+        index_ids = self.workflow_populator.index_ids(limit=1)
+        assert len(index_ids) == 1
+        index_ids_offset = self.workflow_populator.index_ids(limit=1, offset=1)
+        assert len(index_ids_offset) == 1
+        assert index_ids[0] != index_ids_offset[0]
+
     def test_show_shared(self):
         my_workflow_id_1 = self.workflow_populator.simple_workflow("mine_1")
         my_email = self.dataset_populator.user_email()

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -451,6 +451,32 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert len(index_ids) == 1
         assert workflow_id_1 in index_ids
 
+    def test_index_search_name(self):
+        name1, name2 = self.dataset_populator.get_random_name(), self.dataset_populator.get_random_name()
+        workflow_id_1 = self.workflow_populator.simple_workflow(name1)
+        self.workflow_populator.simple_workflow(name2)
+        self.workflow_populator.set_tags(workflow_id_1, [name2])
+        index_ids = self.workflow_populator.index_ids(search=name2)
+        # one found by tag and one found by name...
+        assert len(index_ids) == 2
+        assert workflow_id_1 in index_ids
+
+        index_ids = self.workflow_populator.index_ids(search=f"name:{name2}")
+        assert len(index_ids) == 1
+        assert workflow_id_1 not in index_ids
+
+    def test_index_search_tags(self):
+        name1, name2 = self.dataset_populator.get_random_name(), self.dataset_populator.get_random_name()
+        workflow_id_1 = self.workflow_populator.simple_workflow(name1)
+        self.workflow_populator.simple_workflow(name2)
+        index_ids = self.workflow_populator.index_ids(search="moocowatag")
+        assert len(index_ids) == 0
+        self.workflow_populator.set_tags(workflow_id_1, ["moocowatag", "moocowanothertag"])
+        index_ids = self.workflow_populator.index_ids(search="moocowatag")
+        assert workflow_id_1 in index_ids
+        index_ids = self.workflow_populator.index_ids(search="tag:moocowatag")
+        assert workflow_id_1 in index_ids
+
     def test_index_published(self):
         # published workflows are also the default of what is displayed for anonymous API requests
         # this is tested in test_anonymous_published.

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -390,6 +390,14 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         # after an update to workflow 1, it now comes before workflow 2
         assert index_ids.index(my_workflow_id_1) < index_ids.index(my_workflow_id_2)
 
+    def test_index_sort_by(self):
+        my_workflow_id_y = self.workflow_populator.simple_workflow("y_1")
+        my_workflow_id_z = self.workflow_populator.simple_workflow("z_2")
+        index_ids = self.workflow_populator.index_ids()
+        assert index_ids.index(my_workflow_id_z) < index_ids.index(my_workflow_id_y)
+        index_ids = self.workflow_populator.index_ids(sort_by="name")
+        assert index_ids.index(my_workflow_id_y) < index_ids.index(my_workflow_id_z)
+
     def test_show_shared(self):
         my_workflow_id_1 = self.workflow_populator.simple_workflow("mine_1")
         my_email = self.dataset_populator.user_email()

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -596,16 +596,16 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
 
     def test_update_tags(self):
         workflow_object = self.workflow_populator.load_workflow(name="test_import")
-        upload_response = self.__test_upload(workflow=workflow_object)
-        workflow = upload_response.json()
-        workflow["tags"] = ["a_tag", "b_tag"]
-        update_response = self._update_workflow(workflow["id"], workflow).json()
+        workflow_id = self.__test_upload(workflow=workflow_object).json()["id"]
+        update_payload = {}
+        update_payload["tags"] = ["a_tag", "b_tag"]
+        update_response = self._update_workflow(workflow_id, update_payload).json()
         assert update_response["tags"] == ["a_tag", "b_tag"]
-        del workflow["tags"]
-        update_response = self._update_workflow(workflow["id"], workflow).json()
+        del update_payload["tags"]
+        update_response = self._update_workflow(workflow_id, update_payload).json()
         assert update_response["tags"] == ["a_tag", "b_tag"]
-        workflow["tags"] = []
-        update_response = self._update_workflow(workflow["id"], workflow).json()
+        update_payload["tags"] = []
+        update_response = self._update_workflow(workflow_id, update_payload).json()
         assert update_response["tags"] == []
 
     def test_update_name(self):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1447,6 +1447,7 @@ class BaseWorkflowPopulator(BasePopulator):
         limit: Optional[int] = None,
         offset: Optional[int] = None,
         search: Optional[str] = None,
+        skip_step_counts: Optional[bool] = None,
     ):
         endpoint = "workflows?"
         if show_shared is not None:
@@ -1463,6 +1464,8 @@ class BaseWorkflowPopulator(BasePopulator):
             endpoint += f"offset={offset}&"
         if search is not None:
             endpoint += f"search={search}&"
+        if skip_step_counts is not None:
+            endpoint += f"skip_step_counts={skip_step_counts}&"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1438,18 +1438,24 @@ class BaseWorkflowPopulator(BasePopulator):
         self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=assert_ok)
         time.sleep(0.5)
 
-    def index(self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None):
+    def index(
+        self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None, sort_by: Optional[str] = None
+    ):
         endpoint = "workflows?"
         if show_shared is not None:
             endpoint += f"show_shared={show_shared}"
         if show_published is not None:
             endpoint += f"show_published={show_published}"
+        if sort_by is not None:
+            endpoint += f"sort_by={sort_by}"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
 
-    def index_ids(self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None):
-        return [w["id"] for w in self.index(show_shared=show_shared, show_published=show_published)]
+    def index_ids(
+        self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None, sort_by: Optional[str] = None
+    ):
+        return [w["id"] for w in self.index(show_shared=show_shared, show_published=show_published, sort_by=sort_by)]
 
     def share_with_user(self, workflow_id: str, user_id_or_email: str):
         data = {"user_ids": [user_id_or_email]}

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1446,6 +1446,7 @@ class BaseWorkflowPopulator(BasePopulator):
         sort_desc: Optional[bool] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        search: Optional[str] = None,
     ):
         endpoint = "workflows?"
         if show_shared is not None:
@@ -1460,6 +1461,8 @@ class BaseWorkflowPopulator(BasePopulator):
             endpoint += f"limit={limit}&"
         if offset is not None:
             endpoint += f"offset={offset}&"
+        if search is not None:
+            endpoint += f"search={search}&"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
@@ -1472,6 +1475,7 @@ class BaseWorkflowPopulator(BasePopulator):
         sort_desc: Optional[bool] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        search: Optional[str] = None,
     ):
         workflows = self.index(
             show_shared=show_shared,
@@ -1480,6 +1484,7 @@ class BaseWorkflowPopulator(BasePopulator):
             sort_desc=sort_desc,
             limit=limit,
             offset=offset,
+            search=search,
         )
         return [w["id"] for w in workflows]
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1439,23 +1439,36 @@ class BaseWorkflowPopulator(BasePopulator):
         time.sleep(0.5)
 
     def index(
-        self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None, sort_by: Optional[str] = None
+        self,
+        show_shared: Optional[bool] = None,
+        show_published: Optional[bool] = None,
+        sort_by: Optional[str] = None,
+        sort_desc: Optional[bool] = None,
     ):
         endpoint = "workflows?"
         if show_shared is not None:
-            endpoint += f"show_shared={show_shared}"
+            endpoint += f"show_shared={show_shared}&"
         if show_published is not None:
-            endpoint += f"show_published={show_published}"
+            endpoint += f"show_published={show_published}&"
         if sort_by is not None:
-            endpoint += f"sort_by={sort_by}"
+            endpoint += f"sort_by={sort_by}&"
+        if sort_desc is not None:
+            endpoint += f"sort_desc={sort_desc}&"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
 
     def index_ids(
-        self, show_shared: Optional[bool] = None, show_published: Optional[bool] = None, sort_by: Optional[str] = None
+        self,
+        show_shared: Optional[bool] = None,
+        show_published: Optional[bool] = None,
+        sort_by: Optional[str] = None,
+        sort_desc: Optional[bool] = None,
     ):
-        return [w["id"] for w in self.index(show_shared=show_shared, show_published=show_published, sort_by=sort_by)]
+        workflows = self.index(
+            show_shared=show_shared, show_published=show_published, sort_by=sort_by, sort_desc=sort_desc
+        )
+        return [w["id"] for w in workflows]
 
     def share_with_user(self, workflow_id: str, user_id_or_email: str):
         data = {"user_ids": [user_id_or_email]}

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1258,6 +1258,11 @@ class BaseWorkflowPopulator(BasePopulator):
         else:
             return ordered_load(response.text)
 
+    def set_tags(self, workflow_id: str, tags: List[str]) -> None:
+        update_payload = {"tags": tags}
+        response = self.update_workflow(workflow_id, update_payload)
+        response.raise_for_status()
+
     def update_workflow(self, workflow_id: str, workflow_object: dict) -> Response:
         data = dict(workflow=workflow_object)
         raw_url = f"workflows/{workflow_id}"

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1444,6 +1444,8 @@ class BaseWorkflowPopulator(BasePopulator):
         show_published: Optional[bool] = None,
         sort_by: Optional[str] = None,
         sort_desc: Optional[bool] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ):
         endpoint = "workflows?"
         if show_shared is not None:
@@ -1454,6 +1456,10 @@ class BaseWorkflowPopulator(BasePopulator):
             endpoint += f"sort_by={sort_by}&"
         if sort_desc is not None:
             endpoint += f"sort_desc={sort_desc}&"
+        if limit is not None:
+            endpoint += f"limit={limit}&"
+        if offset is not None:
+            endpoint += f"offset={offset}&"
         response = self._get(endpoint)
         api_asserts.assert_status_code_is_ok(response)
         return response.json()
@@ -1464,9 +1470,16 @@ class BaseWorkflowPopulator(BasePopulator):
         show_published: Optional[bool] = None,
         sort_by: Optional[str] = None,
         sort_desc: Optional[bool] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ):
         workflows = self.index(
-            show_shared=show_shared, show_published=show_published, sort_by=sort_by, sort_desc=sort_desc
+            show_shared=show_shared,
+            show_published=show_published,
+            sort_by=sort_by,
+            sort_desc=sort_desc,
+            limit=limit,
+            offset=offset,
         )
         return [w["id"] for w in workflows]
 

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -538,6 +538,26 @@ class UsesHistoryItemAssertions(NavigatesGalaxyMixin):
         assert hid_text == str(hid), hid_text
 
 
+class TestsGalaxyPagers(GalaxyTestSeleniumContext):
+    @retry_assertion_during_transitions
+    def _assert_current_page_is(self, component, expected_page: int):
+        component.pager.wait_for_visible()
+        page_from_pager = component.pager_page_active.wait_for_present().text
+        assert int(page_from_pager) == expected_page
+
+    def _next_page(self, component):
+        component.pager_page_next.wait_for_and_click()
+
+    def _previous_page(self, component):
+        component.pager_page_previous.wait_for_and_click()
+
+    def _last_page(self, component):
+        component.pager_page_last.wait_for_and_click()
+
+    def _first_page(self, component):
+        component.pager_page_first.wait_for_and_click()
+
+
 class RunsWorkflows(GalaxyTestSeleniumContext):
     def workflow_upload_yaml_with_random_name(self, content: str, **kwds) -> str:
         name = self._get_random_name()

--- a/lib/galaxy_test/selenium/test_invocation_grid.py
+++ b/lib/galaxy_test/selenium/test_invocation_grid.py
@@ -1,0 +1,50 @@
+from galaxy_test.base.workflow_fixtures import WORKFLOW_RENAME_ON_INPUT
+from .framework import (
+    retry_assertion_during_transitions,
+    selenium_test,
+    SeleniumTestCase,
+    TestsGalaxyPagers,
+)
+
+
+class InvocationGridSeleniumTestCase(SeleniumTestCase, TestsGalaxyPagers):
+
+    ensure_registered = True
+
+    @selenium_test
+    def test_grid(self):
+        gx_selenium_context = self
+        history_id = gx_selenium_context.dataset_populator.new_history()
+        gx_selenium_context.workflow_populator.run_workflow(
+            WORKFLOW_RENAME_ON_INPUT,
+            history_id=history_id,
+            assert_ok=True,
+            wait=True,
+            invocations=2,
+        )
+        gx_selenium_context.navigate_to_invocations()
+        self._assert_showing_n_invocations(2)
+
+        # by default the pager only appears when there are too many invocations
+        # for one page - so verify it is absent and then swap to showing just
+        # one invocation per page.
+        invocations = gx_selenium_context.components.invocations
+        invocations.pager.wait_for_absent_or_hidden()
+        self.re_get_with_query_params("rows_per_page=1")
+        self._assert_showing_n_invocations(1)
+        invocations.pager.wait_for_visible()
+        self.screenshot("invocations_paginated_first_page")
+        self._next_page(invocations)
+        self._assert_current_page_is(invocations, 2)
+        self.screenshot("invocations_paginated_next_page")
+        self._previous_page(invocations)
+        self._assert_current_page_is(invocations, 1)
+        self._last_page(invocations)
+        self._assert_current_page_is(invocations, 2)
+        self.screenshot("invocations_paginated_last_page")
+        self._first_page(invocations)
+        self._assert_current_page_is(invocations, 1)
+
+    @retry_assertion_during_transitions
+    def _assert_showing_n_invocations(self, n):
+        self.assertEqual(len(self.invocation_index_table_elements()), n)

--- a/lib/galaxy_test/selenium/test_workflow_invocation_details.py
+++ b/lib/galaxy_test/selenium/test_workflow_invocation_details.py
@@ -28,8 +28,8 @@ class WorkflowInvocationDetailsTestCase(SeleniumTestCase):
             assert len(invocation_rows) > 0
             return invocation_rows[0]
 
-        first_row = assert_has_row()
-        print(first_row)
+        assert_has_row()
+
         invocations.state_details.assert_absent()
         invocations.toggle_invocation_details.wait_for_visible()
         details = invocations.toggle_invocation_details.all()[0]

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -100,6 +100,32 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers):
         self._assert_showing_n_workflows(1)
 
     @selenium_test
+    def test_index_search_filters(self):
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_rename("searchforthis")
+        self._assert_showing_n_workflows(1)
+
+        self.workflow_index_search_for("name:doesnotmatch")
+        self._assert_showing_n_workflows(0)
+        self.screenshot("workflow_manage_search_no_matches")
+
+        self.workflow_index_search_for()
+        self._assert_showing_n_workflows(1)
+
+        self.workflow_index_search_for("name:searchforthis")
+        self._assert_showing_n_workflows(1)
+        self.screenshot("workflow_manage_search_name_filter")
+
+        self.workflow_index_search_for("n:searchforthis")
+        self._assert_showing_n_workflows(1)
+        self.screenshot("workflow_manage_search_name_alias")
+
+        self.workflow_index_search_for("n:doesnotmatch")
+        self._assert_showing_n_workflows(0)
+        self.screenshot("workflow_manage_search_name_alias")
+
+    @selenium_test
     def test_pagination(self):
         self.workflow_index_open()
         self._workflow_import_from_url()

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -72,8 +72,7 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers):
         self.workflow_index_open()
         self._workflow_import_from_url()
 
-        self.workflow_index_click_tag_display()
-        self.tagging_add(["cooltag"])
+        self.workflow_index_add_tag("cooltag")
 
         @retry_assertion_during_transitions
         def check_tags():
@@ -81,6 +80,29 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers):
 
         check_tags()
         self.screenshot("workflow_manage_tags")
+
+    @selenium_test
+    def test_tag_filtering(self):
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_add_tag("mytag")
+        self._workflow_import_from_url()
+        self.workflow_index_add_tag("mytag")
+        self._workflow_import_from_url()
+        self.workflow_index_add_tag("mytaglonger")
+        self._workflow_import_from_url()
+
+        self.workflow_index_search_for("mytag")
+        self._assert_showing_n_workflows(3)
+        self.screenshot("workflow_manage_search_by_tag_freetext")
+        self.workflow_index_search_for("thisisnotatag")
+        self._assert_showing_n_workflows(0)
+
+        self.workflow_index_search_for()
+        self._assert_showing_n_workflows(4)
+
+        self.workflow_index_click_tag("mytag", workflow_index=3)
+        self._assert_showing_n_workflows(3)
 
     @selenium_test
     def test_index_search(self):

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -3,6 +3,7 @@ from .framework import (
     retry_assertion_during_transitions,
     selenium_test,
     SeleniumTestCase,
+    TestsGalaxyPagers,
 )
 
 EXAMPLE_WORKFLOW_URL_1 = (
@@ -10,7 +11,7 @@ EXAMPLE_WORKFLOW_URL_1 = (
 )
 
 
-class WorkflowManagementTestCase(SeleniumTestCase):
+class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers):
 
     ensure_registered = True
 
@@ -97,6 +98,40 @@ class WorkflowManagementTestCase(SeleniumTestCase):
 
         self.workflow_index_search_for("searchforthis")
         self._assert_showing_n_workflows(1)
+
+    @selenium_test
+    def test_pagination(self):
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_open()
+        self._workflow_import_from_url()
+        self.workflow_index_open()
+
+        self._assert_showing_n_workflows(4)
+
+        # by default the pager only appears when there are too many workflows
+        # for one page - so verify it is absent and then swap to showing just
+        # one workflow per page.
+        workflows = self.components.workflows
+        workflows.pager.wait_for_absent_or_hidden()
+        self.re_get_with_query_params("rows_per_page=1")
+        self._assert_showing_n_workflows(1)
+        self.screenshot("workflows_paginated_first_page")
+        self._assert_current_page_is(workflows, 1)
+        self._next_page(workflows)
+        self._assert_current_page_is(workflows, 2)
+        self.screenshot("workflows_paginated_next_page")
+        self._previous_page(workflows)
+        self._assert_current_page_is(workflows, 1)
+        self._last_page(workflows)
+        self._assert_current_page_is(workflows, 4)
+        self.screenshot("workflows_paginated_last_page")
+        self._first_page(workflows)
+        self._assert_current_page_is(workflows, 1)
 
     @retry_assertion_during_transitions
     def _assert_showing_n_workflows(self, n):

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -102,7 +102,8 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers):
         self._assert_showing_n_workflows(4)
 
         self.workflow_index_click_tag("mytag", workflow_index=3)
-        self._assert_showing_n_workflows(3)
+        self._assert_showing_n_workflows(2)
+        self.screenshot("workflow_manage_search_by_tag_exact")
 
     @selenium_test
     def test_index_search(self):

--- a/lib/tool_shed/webapp/search/repo_search.py
+++ b/lib/tool_shed/webapp/search/repo_search.py
@@ -209,6 +209,6 @@ class RepoSearch:
         }
         allow_query, search_term_without_filters = parse_filters(search_term, filters)
         allow_query = (
-            And([Term(t, v) for (t, v) in allow_query] if len(allow_query) > 0 else None) if allow_query else None
+            And([Term(t, v) for (t, v, _) in allow_query] if len(allow_query) > 0 else None) if allow_query else None
         )
         return allow_query, search_term_without_filters

--- a/test/unit/util/test_search.py
+++ b/test/unit/util/test_search.py
@@ -1,4 +1,7 @@
-from galaxy.util.search import parse_filters
+from galaxy.util.search import (
+    parse_filters,
+    parse_filters_structured,
+)
 
 
 def test_parse_filters():
@@ -7,26 +10,87 @@ def test_parse_filters():
     assert result[1] == "moo cow"
 
     result = parse_filters("moo:mooterm cow", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "mooterm"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "mooterm"
     assert result[1] == "cow"
 
     result = parse_filters("moo:'moo term' cow", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "moo term"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "moo term"
     assert result[1] == "cow"
 
     result = parse_filters("""moo:"moo term" cow""", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "moo term"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "moo term"
     assert result[1] == "cow"
 
     result = parse_filters("cow moo:'moo term'", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "moo term"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "moo term"
     assert result[1] == "cow"
 
     result = parse_filters("cow moo:'moo term' other side", {"moo": "mookey"})
-    assert result[0][0][0] == "mookey"
-    assert result[0][0][1] == "moo term"
+    filters = result[0]
+    assert filters
+    assert filters[0][0] == "mookey"
+    assert filters[0][1] == "moo term"
     assert result[1] == "cow other side"
+
+
+def test_parse_filters_structured():
+    result = parse_filters_structured("cow moo:moo other side", {"moo": "mookey"}, preserve_quotes=True)
+    filters = result.filter_terms
+    assert filters
+    assert filters[0].quoted is False
+    text_terms = result.text_terms
+    assert len(text_terms) == 3
+    assert text_terms[0].text == "cow"
+    assert text_terms[0].quoted is False
+    assert text_terms[1].text == "other"
+    assert text_terms[1].quoted is False
+    assert text_terms[2].text == "side"
+    assert text_terms[2].quoted is False
+
+    result = parse_filters_structured("cow moo:'moo' other side", {"moo": "mookey"}, preserve_quotes=True)
+    filters = result.filter_terms
+    assert filters
+    assert filters[0].quoted is True
+    text_terms = result.text_terms
+    assert len(text_terms) == 3
+    assert text_terms[0].text == "cow"
+    assert text_terms[0].quoted is False
+    assert text_terms[1].text == "other"
+    assert text_terms[1].quoted is False
+    assert text_terms[2].text == "side"
+    assert text_terms[2].quoted is False
+
+    result = parse_filters_structured("""cow moo:"moo" other side""", {"moo": "mookey"}, preserve_quotes=True)
+    filters = result.filter_terms
+    assert filters
+    assert filters[0].quoted is True
+
+    result = parse_filters_structured("cow moo:'moo term' other side", {"moo": "mookey"}, preserve_quotes=True)
+    filters = result.filter_terms
+    assert filters
+    assert filters[0].filter == "mookey"
+    assert filters[0].text == "moo term"
+    assert filters[0].quoted is True
+    assert " ".join(t.text for t in result.text_terms) == "cow other side"
+
+    result = parse_filters_structured("cow 'other side' foo", {"moo": "mookey"}, preserve_quotes=True)
+    text_terms = result.text_terms
+    assert len(text_terms) == 3
+    assert text_terms[0].text == "cow"
+    assert text_terms[0].quoted is False
+    assert text_terms[1].text == "other side"
+    assert text_terms[1].quoted is True
+    assert text_terms[2].text == "foo"
+    assert text_terms[2].quoted is False

--- a/test/unit/util/test_search.py
+++ b/test/unit/util/test_search.py
@@ -1,0 +1,32 @@
+from galaxy.util.search import parse_filters
+
+
+def test_parse_filters():
+    result = parse_filters("moo cow", {})
+    assert result[0] is None
+    assert result[1] == "moo cow"
+
+    result = parse_filters("moo:mooterm cow", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "mooterm"
+    assert result[1] == "cow"
+
+    result = parse_filters("moo:'moo term' cow", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "moo term"
+    assert result[1] == "cow"
+
+    result = parse_filters("""moo:"moo term" cow""", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "moo term"
+    assert result[1] == "cow"
+
+    result = parse_filters("cow moo:'moo term'", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "moo term"
+    assert result[1] == "cow"
+
+    result = parse_filters("cow moo:'moo term' other side", {"moo": "mookey"})
+    assert result[0][0][0] == "mookey"
+    assert result[0][0][1] == "moo term"
+    assert result[1] == "cow other side"


### PR DESCRIPTION
Builds on #13786. 

Adds end-to-end tests and make it so that when you click on a tag to filter by that tag only that exact tag is filtered. The tests clarify this but if you have workflows with tags "abcde" and "abcdefg" when you click on the tag "abcde" the workflows with the tag "abcdefg" won't show up. The free text search for "abcde" will still bring up both collections of workflows. I think this is the most useful and intuitive behavior.

The improvements to the search filtering are something I want for filtering by tool IDs in the job index filters also.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
