### PR TITLE
Misc fixes 2022-05

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4672,7 +4672,7 @@
     the process that handled that particular request will tell all
     others to also reload, lock jobs, etc. For connection examples,
     see
-    http://docs.celeryproject.org/projects/kombu/en/latest/userguide/connections.html
+    https://docs.celeryq.dev/projects/kombu/en/stable/userguide/connections.html
     Without specifying anything here, galaxy will first attempt to use
     your specified database_connection above.  If that's not specified
     either, Galaxy will automatically create and use a separate sqlite

--- a/doc/source/admin/mq.md
+++ b/doc/source/admin/mq.md
@@ -2,7 +2,7 @@
 # Message queue
 
 Galaxy uses a message queue internally for communicating between processes. 
-This is powered by the [Kombu MQ library](https://docs.celeryproject.org/projects/kombu/en/stable/). 
+This is powered by the [Kombu MQ library](https://docs.celeryq.dev/projects/kombu/). 
 For example, when reloading the toolbox or locking job execution,
 the process that handled that particular request will tell all others to also reload, lock jobs, etc. 
 
@@ -11,8 +11,8 @@ the process that handled that particular request will tell all others to also re
 <!-- TODO the types of messages being passed, more detailed than above -->
 
 This is configured via the [amqp_internal_connection](https://docs.galaxyproject.org/en/latest/admin/config.html#amqp-internal-connection)
-option in `galaxy.yml`. For connection examples, see the [Kombu connection documentation](https://docs.celeryproject.org/projects/kombu/en/stable/userguide/connections.html).
-See the [URL specification](https://docs.celeryproject.org/projects/kombu/en/stable/userguide/connections.html#urls) on that page for more information on configuring different transports.
+option in `galaxy.yml`. For connection examples, see the [Kombu connection documentation](https://docs.celeryq.dev/projects/kombu/en/stable/userguide/connections.html).
+See the [URL specification](https://docs.celeryq.dev/projects/kombu/en/stable/userguide/connections.html#urls) on that page for more information on configuring different transports.
 
 <!-- TODO copy in an actual rabbit MQ example from the link above 
 ```
@@ -29,7 +29,7 @@ database located in your <galaxy>/database folder.
 Kombu and Galaxy support a variety of MQ transport/server options. 
 [RabbitMQ](https://www.rabbitmq.com/) via AMQP is the most popular for production deployments.
 
-Visit the [Kombu reference index](https://docs.celeryproject.org/projects/kombu/en/latest/reference/index.html) for a
+Visit the [Kombu reference index](https://docs.celeryq.dev/projects/kombu/en/stable/reference/index.html) for a
 complete list of supported transports and their configuration.
 
 <!-- TODO Specify any requirements Galaxy has for transport features. -->

--- a/doc/source/releases/21.05_announce.rst
+++ b/doc/source/releases/21.05_announce.rst
@@ -9,8 +9,8 @@ Highlights
 ===========================================================
 
 **New development stack**
-  Galaxy release 21.09 will ship with a new web framework (`fastAPI <https://fastapi.tiangolo.com/>`__),
-  `Celery <https://docs.celeryproject.org/en/stable/index.html>`__ task queue and process management using `Circus <https://circus.readthedocs.io/en/latest/>`__. You can preview new stack now by running ``APP_WEBSERVER=dev ./run.sh``.
+  Galaxy release 21.09 will ship with a new web framework (`FastAPI <https://fastapi.tiangolo.com/>`__),
+  `Celery <https://docs.celeryq.dev/>`__ task queue and process management using `Circus <https://circus.readthedocs.io/en/latest/>`__. You can preview new stack now by running ``APP_WEBSERVER=dev ./run.sh``.
 
 **Celery for background tasks**
   Galaxy can now run certain tasks in the background. The Celery workers are

--- a/doc/source/releases/22.01_announce.rst
+++ b/doc/source/releases/22.01_announce.rst
@@ -11,7 +11,7 @@ Highlights
 **Galaxy starts as FastAPI application by default**
   Starting Galaxy via ``run.sh`` will use the new `gravity process manager
   <https://github.com/galaxyproject/gravity>`__.
-  The new configuration uses `gunicorn <https://gunicorn.org/>`__ and `FastAPI <https://fastapi.tiangolo.com/>`__ to drive Galaxy's web process and starts job handler and `Celery <https://docs.celeryproject.org/>`__ processes automatically.
+  The new configuration uses `gunicorn <https://gunicorn.org/>`__ and `FastAPI <https://fastapi.tiangolo.com/>`__ to drive Galaxy's web process and starts job handler and `Celery <https://docs.celeryq.dev/>`__ processes automatically.
   For more details and instructions please consult the `Migrating to Gunicorn documentation <https://docs.galaxyproject.org/en/latest/admin/migrating_to_gunicorn.html>`__.
   (`Pull Request 13224`_).
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2307,7 +2307,7 @@ galaxy:
   # For example, when reloading the toolbox or locking job execution,
   # the process that handled that particular request will tell all
   # others to also reload, lock jobs, etc. For connection examples, see
-  # http://docs.celeryproject.org/projects/kombu/en/latest/userguide/connections.html
+  # https://docs.celeryq.dev/projects/kombu/en/stable/userguide/connections.html
   # Without specifying anything here, galaxy will first attempt to use
   # your specified database_connection above.  If that's not specified
   # either, Galaxy will automatically create and use a separate sqlite

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3404,7 +3404,7 @@ mapping:
           example, when reloading the toolbox or locking job execution, the process
           that handled that particular request will tell all others to also reload,
           lock jobs, etc.
-          For connection examples, see http://docs.celeryproject.org/projects/kombu/en/latest/userguide/connections.html
+          For connection examples, see https://docs.celeryq.dev/projects/kombu/en/stable/userguide/connections.html
 
           Without specifying anything here, galaxy will first attempt to use your
           specified database_connection above.  If that's not specified either, Galaxy

--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -111,12 +111,7 @@ class CondaContext(installable.InstallableContext):
         self.conda_prefix = conda_prefix
         if conda_exec is None:
             self.conda_exec = self._bin("conda")
-        if ensure_channels:
-            if not isinstance(ensure_channels, list):
-                ensure_channels = [c for c in ensure_channels.split(",") if c]
-        else:
-            ensure_channels = None
-        self.ensure_channels = ensure_channels
+        self.ensure_channels: List[str] = listify(ensure_channels)
         self._conda_version = None
         self._miniconda_version = None
         self._conda_build_available = None

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -150,45 +150,6 @@ class RegexValidator(Validator):
 class ExpressionValidator(Validator):
     """
     Validator that evaluates a python expression using the value
-
-    >>> from galaxy.util import XML
-    >>> from galaxy.tools.parameters.basic import ToolParameter
-    >>> p = ToolParameter.build(None, XML('''
-    ... <param name="blah" type="text" value="10">
-    ...     <validator type="expression" message="Not gonna happen">value.lower() == "foo"</validator>
-    ... </param>
-    ... '''))
-    >>> t = p.validate("Foo")
-    >>> t = p.validate("foo")
-    >>> t = p.validate("Fop")
-    Traceback (most recent call last):
-        ...
-    ValueError: Not gonna happen
-    >>>
-    >>> p = ToolParameter.build(None, XML('''
-    ... <param name="blah" type="text" value="10">
-    ...     <validator type="expression" message="Not gonna happen" negate="true">value.lower() == "foo"</validator>
-    ... </param>
-    ... '''))
-    >>> t = p.validate("Foo")
-    Traceback (most recent call last):
-        ...
-    ValueError: Not gonna happen
-    >>> t = p.validate("foo")
-    Traceback (most recent call last):
-        ...
-    ValueError: Not gonna happen
-    >>> t = p.validate("Fop")
-    >>> p = ToolParameter.build(None, XML('''
-    ... <param name="blah" type="text" value="10">
-    ...     <validator type="expression" message="Not gonna happen">value</validator>
-    ... </param>
-    ... '''))
-    >>> p.validate("Foo")
-    >>> p.validate("")
-    Traceback (most recent call last):
-        ...
-    ValueError: Not gonna happen
     """
 
     @classmethod
@@ -199,14 +160,15 @@ class ExpressionValidator(Validator):
         if message is None:
             message = f"Value '%s' does not evaluate to {'True' if negate == 'false' else 'False'} for '{expression}'"
         super().__init__(message, negate)
+        self.expression = expression
         # Save compiled expression, code objects are thread safe (right?)
-        self.expression = compile(expression, "<string>", "eval")
+        self.compiled_expression = compile(expression, "<string>", "eval")
 
     def validate(self, value, trans=None):
         try:
-            evalresult = eval(self.expression, dict(value=value))
+            evalresult = eval(self.compiled_expression, dict(value=value))
         except Exception:
-            super().validate(False, value, f"Validator '{self.expression}' could not be evaluated on '%s'")
+            super().validate(False, message=f"Validator '{self.expression}' could not be evaluated on '{value}'")
         super().validate(bool(evalresult), value_to_show=value)
 
 

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -59,7 +59,7 @@ def safe_loads(arg):
     return loaded
 
 
-def safe_dumps(*args, **kwargs):
+def safe_dumps(obj, **kwargs):
     """
     This is a wrapper around dumps that encodes Infinity and NaN values.  It's a
     fairly rare case (which will be low in request volume).  Basically, we tell
@@ -67,9 +67,9 @@ def safe_dumps(*args, **kwargs):
     re-encoding.
     """
     try:
-        dumped = json.dumps(*args, allow_nan=False, **kwargs)
+        dumped = json.dumps(obj, allow_nan=False, **kwargs)
     except ValueError:
-        obj = swap_inf_nan(args[0])
+        obj = swap_inf_nan(obj)
         dumped = json.dumps(obj, allow_nan=False, **kwargs)
     if kwargs.get("escape_closing_tags", True):
         return dumped.replace("</", "<\\/")

--- a/test/integration_selenium/test_trs_import.py
+++ b/test/integration_selenium/test_trs_import.py
@@ -43,7 +43,7 @@ class TrsImportTestCase(SeleniumIntegrationTestCase):
 
     def assert_workflow_imported(self, name):
         self.workflow_index_search_for(name)
-        assert len(self.workflow_index_table_elements()) == 1, "workflow ${name} not imported"
+        assert len(self.workflow_index_table_elements()) == 1, f"workflow ${name} not imported"
 
     def test_import_workflow_by_url_dockstore(self):
         import_url = f"workflows/trs_import?trs_server=dockstore.org&trs_version={TRS_VERSION_DOCKSTORE}&trs_id=%23{TRS_ID_DOCKSTORE}"

--- a/test/unit/app/tools/test_parameter_validation.py
+++ b/test/unit/app/tools/test_parameter_validation.py
@@ -1,0 +1,64 @@
+from .util import BaseParameterTestCase
+
+
+class ParameterValidationTestCase(BaseParameterTestCase):
+    def test_simple_ExpressionValidator(self):
+        p = self._parameter_for(
+            xml="""
+<param name="blah" type="text" value="">
+    <validator type="expression" message="Not gonna happen">value.lower() == "foo"</validator>
+</param>"""
+        )
+        p.validate("Foo")
+        p.validate("foo")
+        with self.assertRaisesRegex(ValueError, "Not gonna happen"):
+            p.validate("Fop")
+
+    def test_negated_ExpressionValidator(self):
+        p = self._parameter_for(
+            xml="""
+<param name="blah" type="text" value="10">
+    <validator type="expression" message="Not gonna happen" negate="true">value.lower() == "foo"</validator>
+</param>
+"""
+        )
+        with self.assertRaisesRegex(ValueError, "Not gonna happen"):
+            p.validate("Foo")
+        p.validate("Fop")
+
+    def test_boolean_ExpressionValidator(self):
+        p = self._parameter_for(
+            xml="""
+<param name="blah" type="text" value="">
+    <validator type="expression" message="Not gonna happen">value</validator>
+</param>"""
+        )
+        p.validate("Foo")
+        with self.assertRaisesRegex(ValueError, "Not gonna happen"):
+            p.validate("")
+
+        p = self._parameter_for(
+            xml="""
+<param name="blah" type="integer" value="">
+    <validator type="expression" message="Not gonna happen">value</validator>
+</param>"""
+        )
+        p.validate(3)
+        with self.assertRaisesRegex(ValueError, "Not gonna happen"):
+            p.validate(0)
+
+    def test_ExpressionValidator_message(self):
+        p = self._parameter_for(
+            xml="""
+<param name="blah" type="text" value="">
+    <validator type="expression">value.lower() == "foo"</validator>
+</param>"""
+        )
+        with self.assertRaisesRegex(
+            ValueError, r"Value 'Fop' does not evaluate to True for 'value.lower\(\) == \"foo\"'"
+        ):
+            p.validate("Fop")
+        with self.assertRaisesRegex(
+            ValueError, r"Validator 'value.lower\(\) == \"foo\"' could not be evaluated on '1'"
+        ):
+            p.validate(1)


### PR DESCRIPTION
- Use `listify()` to split `ensure_channels`; add type annotation.
- Fix error message from `ExpressionValidator` when the expression could not be evaluated. Previously the message would be:
  ```
  Validator '<code object <module> at 0x7fcfdf6737c0, file "<string>", line 1>' could not be evaluated on '%s'
  ```
  Also, move doc tests to unit tests.
- Fix typo in a f-string
- Update Celery and Kombu links
- Fix and simplify `safe_dumps()`: `json.dumps()` can receive only one positional argument.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
