### PR TITLE
[22.01] Raise RequestValidationError in as_form decorator

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -20,9 +20,11 @@ from fastapi import (
     Request,
     Response,
 )
+from fastapi.exceptions import RequestValidationError
 from fastapi.params import Depends
 from fastapi_utils.cbv import cbv
 from fastapi_utils.inferring_router import InferringRouter
+from pydantic import ValidationError
 from pydantic.main import BaseModel
 from starlette.routing import NoMatchFound
 try:
@@ -297,7 +299,10 @@ def as_form(cls: Type[BaseModel]):
     ]
 
     async def _as_form(**data):
-        return cls(**data)
+        try:
+            return cls(**data)
+        except ValidationError as e:
+            raise RequestValidationError(e.raw_errors)
 
     sig = inspect.signature(_as_form)
     sig = sig.replace(parameters=new_params)


### PR DESCRIPTION
Otherwise invalid requests for models with the as_form decorator will result in a 500, instead of a proper validation error.
You can see this in https://github.com/mvdbeek/galaxy/runs/6161486549?check_suite_focus=true#step:15:602

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
