### PR TITLE
[22.01] Move TusMiddleware so XForwardedMiddleware runs first

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1385,16 +1385,16 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
     if asbool(conf.get('use_translogger', True)):
         from galaxy.web.framework.middleware.translogger import TransLogger
         app = wrap_if_allowed(app, stack, TransLogger)
-    # X-Forwarded-Host handling
-    app = wrap_if_allowed(app, stack, XForwardedHostMiddleware)
-    # Request ID middleware
-    app = wrap_if_allowed(app, stack, RequestIDMiddleware)
     # TUS upload middleware
     app = wrap_if_allowed(app, stack, TusMiddleware, kwargs={
         'upload_path': urljoin(f"{application_stack.config.galaxy_url_prefix}/", 'api/upload/resumable_upload'),
         'tmp_dir': application_stack.config.tus_upload_store or application_stack.config.new_file_path,
         'max_size': application_stack.config.maximum_upload_file_size
     })
+    # X-Forwarded-Host handling
+    app = wrap_if_allowed(app, stack, XForwardedHostMiddleware)
+    # Request ID middleware
+    app = wrap_if_allowed(app, stack, RequestIDMiddleware)
     # api batch call processing middleware
     app = wrap_if_allowed(app, stack, BatchMiddleware, args=(webapp, {}))
     if asbool(conf.get('enable_per_request_sql_debugging', False)):


### PR DESCRIPTION
The last middleware to be registered is the first to be called for incoming requests, so by registering `TusMiddleware` before `XForwardedHostMiddleware` `TusMiddleware` should receive the properly modified headers.

Oddly I can't reproduce https://github.com/galaxyproject/galaxy/issues/13678 any more at all (I could in the beginning) ... seems I have the reverse problem, it always works even if it shouldn't.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
