### PR TITLE
More Workflow List Component Improvements

### DIFF
--- a/client/src/components/Indices/SharingIndicators.test.js
+++ b/client/src/components/Indices/SharingIndicators.test.js
@@ -1,0 +1,59 @@
+import SharingIndicators from "./SharingIndicators";
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+
+const localVue = getLocalVue();
+
+describe("SharingIndicators.vue", () => {
+    let wrapper;
+
+    describe("buttons not visible when object unshared", () => {
+        beforeEach(async () => {
+            const propsData = {
+                object: {
+                    published: false,
+                    shared: false,
+                },
+            };
+            wrapper = shallowMount(SharingIndicators, {
+                propsData,
+                localVue,
+            });
+        });
+
+        it("should not have display published button", async () => {
+            expect(wrapper.find(".sharing-indicator-published").exists()).toBeFalsy();
+        });
+
+        it("should not have display shared button", async () => {
+            expect(wrapper.find(".sharing-indicator-shared").exists()).toBeFalsy();
+        });
+    });
+
+    describe("shared objects", () => {
+        beforeEach(async () => {
+            const propsData = {
+                object: {
+                    published: true,
+                    shared: true,
+                },
+            };
+            wrapper = shallowMount(SharingIndicators, {
+                propsData,
+                localVue,
+            });
+        });
+
+        it("should fire a is:published filter on published click", async () => {
+            await wrapper.find(".sharing-indicator-published").trigger("click");
+            const emitted = wrapper.emitted("filter");
+            expect(emitted[0][0]).toBe("is:published");
+        });
+
+        it("should fire a is:shared_with_me filter on shared click", async () => {
+            await wrapper.find(".sharing-indicator-shared").trigger("click");
+            const emitted = wrapper.emitted("filter");
+            expect(emitted[0][0]).toBe("is:shared_with_me");
+        });
+    });
+});

--- a/client/src/components/Indices/SharingIndicators.vue
+++ b/client/src/components/Indices/SharingIndicators.vue
@@ -5,12 +5,14 @@
             v-b-tooltip.hover
             :title="'Published' | localize"
             icon="globe"
+            class="sharing-indicator-published"
             @click="$emit('filter', 'is:published')" />
         <font-awesome-icon
             v-if="object.shared"
             v-b-tooltip.hover
             :title="'Shared' | localize"
             icon="share-alt"
+            class="sharing-indicator-shared"
             @click="$emit('filter', 'is:shared_with_me')" />
     </span>
 </template>

--- a/client/src/components/Indices/filtersMixin.test.js
+++ b/client/src/components/Indices/filtersMixin.test.js
@@ -1,0 +1,46 @@
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import filtersMixin from "./filtersMixin";
+
+const localVue = getLocalVue();
+
+const Component = {
+    render() {},
+    mixins: [filtersMixin],
+};
+
+describe("filtersMixin.js", () => {
+    let wrapper;
+
+    beforeEach(async () => {
+        const propsData = {};
+        wrapper = shallowMount(Component, propsData, localVue);
+    });
+
+    it("should be initially unfiltered", async () => {
+        expect(wrapper.vm.isFiltered).toBeFalsy();
+    });
+
+    it("should combine implicit and explicit filter", async () => {
+        expect(wrapper.vm.filter).toBe("");
+        wrapper.vm.appendTagFilter("name", "foobar");
+        expect(wrapper.vm.filter).toBe("name:'foobar'");
+    });
+
+    it("should be filtered after setting a filter", async () => {
+        wrapper.vm.appendTagFilter("name", "foobar");
+        expect(wrapper.vm.isFiltered).toBeTruthy();
+    });
+
+    it("should be filter space", async () => {
+        wrapper.vm.appendFilter("bar");
+        wrapper.vm.appendFilter("foo");
+        expect(wrapper.vm.filter).toBe("foo bar");
+    });
+
+    it("should not duplicate tagged filters if added twice", async () => {
+        wrapper.vm.appendTagFilter("name", "foobar");
+        wrapper.vm.appendTagFilter("name", "foobar");
+        expect(wrapper.vm.filter).toBe("name:'foobar'");
+    });
+});

--- a/client/src/components/Workflow/WorkflowDropdown.test.js
+++ b/client/src/components/Workflow/WorkflowDropdown.test.js
@@ -1,0 +1,89 @@
+import WorkflowDropdown from "./WorkflowDropdown";
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+
+const localVue = getLocalVue(true);
+
+const TEST_WORKFLOW_NAME = "my workflow";
+const TEST_WORKFLOW_DESCRIPTION = "my cool workflow description";
+
+describe("WorkflowDropdown.vue", () => {
+    let wrapper;
+    let propsData;
+
+    function initWrapperForWorkflow(workflow) {
+        propsData = {
+            root: "/root/",
+            workflow: workflow,
+        };
+        wrapper = shallowMount(WorkflowDropdown, {
+            propsData,
+            localVue,
+        });
+    }
+
+    function workflowOptions() {
+        return wrapper.findAll(".dropdown-menu .dropdown-item");
+    }
+
+    describe("for workflows owned by user", () => {
+        beforeEach(async () => {
+            const workflow = {
+                name: TEST_WORKFLOW_NAME,
+                id: "workflowid123",
+                description: TEST_WORKFLOW_DESCRIPTION,
+                owner: "test",
+            };
+            initWrapperForWorkflow(workflow);
+        });
+
+        it("should not display source metadata if not present", async () => {
+            expect(wrapper.find(".workflow-trs-icon").exists()).toBeFalsy();
+            expect(wrapper.find(".workflow-external-link").exists()).toBeFalsy();
+        });
+
+        it("should display name and description", async () => {
+            expect(wrapper.find(".workflow-dropdown-name").text()).toBe(TEST_WORKFLOW_NAME);
+            expect(wrapper.find(".workflow-dropdown-description").text()).toBe(TEST_WORKFLOW_DESCRIPTION);
+        });
+
+        it("should provide all owner workflow options", () => {
+            expect(workflowOptions().length).toBeGreaterThan(2);
+        });
+    });
+
+    describe("workflows without annotations", () => {
+        beforeEach(async () => {
+            const workflow = {
+                name: TEST_WORKFLOW_NAME,
+                id: "workflowid123",
+                owner: "test",
+            };
+            initWrapperForWorkflow(workflow);
+        });
+
+        it("should display name but not description", async () => {
+            expect(wrapper.find(".workflow-dropdown-name").text()).toBe(TEST_WORKFLOW_NAME);
+            expect(wrapper.find(".workflow-dropdown-description").exists()).toBeFalsy();
+        });
+    });
+
+    describe("for workflows shared with user", () => {
+        beforeEach(async () => {
+            const workflow = {
+                name: TEST_WORKFLOW_NAME,
+                id: "workflowid123",
+                description: TEST_WORKFLOW_DESCRIPTION,
+                shared: true,
+            };
+            initWrapperForWorkflow(workflow);
+        });
+
+        it("should provide a limited number of options", () => {
+            expect(workflowOptions().length).toBe(3);
+            expect(workflowOptions().at(0).text()).toBeLocalizationOf("Copy");
+            expect(workflowOptions().at(1).text()).toBeLocalizationOf("Download");
+            expect(workflowOptions().at(2).text()).toBeLocalizationOf("View");
+        });
+    });
+});

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -7,7 +7,7 @@
             aria-haspopup="true"
             aria-expanded="false">
             <font-awesome-icon icon="caret-down" />
-            <span>{{ workflow.name }}</span>
+            <span class="workflow-dropdown-name">{{ workflow.name }}</span>
         </b-link>
         <font-awesome-icon
             v-if="sourceType.includes('trs')"
@@ -21,57 +21,47 @@
             :title="`Imported from ${workflow.source_metadata.url}`"
             class="workflow-external-link"
             icon="link" />
-        <p v-if="workflow.description">{{ workflow.description }}</p>
-        <div v-if="workflow.shared" class="dropdown-menu" aria-labelledby="workflow-dropdown">
-            <a class="dropdown-item" href="#" @click.prevent="onCopy">
-                <span class="fa fa-copy fa-fw mr-1" />
-                <span>Copy</span>
-            </a>
-            <a class="dropdown-item" :href="urlViewShared">
-                <span class="fa fa-eye fa-fw mr-1" />
-                <span>View</span>
-            </a>
-        </div>
-        <div v-else class="dropdown-menu" aria-labelledby="workflow-dropdown">
-            <a class="dropdown-item" :href="urlEdit">
+        <p class="workflow-dropdown-description" v-if="workflow.description">{{ workflow.description }}</p>
+        <div class="dropdown-menu" aria-labelledby="workflow-dropdown">
+            <a v-if="!readOnly" class="dropdown-item" :href="urlEdit">
                 <span class="fa fa-edit fa-fw mr-1" />
-                <span>Edit</span>
+                <span v-localize>Edit</span>
             </a>
             <a class="dropdown-item" href="#" @click.prevent="onCopy">
                 <span class="fa fa-copy fa-fw mr-1" />
-                <span>Copy</span>
+                <span v-localize>Copy</span>
             </a>
-            <a class="dropdown-item" :href="urlInvocations">
+            <a v-if="!readOnly" class="dropdown-item" :href="urlInvocations">
                 <span class="fa fa-list fa-fw mr-1" />
-                <span>Invocations</span>
+                <span v-localize>Invocations</span>
             </a>
             <a class="dropdown-item" :href="urlDownload">
                 <span class="fa fa-download fa-fw mr-1" />
-                <span>Download</span>
+                <span v-localize>Download</span>
             </a>
-            <a class="dropdown-item" href="#" @click.prevent="onRename">
+            <a v-if="!readOnly" class="dropdown-item" href="#" @click.prevent="onRename">
                 <span class="fa fa-signature fa-fw mr-1" />
-                <span>Rename</span>
+                <span v-localize>Rename</span>
             </a>
-            <a class="dropdown-item" :href="urlShare">
+            <a v-if="!readOnly" class="dropdown-item" :href="urlShare">
                 <span class="fa fa-share-alt fa-fw mr-1" />
-                <span>Share</span>
+                <span v-localize>Share</span>
             </a>
-            <a class="dropdown-item" :href="urlExport">
+            <a v-if="!readOnly" class="dropdown-item" :href="urlExport">
                 <span class="fa fa-file-export fa-fw mr-1" />
-                <span>Export</span>
+                <span v-localize>Export</span>
             </a>
             <a class="dropdown-item" :href="urlView">
                 <span class="fa fa-eye fa-fw mr-1" />
-                <span>View</span>
+                <span v-localize>View</span>
             </a>
             <a v-if="sourceLabel" class="dropdown-item" :href="sourceUrl">
                 <span class="fa fa-globe fa-fw mr-1" />
-                <span>{{ sourceLabel }}</span>
+                <span v-localize>{{ sourceLabel }}</span>
             </a>
-            <a class="dropdown-item" href="#" @click.prevent="onDelete">
+            <a v-if="!readOnly" class="dropdown-item" href="#" @click.prevent="onDelete">
                 <span class="fa fa-trash fa-fw mr-1" />
-                <span>Delete</span>
+                <span v-localize>Delete</span>
             </a>
         </div>
     </div>
@@ -114,6 +104,9 @@ export default {
             return `${getAppRoot()}workflow/display_by_username_and_slug?username=${this.workflow.owner}&slug=${
                 this.workflow.slug
             }`;
+        },
+        readOnly() {
+            return !!this.workflow.shared;
         },
         sourceUrl() {
             if (this.workflow.source_metadata?.url) {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -175,7 +175,9 @@ export default {
             ctx.root = this.root;
             const extraParams = { search: this.filter, skip_step_counts: true };
             const promise = storedWorkflowsProvider(ctx, this.setRows, extraParams).catch(this.onError);
-            this.workflowItems = await promise;
+            const workflowItems = await promise;
+            (workflowItems || []).forEach((item) => this.services._addAttributes(item));
+            this.workflowItems = workflowItems;
             return this.workflowItems;
         },
         bookmarkWorkflow: function (id, checked) {

--- a/client/src/components/Workflow/Workflows.test.js
+++ b/client/src/components/Workflow/Workflows.test.js
@@ -8,6 +8,8 @@ import { parseISO, formatDistanceToNow } from "date-fns";
 
 const localVue = getLocalVue();
 
+jest.mock("app");
+
 const mockWorkflowsData = [
     {
         id: "5f1915bcf9f35612",
@@ -16,8 +18,8 @@ const mockWorkflowsData = [
         name: "workflow name",
         tags: ["tagmoo", "tagcow"],
         published: true,
-        shared: true,
         show_in_tool_panel: true,
+        owner: "test",
     },
 ];
 


### PR DESCRIPTION
Builds on #13876 with more Jest tests for the decomposed widgets. New jest tests for the older WorkflowDropdown component as well and refactoring and localization to remove duplication guided by tests. And a fix for a bug added by my recent work where workflows were missing some attributes added client side previously and dropped in the switch to more direct providers.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
