### PR TITLE
Limit Custos SDK logging from showing up in Galaxy

### DIFF
--- a/lib/galaxy/security/vault.py
+++ b/lib/galaxy/security/vault.py
@@ -18,6 +18,8 @@ try:
     from custos.clients.utils.exceptions.CustosExceptions import KeyDoesNotExist
     from custos.transport.settings import CustosServerClientSettings
 
+    logging.getLogger("custos.clients.resource_secret_management_client").setLevel(logging.CRITICAL)
+
     custos_sdk_available = True
 except ImportError:
     custos_sdk_available = False


### PR DESCRIPTION
Custos SDK logs various exceptions that that were propagated to the Galaxy log unnecessarily so restrict those.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
