### PR TITLE
Use an Enum for invocations view

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/invocations.py
+++ b/lib/galaxy/webapps/galaxy/services/invocations.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import (
     Any,
     Dict,
@@ -19,10 +20,15 @@ from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.webapps.galaxy.services.base import ServiceBase
 
 
+class InvocationSerializationView(str, Enum):
+    element = "element"
+    collection = "collection"
+
+
 class InvocationSerializationParams(BaseModel):
     """Contains common parameters for customizing model serialization."""
 
-    view: Optional[str] = Field(
+    view: Optional[InvocationSerializationView] = Field(
         default=None,
         title="View",
         description=(
@@ -93,7 +99,10 @@ class InvocationsService(ServiceBase):
         return invocation_dict, total_matches
 
     def serialize_workflow_invocation(
-        self, invocation, params: InvocationSerializationParams, default_view: str = "element"
+        self,
+        invocation,
+        params: InvocationSerializationParams,
+        default_view: InvocationSerializationView = InvocationSerializationView.element,
     ):
         view = params.view or default_view
         step_details = params.step_details
@@ -102,7 +111,10 @@ class InvocationsService(ServiceBase):
         return self.security.encode_all_ids(as_dict, recursive=True)
 
     def _serialize_workflow_invocations(
-        self, invocations, params: InvocationSerializationParams, default_view: str = "collection"
+        self,
+        invocations,
+        params: InvocationSerializationParams,
+        default_view: InvocationSerializationView = InvocationSerializationView.collection,
     ):
         return list(
             map(lambda i: self.serialize_workflow_invocation(i, params, default_view=default_view), invocations)


### PR DESCRIPTION
Strong typing means more static checking and also improves the FastAPI docs (or will once we migrate api/workflows.py).

Request by @mvdbeek https://github.com/galaxyproject/galaxy/pull/13867/files/5d1bc15da48de97f5af7b8d2be8651aec6c19aef#diff-d5c8fef66b35c3a11b2ba20299ae3ff577f88348a2b1ecb77a69211db0611da9.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
