### PR TITLE
Workflow List Vue Component Improvements

### DIFF
--- a/client/src/components/DebouncedInput.js
+++ b/client/src/components/DebouncedInput.js
@@ -23,14 +23,23 @@ export default {
             }
         },
     },
+    watch: {
+        incomingValue(val) {
+            if (this.delay === 0) {
+                this.sendUpdate(val);
+            }
+        },
+    },
     beforeMount() {
-        const debounced$ = this.watch$("incomingValue").pipe(
-            debounceTime(this.delay),
-            distinctUntilChanged(),
-            filter((val) => val !== null && val !== this.value),
-            finalize(() => this.sendUpdate(this.incomingValue))
-        );
-        this.$subscribeTo(debounced$, (val) => this.sendUpdate(val));
+        if (this.delay !== 0) {
+            const debounced$ = this.watch$("incomingValue").pipe(
+                debounceTime(this.delay),
+                distinctUntilChanged(),
+                filter((val) => val !== null && val !== this.value),
+                finalize(() => this.sendUpdate(this.incomingValue))
+            );
+            this.$subscribeTo(debounced$, (val) => this.sendUpdate(val));
+        }
     },
     render() {
         return this.$scopedSlots.default({

--- a/client/src/components/Indices/IndexFilter.vue
+++ b/client/src/components/Indices/IndexFilter.vue
@@ -9,11 +9,17 @@
                     autocomplete="off"
                     :placeholder="placeholder | localize"
                     data-description="filter index input"
+                    class="search-query"
+                    :size="size"
                     @input="input"
                     @keyup.esc="onReset" />
             </DebouncedInput>
             <b-input-group-append>
-                <b-button data-description="show deleted filter toggle" @click="onHelp" title="Advanced Filtering Help">
+                <b-button
+                    data-description="show deleted filter toggle"
+                    @click="onHelp"
+                    title="Advanced Filtering Help"
+                    :size="size">
                     <icon icon="question" />
                 </b-button>
             </b-input-group-append>
@@ -56,6 +62,10 @@ export default {
         debounceDelay: {
             type: Number,
             default: 500,
+        },
+        size: {
+            type: String,
+            value: "sm",
         },
         value: {},
     },

--- a/client/src/components/Indices/IndexFilter.vue
+++ b/client/src/components/Indices/IndexFilter.vue
@@ -1,11 +1,11 @@
 <template>
     <span>
         <b-input-group>
-            <DebouncedInput :delay="debounceDelay" v-slot="{ value, input }" v-model="localFilter">
+            <DebouncedInput :delay="debounceDelay" v-slot="{ value: debouncedValue, input }" v-model="localFilter">
                 <b-form-input
                     :id="id"
                     name="query"
-                    :value="value"
+                    :value="debouncedValue"
                     autocomplete="off"
                     :placeholder="placeholder | localize"
                     data-description="filter index input"
@@ -65,9 +65,12 @@ export default {
         },
         size: {
             type: String,
-            value: "sm",
+            default: "sm",
         },
-        value: {},
+        value: {
+            type: String,
+            required: true,
+        },
     },
     data() {
         return {

--- a/client/src/components/Indices/IndexFilter.vue
+++ b/client/src/components/Indices/IndexFilter.vue
@@ -1,0 +1,85 @@
+<template>
+    <span>
+        <b-input-group>
+            <DebouncedInput :delay="debounceDelay" v-slot="{ value, input }" v-model="localFilter">
+                <b-form-input
+                    :id="id"
+                    name="query"
+                    :value="value"
+                    autocomplete="off"
+                    :placeholder="placeholder | localize"
+                    data-description="filter index input"
+                    @input="input"
+                    @keyup.esc="onReset" />
+            </DebouncedInput>
+            <b-input-group-append>
+                <b-button data-description="show deleted filter toggle" @click="onHelp" title="Advanced Filtering Help">
+                    <icon icon="question" />
+                </b-button>
+            </b-input-group-append>
+        </b-input-group>
+        <b-modal v-model="showHelp" title="Filtering Options Help" ok-only>
+            <div v-html="helpHtml"></div>
+        </b-modal>
+    </span>
+</template>
+
+<script>
+import DebouncedInput from "components/DebouncedInput";
+
+import { BInputGroup, BInputGroupAppend, BButton, BModal } from "bootstrap-vue";
+
+/**
+ * Component for the search/filter button on the top of Galaxy object index grids.
+ */
+export default {
+    components: {
+        DebouncedInput,
+        BInputGroup,
+        BInputGroupAppend,
+        BButton,
+        BModal,
+    },
+    props: {
+        id: {
+            type: String,
+            required: true,
+        },
+        placeholder: {
+            type: String,
+            required: true,
+        },
+        helpHtml: {
+            type: String,
+            required: true,
+        },
+        debounceDelay: {
+            type: Number,
+            default: 500,
+        },
+        value: {},
+    },
+    data() {
+        return {
+            showHelp: false,
+            localFilter: this.value,
+        };
+    },
+    watch: {
+        value(newValue) {
+            this.localFilter = newValue;
+        },
+        localFilter(newVal) {
+            this.$emit("input", newVal);
+        },
+    },
+    methods: {
+        onHelp() {
+            this.showHelp = true;
+        },
+        onReset() {
+            this.localFilter = "";
+        },
+    },
+};
+</script>

--- a/client/src/components/Indices/SharingIndicators.vue
+++ b/client/src/components/Indices/SharingIndicators.vue
@@ -1,0 +1,40 @@
+<template>
+    <span>
+        <font-awesome-icon
+            v-if="object.published"
+            v-b-tooltip.hover
+            :title="'Published' | localize"
+            icon="globe"
+            @click="$emit('filter', 'is:published')" />
+        <font-awesome-icon
+            v-if="object.shared"
+            v-b-tooltip.hover
+            :title="'Shared' | localize"
+            icon="share-alt"
+            @click="$emit('filter', 'is:shared_with_me')" />
+    </span>
+</template>
+
+<script>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { VBTooltip } from "bootstrap-vue";
+
+import { faShareAlt, faGlobe } from "@fortawesome/free-solid-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+library.add(faGlobe, faShareAlt);
+
+export default {
+    components: {
+        FontAwesomeIcon,
+    },
+    directives: {
+        VBTooltip,
+    },
+    props: {
+        object: {
+            type: Object,
+            required: true,
+        },
+    },
+};
+</script>

--- a/client/src/components/Indices/filtersMixin.js
+++ b/client/src/components/Indices/filtersMixin.js
@@ -1,0 +1,30 @@
+import IndexFilter from "components/Indices/IndexFilter";
+
+export default {
+    components: {
+        IndexFilter,
+    },
+    data() {
+        return {
+            filter: "",
+        };
+    },
+    computed: {
+        isFiltered() {
+            return !!this.filter;
+        },
+    },
+    methods: {
+        appendTagFilter(tag, text) {
+            this.appendFilter(`${tag}:'${text}'`);
+        },
+        appendFilter(text) {
+            const initialFilter = this.filter;
+            if (initialFilter.length === 0) {
+                this.filter = text;
+            } else if (initialFilter.indexOf(text) < 0) {
+                this.filter = `${text} ${initialFilter}`;
+            }
+        },
+    },
+};

--- a/client/src/components/Indices/readme.txt
+++ b/client/src/components/Indices/readme.txt
@@ -1,0 +1,2 @@
+This directory contains utilities for building out grids and lists for arrays of
+Galaxy objects coming from the API.

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -6,6 +6,8 @@ import { getLocalVue } from "jest/helpers";
 import mockInvocationData from "./test/json/invocation.json";
 import { parseISO, formatDistanceToNow } from "date-fns";
 
+import "jest-location-mock";
+
 const localVue = getLocalVue();
 
 describe("Invocations.vue", () => {
@@ -147,10 +149,8 @@ describe("Invocations.vue", () => {
         });
 
         it("calls executeWorkflow", async () => {
-            const mockMethod = jest.fn();
-            wrapper.vm.executeWorkflow = mockMethod;
-            await wrapper.find("#run-workflow").trigger("click");
-            expect(mockMethod).toHaveBeenCalledWith("workflowId");
+            await wrapper.find(".workflow-run").trigger("click");
+            expect(window.location).toBeAt("workflows/run?id=workflowId");
         });
     });
 });

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -41,6 +41,23 @@ describe("Invocations.vue", () => {
         });
     });
 
+    describe("with server error", () => {
+        beforeEach(async () => {
+            axiosMock.onAny().reply(403, { err_msg: "this is a problem" });
+            const propsData = {
+                ownerGrid: false,
+            };
+            wrapper = mount(Invocations, {
+                propsData,
+                localVue,
+            });
+        });
+
+        it("renders error message", async () => {
+            expect(wrapper.find(".index-grid-message").text()).toContain("this is a problem");
+        });
+    });
+
     describe("for a workflow with an empty invocation list", () => {
         beforeEach(async () => {
             axiosMock.onAny().reply(200, [], { total_matches: "0" });

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -132,9 +132,6 @@ export default {
     computed: {
         ...mapGetters(["getWorkflowNameByInstanceId", "getWorkflowByInstanceId"]),
         ...mapGetters("history", ["getHistoryById", "getHistoryNameById"]),
-        apiUrl() {
-            return `${getAppRoot()}api/invocations`;
-        },
         title() {
             let title = `Workflow Invocations`;
             if (this.storedWorkflowName) {
@@ -171,7 +168,7 @@ export default {
         ...mapCacheActions(["fetchWorkflowForInstanceId"]),
         ...mapCacheActions("history", ["loadHistoryById"]),
         provider(ctx) {
-            ctx.apiUrl = this.apiUrl;
+            ctx.root = getAppRoot();
             const extraParams = this.ownerGrid ? {} : { include_terminal: false };
             if (this.storedWorkflowId) {
                 extraParams["workflow_id"] = this.storedWorkflowId;

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -8,17 +8,10 @@
         </b-alert>
         <b-alert class="index-grid-message" :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
         <b-table
-            :id="tableId"
+            v-bind="indexTableAttrs"
             v-model="invocationItemsModel"
             :fields="invocationFields"
             :items="provider"
-            :per-page="perPage"
-            :current-page="currentPage"
-            hover
-            striped
-            caption-top
-            fixed
-            show-empty
             class="invocations-table">
             <template v-slot:empty>
                 <loading-span v-if="loading" message="Loading workflow invocations" />

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -65,12 +65,7 @@
                 <UtcDate :date="data.value" mode="elapsed" />
             </template>
             <template v-slot:cell(execute)="data">
-                <b-button
-                    id="run-workflow"
-                    v-b-tooltip.hover.bottom
-                    title="Run Workflow"
-                    class="workflow-run btn-sm btn-primary fa fa-play"
-                    @click.stop="executeWorkflow(getWorkflowByInstanceId(data.item.workflow_id).id)" />
+                <WorkflowRunButton :id="getWorkflowByInstanceId(data.item.workflow_id).id" :root="root" />
             </template>
         </b-table>
         <b-pagination
@@ -86,6 +81,7 @@ import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import { invocationsProvider } from "components/providers/InvocationsProvider";
 import { WorkflowInvocationState } from "components/WorkflowInvocationState";
+import WorkflowRunButton from "./WorkflowRunButton.vue";
 import UtcDate from "components/UtcDate";
 import { mapCacheActions } from "vuex-cache";
 import { mapGetters } from "vuex";
@@ -95,6 +91,7 @@ export default {
     components: {
         UtcDate,
         WorkflowInvocationState,
+        WorkflowRunButton,
     },
     mixins: [paginationMixin],
     props: {
@@ -121,6 +118,7 @@ export default {
             invocationItemsModel: [],
             invocationFields: fields,
             perPage: this.rowsPerPage(50),
+            root: getAppRoot(),
         };
     },
     computed: {
@@ -162,7 +160,7 @@ export default {
         ...mapCacheActions(["fetchWorkflowForInstanceId"]),
         ...mapCacheActions("history", ["loadHistoryById"]),
         async provider(ctx) {
-            ctx.root = getAppRoot();
+            ctx.root = this.root;
             const extraParams = this.ownerGrid ? {} : { include_terminal: false };
             if (this.storedWorkflowId) {
                 extraParams["workflow_id"] = this.storedWorkflowId;
@@ -177,9 +175,6 @@ export default {
         },
         swapRowDetails(row) {
             row.toggleDetails();
-        },
-        executeWorkflow: function (workflowId) {
-            window.location = `${getAppRoot()}workflows/run?id=${workflowId}`;
         },
         switchHistory(historyId) {
             const Galaxy = getGalaxyInstance();

--- a/client/src/components/Workflow/WorkflowBookmark.vue
+++ b/client/src/components/Workflow/WorkflowBookmark.vue
@@ -1,0 +1,53 @@
+<template>
+    <b-link @click="onClick" v-b-tooltip.hover :title="title">
+        <font-awesome-icon :icon="['fas', 'star']" v-if="checked" />
+        <font-awesome-icon :icon="['far', 'star']" v-else />
+    </b-link>
+</template>
+
+<script>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BLink } from "bootstrap-vue";
+import { VBTooltip } from "bootstrap-vue";
+
+import { faStar } from "@fortawesome/free-solid-svg-icons";
+import { faStar as farStar } from "@fortawesome/free-regular-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+library.add(faStar, farStar);
+
+const CHECKED_DESCRIPTION =
+    "This workflow is currently bookmarked, click this link to remove this bookmark for this workflow.";
+const UNCHECKED_DESCRIPTION =
+    "This workflow is not currently bookmarked, click this link to add a bookmark for this workflow.";
+const BOOKMARKS_DESCRIPTION = "Workflows that are bookmarked will appear in your Galaxy tool panel for quick access.";
+
+export default {
+    props: {
+        checked: {
+            type: Boolean,
+            required: true,
+        },
+    },
+    components: {
+        BLink,
+        FontAwesomeIcon,
+    },
+    directives: {
+        VBTooltip,
+    },
+    computed: {
+        title() {
+            if (this.checked) {
+                return `${CHECKED_DESCRIPTION} ${BOOKMARKS_DESCRIPTION}`;
+            } else {
+                return `${UNCHECKED_DESCRIPTION} ${BOOKMARKS_DESCRIPTION}`;
+            }
+        },
+    },
+    methods: {
+        onClick() {
+            this.$emit("bookmark", !this.checked);
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/WorkflowIndexActions.test.js
+++ b/client/src/components/Workflow/WorkflowIndexActions.test.js
@@ -1,0 +1,33 @@
+import WorkflowIndexActions from "./WorkflowIndexActions";
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+
+import "jest-location-mock";
+
+const localVue = getLocalVue();
+
+describe("WorkflowIndexActions.vue", () => {
+    let wrapper;
+
+    beforeEach(async () => {
+        const propsData = {
+            root: "/root/",
+        };
+        wrapper = shallowMount(WorkflowIndexActions, {
+            propsData,
+            localVue,
+        });
+    });
+
+    describe("naviation", () => {
+        it("should create a workflow when create is clicked", async () => {
+            await wrapper.find("#workflow-create").trigger("click");
+            expect(window.location).toBeAt("/root/workflows/create");
+        });
+
+        it("should import a workflow when create is clicked", async () => {
+            await wrapper.find("#workflow-import").trigger("click");
+            expect(window.location).toBeAt("/root/workflows/import");
+        });
+    });
+});

--- a/client/src/components/Workflow/WorkflowIndexActions.vue
+++ b/client/src/components/Workflow/WorkflowIndexActions.vue
@@ -1,10 +1,10 @@
 <template>
     <span>
-        <b-button id="workflow-create" class="m-1" @click="createWorkflow">
+        <b-button id="workflow-create" class="m-1" @click="navigateToCreate">
             <font-awesome-icon icon="plus" />
             {{ "Create" | localize }}
         </b-button>
-        <b-button id="workflow-import" class="m-1" @click="importWorkflow">
+        <b-button id="workflow-import" class="m-1" @click="navigateToImport">
             <font-awesome-icon icon="upload" />
             {{ "Import" | localize }}
         </b-button>
@@ -31,10 +31,10 @@ export default {
         },
     },
     methods: {
-        createWorkflow: function () {
+        navigateToCreate: function () {
             window.location.assign(`${this.root}workflows/create`);
         },
-        importWorkflow: function () {
+        navigateToImport: function () {
             window.location.assign(`${this.root}workflows/import`);
         },
     },

--- a/client/src/components/Workflow/WorkflowIndexActions.vue
+++ b/client/src/components/Workflow/WorkflowIndexActions.vue
@@ -1,0 +1,42 @@
+<template>
+    <span>
+        <b-button id="workflow-create" class="m-1" @click="createWorkflow">
+            <font-awesome-icon icon="plus" />
+            {{ "Create" | localize }}
+        </b-button>
+        <b-button id="workflow-import" class="m-1" @click="importWorkflow">
+            <font-awesome-icon icon="upload" />
+            {{ "Import" | localize }}
+        </b-button>
+    </span>
+</template>
+
+<script>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BButton } from "bootstrap-vue";
+
+import { faPlus, faUpload } from "@fortawesome/free-solid-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+library.add(faPlus, faUpload);
+
+export default {
+    components: {
+        BButton,
+        FontAwesomeIcon,
+    },
+    props: {
+        root: {
+            type: String,
+            required: true,
+        },
+    },
+    methods: {
+        createWorkflow: function () {
+            window.location.assign(`${this.root}workflows/create`);
+        },
+        importWorkflow: function () {
+            window.location.assign(`${this.root}workflows/import`);
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -12,16 +12,7 @@
                 </index-filter>
             </b-col>
             <b-col>
-                <span class="float-right">
-                    <b-button id="workflow-create" class="m-1" @click="createWorkflow">
-                        <font-awesome-icon icon="plus" />
-                        {{ titleCreate }}
-                    </b-button>
-                    <b-button id="workflow-import" class="m-1" @click="importWorkflow">
-                        <font-awesome-icon icon="upload" />
-                        {{ titleImport }}
-                    </b-button>
-                </span>
+                <WorkflowIndexActions :root="root" class="float-right"> </WorkflowIndexActions>
             </b-col>
         </b-row>
         <b-table
@@ -102,7 +93,7 @@
 import _l from "utils/localization";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faPlus, faShareAlt, faGlobe, faUpload, faSpinner, faStar } from "@fortawesome/free-solid-svg-icons";
+import { faShareAlt, faGlobe, faStar } from "@fortawesome/free-solid-svg-icons";
 import { faStar as farStar } from "@fortawesome/free-regular-svg-icons";
 import { getAppRoot } from "onload/loadConfig";
 import { Services } from "./services";
@@ -113,8 +104,9 @@ import UtcDate from "components/UtcDate";
 import { getGalaxyInstance } from "app";
 import paginationMixin from "./paginationMixin";
 import IndexFilter from "components/Indices/IndexFilter";
+import WorkflowIndexActions from "./WorkflowIndexActions";
 
-library.add(faPlus, faUpload, faSpinner, faGlobe, faShareAlt, farStar, faStar);
+library.add(faGlobe, faShareAlt, farStar, faStar);
 
 const helpHtml = `<div>
 <p>This textbox box can be used to filter the workflows displayed.
@@ -149,6 +141,7 @@ export default {
         Tags,
         WorkflowDropdown,
         IndexFilter,
+        WorkflowIndexActions,
     },
     props: {
         inputDebounceDelay: {
@@ -195,8 +188,6 @@ export default {
             filter: "",
             loading: true,
             titleSearchWorkflows: _l("Search Workflows"),
-            titleCreate: _l("Create"),
-            titleImport: _l("Import"),
             titleRunWorkflow: _l("Run workflow"),
             workflowItemsModel: [],
             workflowItems: [],
@@ -228,12 +219,6 @@ export default {
             const promise = storedWorkflowsProvider(ctx, this.setRows, extraParams).catch(this.onError);
             this.workflowItems = await promise;
             return this.workflowItems;
-        },
-        createWorkflow: function (workflow) {
-            window.location = `${this.root}workflows/create`;
-        },
-        importWorkflow: function (workflow) {
-            window.location = `${this.root}workflows/import`;
         },
         executeWorkflow: function (workflow) {
             window.location = `${this.root}workflows/run?id=${workflow.id}`;

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -50,18 +50,7 @@
                 <Tags :index="row.index" :tags="row.item.tags" @input="onTags" @tag-click="onTagClick" />
             </template>
             <template v-slot:cell(published)="row">
-                <font-awesome-icon
-                    v-if="row.item.published"
-                    v-b-tooltip.hover
-                    title="Published"
-                    icon="globe"
-                    @click="appendFilter('is:published')" />
-                <font-awesome-icon
-                    v-if="row.item.shared"
-                    v-b-tooltip.hover
-                    title="Shared"
-                    icon="share-alt"
-                    @click="appendFilter('is:shared_with_me')" />
+                <SharingIndicators :object="row.item" @filter="(filter) => appendFilter(filter)" />
             </template>
             <template v-slot:cell(show_in_tool_panel)="row">
                 <WorkflowBookmark
@@ -88,9 +77,6 @@
 </template>
 <script>
 import _l from "utils/localization";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faShareAlt, faGlobe } from "@fortawesome/free-solid-svg-icons";
 import { getAppRoot } from "onload/loadConfig";
 import { Services } from "./services";
 import { storedWorkflowsProvider } from "components/providers/StoredWorkflowsProvider";
@@ -102,8 +88,7 @@ import paginationMixin from "./paginationMixin";
 import IndexFilter from "components/Indices/IndexFilter";
 import WorkflowIndexActions from "./WorkflowIndexActions";
 import WorkflowBookmark from "./WorkflowBookmark";
-
-library.add(faGlobe, faShareAlt);
+import SharingIndicators from "components/Indices/SharingIndicators";
 
 const helpHtml = `<div>
 <p>This textbox box can be used to filter the workflows displayed.
@@ -133,13 +118,13 @@ returned. So <code>name:'RNAseq'</code> would show only workflows named exactly 
 
 export default {
     components: {
-        FontAwesomeIcon,
         UtcDate,
         Tags,
         WorkflowDropdown,
         IndexFilter,
         WorkflowBookmark,
         WorkflowIndexActions,
+        SharingIndicators,
     },
     props: {
         inputDebounceDelay: {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -15,18 +15,7 @@
                 <WorkflowIndexActions :root="root" class="float-right"> </WorkflowIndexActions>
             </b-col>
         </b-row>
-        <b-table
-            :id="tableId"
-            :fields="fields"
-            :items="provider"
-            v-model="workflowItemsModel"
-            :per-page="perPage"
-            :current-page="currentPage"
-            hover
-            striped
-            caption-top
-            fixed
-            show-empty>
+        <b-table :fields="fields" :items="provider" v-model="workflowItemsModel" v-bind="indexTableAttrs">
             <template v-slot:empty>
                 <loading-span v-if="loading" message="Loading workflows" />
                 <b-alert v-else id="no-workflows" variant="info" show>

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -2,7 +2,7 @@
     <div>
         <b-alert class="index-grid-message" :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
         <b-row class="mb-3">
-            <b-col cols="6">
+            <b-col cols="6" class="m-1">
                 <index-filter
                     :debounce-delay="inputDebounceDelay"
                     id="workflow-search"

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -211,9 +211,6 @@ export default {
         showNotAvailable() {
             return !this.filter;
         },
-        apiUrl() {
-            return `${getAppRoot()}api/workflows`;
-        },
     },
     created() {
         this.root = getAppRoot();
@@ -226,7 +223,7 @@ export default {
     },
     methods: {
         async provider(ctx) {
-            ctx.apiUrl = this.apiUrl;
+            ctx.root = this.root;
             const extraParams = { search: this.filter, skip_step_counts: true };
             const promise = storedWorkflowsProvider(ctx, this.setRows, extraParams).catch(this.onError);
             this.workflowItems = await promise;

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -6,7 +6,7 @@
                 <index-filter
                     :debounce-delay="inputDebounceDelay"
                     id="workflow-search"
-                    :placeholder="titleSearchWorkflows"
+                    :placeholder="titleSearch"
                     :help-html="helpHtml"
                     v-model="filter">
                 </index-filter>
@@ -123,7 +123,6 @@ export default {
     data() {
         return {
             tableId: "workflow-table",
-            error: null,
             fields: [
                 {
                     key: "name",
@@ -155,8 +154,7 @@ export default {
                     label: "",
                 },
             ],
-            loading: true,
-            titleSearchWorkflows: _l("Search Workflows"),
+            titleSearch: _l("Search Workflows"),
             workflowItemsModel: [],
             workflowItems: [],
             helpHtml: helpHtml,
@@ -212,7 +210,6 @@ export default {
             workflow.tags = tags;
             this.services
                 .updateWorkflow(workflow.id, {
-                    show_in_tool_panel: workflow.show_in_tool_panel,
                     tags: workflow.tags,
                 })
                 .catch((error) => {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -30,11 +30,11 @@
             <template v-slot:empty>
                 <loading-span v-if="loading" message="Loading workflows" />
                 <b-alert v-else id="no-workflows" variant="info" show>
-                    <div v-if="showNotFound">
+                    <div v-if="isFiltered">
                         No matching entries found for: <span class="font-weight-bold">{{ filter }}</span
                         >.
                     </div>
-                    <div v-if="showNotAvailable">No workflows found. You may create or import new workflows.</div>
+                    <div v-else>No workflows found. You may create or import new workflows.</div>
                 </b-alert>
             </template>
             <template v-slot:cell(name)="row">
@@ -85,7 +85,7 @@ import WorkflowDropdown from "./WorkflowDropdown";
 import UtcDate from "components/UtcDate";
 import { getGalaxyInstance } from "app";
 import paginationMixin from "./paginationMixin";
-import IndexFilter from "components/Indices/IndexFilter";
+import filtersMixin from "components/Indices/filtersMixin";
 import WorkflowIndexActions from "./WorkflowIndexActions";
 import WorkflowBookmark from "./WorkflowBookmark";
 import SharingIndicators from "components/Indices/SharingIndicators";
@@ -121,7 +121,6 @@ export default {
         UtcDate,
         Tags,
         WorkflowDropdown,
-        IndexFilter,
         WorkflowBookmark,
         WorkflowIndexActions,
         SharingIndicators,
@@ -132,7 +131,7 @@ export default {
             default: 500,
         },
     },
-    mixins: [paginationMixin],
+    mixins: [paginationMixin, filtersMixin],
     data() {
         return {
             tableId: "workflow-table",
@@ -168,7 +167,6 @@ export default {
                     label: "",
                 },
             ],
-            filter: "",
             loading: true,
             titleSearchWorkflows: _l("Search Workflows"),
             titleRunWorkflow: _l("Run workflow"),
@@ -177,14 +175,6 @@ export default {
             helpHtml: helpHtml,
             perPage: this.rowsPerPage(50),
         };
-    },
-    computed: {
-        showNotFound() {
-            return this.filter;
-        },
-        showNotAvailable() {
-            return !this.filter;
-        },
     },
     created() {
         this.root = getAppRoot();
@@ -246,16 +236,7 @@ export default {
                 });
         },
         onTagClick: function (tag) {
-            const tagFilter = `tag:'${tag.text}'`;
-            this.appendFilter(tagFilter);
-        },
-        appendFilter(text) {
-            const initialFilter = this.filter;
-            if (initialFilter.length === 0) {
-                this.filter = text;
-            } else if (initialFilter.indexOf(text) < 0) {
-                this.filter = `${text} ${initialFilter}`;
-            }
+            this.appendTagFilter("tag", tag.text);
         },
         onAdd: function (workflow) {
             if (this.currentPage == 1) {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -5,14 +5,13 @@
             <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
             <b-row class="mb-3">
                 <b-col cols="6">
-                    <b-input
+                    <index-filter
+                        :debounce-delay="inputDebounceDelay"
                         id="workflow-search"
-                        class="m-1"
-                        name="query"
                         :placeholder="titleSearchWorkflows"
-                        autocomplete="off"
-                        type="text"
-                        v-model="filter" />
+                        :help-html="helpHtml"
+                        v-model="filter">
+                    </index-filter>
                 </b-col>
                 <b-col>
                     <span class="float-right">
@@ -116,8 +115,35 @@ import WorkflowDropdown from "./WorkflowDropdown";
 import UtcDate from "components/UtcDate";
 import { getGalaxyInstance } from "app";
 import paginationMixin from "./paginationMixin";
+import IndexFilter from "components/Indices/IndexFilter";
 
 library.add(faPlus, faUpload, faSpinner, faGlobe, faShareAlt, farStar, faStar);
+
+const helpHtml = `<div>
+<p>This textbox box can be used to filter the workflows displayed.
+
+<p>Text entered here will be searched against workflow names and tags. Additionally, advanced
+filtering tags can be used to refine the search more precisely. Tags are of the form
+<code>&lt;tag_name&gt;:&lt;tag_value&gt;</code> or <code>&lt;tag_name&gt;:'&lt;tag_value&gt;'</code>.
+For instance to search just for RNAseq in the workflow name, <code>name:rnsseq</code> can be used.
+Notice by default the search is not case-sensitive.
+
+If the quoted version of tag is used, the search is not case sensitive and only full matches will be
+returned. So <code>name:'RNAseq'</code> would show only workflows named exactly <code>RNAseq</code>.
+
+<p>The available tags are:
+<dl>
+    <dt><code>name</code></dt>
+    <dd>This filters only against the workflow name.</dd>
+    <dt><code>tag</code></dt>
+    <dd>This filters only against the workflow tag. You may also just click on a tag in your list of workflows to filter on that tag using this directly.</dd>
+    <dt><code>is:published</code></dt>
+    <dd>This filters the workflows such that only published workflows are shown. You may also just click on the "published" icon of a worklfow in your list to filter on this directly.</dd>
+    <dt><code>is:shared</code></dt>
+    <dd>This filters the workflows such that only workflows shared from another user directly with you are are shown. You may also just click on the "shared with me" icon of a worklfow in your list to filter on this directly.</dd>
+</dl>
+</div>
+`;
 
 export default {
     components: {
@@ -125,6 +151,13 @@ export default {
         UtcDate,
         Tags,
         WorkflowDropdown,
+        IndexFilter,
+    },
+    props: {
+        inputDebounceDelay: {
+            type: Number,
+            default: 500,
+        },
     },
     mixins: [paginationMixin],
     data() {
@@ -172,6 +205,7 @@ export default {
             titleRunWorkflow: _l("Run workflow"),
             workflowItemsModel: [],
             workflowItems: [],
+            helpHtml: helpHtml,
             perPage: this.rowsPerPage(50),
         };
     },

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -64,12 +64,9 @@
                     @click="appendFilter('is:shared_with_me')" />
             </template>
             <template v-slot:cell(show_in_tool_panel)="row">
-                <b-link @click="bookmarkWorkflow(row.item, false)" v-if="row.item.show_in_tool_panel">
-                    <font-awesome-icon :icon="['fas', 'star']" />
-                </b-link>
-                <b-link @click="bookmarkWorkflow(row.item, true)" v-else>
-                    <font-awesome-icon :icon="['far', 'star']" />
-                </b-link>
+                <WorkflowBookmark
+                    :checked="row.item.show_in_tool_panel"
+                    @bookmark="(checked) => bookmarkWorkflow(row.item.id, checked)" />
             </template>
             <template v-slot:cell(update_time)="data">
                 <UtcDate :date="data.value" mode="elapsed" />
@@ -93,8 +90,7 @@
 import _l from "utils/localization";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faShareAlt, faGlobe, faStar } from "@fortawesome/free-solid-svg-icons";
-import { faStar as farStar } from "@fortawesome/free-regular-svg-icons";
+import { faShareAlt, faGlobe } from "@fortawesome/free-solid-svg-icons";
 import { getAppRoot } from "onload/loadConfig";
 import { Services } from "./services";
 import { storedWorkflowsProvider } from "components/providers/StoredWorkflowsProvider";
@@ -105,8 +101,9 @@ import { getGalaxyInstance } from "app";
 import paginationMixin from "./paginationMixin";
 import IndexFilter from "components/Indices/IndexFilter";
 import WorkflowIndexActions from "./WorkflowIndexActions";
+import WorkflowBookmark from "./WorkflowBookmark";
 
-library.add(faGlobe, faShareAlt, farStar, faStar);
+library.add(faGlobe, faShareAlt);
 
 const helpHtml = `<div>
 <p>This textbox box can be used to filter the workflows displayed.
@@ -141,6 +138,7 @@ export default {
         Tags,
         WorkflowDropdown,
         IndexFilter,
+        WorkflowBookmark,
         WorkflowIndexActions,
     },
     props: {
@@ -223,8 +221,7 @@ export default {
         executeWorkflow: function (workflow) {
             window.location = `${this.root}workflows/run?id=${workflow.id}`;
         },
-        bookmarkWorkflow: function (workflow, checked) {
-            const id = workflow.id;
+        bookmarkWorkflow: function (id, checked) {
             const data = {
                 show_in_tool_panel: checked,
             };

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -110,7 +110,6 @@ import { storedWorkflowsProvider } from "components/providers/StoredWorkflowsPro
 import Tags from "components/Common/Tags";
 import WorkflowDropdown from "./WorkflowDropdown";
 import UtcDate from "components/UtcDate";
-import { errorMessageAsString } from "utils/simple-error";
 import { getGalaxyInstance } from "app";
 import paginationMixin from "./paginationMixin";
 import IndexFilter from "components/Indices/IndexFilter";
@@ -195,8 +194,6 @@ export default {
             ],
             filter: "",
             loading: true,
-            message: null,
-            messageVariant: null,
             titleSearchWorkflows: _l("Search Workflows"),
             titleCreate: _l("Create"),
             titleImport: _l("Import"),
@@ -213,9 +210,6 @@ export default {
         },
         showNotAvailable() {
             return !this.filter;
-        },
-        showMessage() {
-            return !!this.message;
         },
         apiUrl() {
             return `${getAppRoot()}api/workflows`;
@@ -311,14 +305,6 @@ export default {
         },
         onUpdate: function (id, data) {
             this.refresh();
-        },
-        onSuccess: function (message) {
-            this.message = message;
-            this.messageVariant = "success";
-        },
-        onError: function (message) {
-            this.message = errorMessageAsString(message);
-            this.messageVariant = "danger";
         },
     },
 };

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
+        <b-alert class="index-grid-message" :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
         <b-row class="mb-3">
             <b-col cols="6">
                 <index-filter
@@ -110,6 +110,7 @@ import { storedWorkflowsProvider } from "components/providers/StoredWorkflowsPro
 import Tags from "components/Common/Tags";
 import WorkflowDropdown from "./WorkflowDropdown";
 import UtcDate from "components/UtcDate";
+import { errorMessageAsString } from "utils/simple-error";
 import { getGalaxyInstance } from "app";
 import paginationMixin from "./paginationMixin";
 import IndexFilter from "components/Indices/IndexFilter";
@@ -233,7 +234,8 @@ export default {
         async provider(ctx) {
             ctx.apiUrl = this.apiUrl;
             const extraParams = { search: this.filter, skip_step_counts: true };
-            this.workflowItems = await storedWorkflowsProvider(ctx, this.setRows, extraParams);
+            const promise = storedWorkflowsProvider(ctx, this.setRows, extraParams).catch(this.onError);
+            this.workflowItems = await promise;
             return this.workflowItems;
         },
         createWorkflow: function (workflow) {
@@ -315,7 +317,7 @@ export default {
             this.messageVariant = "success";
         },
         onError: function (message) {
-            this.message = message;
+            this.message = errorMessageAsString(message);
             this.messageVariant = "danger";
         },
     },

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -1,104 +1,101 @@
 <template>
     <div>
-        <div v-if="error" class="alert alert-danger" show>{{ error }}</div>
-        <div v-else>
-            <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
-            <b-row class="mb-3">
-                <b-col cols="6">
-                    <index-filter
-                        :debounce-delay="inputDebounceDelay"
-                        id="workflow-search"
-                        :placeholder="titleSearchWorkflows"
-                        :help-html="helpHtml"
-                        v-model="filter">
-                    </index-filter>
-                </b-col>
-                <b-col>
-                    <span class="float-right">
-                        <b-button id="workflow-create" class="m-1" @click="createWorkflow">
-                            <font-awesome-icon icon="plus" />
-                            {{ titleCreate }}
-                        </b-button>
-                        <b-button id="workflow-import" class="m-1" @click="importWorkflow">
-                            <font-awesome-icon icon="upload" />
-                            {{ titleImport }}
-                        </b-button>
-                    </span>
-                </b-col>
-            </b-row>
-            <b-table
-                :id="tableId"
-                :fields="fields"
-                :items="provider"
-                v-model="workflowItemsModel"
-                :per-page="perPage"
-                :current-page="currentPage"
-                hover
-                striped
-                caption-top
-                fixed
-                show-empty>
-                <template v-slot:empty>
-                    <loading-span v-if="loading" message="Loading workflows" />
-                    <b-alert v-else id="no-workflows" variant="info" show>
-                        <div v-if="showNotFound">
-                            No matching entries found for: <span class="font-weight-bold">{{ filter }}</span
-                            >.
-                        </div>
-                        <div v-if="showNotAvailable">No workflows found. You may create or import new workflows.</div>
-                    </b-alert>
-                </template>
-                <template v-slot:cell(name)="row">
-                    <WorkflowDropdown
-                        :workflow="row.item"
-                        @onAdd="onAdd"
-                        @onRemove="onRemove"
-                        @onUpdate="onUpdate"
-                        @onSuccess="onSuccess"
-                        @onError="onError" />
-                </template>
-                <template v-slot:cell(tags)="row">
-                    <Tags :index="row.index" :tags="row.item.tags" @input="onTags" @tag-click="onTagClick" />
-                </template>
-                <template v-slot:cell(published)="row">
-                    <font-awesome-icon
-                        v-if="row.item.published"
-                        v-b-tooltip.hover
-                        title="Published"
-                        icon="globe"
-                        @click="appendFilter('is:published')" />
-                    <font-awesome-icon
-                        v-if="row.item.shared"
-                        v-b-tooltip.hover
-                        title="Shared"
-                        icon="share-alt"
-                        @click="appendFilter('is:shared_with_me')" />
-                </template>
-                <template v-slot:cell(show_in_tool_panel)="row">
-                    <b-link @click="bookmarkWorkflow(row.item, false)" v-if="row.item.show_in_tool_panel">
-                        <font-awesome-icon :icon="['fas', 'star']" />
-                    </b-link>
-                    <b-link @click="bookmarkWorkflow(row.item, true)" v-else>
-                        <font-awesome-icon :icon="['far', 'star']" />
-                    </b-link>
-                </template>
-                <template v-slot:cell(update_time)="data">
-                    <UtcDate :date="data.value" mode="elapsed" />
-                </template>
-                <template v-slot:cell(execute)="row">
-                    <b-button
-                        v-b-tooltip.hover.bottom
-                        :title="titleRunWorkflow"
-                        class="workflow-run btn-sm btn-primary fa fa-play"
-                        @click.stop="executeWorkflow(row.item)" />
-                </template>
-            </b-table>
-            <b-pagination
-                v-model="currentPage"
-                v-show="rows >= perPage"
-                class="gx-workflows-grid-pager"
-                v-bind="paginationAttrs"></b-pagination>
-        </div>
+        <b-alert :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
+        <b-row class="mb-3">
+            <b-col cols="6">
+                <index-filter
+                    :debounce-delay="inputDebounceDelay"
+                    id="workflow-search"
+                    :placeholder="titleSearchWorkflows"
+                    :help-html="helpHtml"
+                    v-model="filter">
+                </index-filter>
+            </b-col>
+            <b-col>
+                <span class="float-right">
+                    <b-button id="workflow-create" class="m-1" @click="createWorkflow">
+                        <font-awesome-icon icon="plus" />
+                        {{ titleCreate }}
+                    </b-button>
+                    <b-button id="workflow-import" class="m-1" @click="importWorkflow">
+                        <font-awesome-icon icon="upload" />
+                        {{ titleImport }}
+                    </b-button>
+                </span>
+            </b-col>
+        </b-row>
+        <b-table
+            :id="tableId"
+            :fields="fields"
+            :items="provider"
+            v-model="workflowItemsModel"
+            :per-page="perPage"
+            :current-page="currentPage"
+            hover
+            striped
+            caption-top
+            fixed
+            show-empty>
+            <template v-slot:empty>
+                <loading-span v-if="loading" message="Loading workflows" />
+                <b-alert v-else id="no-workflows" variant="info" show>
+                    <div v-if="showNotFound">
+                        No matching entries found for: <span class="font-weight-bold">{{ filter }}</span
+                        >.
+                    </div>
+                    <div v-if="showNotAvailable">No workflows found. You may create or import new workflows.</div>
+                </b-alert>
+            </template>
+            <template v-slot:cell(name)="row">
+                <WorkflowDropdown
+                    :workflow="row.item"
+                    @onAdd="onAdd"
+                    @onRemove="onRemove"
+                    @onUpdate="onUpdate"
+                    @onSuccess="onSuccess"
+                    @onError="onError" />
+            </template>
+            <template v-slot:cell(tags)="row">
+                <Tags :index="row.index" :tags="row.item.tags" @input="onTags" @tag-click="onTagClick" />
+            </template>
+            <template v-slot:cell(published)="row">
+                <font-awesome-icon
+                    v-if="row.item.published"
+                    v-b-tooltip.hover
+                    title="Published"
+                    icon="globe"
+                    @click="appendFilter('is:published')" />
+                <font-awesome-icon
+                    v-if="row.item.shared"
+                    v-b-tooltip.hover
+                    title="Shared"
+                    icon="share-alt"
+                    @click="appendFilter('is:shared_with_me')" />
+            </template>
+            <template v-slot:cell(show_in_tool_panel)="row">
+                <b-link @click="bookmarkWorkflow(row.item, false)" v-if="row.item.show_in_tool_panel">
+                    <font-awesome-icon :icon="['fas', 'star']" />
+                </b-link>
+                <b-link @click="bookmarkWorkflow(row.item, true)" v-else>
+                    <font-awesome-icon :icon="['far', 'star']" />
+                </b-link>
+            </template>
+            <template v-slot:cell(update_time)="data">
+                <UtcDate :date="data.value" mode="elapsed" />
+            </template>
+            <template v-slot:cell(execute)="row">
+                <b-button
+                    v-b-tooltip.hover.bottom
+                    :title="titleRunWorkflow"
+                    class="workflow-run btn-sm btn-primary fa fa-play"
+                    @click.stop="executeWorkflow(row.item)" />
+            </template>
+        </b-table>
+        <b-pagination
+            v-model="currentPage"
+            v-show="rows >= perPage"
+            class="gx-workflows-grid-pager"
+            v-bind="paginationAttrs"></b-pagination>
     </div>
 </template>
 <script>

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -50,11 +50,7 @@
                 <UtcDate :date="data.value" mode="elapsed" />
             </template>
             <template v-slot:cell(execute)="row">
-                <b-button
-                    v-b-tooltip.hover.bottom
-                    :title="titleRunWorkflow"
-                    class="workflow-run btn-sm btn-primary fa fa-play"
-                    @click.stop="executeWorkflow(row.item)" />
+                <WorkflowRunButton :root="root" :id="row.item.id" />
             </template>
         </b-table>
         <b-pagination
@@ -77,6 +73,8 @@ import paginationMixin from "./paginationMixin";
 import filtersMixin from "components/Indices/filtersMixin";
 import WorkflowIndexActions from "./WorkflowIndexActions";
 import WorkflowBookmark from "./WorkflowBookmark";
+import WorkflowRunButton from "./WorkflowRunButton.vue";
+
 import SharingIndicators from "components/Indices/SharingIndicators";
 
 const helpHtml = `<div>
@@ -113,6 +111,7 @@ export default {
         WorkflowBookmark,
         WorkflowIndexActions,
         SharingIndicators,
+        WorkflowRunButton,
     },
     props: {
         inputDebounceDelay: {
@@ -158,7 +157,6 @@ export default {
             ],
             loading: true,
             titleSearchWorkflows: _l("Search Workflows"),
-            titleRunWorkflow: _l("Run workflow"),
             workflowItemsModel: [],
             workflowItems: [],
             helpHtml: helpHtml,
@@ -181,9 +179,6 @@ export default {
             const promise = storedWorkflowsProvider(ctx, this.setRows, extraParams).catch(this.onError);
             this.workflowItems = await promise;
             return this.workflowItems;
-        },
-        executeWorkflow: function (workflow) {
-            window.location = `${this.root}workflows/run?id=${workflow.id}`;
         },
         bookmarkWorkflow: function (id, checked) {
             const data = {

--- a/client/src/components/Workflow/WorkflowRunButton.vue
+++ b/client/src/components/Workflow/WorkflowRunButton.vue
@@ -1,0 +1,41 @@
+<template>
+    <b-button
+        v-b-tooltip.hover.bottom
+        :title="title | localize"
+        class="workflow-run btn-sm btn-primary fa fa-play"
+        @click.stop="executeWorkflow" />
+</template>
+
+<script>
+import { BButton } from "bootstrap-vue";
+import { VBTooltip } from "bootstrap-vue";
+
+export default {
+    props: {
+        id: {
+            type: String,
+            required: true,
+        },
+        root: {
+            type: String,
+            required: true,
+        },
+    },
+    components: {
+        BButton,
+    },
+    directives: {
+        VBTooltip,
+    },
+    computed: {
+        title() {
+            return "Run workflow";
+        },
+    },
+    methods: {
+        executeWorkflow() {
+            window.location.assign(`${this.root}workflows/run?id=${this.id}`);
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/Workflows.test.js
+++ b/client/src/components/Workflow/Workflows.test.js
@@ -47,6 +47,24 @@ describe("WorkflowList.vue", () => {
         });
     });
 
+    describe(" with server error", () => {
+        beforeEach(async () => {
+            axiosMock
+                .onGet("/api/workflows", { params: { limit: 50, offset: 0, skip_step_counts: true, search: "" } })
+                .reply(403, { err_msg: "this is a problem" });
+            const propsData = {};
+            wrapper = mount(Workflows, {
+                propsData,
+                localVue,
+            });
+            flushPromises();
+        });
+
+        it("renders error message", async () => {
+            expect(wrapper.find(".index-grid-message").text()).toContain("this is a problem");
+        });
+    });
+
     describe(" with single workflow", () => {
         beforeEach(async () => {
             axiosMock

--- a/client/src/components/Workflow/Workflows.test.js
+++ b/client/src/components/Workflow/Workflows.test.js
@@ -52,7 +52,9 @@ describe("WorkflowList.vue", () => {
             axiosMock
                 .onGet("/api/workflows", { params: { limit: 50, offset: 0, skip_step_counts: true, search: "" } })
                 .reply(200, mockWorkflowsData, { total_matches: "1" });
-            const propsData = {};
+            const propsData = {
+                inputDebounceDelay: 0,
+            };
             wrapper = mount(Workflows, {
                 propsData,
                 localVue,
@@ -90,8 +92,9 @@ describe("WorkflowList.vue", () => {
                 .onGet("/api/workflows", { params: { limit: 50, offset: 0, skip_step_counts: true, search: "mytext" } })
                 .reply(200, [], { total_matches: "0" });
 
-            wrapper.find("#workflow-search").setValue("mytext");
+            await wrapper.find("#workflow-search").setValue("mytext");
             flushPromises();
+            expect(wrapper.find("#workflow-search").element.value).toBe("mytext");
             expect(wrapper.vm.filter).toBe("mytext");
         });
 

--- a/client/src/components/Workflow/Workflows.test.js
+++ b/client/src/components/Workflow/Workflows.test.js
@@ -17,6 +17,7 @@ const mockWorkflowsData = [
         tags: ["tagmoo", "tagcow"],
         published: true,
         shared: true,
+        show_in_tool_panel: true,
     },
 ];
 

--- a/client/src/components/Workflow/paginationMixin.js
+++ b/client/src/components/Workflow/paginationMixin.js
@@ -29,6 +29,18 @@ export default {
                 "total-rows": this.rows,
             };
         },
+        indexTableAttrs() {
+            return {
+                hover: true,
+                striped: true,
+                "caption-top": true,
+                fixed: true,
+                "show-empty": true,
+                id: this.tableId,
+                "per-page": this.perPage,
+                "current-page": this.currentPage,
+            };
+        },
         showMessage() {
             return !!this.message;
         },

--- a/client/src/components/Workflow/paginationMixin.js
+++ b/client/src/components/Workflow/paginationMixin.js
@@ -1,5 +1,6 @@
 import QueryStringParsing from "utils/query-string-parsing";
 import LoadingSpan from "components/LoadingSpan";
+import { errorMessageAsString } from "utils/simple-error";
 
 export default {
     components: { LoadingSpan },
@@ -9,6 +10,8 @@ export default {
             perPage: 20,
             rows: 0,
             loading: true,
+            message: null,
+            messageVariant: null,
         };
     },
     computed: {
@@ -26,6 +29,9 @@ export default {
                 "total-rows": this.rows,
             };
         },
+        showMessage() {
+            return !!this.message;
+        },
     },
     methods: {
         refresh() {
@@ -38,6 +44,14 @@ export default {
         rowsPerPage(defaultPerPage) {
             const queryRowsPerPage = QueryStringParsing.get("rows_per_page");
             return queryRowsPerPage || defaultPerPage;
+        },
+        onSuccess: function (message) {
+            this.message = message;
+            this.messageVariant = "success";
+        },
+        onError: function (message) {
+            this.message = errorMessageAsString(message);
+            this.messageVariant = "danger";
         },
     },
 };

--- a/client/src/components/providers/InvocationsProvider.js
+++ b/client/src/components/providers/InvocationsProvider.js
@@ -2,8 +2,9 @@ import axios from "axios";
 import { cleanPaginationParameters } from "./utils";
 
 export function invocationsProvider(ctx, callback, extraParams) {
-    const { apiUrl, ...requestParams } = ctx;
+    const { root, ...requestParams } = ctx;
     const cleanParams = cleanPaginationParameters(requestParams);
+    const apiUrl = `${root}api/invocations`;
     const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });
 
     // Must return a promise that resolves to an array of items

--- a/client/src/components/providers/InvocationsProvider.test.js
+++ b/client/src/components/providers/InvocationsProvider.test.js
@@ -1,0 +1,41 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import mockInvocationData from "components/Workflow/test/json/invocation.json";
+import { invocationsProvider } from "./InvocationsProvider";
+
+describe("invocationsProvider", () => {
+    let axiosMock;
+
+    beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    describe("fetching invocations without an error", () => {
+        it("should make an API call and fire callback", async () => {
+            axiosMock
+                .onGet("/prefix/api/invocations", { params: { limit: 50, offset: 0, include_terminal: false } })
+                .reply(200, [mockInvocationData], { total_matches: "1" });
+
+            const ctx = {
+                root: "/prefix/",
+                perPage: 50,
+                currentPage: 1,
+            };
+            const extras = {
+                include_terminal: false,
+            };
+
+            let called = false;
+            const callback = function () {
+                called = true;
+            };
+            const promise = invocationsProvider(ctx, callback, extras);
+            await promise;
+            expect(called).toBeTruthy();
+        });
+    });
+});

--- a/client/src/components/providers/StoredWorkflowProvider.test.js
+++ b/client/src/components/providers/StoredWorkflowProvider.test.js
@@ -1,0 +1,44 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+import { storedWorkflowsProvider } from "./StoredWorkflowsProvider";
+
+describe("storedWorkflowsProvider", () => {
+    let axiosMock;
+
+    beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    describe("fetching workflows without an error", () => {
+        it("should make an API call and fire callback", async () => {
+            axiosMock
+                .onGet("/prefix/api/workflows", {
+                    params: { limit: 50, offset: 0, skip_step_counts: true, search: "rna" },
+                })
+                .reply(200, [{ model_class: "StoredWorkflow" }], { total_matches: "1" });
+
+            const ctx = {
+                root: "/prefix/",
+                perPage: 50,
+                currentPage: 1,
+            };
+            const extras = {
+                skip_step_counts: true,
+                search: "rna",
+            };
+
+            let called = false;
+            const callback = function () {
+                called = true;
+            };
+            const promise = storedWorkflowsProvider(ctx, callback, extras);
+            await promise;
+            expect(called).toBeTruthy();
+        });
+    });
+});

--- a/client/src/components/providers/StoredWorkflowsProvider.js
+++ b/client/src/components/providers/StoredWorkflowsProvider.js
@@ -5,7 +5,8 @@ import { SingleQueryProvider } from "components/providers/SingleQueryProvider";
 import { rethrowSimple } from "utils/simple-error";
 
 export function storedWorkflowsProvider(ctx, callback, extraParams = {}) {
-    const { apiUrl, ...requestParams } = ctx;
+    const { root, ...requestParams } = ctx;
+    const apiUrl = `${root}api/workflows`;
     const cleanParams = cleanPaginationParameters(requestParams);
     const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });
 

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -566,10 +566,15 @@ class NavigatesGalaxy(HasDriver):
         return "email" in self.get_logged_in_user()
 
     @retry_during_transitions
-    def _inline_search_for(self, selector, search_term=None):
+    def _inline_search_for(self, selector, search_term=None, escape_to_clear=False):
         # Clear tooltip resulting from clicking on the masthead to get here.
         self.clear_tooltips()
         search_box = self.wait_for_and_click(selector)
+        if escape_to_clear:
+            # The combination of DebouncedInput+b-input doesn't seem to uniformly respect
+            # .clear() below. We use escape handling a lot - and that does cauase to the input
+            # to reset correctly and fire the required re-active events/handlers.
+            self.send_escape(search_box)
         search_box.clear()
         if search_term is not None:
             search_box.send_keys(search_term)
@@ -1218,6 +1223,7 @@ class NavigatesGalaxy(HasDriver):
         return self._inline_search_for(
             self.navigation.workflows.search_box,
             search_term,
+            escape_to_clear=True,
         )
 
     def workflow_index_click_import(self):

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -544,7 +544,10 @@ EXAMPLE_WORKFLOW_URL_1 = (
 class UsesWorkflowAssertions(NavigatesGalaxyMixin):
     @retry_assertion_during_transitions
     def _assert_showing_n_workflows(self, n):
-        assert len(self.workflow_index_table_elements()) == n
+        actual_count = len(self.workflow_index_table_elements())
+        if actual_count != n:
+            message = f"Expected {n} workflows to be displayed, based on DOM found {actual_count} workflow rows."
+            raise AssertionError(message)
 
     @skip_if_github_down
     def _workflow_import_from_url(self, url=EXAMPLE_WORKFLOW_URL_1):


### PR DESCRIPTION
Builds on backend improvements in #13867. Decomposes the big WorkflowList component into a lot of smaller pieces - many with their own test. Greatly expands coverage of the Jest unit tests for workflow list and invocation grids. Converges the components with mixins and shared child components - reducing duplicated code. Add a lot more help in in pops and hovers available to the Galaxy user. More use of localized strings, more precise import Bootstrap Vue directives and components. 
 
## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
