### PR TITLE
Citation separation

### DIFF
--- a/client/src/components/Citation/services.js
+++ b/client/src/components/Citation/services.js
@@ -1,21 +1,22 @@
 import axios from "axios";
 import { rethrowSimple } from "utils/simple-error";
 import { getAppRoot } from "onload/loadConfig";
-import Cite from "citation-js";
 
 export async function getCitations(source, id) {
     try {
         const request = await axios.get(`${getAppRoot()}api/${source}/${id}/citations`);
         const rawCitations = request.data;
         const citations = [];
-        for (const rawCitation of rawCitations) {
-            try {
-                const cite = new Cite(rawCitation.content);
-                citations.push({ raw: rawCitation.content, cite: cite });
-            } catch (err) {
-                console.warn(`Error parsing bibtex: ${err}`);
+        import(/* webpackChunkName: "CitationJS" */ "citation-js").then(({ default: Cite }) => {
+            for (const rawCitation of rawCitations) {
+                try {
+                    const cite = new Cite(rawCitation.content);
+                    citations.push({ raw: rawCitation.content, cite: cite });
+                } catch (err) {
+                    console.warn(`Error parsing bibtex: ${err}`);
+                }
             }
-        }
+        });
         return citations;
     } catch (e) {
         rethrowSimple(e);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -11,6 +11,19 @@ const testsBase = path.join(__dirname, "tests");
 const libsBase = path.join(scriptsBase, "libs");
 const styleBase = path.join(scriptsBase, "style");
 
+const modulesExcludedFromLibs = [
+    "jspdf",
+    "canvg",
+    "prismjs",
+    "html2canvas",
+    "handsontable",
+    "pikaday",
+    "moment",
+    "elkjs",
+    "@citation-js",
+    "citeproc",
+].join("|");
+
 module.exports = (env = {}, argv = {}) => {
     // environment name based on -d, -p, webpack flag
     const targetEnv = process.env.NODE_ENV == "production" || argv.mode == "production" ? "production" : "development";
@@ -59,7 +72,9 @@ module.exports = (env = {}, argv = {}) => {
                     },
                     libs: {
                         name: "libs",
-                        test: /node_modules[\\/](?!(jspdf|canvg|prismjs|html2canvas|handsontable|pikaday|moment|elkjs)[\\/])|galaxy\/scripts\/libs/,
+                        test: new RegExp(
+                            `node_modules[\\/](?!(${modulesExcludedFromLibs})[\\/])|galaxy\/scripts\/libs`
+                        ),
                         chunks: "all",
                         priority: -10,
                     },

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -73,7 +73,7 @@ module.exports = (env = {}, argv = {}) => {
                     libs: {
                         name: "libs",
                         test: new RegExp(
-                            `node_modules[\\/](?!(${modulesExcludedFromLibs})[\\/])|galaxy\/scripts\/libs`
+                            `node_modules[\\/](?!(${modulesExcludedFromLibs})[\\/])|galaxy/scripts/libs`
                         ),
                         chunks: "all",
                         priority: -10,


### PR DESCRIPTION
Following the trend of https://github.com/galaxyproject/galaxy/pull/13800 and https://github.com/galaxyproject/galaxy/pull/13837, this is the last major, isolated, chunk we can shift to dynamic loading out of our (now much smaller!) libs bundle easily.  It's about another 30% shaved off the libs bundle, down to 2.2mb parsed now, and the rest is both smaller and more widely used stuff.

Next steps I'm taking here will be addressing the entrypoints, combined with routing and smarter component&component dependency loading.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
