### PR TITLE
[22.01] replace encodestring with encodebytes

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7712,7 +7712,7 @@ class PSAAssociation(Base, AssociationMixin, RepresentById):
             assoc = cls.sa_session.query(cls).filter_by(server_url=server_url, handle=association.handle)[0]
         except IndexError:
             assoc = cls(server_url=server_url, handle=association.handle)
-        assoc.secret = base64.encodestring(association.secret).decode()
+        assoc.secret = base64.encodebytes(association.secret).decode()
         assoc.issued = association.issued
         assoc.lifetime = association.lifetime
         assoc.assoc_type = association.assoc_type


### PR DESCRIPTION
According to https://docs.python.org/3.8/library/base64.html#base64.encodestring , `base64.encodestring()` is deprecated since 3.1.

It was removed with python 3.9 and fails on those versions.