### PR TITLE
Remove animation when expanding items in history

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -53,7 +53,7 @@
             </div>
         </div>
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
-        <div class="detail-animation-wrapper" :class="expandDataset ? '' : 'collapsed'">
+        <div>
             <DatasetDetails v-if="expandDataset" @edit="onEdit" :dataset="item" />
         </div>
     </div>
@@ -158,14 +158,5 @@ export default {
     .name {
         word-break: break-all;
     }
-}
-.detail-animation-wrapper {
-    overflow: hidden;
-    transition: max-height 0.2s ease-out;
-    height: auto;
-    max-height: 400px;
-}
-.detail-animation-wrapper.collapsed {
-    max-height: 0;
 }
 </style>


### PR DESCRIPTION
We recently introduced animation when expanding history items, however the time is already set 0.2s and the effect is not really visible, also re-expanding does not seem to trigger the same animation. Here I am suggesting to strip the animation for now, it would reduce style requirements without any changes to the user experience.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
