### PR TITLE
Don't reprint a traceback that has already been printed at the end of galaxy-tool-test

### DIFF
--- a/lib/galaxy/tool_util/verify/script.py
+++ b/lib/galaxy/tool_util/verify/script.py
@@ -374,7 +374,11 @@ def main(argv=None):
         argv = sys.argv[1:]
 
     args = arg_parser().parse_args(argv)
-    run_tests(args)
+    try:
+        run_tests(args)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 def run_tests(args, test_filters=None, log=None):


### PR DESCRIPTION
They are logged as they are encountered so printing one (and only one, the first one encountered) again at the end is confusing and makes the summary (which is printed before) more difficult to find and read.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
