### PR TITLE
Advanced filter menu enhancements

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryFilters.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryFilters.test.js
@@ -4,6 +4,16 @@ import HistoryFilters from "./HistoryFilters";
 const localVue = getLocalVue();
 
 describe("HistoryFilters", () => {
+    async function expectCorrectEmits(wrapper, showAdvanced, filterText) {
+        // count how many times filterText and toggles are emitted
+        const filterEmits = wrapper.emitted()["update:filter-text"].length;
+        const toggleEmits = wrapper.emitted()["update:show-advanced"].length;
+
+        expect(wrapper.emitted()["update:show-advanced"][toggleEmits - 1][0]).toEqual(showAdvanced);
+        await wrapper.setProps({ showAdvanced: wrapper.emitted()["update:show-advanced"][toggleEmits - 1][0] });
+        expect(wrapper.emitted()["update:filter-text"][filterEmits - 1][0]).toEqual(filterText);
+    }
+
     it("test history filter panel", async () => {
         const wrapper = mount(HistoryFilters, {
             propsData: {
@@ -28,26 +38,67 @@ describe("HistoryFilters", () => {
             "[placeholder='created after']": "January 1, 2022",
             "[placeholder='created before']": "January 1, 2023",
         };
+
+        // only add name filter in the advanced menu
+        let filterName = wrapper.find("[placeholder='any name']");
+        if (filterName.vm && filterName.props().type == "text") {
+            filterName.setValue(filterInputs["[placeholder='any name']"]);
+        }
+
+        // Test: keyup.enter search (should toggle the view out)
+        await filterName.trigger("keyup.enter");
+
+        await expectCorrectEmits(wrapper, false, "name=name-filter");
+
+        // Test: clearing the filterText
+        const clearButton = wrapper.find("[data-description='show deleted filter toggle']");
+        await clearButton.trigger("click");
+
+        await expectCorrectEmits(wrapper, false, "");
+
+        // Test: toggling view back in
+        const toggleButton = wrapper.find("[data-description='show advanced filter toggle']");
+        await toggleButton.trigger("click");
+
+        await expectCorrectEmits(wrapper, true, "");
+
+        // Now add filters in all input fields in the advanced menu
         Object.entries(filterInputs).forEach(([selector, value]) => {
             const filterInput = wrapper.find(selector);
             if (filterInput.vm && filterInput.props().type == "text") {
                 filterInput.setValue(value);
             }
         });
+
+        // Test: search button (should toggle the view out)
         const searchButton = wrapper.find("[description='apply filters']");
         await searchButton.trigger("click");
-        const emitted = wrapper.emitted();
-        expect(emitted["update:show-advanced"][0][0]).toEqual(false);
-        const filterValidation = [
-            "name=name-filter",
-            "extension=ext-filter",
-            "tag='tag filter'",
-            "state=state-filter",
-            "hid>hid-greater",
-            "hid<hid-lower",
-        ];
-        filterValidation.forEach((filterValue) => {
-            expect(emitted["update:filter-text"][0][0]).toContain(filterValue);
-        });
+
+        await expectCorrectEmits(
+            wrapper,
+            false,
+            "create_time>'January 1, 2022' create_time<'January 1, 2023' extension=ext-filter hid>hid-greater hid<hid-lower name=name-filter state=state-filter tag='tag filter'"
+        );
+
+        // -------- Test esc key:  ---------
+        // toggles view out only (doesn't cause a new search / doesn't emulate enter)
+
+        // clear the filterText
+        await clearButton.trigger("click");
+        // toggle view back in
+        await toggleButton.trigger("click");
+
+        await expectCorrectEmits(wrapper, true, "");
+
+        // find name field again (could be destroyed beacause of toggling out)
+        filterName = wrapper.find("[placeholder='any name']");
+        if (filterName.vm && filterName.props().type == "text") {
+            filterName.setValue("newnamefilter");
+        }
+
+        // press esc key from name field (should not change emitted filterText unlike enter key)
+        await filterName.trigger("keyup.esc");
+
+        await expectCorrectEmits(wrapper, false, "");
     });
 });

--- a/client/src/components/History/CurrentHistory/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters.vue
@@ -27,32 +27,53 @@
             </b-input-group-append>
         </b-input-group>
         <div v-if="showAdvanced" class="mt-2" description="advanced filters">
-            <small>Filter by name:</small>
-            <b-form-input v-model="filterSettings['name=']" size="sm" placeholder="any name" />
-            <small class="mt-1">Filter by extension:</small>
-            <b-form-input v-model="filterSettings['extension=']" size="sm" placeholder="any extension" />
-            <small class="mt-1">Filter by tag:</small>
-            <b-form-input v-model="filterSettings['tag=']" size="sm" placeholder="any tag" />
-            <small class="mt-1">Filter by state:</small>
-            <b-form-input v-model="filterSettings['state=']" size="sm" placeholder="any state" />
-            <small class="mt-1">Filter by item index:</small>
-            <b-form-group class="m-0">
-                <b-input-group>
-                    <b-form-input v-model="filterSettings['hid>']" size="sm" placeholder="index greater" />
-                    <b-form-input v-model="filterSettings['hid<']" size="sm" placeholder="index lower" />
-                </b-input-group>
-            </b-form-group>
-            <small class="mt-1">Filter by creation time:</small>
-            <b-form-group class="m-0">
-                <b-input-group>
-                    <b-form-input v-model="filterSettings['create_time>']" size="sm" placeholder="created after" />
-                    <b-form-input v-model="filterSettings['create_time<']" size="sm" placeholder="created before" />
-                </b-input-group>
-            </b-form-group>
-            <small>Show deleted:</small>
-            <b-form-checkbox v-model="filterSettings['deleted=']" size="sm" switch description="filter deleted" />
-            <small>Show visible:</small>
-            <b-form-checkbox v-model="filterSettings['visible=']" size="sm" switch description="filter visible" />
+            <b-form @keyup.enter="onSearch">
+                <small>Filter by name:</small>
+                <b-form-input v-model="filterSettings['name=']" size="sm" placeholder="any name" />
+                <small class="mt-1">Filter by extension:</small>
+                <b-form-input v-model="filterSettings['extension=']" size="sm" placeholder="any extension" />
+                <small class="mt-1">Filter by tag:</small>
+                <b-form-input v-model="filterSettings['tag=']" size="sm" placeholder="any tag" />
+                <small class="mt-1">Filter by state:</small>
+                <b-form-input v-model="filterSettings['state=']" size="sm" placeholder="any state" list="stateSelect" />
+                <datalist id="stateSelect">
+                    <option v-for="state in states" :key="state">
+                        {{ state }}
+                    </option>
+                </datalist>
+                <small class="mt-1">Filter by item index:</small>
+                <b-form-group class="m-0">
+                    <b-input-group>
+                        <b-form-input v-model="filterSettings['hid>']" size="sm" placeholder="index greater" />
+                        <b-form-input v-model="filterSettings['hid<']" size="sm" placeholder="index lower" />
+                    </b-input-group>
+                </b-form-group>
+                <small class="mt-1">Filter by creation time:</small>
+                <b-form-group class="m-0">
+                    <b-input-group>
+                        <b-form-input v-model="filterSettings['create_time>']" size="sm" placeholder="created after" />
+                        <b-input-group-append>
+                            <b-form-datepicker
+                                v-model="filterSettings['create_time>']"
+                                reset-button
+                                button-only
+                                size="sm" />
+                        </b-input-group-append>
+                        <b-form-input v-model="filterSettings['create_time<']" size="sm" placeholder="created before" />
+                        <b-input-group-append>
+                            <b-form-datepicker
+                                v-model="filterSettings['create_time<']"
+                                reset-button
+                                button-only
+                                size="sm" />
+                        </b-input-group-append>
+                    </b-input-group>
+                </b-form-group>
+                <small>Show deleted:</small>
+                <b-form-checkbox v-model="filterSettings['deleted=']" size="sm" switch description="filter deleted" />
+                <small>Show visible:</small>
+                <b-form-checkbox v-model="filterSettings['visible=']" size="sm" switch description="filter visible" />
+            </b-form>
             <div class="mt-3">
                 <b-button class="mr-1" size="sm" variant="primary" description="apply filters" @click="onSearch">
                     <icon icon="search" />
@@ -70,6 +91,7 @@
 <script>
 import DebouncedInput from "components/DebouncedInput";
 import { getFilters, toAlias } from "store/historyStore/model/filtering";
+import { STATES } from "../Content/model/states";
 
 // available filter keys with operator and default setting
 const filterDefaults = {
@@ -108,6 +130,11 @@ export default {
                     this.updateFilter(newVal);
                 }
             },
+        },
+        states() {
+            let stateList = Object.keys(STATES);
+            // stateList.unshift({ value: "", text: "any state" });
+            return stateList;
         },
     },
     watch: {

--- a/client/src/components/History/CurrentHistory/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters.vue
@@ -26,50 +26,53 @@
                 </b-button>
             </b-input-group-append>
         </b-input-group>
-        <div v-if="showAdvanced" class="mt-2" description="advanced filters">
-            <b-form @keyup.enter="onSearch">
-                <small>Filter by name:</small>
-                <b-form-input v-model="filterSettings['name=']" size="sm" placeholder="any name" />
-                <small class="mt-1">Filter by extension:</small>
-                <b-form-input v-model="filterSettings['extension=']" size="sm" placeholder="any extension" />
-                <small class="mt-1">Filter by tag:</small>
-                <b-form-input v-model="filterSettings['tag=']" size="sm" placeholder="any tag" />
-                <small class="mt-1">Filter by state:</small>
-                <b-form-input v-model="filterSettings['state=']" size="sm" placeholder="any state" list="stateSelect" />
-                <b-form-datalist id="stateSelect" :options="states"></b-form-datalist>
-                <small class="mt-1">Filter by item index:</small>
-                <b-form-group class="m-0">
-                    <b-input-group>
-                        <b-form-input v-model="filterSettings['hid>']" size="sm" placeholder="index greater" />
-                        <b-form-input v-model="filterSettings['hid<']" size="sm" placeholder="index lower" />
-                    </b-input-group>
-                </b-form-group>
-                <small class="mt-1">Filter by creation time:</small>
-                <b-form-group class="m-0">
-                    <b-input-group>
-                        <b-form-input v-model="filterSettings['create_time>']" size="sm" placeholder="created after" />
-                        <b-input-group-append>
-                            <b-form-datepicker
-                                v-model="filterSettings['create_time>']"
-                                reset-button
-                                button-only
-                                size="sm" />
-                        </b-input-group-append>
-                        <b-form-input v-model="filterSettings['create_time<']" size="sm" placeholder="created before" />
-                        <b-input-group-append>
-                            <b-form-datepicker
-                                v-model="filterSettings['create_time<']"
-                                reset-button
-                                button-only
-                                size="sm" />
-                        </b-input-group-append>
-                    </b-input-group>
-                </b-form-group>
-                <small>Show deleted:</small>
-                <b-form-checkbox v-model="filterSettings['deleted=']" size="sm" switch description="filter deleted" />
-                <small>Show visible:</small>
-                <b-form-checkbox v-model="filterSettings['visible=']" size="sm" switch description="filter visible" />
-            </b-form>
+        <div
+            v-if="showAdvanced"
+            class="mt-2"
+            description="advanced filters"
+            @keyup.enter="onSearch"
+            @keyup.esc="onToggle">
+            <small>Filter by name:</small>
+            <b-form-input v-model="filterSettings['name=']" size="sm" placeholder="any name" />
+            <small class="mt-1">Filter by extension:</small>
+            <b-form-input v-model="filterSettings['extension=']" size="sm" placeholder="any extension" />
+            <small class="mt-1">Filter by tag:</small>
+            <b-form-input v-model="filterSettings['tag=']" size="sm" placeholder="any tag" />
+            <small class="mt-1">Filter by state:</small>
+            <b-form-input v-model="filterSettings['state=']" size="sm" placeholder="any state" list="stateSelect" />
+            <b-form-datalist id="stateSelect" :options="states"></b-form-datalist>
+            <small class="mt-1">Filter by item index:</small>
+            <b-form-group class="m-0">
+                <b-input-group>
+                    <b-form-input v-model="filterSettings['hid>']" size="sm" placeholder="index greater" />
+                    <b-form-input v-model="filterSettings['hid<']" size="sm" placeholder="index lower" />
+                </b-input-group>
+            </b-form-group>
+            <small class="mt-1">Filter by creation time:</small>
+            <b-form-group class="m-0">
+                <b-input-group>
+                    <b-form-input v-model="filterSettings['create_time>']" size="sm" placeholder="created after" />
+                    <b-input-group-append>
+                        <b-form-datepicker
+                            v-model="filterSettings['create_time>']"
+                            reset-button
+                            button-only
+                            size="sm" />
+                    </b-input-group-append>
+                    <b-form-input v-model="filterSettings['create_time<']" size="sm" placeholder="created before" />
+                    <b-input-group-append>
+                        <b-form-datepicker
+                            v-model="filterSettings['create_time<']"
+                            reset-button
+                            button-only
+                            size="sm" />
+                    </b-input-group-append>
+                </b-input-group>
+            </b-form-group>
+            <small>Show deleted:</small>
+            <b-form-checkbox v-model="filterSettings['deleted=']" size="sm" switch description="filter deleted" />
+            <small>Show visible:</small>
+            <b-form-checkbox v-model="filterSettings['visible=']" size="sm" switch description="filter visible" />
             <div class="mt-3">
                 <b-button class="mr-1" size="sm" variant="primary" description="apply filters" @click="onSearch">
                     <icon icon="search" />

--- a/client/src/components/History/CurrentHistory/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters.vue
@@ -36,11 +36,7 @@
                 <b-form-input v-model="filterSettings['tag=']" size="sm" placeholder="any tag" />
                 <small class="mt-1">Filter by state:</small>
                 <b-form-input v-model="filterSettings['state=']" size="sm" placeholder="any state" list="stateSelect" />
-                <datalist id="stateSelect">
-                    <option v-for="state in states" :key="state">
-                        {{ state }}
-                    </option>
-                </datalist>
+                <b-form-datalist id="stateSelect" :options="states"></b-form-datalist>
                 <small class="mt-1">Filter by item index:</small>
                 <b-form-group class="m-0">
                     <b-input-group>
@@ -132,9 +128,7 @@ export default {
             },
         },
         states() {
-            let stateList = Object.keys(STATES);
-            // stateList.unshift({ value: "", text: "any state" });
-            return stateList;
+            return Object.keys(STATES);
         },
     },
     watch: {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -61,6 +61,10 @@
             <p><strong v-localize class="text-danger">Warning, this operation cannot be undone.</strong></p>
         </b-modal>
     </section>
+     <!-- Fix this: Is out of total items, not active -->
+    <section v-else>
+        <b>{{ totalItemsInQuery }}</b> of {{ Object.keys(history).length }} found
+    </section>
 </template>
 
 <script>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -61,10 +61,6 @@
             <p><strong v-localize class="text-danger">Warning, this operation cannot be undone.</strong></p>
         </b-modal>
     </section>
-     <!-- Fix this: Is out of total items, not active -->
-    <section v-else>
-        <b>{{ totalItemsInQuery }}</b> of {{ Object.keys(history).length }} found
-    </section>
 </template>
 
 <script>


### PR DESCRIPTION
For the advanced history filter menu, I have made the following changes: 
1. Added a datalist to the `state` field 
2. Added a datepicker for the `create_time` field 
3. Pressing the enter key will toggle off the advanced view and trigger a search

(Fixes https://github.com/galaxyproject/galaxy/issues/13840):

https://user-images.githubusercontent.com/78516064/167965032-e07682cc-783e-4b4e-90de-834a0239a451.mov

## Additional possibilities:
If needed/useful, the following changes could also be added:
### 1. Add a `hid=` field:

https://user-images.githubusercontent.com/78516064/167965150-e6315b32-baf0-47c1-8de3-293faf464a68.mov


### 2. Display query count result:

https://user-images.githubusercontent.com/78516064/167965173-52185dbf-e88e-4638-b9d9-3132b1497780.mov


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
