### PR TITLE
[22.01] Allow anonymous users to import published histories

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -169,15 +169,14 @@ class HistoriesService(ServiceBase):
         """Create a new history from scratch, by copying an existing one or by importing
         from URL or File depending on the provided parameters in the payload.
         """
-        if trans.anonymous:
+        copy_this_history_id = payload.history_id
+        if trans.anonymous and not copy_this_history_id:  # Copying/Importing histories is allowed for anonymous users
             raise glx_exceptions.AuthenticationRequired("You need to be logged in to create histories.")
         if trans.user and trans.user.bootstrap_admin_user:
             raise glx_exceptions.RealUserRequiredException("Only real users can create histories.")
         hist_name = None
         if payload.name is not None:
             hist_name = restore_text(payload.name)
-        copy_this_history_id = payload.history_id
-        all_datasets = payload.all_datasets
 
         if payload.archive_source is not None or hasattr(payload.archive_file, "file"):
             archive_source = payload.archive_source
@@ -203,7 +202,7 @@ class HistoriesService(ServiceBase):
             decoded_id = self.decode_id(copy_this_history_id)
             original_history = self.manager.get_accessible(decoded_id, trans.user, current_history=trans.history)
             hist_name = hist_name or (f"Copy of '{original_history.name}'")
-            new_history = original_history.copy(name=hist_name, target_user=trans.user, all_datasets=all_datasets)
+            new_history = original_history.copy(name=hist_name, target_user=trans.user, all_datasets=payload.all_datasets)
 
         # otherwise, create a new empty history
         else:

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -112,6 +112,12 @@ class SessionRequestContext(WorkRequestContext):
     def get_galaxy_session(self):
         return self.galaxy_session
 
+    def set_history(self, history):
+        if history and not history.deleted:
+            self.galaxy_session.current_history = history
+        self.sa_session.add(self.galaxy_session)
+        self.sa_session.flush()
+
 
 def proxy_work_context_for_history(trans: ProvidesHistoryContext, history: Optional[History] = None, workflow_building_mode=False):
     """Create a WorkContext for supplied context with potentially different history.

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -238,6 +238,21 @@ class HistoriesApiTestCase(ApiTestCase, BaseHistories):
         assert source_hda['history_id'] != copied_hda['history_id']
         assert source_hda['hid'] == copied_hda['hid'] == 2
 
+    def test_anonymous_can_import_published(self):
+        history_name = f"for_importing_by_anonymous_{uuid4()}"
+        history_id = self.dataset_populator.new_history(name=history_name)
+        self.dataset_collection_populator.create_list_of_pairs_in_history(history_id)
+        self.dataset_populator.make_public(history_id)
+
+        with self._different_user(anon=True):
+            imported_history_name = f"imported_by_anonymous_{uuid4()}"
+            import_data = {
+                'archive_type': 'url',
+                'history_id': history_id,
+                'name': imported_history_name,
+            }
+            self.dataset_populator.import_history(import_data)
+
 
 class ImportExportTests(BaseHistories):
 


### PR DESCRIPTION
Addresses #13896 for 22.01

Anonymous users cannot create new Histories, but they should be able to import published ones.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow instructions on #13896 in a 22.01 Galaxy instance

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
