### PR TITLE
Custos Login Ambiguity enhancement

### DIFF
--- a/client/src/components/login/RegisterForm.vue
+++ b/client/src/components/login/RegisterForm.vue
@@ -8,25 +8,25 @@
                 <b-form id="registration" @submit.prevent="submit()">
                     <b-card no-body>
                         <!-- OIDC/External Login enabled: encourage users to use it instead of local registration -->
-                        <span v-if="enable_oidc">
+                        <span v-if="custosEnabled">
                             <b-card-header v-b-toggle.accordion-oidc role="button">
                                 Register using institutional account
                             </b-card-header>
                             <b-collapse visible id="accordion-oidc" role="tabpanel" accordion="registration_acc">
                                 <b-card-body>
                                     Create a Galaxy account using an institutional account (e.g.:Google/JHU). This will
-                                    redirect you to your institutional login.
+                                    redirect you to your institutional login through Custos.
                                     <external-login :login_page="false" />
                                 </b-card-body>
                             </b-collapse>
                         </span>
                         <!-- Local Galaxy Registration -->
                         <b-card-header v-b-toggle.accordion-register role="button">
-                            <span v-if="!enable_oidc">Create a Galaxy account</span>
+                            <span v-if="!custosEnabled">Create a Galaxy account</span>
                             <span v-else>Or, register with email</span>
                         </b-card-header>
                         <b-collapse
-                            :visible="!enable_oidc"
+                            :visible="!custosEnabled"
                             id="accordion-register"
                             role="tabpanel"
                             accordion="registration_acc">
@@ -122,6 +122,7 @@ export default {
             session_csrf_token: galaxy.session_csrf_token,
             isAdmin: galaxy.user.isAdmin(),
             enable_oidc: galaxy.config.enable_oidc,
+            prefer_custos_login: galaxy.config.prefer_custos_login,
         };
     },
     computed: {
@@ -130,6 +131,9 @@ export default {
         },
         showRegistrationWarning() {
             return this.registration_warning_message != null;
+        },
+        custosEnabled() {
+            return this.enable_oidc && this.prefer_custos_login;
         },
     },
     methods: {

--- a/client/src/components/login/RegisterForm.vue
+++ b/client/src/components/login/RegisterForm.vue
@@ -7,12 +7,12 @@
                 <b-alert :show="messageShow" :variant="messageVariant" v-html="messageText" />
                 <b-form id="registration" @submit.prevent="submit()">
                     <b-card no-body>
-                        <!-- OIDC/External Login enabled: encourage users to use it instead of local registration -->
-                        <span v-if="custosEnabled">
+                        <!-- OIDC and Custos enabled and prioritized: encourage users to use it instead of local registration -->
+                        <span v-if="custosPreferred">
                             <b-card-header v-b-toggle.accordion-oidc role="button">
                                 Register using institutional account
                             </b-card-header>
-                            <b-collapse visible id="accordion-oidc" role="tabpanel" accordion="registration_acc">
+                            <b-collapse id="accordion-oidc" visible role="tabpanel" accordion="registration_acc">
                                 <b-card-body>
                                     Create a Galaxy account using an institutional account (e.g.:Google/JHU). This will
                                     redirect you to your institutional login through Custos.
@@ -21,13 +21,13 @@
                             </b-collapse>
                         </span>
                         <!-- Local Galaxy Registration -->
-                        <b-card-header v-b-toggle.accordion-register role="button">
-                            <span v-if="!custosEnabled">Create a Galaxy account</span>
-                            <span v-else>Or, register with email</span>
+                        <b-card-header v-if="!custosPreferred">Create a Galaxy account</b-card-header>
+                        <b-card-header v-else v-b-toggle.accordion-register role="button">
+                            Or, register with email
                         </b-card-header>
                         <b-collapse
-                            :visible="!custosEnabled"
                             id="accordion-register"
+                            :visible="!custosPreferred"
                             role="tabpanel"
                             accordion="registration_acc">
                             <b-card-body>
@@ -132,7 +132,7 @@ export default {
         showRegistrationWarning() {
             return this.registration_warning_message != null;
         },
-        custosEnabled() {
+        custosPreferred() {
             return this.enable_oidc && this.prefer_custos_login;
         },
     },

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3331,6 +3331,17 @@
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~
+``prefer_custos_login``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Controls the order of the login page to prefer Custos-based login
+    and registration.
+:Default: ``false``
+:Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~~~
 ``allow_user_creation``
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1659,6 +1659,10 @@ galaxy:
   # page (even if require_login is true).
   #show_welcome_with_login: false
 
+  # Controls the order of the login page to prefer Custos-based login
+  # and registration.
+  #prefer_custos_login: false
+
   # Allow unregistered users to create new accounts (otherwise, they
   # will have to be created by an admin).
   #allow_user_creation: true

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2433,6 +2433,13 @@ mapping:
           Show the site's welcome page (see welcome_url) alongside the login page
           (even if require_login is true).
 
+      prefer_custos_login:
+        type: bool
+        default: false
+        required: False
+        desc: |
+          Controls the order of the login page to prefer Custos-based login and registration.
+
       allow_user_creation:
         type: bool
         default: true

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -156,6 +156,7 @@ class ConfigSerializer(base.ModelSerializer):
             "single_user": _config_is_truthy,
             "enable_oidc": _use_config,
             "oidc": _use_config,
+            "prefer_custos_login": _use_config,
             "enable_quotas": _use_config,
             "remote_user_logout_href": _use_config,
             "datatypes_disable_auto": _use_config,


### PR DESCRIPTION
When Custos/OIDC is enabled, there is an issue where a user might have an existing internal Galaxy account with the same email as their institutional account (e.g.: They made an account with a jh.edu email, then used Custos to login with the same JHU account). This is just a cause for ambiguity, that needs to be clarified (as of my discussion with @afgane).
So, on the registration page, when enable_oidc is true, I have added accordion b-collapses that encourage the user to, instead of creating a local Galaxy account, use their Custos login to create an account. If they do not prefer that, there is still the b-collapse for local registration.
This was implemented earlier as part 2 of https://github.com/galaxyproject/galaxy/pull/13651 (not merged, issue closed as it included a redundant part 1).
This has been demonstrated here:

https://user-images.githubusercontent.com/78516064/161148051-8b71a24e-a8c5-423d-a6c9-f280f2c1596b.mov

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
