### PR TITLE
Use ``load_app_properties()`` to load Galaxy config file

### DIFF
--- a/scripts/config_parse.py
+++ b/scripts/config_parse.py
@@ -3,17 +3,17 @@ import os
 import pprint
 import sys
 
-import yaml
-
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "lib")))
 from galaxy.config import GalaxyAppConfiguration
+from galaxy.util.properties import load_app_properties
 
 
 def main(config, setting):
     # Use explicit config, then env, then guess.
     config = config or os.environ.get("GALAXY_CONFIG_FILE", "config/galaxy.yml")
     if config and os.path.exists(config):
-        gx_config = GalaxyAppConfiguration(**yaml.safe_load(open(config))["galaxy"])
+        app_properties = load_app_properties(config_file=config)
+        gx_config = GalaxyAppConfiguration(**app_properties)
         if setting:
             print(gx_config.get(setting))
         else:


### PR DESCRIPTION
instead of directly loading it as YAML.
Will make it easier to uniformly deal with changes of format (e.g. we are deprecating ini now).

Fix traceback:

```
Traceback (most recent call last):
  File "scripts/config_parse.py", line 31, in <module>
    main(args.config_file, args.setting)
  File "scripts/config_parse.py", line 16, in main
    gx_config = GalaxyAppConfiguration(**yaml.safe_load(open(config))["galaxy"])
  File "/home/berntm/.planemo/gx_venv_3/lib/python3.8/site-packages/yaml/__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
  File "/home/berntm/.planemo/gx_venv_3/lib/python3.8/site-packages/yaml/__init__.py", line 81, in load
    return loader.get_single_data()
  File "/home/berntm/.planemo/gx_venv_3/lib/python3.8/site-packages/yaml/constructor.py", line 49, in get_single_data
    node = self.get_single_node()
  File "/home/berntm/.planemo/gx_venv_3/lib/python3.8/site-packages/yaml/composer.py", line 39, in get_single_node
    if not self.check_event(StreamEndEvent):
  File "/home/berntm/.planemo/gx_venv_3/lib/python3.8/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/home/berntm/.planemo/gx_venv_3/lib/python3.8/site-packages/yaml/parser.py", line 171, in parse_document_start
    raise ParserError(None, None,
yaml.parser.ParserError: expected '<document start>', but found '<scalar>'
  in "/tmp/tmpsffm7of5/galaxy.ini", line 3, column 1
```

when starting Galaxy with a `galaxy.ini` config file (though Galaxy startup will still fail later).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `GALAXY_CONFIG_FILE=config/galaxy.ini ./run.sh`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
