### PR TITLE
Add test for dataset param options filter

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1413,6 +1413,9 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
 
     if found_exceptions and not testdef.expect_test_failure:
         raise JobOutputsError(found_exceptions, job_stdio)
+    elif not found_exceptions and testdef.expect_test_failure:
+        register_exception(AssertionError("Expected job to miss at least one test assumption but all were met."))
+        raise JobOutputsError(found_exceptions, job_stdio)
     else:
         return job_stdio
 

--- a/test/functional/tools/dataset_options_filter.xml
+++ b/test/functional/tools/dataset_options_filter.xml
@@ -20,7 +20,7 @@
       <output name="out_file1" file="simple_line.txt"/>
     </test>
     <!-- functional test of the dbkey filter of input2: only the dbkey of input1 is accepted -->
-    <test>
+    <test expect_test_failure="true">
       <param name="input1" value="simple_line.txt" dbkey="hg17" ftype="txt"/>
       <param name="input2" value="simple_line_x2.txt" dbkey="hg19" ftype="txt"/>
       <output name="out_file1" file="simple_line.txt"/>
@@ -32,7 +32,7 @@
       <output name="out_file1" file="simple_line.txt"/>
     </test>
     <!-- functional test of the dbkey filter of input2: -->
-    <test>
+    <test expect_test_failure="true">
       <param name="input1" value="simple_line.txt" dbkey="hg17" ftype="txt"/>
       <param name="input2" value="simple_line_x2.txt" ftype="txt"/>
       <output name="out_file1" file="simple_line.txt"/>

--- a/test/functional/tools/dataset_options_filter.xml
+++ b/test/functional/tools/dataset_options_filter.xml
@@ -1,0 +1,43 @@
+<tool id="dataset_options_filter" name="dataset_options_filter" version="1.0">
+  <command>
+    cat '$input1' > '$out_file1'
+  </command>
+  <inputs>
+    <param format="txt" name="input1" type="data"/>
+    <param format="txt" name="input2" type="data">
+      <options>
+        <filter type="data_meta" ref="input1" key="dbkey" />
+      </options>
+    </param>
+  </inputs>
+  <outputs>
+    <data format="txt" name="out_file1"/>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input1" value="simple_line.txt" dbkey="hg17" ftype="txt"/>
+      <param name="input2" value="simple_line_x2.txt" dbkey="hg17" ftype="txt"/>
+      <output name="out_file1" file="simple_line.txt"/>
+    </test>
+    <!-- functional test of the dbkey filter of input2: only the dbkey of input1 is accepted -->
+    <test>
+      <param name="input1" value="simple_line.txt" dbkey="hg17" ftype="txt"/>
+      <param name="input2" value="simple_line_x2.txt" dbkey="hg19" ftype="txt"/>
+      <output name="out_file1" file="simple_line.txt"/>
+    </test>
+    <!-- functional test of the dbkey filter of input2: any dbkey is accepted if input1 has no dbkey-->
+    <test>
+      <param name="input1" value="simple_line.txt" ftype="txt"/>
+      <param name="input2" value="simple_line_x2.txt" dbkey="hg19" ftype="txt"/>
+      <output name="out_file1" file="simple_line.txt"/>
+    </test>
+    <!-- functional test of the dbkey filter of input2: -->
+    <test>
+      <param name="input1" value="simple_line.txt" dbkey="hg17" ftype="txt"/>
+      <param name="input2" value="simple_line_x2.txt" ftype="txt"/>
+      <output name="out_file1" file="simple_line.txt"/>
+    </test>
+  </tests>
+  <help>
+  </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -215,6 +215,7 @@
   <tool file="interactivetool_simple.xml" />
   <tool file="interactivetool_two_entry_points.xml" />
   <tool file="converter_target_datatype.xml" />
+  <tool file="dataset_options_filter.xml" />
 
   <!-- Tools interesting only for building up test workflows. -->
 


### PR DESCRIPTION
Realized that options filters for dataset parameters have no test. So I added one and found out that the the filters have absolutely no effect on the tests (some of them should fail). 

Edit: I guess that the not-failing tests are also caused by https://github.com/galaxyproject/galaxy/pull/12073/

I also tested the test tool with `planemo serve --galaxy_branch release_22.01` (because `serve` currently does not work for the dev branch): 

- added two datasets: one with dbkey hg17 and the other hg38

Found that the behavior of the UI inconsistent: 

- hg38 as input1 only allows hg38 for input2
- hg17 as input1 shows both datasets for input2 (hg38 as unavailable .. but the combination can still be executed)

![Peek 2022-04-26 12-38](https://user-images.githubusercontent.com/25689525/165283125-5eb15065-3581-438b-8d33-266abb7ac281.gif)

Not sure what is needed to fix this: 

- If I add an exception here https://github.com/galaxyproject/galaxy/blob/006753c191f6074c8d438cbaaad451c6d6d0015f/lib/galaxy/tools/parameters/basic.py#L2255 then the UI works as expected.. Is there any other case where a dataset is unavailable? 
- Maybe parts of https://github.com/galaxyproject/galaxy/pull/12679 may also help

Also tried to bisect in order to find out if this ever worked, but planemo rest does not work for older releases like 17.01

TODO:

- [ ] remove https://github.com/galaxyproject/galaxy/pull/13812/commits/c483dc9a44ec72d70e124ea9178b144afbfcbae1 which I cherry picked from https://github.com/galaxyproject/galaxy/pull/13815

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
