### PR TITLE
Fix up configuration for STS.  Can't rebuild config without this.

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -696,6 +696,18 @@
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``short_term_storage_maximum_duration``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The maximum duration short term storage files can hosted before
+    they will be marked for clean up.  The default setting of 0
+    indicates no limit here.
+:Default: ``0``
+:Type: int
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``short_term_storage_cleanup_interval``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -507,7 +507,7 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
         short_term_storage_maximum_duration = self.config.short_term_storage_maximum_duration
         if short_term_storage_default_duration is not None:
             short_term_storage_config_kwds["default_storage_duration"] = short_term_storage_default_duration
-        if short_term_storage_maximum_duration is not None and short_term_storage_maximum_duration != 0:
+        if short_term_storage_maximum_duration != 0:
             short_term_storage_config_kwds["maximum_storage_duration"] = short_term_storage_maximum_duration
 
         short_term_storage_config = ShortTermStorageConfiguration(**short_term_storage_config_kwds)

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -507,7 +507,7 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
         short_term_storage_maximum_duration = self.config.short_term_storage_maximum_duration
         if short_term_storage_default_duration is not None:
             short_term_storage_config_kwds["default_storage_duration"] = short_term_storage_default_duration
-        if short_term_storage_maximum_duration is not None:
+        if short_term_storage_maximum_duration is not None and short_term_storage_maximum_duration != 0:
             short_term_storage_config_kwds["maximum_storage_duration"] = short_term_storage_maximum_duration
 
         short_term_storage_config = ShortTermStorageConfiguration(**short_term_storage_config_kwds)

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -507,7 +507,7 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
         short_term_storage_maximum_duration = self.config.short_term_storage_maximum_duration
         if short_term_storage_default_duration is not None:
             short_term_storage_config_kwds["default_storage_duration"] = short_term_storage_default_duration
-        if short_term_storage_maximum_duration != 0:
+        if short_term_storage_maximum_duration:
             short_term_storage_config_kwds["maximum_storage_duration"] = short_term_storage_maximum_duration
 
         short_term_storage_config = ShortTermStorageConfiguration(**short_term_storage_config_kwds)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -472,6 +472,11 @@ galaxy:
   # up by Galaxy tasks (in seconds). The default duration is 1 day.
   #short_term_storage_default_duration: 86400
 
+  # The maximum duration short term storage files can hosted before they
+  # will be marked for clean up.  The default setting of 0 indicates no
+  # limit here.
+  #short_term_storage_maximum_duration: 0
+
   # How many seconds between instances of short term storage being
   # cleaned up in default Celery task configuration.
   #short_term_storage_cleanup_interval: 3600

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -517,9 +517,10 @@ mapping:
       short_term_storage_maximum_duration:
         type: int
         required: false
+        default: 0
         desc: |
           The maximum duration short term storage files can hosted before they will be marked for
-          clean up. By default there is no default.
+          clean up.  The default setting of 0 indicates no limit here.
 
       short_term_storage_cleanup_interval:
         type: int


### PR DESCRIPTION
I think this is the right thing to do here; otherwise when validating the schema you get this when building config (to add additional config options unrelated to this, for example):
```
Exception: Failed to parse value for {'type': 'int', 'unknown_option': False, 'default': None, 'desc': 'The maximum duration short term storage files can hosted before they will be marked for\nclean up. By default there is no default.\n', 'required': False}, expected int got None
```

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `make config-rebuild`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
