### PR TITLE
[WIP] Improved jobs and workflows indexing APIs and grids.

### DIFF
--- a/client/src/components/DebouncedInput.js
+++ b/client/src/components/DebouncedInput.js
@@ -23,14 +23,23 @@ export default {
             }
         },
     },
+    watch: {
+        incomingValue(val) {
+            if (this.delay === 0) {
+                this.sendUpdate(val);
+            }
+        },
+    },
     beforeMount() {
-        const debounced$ = this.watch$("incomingValue").pipe(
-            debounceTime(this.delay),
-            distinctUntilChanged(),
-            filter((val) => val !== null && val !== this.value),
-            finalize(() => this.sendUpdate(this.incomingValue))
-        );
-        this.$subscribeTo(debounced$, (val) => this.sendUpdate(val));
+        if (this.delay !== 0) {
+            const debounced$ = this.watch$("incomingValue").pipe(
+                debounceTime(this.delay),
+                distinctUntilChanged(),
+                filter((val) => val !== null && val !== this.value),
+                finalize(() => this.sendUpdate(this.incomingValue))
+            );
+            this.$subscribeTo(debounced$, (val) => this.sendUpdate(val));
+        }
     },
     render() {
         return this.$scopedSlots.default({

--- a/client/src/components/Workflow/IndexFilter.vue
+++ b/client/src/components/Workflow/IndexFilter.vue
@@ -1,0 +1,82 @@
+<template>
+    <span>
+        <b-input-group>
+            <DebouncedInput :delay="debounceDelay" v-slot="{ value, input }" v-model="localFilter">
+                <b-form-input
+                    :id="id"
+                    name="query"
+                    :value="value"
+                    autocomplete="off"
+                    :placeholder="placeholder | localize"
+                    data-description="filter index input"
+                    @input="input"
+                    @keyup.esc="onReset" />
+            </DebouncedInput>
+            <b-input-group-append>
+                <b-button data-description="show deleted filter toggle" @click="onHelp" title="Advanced Filtering Help">
+                    <icon icon="question" />
+                </b-button>
+            </b-input-group-append>
+        </b-input-group>
+        <b-modal v-model="showHelp" title="Filtering Options Help" ok-only>
+            <div v-html="helpHtml"></div>
+        </b-modal>
+    </span>
+</template>
+
+<script>
+import DebouncedInput from "components/DebouncedInput";
+
+import { BInputGroup, BInputGroupAppend, BButton, BModal } from "bootstrap-vue";
+
+export default {
+    components: {
+        DebouncedInput,
+        BInputGroup,
+        BInputGroupAppend,
+        BButton,
+        BModal,
+    },
+    props: {
+        id: {
+            type: String,
+            required: true,
+        },
+        placeholder: {
+            type: String,
+            required: true,
+        },
+        helpHtml: {
+            type: String,
+            required: true,
+        },
+        debounceDelay: {
+            type: Number,
+            default: 500,
+        },
+        value: {},
+    },
+    data() {
+        return {
+            showHelp: false,
+            localFilter: this.value,
+        };
+    },
+    watch: {
+        value(newValue) {
+            this.localFilter = newValue;
+        },
+        localFilter(newVal) {
+            this.$emit("input", newVal);
+        },
+    },
+    methods: {
+        onHelp() {
+            this.showHelp = true;
+        },
+        onReset() {
+            this.localFilter = "";
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -41,6 +41,23 @@ describe("Invocations.vue", () => {
         });
     });
 
+    describe("with server error", () => {
+        beforeEach(async () => {
+            axiosMock.onAny().reply(403, { err_msg: "this is a problem" });
+            const propsData = {
+                ownerGrid: false,
+            };
+            wrapper = mount(Invocations, {
+                propsData,
+                localVue,
+            });
+        });
+
+        it("renders error message", async () => {
+            expect(wrapper.find(".index-grid-message").text()).toContain("this is a problem");
+        });
+    });
+
     describe("for a workflow with an empty invocation list", () => {
         beforeEach(async () => {
             axiosMock.onAny().reply(200, [], { total_matches: "0" });

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -132,9 +132,6 @@ export default {
     computed: {
         ...mapGetters(["getWorkflowNameByInstanceId", "getWorkflowByInstanceId"]),
         ...mapGetters("history", ["getHistoryById", "getHistoryNameById"]),
-        apiUrl() {
-            return `${getAppRoot()}api/invocations`;
-        },
         title() {
             let title = `Workflow Invocations`;
             if (this.storedWorkflowName) {
@@ -171,7 +168,7 @@ export default {
         ...mapCacheActions(["fetchWorkflowForInstanceId"]),
         ...mapCacheActions("history", ["loadHistoryById"]),
         provider(ctx) {
-            ctx.apiUrl = this.apiUrl;
+            ctx.root = getAppRoot();
             const extraParams = this.ownerGrid ? {} : { include_terminal: false };
             if (this.storedWorkflowId) {
                 extraParams["workflow_id"] = this.storedWorkflowId;

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -226,7 +226,7 @@ export default {
     },
     methods: {
         async provider(ctx) {
-            ctx.apiUrl = this.apiUrl;
+            ctx.root = this.root;
             const extraParams = { search: this.filter, skip_step_counts: true };
             const promise = storedWorkflowsProvider(ctx, this.setRows, extraParams).catch(this.onError);
             this.workflowItems = await promise;

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
+        <b-alert class="index-grid-message" :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
         <b-row class="mb-3">
             <b-col cols="6">
                 <index-filter
@@ -110,6 +110,7 @@ import { storedWorkflowsProvider } from "components/providers/StoredWorkflowsPro
 import Tags from "components/Common/Tags";
 import WorkflowDropdown from "./WorkflowDropdown";
 import UtcDate from "components/UtcDate";
+import { errorMessageAsString } from "utils/simple-error";
 import { getGalaxyInstance } from "app";
 import paginationMixin from "./paginationMixin";
 import IndexFilter from "./IndexFilter";
@@ -233,7 +234,8 @@ export default {
         async provider(ctx) {
             ctx.apiUrl = this.apiUrl;
             const extraParams = { search: this.filter, skip_step_counts: true };
-            this.workflowItems = await storedWorkflowsProvider(ctx, this.setRows, extraParams);
+            const promise = storedWorkflowsProvider(ctx, this.setRows, extraParams).catch(this.onError);
+            this.workflowItems = await promise;
             return this.workflowItems;
         },
         createWorkflow: function (workflow) {
@@ -317,7 +319,7 @@ export default {
             this.messageVariant = "success";
         },
         onError: function (message) {
-            this.message = message;
+            this.message = errorMessageAsString(message);
             this.messageVariant = "danger";
         },
     },

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -62,8 +62,18 @@
                     <Tags :index="row.index" :tags="row.item.tags" @input="onTags" @tag-click="onTagClick" />
                 </template>
                 <template v-slot:cell(published)="row">
-                    <font-awesome-icon v-if="row.item.published" v-b-tooltip.hover title="Published" icon="globe" />
-                    <font-awesome-icon v-if="row.item.shared" v-b-tooltip.hover title="Shared" icon="share-alt" />
+                    <font-awesome-icon
+                        v-if="row.item.published"
+                        v-b-tooltip.hover
+                        title="Published"
+                        icon="globe"
+                        @click="appendFilter('is:published')" />
+                    <font-awesome-icon
+                        v-if="row.item.shared"
+                        v-b-tooltip.hover
+                        title="Shared"
+                        icon="share-alt"
+                        @click="appendFilter('is:shared_with_me')" />
                 </template>
                 <template v-slot:cell(show_in_tool_panel)="row">
                     <b-link @click="bookmarkWorkflow(row.item, false)" v-if="row.item.show_in_tool_panel">
@@ -248,11 +258,14 @@ export default {
         },
         onTagClick: function (tag) {
             const tagFilter = `tag:'${tag.text}'`;
+            this.appendFilter(tagFilter);
+        },
+        appendFilter(text) {
             const initialFilter = this.filter;
             if (initialFilter.length === 0) {
-                this.filter = tagFilter;
-            } else if (initialFilter.indexOf(tagFilter) < 0) {
-                this.filter = `${tagFilter} ${initialFilter}`;
+                this.filter = text;
+            } else if (initialFilter.indexOf(text) < 0) {
+                this.filter = `${text} ${initialFilter}`;
             }
         },
         onAdd: function (workflow) {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -110,7 +110,6 @@ import { storedWorkflowsProvider } from "components/providers/StoredWorkflowsPro
 import Tags from "components/Common/Tags";
 import WorkflowDropdown from "./WorkflowDropdown";
 import UtcDate from "components/UtcDate";
-import { errorMessageAsString } from "utils/simple-error";
 import { getGalaxyInstance } from "app";
 import paginationMixin from "./paginationMixin";
 import IndexFilter from "./IndexFilter";
@@ -195,8 +194,6 @@ export default {
             ],
             filter: "",
             loading: true,
-            message: null,
-            messageVariant: null,
             titleSearchWorkflows: _l("Search Workflows"),
             titleCreate: _l("Create"),
             titleImport: _l("Import"),
@@ -213,9 +210,6 @@ export default {
         },
         showNotAvailable() {
             return !this.filter;
-        },
-        showMessage() {
-            return !!this.message;
         },
         apiUrl() {
             return `${getAppRoot()}api/workflows`;
@@ -313,14 +307,6 @@ export default {
         },
         onUpdate: function (id, data) {
             this.refresh();
-        },
-        onSuccess: function (message) {
-            this.message = message;
-            this.messageVariant = "success";
-        },
-        onError: function (message) {
-            this.message = errorMessageAsString(message);
-            this.messageVariant = "danger";
         },
     },
 };

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -5,14 +5,13 @@
             <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
             <b-row class="mb-3">
                 <b-col cols="6">
-                    <b-input
+                    <index-filter
+                        :debounce-delay="inputDebounceDelay"
                         id="workflow-search"
-                        class="m-1"
-                        name="query"
                         :placeholder="titleSearchWorkflows"
-                        autocomplete="off"
-                        type="text"
-                        v-model="filter" />
+                        :help-html="helpHtml"
+                        v-model="filter">
+                    </index-filter>
                 </b-col>
                 <b-col>
                     <span class="float-right">
@@ -116,8 +115,35 @@ import WorkflowDropdown from "./WorkflowDropdown";
 import UtcDate from "components/UtcDate";
 import { getGalaxyInstance } from "app";
 import paginationMixin from "./paginationMixin";
+import IndexFilter from "./IndexFilter";
 
 library.add(faPlus, faUpload, faSpinner, faGlobe, faShareAlt, farStar, faStar);
+
+const helpHtml = `<div>
+<p>This textbox box can be used to filter the workflows displayed.
+
+<p>Text entered here will be searched against workflow names and tags. Additionally, advanced
+filtering tags can be used to refine the search more precisely. Tags are of the form
+<code>&lt;tag_name&gt;:&lt;tag_value&gt;</code> or <code>&lt;tag_name&gt;:'&lt;tag_value&gt;'</code>.
+For instance to search just for RNAseq in the workflow name, <code>name:rnsseq</code> can be used.
+Notice by default the search is not case-sensitive.
+
+If the quoted version of tag is used, the search is not case sensitive and only full matches will be
+returned. So <code>name:'RNAseq'</code> would show only workflows named exactly <code>RNAseq</code>.
+
+<p>The available tags are:
+<dl>
+    <dt><code>name</code></dt>
+    <dd>This filters only against the workflow name.</dd>
+    <dt><code>tag</code></dt>
+    <dd>This filters only against the workflow tag. You may also just click on a tag in your list of workflows to filter on that tag using this directly.</dd>
+    <dt><code>is:published</code></dt>
+    <dd>This filters the workflows such that only published workflows are shown. You may also just click on the "published" icon of a worklfow in your list to filter on this directly.</dd>
+    <dt><code>is:shared</code></dt>
+    <dd>This filters the workflows such that only workflows shared from another user directly with you are are shown. You may also just click on the "shared with me" icon of a worklfow in your list to filter on this directly.</dd>
+</dl>
+</div>
+`;
 
 export default {
     components: {
@@ -125,6 +151,13 @@ export default {
         UtcDate,
         Tags,
         WorkflowDropdown,
+        IndexFilter,
+    },
+    props: {
+        inputDebounceDelay: {
+            type: Number,
+            default: 500,
+        },
     },
     mixins: [paginationMixin],
     data() {
@@ -172,6 +205,7 @@ export default {
             titleRunWorkflow: _l("Run workflow"),
             workflowItemsModel: [],
             workflowItems: [],
+            helpHtml: helpHtml,
             perPage: this.rowsPerPage(50),
         };
     },

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -1,104 +1,101 @@
 <template>
     <div>
-        <div v-if="error" class="alert alert-danger" show>{{ error }}</div>
-        <div v-else>
-            <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
-            <b-row class="mb-3">
-                <b-col cols="6">
-                    <index-filter
-                        :debounce-delay="inputDebounceDelay"
-                        id="workflow-search"
-                        :placeholder="titleSearchWorkflows"
-                        :help-html="helpHtml"
-                        v-model="filter">
-                    </index-filter>
-                </b-col>
-                <b-col>
-                    <span class="float-right">
-                        <b-button id="workflow-create" class="m-1" @click="createWorkflow">
-                            <font-awesome-icon icon="plus" />
-                            {{ titleCreate }}
-                        </b-button>
-                        <b-button id="workflow-import" class="m-1" @click="importWorkflow">
-                            <font-awesome-icon icon="upload" />
-                            {{ titleImport }}
-                        </b-button>
-                    </span>
-                </b-col>
-            </b-row>
-            <b-table
-                :id="tableId"
-                :fields="fields"
-                :items="provider"
-                v-model="workflowItemsModel"
-                :per-page="perPage"
-                :current-page="currentPage"
-                hover
-                striped
-                caption-top
-                fixed
-                show-empty>
-                <template v-slot:empty>
-                    <loading-span v-if="loading" message="Loading workflows" />
-                    <b-alert v-else id="no-workflows" variant="info" show>
-                        <div v-if="showNotFound">
-                            No matching entries found for: <span class="font-weight-bold">{{ filter }}</span
-                            >.
-                        </div>
-                        <div v-if="showNotAvailable">No workflows found. You may create or import new workflows.</div>
-                    </b-alert>
-                </template>
-                <template v-slot:cell(name)="row">
-                    <WorkflowDropdown
-                        :workflow="row.item"
-                        @onAdd="onAdd"
-                        @onRemove="onRemove"
-                        @onUpdate="onUpdate"
-                        @onSuccess="onSuccess"
-                        @onError="onError" />
-                </template>
-                <template v-slot:cell(tags)="row">
-                    <Tags :index="row.index" :tags="row.item.tags" @input="onTags" @tag-click="onTagClick" />
-                </template>
-                <template v-slot:cell(published)="row">
-                    <font-awesome-icon
-                        v-if="row.item.published"
-                        v-b-tooltip.hover
-                        title="Published"
-                        icon="globe"
-                        @click="appendFilter('is:published')" />
-                    <font-awesome-icon
-                        v-if="row.item.shared"
-                        v-b-tooltip.hover
-                        title="Shared"
-                        icon="share-alt"
-                        @click="appendFilter('is:shared_with_me')" />
-                </template>
-                <template v-slot:cell(show_in_tool_panel)="row">
-                    <b-link @click="bookmarkWorkflow(row.item, false)" v-if="row.item.show_in_tool_panel">
-                        <font-awesome-icon :icon="['fas', 'star']" />
-                    </b-link>
-                    <b-link @click="bookmarkWorkflow(row.item, true)" v-else>
-                        <font-awesome-icon :icon="['far', 'star']" />
-                    </b-link>
-                </template>
-                <template v-slot:cell(update_time)="data">
-                    <UtcDate :date="data.value" mode="elapsed" />
-                </template>
-                <template v-slot:cell(execute)="row">
-                    <b-button
-                        v-b-tooltip.hover.bottom
-                        :title="titleRunWorkflow"
-                        class="workflow-run btn-sm btn-primary fa fa-play"
-                        @click.stop="executeWorkflow(row.item)" />
-                </template>
-            </b-table>
-            <b-pagination
-                v-model="currentPage"
-                v-show="rows >= perPage"
-                class="gx-workflows-grid-pager"
-                v-bind="paginationAttrs"></b-pagination>
-        </div>
+        <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
+        <b-row class="mb-3">
+            <b-col cols="6">
+                <index-filter
+                    :debounce-delay="inputDebounceDelay"
+                    id="workflow-search"
+                    :placeholder="titleSearchWorkflows"
+                    :help-html="helpHtml"
+                    v-model="filter">
+                </index-filter>
+            </b-col>
+            <b-col>
+                <span class="float-right">
+                    <b-button id="workflow-create" class="m-1" @click="createWorkflow">
+                        <font-awesome-icon icon="plus" />
+                        {{ titleCreate }}
+                    </b-button>
+                    <b-button id="workflow-import" class="m-1" @click="importWorkflow">
+                        <font-awesome-icon icon="upload" />
+                        {{ titleImport }}
+                    </b-button>
+                </span>
+            </b-col>
+        </b-row>
+        <b-table
+            :id="tableId"
+            :fields="fields"
+            :items="provider"
+            v-model="workflowItemsModel"
+            :per-page="perPage"
+            :current-page="currentPage"
+            hover
+            striped
+            caption-top
+            fixed
+            show-empty>
+            <template v-slot:empty>
+                <loading-span v-if="loading" message="Loading workflows" />
+                <b-alert v-else id="no-workflows" variant="info" show>
+                    <div v-if="showNotFound">
+                        No matching entries found for: <span class="font-weight-bold">{{ filter }}</span
+                        >.
+                    </div>
+                    <div v-if="showNotAvailable">No workflows found. You may create or import new workflows.</div>
+                </b-alert>
+            </template>
+            <template v-slot:cell(name)="row">
+                <WorkflowDropdown
+                    :workflow="row.item"
+                    @onAdd="onAdd"
+                    @onRemove="onRemove"
+                    @onUpdate="onUpdate"
+                    @onSuccess="onSuccess"
+                    @onError="onError" />
+            </template>
+            <template v-slot:cell(tags)="row">
+                <Tags :index="row.index" :tags="row.item.tags" @input="onTags" @tag-click="onTagClick" />
+            </template>
+            <template v-slot:cell(published)="row">
+                <font-awesome-icon
+                    v-if="row.item.published"
+                    v-b-tooltip.hover
+                    title="Published"
+                    icon="globe"
+                    @click="appendFilter('is:published')" />
+                <font-awesome-icon
+                    v-if="row.item.shared"
+                    v-b-tooltip.hover
+                    title="Shared"
+                    icon="share-alt"
+                    @click="appendFilter('is:shared_with_me')" />
+            </template>
+            <template v-slot:cell(show_in_tool_panel)="row">
+                <b-link @click="bookmarkWorkflow(row.item, false)" v-if="row.item.show_in_tool_panel">
+                    <font-awesome-icon :icon="['fas', 'star']" />
+                </b-link>
+                <b-link @click="bookmarkWorkflow(row.item, true)" v-else>
+                    <font-awesome-icon :icon="['far', 'star']" />
+                </b-link>
+            </template>
+            <template v-slot:cell(update_time)="data">
+                <UtcDate :date="data.value" mode="elapsed" />
+            </template>
+            <template v-slot:cell(execute)="row">
+                <b-button
+                    v-b-tooltip.hover.bottom
+                    :title="titleRunWorkflow"
+                    class="workflow-run btn-sm btn-primary fa fa-play"
+                    @click.stop="executeWorkflow(row.item)" />
+            </template>
+        </b-table>
+        <b-pagination
+            v-model="currentPage"
+            v-show="rows >= perPage"
+            class="gx-workflows-grid-pager"
+            v-bind="paginationAttrs"></b-pagination>
     </div>
 </template>
 <script>

--- a/client/src/components/Workflow/Workflows.test.js
+++ b/client/src/components/Workflow/Workflows.test.js
@@ -47,6 +47,24 @@ describe("WorkflowList.vue", () => {
         });
     });
 
+    describe(" with server error", () => {
+        beforeEach(async () => {
+            axiosMock
+                .onGet("/api/workflows", { params: { limit: 50, offset: 0, skip_step_counts: true, search: "" } })
+                .reply(403, { err_msg: "this is a problem" });
+            const propsData = {};
+            wrapper = mount(Workflows, {
+                propsData,
+                localVue,
+            });
+            flushPromises();
+        });
+
+        it("renders error message", async () => {
+            expect(wrapper.find(".index-grid-message").text()).toContain("this is a problem");
+        });
+    });
+
     describe(" with single workflow", () => {
         beforeEach(async () => {
             axiosMock

--- a/client/src/components/Workflow/Workflows.test.js
+++ b/client/src/components/Workflow/Workflows.test.js
@@ -124,5 +124,31 @@ describe("WorkflowList.vue", () => {
             flushPromises();
             expect(wrapper.vm.filter).toBe("tag:'tagmoo'");
         });
+
+        it("update filter when published icon is clicked", async () => {
+            axiosMock
+                .onGet("/api/workflows", {
+                    params: { limit: 50, offset: 0, skip_step_counts: true, search: "is:published" },
+                })
+                .reply(200, mockWorkflowsData, { total_matches: "1" });
+            const rows = wrapper.findAll("tbody > tr").wrappers;
+            const row = rows[0];
+            row.find(".fa-globe").trigger("click");
+            flushPromises();
+            expect(wrapper.vm.filter).toBe("is:published");
+        });
+
+        it("update filter when shared with me icon is clicked", async () => {
+            axiosMock
+                .onGet("/api/workflows", {
+                    params: { limit: 50, offset: 0, skip_step_counts: true, search: "is:shared_with_me" },
+                })
+                .reply(200, mockWorkflowsData, { total_matches: "1" });
+            const rows = wrapper.findAll("tbody > tr").wrappers;
+            const row = rows[0];
+            row.find(".fa-share-alt").trigger("click");
+            flushPromises();
+            expect(wrapper.vm.filter).toBe("is:shared_with_me");
+        });
     });
 });

--- a/client/src/components/Workflow/Workflows.test.js
+++ b/client/src/components/Workflow/Workflows.test.js
@@ -52,7 +52,9 @@ describe("WorkflowList.vue", () => {
             axiosMock
                 .onGet("/api/workflows", { params: { limit: 50, offset: 0, skip_step_counts: true, search: "" } })
                 .reply(200, mockWorkflowsData, { total_matches: "1" });
-            const propsData = {};
+            const propsData = {
+                inputDebounceDelay: 0,
+            };
             wrapper = mount(Workflows, {
                 propsData,
                 localVue,
@@ -90,8 +92,9 @@ describe("WorkflowList.vue", () => {
                 .onGet("/api/workflows", { params: { limit: 50, offset: 0, skip_step_counts: true, search: "mytext" } })
                 .reply(200, [], { total_matches: "0" });
 
-            wrapper.find("#workflow-search").setValue("mytext");
+            await wrapper.find("#workflow-search").setValue("mytext");
             flushPromises();
+            expect(wrapper.find("#workflow-search").element.value).toBe("mytext");
             expect(wrapper.vm.filter).toBe("mytext");
         });
 

--- a/client/src/components/Workflow/paginationMixin.js
+++ b/client/src/components/Workflow/paginationMixin.js
@@ -1,5 +1,6 @@
 import QueryStringParsing from "utils/query-string-parsing";
 import LoadingSpan from "components/LoadingSpan";
+import { errorMessageAsString } from "utils/simple-error";
 
 export default {
     components: { LoadingSpan },
@@ -9,6 +10,8 @@ export default {
             perPage: 20,
             rows: 0,
             loading: true,
+            message: null,
+            messageVariant: null,
         };
     },
     computed: {
@@ -26,6 +29,9 @@ export default {
                 "total-rows": this.rows,
             };
         },
+        showMessage() {
+            return !!this.message;
+        },
     },
     methods: {
         refresh() {
@@ -38,6 +44,14 @@ export default {
         rowsPerPage(defaultPerPage) {
             const queryRowsPerPage = QueryStringParsing.get("rows_per_page");
             return queryRowsPerPage || defaultPerPage;
+        },
+        onSuccess: function (message) {
+            this.message = message;
+            this.messageVariant = "success";
+        },
+        onError: function (message) {
+            this.message = errorMessageAsString(message);
+            this.messageVariant = "danger";
         },
     },
 };

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -31,7 +31,7 @@
                     <b-form-group
                         id="cutoff"
                         label="Cutoff time period"
-                        :disabled="showAllRunning"
+                        v-show="!showAllRunning"
                         description="in minutes">
                         <b-input-group>
                             <b-form-input id="cutoff" v-model="cutoffMin" type="number"> </b-form-input>

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -38,13 +38,9 @@
                         </b-input-group>
                     </b-form-group>
                 </b-form>
-                <b-form-group
-                    label="Filter Jobs"
-                    label-for="filter-regex"
-                    description="by strings or regular expressions">
-                    <b-input-group id="filter-regex">
-                        <b-form-input v-model="filter" placeholder="Type to Search" @keyup.esc.native="filter = ''" />
-                    </b-input-group>
+                <b-form-group label="Filter Jobs">
+                    <index-filter id="job-search" :placeholder="titleSearchJobs" :help-html="helpHtml" v-model="filter">
+                    </index-filter>
                 </b-form-group>
             </b-col>
         </b-row>
@@ -112,14 +108,41 @@ import JOB_STATES_MODEL from "mvc/history/job-states-model";
 import { commonJobFields } from "./JobFields";
 import { errorMessageAsString } from "utils/simple-error";
 import { jobsProvider } from "components/providers/JobProvider";
+import IndexFilter from "components/Workflow/IndexFilter";
 
 function cancelJob(jobId, message) {
     const url = `${getAppRoot()}api/jobs/${jobId}`;
     return axios.delete(url, { data: { message: message } });
 }
 
+const helpHtml = `<div>
+<p>This textbox box can be used to filter the jobs displayed.
+
+<p>Text entered here will be searched against job user, tool ID, job runner, and handler. Additionally,
+advanced filtering tags can be used to refine the search more precisely. Tags are of the form
+<code>&lt;tag_name&gt;:&lt;tag_value&gt;</code> or <code>&lt;tag_name&gt;:'&lt;tag_value&gt;'</code>.
+For instance to search just for jobs with <code>cat1</code> in the tool name, <code>tool_id:cat1</code> can be used.
+Notice by default the search is not case-sensitive.
+
+If the quoted version of tag is used, the search is not case sensitive and only full matches will be
+returned. So <code>tool_id:'cat1'</code> would show only jobs from the <code>cat1</code> tool exactly.
+
+<p>The available tags are:
+<dl>
+    <dt><code>user</code></dt>
+    <dd>This filters the job index to contain only jobs executed by matching user(s). You may also just click on a user in the list of jobs to filter on that exact user using this directly.</dd>
+    <dt><code>handler</code></dt>
+    <dd>This filters the job index to contain only jobs executed on matching handler(s).  You may also just click on a handler in the list of jobs to filter on that exact user using this directly.</dd>
+    <dt><code>runner</code></dt>
+    <dd>This filters the job index to contain only jobs executed on matching job runner(s).  You may also just click on a runner in the list of jobs to filter on that exact user using this directly.</dd>
+    <dt><code>tool</code></dt>
+    <dd>This filters the job index to contain only jobs from the matching tool(s).  You may also just click on a tool in the list of jobs to filter on that exact user using this directly.</dd>
+</dl>
+</div>
+`;
+
 export default {
-    components: { JobLock, JobsTable },
+    components: { JobLock, JobsTable, IndexFilter },
     data() {
         return {
             jobs: [],
@@ -144,6 +167,8 @@ export default {
             busy: true,
             cutoffMin: 5,
             showAllRunning: false,
+            titleSearchJobs: `Search Jobs`,
+            helpHtml: helpHtml,
         };
     },
     computed: {

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -35,9 +35,6 @@
                         description="in minutes">
                         <b-input-group>
                             <b-form-input id="cutoff" v-model="cutoffMin" type="number"> </b-form-input>
-                            <b-input-group-append>
-                                <b-btn type="submit">Refresh</b-btn>
-                            </b-input-group-append>
                         </b-input-group>
                     </b-form-group>
                 </b-form>
@@ -47,9 +44,6 @@
                     description="by strings or regular expressions">
                     <b-input-group id="filter-regex">
                         <b-form-input v-model="filter" placeholder="Type to Search" @keyup.esc.native="filter = ''" />
-                        <b-input-group-append>
-                            <b-btn :disabled="!filter" @click="filter = ''">Clear (esc)</b-btn>
-                        </b-input-group-append>
                     </b-input-group>
                 </b-form-group>
             </b-col>
@@ -172,6 +166,12 @@ export default {
         },
     },
     watch: {
+        filter(newVal) {
+            this.update();
+        },
+        cutoffMin(newVal) {
+            this.update();
+        },
         selectedStopJobIds(newVal) {
             if (newVal.length === 0) {
                 this.indeterminate = false;

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -72,7 +72,6 @@
             v-model="jobsItemsModel"
             :fields="unfinishedJobFields"
             :items="unfinishedJobs"
-            :filter="filter"
             :table-caption="runningTableCaption"
             :no-items-message="runningNoJobsMessage"
             :loading="loading"
@@ -98,9 +97,12 @@
                 :table-caption="finishedTableCaption"
                 :fields="finishedJobFields"
                 :items="finishedJobs"
-                :filter="filter"
                 :no-items-message="finishedNoJobsMessage"
                 :loading="loading"
+                @tool-clicked="(toolId) => appendTagFilter('tool', toolId)"
+                @runner-clicked="(runner) => appendTagFilter('runner', runner)"
+                @handler-clicked="(handler) => appendTagFilter('handler', handler)"
+                @user-clicked="(user) => appendTagFilter('user', user)"
                 :busy="busy">
             </jobs-table>
         </template>
@@ -210,6 +212,9 @@ export default {
                 const dateRangeMin = new Date(Date.now() - cutoff * 60 * 1000).toISOString();
                 params.date_range_min = `${dateRangeMin}`;
             }
+            if (this.filter) {
+                params.search = this.filter;
+            }
             const ctx = {
                 apiUrl: `${getAppRoot()}api/jobs`,
                 ...params,
@@ -238,6 +243,17 @@ export default {
         },
         toggleAll(checked) {
             this.selectedStopJobIds = checked ? this.jobsItemsModel.reduce((acc, j) => [...acc, j["id"]], []) : [];
+        },
+        appendTagFilter(tag, text) {
+            this.appendFilter(`${tag}:'${text}'`);
+        },
+        appendFilter(text) {
+            const initialFilter = this.filter;
+            if (initialFilter.length === 0) {
+                this.filter = text;
+            } else if (initialFilter.indexOf(text) < 0) {
+                this.filter = `${text} ${initialFilter}`;
+            }
         },
     },
 };

--- a/client/src/components/admin/JobsTable.vue
+++ b/client/src/components/admin/JobsTable.vue
@@ -4,7 +4,6 @@
             v-model="innerValue"
             :fields="fields"
             :items="items"
-            :filter="filter"
             hover
             responsive
             striped
@@ -26,6 +25,18 @@
             </template>
             <template v-slot:row-details="row">
                 <job-details :job="row.item" />
+            </template>
+            <template v-slot:cell(user_email)="data">
+                <a class="job-filter-link-user" @click="$emit('user-clicked', data.value)">{{ data.value }}</a>
+            </template>
+            <template v-slot:cell(tool_id)="data">
+                <a class="job-filter-link-tool-id" @click="$emit('tool-clicked', data.value)">{{ data.value }}</a>
+            </template>
+            <template v-slot:cell(job_runner_name)="data">
+                <a class="job-filter-link-runner" @click="$emit('runner-clicked', data.value)">{{ data.value }}</a>
+            </template>
+            <template v-slot:cell(handler)="data">
+                <a class="job-filter-link-handler" @click="$emit('handler-clicked', data.value)">{{ data.value }}</a>
             </template>
             <template v-for="(index, name) in $slots" v-slot:[name]>
                 <slot :name="name" />
@@ -53,10 +64,6 @@ export default {
             required: true,
         },
         items: {
-            required: true,
-        },
-        filter: {
-            type: String,
             required: true,
         },
         busy: {

--- a/client/src/components/providers/InvocationsProvider.js
+++ b/client/src/components/providers/InvocationsProvider.js
@@ -2,8 +2,9 @@ import axios from "axios";
 import { cleanPaginationParameters } from "./utils";
 
 export function invocationsProvider(ctx, callback, extraParams) {
-    const { apiUrl, ...requestParams } = ctx;
+    const { root, ...requestParams } = ctx;
     const cleanParams = cleanPaginationParameters(requestParams);
+    const apiUrl = `${root}api/invocations`;
     const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });
 
     // Must return a promise that resolves to an array of items

--- a/client/src/components/providers/InvocationsProvider.test.js
+++ b/client/src/components/providers/InvocationsProvider.test.js
@@ -1,0 +1,41 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import mockInvocationData from "components/Workflow/test/json/invocation.json";
+import { invocationsProvider } from "./InvocationsProvider";
+
+describe("invocationsProvider", () => {
+    let axiosMock;
+
+    beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    describe("fetching invocations without an error", () => {
+        it("should make an API call and fire callback", async () => {
+            axiosMock
+                .onGet("/prefix/api/invocations", { params: { limit: 50, offset: 0, include_terminal: false } })
+                .reply(200, [mockInvocationData], { total_matches: "1" });
+
+            const ctx = {
+                root: "/prefix/",
+                perPage: 50,
+                currentPage: 1,
+            };
+            const extras = {
+                include_terminal: false,
+            };
+
+            let called = false;
+            const callback = function () {
+                called = true;
+            };
+            const promise = invocationsProvider(ctx, callback, extras);
+            await promise;
+            expect(called).toBeTruthy();
+        });
+    });
+});

--- a/client/src/components/providers/JobProvider.js
+++ b/client/src/components/providers/JobProvider.js
@@ -3,6 +3,7 @@ import { getAppRoot } from "onload/loadConfig";
 import { SingleQueryProvider } from "components/providers/SingleQueryProvider";
 import { rethrowSimple } from "utils/simple-error";
 import { stateIsTerminal } from "./utils";
+import { cleanPaginationParameters } from "./utils";
 
 async function jobDetails({ jobid }) {
     const url = `${getAppRoot()}api/jobs/${jobid}?full=True`;
@@ -26,3 +27,18 @@ async function jobProblems({ jobid }) {
 
 export const JobDetailsProvider = SingleQueryProvider(jobDetails, stateIsTerminal);
 export const JobProblemProvider = SingleQueryProvider(jobProblems, stateIsTerminal);
+
+export function jobsProvider(ctx, callback, extraParams = {}) {
+    const { apiUrl, ...requestParams } = ctx;
+    const cleanParams = cleanPaginationParameters(requestParams);
+    const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });
+
+    // Must return a promise that resolves to an array of items
+    return promise.then((data) => {
+        // Pluck the array of items off our axios response
+        const items = data.data;
+        callback && callback(data);
+        // Must return an array of items or an empty array if an error occurred
+        return items || [];
+    });
+}

--- a/client/src/components/providers/StoredWorkflowProvider.test.js
+++ b/client/src/components/providers/StoredWorkflowProvider.test.js
@@ -1,0 +1,44 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+import { storedWorkflowsProvider } from "./StoredWorkflowsProvider";
+
+describe("storedWorkflowsProvider", () => {
+    let axiosMock;
+
+    beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    describe("fetching workflows without an error", () => {
+        it("should make an API call and fire callback", async () => {
+            axiosMock
+                .onGet("/prefix/api/workflows", {
+                    params: { limit: 50, offset: 0, skip_step_counts: true, search: "rna" },
+                })
+                .reply(200, [{ model_class: "StoredWorkflow" }], { total_matches: "1" });
+
+            const ctx = {
+                root: "/prefix/",
+                perPage: 50,
+                currentPage: 1,
+            };
+            const extras = {
+                skip_step_counts: true,
+                search: "rna",
+            };
+
+            let called = false;
+            const callback = function () {
+                called = true;
+            };
+            const promise = storedWorkflowsProvider(ctx, callback, extras);
+            await promise;
+            expect(called).toBeTruthy();
+        });
+    });
+});

--- a/client/src/components/providers/StoredWorkflowsProvider.js
+++ b/client/src/components/providers/StoredWorkflowsProvider.js
@@ -5,7 +5,8 @@ import { SingleQueryProvider } from "components/providers/SingleQueryProvider";
 import { rethrowSimple } from "utils/simple-error";
 
 export function storedWorkflowsProvider(ctx, callback, extraParams = {}) {
-    const { apiUrl, ...requestParams } = ctx;
+    const { root, ...requestParams } = ctx;
+    const apiUrl = `${root}api/workflows`;
     const cleanParams = cleanPaginationParameters(requestParams);
     const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });
 

--- a/lib/galaxy/model/index_filter_util.py
+++ b/lib/galaxy/model/index_filter_util.py
@@ -4,7 +4,10 @@ from sqlalchemy import (
     or_,
 )
 
-from galaxy.util.search import FilteredTerm, RawTextTerm
+from galaxy.util.search import (
+    FilteredTerm,
+    RawTextTerm,
+)
 
 
 def text_column_filter(column, term: FilteredTerm):

--- a/lib/galaxy/model/index_filter_util.py
+++ b/lib/galaxy/model/index_filter_util.py
@@ -1,0 +1,43 @@
+"""Utility functions used to adapt galaxy.util.search to Galaxy model index queries."""
+from sqlalchemy import (
+    and_,
+    or_,
+)
+
+from galaxy.util.search import FilteredTerm, RawTextTerm
+
+
+def text_column_filter(column, term: FilteredTerm):
+    if term.quoted:
+        filter = column == term.text
+    else:
+        filter = column.ilike(f"%{term.text}%")
+    return filter
+
+
+def raw_text_column_filter(columns: list, term: RawTextTerm):
+    like_text = f"%{term.text}%"
+    if len(columns) == 1:
+        return columns[0].ilike(like_text)
+    else:
+        return or_(*[c.ilike(like_text) for c in columns])
+
+
+def tag_filter(assocation_model_class, term_text, quoted: bool = False):
+    if ":" in term_text:
+        key, value = term_text.rsplit(":", 1)
+        if not quoted:
+            return and_(
+                assocation_model_class.user_tname.ilike(key),
+                assocation_model_class.user_value.ilike(f"%{value}%"),
+            )
+        else:
+            return and_(
+                assocation_model_class.user_tname == key,
+                assocation_model_class.user_value == value,
+            )
+    else:
+        if not quoted:
+            return assocation_model_class.user_tname.ilike(f"%{term_text}%")
+        else:
+            return assocation_model_class.user_tname == term_text

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -566,10 +566,15 @@ class NavigatesGalaxy(HasDriver):
         return "email" in self.get_logged_in_user()
 
     @retry_during_transitions
-    def _inline_search_for(self, selector, search_term=None):
+    def _inline_search_for(self, selector, search_term=None, escape_to_clear=False):
         # Clear tooltip resulting from clicking on the masthead to get here.
         self.clear_tooltips()
         search_box = self.wait_for_and_click(selector)
+        if escape_to_clear:
+            # The combination of DebouncedInput+b-input doesn't seem to uniformly respect
+            # .clear() below. We use escape handling a lot - and that does cauase to the input
+            # to reset correctly and fire the required re-active events/handlers.
+            self.send_escape(search_box)
         search_box.clear()
         if search_term is not None:
             search_box.send_keys(search_term)
@@ -1217,6 +1222,7 @@ class NavigatesGalaxy(HasDriver):
         return self._inline_search_for(
             self.navigation.workflows.search_box,
             search_term,
+            escape_to_clear=True,
         )
 
     def workflow_index_click_import(self):

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -3,10 +3,12 @@ This module *does not* contain API routes. It exclusively contains dependencies 
 """
 import inspect
 from enum import Enum
+from string import Template
 from typing import (
     Any,
     AsyncGenerator,
     cast,
+    NamedTuple,
     Optional,
     Tuple,
     Type,
@@ -410,3 +412,58 @@ async def try_get_request_body_as_json(request: Request) -> Optional[Any]:
         body = await request.json()
         return body
     return None
+
+
+search_description_template = Template(
+    """A mix of free text and Github-style tags used to filter the index operation.
+
+## Query Structure
+
+Github-style filter tags (not be confused with Galaxy tags) are tags of the form
+`<tag_name>:<text_no_spaces>` or `<tag_name>:'<text with potential spaces>'`. The tag name
+*generally* (but not exclusively) corresponds to the name of an attribute on the model
+being indexed (i.e. a column in the database).
+
+If the tag is quoted, the attribute will be filtered exactly. If the tag is unquoted,
+generally a partial match will be used to filter the query (i.e. in terms of the implementation
+this means the database operation `ILIKE` will typically be used).
+
+Once the tagged filters are extracted from the search query, the remaing text is just
+used to search various documented attributes of the object.
+
+## Githb-style Tags Available
+
+${tags}
+
+## Free Text
+
+Free text search terms will be searched against the following attributes of the
+${model_name}s: ${freetext}.
+
+"""
+)
+
+
+class IndexQueryTag(NamedTuple):
+    tag: str
+    description: str
+    alias: Optional[str] = None
+
+    def as_markdown(self):
+        desc = self.description
+        alias = self.alias
+        if alias:
+            desc += f" (The tag `{alias}` can be used a short hand alias for this tag to filter on this attribute.)"
+        return f"`{self.tag}`\n: {desc}"
+
+
+def search_query_param(model_name: str, tags: list, free_text_fields: list) -> Optional[str]:
+    tags_markdown_str = "\n\n".join([t.as_markdown() for t in tags])
+    description = search_description_template.safe_substitute(
+        model_name=model_name, tags=tags_markdown_str, freetext=", ".join([f"`{t}`" for t in free_text_fields])
+    )
+    return Query(
+        default=None,
+        title="Search query.",
+        description=description,
+    )

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -74,7 +74,7 @@ StateQueryParam: Optional[str] = Query(
 UserDetailsQueryParam: bool = Query(
     default=False,
     title="Include user details",
-    description="If true, and requestor is an admin, will return external job id and user email.",
+    description="If true, and requestor is an admin, will return external job id and user email. This is only available to admins.",
 )
 
 UserIdQueryParam: Optional[str] = Query(
@@ -216,6 +216,8 @@ class FastAPIJobs:
             else:
                 query = trans.sa_session.query(model.Job)
         else:
+            if user_details:
+                raise exceptions.AdminRequiredException("Only admins can index the jobs with user details enabled")
             if decoded_user_id is not None and decoded_user_id != trans.user.id:
                 raise exceptions.AdminRequiredException("Only admins can index the jobs of others")
             query = trans.sa_session.query(model.Job).filter(model.Job.user_id == trans.user.id)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -50,7 +50,9 @@ from . import (
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
+    IndexQueryTag,
     Router,
+    search_query_param,
 )
 
 log = logging.getLogger(__name__)
@@ -140,10 +142,17 @@ OffsetQueryParam: int = Query(
     description="Return jobs starting from this specified position. For example, if ``limit`` is set to 100 and ``offset`` to 200, jobs 200-299 will be returned.",
 )
 
-SearchQueryParameter: Optional[str] = Query(
-    default=None,
-    title="Search query.",
-    description="Free text used to filter the query. Currently this just filters by the tool ID corresponding to the job.",
+query_tags = [
+    IndexQueryTag("user", "The user email of the user that executed the Job.", "u"),
+    IndexQueryTag("tool_id", "The tool ID corresponding to the job.", "t"),
+    IndexQueryTag("runner", "The job runner name used to execte the job.", "r"),
+    IndexQueryTag("handler", "The job handler name used to execute the job.", "h"),
+]
+
+SearchQueryParam: Optional[str] = search_query_param(
+    model_name="Job",
+    tags=query_tags,
+    free_text_fields=["user", "tool", "handler", "runner"],
 )
 
 
@@ -183,7 +192,7 @@ class FastAPIJobs:
         workflow_id: Optional[str] = WorkflowIdQueryParam,
         invocation_id: Optional[str] = InvocationIdQueryParam,
         order_by: JobIndexSortByEnum = SortByQueryParam,
-        search: Optional[str] = SearchQueryParameter,
+        search: Optional[str] = SearchQueryParam,
         limit: int = LimitQueryParam,
         offset: int = OffsetQueryParam,
     ) -> List[Dict[str, Any]]:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -81,7 +81,9 @@ from . import (
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
+    IndexQueryTag,
     Router,
+    search_query_param,
 )
 
 log = logging.getLogger(__name__)
@@ -1460,10 +1462,27 @@ OffsetQueryParam: Optional[int] = Query(
     title="Number of workflows to skip in sorted query (to enable pagination).",
 )
 
-SearchQueryParam: Optional[str] = Query(
-    default=None,
-    title="Search query.",
-    description="Free text used to filter the query. Filters on a name and tags, Github-style tags can be used to be more specific. Free-text search is case-insensitive.",
+query_tags = [
+    IndexQueryTag("name", "The stored workflow's name.", "n"),
+    IndexQueryTag(
+        "tag",
+        "The workflow's tag, if the tag contains a colon an approach will be made to match the key and value of the tag separately.",
+        "t",
+    ),
+    IndexQueryTag(
+        "is:published",
+        "Include only published workflows in the final result. Be sure the the query parameter `show_published` is set to `true` if to include all published workflows and not just the requesting user's.",
+    ),
+    IndexQueryTag(
+        "is:share_with_me",
+        "Include only workflows shared with the requesting user.  Be sure the the query parameter `show_shared` is set to `true` if to include shared workflows.",
+    ),
+]
+
+SearchQueryParam: Optional[str] = search_query_param(
+    model_name="Stored Workflow",
+    tags=query_tags,
+    free_text_fields=["name", "tag"],
 )
 
 SkipStepCountsQueryParam: bool = Query(
@@ -1498,7 +1517,7 @@ class FastAPIWorkflows:
         search: Optional[str] = SearchQueryParam,
         skip_step_counts: bool = SkipStepCountsQueryParam,
     ) -> List[Dict[str, Any]]:
-        """Return the sharing status of the item."""
+        """Lists stored workflows viewable by the user."""
         payload = WorkflowIndexPayload(
             show_published=show_published,
             show_hidden=show_hidden,

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -1,0 +1,218 @@
+from enum import Enum
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
+
+from sqlalchemy import or_
+
+from galaxy import (
+    exceptions,
+    model,
+)
+from galaxy.managers import hdas
+from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.jobs import (
+    JobManager,
+    JobSearch,
+    view_show_job,
+)
+from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import Model
+from galaxy.util.search import (
+    FilteredTerm,
+    parse_filters_structured,
+    RawTextTerm,
+)
+
+
+class JobIndexViewEnum(str, Enum):
+    collection = "collection"
+    admin_job_list = "admin_job_list"
+
+
+class JobIndexSortByEnum(str, Enum):
+    create_time = "create_time"
+    update_time = "update_time"
+
+
+class JobIndexPayload(Model):
+    states: Optional[List[str]] = None
+    user_details: bool = False
+    user_id: Optional[str] = None
+    view: JobIndexViewEnum = JobIndexViewEnum.collection
+    tool_ids: Optional[List[str]] = None
+    tool_ids_like: Optional[List[str]] = None
+    date_range_min: Optional[str] = None
+    date_range_max: Optional[str] = None
+    history_id: Optional[str] = None
+    workflow_id: Optional[str] = None
+    invocation_id: Optional[str] = None
+    order_by: JobIndexSortByEnum = JobIndexSortByEnum.update_time
+    search: Optional[str] = None
+    limit: int = 500
+    offset: int = 0
+
+
+class JobsService:
+    job_manager: JobManager
+    job_search: JobSearch
+    hda_manager: hdas.HDAManager
+
+    def __init__(
+        self,
+        job_manager: JobManager,
+        job_search: JobSearch,
+        hda_manager: hdas.HDAManager,
+    ):
+        self.job_manager = job_manager
+        self.job_search = job_search
+        self.hda_manager = hda_manager
+
+    def show(
+        self,
+        trans: ProvidesUserContext,
+        id: EncodedDatabaseIdField,
+        full: bool = False,
+    ) -> Dict[str, Any]:
+        id = trans.app.security.decode_id(id)
+        job = self.job_manager.get_accessible_job(trans, id)
+        return view_show_job(trans, job, bool(full))
+
+    def index(
+        self,
+        trans: ProvidesUserContext,
+        payload: JobIndexPayload,
+    ):
+        security = trans.security
+        is_admin = trans.user_is_admin
+        user_details = payload.user_details
+        if payload.view == JobIndexViewEnum.admin_job_list and not is_admin:
+            raise exceptions.AdminRequiredException("Only admins can use the admin_job_list view")
+        user_id = payload.user_id
+        if user_id:
+            decoded_user_id = security.decode_id(user_id)
+        else:
+            decoded_user_id = None
+
+        if is_admin:
+            if decoded_user_id is not None:
+                query = trans.sa_session.query(model.Job).filter(model.Job.user_id == decoded_user_id)
+            else:
+                query = trans.sa_session.query(model.Job)
+            if user_details:
+                query = query.outerjoin(model.Job.user)
+
+        else:
+            if user_details:
+                raise exceptions.AdminRequiredException("Only admins can index the jobs with user details enabled")
+            if decoded_user_id is not None and decoded_user_id != trans.user.id:
+                raise exceptions.AdminRequiredException("Only admins can index the jobs of others")
+            query = trans.sa_session.query(model.Job).filter(model.Job.user_id == trans.user.id)
+
+        def build_and_apply_filters(query, objects, filter_func):
+            if objects is not None:
+                if isinstance(objects, str):
+                    query = query.filter(filter_func(objects))
+                elif isinstance(objects, list):
+                    t = []
+                    for obj in objects:
+                        t.append(filter_func(obj))
+                    query = query.filter(or_(*t))
+            return query
+
+        query = build_and_apply_filters(query, payload.states, lambda s: model.Job.state == s)
+        query = build_and_apply_filters(query, payload.tool_ids, lambda t: model.Job.tool_id == t)
+        query = build_and_apply_filters(query, payload.tool_ids_like, lambda t: model.Job.tool_id.like(t))
+        query = build_and_apply_filters(query, payload.date_range_min, lambda dmin: model.Job.update_time >= dmin)
+        query = build_and_apply_filters(query, payload.date_range_max, lambda dmax: model.Job.update_time <= dmax)
+
+        history_id = payload.history_id
+        workflow_id = payload.workflow_id
+        invocation_id = payload.invocation_id
+        if history_id is not None:
+            decoded_history_id = security.decode_id(history_id)
+            query = query.filter(model.Job.history_id == decoded_history_id)
+        if workflow_id or invocation_id:
+            if workflow_id is not None:
+                decoded_workflow_id = security.decode_id(workflow_id)
+                wfi_step = (
+                    trans.sa_session.query(model.WorkflowInvocationStep)
+                    .join(model.WorkflowInvocation)
+                    .join(model.Workflow)
+                    .filter(
+                        model.Workflow.stored_workflow_id == decoded_workflow_id,
+                    )
+                    .subquery()
+                )
+            elif invocation_id is not None:
+                decoded_invocation_id = security.decode_id(invocation_id)
+                wfi_step = (
+                    trans.sa_session.query(model.WorkflowInvocationStep)
+                    .filter(model.WorkflowInvocationStep.workflow_invocation_id == decoded_invocation_id)
+                    .subquery()
+                )
+            query1 = query.join(wfi_step)
+            query2 = query.join(model.ImplicitCollectionJobsJobAssociation).join(
+                wfi_step,
+                model.ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id
+                == wfi_step.c.implicit_collection_jobs_id,
+            )
+            query = query1.union(query2)
+
+        search = payload.search
+        if search:
+            search_filters = {
+                "tool": "tool",
+                "t": "tool",
+                "user": "user",
+                "u": "user",
+            }
+            parsed_search = parse_filters_structured(search, search_filters)
+            for term in parsed_search.terms:
+                if isinstance(term, FilteredTerm):
+                    key = term.filter
+                    q = term.text
+                    if key == "user":
+                        if term.quoted:
+                            query = query.filter(model.User.email == q)
+                        else:
+                            query = query.filter(model.User.email.ilike(f"%{q}%"))
+                    elif key == "tool":
+                        if term.quoted:
+                            query = query.filter(model.Job.tool_id == q)
+                        else:
+                            query = query.filter(model.Job.tool_id.ilike(f"%{q}%"))
+                elif isinstance(term, RawTextTerm):
+                    q = term.text
+                    filters = []
+                    filters.append(model.Job.tool_id.ilike(f"%{q}%"))
+                    if user_details:
+                        filters.append(model.User.email.ilike(f"%{q}%"))
+                    if len(filters) > 1:
+                        query = query.filter(or_(*filters))
+                    else:
+                        query = query.filter(filters[0])
+
+        if payload.order_by == JobIndexSortByEnum.create_time:
+            order_by = model.Job.create_time.desc()
+        else:
+            order_by = model.Job.update_time.desc()
+        query = query.order_by(order_by)
+
+        query = query.offset(payload.offset)
+        query = query.limit(payload.limit)
+        out = []
+        view = payload.view
+        for job in query.yield_per(model.YIELD_PER_ROWS):
+            job_dict = job.to_dict(view, system_details=is_admin)
+            j = security.encode_all_ids(job_dict, True)
+            if view == JobIndexViewEnum.admin_job_list:
+                j["decoded_job_id"] = job.id
+            if user_details:
+                j["user_email"] = job.get_user_email()
+            out.append(j)
+
+        return out

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -45,6 +45,7 @@ INDEX_SEARCH_FILTERS = {
     "tag": "tag",
     "n": "name",
     "t": "tag",
+    "is": "is",
 }
 
 
@@ -149,6 +150,14 @@ class WorkflowsService(ServiceBase):
                         query = query.filter(tag_filter(term.text, term.quoted))
                     elif key == "name":
                         query = query.filter(name_filter(q, term.quoted))
+                    elif key == "is":
+                        if q == "published":
+                            query = query.filter(model.StoredWorkflow.published == true())
+                        elif q == "shared_with_me":
+                            if not show_shared:
+                                message = "Can only use tag is:shared_with_me if show_shared parameter also true."
+                                raise exceptions.RequestParameterInvalidException(message)
+                            query = query.filter(model.StoredWorkflowUserShareAssociation.user == user)
                 elif isinstance(term, RawTextTerm):
                     query = query.filter(
                         or_(

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -116,7 +116,6 @@ class WorkflowsService(ServiceBase):
             parsed_search = parse_filters_structured(search_query, INDEX_SEARCH_FILTERS)
 
             def tag_filter(term_text: str, quoted: bool):
-                term_text = term.text
                 if ":" in term_text:
                     key, value = term_text.rsplit(":", 1)
                     if not quoted:

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -182,8 +182,7 @@ steps:
         jobs = self.__jobs_index(data={"history_id": history_id, "limit": 0})
         assert len(jobs) == 0
 
-    @uses_test_history(require_new=True)
-    def test_index_user_filter(self, history_id):
+    def test_index_user_filter(self):
         test_user_email = "user_for_jobs_index_test@bx.psu.edu"
         user = self._setup_user(test_user_email)
         with self._different_user(email=test_user_email):

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -182,6 +182,37 @@ steps:
         jobs = self.__jobs_index(data={"history_id": history_id, "limit": 0})
         assert len(jobs) == 0
 
+    @uses_test_history(require_new=True)
+    def test_index_search_filter_tool_id(self, history_id):
+        self.__history_with_new_dataset(history_id)
+        jobs = self.__jobs_index(data={"history_id": history_id})
+        assert len(jobs) > 0
+        length = len(jobs)
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": "emptyresult"})
+        assert len(jobs) == 0
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": "FETCH"})
+        assert len(jobs) == length
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": "tool:'FETCH'"})
+        assert len(jobs) == 0
+
+    @uses_test_history(require_new=True)
+    def test_index_search_filter_email(self, history_id):
+        self.__history_with_new_dataset(history_id)
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": "FETCH"})
+        user_email = self.dataset_populator.user_email()
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": user_email})
+        assert len(jobs) == 0
+        # we can search on email...
+        jobs = self.__jobs_index(
+            data={"history_id": history_id, "search": user_email, "user_details": True}, admin=True
+        )
+        assert len(jobs) == 1
+        # but only if user details are joined in.
+        jobs = self.__jobs_index(
+            data={"history_id": history_id, "search": user_email, "user_details": False}, admin=True
+        )
+        assert len(jobs) == 0
+
     def test_index_user_filter(self):
         test_user_email = "user_for_jobs_index_test@bx.psu.edu"
         user = self._setup_user(test_user_email)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -538,6 +538,24 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert workflow_id in self.workflow_populator.index_ids(show_published=True)
         assert workflow_id not in self.workflow_populator.index_ids(show_published=False)
 
+    def test_index_search_is_tags(self):
+        my_workflow_id_1 = self.workflow_populator.simple_workflow("sitags_m_1")
+        my_email = self.dataset_populator.user_email()
+        with self._different_user():
+            their_workflow_id_1 = self.workflow_populator.simple_workflow("sitags_shwm_1")
+            self.workflow_populator.share_with_user(their_workflow_id_1, my_email)
+            published_workflow_id_1 = self.workflow_populator.simple_workflow("sitags_p_1", publish=True)
+
+        index_ids = self.workflow_populator.index_ids(search="is:published", show_published=True)
+        assert published_workflow_id_1 in index_ids
+        assert their_workflow_id_1 not in index_ids
+        assert my_workflow_id_1 not in index_ids
+
+        index_ids = self.workflow_populator.index_ids(search="is:shared_with_me")
+        assert published_workflow_id_1 not in index_ids
+        assert their_workflow_id_1 in index_ids
+        assert my_workflow_id_1 not in index_ids
+
     def test_index_parameter_invalid_combinations(self):
         # these can all be called by themselves and return 200...
         response = self._get("workflows?show_hidden=true")

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -544,7 +544,10 @@ EXAMPLE_WORKFLOW_URL_1 = (
 class UsesWorkflowAssertions(NavigatesGalaxyMixin):
     @retry_assertion_during_transitions
     def _assert_showing_n_workflows(self, n):
-        assert len(self.workflow_index_table_elements()) == n
+        actual_count = len(self.workflow_index_table_elements())
+        if actual_count != n:
+            message = f"Expected {n} workflows to be displayed, based on DOM found {actual_count} workflow rows."
+            raise AssertionError(message)
 
     @skip_if_github_down
     def _workflow_import_from_url(self, url=EXAMPLE_WORKFLOW_URL_1):

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -117,7 +117,7 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers, UsesWorkfl
         self.workflow_index_search_for("doesnotmatch")
         self._assert_showing_n_workflows(0)
 
-        self.workflow_index_search_for()
+        self.workflow_index_search_for(" ")
         self._assert_showing_n_workflows(1)
 
         self.workflow_index_search_for("searchforthis")


### PR DESCRIPTION
Builds on #13786 and improves the documentation, testing, and functionality of the workflow grid. Applies all of the same ideas and documentation enhancements to the admin Jobs grid.

In addition to clicking on the tags in the workflow grid - now you can click on the "published" or "shared with me" icons to filter by those sharing strategies. Additionally in the jobs grid (now more reactive like the workflow grid) one can click on runner, tool id, handler, or user to filter the jobs grid.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
