### PR TITLE
Add client build timestamp to application config.

### DIFF
--- a/client/src/app/galaxy.js
+++ b/client/src/app/galaxy.js
@@ -293,13 +293,6 @@ GalaxyApp.prototype.debuggingNamespaces = function _debuggingNamespaces(namespac
     }
 };
 
-GalaxyApp.prototype.clientBuildInfo = {
-    /* global __targetEnv__, __buildTimestamp__ */
-    // These are plugged in from webpack/DefinePlugin at client build time.
-    env: __targetEnv__,
-    buildTimestamp: __buildTimestamp__,
-};
-
 /** string rep */
 GalaxyApp.prototype.toString = function toString() {
     const userEmail = this.user ? this.user.get("email") || "(anonymous)" : "uninitialized";

--- a/client/src/app/galaxy.js
+++ b/client/src/app/galaxy.js
@@ -293,6 +293,13 @@ GalaxyApp.prototype.debuggingNamespaces = function _debuggingNamespaces(namespac
     }
 };
 
+GalaxyApp.prototype.clientBuildInfo = {
+    /* global __targetEnv__, __buildTimestamp__ */
+    // These are plugged in from webpack/DefinePlugin at client build time.
+    env: __targetEnv__,
+    buildTimestamp: __buildTimestamp__,
+};
+
 /** string rep */
 GalaxyApp.prototype.toString = function toString() {
     const userEmail = this.user ? this.user.get("email") || "(anonymous)" : "uninitialized";

--- a/client/src/components/providers/UserHistories.test.js
+++ b/client/src/components/providers/UserHistories.test.js
@@ -10,6 +10,10 @@ let historySummaries;
 let fullHistories;
 let currentHistoryId;
 
+// These history tests can be flaky, so we allow a few retries while we work out
+// what's going on.
+jest.retryTimes(3, { logErrorsBeforeRetry: true });
+
 const resetTestData = () => {
     const ids = [1, 2, 3, 4];
     currentHistoryId = ids[0];

--- a/client/src/config/development.js
+++ b/client/src/config/development.js
@@ -7,4 +7,6 @@ export default {
         revs_limit: 1,
         pageSize: 50,
     },
+    /* global __buildTimestamp__ */
+    buildTimestamp: __buildTimestamp__,
 };

--- a/client/src/config/production.js
+++ b/client/src/config/production.js
@@ -7,4 +7,6 @@ export default {
         revs_limit: 1,
         pageSize: 60,
     },
+    /* global __buildTimestamp__ */
+    buildTimestamp: __buildTimestamp__,
 };

--- a/client/src/onload/index.js
+++ b/client/src/onload/index.js
@@ -19,5 +19,6 @@ export { getRootFromIndexLink } from "./getRootFromIndexLink";
 import config from "config";
 
 if (!config.testBuild === true) {
-    console.log("Configs:", config.name, config);
+    console.log(`Galaxy Client '${config.name}' build, dated ${config.buildTimestamp}`);
+    console.debug("Full configuration:", config);
 }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -72,9 +72,7 @@ module.exports = (env = {}, argv = {}) => {
                     },
                     libs: {
                         name: "libs",
-                        test: new RegExp(
-                            `node_modules[\\/](?!(${modulesExcludedFromLibs})[\\/])|galaxy/scripts/libs`
-                        ),
+                        test: new RegExp(`node_modules[\\/](?!(${modulesExcludedFromLibs})[\\/])|galaxy/scripts/libs`),
                         chunks: "all",
                         priority: -10,
                     },
@@ -192,6 +190,10 @@ module.exports = (env = {}, argv = {}) => {
                 Galaxy: ["app", "monitor"],
                 Buffer: ["buffer", "Buffer"],
                 process: "process/browser",
+            }),
+            new webpack.DefinePlugin({
+                __targetEnv__: JSON.stringify(targetEnv),
+                __buildTimestamp__: JSON.stringify(new Date().toISOString()),
             }),
             new VueLoaderPlugin(),
             new MiniCssExtractPlugin({


### PR DESCRIPTION
Suggestion from @mvdbeek to aid in debugging client issues.  This adds a `__targetEnv__` and `__buildTimestamp__` at build (webpack) time and automatically logs those values in our basic onload.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run galaxy, look for something like `Galaxy Client 'development' build, dated 2022-05-05T19:19:16.107Z` as a browser console log message.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
