### PR TITLE
Improve name tag display in New History

### DIFF
--- a/client/src/components/History/Content/ContentItem.test.js
+++ b/client/src/components/History/Content/ContentItem.test.js
@@ -32,11 +32,13 @@ describe("ContentItem", () => {
     it("check basics", async () => {
         expect(wrapper.attributes("data-hid")).toBe("1");
         expect(wrapper.find(".content-title").text()).toBe("name");
-        const tags = wrapper.find(".nametags").findAll(".badge");
+        const tags = wrapper.find(".alltags").findAll(".ti-tag");
         // verify tags
         expect(tags.length).toBe(3);
         for (let i = 0; i < 3; i++) {
             expect(tags.at(i).text()).toBe(`tag${i + 1}`);
+            await tags.at(i).find(".tag-name").trigger("click");
+            expect(wrapper.emitted()["tag-click"][i][0]).toBe(`tag${i + 1}`);
         }
         // expansion button
         const $el = wrapper.find(".cursor-pointer");

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -34,9 +34,6 @@
                         :collection-type="item.collection_type"
                         :element-count="item.element_count"
                         :elements-datatypes="item.elements_datatypes" />
-                    <div v-if="item.tags && item.tags.length > 0" class="nametags">
-                        <Nametag v-for="tag in item.tags" :key="tag" :tag="tag" />
-                    </div>
                 </span>
                 <ContentOptions
                     :is-dataset="isDataset"
@@ -52,6 +49,14 @@
                     @unhide="$emit('unhide')" />
             </div>
         </div>
+        <div class="p-1 alltags">
+            <StatelessTags
+                v-model="tags"
+                :use-toggle-link="false"
+                :disabled="!expandDataset || !isHistoryItem"
+                @tag-click="onTagClick"
+                @input="onTags" />
+        </div>
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
         <div class="detail-animation-wrapper" :class="expandDataset ? '' : 'collapsed'">
             <DatasetDetails v-if="expandDataset" :dataset="item" @edit="onEdit" />
@@ -61,18 +66,19 @@
 
 <script>
 import { backboneRoute, useGalaxy, iframeRedirect } from "components/plugins/legacyNavigation";
-import { Nametag } from "components/Nametags";
+import { StatelessTags } from "components/Tags";
 import { STATES } from "./model/states";
 import CollectionDescription from "./Collection/CollectionDescription";
 import ContentOptions from "./ContentOptions";
 import DatasetDetails from "./Dataset/DatasetDetails";
+import { updateContentFields } from "components/History/model/queries";
 
 export default {
     components: {
         CollectionDescription,
         ContentOptions,
         DatasetDetails,
-        Nametag,
+        StatelessTags,
     },
     props: {
         expandDataset: { type: Boolean, required: true },
@@ -116,6 +122,9 @@ export default {
                 return this.item.state;
             }
         },
+        tags() {
+            return this.item.tags;
+        },
     },
     methods: {
         onClick() {
@@ -146,6 +155,12 @@ export default {
             } else {
                 backboneRoute("datasets/edit", { dataset_id: this.item.id });
             }
+        },
+        onTags(newTags) {
+            updateContentFields(this.item, { tags: newTags });
+        },
+        onTagClick(tag) {
+            this.$emit("tag-click", tag.label);
         },
     },
 };

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -54,45 +54,20 @@
                     <span class="fa fa-question" />
                 </b-button>
             </div>
-            <div class="btn-group float-right">
-                <b-button
-                    class="px-1"
-                    title="Edit Tags"
-                    size="sm"
-                    variant="link"
-                    :pressed="showTags"
-                    @click="onToggleTags">
-                    <span class="fa fa-tags" />
-                </b-button>
-            </div>
-        </div>
-        <div v-if="showTags" class="mb-2">
-            <StatelessTags v-model="tags" class="tags" @input="onTags" />
         </div>
     </div>
 </template>
 
 <script>
-import { StatelessTags } from "components/Tags";
 import { legacyNavigationMixin } from "components/plugins/legacyNavigation";
 import { prependPath } from "utils/redirect";
 import { copy as sendToClipboard } from "utils/clipboard";
 import { absPath } from "utils/redirect";
-import { updateContentFields } from "components/History/model/queries";
 
 export default {
-    components: {
-        StatelessTags,
-    },
     mixins: [legacyNavigationMixin],
     props: {
         item: { type: Object, required: true },
-    },
-    data() {
-        return {
-            showTags: false,
-            tags: this.item.tags,
-        };
     },
     computed: {
         downloadUrl() {
@@ -136,12 +111,6 @@ export default {
         },
         onRerun() {
             this.backboneRoute(`root?job_id=${this.item.creating_job}`);
-        },
-        onTags() {
-            updateContentFields(this.item, { tags: this.tags });
-        },
-        onToggleTags() {
-            this.showTags = !this.showTags;
         },
         onVisualize() {
             const path = `visualizations?dataset_id=${this.item.id}`;

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -98,6 +98,7 @@
                                         :is-dataset="isDataset(item)"
                                         :selected="isSelected(item)"
                                         :selectable="showSelection"
+                                        @tag-click="onTagClick"
                                         @update:expand-dataset="setExpanded(item, $event)"
                                         @update:selected="setSelected(item, $event)"
                                         @view-collection="$emit('view-collection', item)"
@@ -229,6 +230,13 @@ export default {
         },
         setInvisible(item) {
             Vue.set(this.invisible, item.hid, true);
+        },
+        onTagClick(tag) {
+            if (this.filterText == "tag=" + tag) {
+                this.filterText = "";
+            } else {
+                this.filterText = "tag=" + tag;
+            }
         },
         onOperationError(error) {
             console.debug("OPERATION ERROR", error);

--- a/client/src/components/Tags/StatelessTags.vue
+++ b/client/src/components/Tags/StatelessTags.vue
@@ -70,7 +70,9 @@ export default {
             };
         },
         tagModels() {
-            return this.value.map(createTag);
+            const sortedValue = [...this.value];
+            sortedValue.sort((a, b) => b.indexOf("name:") - a.indexOf("name:"));
+            return sortedValue.map(createTag);
         },
         autocompleteTags() {
             return this.autocompleteItems.map(createTag);
@@ -184,6 +186,9 @@ export default {
             border-radius: 4px;
             font-size: 0.8rem;
             font-weight: 400;
+        }
+        .ti-tag:hover {
+            filter: brightness(115%) !important;
         }
         &.tag-area {
             background-color: transparent;

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1655,10 +1655,10 @@ class NavigatesGalaxy(HasDriver):
         viz_menu_selectors = f"{self.history_panel_item_selector(hid)} a.visualization-link"
         return self.driver.find_elements_by_css_selector(viz_menu_selectors)
 
-    def history_panel_item_get_nametags(self, hid):
+    def history_panel_item_get_tags(self, hid):
         item_component = self.history_panel_item_component(hid=hid)
         item_component.wait_for_visible()
-        return [e.text for e in item_component.nametags.all()]
+        return [e.text for e in item_component.alltags.all()]
 
     def history_panel_item_available_visualizations(self, hid):
         # Precondition: viz menu has been opened with history_panel_item_click_visualization_menu

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -149,7 +149,7 @@ history_panel:
       info_button: '${_} .icon-btn.params-btn'
       tool_help_button: '${_} .fa.fa-question'
       rerun_button: '${_} .icon-btn.rerun-btn'
-      nametags: '${_} .nametags .badge-tags'
+      alltags: '${_} .alltags .ti-tags'
 
   # beta content item
   content_item:
@@ -177,7 +177,7 @@ history_panel:
       # Action buttons...
       download_button: '${_} .download-btn'
       info_button: '${_} .params-btn'
-      nametags: '${_} .nametags .badge-tags'
+      alltags: '${_} .alltags .ti-tags'
 
       dataset_operations_dropdown: '${_}  .dataset-actions'
 

--- a/lib/galaxy_test/selenium/test_history_panel_collections.py
+++ b/lib/galaxy_test/selenium/test_history_panel_collections.py
@@ -194,8 +194,8 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
         self._back_to_history()
         self.sleep_for(self.wait_types.UX_RENDER)
         self.history_panel_wait_for_hid_state(collection_hid, "ok")
-        nametags = self.history_panel_item_get_nametags(collection_hid)
-        assert nametags == ["moo"]
+        nametags = self.history_panel_item_get_tags(collection_hid)
+        assert nametags == ["#moo"]
         self.screenshot("history_panel_collection_with_nametag")
 
     @selenium_test


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/13747 and Fixes https://github.com/galaxyproject/galaxy/issues/13865. Previously all tags for an item were being shown but in the same color scheme, I have made it so that only name (`name:tag_x`) tags are shown in unique colors and the rest are colored the same. Here is a **Before and After**:
### Before:

https://user-images.githubusercontent.com/78516064/166305584-0cc615a3-8790-46e1-acee-e6cc7666579c.mov
### After:

https://user-images.githubusercontent.com/78516064/167178392-1dd7fffc-a2bb-4b90-bd26-5eac85428f93.mov
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
