### PR TITLE
[22.01] Bump ncb-datasets-cli dependency to 13.14.0

### DIFF
--- a/tools/data_source/ncbi_datasets.xml
+++ b/tools/data_source/ncbi_datasets.xml
@@ -1,10 +1,10 @@
-<tool name="NCBI Datasets Genomes" id="ncbi_datasets_source" tool_type="data_source" version="1.0" profile="21.09">
+<tool name="NCBI Datasets Genomes" id="ncbi_datasets_source" tool_type="data_source" version="1.1" profile="21.09">
     <description>import data from the NCBI Datasets Genomes page</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>
     </edam_operations>
     <requirements>
-        <requirement type="package" version="12.11.0">ncbi-datasets-cli</requirement>
+        <requirement type="package" version="13.14.0">ncbi-datasets-cli</requirement>
     </requirements>
     <version_command>datasets version</version_command>
     <command><![CDATA[

--- a/tools/data_source/ncbi_datasets.xml
+++ b/tools/data_source/ncbi_datasets.xml
@@ -1,10 +1,13 @@
-<tool name="NCBI Datasets Genomes" id="ncbi_datasets_source" tool_type="data_source" version="1.1" profile="21.09">
+<tool name="NCBI Datasets Genomes" id="ncbi_datasets_source" tool_type="data_source" version="@TOOL_VERSION@" profile="21.09">
     <description>import data from the NCBI Datasets Genomes page</description>
     <edam_operations>
         <edam_operation>operation_0224</edam_operation>
     </edam_operations>
+    <macros>
+        <token name="@TOOL_VERSION@">13.14.0</token>
+    </macros>
     <requirements>
-        <requirement type="package" version="13.14.0">ncbi-datasets-cli</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">ncbi-datasets-cli</requirement>
     </requirements>
     <version_command>datasets version</version_command>
     <command><![CDATA[


### PR DESCRIPTION
Fixes

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x8a3fea]

goroutine 1 [running]:
main/datasets/datasets.downloadData(0xc000010380, 0x0, 0x0, 0x0, 0x7ffe36956316, 0x62, 0xffffffffffffffff, 0x0, 0x0)
	src/datasets/datasets/Download.go:41 +0xea
main/datasets/datasets.downloadAssembly(0xc000069100, 0x7ffe36956316, 0x62, 0x8ef4a0, 0xc000010298)
	src/datasets/datasets/DownloadGenome.go:63 +0x294
main/datasets/datasets.glob..func1(0xd9d080, 0xc000074730, 0x0, 0x5, 0x0, 0x0)
	src/datasets/datasets/Download.go:106 +0x2a7
github.com/spf13/cobra.(*Command).execute(0xd9d080, 0xc0000746e0, 0x5, 0x5, 0xd9d080, 0xc0000746e0)
	external/com_github_spf13_cobra/command.go:842 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0xd9cde0, 0x4686c5, 0xc000000180, 0x200000003)
	external/com_github_spf13_cobra/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	external/com_github_spf13_cobra/command.go:887
main/datasets/datasets.Execute()
	src/datasets/datasets/root.go:444 +0x31
main.main()
	src/cmd/datasets/main.go:10 +0x25
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
