### PR TITLE
Replace last use of deprecated ``imp`` module

### DIFF
--- a/lib/galaxy/tool_shed/galaxy_install/datatypes/custom_datatype_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/datatypes/custom_datatype_manager.py
@@ -13,7 +13,7 @@ class CustomDatatypeLoader:
     def __init__(self, app):
         self.app = app
 
-    def alter_config_and_load_prorietary_datatypes(
+    def alter_config_and_load_proprietary_datatypes(
         self, datatypes_config, relative_install_dir, deactivate=False, override=True
     ):
         """
@@ -159,7 +159,7 @@ class CustomDatatypeLoader:
         repository_dict = None
         datatypes_config = get_config_from_disk(DATATYPES_CONFIG_FILENAME, relative_install_dir)
         if datatypes_config:
-            converter_path, display_path = self.alter_config_and_load_prorietary_datatypes(
+            converter_path, display_path = self.alter_config_and_load_proprietary_datatypes(
                 datatypes_config, relative_install_dir, deactivate=deactivate
             )
             if converter_path or display_path:

--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -696,7 +696,7 @@ class InstallRepositoryManager:
             datatypes_config = hg_util.get_config_from_disk(suc.DATATYPES_CONFIG_FILENAME, files_dir)
             # Load data types required by tools.
             cdl = custom_datatype_manager.CustomDatatypeLoader(self.app)
-            converter_path, display_path = cdl.alter_config_and_load_prorietary_datatypes(
+            converter_path, display_path = cdl.alter_config_and_load_proprietary_datatypes(
                 datatypes_config, files_dir, override=False
             )
             if converter_path or display_path:


### PR DESCRIPTION
This is tested in `lib/tool_shed/test/functional/test_1450_installing_datatypes_sniffers.py`

Fix https://github.com/galaxyproject/galaxy/issues/12658 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
