### PR TITLE
Refactor bulk operation processing

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Index.vue
@@ -44,14 +44,14 @@ export default {
         history: { type: Object, required: true },
         showSelection: { type: Boolean, required: true },
         hasMatches: { type: Boolean, required: true },
-        expandedCount: { type: Number, required: false, default: 0 },
+        expandedCount: { type: Number, default: 0 },
     },
     methods: {
         toggleSelection() {
             this.$emit("update:show-selection", !this.showSelection);
         },
-        onUpdateOperationStatus(running) {
-            this.$emit("update:operation-running", running);
+        onUpdateOperationStatus(updateTime) {
+            this.$emit("update:operation-running", updateTime);
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
@@ -52,19 +52,19 @@ export default {
         onCopy() {
             iframeRedirect("/dataset/copy_datasets");
         },
-        async unhideAll() {
-            await this.runOperation(() => unhideAllHiddenContent(this.history));
+        unhideAll() {
+            this.runOperation(() => unhideAllHiddenContent(this.history));
         },
-        async deleteAllHidden() {
-            await this.runOperation(() => deleteAllHiddenContent(this.history));
+        deleteAllHidden() {
+            this.runOperation(() => deleteAllHiddenContent(this.history));
         },
-        async purgeAllDeleted() {
-            await this.runOperation(() => purgeAllDeletedContent(this.history));
+        purgeAllDeleted() {
+            this.runOperation(() => purgeAllDeletedContent(this.history));
         },
         async runOperation(operation) {
-            this.$emit("update:operation-running", true);
+            this.$emit("update:operation-running", this.history.update_time);
             await operation();
-            this.$emit("update:operation-running", false);
+            this.$emit("update:operation-running", this.history.update_time);
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -119,28 +119,28 @@ export default {
     },
     methods: {
         // Selected content manipulation, hide/show/delete/purge
-        async hideSelected() {
-            await this.runOnSelection(hideSelectedContent);
+        hideSelected() {
+            this.runOnSelection(hideSelectedContent);
         },
-        async unhideSelected() {
-            await this.runOnSelection(unhideSelectedContent);
+        unhideSelected() {
+            this.runOnSelection(unhideSelectedContent);
         },
-        async deleteSelected() {
-            await this.runOnSelection(deleteSelectedContent);
+        deleteSelected() {
+            this.runOnSelection(deleteSelectedContent);
         },
-        async undeleteSelected() {
-            await this.runOnSelection(undeleteSelectedContent);
+        undeleteSelected() {
+            this.runOnSelection(undeleteSelectedContent);
         },
-        async purgeSelected() {
-            await this.runOnSelection(purgeSelectedContent);
+        purgeSelected() {
+            this.runOnSelection(purgeSelectedContent);
         },
         async runOnSelection(operation) {
-            this.$emit("update:operation-running", true);
+            this.$emit("update:operation-running", this.history.update_time);
             const items = this.getExplicitlySelectedItems();
             const filters = getQueryDict(this.filterText);
             this.$emit("update:show-selection", false);
             await operation(this.history, filters, items);
-            this.$emit("update:operation-running", false);
+            this.$emit("update:operation-running", this.history.update_time);
         },
         getExplicitlySelectedItems() {
             if (this.isQuerySelection) {

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -42,8 +42,8 @@
                             :show-selection="showSelection"
                             :expanded-count="expandedCount"
                             :has-matches="hasMatches(itemsLoaded)"
+                            :operation-running.sync="operationRunning"
                             @update:show-selection="setShowSelection"
-                            @update:operation-running="onUpdateOperationStatus"
                             @collapse-all="collapseAll">
                             <template v-slot:selection-operations>
                                 <HistorySelectionOperations
@@ -53,8 +53,8 @@
                                     :selection-size="selectionSize"
                                     :is-query-selection="isQuerySelection"
                                     :total-items-in-query="totalItemsInQuery"
+                                    :operation-running.sync="operationRunning"
                                     @update:show-selection="setShowSelection"
-                                    @update:operation-running="onUpdateOperationStatus"
                                     @hide-selection="onHideSelection"
                                     @reset-selection="resetSelection" />
                                 <HistorySelectionStatus
@@ -155,8 +155,7 @@ export default {
             invisible: {},
             offset: 0,
             showAdvanced: false,
-            isOperationRunning: false,
-            updateExpectedAfterDate: null,
+            operationRunning: null,
             querySelectionBreak: false,
         };
     },
@@ -178,12 +177,8 @@ export default {
             return !this.queryDefault;
         },
         /** @returns {Boolean} */
-        isHistoryUpdated() {
-            return !this.updateExpectedAfterDate || this.history.update_time > this.updateExpectedAfterDate;
-        },
-        /** @returns {Boolean} */
         isProcessing() {
-            return this.isOperationRunning || !this.isHistoryUpdated;
+            return this.operationRunning >= this.history.update_time;
         },
     },
     watch: {
@@ -193,12 +188,7 @@ export default {
         },
         historyId(newVal, oldVal) {
             if (newVal !== oldVal) {
-                this.stopExpectingHistoryUpdate();
-            }
-        },
-        isHistoryUpdated(updated) {
-            if (updated) {
-                this.stopExpectingHistoryUpdate();
+                this.operationRunning = null;
             }
         },
     },
@@ -231,18 +221,6 @@ export default {
         },
         setInvisible(item) {
             Vue.set(this.invisible, item.hid, true);
-        },
-        onUpdateOperationStatus(running) {
-            if (running) {
-                this.expectHistoryUpdate();
-            }
-            this.isOperationRunning = running;
-        },
-        expectHistoryUpdate() {
-            this.updateExpectedAfterDate = this.history.update_time;
-        },
-        stopExpectingHistoryUpdate() {
-            this.updateExpectedAfterDate = null;
         },
     },
 };

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -5,36 +5,36 @@ import { bulkUpdate } from "./queries";
  */
 
 export async function hideSelectedContent(history, filters, items) {
-    return await bulkUpdate(history, "hide", filters, items);
+    return bulkUpdate(history, "hide", filters, items);
 }
 
 export async function unhideSelectedContent(history, filters, items) {
-    return await bulkUpdate(history, "unhide", filters, items);
+    return bulkUpdate(history, "unhide", filters, items);
 }
 
 export async function deleteSelectedContent(history, filters, items) {
-    return await bulkUpdate(history, "delete", filters, items);
+    return bulkUpdate(history, "delete", filters, items);
 }
 
 export async function undeleteSelectedContent(history, filters, items) {
-    return await bulkUpdate(history, "undelete", filters, items);
+    return bulkUpdate(history, "undelete", filters, items);
 }
 
 export async function purgeSelectedContent(history, filters, items) {
-    return await bulkUpdate(history, "purge", filters, items);
+    return bulkUpdate(history, "purge", filters, items);
 }
 
 export async function unhideAllHiddenContent(history) {
     const filters = { visible: false };
-    return await unhideSelectedContent(history, filters);
+    return unhideSelectedContent(history, filters);
 }
 
 export async function deleteAllHiddenContent(history) {
     const filters = { deleted: false, visible: false };
-    return await deleteSelectedContent(history, filters);
+    return deleteSelectedContent(history, filters);
 }
 
 export async function purgeAllDeletedContent(history) {
     const filters = { deleted: true };
-    return await purgeSelectedContent(history, filters);
+    return purgeSelectedContent(history, filters);
 }

--- a/client/src/components/History/model/crud.js
+++ b/client/src/components/History/model/crud.js
@@ -4,37 +4,37 @@ import { bulkUpdate } from "./queries";
  * Content operations
  */
 
-export async function hideSelectedContent(history, filters, items) {
+export function hideSelectedContent(history, filters, items) {
     return bulkUpdate(history, "hide", filters, items);
 }
 
-export async function unhideSelectedContent(history, filters, items) {
+export function unhideSelectedContent(history, filters, items) {
     return bulkUpdate(history, "unhide", filters, items);
 }
 
-export async function deleteSelectedContent(history, filters, items) {
+export function deleteSelectedContent(history, filters, items) {
     return bulkUpdate(history, "delete", filters, items);
 }
 
-export async function undeleteSelectedContent(history, filters, items) {
+export function undeleteSelectedContent(history, filters, items) {
     return bulkUpdate(history, "undelete", filters, items);
 }
 
-export async function purgeSelectedContent(history, filters, items) {
+export function purgeSelectedContent(history, filters, items) {
     return bulkUpdate(history, "purge", filters, items);
 }
 
-export async function unhideAllHiddenContent(history) {
+export function unhideAllHiddenContent(history) {
     const filters = { visible: false };
     return unhideSelectedContent(history, filters);
 }
 
-export async function deleteAllHiddenContent(history) {
+export function deleteAllHiddenContent(history) {
     const filters = { deleted: false, visible: false };
     return deleteSelectedContent(history, filters);
 }
 
-export async function purgeAllDeletedContent(history) {
+export function purgeAllDeletedContent(history) {
     const filters = { deleted: true };
     return purgeSelectedContent(history, filters);
 }


### PR DESCRIPTION
Attempts to slightly refactor bulk operation handling on the client, reduce used props and functions and highlight the actual process more clearly. Added a JSFiddle to indicate usage of async/await only when necessary: https://jsfiddle.net/ujzbmp6d/2/.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
