### PR TITLE
Trigger scroller refresh when history changes

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -4,6 +4,7 @@
         v-slot="{ loading, result: payload, count: totalItemsInQuery }"
         :history-id="historyId"
         :offset="offset"
+        :update-time="history.update_time"
         :filter-text="filterText">
         <ExpandedItems
             v-slot="{ expandedCount, isExpanded, setExpanded, collapseAll }"


### PR DESCRIPTION
This PR submits an additional request to keep the scroller up-to-date if the history changes. We would like to avoid this additional request in the future but for now it might be helpful to overcome refresh issues when applying bulk operations. May help with #13783.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
