### PR TITLE
Refactor toward invocations service layer.

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -54,6 +54,7 @@ from galaxy import (
 )
 from galaxy.model import tool_shed_install
 from galaxy.schema import ValueFilterQueryParams
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import (
     BasicSharedApp,
@@ -141,7 +142,10 @@ def get_class(class_name):
 def decode_id(app: BasicSharedApp, id: Any):
     # note: use str - occasionally a fully numeric id will be placed in post body and parsed as int via JSON
     #   resulting in error for valid id
-    return decode_with_security(app.security, id)
+    if isinstance(id, DecodedDatabaseIdField):
+        return int(id)
+    else:
+        return decode_with_security(app.security, id)
 
 
 def decode_with_security(security: IdEncodingHelper, id: Any):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -338,19 +338,6 @@ class WorkflowsManager(sharable.SharableModelManager):
         ]
         return invocations, total_matches
 
-    def serialize_workflow_invocation(self, invocation, **kwd):
-        app = self.app
-        view = kwd.get("view", "element")
-        step_details = util.string_as_bool(kwd.get("step_details", False))
-        legacy_job_state = util.string_as_bool(kwd.get("legacy_job_state", False))
-        as_dict = invocation.to_dict(view, step_details=step_details, legacy_job_state=legacy_job_state)
-        return app.security.encode_all_ids(as_dict, recursive=True)
-
-    def serialize_workflow_invocations(self, invocations, **kwd):
-        if "view" not in kwd:
-            kwd["view"] = "collection"
-        return list(map(lambda i: self.serialize_workflow_invocation(i, **kwd), invocations))
-
 
 CreatedWorkflow = namedtuple("CreatedWorkflow", ["stored_workflow", "workflow", "missing_tools"])
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1073,7 +1073,7 @@ class InvocationSortByEnum(str, Enum):
     none = None
 
 
-class InvocationIndexPayload(Model):
+class InvocationIndexQueryPayload(Model):
     workflow_id: Optional[DecodedDatabaseIdField] = Field(
         title="Workflow ID", description="Return only invocations for this Workflow ID"
     )
@@ -1096,7 +1096,6 @@ class InvocationIndexPayload(Model):
         lt=1000,
     )
     offset: Optional[int] = Field(default=0, description="Number of invocations to skip")
-    instance: bool = Field(default=False, description="Is provided workflow id for Workflow instead of StoredWorkflow?")
 
 
 class CreateHistoryPayload(Model):

--- a/lib/galaxy/webapps/galaxy/services/invocations.py
+++ b/lib/galaxy/webapps/galaxy/services/invocations.py
@@ -1,0 +1,109 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+)
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
+from galaxy.exceptions import AdminRequiredException
+from galaxy.managers.histories import HistoryManager
+from galaxy.managers.workflows import WorkflowsManager
+from galaxy.schema.schema import InvocationIndexQueryPayload
+from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.webapps.galaxy.services.base import ServiceBase
+
+
+class InvocationSerializationParams(BaseModel):
+    """Contains common parameters for customizing model serialization."""
+
+    view: Optional[str] = Field(
+        default=None,
+        title="View",
+        description=(
+            "The name of the view used to serialize this item. "
+            "This will return a predefined set of attributes of the item."
+        ),
+        example="element",
+    )
+    step_details: bool = Field(
+        default=False, title="Include step details", description="Include details for individual invocation steps."
+    )
+    legacy_job_state: bool = Field(
+        default=False,
+        deprecated=True,
+    )
+
+
+class InvocationIndexPayload(InvocationIndexQueryPayload):
+    instance: bool = Field(default=False, description="Is provided workflow id for Workflow instead of StoredWorkflow?")
+
+
+class InvocationsService(ServiceBase):
+    def __init__(
+        self, security: IdEncodingHelper, histories_manager: HistoryManager, workflows_manager: WorkflowsManager
+    ):
+        super().__init__(security=security)
+        self._histories_manager = histories_manager
+        self._workflows_manager = workflows_manager
+
+    def index(
+        self, trans, invocation_payload: InvocationIndexPayload, serialization_params: InvocationSerializationParams
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        workflow_id = invocation_payload.workflow_id
+        if invocation_payload.instance:
+            instance = invocation_payload.instance
+            invocation_payload.workflow_id = self._workflows_manager.get_stored_workflow(
+                trans, workflow_id, by_stored_id=not instance
+            ).id
+        if invocation_payload.history_id:
+            # access check
+            self._histories_manager.get_accessible(
+                invocation_payload.history_id, trans.user, current_history=trans.history
+            )
+        if not trans.user_is_admin:
+            # We restrict the query to the current users' invocations
+            # Endpoint requires user login, so trans.user.id is never None
+            # TODO: user_id should be optional!
+            user_id = trans.user.id
+            if invocation_payload.user_id and invocation_payload.user_id != user_id:
+                raise AdminRequiredException("Only admins can index the invocations of others")
+        else:
+            # Get all invocations if user is admin (and user_id is None).
+            # xref https://github.com/galaxyproject/galaxy/pull/13862#discussion_r865732297
+            user_id = invocation_payload.user_id
+        invocations, total_matches = self._workflows_manager.build_invocations_query(
+            trans,
+            stored_workflow_id=invocation_payload.workflow_id,
+            history_id=invocation_payload.history_id,
+            job_id=invocation_payload.job_id,
+            user_id=user_id,
+            include_terminal=invocation_payload.include_terminal,
+            limit=invocation_payload.limit,
+            offset=invocation_payload.offset,
+            sort_by=invocation_payload.sort_by,
+            sort_desc=invocation_payload.sort_desc,
+        )
+        invocation_dict = self._serialize_workflow_invocations(invocations, serialization_params)
+        return invocation_dict, total_matches
+
+    def serialize_workflow_invocation(
+        self, invocation, params: InvocationSerializationParams, default_view: str = "element"
+    ):
+        view = params.view or default_view
+        step_details = params.step_details
+        legacy_job_state = params.legacy_job_state
+        as_dict = invocation.to_dict(view, step_details=step_details, legacy_job_state=legacy_job_state)
+        return self.security.encode_all_ids(as_dict, recursive=True)
+
+    def _serialize_workflow_invocations(
+        self, invocations, params: InvocationSerializationParams, default_view: str = "collection"
+    ):
+        return list(
+            map(lambda i: self.serialize_workflow_invocation(i, params, default_view=default_view), invocations)
+        )


### PR DESCRIPTION
Lays some groundwork for a transition to FastAPI endpoints for a some of this older style controller code and has more structured parsing of invocation serialization parameters.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
