### PR TITLE
Jobs Index and Grid Improvements

### DIFF
--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -31,7 +31,7 @@
                     <b-form-group
                         id="cutoff"
                         label="Cutoff time period"
-                        :disabled="showAllRunning"
+                        v-show="!showAllRunning"
                         description="in minutes">
                         <b-input-group>
                             <b-form-input id="cutoff" v-model="cutoffMin" type="number"> </b-form-input>

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -35,9 +35,6 @@
                         description="in minutes">
                         <b-input-group>
                             <b-form-input id="cutoff" v-model="cutoffMin" type="number"> </b-form-input>
-                            <b-input-group-append>
-                                <b-btn type="submit">Refresh</b-btn>
-                            </b-input-group-append>
                         </b-input-group>
                     </b-form-group>
                 </b-form>
@@ -47,9 +44,6 @@
                     description="by strings or regular expressions">
                     <b-input-group id="filter-regex">
                         <b-form-input v-model="filter" placeholder="Type to Search" @keyup.esc.native="filter = ''" />
-                        <b-input-group-append>
-                            <b-btn :disabled="!filter" @click="filter = ''">Clear (esc)</b-btn>
-                        </b-input-group-append>
                     </b-input-group>
                 </b-form-group>
             </b-col>
@@ -169,6 +163,12 @@ export default {
         },
     },
     watch: {
+        filter(newVal) {
+            this.update();
+        },
+        cutoffMin(newVal) {
+            this.update();
+        },
         selectedStopJobIds(newVal) {
             if (newVal.length === 0) {
                 this.indeterminate = false;

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -109,6 +109,7 @@ import JobLock from "./JobLock";
 import JOB_STATES_MODEL from "mvc/history/job-states-model";
 import { commonJobFields } from "./JobFields";
 import { errorMessageAsString } from "utils/simple-error";
+import { jobsProvider } from "components/providers/JobProvider";
 
 function cancelJob(jobId, message) {
     const url = `${getAppRoot()}api/jobs/${jobId}`;
@@ -199,31 +200,31 @@ export default {
         this.update();
     },
     methods: {
-        update() {
+        async update() {
             this.busy = true;
-            let params = [];
-            params.push("view=admin_job_list");
+            const params = { view: "admin_job_list" };
             if (this.showAllRunning) {
-                params.push("state=running");
+                params.state = "running";
             } else {
                 const cutoff = Math.floor(this.cutoffMin);
                 const dateRangeMin = new Date(Date.now() - cutoff * 60 * 1000).toISOString();
-                params.push(`date_range_min=${dateRangeMin}`);
+                params.date_range_min = `${dateRangeMin}`;
             }
-            params = params.join("&");
-            axios
-                .get(`${getAppRoot()}api/jobs?${params}`)
-                .then((response) => {
-                    this.jobs = response.data;
-                    this.loading = false;
-                    this.busy = false;
-                    this.status = "info";
-                })
-                .catch((error) => {
-                    this.message = errorMessageAsString(error);
-                    this.status = "danger";
-                    console.log(error.response);
-                });
+            const ctx = {
+                root: getAppRoot(),
+                ...params,
+            };
+            try {
+                const jobs = await jobsProvider(ctx);
+                this.jobs = jobs;
+                this.loading = false;
+                this.busy = false;
+                this.status = "info";
+            } catch (error) {
+                console.log(error);
+                this.message = errorMessageAsString(error);
+                this.status = "danger";
+            }
         },
         onRefresh() {
             this.update();

--- a/client/src/components/providers/JobProvider.js
+++ b/client/src/components/providers/JobProvider.js
@@ -3,6 +3,7 @@ import { getAppRoot } from "onload/loadConfig";
 import { SingleQueryProvider } from "components/providers/SingleQueryProvider";
 import { rethrowSimple } from "utils/simple-error";
 import { stateIsTerminal } from "./utils";
+import { cleanPaginationParameters } from "./utils";
 
 async function jobDetails({ jobid }) {
     const url = `${getAppRoot()}api/jobs/${jobid}?full=True`;
@@ -26,3 +27,19 @@ async function jobProblems({ jobid }) {
 
 export const JobDetailsProvider = SingleQueryProvider(jobDetails, stateIsTerminal);
 export const JobProblemProvider = SingleQueryProvider(jobProblems, stateIsTerminal);
+
+export function jobsProvider(ctx, callback, extraParams = {}) {
+    const { root, ...requestParams } = ctx;
+    const apiUrl = `${root}api/jobs`;
+    const cleanParams = cleanPaginationParameters(requestParams);
+    const promise = axios.get(apiUrl, { params: { ...cleanParams, ...extraParams } });
+
+    // Must return a promise that resolves to an array of items
+    return promise.then((data) => {
+        // Pluck the array of items off our axios response
+        const items = data.data;
+        callback && callback(data);
+        // Must return an array of items or an empty array if an error occurred
+        return items || [];
+    });
+}

--- a/client/src/components/providers/JobProvider.test.js
+++ b/client/src/components/providers/JobProvider.test.js
@@ -1,0 +1,43 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+import { jobsProvider } from "./JobProvider";
+
+describe("JobProvider", () => {
+    let axiosMock;
+
+    beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    describe("fetching jobs without an error", () => {
+        it("should make an API call and fire callback", async () => {
+            axiosMock
+                .onGet("/prefixj/api/jobs", {
+                    params: { limit: 50, offset: 0, search: "tool_id:'cat1'" },
+                })
+                .reply(200, [{ model_class: "Job" }], { total_matches: "1" });
+
+            const ctx = {
+                root: "/prefixj/",
+                perPage: 50,
+                currentPage: 1,
+            };
+            const extras = {
+                search: "tool_id:'cat1'",
+            };
+
+            let called = false;
+            const callback = function () {
+                called = true;
+            };
+            const promise = jobsProvider(ctx, callback, extras);
+            await promise;
+            expect(called).toBeTruthy();
+        });
+    });
+});

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -18,6 +18,7 @@ from sqlalchemy.sql import select
 
 from galaxy import model
 from galaxy.exceptions import (
+    AdminRequiredException,
     ItemAccessibilityException,
     ObjectNotFound,
     RequestParameterInvalidException,
@@ -30,13 +31,26 @@ from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
+from galaxy.model.index_filter_util import (
+    raw_text_column_filter,
+    text_column_filter,
+)
 from galaxy.model.scoped_session import galaxy_scoped_session
+from galaxy.schema.schema import (
+    JobIndexQueryPayload,
+    JobIndexSortByEnum,
+)
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import StructuredApp
 from galaxy.util import (
     defaultdict,
     ExecutionTimer,
     listify,
+)
+from galaxy.util.search import (
+    FilteredTerm,
+    parse_filters_structured,
+    RawTextTerm,
 )
 
 log = logging.getLogger(__name__)
@@ -69,6 +83,131 @@ class JobManager:
     def __init__(self, app: StructuredApp):
         self.app = app
         self.dataset_manager = DatasetManager(app)
+
+    def index_query(self, trans, payload: JobIndexQueryPayload):
+        is_admin = trans.user_is_admin
+        user_details = payload.user_details
+
+        decoded_user_id = payload.user_id
+
+        if is_admin:
+            if decoded_user_id is not None:
+                query = trans.sa_session.query(model.Job).filter(model.Job.user_id == decoded_user_id)
+            else:
+                query = trans.sa_session.query(model.Job)
+            if user_details:
+                query = query.outerjoin(model.Job.user)
+
+        else:
+            if user_details:
+                raise AdminRequiredException("Only admins can index the jobs with user details enabled")
+            if decoded_user_id is not None and decoded_user_id != trans.user.id:
+                raise AdminRequiredException("Only admins can index the jobs of others")
+            query = trans.sa_session.query(model.Job).filter(model.Job.user_id == trans.user.id)
+
+        def build_and_apply_filters(query, objects, filter_func):
+            if objects is not None:
+                if isinstance(objects, str):
+                    query = query.filter(filter_func(objects))
+                elif isinstance(objects, list):
+                    t = []
+                    for obj in objects:
+                        t.append(filter_func(obj))
+                    query = query.filter(or_(*t))
+            return query
+
+        query = build_and_apply_filters(query, payload.states, lambda s: model.Job.state == s)
+        query = build_and_apply_filters(query, payload.tool_ids, lambda t: model.Job.tool_id == t)
+        query = build_and_apply_filters(query, payload.tool_ids_like, lambda t: model.Job.tool_id.like(t))
+        query = build_and_apply_filters(query, payload.date_range_min, lambda dmin: model.Job.update_time >= dmin)
+        query = build_and_apply_filters(query, payload.date_range_max, lambda dmax: model.Job.update_time <= dmax)
+
+        history_id = payload.history_id
+        workflow_id = payload.workflow_id
+        invocation_id = payload.invocation_id
+        if history_id is not None:
+            decoded_history_id = security.decode_id(history_id)
+            query = query.filter(model.Job.history_id == decoded_history_id)
+        if workflow_id or invocation_id:
+            if workflow_id is not None:
+                decoded_workflow_id = security.decode_id(workflow_id)
+                wfi_step = (
+                    trans.sa_session.query(model.WorkflowInvocationStep)
+                    .join(model.WorkflowInvocation)
+                    .join(model.Workflow)
+                    .filter(
+                        model.Workflow.stored_workflow_id == decoded_workflow_id,
+                    )
+                    .subquery()
+                )
+            elif invocation_id is not None:
+                decoded_invocation_id = security.decode_id(invocation_id)
+                wfi_step = (
+                    trans.sa_session.query(model.WorkflowInvocationStep)
+                    .filter(model.WorkflowInvocationStep.workflow_invocation_id == decoded_invocation_id)
+                    .subquery()
+                )
+            query1 = query.join(wfi_step)
+            query2 = query.join(model.ImplicitCollectionJobsJobAssociation).join(
+                wfi_step,
+                model.ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id
+                == wfi_step.c.implicit_collection_jobs_id,
+            )
+            query = query1.union(query2)
+
+        search = payload.search
+        if search:
+            search_filters = {
+                "tool": "tool",
+                "t": "tool",
+            }
+            if user_details:
+                search_filters.update(
+                    {
+                        "user": "user",
+                        "u": "user",
+                    }
+                )
+
+            if is_admin:
+                search_filters.update(
+                    {
+                        "runner": "runner",
+                        "r": "runner",
+                        "handler": "handler",
+                        "h": "handler",
+                    }
+                )
+            parsed_search = parse_filters_structured(search, search_filters)
+            for term in parsed_search.terms:
+                if isinstance(term, FilteredTerm):
+                    key = term.filter
+                    if key == "user":
+                        query = query.filter(text_column_filter(model.User.email, term))
+                    elif key == "tool":
+                        query = query.filter(text_column_filter(model.Job.tool_id, term))
+                    elif key == "handler":
+                        query = query.filter(text_column_filter(model.Job.handler, term))
+                    elif key == "runner":
+                        query = query.filter(text_column_filter(model.Job.job_runner_name, term))
+                elif isinstance(term, RawTextTerm):
+                    columns = [model.Job.tool_id]
+                    if user_details:
+                        columns.append(model.User.email)
+                    if is_admin:
+                        columns.append(model.Job.handler)
+                        columns.append(model.Job.job_runner_name)
+                    query = query.filter(raw_text_column_filter(columns, term))
+
+        if payload.order_by == JobIndexSortByEnum.create_time:
+            order_by = model.Job.create_time.desc()
+        else:
+            order_by = model.Job.update_time.desc()
+        query = query.order_by(order_by)
+
+        query = query.offset(payload.offset)
+        query = query.limit(payload.limit)
+        return query
 
     def job_lock(self) -> JobLock:
         return JobLock(active=self.app.job_manager.job_lock)

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -126,25 +126,22 @@ class JobManager:
         workflow_id = payload.workflow_id
         invocation_id = payload.invocation_id
         if history_id is not None:
-            decoded_history_id = security.decode_id(history_id)
-            query = query.filter(model.Job.history_id == decoded_history_id)
+            query = query.filter(model.Job.history_id == history_id)
         if workflow_id or invocation_id:
             if workflow_id is not None:
-                decoded_workflow_id = security.decode_id(workflow_id)
                 wfi_step = (
                     trans.sa_session.query(model.WorkflowInvocationStep)
                     .join(model.WorkflowInvocation)
                     .join(model.Workflow)
                     .filter(
-                        model.Workflow.stored_workflow_id == decoded_workflow_id,
+                        model.Workflow.stored_workflow_id == workflow_id,
                     )
                     .subquery()
                 )
             elif invocation_id is not None:
-                decoded_invocation_id = security.decode_id(invocation_id)
                 wfi_step = (
                     trans.sa_session.query(model.WorkflowInvocationStep)
-                    .filter(model.WorkflowInvocationStep.workflow_invocation_id == decoded_invocation_id)
+                    .filter(model.WorkflowInvocationStep.workflow_invocation_id == invocation_id)
                     .subquery()
                 )
             query1 = query.join(wfi_step)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1074,14 +1074,14 @@ class JobIndexSortByEnum(str, Enum):
 class JobIndexQueryPayload(Model):
     states: Optional[List[str]] = None
     user_details: bool = False
-    user_id: Optional[str] = None
+    user_id: Optional[DecodedDatabaseIdField] = None
     tool_ids: Optional[List[str]] = None
     tool_ids_like: Optional[List[str]] = None
     date_range_min: Optional[str] = None
     date_range_max: Optional[str] = None
-    history_id: Optional[str] = None
-    workflow_id: Optional[str] = None
-    invocation_id: Optional[str] = None
+    history_id: Optional[DecodedDatabaseIdField] = None
+    workflow_id: Optional[DecodedDatabaseIdField] = None
+    invocation_id: Optional[DecodedDatabaseIdField] = None
     order_by: JobIndexSortByEnum = JobIndexSortByEnum.update_time
     search: Optional[str] = None
     limit: int = 500

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1066,6 +1066,28 @@ class WorkflowIndexQueryPayload(Model):
     skip_step_counts: bool = False
 
 
+class JobIndexSortByEnum(str, Enum):
+    create_time = "create_time"
+    update_time = "update_time"
+
+
+class JobIndexQueryPayload(Model):
+    states: Optional[List[str]] = None
+    user_details: bool = False
+    user_id: Optional[str] = None
+    tool_ids: Optional[List[str]] = None
+    tool_ids_like: Optional[List[str]] = None
+    date_range_min: Optional[str] = None
+    date_range_max: Optional[str] = None
+    history_id: Optional[str] = None
+    workflow_id: Optional[str] = None
+    invocation_id: Optional[str] = None
+    order_by: JobIndexSortByEnum = JobIndexSortByEnum.update_time
+    search: Optional[str] = None
+    limit: int = 500
+    offset: int = 0
+
+
 class InvocationSortByEnum(str, Enum):
     create_time = "create_time"
     update_time = "update_time"

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -450,12 +450,15 @@ class IndexQueryTag(NamedTuple):
     tag: str
     description: str
     alias: Optional[str] = None
+    admin_only: bool = False
 
     def as_markdown(self):
         desc = self.description
         alias = self.alias
         if alias:
             desc += f" (The tag `{alias}` can be used a short hand alias for this tag to filter on this attribute.)"
+        if self.admin_only:
+            desc += " This tag is only available for requests using admin keys and/or sessions."
         return f"`{self.tag}`\n: {desc}"
 
 

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -74,7 +74,7 @@ StateQueryParam: Optional[str] = Query(
 UserDetailsQueryParam: bool = Query(
     default=False,
     title="Include user details",
-    description="If true, and requestor is an admin, will return external job id and user email.",
+    description="If true, and requestor is an admin, will return external job id and user email. This is only available to admins.",
 )
 
 UserIdQueryParam: Optional[str] = Query(
@@ -216,6 +216,8 @@ class FastAPIJobs:
             else:
                 query = trans.sa_session.query(model.Job)
         else:
+            if user_details:
+                raise exceptions.AdminRequiredException("Only admins can index the jobs with user details enabled")
             if decoded_user_id is not None and decoded_user_id != trans.user.id:
                 raise exceptions.AdminRequiredException("Only admins can index the jobs of others")
             query = trans.sa_session.query(model.Job).filter(model.Job.user_id == trans.user.id)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -145,8 +145,8 @@ OffsetQueryParam: int = Query(
 query_tags = [
     IndexQueryTag("user", "The user email of the user that executed the Job.", "u"),
     IndexQueryTag("tool_id", "The tool ID corresponding to the job.", "t"),
-    IndexQueryTag("runner", "The job runner name used to execte the job.", "r"),
-    IndexQueryTag("handler", "The job handler name used to execute the job.", "h"),
+    IndexQueryTag("runner", "The job runner name used to execte the job.", "r", admin_only=True),
+    IndexQueryTag("handler", "The job handler name used to execute the job.", "h", admin_only=True),
 ]
 
 SearchQueryParam: Optional[str] = search_query_param(

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -72,7 +72,7 @@ UserDetailsQueryParam: bool = Query(
     description="If true, and requestor is an admin, will return external job id and user email. This is only available to admins.",
 )
 
-UserIdQueryParam: Optional[str] = Query(
+UserIdQueryParam: Optional[EncodedDatabaseIdField] = Query(
     default=None,
     title="User ID",
     description="an encoded user id to restrict query to, must be own id if not admin user",
@@ -110,19 +110,19 @@ DateRangeMaxQueryParam: Optional[str] = Query(
     description="Limit listing of jobs to those that are updated before specified date (e.g. '2014-01-01')",
 )
 
-HistoryIdQueryParam: Optional[str] = Query(
+HistoryIdQueryParam: Optional[EncodedDatabaseIdField] = Query(
     default=None,
     title="History ID",
     description="Limit listing of jobs to those that match the history_id. If none, jobs from any history may be returned.",
 )
 
-WorkflowIdQueryParam: Optional[str] = Query(
+WorkflowIdQueryParam: Optional[EncodedDatabaseIdField] = Query(
     default=None,
     title="Workflow ID",
     description="Limit listing of jobs to those that match the specified workflow ID. If none, jobs from any workflow (or from no workflows) may be returned.",
 )
 
-InvocationIdQueryParam: Optional[str] = Query(
+InvocationIdQueryParam: Optional[EncodedDatabaseIdField] = Query(
     default=None,
     title="Invocation ID",
     description="Limit listing of jobs to those that match the specified workflow invocation ID. If none, jobs from any workflow invocation (or from no workflows) may be returned.",
@@ -182,15 +182,15 @@ class FastAPIJobs:
         trans: ProvidesUserContext = DependsOnTrans,
         state: Optional[str] = StateQueryParam,
         user_details: bool = UserDetailsQueryParam,
-        user_id: Optional[str] = UserIdQueryParam,
+        user_id: Optional[EncodedDatabaseIdField] = UserIdQueryParam,
         view: JobIndexViewEnum = ViewQueryParam,
         tool_id: Optional[str] = ToolIdQueryParam,
         tool_id_like: Optional[str] = ToolIdLikeQueryParam,
         date_range_min: Optional[str] = DateRangeMinQueryParam,
         date_range_max: Optional[str] = DateRangeMaxQueryParam,
-        history_id: Optional[str] = HistoryIdQueryParam,
-        workflow_id: Optional[str] = WorkflowIdQueryParam,
-        invocation_id: Optional[str] = InvocationIdQueryParam,
+        history_id: Optional[EncodedDatabaseIdField] = HistoryIdQueryParam,
+        workflow_id: Optional[EncodedDatabaseIdField] = WorkflowIdQueryParam,
+        invocation_id: Optional[EncodedDatabaseIdField] = InvocationIdQueryParam,
         order_by: JobIndexSortByEnum = SortByQueryParam,
         search: Optional[str] = SearchQueryParam,
         limit: int = LimitQueryParam,

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -32,6 +32,7 @@ from galaxy.managers.jobs import (
     summarize_job_parameters,
 )
 from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import JobIndexSortByEnum
 from galaxy.util import listify
 from galaxy.web import (
     expose_api,
@@ -41,7 +42,6 @@ from galaxy.web import (
 from galaxy.webapps.base.controller import UsesVisualizationMixin
 from galaxy.webapps.galaxy.services.jobs import (
     JobIndexPayload,
-    JobIndexSortByEnum,
     JobIndexViewEnum,
     JobsService,
 )

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -50,7 +50,9 @@ from . import (
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
+    IndexQueryTag,
     Router,
+    search_query_param,
 )
 
 log = logging.getLogger(__name__)
@@ -140,10 +142,17 @@ OffsetQueryParam: int = Query(
     description="Return jobs starting from this specified position. For example, if ``limit`` is set to 100 and ``offset`` to 200, jobs 200-299 will be returned.",
 )
 
-SearchQueryParameter: Optional[str] = Query(
-    default=None,
-    title="Search query.",
-    description="Free text used to filter the query. Currently this just filters by the tool ID corresponding to the job.",
+query_tags = [
+    IndexQueryTag("user", "The user email of the user that executed the Job.", "u"),
+    IndexQueryTag("tool_id", "The tool ID corresponding to the job.", "t"),
+    IndexQueryTag("runner", "The job runner name used to execte the job.", "r"),
+    IndexQueryTag("handler", "The job handler name used to execute the job.", "h"),
+]
+
+SearchQueryParam: Optional[str] = search_query_param(
+    model_name="Job",
+    tags=query_tags,
+    free_text_fields=["user", "tool", "handler", "runner"],
 )
 
 
@@ -183,7 +192,7 @@ class FastAPIJobs:
         workflow_id: Optional[str] = WorkflowIdQueryParam,
         invocation_id: Optional[str] = InvocationIdQueryParam,
         order_by: JobIndexSortByEnum = SortByQueryParam,
-        search: Optional[str] = SearchQueryParameter,
+        search: Optional[str] = SearchQueryParam,
         limit: int = LimitQueryParam,
         offset: int = OffsetQueryParam,
     ) -> List[Dict[str, Any]]:

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -2,11 +2,7 @@ from enum import Enum
 from typing import (
     Any,
     Dict,
-    List,
-    Optional,
 )
-
-from sqlalchemy import or_
 
 from galaxy import (
     exceptions,
@@ -19,17 +15,8 @@ from galaxy.managers.jobs import (
     JobSearch,
     view_show_job,
 )
-from galaxy.model.index_filter_util import (
-    raw_text_column_filter,
-    text_column_filter,
-)
 from galaxy.schema.fields import EncodedDatabaseIdField
-from galaxy.schema.schema import Model
-from galaxy.util.search import (
-    FilteredTerm,
-    parse_filters_structured,
-    RawTextTerm,
-)
+from galaxy.schema.schema import JobIndexQueryPayload
 
 
 class JobIndexViewEnum(str, Enum):
@@ -37,27 +24,8 @@ class JobIndexViewEnum(str, Enum):
     admin_job_list = "admin_job_list"
 
 
-class JobIndexSortByEnum(str, Enum):
-    create_time = "create_time"
-    update_time = "update_time"
-
-
-class JobIndexPayload(Model):
-    states: Optional[List[str]] = None
-    user_details: bool = False
-    user_id: Optional[str] = None
+class JobIndexPayload(JobIndexQueryPayload):
     view: JobIndexViewEnum = JobIndexViewEnum.collection
-    tool_ids: Optional[List[str]] = None
-    tool_ids_like: Optional[List[str]] = None
-    date_range_min: Optional[str] = None
-    date_range_max: Optional[str] = None
-    history_id: Optional[str] = None
-    workflow_id: Optional[str] = None
-    invocation_id: Optional[str] = None
-    order_by: JobIndexSortByEnum = JobIndexSortByEnum.update_time
-    search: Optional[str] = None
-    limit: int = 500
-    offset: int = 0
 
 
 class JobsService:
@@ -92,132 +60,12 @@ class JobsService:
     ):
         security = trans.security
         is_admin = trans.user_is_admin
-        user_details = payload.user_details or payload.view == JobIndexViewEnum.admin_job_list
+        if payload.view == JobIndexViewEnum.admin_job_list:
+            payload.user_details = True
+        user_details = payload.user_details
         if payload.view == JobIndexViewEnum.admin_job_list and not is_admin:
             raise exceptions.AdminRequiredException("Only admins can use the admin_job_list view")
-        user_id = payload.user_id
-        if user_id:
-            decoded_user_id = security.decode_id(user_id)
-        else:
-            decoded_user_id = None
-
-        if is_admin:
-            if decoded_user_id is not None:
-                query = trans.sa_session.query(model.Job).filter(model.Job.user_id == decoded_user_id)
-            else:
-                query = trans.sa_session.query(model.Job)
-            if user_details:
-                query = query.outerjoin(model.Job.user)
-
-        else:
-            if user_details:
-                raise exceptions.AdminRequiredException("Only admins can index the jobs with user details enabled")
-            if decoded_user_id is not None and decoded_user_id != trans.user.id:
-                raise exceptions.AdminRequiredException("Only admins can index the jobs of others")
-            query = trans.sa_session.query(model.Job).filter(model.Job.user_id == trans.user.id)
-
-        def build_and_apply_filters(query, objects, filter_func):
-            if objects is not None:
-                if isinstance(objects, str):
-                    query = query.filter(filter_func(objects))
-                elif isinstance(objects, list):
-                    t = []
-                    for obj in objects:
-                        t.append(filter_func(obj))
-                    query = query.filter(or_(*t))
-            return query
-
-        query = build_and_apply_filters(query, payload.states, lambda s: model.Job.state == s)
-        query = build_and_apply_filters(query, payload.tool_ids, lambda t: model.Job.tool_id == t)
-        query = build_and_apply_filters(query, payload.tool_ids_like, lambda t: model.Job.tool_id.like(t))
-        query = build_and_apply_filters(query, payload.date_range_min, lambda dmin: model.Job.update_time >= dmin)
-        query = build_and_apply_filters(query, payload.date_range_max, lambda dmax: model.Job.update_time <= dmax)
-
-        history_id = payload.history_id
-        workflow_id = payload.workflow_id
-        invocation_id = payload.invocation_id
-        if history_id is not None:
-            decoded_history_id = security.decode_id(history_id)
-            query = query.filter(model.Job.history_id == decoded_history_id)
-        if workflow_id or invocation_id:
-            if workflow_id is not None:
-                decoded_workflow_id = security.decode_id(workflow_id)
-                wfi_step = (
-                    trans.sa_session.query(model.WorkflowInvocationStep)
-                    .join(model.WorkflowInvocation)
-                    .join(model.Workflow)
-                    .filter(
-                        model.Workflow.stored_workflow_id == decoded_workflow_id,
-                    )
-                    .subquery()
-                )
-            elif invocation_id is not None:
-                decoded_invocation_id = security.decode_id(invocation_id)
-                wfi_step = (
-                    trans.sa_session.query(model.WorkflowInvocationStep)
-                    .filter(model.WorkflowInvocationStep.workflow_invocation_id == decoded_invocation_id)
-                    .subquery()
-                )
-            query1 = query.join(wfi_step)
-            query2 = query.join(model.ImplicitCollectionJobsJobAssociation).join(
-                wfi_step,
-                model.ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id
-                == wfi_step.c.implicit_collection_jobs_id,
-            )
-            query = query1.union(query2)
-
-        search = payload.search
-        if search:
-            search_filters = {
-                "tool": "tool",
-                "t": "tool",
-            }
-            if user_details:
-                search_filters.update(
-                    {
-                        "user": "user",
-                        "u": "user",
-                    }
-                )
-
-            if is_admin:
-                search_filters.update(
-                    {
-                        "runner": "runner",
-                        "r": "runner",
-                        "handler": "handler",
-                        "h": "handler",
-                    }
-                )
-            parsed_search = parse_filters_structured(search, search_filters)
-            for term in parsed_search.terms:
-                if isinstance(term, FilteredTerm):
-                    key = term.filter
-                    if key == "user":
-                        query = query.filter(text_column_filter(model.User.email, term))
-                    elif key == "tool":
-                        query = query.filter(text_column_filter(model.Job.tool_id, term))
-                    elif key == "handler":
-                        query = query.filter(text_column_filter(model.Job.handler, term))
-                    elif key == "runner":
-                        query = query.filter(text_column_filter(model.Job.job_runner_name, term))
-                elif isinstance(term, RawTextTerm):
-                    columns = [model.Job.tool_id]
-                    if user_details:
-                        columns.append(model.User.email)
-                    if is_admin:
-                        columns.append(model.Job.handler)
-                        columns.append(model.Job.job_runner_name)
-                    query = query.filter(raw_text_column_filter(columns, term))
-
-        if payload.order_by == JobIndexSortByEnum.create_time:
-            order_by = model.Job.create_time.desc()
-        else:
-            order_by = model.Job.update_time.desc()
-        query = query.order_by(order_by)
-
-        query = query.offset(payload.offset)
-        query = query.limit(payload.limit)
+        query = self.job_manager.index_query(trans, payload)
         out = []
         view = payload.view
         for job in query.yield_per(model.YIELD_PER_ROWS):

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -1,0 +1,218 @@
+from enum import Enum
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
+
+from sqlalchemy import or_
+
+from galaxy import (
+    exceptions,
+    model,
+)
+from galaxy.managers import hdas
+from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.jobs import (
+    JobManager,
+    JobSearch,
+    view_show_job,
+)
+from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import Model
+from galaxy.util.search import (
+    FilteredTerm,
+    parse_filters_structured,
+    RawTextTerm,
+)
+
+
+class JobIndexViewEnum(str, Enum):
+    collection = "collection"
+    admin_job_list = "admin_job_list"
+
+
+class JobIndexSortByEnum(str, Enum):
+    create_time = "create_time"
+    update_time = "update_time"
+
+
+class JobIndexPayload(Model):
+    states: Optional[List[str]] = None
+    user_details: bool = False
+    user_id: Optional[str] = None
+    view: JobIndexViewEnum = JobIndexViewEnum.collection
+    tool_ids: Optional[List[str]] = None
+    tool_ids_like: Optional[List[str]] = None
+    date_range_min: Optional[str] = None
+    date_range_max: Optional[str] = None
+    history_id: Optional[str] = None
+    workflow_id: Optional[str] = None
+    invocation_id: Optional[str] = None
+    order_by: JobIndexSortByEnum = JobIndexSortByEnum.update_time
+    search: Optional[str] = None
+    limit: int = 500
+    offset: int = 0
+
+
+class JobsService:
+    job_manager: JobManager
+    job_search: JobSearch
+    hda_manager: hdas.HDAManager
+
+    def __init__(
+        self,
+        job_manager: JobManager,
+        job_search: JobSearch,
+        hda_manager: hdas.HDAManager,
+    ):
+        self.job_manager = job_manager
+        self.job_search = job_search
+        self.hda_manager = hda_manager
+
+    def show(
+        self,
+        trans: ProvidesUserContext,
+        id: EncodedDatabaseIdField,
+        full: bool = False,
+    ) -> Dict[str, Any]:
+        id = trans.app.security.decode_id(id)
+        job = self.job_manager.get_accessible_job(trans, id)
+        return view_show_job(trans, job, bool(full))
+
+    def index(
+        self,
+        trans: ProvidesUserContext,
+        payload: JobIndexPayload,
+    ):
+        security = trans.security
+        is_admin = trans.user_is_admin
+        user_details = payload.user_details
+        if payload.view == JobIndexViewEnum.admin_job_list and not is_admin:
+            raise exceptions.AdminRequiredException("Only admins can use the admin_job_list view")
+        user_id = payload.user_id
+        if user_id:
+            decoded_user_id = security.decode_id(user_id)
+        else:
+            decoded_user_id = None
+
+        if is_admin:
+            if decoded_user_id is not None:
+                query = trans.sa_session.query(model.Job).filter(model.Job.user_id == decoded_user_id)
+            else:
+                query = trans.sa_session.query(model.Job)
+            if user_details:
+                query = query.outerjoin(model.Job.user)
+
+        else:
+            if user_details:
+                raise exceptions.AdminRequiredException("Only admins can index the jobs with user details enabled")
+            if decoded_user_id is not None and decoded_user_id != trans.user.id:
+                raise exceptions.AdminRequiredException("Only admins can index the jobs of others")
+            query = trans.sa_session.query(model.Job).filter(model.Job.user_id == trans.user.id)
+
+        def build_and_apply_filters(query, objects, filter_func):
+            if objects is not None:
+                if isinstance(objects, str):
+                    query = query.filter(filter_func(objects))
+                elif isinstance(objects, list):
+                    t = []
+                    for obj in objects:
+                        t.append(filter_func(obj))
+                    query = query.filter(or_(*t))
+            return query
+
+        query = build_and_apply_filters(query, payload.states, lambda s: model.Job.state == s)
+        query = build_and_apply_filters(query, payload.tool_ids, lambda t: model.Job.tool_id == t)
+        query = build_and_apply_filters(query, payload.tool_ids_like, lambda t: model.Job.tool_id.like(t))
+        query = build_and_apply_filters(query, payload.date_range_min, lambda dmin: model.Job.update_time >= dmin)
+        query = build_and_apply_filters(query, payload.date_range_max, lambda dmax: model.Job.update_time <= dmax)
+
+        history_id = payload.history_id
+        workflow_id = payload.workflow_id
+        invocation_id = payload.invocation_id
+        if history_id is not None:
+            decoded_history_id = security.decode_id(history_id)
+            query = query.filter(model.Job.history_id == decoded_history_id)
+        if workflow_id or invocation_id:
+            if workflow_id is not None:
+                decoded_workflow_id = security.decode_id(workflow_id)
+                wfi_step = (
+                    trans.sa_session.query(model.WorkflowInvocationStep)
+                    .join(model.WorkflowInvocation)
+                    .join(model.Workflow)
+                    .filter(
+                        model.Workflow.stored_workflow_id == decoded_workflow_id,
+                    )
+                    .subquery()
+                )
+            elif invocation_id is not None:
+                decoded_invocation_id = security.decode_id(invocation_id)
+                wfi_step = (
+                    trans.sa_session.query(model.WorkflowInvocationStep)
+                    .filter(model.WorkflowInvocationStep.workflow_invocation_id == decoded_invocation_id)
+                    .subquery()
+                )
+            query1 = query.join(wfi_step)
+            query2 = query.join(model.ImplicitCollectionJobsJobAssociation).join(
+                wfi_step,
+                model.ImplicitCollectionJobsJobAssociation.implicit_collection_jobs_id
+                == wfi_step.c.implicit_collection_jobs_id,
+            )
+            query = query1.union(query2)
+
+        search = payload.search
+        if search:
+            search_filters = {
+                "tool": "tool",
+                "t": "tool",
+                "user": "user",
+                "u": "user",
+            }
+            parsed_search = parse_filters_structured(search, search_filters)
+            for term in parsed_search.terms:
+                if isinstance(term, FilteredTerm):
+                    key = term.filter
+                    q = term.text
+                    if key == "user":
+                        if term.quoted:
+                            query = query.filter(model.User.email == q)
+                        else:
+                            query = query.filter(model.User.email.ilike(f"%{q}%"))
+                    elif key == "tool":
+                        if term.quoted:
+                            query = query.filter(model.Job.tool_id == q)
+                        else:
+                            query = query.filter(model.Job.tool_id.ilike(f"%{q}%"))
+                elif isinstance(term, RawTextTerm):
+                    q = term.text
+                    filters = []
+                    filters.append(model.Job.tool_id.ilike(f"%{q}%"))
+                    if user_details:
+                        filters.append(model.User.email.ilike(f"%{q}%"))
+                    if len(filters) > 1:
+                        query = query.filter(or_(*filters))
+                    else:
+                        query = query.filter(filters[0])
+
+        if payload.order_by == JobIndexSortByEnum.create_time:
+            order_by = model.Job.create_time.desc()
+        else:
+            order_by = model.Job.update_time.desc()
+        query = query.order_by(order_by)
+
+        query = query.offset(payload.offset)
+        query = query.limit(payload.limit)
+        out = []
+        view = payload.view
+        for job in query.yield_per(model.YIELD_PER_ROWS):
+            job_dict = job.to_dict(view, system_details=is_admin)
+            j = security.encode_all_ids(job_dict, True)
+            if view == JobIndexViewEnum.admin_job_list:
+                j["decoded_job_id"] = job.id
+            if user_details:
+                j["user_email"] = job.get_user_email()
+            out.append(j)
+
+        return out

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -182,8 +182,7 @@ steps:
         jobs = self.__jobs_index(data={"history_id": history_id, "limit": 0})
         assert len(jobs) == 0
 
-    @uses_test_history(require_new=True)
-    def test_index_user_filter(self, history_id):
+    def test_index_user_filter(self):
         test_user_email = "user_for_jobs_index_test@bx.psu.edu"
         user = self._setup_user(test_user_email)
         with self._different_user(email=test_user_email):

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -182,6 +182,37 @@ steps:
         jobs = self.__jobs_index(data={"history_id": history_id, "limit": 0})
         assert len(jobs) == 0
 
+    @uses_test_history(require_new=True)
+    def test_index_search_filter_tool_id(self, history_id):
+        self.__history_with_new_dataset(history_id)
+        jobs = self.__jobs_index(data={"history_id": history_id})
+        assert len(jobs) > 0
+        length = len(jobs)
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": "emptyresult"})
+        assert len(jobs) == 0
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": "FETCH"})
+        assert len(jobs) == length
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": "tool:'FETCH'"})
+        assert len(jobs) == 0
+
+    @uses_test_history(require_new=True)
+    def test_index_search_filter_email(self, history_id):
+        self.__history_with_new_dataset(history_id)
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": "FETCH"})
+        user_email = self.dataset_populator.user_email()
+        jobs = self.__jobs_index(data={"history_id": history_id, "search": user_email})
+        assert len(jobs) == 0
+        # we can search on email...
+        jobs = self.__jobs_index(
+            data={"history_id": history_id, "search": user_email, "user_details": True}, admin=True
+        )
+        assert len(jobs) == 1
+        # but only if user details are joined in.
+        jobs = self.__jobs_index(
+            data={"history_id": history_id, "search": user_email, "user_details": False}, admin=True
+        )
+        assert len(jobs) == 0
+
     def test_index_user_filter(self):
         test_user_email = "user_for_jobs_index_test@bx.psu.edu"
         user = self._setup_user(test_user_email)

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -110,6 +110,7 @@ class JobsApiTestCase(ApiTestCase, TestsTools):
             assert len(jobs) == 0
 
     @uses_test_history(require_new=True)
+    @skip_without_tool("cat1")
     def test_index_workflow_and_invocation_filter(self, history_id):
         workflow_simple = """
 class: GalaxyWorkflow


### PR DESCRIPTION
Gets the backend and frontend for Job related stuff prepared to use pagination and other WorkflowList/Invocations improvements downstream.

-  Make the frontend grid more reactive - so the text always matches the query, etc... Matches Galaxy's user experience better from other places in the app.
- Move index logic from the API into the manager layer where it belongs.
- Implement backend search of jobs grid to match Workflows and to allow pagination in a future commit.
- Switch admin Jobs component to use a provider to match the other grids referenced. Add test case for this provider.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
