### PR TITLE
[22.01] Backport: Respect GRAVITY_STATE_DIR when activating venv

### DIFF
--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -137,7 +137,7 @@ setup_gravity_state_dir() {
         echo "Setting \$GRAVITY_STATE_DIR in ${GALAXY_VIRTUAL_ENV}/bin/activate"
         echo '' >> "${GALAXY_VIRTUAL_ENV}/bin/activate"
         echo '# Galaxy Gravity per-instance state directory configured by Galaxy common_startup.sh' >> "${GALAXY_VIRTUAL_ENV}/bin/activate"
-        echo "GRAVITY_STATE_DIR='$(pwd)/database/gravity'" >> "${GALAXY_VIRTUAL_ENV}/bin/activate"
+        echo "GRAVITY_STATE_DIR=\${GRAVITY_STATE_DIR:-'$(pwd)/database/gravity'}" >> "${GALAXY_VIRTUAL_ENV}/bin/activate"
         echo 'export GRAVITY_STATE_DIR' >> "${GALAXY_VIRTUAL_ENV}/bin/activate"
     fi
 }


### PR DESCRIPTION
So that:

export GRAVITY_STATE_DIR=/srv/galaxy/gravity
./run.sh

writes gravity state/log files to the right place.

Backport of https://github.com/galaxyproject/galaxy/pull/13685, needed to use gravity in planemo

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
