### PR TITLE
Beta History: selection and operations small fixes

### DIFF
--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -67,6 +67,8 @@ export default {
         reset() {
             this.items = new Map();
             this.resetQuerySelection();
+        },
+        cancelSelection() {
             this.showSelection = false;
         },
     },
@@ -74,6 +76,7 @@ export default {
         scopeKey(newKey, oldKey) {
             if (newKey !== oldKey) {
                 this.reset();
+                this.cancelSelection();
             }
         },
         selectionSize(newSize) {

--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -89,6 +89,11 @@ export default {
                 this.reset();
             }
         },
+        totalItemsInQuery(newVal, oldVal) {
+            if (this.allSelected && newVal !== oldVal) {
+                this.resetQuerySelection();
+            }
+        },
     },
     render() {
         return this.$scopedSlots.default({

--- a/client/src/components/History/Content/SelectedItems.test.js
+++ b/client/src/components/History/Content/SelectedItems.test.js
@@ -1,0 +1,199 @@
+import { shallowMount } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import { getLocalVue } from "jest/helpers";
+import SelectedItems from "./SelectedItems";
+
+const localVue = getLocalVue();
+
+const DEFAULT_PROPS = {
+    scopeKey: "scope",
+    getItemKey: (item) => `item-key-${item.id}`,
+    filterText: "",
+    totalItemsInQuery: 100,
+};
+
+describe("History SelectedItems", () => {
+    let wrapper;
+    let slotProps;
+
+    beforeEach(async () => {
+        wrapper = shallowMount(SelectedItems, {
+            localVue,
+            propsData: DEFAULT_PROPS,
+            scopedSlots: {
+                default(props) {
+                    slotProps = props;
+                },
+            },
+        });
+        await flushPromises();
+    });
+
+    afterEach(async () => {
+        if (wrapper) {
+            await wrapper.destroy();
+        }
+    });
+
+    it("should be able to enable/disable selection mode", async () => {
+        expectSelectionDisabled();
+
+        await enableSelection();
+        expectSelectionEnabled();
+
+        await disableSelection();
+        expectSelectionDisabled();
+    });
+
+    it("should discard the current selection when disabling the selection", async () => {
+        const numberOfExpectedItems = 3;
+        await selectSomeItemsManually(numberOfExpectedItems);
+        expect(slotProps.selectionSize).toBe(numberOfExpectedItems);
+
+        await disableSelection();
+        expectSelectionDisabled();
+    });
+
+    it("should disable/discard the current selection when the `scopeKey` changes", async () => {
+        const numberOfExpectedItems = 3;
+        await selectSomeItemsManually(numberOfExpectedItems);
+        expect(slotProps.selectionSize).toBe(numberOfExpectedItems);
+
+        await wrapper.setProps({ scopeKey: "different-scope" });
+
+        expectSelectionDisabled();
+    });
+
+    describe("Query Selection Mode", () => {
+        it("is considered a query selection when we select `all items` and the query contains more items than we have currently loaded", async () => {
+            const expectedTotalItemsInQuery = 100;
+            const numberOfLoadedItems = 10;
+            const loadedItems = generateTestItems(numberOfLoadedItems);
+
+            await selectAllItemsInCurrentQuery(loadedItems);
+
+            expect(slotProps.isQuerySelection).toBe(true);
+            expect(slotProps.selectionSize).toBe(expectedTotalItemsInQuery);
+        });
+
+        it("shouldn't be a query selection when we already have all items loaded", async () => {
+            const expectedTotalItemsInQuery = 10;
+            const numberOfLoadedItems = 10;
+            const loadedItems = generateTestItems(numberOfLoadedItems);
+            await wrapper.setProps({ totalItemsInQuery: expectedTotalItemsInQuery });
+
+            await selectAllItemsInCurrentQuery(loadedItems);
+
+            expect(slotProps.isQuerySelection).toBe(false);
+            expect(slotProps.selectionSize).toBe(expectedTotalItemsInQuery);
+        });
+
+        it("should `break` query selection mode when we unselect an item", async () => {
+            const expectedTotalItemsInQuery = 100;
+            const numberOfLoadedItems = 10;
+            const loadedItems = generateTestItems(numberOfLoadedItems);
+            await selectAllItemsInCurrentQuery(loadedItems);
+            expect(slotProps.isQuerySelection).toBe(true);
+            expect(slotProps.selectionSize).toBe(expectedTotalItemsInQuery);
+
+            await unselectItem(loadedItems[0]);
+
+            expect(slotProps.isQuerySelection).toBe(false);
+            expect(slotProps.selectionSize).toBe(numberOfLoadedItems - 1);
+        });
+
+        it("should `break` query selection mode when the total number of items changes", async () => {
+            const numberOfLoadedItems = 10;
+            const loadedItems = generateTestItems(numberOfLoadedItems);
+            await selectAllItemsInCurrentQuery(loadedItems);
+            expect(slotProps.isQuerySelection).toBe(true);
+
+            await wrapper.setProps({ totalItemsInQuery: 80 });
+
+            expect(slotProps.isQuerySelection).toBe(false);
+            expect(slotProps.selectionSize).toBe(numberOfLoadedItems);
+        });
+    });
+
+    describe("Selection Size", () => {
+        it("should match the number of items explicitly selected (non query)", async () => {
+            const numberOfExpectedItems = 3;
+            const items = generateTestItems(numberOfExpectedItems);
+            await selectItems(items);
+            expect(slotProps.isQuerySelection).toBe(false);
+            expect(slotProps.selectionSize).toBe(numberOfExpectedItems);
+
+            await unselectItem(items[0]);
+
+            expect(slotProps.selectionSize).toBe(numberOfExpectedItems - 1);
+        });
+
+        it("should match the number of items in query when selecting all items", async () => {
+            const expectedTotalItemsInQuery = 100;
+            const loadedItems = []; // Even if there are no explicit items selected
+            await selectAllItemsInCurrentQuery(loadedItems);
+            expect(slotProps.isQuerySelection).toBe(true);
+            expect(slotProps.selectionSize).toBe(expectedTotalItemsInQuery);
+        });
+    });
+
+    async function enableSelection() {
+        const { setShowSelection } = slotProps;
+        expect(setShowSelection).toBeInstanceOf(Function);
+        await setShowSelection(true);
+    }
+
+    async function disableSelection() {
+        const { setShowSelection } = slotProps;
+        expect(setShowSelection).toBeInstanceOf(Function);
+        await setShowSelection(false);
+    }
+
+    async function selectItems(items) {
+        const { selectItems } = slotProps;
+        expect(selectItems).toBeInstanceOf(Function);
+
+        await selectItems(items);
+    }
+
+    async function selectSomeItemsManually(numberOfItems) {
+        const items = generateTestItems(numberOfItems);
+        await selectItems(items);
+    }
+
+    async function unselectItem(item) {
+        const { setSelected } = slotProps;
+        expect(setSelected).toBeInstanceOf(Function);
+        await setSelected(item, false);
+    }
+
+    async function selectAllItemsInCurrentQuery(loadedItems) {
+        const { selectAllInCurrentQuery } = slotProps;
+        expect(selectAllInCurrentQuery).toBeInstanceOf(Function);
+
+        await selectAllInCurrentQuery(loadedItems);
+    }
+
+    function generateTestItems(numberOfItems) {
+        return Array.from({ length: numberOfItems }, (_, i) => {
+            return {
+                id: i,
+            };
+        });
+    }
+
+    function expectSelectionDisabled() {
+        expect(slotProps.showSelection).toBe(false);
+        expectNothingSelected();
+    }
+
+    function expectSelectionEnabled() {
+        expect(slotProps.showSelection).toBe(true);
+    }
+
+    function expectNothingSelected() {
+        expect(slotProps.selectionSize).toBe(0);
+        expect(slotProps.selectedItems.size).toEqual(slotProps.selectionSize);
+        expect(slotProps.isQuerySelection).toBe(false);
+    }
+});

--- a/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
@@ -28,7 +28,7 @@
             <DefaultOperations
                 v-show="!showSelection"
                 :history="history"
-                @update:long-operation-running="onUpdateOperationStatus" />
+                @update:operation-running="onUpdateOperationStatus" />
         </nav>
     </section>
 </template>
@@ -51,7 +51,7 @@ export default {
             this.$emit("update:show-selection", !this.showSelection);
         },
         onUpdateOperationStatus(running) {
-            this.$emit("update:long-operation-running", running);
+            this.$emit("update:operation-running", running);
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
@@ -62,9 +62,9 @@ export default {
             await this.runOperation(() => purgeAllDeletedContent(this.history));
         },
         async runOperation(operation) {
-            this.$emit("update:long-operation-running", true);
+            this.$emit("update:operation-running", true);
             await operation();
-            this.$emit("update:long-operation-running", false);
+            this.$emit("update:operation-running", false);
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -134,12 +134,12 @@ export default {
             await this.runOnSelection(purgeSelectedContent);
         },
         async runOnSelection(operation) {
-            this.$emit("update:long-operation-running", true);
+            this.$emit("update:operation-running", true);
             const items = this.getExplicitlySelectedItems();
             const filters = getQueryDict(this.filterText);
             this.$emit("reset-selection");
             await operation(this.history, filters, items);
-            this.$emit("update:long-operation-running", false);
+            this.$emit("update:operation-running", false);
         },
         getExplicitlySelectedItems() {
             if (this.isQuerySelection) {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -137,7 +137,7 @@ export default {
             this.$emit("update:operation-running", true);
             const items = this.getExplicitlySelectedItems();
             const filters = getQueryDict(this.filterText);
-            this.$emit("reset-selection");
+            this.$emit("update:show-selection", false);
             await operation(this.history, filters, items);
             this.$emit("update:operation-running", false);
         },

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -57,7 +57,8 @@
             <p v-localize>Really restore {{ numSelected }} content items?</p>
         </b-modal>
         <b-modal id="purge-selected-content" title="Purge Selected Content?" title-tag="h2" @ok="purgeSelected">
-            <p v-localize>Permanently delete {{ numSelected }} content items? This cannot be undone.</p>
+            <p v-localize>Permanently delete {{ numSelected }} content items?</p>
+            <p><strong v-localize class="text-danger">Warning, this operation cannot be undone.</strong></p>
         </b-modal>
     </section>
 </template>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -52,6 +52,7 @@
                                     :selection-size="selectionSize"
                                     :is-query-selection="isQuerySelection"
                                     :total-items-in-query="totalItemsInQuery"
+                                    @update:show-selection="setShowSelection"
                                     @update:operation-running="onUpdateOperationStatus"
                                     @hide-selection="onHideSelection"
                                     @reset-selection="resetSelection" />

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -42,7 +42,7 @@
                             :expanded-count="expandedCount"
                             :has-matches="hasMatches(itemsLoaded)"
                             @update:show-selection="setShowSelection"
-                            @update:long-operation-running="onUpdateOperationStatus"
+                            @update:operation-running="onUpdateOperationStatus"
                             @collapse-all="collapseAll">
                             <template v-slot:selection-operations>
                                 <HistorySelectionOperations
@@ -52,7 +52,7 @@
                                     :selection-size="selectionSize"
                                     :is-query-selection="isQuerySelection"
                                     :total-items-in-query="totalItemsInQuery"
-                                    @update:long-operation-running="onUpdateOperationStatus"
+                                    @update:operation-running="onUpdateOperationStatus"
                                     @hide-selection="onHideSelection"
                                     @reset-selection="resetSelection" />
                                 <HistorySelectionStatus
@@ -150,7 +150,7 @@ export default {
             invisible: {},
             offset: 0,
             showAdvanced: false,
-            isLongOperationRunning: false,
+            isOperationRunning: false,
             updateExpectedAfterDate: null,
         };
     },
@@ -177,7 +177,7 @@ export default {
         },
         /** @returns {Boolean} */
         isProcessing() {
-            return this.isLongOperationRunning || !this.isHistoryUpdated;
+            return this.isOperationRunning || !this.isHistoryUpdated;
         },
     },
     watch: {
@@ -230,7 +230,7 @@ export default {
             if (running) {
                 this.expectHistoryUpdate();
             }
-            this.isLongOperationRunning = running;
+            this.isOperationRunning = running;
         },
         expectHistoryUpdate() {
             this.updateExpectedAfterDate = this.history.update_time;


### PR DESCRIPTION
Follow-up on #13844, fixes https://github.com/galaxyproject/galaxy/pull/13844#issuecomment-1116869948, thanks @guerler for noticing.

And other minor refactorings, see individual commits for more details.

Includes a bunch of unit tests for the `SelectItems` component.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:

  ![fix-selection](https://user-images.githubusercontent.com/46503462/166686810-d959559e-2e96-46f1-bbc1-ebf963f94446.gif)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
