### PR TITLE
Beta History: handle bulk operation errors

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/OperationErrorDialog.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/OperationErrorDialog.vue
@@ -1,0 +1,63 @@
+<template>
+    <b-modal
+        v-model="show"
+        title="Something went wrong..."
+        header-text-variant="danger"
+        title-tag="h2"
+        scrollable
+        ok-only
+        @hide="onHide">
+        <p v-if="isPartialSuccess" v-localize>
+            -<strong>{{ success_count }}</strong
+            >- items were processed successfully, unfortunately, -<strong>{{ error_count }}</strong
+            >- items failed because of the following reasons:
+        </p>
+        <p v-else v-localize>The operation failed for the following reasons:</p>
+        <div>
+            <ul>
+                <li v-for="(reason, index) in reasons" :key="`error-${index}`">
+                    {{ reason }}
+                </li>
+            </ul>
+        </div>
+    </b-modal>
+</template>
+
+<script>
+import { BModal } from "bootstrap-vue";
+export default {
+    components: {
+        BModal,
+    },
+    props: {
+        operationError: { type: Object, default: null },
+    },
+    data: function () {
+        return {
+            show: this.operationError != null,
+        };
+    },
+    computed: {
+        isPartialSuccess() {
+            return this.operationError?.result?.success_count > 0;
+        },
+        success_count() {
+            return this.operationError?.result?.success_count || 0;
+        },
+        error_count() {
+            return this.operationError?.result?.errors.length || 0;
+        },
+        reasons() {
+            if (this.operationError && this.operationError.result) {
+                return [...new Set(this.operationError.result.errors.map((e) => e.error))];
+            }
+            return [];
+        },
+    },
+    methods: {
+        onHide() {
+            this.$emit("hide");
+        },
+    },
+};
+</script>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -1,0 +1,169 @@
+import { shallowMount } from "@vue/test-utils";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import flushPromises from "flush-promises";
+import { getLocalVue } from "jest/helpers";
+import SelectionOperations from "./SelectionOperations.vue";
+
+const localVue = getLocalVue();
+
+const FAKE_HISTORY_ID = "fake_history_id";
+const FAKE_HISTORY = { id: FAKE_HISTORY_ID, update_time: new Date() };
+const BULK_OPERATIONS_ENDPOINT = new RegExp(`/api/histories/${FAKE_HISTORY_ID}/contents/bulk`);
+const BULK_SUCCESS_RESPONSE = { success_count: 1, errors: [] };
+const BULK_ERROR_RESPONSE = {
+    success_count: 0,
+    errors: [{ error: "Error reason", item: { history_content_type: "dataset", id: "dataset_id" } }],
+};
+
+describe("History Selection Operations", () => {
+    let axiosMock;
+    let wrapper;
+
+    beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+        wrapper = shallowMount(
+            SelectionOperations,
+            {
+                propsData: {
+                    history: FAKE_HISTORY,
+                    filterText: "",
+                    contentSelection: new Map(),
+                    selectionSize: 1,
+                    isQuerySelection: false,
+                    totalItemsInQuery: 5,
+                },
+            },
+            localVue
+        );
+        await flushPromises();
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    describe("Dropdown Menu", () => {
+        it("should not render if there is nothing selected", async () => {
+            await wrapper.setProps({ selectionSize: 0 });
+            expect(wrapper.html()).toBe("");
+        });
+
+        it("should display the total number of items to apply the operation", async () => {
+            await wrapper.setProps({ selectionSize: 10 });
+            expect(wrapper.find('[data-test-id="selected-count"]').text()).toContain("10");
+        });
+
+        it("should display 'hide' option only on visible items", async () => {
+            const option = '[data-test-id="hide-option"]';
+            expect(wrapper.find(option).exists()).toBe(true);
+            await wrapper.setProps({ filterText: "visible=false" });
+            expect(wrapper.find(option).exists()).toBe(false);
+        });
+
+        it("should display 'unhide' option only on hidden items", async () => {
+            const option = '[data-test-id="unhide-option"]';
+            expect(wrapper.find(option).exists()).toBe(false);
+            await wrapper.setProps({ filterText: "visible=false" });
+            expect(wrapper.find(option).exists()).toBe(true);
+        });
+
+        it("should display 'delete' option only on non-deleted items", async () => {
+            const option = '[data-test-id="delete-option"]';
+            expect(wrapper.find(option).exists()).toBe(true);
+            await wrapper.setProps({ filterText: "deleted=true" });
+            expect(wrapper.find(option).exists()).toBe(false);
+        });
+
+        it("should display 'undelete' option only on deleted items", async () => {
+            const option = '[data-test-id="undelete-option"]';
+            expect(wrapper.find(option).exists()).toBe(false);
+            await wrapper.setProps({ filterText: "deleted=true" });
+            expect(wrapper.find(option).exists()).toBe(true);
+        });
+
+        it("should display collection building options only on visible and non-deleted items", async () => {
+            const buildListOption = '[data-description="build list"]';
+            const buildPairOption = '[data-description="build pair"]';
+            const buildListOfPairsOption = '[data-description="build list of pairs"]';
+            expect(wrapper.find(buildListOption).exists()).toBe(true);
+            expect(wrapper.find(buildPairOption).exists()).toBe(true);
+            expect(wrapper.find(buildListOfPairsOption).exists()).toBe(true);
+            await wrapper.setProps({ filterText: "visible=false" });
+            expect(wrapper.find(buildListOption).exists()).toBe(false);
+            expect(wrapper.find(buildPairOption).exists()).toBe(false);
+            expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
+            await wrapper.setProps({ filterText: "deleted=true" });
+            expect(wrapper.find(buildListOption).exists()).toBe(false);
+            expect(wrapper.find(buildPairOption).exists()).toBe(false);
+            expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
+        });
+    });
+
+    describe("Operation Run", () => {
+        it("should emit event to disable selection", async () => {
+            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_SUCCESS_RESPONSE);
+
+            expect(wrapper.emitted()).not.toHaveProperty("update:show-selection");
+            wrapper.vm.hideSelected();
+            await flushPromises();
+            expect(wrapper.emitted()).toHaveProperty("update:show-selection");
+            expect(wrapper.emitted()["update:show-selection"][0][0]).toBe(false);
+        });
+
+        it("should update operation-running state when running any operation that succeeds", async () => {
+            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_SUCCESS_RESPONSE);
+
+            expect(wrapper.emitted()).not.toHaveProperty("update:operation-running");
+            wrapper.vm.hideSelected();
+            await flushPromises();
+            expect(wrapper.emitted()).toHaveProperty("update:operation-running");
+
+            const operationRunningEvents = wrapper.emitted("update:operation-running");
+            expect(operationRunningEvents).toHaveLength(1);
+            // The event sets the current History update time for waiting until the next history update
+            expect(operationRunningEvents[0]).toEqual([FAKE_HISTORY.update_time]);
+        });
+
+        it("should update operation-running state to null when the operation fails", async () => {
+            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(400);
+
+            expect(wrapper.emitted()).not.toHaveProperty("update:operation-running");
+            wrapper.vm.hideSelected();
+            await flushPromises();
+            expect(wrapper.emitted()).toHaveProperty("update:show-selection");
+
+            const operationRunningEvents = wrapper.emitted("update:operation-running");
+            // We expect 2 events, one before running the operation and another one after completion
+            expect(operationRunningEvents).toHaveLength(2);
+            // The first event sets the current History update time for waiting until the next history update
+            expect(operationRunningEvents[0]).toEqual([FAKE_HISTORY.update_time]);
+            // The second is null to signal that we shouldn't wait for a history change anymore since the operation has failed
+            expect(operationRunningEvents[1]).toEqual([null]);
+        });
+
+        it("should emit operation error event when the operation fails", async () => {
+            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(400);
+
+            expect(wrapper.emitted()).not.toHaveProperty("operation-error");
+            wrapper.vm.hideSelected();
+            await flushPromises();
+            expect(wrapper.emitted()).toHaveProperty("operation-error");
+        });
+
+        it("should emit operation error event with details when any item fail", async () => {
+            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_ERROR_RESPONSE);
+
+            expect(wrapper.emitted()).not.toHaveProperty("operation-error");
+            wrapper.vm.hideSelected();
+            await flushPromises();
+            expect(wrapper.emitted()).toHaveProperty("operation-error");
+
+            const operationErrorEvents = wrapper.emitted("operation-error");
+            expect(operationErrorEvents).toHaveLength(1);
+            const errorEvent = operationErrorEvents[0][0];
+            expect(errorEvent).toHaveProperty("details");
+            expect(errorEvent.details).toHaveLength(BULK_ERROR_RESPONSE.errors.length);
+        });
+    });
+});

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -51,32 +51,32 @@ describe("History Selection Operations", () => {
 
         it("should display the total number of items to apply the operation", async () => {
             await wrapper.setProps({ selectionSize: 10 });
-            expect(wrapper.find('[data-test-id="selected-count"]').text()).toContain("10");
+            expect(wrapper.find('[data-description="selected count"]').text()).toContain("10");
         });
 
         it("should display 'hide' option only on visible items", async () => {
-            const option = '[data-test-id="hide-option"]';
+            const option = '[data-description="hide option"]';
             expect(wrapper.find(option).exists()).toBe(true);
             await wrapper.setProps({ filterText: "visible=false" });
             expect(wrapper.find(option).exists()).toBe(false);
         });
 
         it("should display 'unhide' option only on hidden items", async () => {
-            const option = '[data-test-id="unhide-option"]';
+            const option = '[data-description="unhide option"]';
             expect(wrapper.find(option).exists()).toBe(false);
             await wrapper.setProps({ filterText: "visible=false" });
             expect(wrapper.find(option).exists()).toBe(true);
         });
 
         it("should display 'delete' option only on non-deleted items", async () => {
-            const option = '[data-test-id="delete-option"]';
+            const option = '[data-description="delete option"]';
             expect(wrapper.find(option).exists()).toBe(true);
             await wrapper.setProps({ filterText: "deleted=true" });
             expect(wrapper.find(option).exists()).toBe(false);
         });
 
         it("should display 'undelete' option only on deleted items", async () => {
-            const option = '[data-test-id="undelete-option"]';
+            const option = '[data-description="undelete option"]';
             expect(wrapper.find(option).exists()).toBe(false);
             await wrapper.setProps({ filterText: "deleted=true" });
             expect(wrapper.find(option).exists()).toBe(true);

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -151,7 +151,7 @@ describe("History Selection Operations", () => {
             expect(wrapper.emitted()).toHaveProperty("operation-error");
         });
 
-        it("should emit operation error event with details when any item fail", async () => {
+        it("should emit operation error event with the result when any item fail", async () => {
             axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_ERROR_RESPONSE);
 
             expect(wrapper.emitted()).not.toHaveProperty("operation-error");
@@ -162,8 +162,8 @@ describe("History Selection Operations", () => {
             const operationErrorEvents = wrapper.emitted("operation-error");
             expect(operationErrorEvents).toHaveLength(1);
             const errorEvent = operationErrorEvents[0][0];
-            expect(errorEvent).toHaveProperty("details");
-            expect(errorEvent.details).toHaveLength(BULK_ERROR_RESPONSE.errors.length);
+            expect(errorEvent).toHaveProperty("result");
+            expect(errorEvent.result).toEqual(BULK_ERROR_RESPONSE);
         });
     });
 });

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -10,21 +10,21 @@
                 </span>
             </template>
             <b-dropdown-text>
-                <span v-localize data-test-id="selected-count">With {{ numSelected }} selected...</span>
+                <span v-localize data-description="selected count">With {{ numSelected }} selected...</span>
             </b-dropdown-text>
-            <b-dropdown-item v-if="showHidden" v-b-modal:show-selected-content data-test-id="unhide-option">
+            <b-dropdown-item v-if="showHidden" v-b-modal:show-selected-content data-description="unhide option">
                 <span v-localize>Unhide</span>
             </b-dropdown-item>
-            <b-dropdown-item v-else v-b-modal:hide-selected-content data-test-id="hide-option">
+            <b-dropdown-item v-else v-b-modal:hide-selected-content data-description="hide option">
                 <span v-localize>Hide</span>
             </b-dropdown-item>
-            <b-dropdown-item v-if="showDeleted" v-b-modal:restore-selected-content data-test-id="undelete-option">
+            <b-dropdown-item v-if="showDeleted" v-b-modal:restore-selected-content data-description="undelete option">
                 <span v-localize>Undelete</span>
             </b-dropdown-item>
-            <b-dropdown-item v-else v-b-modal:delete-selected-content data-test-id="delete-option">
+            <b-dropdown-item v-else v-b-modal:delete-selected-content data-description="delete option">
                 <span v-localize>Delete</span>
             </b-dropdown-item>
-            <b-dropdown-item v-if="!showDeleted" v-b-modal:purge-selected-content data-test-id="purge-option">
+            <b-dropdown-item v-if="!showDeleted" v-b-modal:purge-selected-content data-description="purge option">
                 <span v-localize>Delete (permanently)</span>
             </b-dropdown-item>
             <b-dropdown-item v-if="showBuildOptions" data-description="build list" @click="buildDatasetList">

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -10,21 +10,21 @@
                 </span>
             </template>
             <b-dropdown-text>
-                <span v-localize>With {{ numSelected }} selected...</span>
+                <span v-localize data-test-id="selected-count">With {{ numSelected }} selected...</span>
             </b-dropdown-text>
-            <b-dropdown-item v-if="showHidden" v-b-modal:show-selected-content>
+            <b-dropdown-item v-if="showHidden" v-b-modal:show-selected-content data-test-id="unhide-option">
                 <span v-localize>Unhide</span>
             </b-dropdown-item>
-            <b-dropdown-item v-else v-b-modal:hide-selected-content>
+            <b-dropdown-item v-else v-b-modal:hide-selected-content data-test-id="hide-option">
                 <span v-localize>Hide</span>
             </b-dropdown-item>
-            <b-dropdown-item v-if="showDeleted" v-b-modal:restore-selected-content>
+            <b-dropdown-item v-if="showDeleted" v-b-modal:restore-selected-content data-test-id="undelete-option">
                 <span v-localize>Undelete</span>
             </b-dropdown-item>
-            <b-dropdown-item v-else v-b-modal:delete-selected-content>
+            <b-dropdown-item v-else v-b-modal:delete-selected-content data-test-id="delete-option">
                 <span v-localize>Delete</span>
             </b-dropdown-item>
-            <b-dropdown-item v-if="!showDeleted" v-b-modal:purge-selected-content>
+            <b-dropdown-item v-if="!showDeleted" v-b-modal:purge-selected-content data-test-id="purge-option">
                 <span v-localize>Delete (permanently)</span>
             </b-dropdown-item>
             <b-dropdown-item v-if="showBuildOptions" data-description="build list" @click="buildDatasetList">
@@ -139,12 +139,12 @@ export default {
             const items = this.getExplicitlySelectedItems();
             const filters = getQueryDict(this.filterText);
             this.$emit("update:show-selection", false);
-            let waitForHistoryUpdate = false;
+            let expectHistoryUpdate = false;
             try {
                 const result = await operation(this.history, filters, items);
-                waitForHistoryUpdate = result.success_count > 0;
+                expectHistoryUpdate = result.success_count > 0;
                 if (result.errors.length) {
-                    const message = waitForHistoryUpdate
+                    const message = expectHistoryUpdate
                         ? "Some items couldn't be successfully processed"
                         : "The operation failed";
                     this.handleOperationError(message, result.errors);
@@ -152,7 +152,9 @@ export default {
             } catch (error) {
                 this.handleOperationError(error);
             }
-            this.$emit("update:operation-running", waitForHistoryUpdate ? this.history.update_time : null);
+            if (!expectHistoryUpdate) {
+                this.$emit("update:operation-running", null);
+            }
         },
         getExplicitlySelectedItems() {
             if (this.isQuerySelection) {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -144,13 +144,10 @@ export default {
                 const result = await operation(this.history, filters, items);
                 expectHistoryUpdate = result.success_count > 0;
                 if (result.errors.length) {
-                    const message = expectHistoryUpdate
-                        ? "Some items couldn't be successfully processed"
-                        : "The operation failed";
-                    this.handleOperationError(message, result.errors);
+                    this.handleOperationError(null, result);
                 }
             } catch (error) {
-                this.handleOperationError(error);
+                this.handleOperationError(error, null);
             }
             if (!expectHistoryUpdate) {
                 this.$emit("update:operation-running", null);
@@ -165,8 +162,8 @@ export default {
             });
             return items;
         },
-        handleOperationError(errorMessage, details = null) {
-            this.$emit("operation-error", { errorMessage, details });
+        handleOperationError(errorMessage, result) {
+            this.$emit("operation-error", { errorMessage, result });
         },
 
         // collection creation, fires up a modal

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -55,6 +55,7 @@
                                     :total-items-in-query="totalItemsInQuery"
                                     :operation-running.sync="operationRunning"
                                     @update:show-selection="setShowSelection"
+                                    @operation-error="onOperationError"
                                     @hide-selection="onHideSelection"
                                     @reset-selection="resetSelection" />
                                 <HistorySelectionStatus
@@ -65,6 +66,10 @@
                             </template>
                         </HistoryOperations>
                         <SelectionChangeWarning :query-selection-break="querySelectionBreak" />
+                        <OperationErrorDialog
+                            v-if="operationError"
+                            :operation-error="operationError"
+                            @hide="operationError = null" />
                     </section>
                     <section v-if="!showAdvanced" class="position-relative flex-grow-1 scroller">
                         <div>
@@ -127,6 +132,7 @@ import HistoryMessages from "./HistoryMessages";
 import HistorySelectionOperations from "./HistoryOperations/SelectionOperations";
 import HistorySelectionStatus from "./HistoryOperations/SelectionStatus";
 import SelectionChangeWarning from "./HistoryOperations/SelectionChangeWarning";
+import OperationErrorDialog from "./HistoryOperations/OperationErrorDialog";
 
 export default {
     components: {
@@ -145,6 +151,7 @@ export default {
         Listing,
         SelectedItems,
         SelectionChangeWarning,
+        OperationErrorDialog,
     },
     props: {
         history: { type: Object, required: true },
@@ -156,6 +163,7 @@ export default {
             offset: 0,
             showAdvanced: false,
             operationRunning: null,
+            operationError: null,
             querySelectionBreak: false,
         };
     },
@@ -221,6 +229,10 @@ export default {
         },
         setInvisible(item) {
             Vue.set(this.invisible, item.hid, true);
+        },
+        onOperationError(error) {
+            console.debug("OPERATION ERROR", error);
+            this.operationError = error;
         },
     },
 };


### PR DESCRIPTION
- Fixes `Processing operation...` message getting stuck when the history is not expected to change (due to errors during the operation, etc.)
- Includes a bunch of tests for `SelectionOperations` component
- Display an error dialog with the error details if any of the items fail to be processed
  
  ![error-dialog](https://user-images.githubusercontent.com/46503462/168333650-94370329-89bc-4032-bd6d-72e218756724.gif)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
