### PR TITLE
Decompose History Export UI

### DIFF
--- a/client/src/components/Common/ExportForm.test.js
+++ b/client/src/components/Common/ExportForm.test.js
@@ -1,0 +1,38 @@
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import ExportForm from "./ExportForm.vue";
+
+const localVue = getLocalVue(true);
+
+jest.mock("components/JobStates/wait");
+
+describe("ExportForm.vue", () => {
+    let wrapper;
+
+    beforeEach(async () => {
+        wrapper = shallowMount(ExportForm, {
+            propsData: {},
+            localVue,
+        });
+    });
+
+    it("should render a form with export disable because inputs empty", async () => {
+        expect(wrapper.find(".export-button").exists()).toBeTruthy();
+        expect(wrapper.find(".export-button").attributes("disabled")).toBeTruthy();
+        expect(wrapper.vm.canExport).toBeFalsy();
+    });
+
+    it("should allow export when name and directory available", async () => {
+        await wrapper.setData({
+            name: "export.tar.gz",
+            directory: "gxfiles://",
+        });
+        expect(wrapper.vm.directory).toEqual("gxfiles://");
+        expect(wrapper.vm.name).toEqual("export.tar.gz");
+        expect(wrapper.vm.canExport).toBeTruthy();
+    });
+
+    it("should localize button text", async () => {
+        expect(wrapper.find(".export-button").text()).toBeLocalizationOf("Export");
+    });
+});

--- a/client/src/components/Common/ExportForm.vue
+++ b/client/src/components/Common/ExportForm.vue
@@ -1,0 +1,65 @@
+<template>
+    <div>
+        <b-form-group
+            id="fieldset-directory"
+            label-for="directory"
+            :description="directoryDescription | localize"
+            class="mt-3">
+            <files-input id="directory" v-model="directory" mode="directory" :require-writable="true" />
+        </b-form-group>
+        <b-form-group id="fieldset-name" label-for="name" :description="nameDescription | localize" class="mt-3">
+            <b-form-input id="name" v-model="name" :placeholder="namePlaceholder | localize" required></b-form-input>
+        </b-form-group>
+        <b-row align-h="end">
+            <b-col
+                ><b-button class="export-button" variant="primary" :disabled="!canExport" @click.prevent="doExport">{{
+                    exportButtonText | localize
+                }}</b-button></b-col
+            >
+        </b-row>
+    </div>
+</template>
+
+<script>
+import FilesInput from "components/FilesDialog/FilesInput.vue";
+
+export default {
+    components: {
+        FilesInput,
+    },
+    props: {
+        what: {
+            type: String,
+            default: "archive",
+        },
+    },
+    data() {
+        return {
+            directory: null,
+            name: null,
+        };
+    },
+    computed: {
+        directoryDescription() {
+            return `Select a 'remote files' directory to export ${this.what} to.`;
+        },
+        nameDescription() {
+            return "Give the exported file a name.";
+        },
+        namePlaceholder() {
+            return "Name";
+        },
+        exportButtonText() {
+            return "Export";
+        },
+        canExport() {
+            return !!this.name && !!this.directory;
+        },
+    },
+    methods: {
+        doExport() {
+            this.$emit("export", this.directory, this.name);
+        },
+    },
+};
+</script>

--- a/client/src/components/Common/exportsMixin.js
+++ b/client/src/components/Common/exportsMixin.js
@@ -1,0 +1,26 @@
+import LoadingSpan from "components/LoadingSpan";
+import { Services } from "components/FilesDialog/services";
+
+export default {
+    components: {
+        LoadingSpan,
+    },
+    data() {
+        return {
+            initializingFileSources: true,
+            hasWritableFileSources: false,
+        };
+    },
+    computed: {
+        initializeFileSourcesMessage() {
+            return "Loading file sources configuration from Galaxy server.";
+        },
+    },
+    methods: {
+        async initializeFilesSources() {
+            const fileSources = await new Services().getFileSources();
+            this.hasWritableFileSources = fileSources.some((fs) => fs.writable);
+            this.initializingFileSources = false;
+        },
+    },
+};

--- a/client/src/components/Common/exportsMixin.test.js
+++ b/client/src/components/Common/exportsMixin.test.js
@@ -1,0 +1,50 @@
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import exportsMixin from "./exportsMixin";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+const TEST_PLUGINS_URL = "/api/remote_files/plugins";
+
+const localVue = getLocalVue();
+
+const Component = {
+    render() {},
+    mixins: [exportsMixin],
+};
+
+describe("exportsMixin.js", () => {
+    let wrapper;
+    let axiosMock;
+
+    beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+        const propsData = {};
+        wrapper = shallowMount(Component, propsData, localVue);
+    });
+
+    function mockGet(writable) {
+        axiosMock.onGet(TEST_PLUGINS_URL).reply(200, [{ id: "foo", writable: writable }]);
+    }
+
+    afterEach(async () => {
+        axiosMock.restore();
+    });
+
+    it("should be initially uninitialized", async () => {
+        expect(wrapper.vm.initializingFileSources).toBeTruthy();
+    });
+
+    it("should be initialized after fetching configuration", async () => {
+        mockGet(false);
+        await wrapper.vm.initializeFilesSources();
+        expect(wrapper.vm.initializingFileSources).toBeFalsy();
+        expect(wrapper.vm.hasWritableFileSources).toBeFalsy();
+    });
+
+    it("should be have writable sources if any are writable", async () => {
+        mockGet(true);
+        await wrapper.vm.initializeFilesSources();
+        expect(wrapper.vm.initializingFileSources).toBeFalsy();
+        expect(wrapper.vm.hasWritableFileSources).toBeTruthy();
+    });
+});

--- a/client/src/components/HistoryExport/Index.vue
+++ b/client/src/components/HistoryExport/Index.vue
@@ -1,8 +1,8 @@
 <template>
     <span class="history-export-component">
         <h2>Export history archive</h2>
-        <span v-if="initializing">
-            <loading-span message="Loading server configuration." />
+        <span v-if="initializingFileSources">
+            <loading-span :message="initializeFileSourcesMessage" />
         </span>
         <span v-else-if="hasWritableFileSources">
             <b-card no-body>
@@ -30,39 +30,26 @@
 import { BCard, BTabs, BTab } from "bootstrap-vue";
 import ToLink from "./ToLink.vue";
 import ToRemoteFile from "./ToRemoteFile.vue";
-import { Services } from "components/FilesDialog/services";
-import LoadingSpan from "components/LoadingSpan";
+
+import exportsMixin from "components/Common/exportsMixin";
 
 export default {
     components: {
-        LoadingSpan,
         ToLink,
         ToRemoteFile,
         BCard,
         BTabs,
         BTab,
     },
+    mixins: [exportsMixin],
     props: {
         historyId: {
             type: String,
             required: true,
         },
     },
-    data() {
-        return {
-            initializing: true,
-            hasWritableFileSources: false,
-        };
-    },
     async mounted() {
-        await this.initialize();
-    },
-    methods: {
-        async initialize() {
-            const fileSources = await new Services().getFileSources();
-            this.hasWritableFileSources = fileSources.some((fs) => fs.writable);
-            this.initializing = false;
-        },
+        await this.initializeFilesSources();
     },
 };
 </script>

--- a/client/src/components/HistoryExport/ToRemoteFile.test.js
+++ b/client/src/components/HistoryExport/ToRemoteFile.test.js
@@ -27,27 +27,7 @@ describe("ToRemoteFile.vue", () => {
         });
     });
 
-    it("should render a form with export disable because inputs empty", async () => {
-        expect(wrapper.find(".export-button").exists()).toBeTruthy();
-        expect(wrapper.find(".export-button").attributes("disabled")).toBeTruthy();
-        expect(wrapper.vm.canExport).toBeFalsy();
-    });
-
-    it("should allow export when name and directory available", async () => {
-        await wrapper.setData({
-            name: "export.tar.gz",
-            directory: "gxfiles://",
-        });
-        expect(wrapper.vm.directory).toEqual("gxfiles://");
-        expect(wrapper.vm.name).toEqual("export.tar.gz");
-        expect(wrapper.vm.canExport).toBeTruthy();
-    });
-
     it("should issue export PUT request on export", async () => {
-        await wrapper.setData({
-            name: "export.tar.gz",
-            directory: "gxfiles://",
-        });
         let request;
         axiosMock.onPut(TEST_EXPORTS_URL).reply((request_) => {
             request = request_;
@@ -58,7 +38,7 @@ describe("ToRemoteFile.vue", () => {
                 then({ state: "ok" });
             })
         );
-        wrapper.vm.doExport();
+        wrapper.vm.doExport("gxfiles://", "export.tar.gz");
         await flushPromises();
         const putData = JSON.parse(request.data);
         expect(putData.directory_uri).toEqual("gxfiles://");

--- a/client/src/components/HistoryExport/ToRemoteFile.vue
+++ b/client/src/components/HistoryExport/ToRemoteFile.vue
@@ -17,25 +17,7 @@
                 <p>History successfully exported.</p>
             </b-alert>
         </div>
-        <div v-else>
-            <b-form-group
-                id="fieldset-directory"
-                label-for="directory"
-                description="Select a 'remote files' directory to export history archive to."
-                class="mt-3">
-                <files-input id="directory" v-model="directory" mode="directory" :require-writable="true" />
-            </b-form-group>
-            <b-form-group id="fieldset-name" label-for="name" description="Give the exported file a name." class="mt-3">
-                <b-form-input id="name" v-model="name" placeholder="Name" required></b-form-input>
-            </b-form-group>
-            <b-row align-h="end">
-                <b-col
-                    ><b-button class="export-button" variant="primary" :disabled="!canExport" @click="doExport"
-                        >Export</b-button
-                    ></b-col
-                >
-            </b-row>
-        </div>
+        <ExportForm v-else what="history archive" @export="doExport" />
     </div>
 </template>
 
@@ -45,15 +27,15 @@ import axios from "axios";
 import { waitOnJob } from "components/JobStates/wait";
 import { errorMessageAsString } from "utils/simple-error";
 import LoadingSpan from "components/LoadingSpan";
-import FilesInput from "components/FilesDialog/FilesInput.vue";
 import JobError from "components/JobInformation/JobError";
+import ExportForm from "components/Common/ExportForm";
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
 Vue.use(BootstrapVue);
 
 export default {
     components: {
-        FilesInput,
+        ExportForm,
         LoadingSpan,
         JobError,
     },
@@ -66,23 +48,16 @@ export default {
     data() {
         return {
             errorMessage: null,
-            name: null,
-            directory: null,
             waitingOnJob: false,
             jobComplete: false,
             jobError: null,
         };
     },
-    computed: {
-        canExport() {
-            return !!this.name && !!this.directory;
-        },
-    },
     methods: {
-        doExport() {
+        doExport(directory, name) {
             const data = {
-                directory_uri: this.directory,
-                file_name: this.name,
+                directory_uri: directory,
+                file_name: name,
             };
             this.waitingOnJob = true;
             const url = `${getAppRoot()}api/histories/${this.historyId}/exports`;


### PR DESCRIPTION
Add a few more tests and localization.

I want to reuse some of these components downstream for workflow invocation exports.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
