### PR TITLE
Beta History: display `global` history bulk operations only when necessary

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
@@ -13,16 +13,16 @@
             <b-dropdown-text id="history-op-all-content">
                 <span v-localize>With entire history...</span>
             </b-dropdown-text>
-            <b-dropdown-item data-description="copy datasets" @click="onCopy">
+            <b-dropdown-item v-if="history.contents_active.active" data-description="copy datasets" @click="onCopy">
                 <span v-localize>Copy Datasets</span>
             </b-dropdown-item>
-            <b-dropdown-item v-b-modal:show-all-hidden-content>
+            <b-dropdown-item v-if="history.contents_active.hidden" v-b-modal:show-all-hidden-content>
                 <span v-localize>Unhide All Hidden Content</span>
             </b-dropdown-item>
-            <b-dropdown-item v-b-modal:delete-all-hidden-content>
+            <b-dropdown-item v-if="history.contents_active.hidden" v-b-modal:delete-all-hidden-content>
                 <span v-localize>Delete All Hidden Content</span>
             </b-dropdown-item>
-            <b-dropdown-item v-b-modal:purge-all-deleted-content>
+            <b-dropdown-item v-if="history.contents_active.deleted" v-b-modal:purge-all-deleted-content>
                 <span v-localize>Purge All Deleted Content</span>
             </b-dropdown-item>
         </b-dropdown>


### PR DESCRIPTION
Since we already have that information in the history summary... it should be less confusing for the users.

![hide-global-ops](https://user-images.githubusercontent.com/46503462/166261465-2c4270d6-c65f-4f08-9899-cd205607c1da.gif)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Try to run bulk operations on the entire history (cog menu) in different scenarios with hidden/deleted items.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
