### PR TITLE
Duplicates removed from filtering.js

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters.vue
@@ -68,7 +68,7 @@
 
 <script>
 import DebouncedInput from "components/DebouncedInput";
-import { getFilterSettings } from "store/historyStore/model/filtering";
+import { getFilters, toAlias } from "store/historyStore/model/filtering";
 
 // available filter keys with operator and default setting
 const filterDefaults = {
@@ -111,14 +111,12 @@ export default {
     },
     watch: {
         localFilter(newFilterText) {
+            // get dict in form of converted aliases
+            const newFilterSettings = toAlias(getFilters(newFilterText));
             // reset filterSettings when filterText changes
             this.filterSettings = { ...filterDefaults };
-            var newfilterSettings = getFilterSettings(newFilterText);
-            Object.entries(newfilterSettings).forEach(([key, value]) => {
-                if (this.filterSettings[key] !== value) {
-                    this.filterSettings[key] = value;
-                }
-            });
+            // update filterSettings
+            Object.assign(this.filterSettings, newFilterSettings);
         },
     },
     methods: {

--- a/client/src/store/historyStore/model/filtering.js
+++ b/client/src/store/historyStore/model/filtering.js
@@ -208,21 +208,22 @@ export function testFilters(filters, item) {
  * e.g.: Unlike getFilters or getQueryDict, this maintains "hid>":"3" instead
  *       of changing it to "hid-gt":"3"
  * Only used to sync filterSettings (in HistoryFilters)
- * @param {String} filterText The raw filter text
+ * @param {Object} filters Parsed filterText from getFilters()
  */
 export function toAlias(filters) {
     const result = {};
     for (const [key, value] of filters) {
+        let hasAlias = false;
         for (const [alias, substitute] of validAlias) {
-            let hasAlias = false;
-            if (key.includes(substitute)) {
-                result[key.replace(substitute, alias)] = value;
+            if (key.endsWith(substitute)) {
+                const keyPrefix = key.substr(0, key.length - substitute.length);
+                result[`${keyPrefix}${alias}`] = value;
                 hasAlias = true;
                 break;
             }
-            if (!hasAlias) {
-                result[`${key}=`] = value;
-            }
+        }
+        if (!hasAlias) {
+            result[`${key}=`] = value;
         }
     }
     return result;

--- a/client/src/store/historyStore/model/filtering.test.js
+++ b/client/src/store/historyStore/model/filtering.test.js
@@ -89,35 +89,21 @@ describe("filtering", () => {
     });
     test("Parsing & sync of filter settings", () => {
         // Expected parsed settings
-        const parsedFilterSettings = [
-            {
-                "name=": "name of item",
-                "hid>": "10",
-                "hid<": "100",
-                "create_time>": "2021-01-01",
-                "update_time<": "2022-01-01",
-                "state=": "success",
-                "extension=": "ext",
-                "tag=": "first",
-                "deleted=": "false",
-                "visible=": "true",
-            },
-            {
-                "name=": "name of item",
-                "hid_gt=": "10",
-                "hid_lt=": "100",
-                "create_time_gt=": "2021-01-01",
-                "update_time_lt=": "2022-01-01",
-                "state=": "success",
-                "extension=": "ext",
-                "tag=": "first",
-                "deleted=": "false",
-                "visible=": "true",
-            },
-        ];
+        const parsedFilterSettings = {
+            "name=": "name of item",
+            "hid>": "10",
+            "hid<": "100",
+            "create_time>": "2021-01-01",
+            "update_time<": "2022-01-01",
+            "state=": "success",
+            "extension=": "ext",
+            "tag=": "first",
+            "deleted=": "false",
+            "visible=": "true",
+        };
         // iterate through filterTexts and compare with parsedFilterSettings
         filterTexts.forEach((filterText, index) => {
-            expect(toAlias(getFilters(filterTexts[index]))).toEqual(parsedFilterSettings[index]);
+            expect(toAlias(getFilters(filterTexts[index]))).toEqual(parsedFilterSettings);
         });
     });
 });

--- a/client/src/store/historyStore/model/filtering.test.js
+++ b/client/src/store/historyStore/model/filtering.test.js
@@ -1,4 +1,4 @@
-import { checkFilter, getFilters, getFilterSettings, getQueryDict, testFilters } from "./filtering";
+import { checkFilter, getFilters, toAlias, getQueryDict, testFilters } from "./filtering";
 
 const filterTexts = [
     "name='name of item' hid>10 hid<100 create-time>'2021-01-01' update-time<'2022-01-01' state=success extension=ext tag=first deleted=False visible='TRUE'",
@@ -117,7 +117,7 @@ describe("filtering", () => {
         ];
         // iterate through filterTexts and compare with parsedFilterSettings
         filterTexts.forEach((filterText, index) => {
-            expect(getFilterSettings(filterTexts[index])).toEqual(parsedFilterSettings[index]);
+            expect(toAlias(getFilters(filterTexts[index]))).toEqual(parsedFilterSettings[index]);
         });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/pull/13821. As discussed with @guerler, there was a function added to https://github.com/galaxyproject/galaxy/blob/dev/client/src/store/historyStore/model/filtering.js called `getFiltersSettings`: https://github.com/galaxyproject/galaxy/blob/ce8a83ffbae792efe3255ad0f24d0826f6cb1189/client/src/store/historyStore/model/filtering.js#L200
and this function had duplicated code. I changed the function to `toAlias` and it takes `getFilters` as parameter instead.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
