### PR TITLE
[22.01] Set default celery app for all threads

### DIFF
--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -72,6 +72,7 @@ def get_history_audit_table_prune_interval():
 
 broker = get_broker()
 celery_app = Celery('galaxy', broker=broker, include=['galaxy.celery.tasks'])
+celery_app.set_default()
 prune_interval = get_history_audit_table_prune_interval()
 if prune_interval > 0:
     celery_app.conf.beat_schedule = {


### PR DESCRIPTION
Fixes:
```
[2022-05-09 16:22:11 +0200] [219391] [ERROR] Exception in ASGI application
Traceback (most recent call last):
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/utils/functional.py", line 30, in __call__
    return self.__value__
AttributeError: 'ChannelPromise' object has no attribute '__value__'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/connection.py", line 446, in _reraise_as_library_errors
    yield
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/connection.py", line 433, in _ensure_connection
    return retry_over_time(
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/utils/functional.py", line 312, in retry_over_time
    return fun(*args, **kwargs)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/connection.py", line 877, in _connection_factory
    self._connection = self._establish_connection()
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/connection.py", line 812, in _establish_connection
    conn = self.transport.establish_connection()
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/transport/pyamqp.py", line 201, in establish_connection
    conn.connect()
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/amqp/connection.py", line 323, in connect
    self.transport.connect()
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/amqp/transport.py", line 129, in connect
    self._connect(self.host, self.port, self.connect_timeout)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/amqp/transport.py", line 184, in _connect
    self.sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 366, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/fastapi/applications.py", line 261, in __call__
    await super().__call__(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette_context/middleware/raw_middleware.py", line 96, in __call__
    await self.app(scope, receive, send_wrapper)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 63, in __call__
    response = await self.dispatch_func(request, call_next)
  File "/home/davelopez/dev/galaxy/lib/galaxy/webapps/galaxy/fast_app.py", line 103, in add_x_frame_options
    response = await call_next(request)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 44, in call_next
    raise app_exc
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 34, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/routing.py", line 656, in __call__
    await route.handle(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/routing.py", line 259, in handle
    await self.app(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/routing.py", line 61, in app
    response = await func(request)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/fastapi/routing.py", line 227, in app
    raw_response = await run_endpoint_function(
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/fastapi/routing.py", line 162, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/starlette/concurrency.py", line 39, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/anyio/to_thread.py", line 28, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(func, *args, cancellable=cancellable,
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 818, in run_sync_in_worker_thread
    return await future
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 754, in run
    result = context.run(func, *args)
  File "/home/davelopez/dev/galaxy/lib/galaxy/webapps/galaxy/api/history_contents.py", line 671, in delete
    rval = self.service.delete(
  File "/home/davelopez/dev/galaxy/lib/galaxy/webapps/galaxy/services/history_contents.py", line 576, in delete
    self.dataset_collection_manager.delete(
  File "/home/davelopez/dev/galaxy/lib/galaxy/managers/collections.py", line 424, in delete
    self.hda_manager.purge(dataset)
  File "/home/davelopez/dev/galaxy/lib/galaxy/managers/hdas.py", line 162, in purge
    purge_hda.delay(hda_id=hda.id)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/celery/app/task.py", line 425, in delay
    return self.apply_async(args, kwargs)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/celery/app/task.py", line 575, in apply_async
    return app.send_task(
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/celery/app/base.py", line 788, in send_task
    amqp.send_task_message(P, name, message, **options)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/celery/app/amqp.py", line 510, in send_task_message
    ret = producer.publish(
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/messaging.py", line 177, in publish
    return _publish(
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/connection.py", line 523, in _ensured
    return fun(*args, **kwargs)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/messaging.py", line 186, in _publish
    channel = self.channel
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/messaging.py", line 209, in _get_channel
    channel = self._channel = channel()
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/utils/functional.py", line 32, in __call__
    value = self.__value__ = self.__contract__()
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/messaging.py", line 225, in <lambda>
    channel = ChannelPromise(lambda: connection.default_channel)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/connection.py", line 895, in default_channel
    self._ensure_connection(**conn_opts)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/connection.py", line 432, in _ensure_connection
    with ctx():
  File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/kombu/connection.py", line 450, in _reraise_as_library_errors
    raise ConnectionError(str(exc)) from exc
kombu.exceptions.OperationalError: [Errno 111] Connection refused
```
Which happens because Celery will construct a default Celery instance if there is no Celery app registered, and that default instance will attempt to connect to `amqp://guest:guest@localhost:5672`.
This is not a problem in testing because the celery pytest fixture calls `app.set_default()`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
