### PR TITLE
Beta History: notify query selection break

### DIFF
--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -50,7 +50,7 @@ export default {
             const newSelected = new Map(this.items);
             selected ? newSelected.set(key, item) : newSelected.delete(key);
             this.items = newSelected;
-            this.resetQuerySelection();
+            this.breakQuerySelection();
         },
         selectItems(items = []) {
             const newItems = [...this.items.values(), ...items];
@@ -59,16 +59,17 @@ export default {
                 return [key, item];
             });
             this.items = new Map(newEntries);
-            this.resetQuerySelection();
+            this.breakQuerySelection();
         },
-        resetQuerySelection() {
+        breakQuerySelection() {
+            if (this.allSelected) {
+                this.$emit("query-selection-break");
+            }
             this.allSelected = false;
         },
         reset() {
             this.items = new Map();
-            this.resetQuerySelection();
-        },
-        cancelSelection() {
+            this.allSelected = false;
             this.showSelection = false;
         },
     },
@@ -76,7 +77,6 @@ export default {
         scopeKey(newKey, oldKey) {
             if (newKey !== oldKey) {
                 this.reset();
-                this.cancelSelection();
             }
         },
         selectionSize(newSize) {
@@ -91,7 +91,7 @@ export default {
         },
         totalItemsInQuery(newVal, oldVal) {
             if (this.allSelected && newVal !== oldVal) {
-                this.resetQuerySelection();
+                this.breakQuerySelection();
             }
         },
     },

--- a/client/src/components/History/Content/SelectedItems.test.js
+++ b/client/src/components/History/Content/SelectedItems.test.js
@@ -95,11 +95,13 @@ describe("History SelectedItems", () => {
             await selectAllItemsInCurrentQuery(loadedItems);
             expect(slotProps.isQuerySelection).toBe(true);
             expect(slotProps.selectionSize).toBe(expectedTotalItemsInQuery);
+            expect(wrapper.emitted()["query-selection-break"]).toBeUndefined();
 
             await unselectItem(loadedItems[0]);
 
             expect(slotProps.isQuerySelection).toBe(false);
             expect(slotProps.selectionSize).toBe(numberOfLoadedItems - 1);
+            expect(wrapper.emitted()["query-selection-break"]).toBeDefined();
         });
 
         it("should `break` query selection mode when the total number of items changes", async () => {
@@ -107,11 +109,13 @@ describe("History SelectedItems", () => {
             const loadedItems = generateTestItems(numberOfLoadedItems);
             await selectAllItemsInCurrentQuery(loadedItems);
             expect(slotProps.isQuerySelection).toBe(true);
+            expect(wrapper.emitted()["query-selection-break"]).toBeUndefined();
 
             await wrapper.setProps({ totalItemsInQuery: 80 });
 
             expect(slotProps.isQuerySelection).toBe(false);
             expect(slotProps.selectionSize).toBe(numberOfLoadedItems);
+            expect(wrapper.emitted()["query-selection-break"]).toBeDefined();
         });
     });
 

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionChangeWarning.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionChangeWarning.vue
@@ -15,6 +15,7 @@
 </template>
 
 <script>
+import { mapGetters, mapActions } from "vuex";
 import { BAlert, BLink, BProgress } from "bootstrap-vue";
 export default {
     components: {
@@ -31,18 +32,22 @@ export default {
             dismissCountDown: 0,
         };
     },
+    computed: {
+        ...mapGetters("userFlags", ["getShowSelectionQueryBreakWarning"]),
+    },
     watch: {
         querySelectionBreak() {
-            this.dismissCountDown = this.dismissSecs;
+            this.dismissCountDown = this.getShowSelectionQueryBreakWarning() ? this.dismissSecs : 0;
         },
     },
     methods: {
+        ...mapActions("userFlags", ["ignoreSelectionQueryBreakWarning"]),
         onDismissed() {
             this.dismissCountDown = 0;
         },
         onDoNotShowAgain() {
             this.onDismissed();
-            //TODO: set some flag in local storage
+            this.ignoreSelectionQueryBreakWarning();
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionChangeWarning.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionChangeWarning.vue
@@ -1,0 +1,49 @@
+<template>
+    <b-alert
+        class="m-2"
+        variant="info"
+        :show="dismissCountDown"
+        dismissible
+        fade
+        @dismissed="onDismissed"
+        @dismiss-count-down="dismissCountDown = $event">
+        <b>Please notice your selection has changed.</b> Manually unselecting items or adding new ones will disable the
+        `select all` status.
+        <b-progress variant="info" :max="dismissSecs" :value="dismissCountDown" height="4px" />
+        <b-link @click="onDoNotShowAgain">Do not show again</b-link>
+    </b-alert>
+</template>
+
+<script>
+import { BAlert, BLink, BProgress } from "bootstrap-vue";
+export default {
+    components: {
+        "b-alert": BAlert,
+        "b-link": BLink,
+        "b-progress": BProgress,
+    },
+    props: {
+        querySelectionBreak: { type: Boolean, required: true },
+    },
+    data() {
+        return {
+            dismissSecs: 10,
+            dismissCountDown: 0,
+        };
+    },
+    watch: {
+        querySelectionBreak() {
+            this.dismissCountDown = this.dismissSecs;
+        },
+    },
+    methods: {
+        onDismissed() {
+            this.dismissCountDown = 0;
+        },
+        onDoNotShowAgain() {
+            this.onDismissed();
+            //TODO: set some flag in local storage
+        },
+    },
+};
+</script>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -25,7 +25,8 @@
                 :scope-key="queryKey"
                 :get-item-key="(item) => item.type_id"
                 :filter-text="filterText"
-                :total-items-in-query="totalItemsInQuery">
+                :total-items-in-query="totalItemsInQuery"
+                @query-selection-break="querySelectionBreak = true">
                 <section class="history-layout d-flex flex-column">
                     <slot name="navigation" :history="history" />
                     <HistoryFilters
@@ -63,6 +64,7 @@
                                     @reset-selection="resetSelection" />
                             </template>
                         </HistoryOperations>
+                        <SelectionChangeWarning :query-selection-break="querySelectionBreak" />
                     </section>
                     <section v-if="!showAdvanced" class="position-relative flex-grow-1 scroller">
                         <div>
@@ -124,6 +126,7 @@ import HistoryFilters from "./HistoryFilters";
 import HistoryMessages from "./HistoryMessages";
 import HistorySelectionOperations from "./HistoryOperations/SelectionOperations";
 import HistorySelectionStatus from "./HistoryOperations/SelectionStatus";
+import SelectionChangeWarning from "./HistoryOperations/SelectionChangeWarning";
 
 export default {
     components: {
@@ -141,6 +144,7 @@ export default {
         LoadingSpan,
         Listing,
         SelectedItems,
+        SelectionChangeWarning,
     },
     props: {
         history: { type: Object, required: true },
@@ -153,6 +157,7 @@ export default {
             showAdvanced: false,
             isOperationRunning: false,
             updateExpectedAfterDate: null,
+            querySelectionBreak: false,
         };
     },
     computed: {

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -16,7 +16,7 @@ import { jobMetricsStore } from "./jobMetricsStore";
 import { jobDestinationParametersStore } from "./jobDestinationParametersStore";
 import { invocationStore } from "./invocationStore";
 import { collectionElementsStore, datasetStore, historyItemsStore, historyStore } from "./historyStore";
-import { userStore } from "./userStore";
+import { userStore, userFlagsStore } from "./userStore";
 import { configStore } from "./configStore";
 import { workflowStore } from "./workflowStore";
 import { toolStore } from "./toolStore";
@@ -44,7 +44,7 @@ galaxyStorage.config({
 const panelsPersistence = new VuexPersistence({
     storage: galaxyStorage,
     asyncStorage: true,
-    modules: ["panels"],
+    modules: ["panels", "userFlags"],
 });
 
 export function createStore() {
@@ -70,6 +70,7 @@ export function createStore() {
             tags: tagStore,
             tools: toolStore,
             user: userStore,
+            userFlags: userFlagsStore,
             workflows: workflowStore,
         },
     };

--- a/client/src/store/userStore/index.js
+++ b/client/src/store/userStore/index.js
@@ -1,3 +1,4 @@
 export { userStore } from "./userStore";
 export { default as User } from "./User";
 export { syncUserToGalaxy } from "./syncUserToGalaxy";
+export { userFlagsStore } from "./userFlagsStore";

--- a/client/src/store/userStore/userFlagsStore.js
+++ b/client/src/store/userStore/userFlagsStore.js
@@ -1,0 +1,34 @@
+/**
+ * Contains flags for simple options that doesn't fit as full user's preferences.
+ * Like permanently acknowledge or dismissing certain messages.
+ */
+
+const state = {
+    showSelectionQueryBreakWarning: true,
+};
+
+const getters = {
+    getShowSelectionQueryBreakWarning: (state) => () => {
+        return state.showSelectionQueryBreakWarning;
+    },
+};
+
+const actions = {
+    ignoreSelectionQueryBreakWarning: ({ commit }) => {
+        commit("saveShowSelectionQueryBreakWarningFlag", { show: false });
+    },
+};
+
+const mutations = {
+    saveShowSelectionQueryBreakWarningFlag: (state, { show }) => {
+        state.showSelectionQueryBreakWarning = show;
+    },
+};
+
+export const userFlagsStore = {
+    namespaced: true,
+    state,
+    getters,
+    mutations,
+    actions,
+};


### PR DESCRIPTION
Requires #13858 and fixes #13736

For the `Do not show again` option in the notification, we set a flag in the local storage. For possible future use of more of these kinds of user flags, a new store [client/src/store/userStore/userFlagsStore.js](https://github.com/galaxyproject/galaxy/pull/13850/files#diff-c48ea0f253fd659f3d5567f4e2c80ab11d93b1f4d55dc7b527479047e9e08092) has been included. If this is too overkill we can drop it though.

Anyway, the notification will show only once per session independently of the flag.

![notify-query-break](https://user-images.githubusercontent.com/46503462/167109722-ec41cbe1-5ae7-44ad-bb7b-dfeb5c8e7af9.gif)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Switch to a History (with more than 100 items)
  - Go to selection mode and `Select All` items
  - Unselect or upload a new item with all items selected
  - You should see the notification clarifying why the selection changed

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
