### PR TITLE
[22.05] History animation method change, constrained info box

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -77,14 +77,14 @@
             @tag-click="onTagClick"
             @input="onTags" />
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
-        <div class="detail-animation-wrapper" :class="expandDataset ? '' : 'collapsed'">
+        <b-collapse :visible="expandDataset">
             <DatasetDetails
                 v-if="expandDataset"
                 :dataset="item"
                 :show-highlight="isHistoryItem && isHistPanel"
                 @edit="onEdit"
                 @toggleHighlights="toggleHighlights" />
-        </div>
+        </b-collapse>
     </div>
 </template>
 
@@ -213,14 +213,5 @@ export default {
     .name {
         word-break: break-all;
     }
-}
-.detail-animation-wrapper {
-    overflow: hidden;
-    transition: max-height 0.2s ease-out;
-    height: auto;
-    max-height: 400px;
-}
-.detail-animation-wrapper.collapsed {
-    max-height: 0;
 }
 </style>

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -25,6 +25,32 @@
                 <pre v-if="result.peek" class="dataset-peek p-1" v-html="result.peek" />
             </div>
         </div>
+        <div v-else class="dataset">
+            <!--
+                placeholder skeleton for loading smoothly without a spinner
+                (which you don't even see since this happens pretty fast)
+            -->
+            <div class="p-2 details">
+                <div class="summary">
+                    <div class="mb-1">
+                        <b-skeleton width="85%"></b-skeleton>
+                    </div>
+                    <span class="datatype">
+                        <b-skeleton width="55%"></b-skeleton>
+                    </span>
+                    <div class="info">
+                        <span class="value">Dataset Information Loading.</span>
+                    </div>
+                </div>
+                <pre class="dataset-peek p-1">
+                    <table cellspacing="0" cellpadding="3">
+                        <tbody>
+                            <tr><td>Loading...</td></tr>
+                        </tbody>
+                    </table>
+                </pre>
+            </div>
+        </div>
     </DatasetProvider>
 </template>
 

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -58,11 +58,14 @@
 import { STATES } from "components/History/Content/model/states";
 import { DatasetProvider } from "components/providers/storeProviders";
 import DatasetActions from "./DatasetActions";
+import { BLink, BSkeleton } from "bootstrap-vue";
 
 export default {
     components: {
         DatasetActions,
         DatasetProvider,
+        BLink,
+        BSkeleton,
     },
     props: {
         dataset: { type: Object, required: true },

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -80,3 +80,9 @@ export default {
     },
 };
 </script>
+<style scoped>
+.details .summary div.info {
+    max-height: 4rem;
+    overflow-y: auto;
+}
+</style>

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -83,14 +83,13 @@
 import { STATES } from "components/History/Content/model/states";
 import { DatasetProvider } from "components/providers/storeProviders";
 import DatasetActions from "./DatasetActions";
-import { BLink, BSkeleton } from "bootstrap-vue";
+import { BLink } from "bootstrap-vue";
 
 export default {
     components: {
         DatasetActions,
         DatasetProvider,
         BLink,
-        BSkeleton,
     },
     props: {
         dataset: { type: Object, required: true },

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -32,20 +32,25 @@
             -->
             <div class="p-2 details">
                 <div class="summary">
-                    <div class="mb-1">
-                        <b-skeleton width="85%"></b-skeleton>
+                    <div class="blurb">
+                        <span class="value">...</span>
                     </div>
                     <span class="datatype">
-                        <b-skeleton width="55%"></b-skeleton>
+                        <label v-localize class="prompt">format</label>
+                        <span class="value">...</span>
+                    </span>
+                    <span class="dbkey">
+                        <label v-localize class="prompt">database</label>
+                        <span class="value">?</span>
                     </span>
                     <div class="info">
-                        <span class="value">Dataset Information Loading.</span>
+                        <span class="value">Loading</span>
                     </div>
                 </div>
                 <pre class="dataset-peek p-1">
                     <table cellspacing="0" cellpadding="3">
                         <tbody>
-                            <tr><td>Loading...</td></tr>
+                            <tr><td>Dataset peek loading...</td></tr>
                         </tbody>
                     </table>
                 </pre>

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -28,12 +28,15 @@
         <div v-else class="dataset">
             <!--
                 placeholder skeleton for loading smoothly without a spinner
-                (which you don't even see since this happens pretty fast)
+                (which you don't even see since this happens pretty fast, but it
+                should be pretty accurate -- longer term it might be worth
+                having more standard 'placeholder' versions of pre-loaded
+                components) )
             -->
             <div class="p-2 details">
                 <div class="summary">
                     <div class="blurb">
-                        <span class="value">...</span>
+                        <span class="value">? lines</span>
                     </div>
                     <span class="datatype">
                         <label v-localize class="prompt">format</label>
@@ -47,13 +50,30 @@
                         <span class="value">Loading</span>
                     </div>
                 </div>
-                <pre class="dataset-peek p-1">
-                    <table cellspacing="0" cellpadding="3">
-                        <tbody>
-                            <tr><td>Dataset peek loading...</td></tr>
-                        </tbody>
-                    </table>
-                </pre>
+                <div class="dataset-actions mb-1">
+                    <div class="clearfix">
+                        <div class="btn-group float-left">
+                            <button disabled class="btn px-1 btn-link btn-sm">
+                                <span class="fa fa-save"></span>
+                            </button>
+                            <button disabled class="btn px-1 btn-link btn-sm">
+                                <span class="fa fa-link"></span>
+                            </button>
+                            <button disabled class="btn px-1 btn-link btn-sm">
+                                <span class="fa fa-info-circle"></span>
+                            </button>
+                            <button disabled class="btn px-1 btn-link btn-sm">
+                                <span class="fa fa-bar-chart-o"></span>
+                            </button>
+                            <button disabled class="btn px-1 btn-link btn-sm">
+                                <span class="fa fa-sitemap"></span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+                <!-- this looks a mess, but whitespace pads the pre and makes it look wonky -->
+                <pre
+                    class="dataset-peek p-1"><table cellspacing="0" cellpadding="3"><tbody><tr><td>Dataset peek loading...</td></tr></tbody></table></pre>
             </div>
         </div>
     </DatasetProvider>


### PR DESCRIPTION
Instead of custom animations this swaps to the bootstrap collapse directive.  We have (slightly) less control over this, but it animation speed is now consistent across the application for all things using the directive.  Additionally, we don't have to fiddle with element height directly, which avoids issues with having giant dataset info blocks that push details past max-height. (fixes https://github.com/galaxyproject/galaxy/issues/14098 and https://github.com/galaxyproject/galaxy/issues/14014)

Also constrains the info box to a max height of 4 lines, scrolling past that.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Toggle history items open/closed; try one with a gigantic 'info' field and note it opens all the way.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
