### PR TITLE
[22.01] Redirect stderr of trap cleanup

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -282,7 +282,7 @@ class CommandsBuilder:
         if TRAP_KILL_CONTAINER in self.commands:
             # We need to replace the container kill trap with one that removes the named pipes and kills the container
             self.commands = self.commands.replace(TRAP_KILL_CONTAINER, "")
-            trap_command = """trap 'rm "$__out" "$__err"; _on_exit' EXIT"""
+            trap_command = """trap 'rm "$__out" "$__err" 2> /dev/null || true; _on_exit' EXIT"""
         self.prepend_command(
             f"""__out="${{TMPDIR:-.}}/out.$$" __err="${{TMPDIR:-.}}/err.$$"
 mkfifo "$__out" "$__err"

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -54,7 +54,7 @@ class TestCommandFactory(TestCase):
         self.job_wrapper.command_line = f"{TRAP_KILL_CONTAINER}{MOCK_COMMAND_LINE}"
         expected_command_line = self._surround_command(MOCK_COMMAND_LINE).replace(
             """trap 'rm "$__out" "$__err"' EXIT""",
-            """trap 'rm "$__out" "$__err"; _on_exit' EXIT"""
+            """trap 'rm "$__out" "$__err" 2> /dev/null || true; _on_exit' EXIT"""
         )
         self.__assert_command_is(expected_command_line)
 


### PR DESCRIPTION
Prevents
```
rm: cannot remove '/data/jwd/main/046/709/46709070/tmp/out.471762': No such file or directory
rm: cannot remove '/data/jwd/main/046/709/46709070/tmp/err.471762': No such file or directory
```
reported in https://github.com/galaxyproject/galaxy/issues/13902.

I don't think this is what fails the job, there is likely something else
wrong on top of this.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
