### PR TITLE
[21.09] Skip non JSON-encodable values in ``params_to_strings()``

### DIFF
--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -1,7 +1,7 @@
 """
 Classes encapsulating Galaxy tool parameters.
 """
-
+import logging
 from json import dumps
 
 from boltons.iterutils import remap
@@ -18,6 +18,8 @@ from .basic import (
     SelectToolParameter,
 )
 from .grouping import Conditional, Repeat, Section, UploadDataset
+
+log = logging.getLogger(__name__)
 
 REPLACE_ON_TRUTHY = object()
 
@@ -205,14 +207,21 @@ def params_to_strings(params, param_values, app, nested=False, use_security=Fals
     Convert a dictionary of parameter values to a dictionary of strings
     suitable for persisting. The `value_to_basic` method of each parameter
     is called to convert its value to basic types, the result of which
-    is then json encoded (this allowing complex nested parameters and
+    is then JSON encoded (this allowing complex nested parameters and
     such).
+    If the value is not JSON-encodable, the key/value pair is skipped.
     """
     rval = dict()
     for key, value in param_values.items():
         if key in params:
             value = params[key].value_to_basic(value, app, use_security=use_security)
-        rval[key] = value if nested or value is None else str(dumps(value, sort_keys=True))
+        if not nested and value is not None:
+            try:
+                value = dumps(value, sort_keys=True)
+            except Exception as e:
+                log.warning(f"Error while serializing value {value} for key {key}: {e}")
+                continue
+        rval[key] = value
     return rval
 
 

--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -131,7 +131,7 @@ class BooleanExpressionEvaluator:
         action.evaluator = evaluator
         boolOperand = TRUE | FALSE | Word(token_format or DEFAULT_TOKEN_FORMAT)
         boolOperand.setParseAction(action)
-        self.boolExpr = infixNotation(
+        self.boolExpr: ParserElement = infixNotation(
             boolOperand,
             [
                 (NOT_OP, 1, opAssoc.RIGHT, BoolNot),

--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -14,7 +14,6 @@ from typing import (
 from pyparsing import (
     alphanums,
     CaselessKeyword,
-    Forward,
     infixNotation,
     Keyword,
     opAssoc,
@@ -132,7 +131,7 @@ class BooleanExpressionEvaluator:
         action.evaluator = evaluator
         boolOperand = TRUE | FALSE | Word(token_format or DEFAULT_TOKEN_FORMAT)
         boolOperand.setParseAction(action)
-        self.boolExpr: Forward = infixNotation(
+        self.boolExpr = infixNotation(
             boolOperand,
             [
                 (NOT_OP, 1, opAssoc.RIGHT, BoolNot),


### PR DESCRIPTION
Fix the error reported in https://github.com/galaxyproject/galaxy/issues/13455 , which was due to BioMart sending some binary empty strings as values, e.g. for the `hsapiens_gene_ensembl__filter.chromosomal_region__file` key.

N.B.: the BioMart tool still doesn't work after this fix (probably BioMart's fault), but at least Galaxy doesn't fail with the mysterious: "Error executing tool id 'biomart': Object of type bytes is not JSON serializable"

Also, cherry-pick commits from dev to fix test failures.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. See https://github.com/galaxyproject/galaxy/issues/13455

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
