### PR TITLE
Beta History: display 'processing' message while running bulk operations

### DIFF
--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -62,11 +62,12 @@ export default {
             this.resetQuerySelection();
         },
         resetQuerySelection() {
-            this.allSelected = this.totalItemsInQuery === this.items.size;
+            this.allSelected = false;
         },
         reset() {
             this.items = new Map();
             this.resetQuerySelection();
+            this.showSelection = false;
         },
     },
     watch: {

--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -10,12 +10,13 @@ export default {
         scopeKey: { type: String, required: true },
         getItemKey: { type: Function, required: true },
         filterText: { type: String, required: true },
+        totalItemsInQuery: { type: Number, required: false },
     },
     data() {
         return {
             items: new Map(),
             showSelection: false,
-            totalItemsInQuery: 0,
+            allSelected: false,
         };
     },
     computed: {
@@ -23,7 +24,7 @@ export default {
             return this.isQuerySelection ? this.totalItemsInQuery : this.items.size;
         },
         isQuerySelection() {
-            return this.totalItemsInQuery !== this.items.size;
+            return this.allSelected && this.totalItemsInQuery !== this.items.size;
         },
         currentFilters() {
             return getFilters(this.filterText);
@@ -33,9 +34,9 @@ export default {
         setShowSelection(val) {
             this.showSelection = val;
         },
-        selectAllInCurrentQuery(loadedItems = [], totalItemsInQuery) {
+        selectAllInCurrentQuery(loadedItems = []) {
             this.selectItems(loadedItems);
-            this.totalItemsInQuery = totalItemsInQuery;
+            this.allSelected = true;
         },
         isSelected(item) {
             if (this.isQuerySelection) {
@@ -61,7 +62,7 @@ export default {
             this.resetQuerySelection();
         },
         resetQuerySelection() {
-            this.totalItemsInQuery = this.items.size;
+            this.allSelected = this.totalItemsInQuery === this.items.size;
         },
         reset() {
             this.items = new Map();

--- a/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
@@ -22,10 +22,13 @@
                     <Icon icon="compress" />
                 </b-button>
             </b-button-group>
-            <b-button-group v-if="showSelection">
+            <b-button-group v-show="showSelection">
                 <slot name="selection-operations" />
             </b-button-group>
-            <DefaultOperations v-else :history="history" @update:long-operation-running="onUpdateOperationStatus" />
+            <DefaultOperations
+                v-show="!showSelection"
+                :history="history"
+                @update:long-operation-running="onUpdateOperationStatus" />
         </nav>
     </section>
 </template>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
@@ -25,11 +25,7 @@
             <b-button-group v-if="showSelection">
                 <slot name="selection-operations" />
             </b-button-group>
-            <DefaultOperations
-                v-else
-                :history="history"
-                :show-selection="showSelection"
-                :expanded-count="expandedCount" />
+            <DefaultOperations v-else :history="history" />
         </nav>
     </section>
 </template>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
@@ -25,7 +25,7 @@
             <b-button-group v-if="showSelection">
                 <slot name="selection-operations" />
             </b-button-group>
-            <DefaultOperations v-else :history="history" />
+            <DefaultOperations v-else :history="history" @update:long-operation-running="onUpdateOperationStatus" />
         </nav>
     </section>
 </template>
@@ -46,6 +46,9 @@ export default {
     methods: {
         toggleSelection() {
             this.$emit("update:show-selection", !this.showSelection);
+        },
+        onUpdateOperationStatus(running) {
+            this.$emit("update:long-operation-running", running);
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
@@ -47,8 +47,6 @@ import { iframeRedirect } from "components/plugins/legacyNavigation";
 export default {
     props: {
         history: { type: Object, required: true },
-        showSelection: { type: Boolean, required: true },
-        expandedCount: { type: Number, required: false, default: 0 },
     },
     methods: {
         onCopy() {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
@@ -52,19 +52,19 @@ export default {
         onCopy() {
             iframeRedirect("/dataset/copy_datasets");
         },
-        toggleSelection() {
-            this.$emit("update:show-selection", !this.showSelection);
+        async unhideAll() {
+            await this.runOperation(() => unhideAllHiddenContent(this.history));
         },
-
-        // History-wide bulk updates, does server query first to determine "selection"
-        async unhideAll(evt) {
-            await unhideAllHiddenContent(this.history);
+        async deleteAllHidden() {
+            await this.runOperation(() => deleteAllHiddenContent(this.history));
         },
-        async deleteAllHidden(evt) {
-            await deleteAllHiddenContent(this.history);
+        async purgeAllDeleted() {
+            await this.runOperation(() => purgeAllDeletedContent(this.history));
         },
-        async purgeAllDeleted(evt) {
-            await purgeAllDeletedContent(this.history);
+        async runOperation(operation) {
+            this.$emit("update:long-operation-running", true);
+            await operation();
+            this.$emit("update:long-operation-running", false);
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -81,7 +81,7 @@ export default {
         contentSelection: { type: Map, required: true },
         selectionSize: { type: Number, required: true },
         isQuerySelection: { type: Boolean, required: true },
-        totalItemsInQuery: { type: Number, required: true },
+        totalItemsInQuery: { type: Number, required: false, default: 0 },
     },
     computed: {
         /** @returns {Boolean} */

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -108,6 +108,10 @@ export default {
         selectionMatchesQuery() {
             return this.totalItemsInQuery === this.selectionSize;
         },
+        /** @returns {Boolean} */
+        isLongRunningOperation() {
+            return this.selectionSize > 10; // Totally arbitrary number...
+        },
     },
     watch: {
         hasSelection(newVal) {
@@ -118,26 +122,28 @@ export default {
     },
     methods: {
         // Selected content manipulation, hide/show/delete/purge
-        hideSelected() {
-            this.runOnSelection(hideSelectedContent);
+        async hideSelected() {
+            await this.runOnSelection(hideSelectedContent);
         },
-        unhideSelected() {
-            this.runOnSelection(unhideSelectedContent);
+        async unhideSelected() {
+            await this.runOnSelection(unhideSelectedContent);
         },
-        deleteSelected() {
-            this.runOnSelection(deleteSelectedContent);
+        async deleteSelected() {
+            await this.runOnSelection(deleteSelectedContent);
         },
-        undeleteSelected() {
-            this.runOnSelection(undeleteSelectedContent);
+        async undeleteSelected() {
+            await this.runOnSelection(undeleteSelectedContent);
         },
-        purgeSelected() {
-            this.runOnSelection(purgeSelectedContent);
+        async purgeSelected() {
+            await this.runOnSelection(purgeSelectedContent);
         },
-        async runOnSelection(fn) {
+        async runOnSelection(operation) {
+            this.$emit("update:long-operation-running", this.isLongRunningOperation);
             const items = this.getExplicitlySelectedItems();
             const filters = getQueryDict(this.filterText);
-            await fn(this.history, filters, items);
             this.$emit("reset-selection");
+            await operation(this.history, filters, items);
+            this.$emit("update:long-operation-running", false);
         },
         getExplicitlySelectedItems() {
             if (this.isQuerySelection) {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -108,10 +108,6 @@ export default {
         selectionMatchesQuery() {
             return this.totalItemsInQuery === this.selectionSize;
         },
-        /** @returns {Boolean} */
-        isLongRunningOperation() {
-            return this.selectionSize > 10; // Totally arbitrary number...
-        },
     },
     watch: {
         hasSelection(newVal) {
@@ -138,7 +134,7 @@ export default {
             await this.runOnSelection(purgeSelectedContent);
         },
         async runOnSelection(operation) {
-            this.$emit("update:long-operation-running", this.isLongRunningOperation);
+            this.$emit("update:long-operation-running", true);
             const items = this.getExplicitlySelectedItems();
             const filters = getQueryDict(this.filterText);
             this.$emit("reset-selection");

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -1,7 +1,7 @@
 <template>
     <HistoryItemsProvider
         :key="historyId"
-        v-slot="{ loading, result: payload, count: totalItemsInQuery }"
+        v-slot="{ loading, result: itemsLoaded, count: totalItemsInQuery }"
         :history-id="historyId"
         :offset="offset"
         :update-time="history.update_time"
@@ -41,7 +41,7 @@
                             :history="history"
                             :show-selection="showSelection"
                             :expanded-count="expandedCount"
-                            :has-matches="hasMatches(payload)"
+                            :has-matches="hasMatches(itemsLoaded)"
                             @update:show-selection="setShowSelection"
                             @collapse-all="collapseAll">
                             <template v-slot:selection-operations>
@@ -59,14 +59,14 @@
                                 <HistorySelectionStatus
                                     v-if="showSelection"
                                     :selection-size="selectionSize"
-                                    @select-all="selectAllInCurrentQuery(payload)"
+                                    @select-all="selectAllInCurrentQuery(itemsLoaded)"
                                     @reset-selection="resetSelection" />
                             </template>
                         </HistoryOperations>
                     </section>
                     <section v-if="!showAdvanced" class="position-relative flex-grow-1 scroller">
                         <div>
-                            <div v-if="payload && payload.length == 0">
+                            <div v-if="itemsLoaded && itemsLoaded.length == 0">
                                 <b-alert v-if="loading" class="m-2" variant="info" show>
                                     <LoadingSpan message="Loading History" />
                                 </b-alert>
@@ -77,7 +77,7 @@
                                     </b-alert>
                                 </div>
                             </div>
-                            <Listing v-else :items="payload" :query-key="queryKey" @scroll="onScroll">
+                            <Listing v-else :items="itemsLoaded" :query-key="queryKey" @scroll="onScroll">
                                 <template v-slot:item="{ item }">
                                     <ContentItem
                                         v-if="!invisible[item.hid]"
@@ -175,8 +175,8 @@ export default {
         },
     },
     methods: {
-        hasMatches(payload) {
-            return !!payload && payload.length > 0;
+        hasMatches(items) {
+            return !!items && items.length > 0;
         },
         isDataset(item) {
             return item.history_content_type == "dataset";

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -25,7 +25,8 @@
                 }"
                 :scope-key="queryKey"
                 :get-item-key="(item) => item.type_id"
-                :filter-text="filterText">
+                :filter-text="filterText"
+                :total-items-in-query="totalItemsInQuery">
                 <section class="history-layout d-flex flex-column">
                     <slot name="navigation" :history="history" />
                     <HistoryFilters
@@ -58,7 +59,7 @@
                                 <HistorySelectionStatus
                                     v-if="showSelection"
                                     :selection-size="selectionSize"
-                                    @select-all="selectAllInCurrentQuery(payload, totalItemsInQuery)"
+                                    @select-all="selectAllInCurrentQuery(payload)"
                                     @reset-selection="resetSelection" />
                             </template>
                         </HistoryOperations>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -42,6 +42,7 @@
                             :expanded-count="expandedCount"
                             :has-matches="hasMatches(itemsLoaded)"
                             @update:show-selection="setShowSelection"
+                            @update:long-operation-running="onUpdateOperationStatus"
                             @collapse-all="collapseAll">
                             <template v-slot:selection-operations>
                                 <HistorySelectionOperations
@@ -52,7 +53,7 @@
                                     :selection-size="selectionSize"
                                     :is-query-selection="isQuerySelection"
                                     :total-items-in-query="totalItemsInQuery"
-                                    @update:content-selection="selectItems"
+                                    @update:long-operation-running="onUpdateOperationStatus"
                                     @hide-selection="onHideSelection"
                                     @reset-selection="resetSelection" />
                                 <HistorySelectionStatus
@@ -76,6 +77,9 @@
                                     </b-alert>
                                 </div>
                             </div>
+                            <b-alert v-else-if="isLongOperationRunning" class="m-2" variant="info" show>
+                                <LoadingSpan message="Processing operation" />
+                            </b-alert>
                             <Listing v-else :items="itemsLoaded" :query-key="queryKey" @scroll="onScroll">
                                 <template v-slot:item="{ item }">
                                     <ContentItem
@@ -147,6 +151,7 @@ export default {
             invisible: {},
             offset: 0,
             showAdvanced: false,
+            isLongOperationRunning: false,
         };
     },
     computed: {
@@ -202,6 +207,9 @@ export default {
         },
         setInvisible(item) {
             Vue.set(this.invisible, item.hid, true);
+        },
+        onUpdateOperationStatus(running) {
+            this.isLongOperationRunning = running;
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -18,7 +18,6 @@
                     selectionSize,
                     setShowSelection,
                     selectAllInCurrentQuery,
-                    selectItems,
                     isSelected,
                     setSelected,
                     resetSelection,

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -185,6 +185,16 @@ export default {
             this.invisible = {};
             this.offset = 0;
         },
+        historyId(newVal, oldVal) {
+            if (newVal !== oldVal) {
+                this.stopExpectingHistoryUpdate();
+            }
+        },
+        isHistoryUpdated(updated) {
+            if (updated) {
+                this.stopExpectingHistoryUpdate();
+            }
+        },
     },
     methods: {
         hasMatches(items) {
@@ -224,6 +234,9 @@ export default {
         },
         expectHistoryUpdate() {
             this.updateExpectedAfterDate = this.history.update_time;
+        },
+        stopExpectingHistoryUpdate() {
+            this.updateExpectedAfterDate = null;
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -46,7 +46,6 @@
                             @collapse-all="collapseAll">
                             <template v-slot:selection-operations>
                                 <HistorySelectionOperations
-                                    v-if="showSelection"
                                     :history="history"
                                     :filter-text="filterText"
                                     :content-selection="selectedItems"

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -76,7 +76,7 @@
                                     </b-alert>
                                 </div>
                             </div>
-                            <b-alert v-else-if="isLongOperationRunning" class="m-2" variant="info" show>
+                            <b-alert v-else-if="isProcessing" class="m-2" variant="info" show>
                                 <LoadingSpan message="Processing operation" />
                             </b-alert>
                             <Listing v-else :items="itemsLoaded" :query-key="queryKey" @scroll="onScroll">
@@ -151,6 +151,7 @@ export default {
             offset: 0,
             showAdvanced: false,
             isLongOperationRunning: false,
+            updateExpectedAfterDate: null,
         };
     },
     computed: {
@@ -169,6 +170,14 @@ export default {
         /** @returns {Boolean} */
         hasFilters() {
             return !this.queryDefault;
+        },
+        /** @returns {Boolean} */
+        isHistoryUpdated() {
+            return !this.updateExpectedAfterDate || this.history.update_time > this.updateExpectedAfterDate;
+        },
+        /** @returns {Boolean} */
+        isProcessing() {
+            return this.isLongOperationRunning || !this.isHistoryUpdated;
         },
     },
     watch: {
@@ -208,7 +217,13 @@ export default {
             Vue.set(this.invisible, item.hid, true);
         },
         onUpdateOperationStatus(running) {
+            if (running) {
+                this.expectHistoryUpdate();
+            }
             this.isLongOperationRunning = running;
+        },
+        expectHistoryUpdate() {
+            this.updateExpectedAfterDate = this.history.update_time;
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -65,20 +65,20 @@
                     </section>
                     <section v-if="!showAdvanced" class="position-relative flex-grow-1 scroller">
                         <div>
-                            <div v-if="itemsLoaded && itemsLoaded.length == 0">
-                                <b-alert v-if="loading" class="m-2" variant="info" show>
+                            <div v-if="itemsLoaded && itemsLoaded.length == 0 && loading">
+                                <b-alert class="m-2" variant="info" show>
                                     <LoadingSpan message="Loading History" />
                                 </b-alert>
-                                <div v-else>
-                                    <HistoryEmpty v-if="queryDefault" class="m-2" />
-                                    <b-alert v-else class="m-2" variant="info" show>
-                                        No data found for selected filter.
-                                    </b-alert>
-                                </div>
                             </div>
                             <b-alert v-else-if="isProcessing" class="m-2" variant="info" show>
                                 <LoadingSpan message="Processing operation" />
                             </b-alert>
+                            <div v-else-if="totalItemsInQuery == 0">
+                                <HistoryEmpty v-if="queryDefault" class="m-2" />
+                                <b-alert v-else class="m-2" variant="info" show>
+                                    No data found for selected filter.
+                                </b-alert>
+                            </div>
                             <Listing v-else :items="itemsLoaded" :query-key="queryKey" @scroll="onScroll">
                                 <template v-slot:item="{ item }">
                                     <ContentItem


### PR DESCRIPTION
Requires #13783

See individual commits for details.

![operation-message](https://user-images.githubusercontent.com/46503462/166255744-44c09a37-ff9e-4ba7-8817-fed53af8cedb.gif)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Run any history operation in bulk (with more than 10 items)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
