### PR TITLE
Fix flaky user histories providers test

### DIFF
--- a/client/src/components/providers/UserHistories.test.js
+++ b/client/src/components/providers/UserHistories.test.js
@@ -1,32 +1,8 @@
 import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
-import { getLocalVue, wait, waitForLifecyleEvent, watchForChange } from "jest/helpers";
+import { getLocalVue } from "jest/helpers";
 import { historyStore } from "store/historyStore/historyStore";
 import UserHistories from "./UserHistories";
-
-// #region Test Data
-
-let historySummaries;
-let fullHistories;
-let currentHistoryId;
-
-// These history tests can be flaky, so we allow a few retries while we work out
-// what's going on.
-jest.retryTimes(3, { logErrorsBeforeRetry: true });
-
-const resetTestData = () => {
-    const ids = [1, 2, 3, 4];
-    currentHistoryId = ids[0];
-    historySummaries = ids.map((i) => ({ id: i, name: `History #${i}` }));
-    fullHistories = historySummaries.map((h) => ({ ...h, detailView: true }));
-};
-
-const fakeUser = { id: 123234, name: "Bob" };
-
-// #endregion
-
-// #region Mock server responses
-
 import {
     getHistoryList,
     getHistoryById,
@@ -40,78 +16,69 @@ import {
 jest.mock("app");
 jest.mock("store/historyStore/model/queries");
 
-const maxServerDelay = 60;
-const serverDelay = async (min = 0, max = maxServerDelay) => {
-    const delay = min + Math.random() * (max - min);
-    await wait(delay);
-};
-
-getHistoryList.mockImplementation(async () => {
-    await serverDelay();
-    return [...historySummaries];
-});
-
-getCurrentHistoryFromServer.mockImplementation(async () => {
-    await serverDelay();
-    return fullHistories.find((o) => o.id == currentHistoryId);
-});
-
-getHistoryById.mockImplementation(async (id) => {
-    await serverDelay();
-    return fullHistories.find((o) => o.id == id);
-});
-
-const createdHistory = { id: 666, name: "I am new" };
-createNewHistory.mockImplementation(async () => {
-    await serverDelay();
-    historySummaries.push(createdHistory);
-    const newFullHistory = { ...createdHistory, detailView: true };
-    fullHistories.push(newFullHistory);
-    return Object.assign({}, newFullHistory);
-});
-
-setCurrentHistoryOnServer.mockImplementation(async (id) => {
-    await serverDelay();
-    currentHistoryId = id;
-    const result = fullHistories.find((h) => h.id == id);
-    return Object.assign({}, result);
-});
-
-updateHistoryFields.mockImplementation(async (id, payload = {}) => {
-    await serverDelay();
-    const existingHistory = fullHistories.find((h) => h.id == id);
-    return { ...existingHistory, ...payload };
-});
-
-deleteHistoryById.mockImplementation(async (id) => {
-    await serverDelay();
-    return fullHistories.find((h) => h.id == id);
-});
-
-// #endregion
-
-// #region Mounting
-
 const localVue = getLocalVue();
 
-// Generate store for tesint, just need the one module we talk to
-const historiesStore = new Vuex.Store({
+// generate store for testing
+const localStore = new Vuex.Store({
     modules: {
         history: historyStore,
     },
 });
 
-// #endregion
+// test user data
+const fakeUser = { id: 123234, name: "Bob" };
+const createdHistory = { id: 666, name: "I am new" };
 
+// test store data
+let currentHistoryId;
+let historyDetails;
+let historySummaries;
+const setTestData = () => {
+    const ids = [1, 2, 3, 4];
+    currentHistoryId = ids[0];
+    historySummaries = ids.map((i) => ({ id: i, name: `History #${i}` }));
+    historyDetails = historySummaries.map((h) => ({ ...h, detailView: true }));
+};
+
+// mock store queries
+getHistoryList.mockImplementation(async () => {
+    return [...historySummaries];
+});
+getCurrentHistoryFromServer.mockImplementation(async () => {
+    return historyDetails.find((o) => o.id == currentHistoryId);
+});
+getHistoryById.mockImplementation(async (id) => {
+    return historyDetails.find((o) => o.id == id);
+});
+createNewHistory.mockImplementation(async () => {
+    historySummaries.push(createdHistory);
+    const newFullHistory = { ...createdHistory, detailView: true };
+    historyDetails.push(newFullHistory);
+    return Object.assign({}, newFullHistory);
+});
+setCurrentHistoryOnServer.mockImplementation(async (id) => {
+    currentHistoryId = id;
+    const result = historyDetails.find((h) => h.id == id);
+    return Object.assign({}, result);
+});
+updateHistoryFields.mockImplementation(async (id, payload = {}) => {
+    const existingHistory = historyDetails.find((h) => h.id == id);
+    return { ...existingHistory, ...payload };
+});
+deleteHistoryById.mockImplementation(async (id) => {
+    return historyDetails.find((h) => h.id == id);
+});
+
+// user histories provider test cases
 describe("UserHistories", () => {
     let wrapper;
     let slotProps;
 
     beforeEach(async () => {
-        resetTestData();
+        setTestData();
         wrapper = shallowMount(UserHistories, {
             localVue,
-            store: historiesStore,
+            store: localStore,
             propsData: {
                 user: fakeUser,
             },
@@ -121,17 +88,16 @@ describe("UserHistories", () => {
                 },
             },
         });
-        await waitForLifecyleEvent(wrapper.vm, "updated");
     });
 
     afterEach(async () => {
-        historiesStore.dispatch("history/resetHistory");
+        localStore.dispatch("history/resetHistory");
         if (wrapper) {
             await wrapper.destroy();
         }
     });
 
-    describe("slotProps: values", () => {
+    describe("slotProp values", () => {
         test("histories", async () => {
             const { histories } = slotProps;
             expect(histories).toBeInstanceOf(Array);
@@ -152,18 +118,10 @@ describe("UserHistories", () => {
         test("setCurrentHistory", async () => {
             const { setCurrentHistory } = slotProps.handlers;
             expect(setCurrentHistory).toBeInstanceOf(Function);
-
             // set another history as current
             const nextHistory = historySummaries[1];
-            setCurrentHistory(nextHistory);
-
-            await watchForChange({
-                vm: wrapper.vm,
-                propName: "currentHistory",
-                label: "currenntHistoryChange",
-            });
-
-            // wait for it to register
+            await setCurrentHistory(nextHistory);
+            // verify that current history has changed
             const { currentHistory: changedHistory, histories: newHistories } = slotProps;
             expect(changedHistory.id).toEqual(nextHistory.id);
             expect(changedHistory).toBeInstanceOf(Object);
@@ -173,16 +131,11 @@ describe("UserHistories", () => {
         test("createNewHistory", async () => {
             const { createNewHistory } = slotProps.handlers;
             expect(createNewHistory).toBeInstanceOf(Function);
-
+            // expect initial history id
+            expect(slotProps.currentHistory.id).toEqual(historySummaries[0].id);
             // create new history
             await createNewHistory();
-
-            await watchForChange({
-                vm: wrapper.vm,
-                propName: "currentHistory",
-            });
-
-            // wait for it to come out of the slot
+            // expect new history id
             expect(slotProps.currentHistory.id).toEqual(createdHistory.id);
         });
 
@@ -194,11 +147,8 @@ describe("UserHistories", () => {
             expect(updateHistory).toBeInstanceOf(Function);
             expect(currentHistory).toBeInstanceOf(Object);
             const modifiedHistory = { ...currentHistory, foo: "bar" };
-
             expect(modifiedHistory.id).toBeDefined();
             await updateHistory(modifiedHistory);
-            await waitForLifecyleEvent(wrapper.vm, "updated");
-
             expect(slotProps.histories.find((h) => h.foo == "bar")).toBeTruthy();
         });
 
@@ -207,11 +157,8 @@ describe("UserHistories", () => {
                 currentHistory,
                 handlers: { deleteHistory },
             } = slotProps;
-
             expect(deleteHistory).toBeInstanceOf(Function);
-
             await deleteHistory(currentHistory);
-            await waitForLifecyleEvent(wrapper.vm, "updated");
             expect(slotProps.histories.find((h) => h.id == currentHistory.id)).toBeFalsy();
             expect(slotProps.currentHistory.id).not.toEqual(currentHistory.id);
         });

--- a/client/src/components/providers/UserHistories.test.js
+++ b/client/src/components/providers/UserHistories.test.js
@@ -31,42 +31,38 @@ const createdHistory = { id: 666, name: "I am new" };
 
 // test store data
 let currentHistoryId;
-let historyDetails;
-let historySummaries;
+let histories;
 const setTestData = () => {
     const ids = [1, 2, 3, 4];
     currentHistoryId = ids[0];
-    historySummaries = ids.map((i) => ({ id: i, name: `History #${i}` }));
-    historyDetails = historySummaries.map((h) => ({ ...h, detailView: true }));
+    histories = ids.map((i) => ({ id: i, name: `History #${i}` }));
 };
 
 // mock store queries
 getHistoryList.mockImplementation(async () => {
-    return [...historySummaries];
+    return [...histories];
 });
 getCurrentHistoryFromServer.mockImplementation(async () => {
-    return historyDetails.find((o) => o.id == currentHistoryId);
+    return histories.find((o) => o.id == currentHistoryId);
 });
 getHistoryById.mockImplementation(async (id) => {
-    return historyDetails.find((o) => o.id == id);
+    return histories.find((o) => o.id == id);
 });
 createNewHistory.mockImplementation(async () => {
-    historySummaries.push(createdHistory);
-    const newFullHistory = { ...createdHistory, detailView: true };
-    historyDetails.push(newFullHistory);
-    return Object.assign({}, newFullHistory);
+    histories.push(createdHistory);
+    return Object.assign({}, createdHistory);
 });
 setCurrentHistoryOnServer.mockImplementation(async (id) => {
     currentHistoryId = id;
-    const result = historyDetails.find((h) => h.id == id);
+    const result = histories.find((h) => h.id == id);
     return Object.assign({}, result);
 });
 updateHistoryFields.mockImplementation(async (id, payload = {}) => {
-    const existingHistory = historyDetails.find((h) => h.id == id);
+    const existingHistory = histories.find((h) => h.id == id);
     return { ...existingHistory, ...payload };
 });
 deleteHistoryById.mockImplementation(async (id) => {
-    return historyDetails.find((h) => h.id == id);
+    return histories.find((h) => h.id == id);
 });
 
 // user histories provider test cases
@@ -101,7 +97,7 @@ describe("UserHistories", () => {
         test("histories", async () => {
             const { histories } = slotProps;
             expect(histories).toBeInstanceOf(Array);
-            expect(histories.length).toEqual(historySummaries.length);
+            expect(histories.length).toEqual(histories.length);
             histories.forEach((h) => {
                 expect(h).toBeInstanceOf(Object);
             });
@@ -119,7 +115,7 @@ describe("UserHistories", () => {
             const { setCurrentHistory } = slotProps.handlers;
             expect(setCurrentHistory).toBeInstanceOf(Function);
             // set another history as current
-            const nextHistory = historySummaries[1];
+            const nextHistory = histories[1];
             await setCurrentHistory(nextHistory);
             // verify that current history has changed
             const { currentHistory: changedHistory, histories: newHistories } = slotProps;
@@ -132,7 +128,7 @@ describe("UserHistories", () => {
             const { createNewHistory } = slotProps.handlers;
             expect(createNewHistory).toBeInstanceOf(Function);
             // expect initial history id
-            expect(slotProps.currentHistory.id).toEqual(historySummaries[0].id);
+            expect(slotProps.currentHistory.id).toEqual(histories[0].id);
             // create new history
             await createNewHistory();
             // expect new history id

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -84,12 +84,12 @@ const promises = {
 const actions = {
     async copyHistory({ dispatch }, { history, name, copyAll }) {
         const newHistory = await cloneHistory(history, name, copyAll);
-        dispatch("selectHistory", newHistory);
+        await dispatch("selectHistory", newHistory);
     },
     async createNewHistory({ dispatch }) {
         // create history, then select it as current at the same time
         const newHistory = await createNewHistory();
-        dispatch("selectHistory", newHistory);
+        await dispatch("selectHistory", newHistory);
     },
     async deleteHistory({ dispatch, commit, getters }, { history, purge = false }) {
         const deletedHistory = await deleteHistoryById(history.id, purge);

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -84,20 +84,20 @@ const promises = {
 const actions = {
     async copyHistory({ dispatch }, { history, name, copyAll }) {
         const newHistory = await cloneHistory(history, name, copyAll);
-        await dispatch("selectHistory", newHistory);
+        return dispatch("selectHistory", newHistory);
     },
     async createNewHistory({ dispatch }) {
         // create history, then select it as current at the same time
         const newHistory = await createNewHistory();
-        await dispatch("selectHistory", newHistory);
+        return dispatch("selectHistory", newHistory);
     },
     async deleteHistory({ dispatch, commit, getters }, { history, purge = false }) {
         const deletedHistory = await deleteHistoryById(history.id, purge);
         commit("deleteHistory", deletedHistory);
         if (getters.firstHistoryId) {
-            await dispatch("setCurrentHistoryId", getters.firstHistoryId);
+            return dispatch("setCurrentHistoryId", getters.firstHistoryId);
         } else {
-            await dispatch("createNewHistory");
+            return dispatch("createNewHistory");
         }
     },
     loadCurrentHistory({ dispatch }) {


### PR DESCRIPTION
This PR fixes the flaky histories providers test by streamlining it without randomly attempting to mock server delays. Test coverage is fully preserved.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
