### PR TITLE
galaxy-tool-util: better link in the README

### DIFF
--- a/packages/tool_util/README.rst
+++ b/packages/tool_util/README.rst
@@ -9,6 +9,6 @@ Overview
 The Galaxy_ tool utilities.
 
 * Free software: Academic Free License version 3.0
-* Code: https://github.com/galaxyproject/galaxy
+* Code: https://github.com/galaxyproject/galaxy/tree/dev/packages/tool_util
 
 .. _Galaxy: http://galaxyproject.org/


### PR DESCRIPTION
https://pypi.org/project/galaxy-tool-util/ doesn't tell you where to browse the packaged code, it just links to https://github.com/galaxyproject/galaxy which is not so helpful

Maybe it should link directly to https://github.com/galaxyproject/galaxy/tree/dev/lib/galaxy/tool_util ? The symlink isn't browsable on github.com

Let me know if I should add a link to https://docs.galaxyproject.org/en/master/lib/galaxy.tool_util.html (though it is unclear to me how to match the release on PyPI (21.9.2, 21.9.1, 21.9.0, …) to the available docs versions (22.01, 21.09, 21.05, …)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
