### PR TITLE
Add more bulk operations to Beta History

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/OperationErrorDialog.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/OperationErrorDialog.vue
@@ -14,6 +14,9 @@
         </p>
         <p v-else v-localize>The operation failed for the following reasons:</p>
         <div>
+            <ul v-if="errorMessage">
+                <li>{{ errorMessage }}</li>
+            </ul>
             <ul>
                 <li v-for="(reason, index) in reasons" :key="`error-${index}`">
                     {{ reason }}
@@ -52,6 +55,9 @@ export default {
                 return [...new Set(this.operationError.result.errors.map((e) => e.error))];
             }
             return [];
+        },
+        errorMessage() {
+            return this.operationError?.errorMessage?.message;
         },
     },
     methods: {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -80,7 +80,7 @@
                     collection-name="Genomes"
                     :loading="loadingGenomes"
                     :items="genomes"
-                    current-item-id="?"
+                    :current-item-id="selectedGnomeId"
                     @update:selected-item="onSelectedGenome" />
             </GenomeProvider>
         </b-modal>
@@ -133,7 +133,7 @@ export default {
     },
     data: function () {
         return {
-            selectedGnomeId: null,
+            selectedGnomeId: "?",
             selectedTags: [],
         };
     },
@@ -189,7 +189,7 @@ export default {
         },
         changeDbkeyOfSelected() {
             this.runOnSelection(changeDbkeyOfSelectedContent, { dbkey: this.selectedGnomeId });
-            this.selectedGnomeId = null;
+            this.selectedGnomeId = "?";
         },
         addTagsToSelected() {
             this.runOnSelection(addTagsToSelectedContent, { tags: this.selectedTags });

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -47,9 +47,9 @@
             <b-dropdown-item v-b-modal:change-dbkey-of-selected-content data-description="change reference gnome">
                 <span v-localize>Change reference Gnome</span>
             </b-dropdown-item>
-            <b-dropdown-item v-b-modal:change-datatype-of-selected-content data-description="change data type">
+            <!-- <b-dropdown-item v-b-modal:change-datatype-of-selected-content data-description="change data type">
                 <span v-localize>Change data type</span>
-            </b-dropdown-item>
+            </b-dropdown-item> -->
             <b-dropdown-item v-b-modal:add-tags-to-selected-content data-description="add tags">
                 <span v-localize>Add tags</span>
             </b-dropdown-item>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -81,6 +81,7 @@
                     :loading="loadingGenomes"
                     :items="genomes"
                     :current-item-id="selectedGnomeId"
+                    class="mb-5 pb-5"
                     @update:selected-item="onSelectedGenome" />
             </GenomeProvider>
         </b-modal>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -45,6 +45,9 @@
             <b-dropdown-item v-b-modal:change-dbkey-of-selected-content data-description="change reference gnome">
                 <span v-localize>Change reference Gnome</span>
             </b-dropdown-item>
+            <b-dropdown-item v-b-modal:add-tags-to-selected-content data-description="add tags">
+                <span v-localize>Add tags</span>
+            </b-dropdown-item>
         </b-dropdown>
 
         <b-modal id="hide-selected-content" title="Hide Selected Content?" title-tag="h2" @ok="hideSelected">
@@ -78,6 +81,10 @@
                     @update:selected-item="onSelectedGenome" />
             </GenomeProvider>
         </b-modal>
+        <b-modal id="add-tags-to-selected-content" title="Add tag?" title-tag="h2" @ok="addTagToSelected">
+            <p v-localize>Apply same tags to {{ numSelected }} items:</p>
+            <StatelessTags v-model="selectedTags" class="tags" />
+        </b-modal>
     </section>
 </template>
 
@@ -89,17 +96,20 @@ import {
     undeleteSelectedContent,
     purgeSelectedContent,
     changeDbkeyOfSelectedContent,
+    addTagsToSelectedContent,
 } from "components/History/model/crud";
 import { createDatasetCollection } from "components/History/model/queries";
 import { buildCollectionModal } from "components/History/adapters/buildCollectionModal";
 import { checkFilter, getQueryDict } from "store/historyStore/model/filtering";
 import { GenomeProvider } from "components/providers";
 import SingleItemSelector from "components/SingleItemSelector";
+import { StatelessTags } from "components/Tags";
 
 export default {
     components: {
         GenomeProvider,
         SingleItemSelector,
+        StatelessTags,
     },
     props: {
         history: { type: Object, required: true },
@@ -108,6 +118,12 @@ export default {
         selectionSize: { type: Number, required: true },
         isQuerySelection: { type: Boolean, required: true },
         totalItemsInQuery: { type: Number, default: 0 },
+    },
+    data: function () {
+        return {
+            selectedGnomeId: null,
+            selectedTags: [],
+        };
     },
     computed: {
         /** @returns {Boolean} */
@@ -161,6 +177,9 @@ export default {
         },
         changeDbkeyOfSelected() {
             this.runOnSelection(changeDbkeyOfSelectedContent, { dbkey: this.selectedGnomeId });
+        },
+        addTagToSelected() {
+            this.runOnSelection(addTagsToSelectedContent, { tags: this.selectedTags });
         },
         async runOnSelection(operation, extraParams = null) {
             this.$emit("update:operation-running", this.history.update_time);

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -47,6 +47,9 @@
             <b-dropdown-item v-b-modal:change-dbkey-of-selected-content data-description="change reference gnome">
                 <span v-localize>Change reference Gnome</span>
             </b-dropdown-item>
+            <b-dropdown-item v-b-modal:change-datatype-of-selected-content data-description="change data type">
+                <span v-localize>Change data type</span>
+            </b-dropdown-item>
             <b-dropdown-item v-b-modal:add-tags-to-selected-content data-description="add tags">
                 <span v-localize>Add tags</span>
             </b-dropdown-item>
@@ -88,6 +91,23 @@
             </GenomeProvider>
         </b-modal>
         <b-modal
+            id="change-datatype-of-selected-content"
+            title="Change data type?"
+            title-tag="h2"
+            :ok-disabled="selectedDatatype == null"
+            @ok="changeDatatypeOfSelected">
+            <p v-localize>Select a new data type for {{ numSelected }} items:</p>
+            <DatatypesProvider v-slot="{ item: datatypes, loading: loadingDatatypes }">
+                <SingleItemSelector
+                    collection-name="Data Types"
+                    :loading="loadingDatatypes"
+                    :items="datatypes"
+                    :current-item-id="selectedDatatype"
+                    class="mb-5 pb-5"
+                    @update:selected-item="onSelectedDatatype" />
+            </DatatypesProvider>
+        </b-modal>
+        <b-modal
             id="add-tags-to-selected-content"
             title="Add tags?"
             title-tag="h2"
@@ -116,19 +136,21 @@ import {
     undeleteSelectedContent,
     purgeSelectedContent,
     changeDbkeyOfSelectedContent,
+    changeDatatypeOfSelectedContent,
     addTagsToSelectedContent,
     removeTagsFromSelectedContent,
 } from "components/History/model/crud";
 import { createDatasetCollection } from "components/History/model/queries";
 import { buildCollectionModal } from "components/History/adapters/buildCollectionModal";
 import { checkFilter, getQueryDict } from "store/historyStore/model/filtering";
-import { GenomeProvider } from "components/providers";
+import { GenomeProvider, DatatypesProvider } from "components/providers";
 import SingleItemSelector from "components/SingleItemSelector";
 import { StatelessTags } from "components/Tags";
 
 export default {
     components: {
         GenomeProvider,
+        DatatypesProvider,
         SingleItemSelector,
         StatelessTags,
     },
@@ -143,6 +165,7 @@ export default {
     data: function () {
         return {
             selectedGnomeId: "?",
+            selectedDatatype: "auto",
             selectedTags: [],
         };
     },
@@ -203,6 +226,10 @@ export default {
             this.runOnSelection(changeDbkeyOfSelectedContent, { dbkey: this.selectedGnomeId });
             this.selectedGnomeId = "?";
         },
+        changeDatatypeOfSelected() {
+            this.runOnSelection(changeDatatypeOfSelectedContent, { datatype: this.selectedDatatype });
+            this.selectedDatatype = "auto";
+        },
         addTagsToSelected() {
             this.runOnSelection(addTagsToSelectedContent, { tags: this.selectedTags });
             this.selectedTags = [];
@@ -244,6 +271,9 @@ export default {
         },
         onSelectedGenome(genome) {
             this.selectedGnomeId = genome.id;
+        },
+        onSelectedDatatype(datatype) {
+            this.selectedDatatype = datatype.id;
         },
 
         // collection creation, fires up a modal

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -84,7 +84,12 @@
                     @update:selected-item="onSelectedGenome" />
             </GenomeProvider>
         </b-modal>
-        <b-modal id="add-tags-to-selected-content" title="Add tags?" title-tag="h2" @ok="addTagsToSelected">
+        <b-modal
+            id="add-tags-to-selected-content"
+            title="Add tags?"
+            title-tag="h2"
+            :ok-disabled="noTagsSelected"
+            @ok="addTagsToSelected">
             <p v-localize>Apply the following tags to {{ numSelected }} items:</p>
             <StatelessTags v-model="selectedTags" class="tags" />
         </b-modal>
@@ -92,6 +97,7 @@
             id="remove-tags-from-selected-content"
             title="Remove tags?"
             title-tag="h2"
+            :ok-disabled="noTagsSelected"
             @ok="removeTagsFromSelected">
             <p v-localize>Remove the following tags from {{ numSelected }} items:</p>
             <StatelessTags v-model="selectedTags" class="tags" />
@@ -161,6 +167,9 @@ export default {
         /** @returns {Boolean} */
         selectionMatchesQuery() {
             return this.totalItemsInQuery === this.selectionSize;
+        },
+        noTagsSelected() {
+            return this.selectedTags.length === 0;
         },
     },
     watch: {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -44,8 +44,8 @@
                 <span v-localize>Build Collection from Rules</span>
             </b-dropdown-item>
             <b-dropdown-divider />
-            <b-dropdown-item v-b-modal:change-dbkey-of-selected-content data-description="change reference gnome">
-                <span v-localize>Change reference Gnome</span>
+            <b-dropdown-item v-b-modal:change-dbkey-of-selected-content data-description="change database build">
+                <span v-localize>Change Database/Build</span>
             </b-dropdown-item>
             <!-- <b-dropdown-item v-b-modal:change-datatype-of-selected-content data-description="change data type">
                 <span v-localize>Change data type</span>
@@ -76,18 +76,18 @@
         </b-modal>
         <b-modal
             id="change-dbkey-of-selected-content"
-            title="Change reference gnome?"
+            title="Change Database/Build?"
             title-tag="h2"
             @ok="changeDbkeyOfSelected">
-            <p v-localize>Select a new reference genome for {{ numSelected }} items:</p>
-            <GenomeProvider v-slot="{ item: genomes, loading: loadingGenomes }">
+            <p v-localize>Select a new Database/Build for {{ numSelected }} items:</p>
+            <GenomeProvider v-slot="{ item: dbkeys, loading: loadingDbKeys }">
                 <SingleItemSelector
-                    collection-name="Genomes"
-                    :loading="loadingGenomes"
-                    :items="genomes"
-                    :current-item-id="selectedGnomeId"
+                    collection-name="Database/Builds"
+                    :loading="loadingDbKeys"
+                    :items="dbkeys"
+                    :current-item-id="selectedDbKey"
                     class="mb-5 pb-5"
-                    @update:selected-item="onSelectedGenome" />
+                    @update:selected-item="onSelectedDbKey" />
             </GenomeProvider>
         </b-modal>
         <b-modal
@@ -164,7 +164,7 @@ export default {
     },
     data: function () {
         return {
-            selectedGnomeId: "?",
+            selectedDbKey: "?",
             selectedDatatype: "auto",
             selectedTags: [],
         };
@@ -223,8 +223,8 @@ export default {
             this.runOnSelection(purgeSelectedContent);
         },
         changeDbkeyOfSelected() {
-            this.runOnSelection(changeDbkeyOfSelectedContent, { dbkey: this.selectedGnomeId });
-            this.selectedGnomeId = "?";
+            this.runOnSelection(changeDbkeyOfSelectedContent, { dbkey: this.selectedDbKey });
+            this.selectedDbKey = "?";
         },
         changeDatatypeOfSelected() {
             this.runOnSelection(changeDatatypeOfSelectedContent, { datatype: this.selectedDatatype });
@@ -269,8 +269,8 @@ export default {
         handleOperationError(errorMessage, result) {
             this.$emit("operation-error", { errorMessage, result });
         },
-        onSelectedGenome(genome) {
-            this.selectedGnomeId = genome.id;
+        onSelectedDbKey(dbkey) {
+            this.selectedDbKey = dbkey.id;
         },
         onSelectedDatatype(datatype) {
             this.selectedDatatype = datatype.id;

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -48,6 +48,9 @@
             <b-dropdown-item v-b-modal:add-tags-to-selected-content data-description="add tags">
                 <span v-localize>Add tags</span>
             </b-dropdown-item>
+            <b-dropdown-item v-b-modal:remove-tags-from-selected-content data-description="remove tags">
+                <span v-localize>Remove tags</span>
+            </b-dropdown-item>
         </b-dropdown>
 
         <b-modal id="hide-selected-content" title="Hide Selected Content?" title-tag="h2" @ok="hideSelected">
@@ -81,8 +84,16 @@
                     @update:selected-item="onSelectedGenome" />
             </GenomeProvider>
         </b-modal>
-        <b-modal id="add-tags-to-selected-content" title="Add tag?" title-tag="h2" @ok="addTagToSelected">
-            <p v-localize>Apply same tags to {{ numSelected }} items:</p>
+        <b-modal id="add-tags-to-selected-content" title="Add tags?" title-tag="h2" @ok="addTagsToSelected">
+            <p v-localize>Apply the following tags to {{ numSelected }} items:</p>
+            <StatelessTags v-model="selectedTags" class="tags" />
+        </b-modal>
+        <b-modal
+            id="remove-tags-from-selected-content"
+            title="Remove tags?"
+            title-tag="h2"
+            @ok="removeTagsFromSelected">
+            <p v-localize>Remove the following tags from {{ numSelected }} items:</p>
             <StatelessTags v-model="selectedTags" class="tags" />
         </b-modal>
     </section>
@@ -97,6 +108,7 @@ import {
     purgeSelectedContent,
     changeDbkeyOfSelectedContent,
     addTagsToSelectedContent,
+    removeTagsFromSelectedContent,
 } from "components/History/model/crud";
 import { createDatasetCollection } from "components/History/model/queries";
 import { buildCollectionModal } from "components/History/adapters/buildCollectionModal";
@@ -177,9 +189,15 @@ export default {
         },
         changeDbkeyOfSelected() {
             this.runOnSelection(changeDbkeyOfSelectedContent, { dbkey: this.selectedGnomeId });
+            this.selectedGnomeId = null;
         },
-        addTagToSelected() {
+        addTagsToSelected() {
             this.runOnSelection(addTagsToSelectedContent, { tags: this.selectedTags });
+            this.selectedTags = [];
+        },
+        removeTagsFromSelected() {
+            this.runOnSelection(removeTagsFromSelectedContent, { tags: this.selectedTags });
+            this.selectedTags = [];
         },
         async runOnSelection(operation, extraParams = null) {
             this.$emit("update:operation-running", this.history.update_time);

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -27,6 +27,7 @@
             <b-dropdown-item v-if="!showDeleted" v-b-modal:purge-selected-content data-description="purge option">
                 <span v-localize>Delete (permanently)</span>
             </b-dropdown-item>
+            <b-dropdown-divider />
             <b-dropdown-item v-if="showBuildOptions" data-description="build list" @click="buildDatasetList">
                 <span v-localize>Build Dataset List</span>
             </b-dropdown-item>
@@ -42,6 +43,7 @@
                 @click="buildCollectionFromRules">
                 <span v-localize>Build Collection from Rules</span>
             </b-dropdown-item>
+            <b-dropdown-divider />
             <b-dropdown-item v-b-modal:change-dbkey-of-selected-content data-description="change reference gnome">
                 <span v-localize>Change reference Gnome</span>
             </b-dropdown-item>

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -44,3 +44,9 @@ export function changeDbkeyOfSelectedContent(history, filters, items, extraParam
     const params = { type: operationType, dbkey: extraParams.dbkey };
     return bulkUpdate(history, operationType, filters, items, params);
 }
+
+export function addTagsToSelectedContent(history, filters, items, extraParams) {
+    const operationType = "add_tags";
+    const params = { type: operationType, tags: extraParams.tags };
+    return bulkUpdate(history, operationType, filters, items, params);
+}

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -50,3 +50,9 @@ export function addTagsToSelectedContent(history, filters, items, extraParams) {
     const params = { type: operationType, tags: extraParams.tags };
     return bulkUpdate(history, operationType, filters, items, params);
 }
+
+export function removeTagsFromSelectedContent(history, filters, items, extraParams) {
+    const operationType = "remove_tags";
+    const params = { type: operationType, tags: extraParams.tags };
+    return bulkUpdate(history, operationType, filters, items, params);
+}

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -38,3 +38,9 @@ export function purgeAllDeletedContent(history) {
     const filters = { deleted: true };
     return purgeSelectedContent(history, filters);
 }
+
+export function changeDbkeyOfSelectedContent(history, filters, items, extraParams) {
+    const operationType = "change_dbkey";
+    const params = { type: operationType, dbkey: extraParams.dbkey };
+    return bulkUpdate(history, operationType, filters, items, params);
+}

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -45,6 +45,12 @@ export function changeDbkeyOfSelectedContent(history, filters, items, extraParam
     return bulkUpdate(history, operationType, filters, items, params);
 }
 
+export function changeDatatypeOfSelectedContent(history, filters, items, extraParams) {
+    const operationType = "change_datatype";
+    const params = { type: operationType, datatype: extraParams.datatype };
+    return bulkUpdate(history, operationType, filters, items, params);
+}
+
 export function addTagsToSelectedContent(history, filters, items, extraParams) {
     const operationType = "add_tags";
     const params = { type: operationType, tags: extraParams.tags };

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -75,17 +75,19 @@ export async function updateContentFields(content, newFields = {}) {
  * @param {String} operation The operation to perform on all items
  * @param {Object} filters The filter query parameters
  * @param {Object[]} items The set of items to process as `{ id, history_content_type }`
+ * @param {Object} params Optional extra parameters passed to the operation
  */
-export async function bulkUpdate(history, operation, filters, items = []) {
+export async function bulkUpdate(history, operation, filters, items = [], params = null) {
     const { id } = history;
     const filterQuery = buildQueryStringFrom(filters);
     const url = `api/histories/${id}/contents/bulk?${filterQuery}`;
     const payload = {
         operation,
         items,
+        params,
     };
     const response = await axios.put(prependPath(url), payload);
-    console.debug(`Submitted request to ${operation} selected content in bulk.`, response);
+    console.debug(`Submitted request to ${operation} selected content in bulk. Parameters: ${params}`, response);
     return doResponse(response);
 }
 

--- a/lib/galaxy/managers/genomes.py
+++ b/lib/galaxy/managers/genomes.py
@@ -20,6 +20,13 @@ class GenomesManager:
     def get_dbkeys(self, user: m.User, chrom_info: bool) -> List[List[str]]:
         return self.genomes.get_dbkeys(user, chrom_info)
 
+    def is_registered_dbkey(self, dbkey: str, user: m.User) -> bool:
+        dbkeys = self.get_dbkeys(user, chrom_info=False)
+        for _, key in dbkeys:
+            if dbkey == key:
+                return True
+        return False
+
     def get_genome(
         self, trans: ProvidesUserContext, id: str, num: int, chrom: str, low: int, high: int, reference: bool
     ) -> Any:

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -829,8 +829,8 @@ class HistoryContentItemOperation(str, Enum):
     purge = "purge"
     change_datatype = "change_datatype"
     change_dbkey = "change_dbkey"
-    add_tag = "add_tag"
-    remove_tag = "remove_tag"
+    add_tags = "add_tags"
+    remove_tags = "remove_tags"
 
 
 class BulkOperationParams(Model):
@@ -848,8 +848,8 @@ class ChangeDbkeyOperationParams(BulkOperationParams):
 
 
 class TagOperationParams(BulkOperationParams):
-    type: Union[Literal["add_tag"], Literal["remove_tag"]]
-    tag_name: str
+    type: Union[Literal["add_tags"], Literal["remove_tags"]]
+    tags: List[str]
 
 
 AnyBulkOperationParams = Union[

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -23,6 +23,7 @@ from pydantic import (
     Json,
     UUID4,
 )
+from typing_extensions import Literal
 
 from galaxy.model import (
     Dataset,
@@ -826,11 +827,42 @@ class HistoryContentItemOperation(str, Enum):
     delete = "delete"
     undelete = "undelete"
     purge = "purge"
+    change_datatype = "change_datatype"
+    change_dbkey = "change_dbkey"
+    add_tag = "add_tag"
+    remove_tag = "remove_tag"
+
+
+class BulkOperationParams(Model):
+    type: str
+
+
+class ChangeDatatypeOperationParams(BulkOperationParams):
+    type: Literal["change_datatype"]
+    datatype: str
+
+
+class ChangeDbkeyOperationParams(BulkOperationParams):
+    type: Literal["change_dbkey"]
+    dbkey: str
+
+
+class TagOperationParams(BulkOperationParams):
+    type: Union[Literal["add_tag"], Literal["remove_tag"]]
+    tag_name: str
+
+
+AnyBulkOperationParams = Union[
+    ChangeDatatypeOperationParams,
+    ChangeDbkeyOperationParams,
+    TagOperationParams,
+]
 
 
 class HistoryContentBulkOperationPayload(Model):
     operation: HistoryContentItemOperation
     items: Optional[List[HistoryContentItem]]
+    params: Optional[AnyBulkOperationParams]
 
 
 class BulkOperationItemError(Model):
@@ -2930,7 +2962,7 @@ class AsyncTaskResultSummary(BaseModel):
     ignored: bool = Field(
         ...,
         title="Ignored",
-        description="Indicated whether the Celery AsyncResult will be available for retrivial",
+        description="Indicated whether the Celery AsyncResult will be available for retrieval",
     )
     name: Optional[str] = Field(
         None,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -827,7 +827,7 @@ class HistoryContentItemOperation(str, Enum):
     delete = "delete"
     undelete = "undelete"
     purge = "purge"
-    change_datatype = "change_datatype"
+    # change_datatype = "change_datatype"
     change_dbkey = "change_dbkey"
     add_tags = "add_tags"
     remove_tags = "remove_tags"

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1555,9 +1555,9 @@ class HistoryItemOperator:
             HistoryContentItemOperation.delete: lambda item, params, trans: self._delete(item),
             HistoryContentItemOperation.undelete: lambda item, params, trans: self._undelete(item),
             HistoryContentItemOperation.purge: lambda item, params, trans: self._purge(item, trans),
-            HistoryContentItemOperation.change_datatype: lambda item, params, trans: self._change_datatype(
-                item, params
-            ),
+            # HistoryContentItemOperation.change_datatype: lambda item, params, trans: self._change_datatype(
+            #     item, params
+            # ),
             HistoryContentItemOperation.change_dbkey: lambda item, params, trans: self._change_dbkey(item, params),
             HistoryContentItemOperation.add_tags: lambda item, params, trans: self._add_tags(item, trans.user, params),
             HistoryContentItemOperation.remove_tags: lambda item, params, trans: self._remove_tags(

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1559,8 +1559,8 @@ class HistoryItemOperator:
                 item, params
             ),
             HistoryContentItemOperation.change_dbkey: lambda item, params, trans: self._change_dbkey(item, params),
-            HistoryContentItemOperation.add_tag: lambda item, params, trans: self._add_tag(item, trans.user, params),
-            HistoryContentItemOperation.remove_tag: lambda item, params, trans: self._remove_tag(
+            HistoryContentItemOperation.add_tags: lambda item, params, trans: self._add_tags(item, trans.user, params),
+            HistoryContentItemOperation.remove_tags: lambda item, params, trans: self._remove_tags(
                 item, trans.user, params
             ),
         }
@@ -1608,10 +1608,10 @@ class HistoryItemOperator:
         if isinstance(item, HistoryDatasetAssociation):
             item.set_dbkey(params.dbkey)
 
-    def _add_tag(self, item: HistoryItemModel, user: User, params: TagOperationParams):
+    def _add_tags(self, item: HistoryItemModel, user: User, params: TagOperationParams):
         manager = self._get_item_manager(item)
-        manager.tag_handler.apply_item_tag(user, item, name=params.tag_name, flush=self.flush)
+        manager.tag_handler.add_tags_from_list(user, item, params.tags, flush=self.flush)
 
-    def _remove_tag(self, item: HistoryItemModel, user: User, params: TagOperationParams):
+    def _remove_tags(self, item: HistoryItemModel, user: User, params: TagOperationParams):
         manager = self._get_item_manager(item)
-        manager.tag_handler.remove_item_tag(user, item, params.tag_name)
+        manager.tag_handler.remove_tags_from_list(user, item, params.tags, flush=self.flush)

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1167,13 +1167,13 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
         with self.dataset_populator.test_history() as history_id:
             _, collection_ids, history_contents = self._create_test_history_contents(history_id)
 
-            expected_tag = "cool_tag"
+            expected_tags = ["cool_tag", "tag01"]
             # Add same tag to all items
             payload = {
-                "operation": "add_tag",
+                "operation": "add_tags",
                 "params": {
-                    "type": "add_tag",
-                    "tag_name": expected_tag,
+                    "type": "add_tags",
+                    "tags": expected_tags,
                 },
             }
             expected_success_count = len(history_contents)
@@ -1181,14 +1181,15 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             self._assert_bulk_success(bulk_operation_result, expected_success_count)
             history_contents = self._get_history_contents(history_id)
             for item in history_contents:
-                assert expected_tag in item["tags"]
+                for expected_tag in expected_tags:
+                    assert expected_tag in item["tags"]
 
             # Remove tag from all collections
             payload = {
-                "operation": "remove_tag",
+                "operation": "remove_tags",
                 "params": {
-                    "type": "remove_tag",
-                    "tag_name": expected_tag,
+                    "type": "remove_tags",
+                    "tags": expected_tags,
                 },
             }
             query = "q=history_content_type-eq&qv=dataset_collection"
@@ -1200,7 +1201,8 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
                 if item["history_content_type"] == "dataset_collection":
                     assert not item["tags"]
                 else:
-                    assert expected_tag in item["tags"]
+                    for expected_tag in expected_tags:
+                        assert expected_tag in item["tags"]
 
     def test_bulk_dbkey_change(self):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
Fixes #13828

New operations supported by `api/histories/{history_id}/contents/bulk` in the API:
- [x] Change datatype (temporarily disabled)
  - [ ]  *Needs regenerating the metadata using Celery.* #14033
- [x] Change dbkey
  - [x] Validate the `dbkey` to allow only registered (and user-defined) ones
- [x] Add multiple tags
- [x] Remove multiple tags

## TODO
- [x] Add API tests
- [x] Add operations to the client

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Add / remove tags in bulk
  
    ![add-remove-tags](https://user-images.githubusercontent.com/46503462/170365714-f2a5a3e7-6235-4ee6-b3fc-0801033389bc.gif)

  - Change `dbkey` in bulk
      
    ![change_dbkey](https://user-images.githubusercontent.com/46503462/172572648-0a3fd1ff-472b-4979-8c8a-d2a9e14c03d0.gif)



## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
