### PR TITLE
Populate filterSettings when filterText changes

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters.vue
@@ -68,6 +68,7 @@
 
 <script>
 import DebouncedInput from "components/DebouncedInput";
+import { getFilterSettings } from "store/historyStore/model/filtering";
 
 // available filter keys with operator and default setting
 const filterDefaults = {
@@ -95,6 +96,18 @@ export default {
         return {
             filterSettings: { ...filterDefaults },
         };
+    },
+    watch: {
+        localFilter(newFilterText) {
+            // reset filterSettings when filterText changes
+            this.filterSettings = { ...filterDefaults };
+            var newfilterSettings = getFilterSettings(newFilterText);
+            Object.entries(newfilterSettings).forEach(([key, value]) => {
+                if (this.filterSettings[key] !== value) {
+                    this.filterSettings[key] = value;
+                }
+            });
+        },
     },
     computed: {
         localFilter: {

--- a/client/src/components/History/CurrentHistory/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters.vue
@@ -97,18 +97,6 @@ export default {
             filterSettings: { ...filterDefaults },
         };
     },
-    watch: {
-        localFilter(newFilterText) {
-            // reset filterSettings when filterText changes
-            this.filterSettings = { ...filterDefaults };
-            var newfilterSettings = getFilterSettings(newFilterText);
-            Object.entries(newfilterSettings).forEach(([key, value]) => {
-                if (this.filterSettings[key] !== value) {
-                    this.filterSettings[key] = value;
-                }
-            });
-        },
-    },
     computed: {
         localFilter: {
             get() {
@@ -119,6 +107,18 @@ export default {
                     this.updateFilter(newVal);
                 }
             },
+        },
+    },
+    watch: {
+        localFilter(newFilterText) {
+            // reset filterSettings when filterText changes
+            this.filterSettings = { ...filterDefaults };
+            var newfilterSettings = getFilterSettings(newFilterText);
+            Object.entries(newfilterSettings).forEach(([key, value]) => {
+                if (this.filterSettings[key] !== value) {
+                    this.filterSettings[key] = value;
+                }
+            });
         },
     },
     methods: {

--- a/client/src/store/historyStore/model/filtering.js
+++ b/client/src/store/historyStore/model/filtering.js
@@ -222,7 +222,7 @@ export function getQueryDict(filterText) {
  * Only used to sync filterSettings (in HistoryFilters)
  * @param {String} filterText The raw filter text
  */
- export function getFilterSettings(filterText) {
+export function getFilterSettings(filterText) {
     const pairSplitRE = /[^\s']+(?:'[^']*'[^\s']*)*|(?:'[^']*'[^\s']*)+/g;
     const result = {};
     const matches = filterText.match(pairSplitRE);

--- a/client/src/store/historyStore/model/filtering.test.js
+++ b/client/src/store/historyStore/model/filtering.test.js
@@ -1,4 +1,4 @@
-import { checkFilter, getFilters, getQueryDict, testFilters } from "./filtering";
+import { checkFilter, getFilters, getFilterSettings, getQueryDict, testFilters } from "./filtering";
 
 const filterTexts = [
     "name='name of item' hid>10 hid<100 create-time>'2021-01-01' update-time<'2022-01-01' state=success extension=ext tag=first deleted=False visible='TRUE'",
@@ -60,19 +60,19 @@ describe("filtering", () => {
         });
     });
     test("validate filtering of a history item", () => {
+        const item = {
+            create_time: "2021-06-01",
+            extension: "ext",
+            deleted: false,
+            hid: 11,
+            name: "contains the name of item.",
+            state: "success",
+            tags: ["first", "second"],
+            update_time: "2021-06-01",
+            visible: true,
+        };
         filterTexts.forEach((filterText) => {
             const filters = getFilters(filterText);
-            const item = {
-                create_time: "2021-06-01",
-                extension: "ext",
-                deleted: false,
-                hid: 11,
-                name: "contains the name of item.",
-                state: "success",
-                tags: ["first", "second"],
-                update_time: "2021-06-01",
-                visible: true,
-            };
             expect(testFilters(filters, { ...item })).toBe(true);
             expect(testFilters(filters, { ...item, hid: 10 })).toBe(false);
             expect(testFilters(filters, { ...item, hid: 100 })).toBe(false);
@@ -85,6 +85,39 @@ describe("filtering", () => {
             expect(testFilters(filters, { ...item, tags: ["second"] })).toBe(false);
             expect(testFilters(filters, { ...item, visible: false })).toBe(false);
             expect(testFilters(filters, { ...item, deleted: true })).toBe(false);
+        });
+    });
+    test("Parsing & sync of filter settings", () => {
+        // Expected parsed settings
+        const parsedFilterSettings = [
+            {
+                "name=": "name of item",
+                "hid>": "10",
+                "hid<": "100",
+                "create_time>": "2021-01-01",
+                "update_time<": "2022-01-01",
+                "state=": "success",
+                "extension=": "ext",
+                "tag=": "first",
+                "deleted=": "false",
+                "visible=": "true",
+            },
+            {
+                "name=": "name of item",
+                "hid_gt=": "10",
+                "hid_lt=": "100",
+                "create_time_gt=": "2021-01-01",
+                "update_time_lt=": "2022-01-01",
+                "state=": "success",
+                "extension=": "ext",
+                "tag=": "first",
+                "deleted=": "false",
+                "visible=": "true",
+            },
+        ];
+        // iterate through filterTexts and compare with parsedFilterSettings
+        filterTexts.forEach((filterText, index) => {
+            expect(getFilterSettings(filterTexts[index])).toEqual(parsedFilterSettings[index]);
         });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/13742. The `filterText` input query does not impact the values in the advanced `filterSettings`. I have made it so that the input query is now synced to the `filterSettings`.


https://user-images.githubusercontent.com/78516064/165651093-fe8771ce-d0e1-46fe-9c72-b2e01113e09f.mov



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
