### PR TITLE
Do not set check_migrate_databases as a config attribute

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -361,7 +361,7 @@ class ConfiguresGalaxyMixin:
             install_engine = build_engine(install_db_url, self.config.install_database_engine_options)
         return engine, install_engine
 
-    def _configure_models(self, check_migrate_databases=False, config_file=None):
+    def _configure_models(self, check_migrate_databases=True, config_file=None):
         """Preconditions: object_store must be set on self."""
         # TODO this block doesn't seem to belong in this method
         if getattr(self.config, "max_metadata_value_size", None):
@@ -433,7 +433,7 @@ class ConfiguresGalaxyMixin:
 class MinimalGalaxyApplication(BasicSharedApp, ConfiguresGalaxyMixin, HaltableContainer, SentryClientMixin):
     """Encapsulates the state of a minimal Galaxy application"""
 
-    def __init__(self, fsmon=False, **kwargs) -> None:
+    def __init__(self, fsmon=False, check_migrate_databases=True, **kwargs) -> None:
         super().__init__()
         self.haltables = [
             ("object store", self._shutdown_object_store),
@@ -455,7 +455,8 @@ class MinimalGalaxyApplication(BasicSharedApp, ConfiguresGalaxyMixin, HaltableCo
         config_file = kwargs.get("global_conf", {}).get("__file__", None)
         if config_file:
             log.debug('Using "galaxy.ini" config file: %s', config_file)
-        self._configure_models(check_migrate_databases=self.config.check_migrate_databases, config_file=config_file)
+        self._configure_models(check_migrate_databases=check_migrate_databases, config_file=config_file)
+
         # Security helper
         self._configure_security()
         self._register_singleton(IdEncodingHelper, self.security)

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -57,10 +57,11 @@ def get_galaxy_app():
 def build_app():
     kwargs = get_app_properties()
     if kwargs:
-        kwargs["check_migrate_databases"] = False
         import galaxy.app
 
-        galaxy_app = galaxy.app.GalaxyManagerApplication(configure_logging=False, **kwargs)
+        galaxy_app = galaxy.app.GalaxyManagerApplication(
+            configure_logging=False, check_migrate_databases=False, **kwargs
+        )
         return galaxy_app
 
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -766,7 +766,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self.version_minor = VERSION_MINOR
 
         # Database related configuration
-        self.check_migrate_databases = string_as_bool(kwargs.get("check_migrate_databases", True))
         if not self.database_connection:  # Provide default if not supplied by user
             db_path = self._in_data_dir("universe.sqlite")
             self.database_connection = f"sqlite:///{db_path}?isolation_level=IMMEDIATE"

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -388,7 +388,6 @@ def copy_database_template(source, db_path):
 def database_conf(db_path, prefix="GALAXY", prefer_template_database=False):
     """Find (and populate if needed) Galaxy database connection."""
     database_auto_migrate = False
-    check_migrate_databases = True
     dburi_var = f"{prefix}_TEST_DBURI"
     template_name = None
     if dburi_var in os.environ:
@@ -406,7 +405,6 @@ def database_conf(db_path, prefix="GALAXY", prefer_template_database=False):
                 create_database(database_connection)
                 mapping.init("/tmp", database_connection, create_tables=True, map_install_models=True)
                 toolshed_mapping.init(database_connection, create_tables=True)
-                check_migrate_databases = False
     else:
         default_db_filename = f"{prefix.lower()}.sqlite"
         template_var = f"{prefix}_TEST_DB_TEMPLATE"
@@ -421,7 +419,6 @@ def database_conf(db_path, prefix="GALAXY", prefer_template_database=False):
             database_auto_migrate = True
         database_connection = f"sqlite:///{db_path}"
     config = {
-        "check_migrate_databases": check_migrate_databases,
         "database_connection": database_connection,
         "database_auto_migrate": database_auto_migrate,
     }


### PR DESCRIPTION
Celery is the only context in which this setting is used. I think it should not be added as an attribute to the config object because it's meant to be used internally. It should be set by default (so changing the default to `True`). Passing it explicitly as opposed to part of `**kwargs` to emphasize its built-in/special nature in comparison with whatever is passed in `kwargs`.

Not setting it from the test driver (and, therefore, checking the database state from tests) should have no effect. However, opening as draft to verify this first.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
