### PR TITLE
Infrastructure for Jest Testing of Localization

### DIFF
--- a/client/src/components/InteractiveTools/InteractiveTools.test.js
+++ b/client/src/components/InteractiveTools/InteractiveTools.test.js
@@ -2,7 +2,6 @@ import InteractiveTools from "./InteractiveTools";
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import flushPromises from "flush-promises";
-import _l from "utils/localization";
 import testInteractiveToolsResponse from "./testData/testInteractiveToolsResponse";
 
 import MockAdapter from "axios-mock-adapter";
@@ -10,7 +9,6 @@ import axios from "axios";
 
 describe("InteractiveTools/InteractiveTools.vue", () => {
     const localVue = getLocalVue();
-    localVue.filter("localize", (value) => _l(value));
     let wrapper;
     let axiosMock;
 

--- a/client/src/components/Tags/StatelessTags.test.js
+++ b/client/src/components/Tags/StatelessTags.test.js
@@ -1,10 +1,8 @@
 import { mount, createLocalVue } from "@vue/test-utils";
 import StatelessTags from "./StatelessTags";
-import _l from "utils/localization";
 
 describe("Tags/StatelessTags.vue", () => {
     const localVue = createLocalVue();
-    localVue.filter("localize", (value) => _l(value));
 
     const testTags = ["abc", "def", "ghi"];
     let wrapper;

--- a/client/src/components/Tool/ToolFooter.test.js
+++ b/client/src/components/Tool/ToolFooter.test.js
@@ -5,7 +5,7 @@ import { getLocalVue } from "jest/helpers";
 import flushPromises from "flush-promises";
 import ToolFooter from "./ToolFooter";
 
-const localVue = getLocalVue();
+const localVue = getLocalVue(true);
 
 const citationsA = [{ format: "bibtex", content: "@misc{entry_a, year = {1111}}" }];
 const citationsB = [{ format: "bibtex", content: "@misc{entry_b, year = {2222}}" }];
@@ -45,6 +45,7 @@ describe("ToolFooter", () => {
 
     it("check props", async () => {
         await flushPromises();
+        expect(wrapper.findAll(".footer-section-name").at(0).text()).toBeLocalizationOf("Citations");
         const referenceA = wrapper.find(".formatted-reference .csl-entry");
         expect(referenceA.attributes()["data-csl-entry-id"]).toBe("entry_a");
         expect(referenceA.text()).toContain("1111");

--- a/client/src/components/Tool/ToolFooter.vue
+++ b/client/src/components/Tool/ToolFooter.vue
@@ -1,7 +1,7 @@
 <template>
     <b-card v-if="hasContent" class="tool-footer">
         <div v-if="hasCitations" class="mb-1">
-            <span class="font-weight-bold">Citations:</span>
+            <span class="footer-section-name" v-localize>Citations</span>
             <font-awesome-icon
                 v-b-tooltip.hover
                 title="Copy all citations as BibTeX"
@@ -17,23 +17,21 @@
                 prefix="-" />
         </div>
         <div v-if="hasRequirements" class="mb-1">
-            <span class="font-weight-bold"
-                >Requirements:
-                <a href="https://galaxyproject.org/tools/requirements/" target="_blank">
-                    <font-awesome-icon v-b-tooltip.hover title="Learn more about Galaxy Requirements" icon="question" />
-                </a>
-            </span>
+            <span class="footer-section-name" v-localize>Requirements</span>
+            <a href="https://galaxyproject.org/tools/requirements/" target="_blank">
+                <font-awesome-icon v-b-tooltip.hover title="Learn more about Galaxy Requirements" icon="question" />
+            </a>
             <div v-for="(requirement, index) in requirements" :key="index">
                 - {{ requirement.name }}
                 <span v-if="requirement.version"> (Version {{ requirement.version }}) </span>
             </div>
         </div>
         <div v-if="hasLicense" class="mb-1">
-            <span class="font-weight-bold">License:</span>
+            <span class="footer-section-name" v-localize>License</span>
             <License :license-id="license" />
         </div>
         <div v-if="hasReferences" class="mb-1">
-            <span class="font-weight-bold">References:</span>
+            <span class="footer-section-name" v-localize>References</span>
             <div v-for="(xref, index) in xrefs" :key="index">
                 -
                 <template v-if="xref.reftype == 'bio.tools'">
@@ -164,3 +162,12 @@ export default {
     },
 };
 </script>
+
+<style scoped>
+.footer-section-name {
+    font-weight: bold;
+}
+.footer-section-name::after {
+    content: ":";
+}
+</style>

--- a/client/src/components/plugins/localization.js
+++ b/client/src/components/plugins/localization.js
@@ -7,29 +7,36 @@ import _l from "utils/localization";
 const newlineMatch = /\r?\n|\r/g;
 const doublespaces = /\s\s+/g;
 
-const localizeDirective = {
-    // TODO consider using a different hook if we need dynamic updates in content translation
-    bind(el, binding, vnode) {
-        el.childNodes.forEach((node) => {
-            const standardizedContent = node.textContent.replace(newlineMatch, " ").replace(doublespaces, " ").trim();
-            node.textContent = _l(standardizedContent);
-        });
-    },
-};
+function localizeDirective(l) {
+    return {
+        // TODO consider using a different hook if we need dynamic updates in content translation
+        bind(el, binding, vnode) {
+            el.childNodes.forEach((node) => {
+                const standardizedContent = node.textContent
+                    .replace(newlineMatch, " ")
+                    .replace(doublespaces, " ")
+                    .trim();
+                node.textContent = l(standardizedContent);
+            });
+        },
+    };
+}
 
 // adds localizeText mixin
-const localizeMixin = {
-    methods: {
-        l: _l,
-        localize: _l,
-    },
-};
+function localizeMixin(l) {
+    return {
+        methods: {
+            l: l,
+            localize: l,
+        },
+    };
+}
 
 export const localizationPlugin = {
-    install(Vue) {
-        Vue.filter("localize", _l);
-        Vue.filter("l", _l);
-        Vue.directive("localize", localizeDirective);
-        Vue.mixin(localizeMixin);
+    install(Vue, l = _l) {
+        Vue.filter("localize", l);
+        Vue.filter("l", l);
+        Vue.directive("localize", localizeDirective(l));
+        Vue.mixin(localizeMixin(l));
     },
 };

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -10,8 +10,69 @@ import { eventHubPlugin } from "components/plugins/eventHub";
 import { iconPlugin } from "components/plugins/icons";
 import BootstrapVue from "bootstrap-vue";
 import Vuex from "vuex";
+import _l from "utils/localization";
 
 const defaultComparator = (a, b) => a == b;
+
+function testLocalize(text) {
+    if(text) {
+        return `test_localized<${text}>`;
+    } else {
+        return text;
+    }
+}
+
+function isTestLocalized(text) {
+    return text && text.indexOf("test_localized<") == 0
+}
+
+expect.extend({
+    toBeLocalizationOf(received) {
+        const pass = isTestLocalized(received);
+        if (pass) {
+            return {
+              message: () =>
+                `expected ${received} to be localized`,
+              pass: true,
+            };
+          } else {
+            return {
+              message: () =>
+                `expected ${received} to be localized`,
+              pass: false,
+            };
+          }
+    },
+    toBeLocalizationOf(received, str) {
+        let unlocalized
+        if(received.indexOf("test_localized<") == 0) {
+            unlocalized = received.substr("test_localized<".length);
+            unlocalized = unlocalized.substr(0, unlocalized.length - 1);
+        } else {
+            unlocalized = received;
+        }
+      const pass = testLocalize(str) == received;
+      if (pass) {
+        return {
+          message: () =>
+            `expected ${unlocalized} to be localization of ${str}`,
+          pass: true,
+        };
+      } else if (!isTestLocalized(received)) {
+        return {
+          message: () =>
+            `expected ${received} to be localized`,
+          pass: false,
+        };
+      } else {
+        return {
+          message: () =>
+            `expected ${unlocalized} to be localization of ${str}`,
+          pass: false,
+        };
+      }
+    },
+  });
 
 // Creates a watcher on the indicated vm/prop for use in testing
 export function watchForChange(cfg = {}) {
@@ -86,14 +147,15 @@ export const showAll = (vm) => {
 export const wait = (n) => timer(n).pipe(take(1)).toPromise();
 
 // Gets a localVue with custom directives
-export function getLocalVue() {
+export function getLocalVue(instrumentLocalization = false) {
     const localVue = createLocalVue();
     const mockedDirective = {
         bind() {},
     };
     localVue.use(Vuex);
     localVue.use(BootstrapVue);
-    localVue.use(localizationPlugin);
+    const l = instrumentLocalization ? testLocalize : _l;
+    localVue.use(localizationPlugin, l);
     localVue.use(vueRxShortcutPlugin);
     localVue.use(eventHubPlugin);
     localVue.use(iconPlugin);


### PR DESCRIPTION
One can now tell ``getLocalVue`` in Jest test helpers to instrument localization plugin without mocking and I've added test expectations ``toBeLocalized()`` and ``toBeLocalizationOf("text")`` to implement assertions about localization when they are instrumented this way. I added a test and localization to the ToolFooter mostly just as an example of how to use it.

I also cleaned up some old localization stuff that predates the jest helper centralization effort I think - again mostly just to verify there wasn't another effort to do something like this.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
