### PR TITLE
[21.05] Fix condition importing histories anonymously

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -334,7 +334,7 @@ class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin, ImportsH
         :rtype:     dict
         :returns:   element view of new history
         """
-        if trans.user.bootstrap_admin_user:
+        if trans.user and trans.user.bootstrap_admin_user:
             raise exceptions.RealUserRequiredException("Only real users can create histories.")
         hist_name = None
         if payload.get('name', None):


### PR DESCRIPTION
Fixes #13896 for 21.05

This fix is already included in 21.09 along with heavy refactoring, so no need to merge this forward.

The API test is included in 22.01 (also after heavy refactorings) https://github.com/galaxyproject/galaxy/pull/13906/commits/2c9ccc56270fa79f019d3a52a54ff63fc3b01441

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow instructions on #13896 in a 21.05 Galaxy instance

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
