### PR TITLE
Fix workflow bookmarking API.

### DIFF
--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -206,10 +206,8 @@ export default {
         },
         bookmarkWorkflow: function (workflow, checked) {
             const id = workflow.id;
-            const tags = workflow.tags;
             const data = {
                 show_in_tool_panel: checked,
-                tags: tags,
             };
             this.services
                 .updateWorkflow(id, data)


### PR DESCRIPTION
And drop client-side hack that I assume was working around it.

I tried dropping the tags argument that seems like shouldn't be needed and the results were not being persisted. Presumably someone realized the tags caused a flush and so sticking them in there worked around a bug related to a missing flush in this API.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Open the workflow list and try to bookmark a workflow. Fresh the the grid and verify the workflow is still bookmarked. Repeat for un-bookmarking the workflow.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
