### PR TITLE
Fix date handling in workflow editor attributes panel

### DIFF
--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -1,7 +1,6 @@
 import { mount, createLocalVue } from "@vue/test-utils";
 import Attributes from "./Attributes";
 import { UntypedParameters } from "./modules/parameters";
-import { isDate } from "date-fns";
 
 jest.mock("app");
 

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -7,7 +7,7 @@ jest.mock("app");
 
 const TEST_ANNOTATION = "my cool annotation";
 const TEST_NAME = "workflow_name";
-const TEST_VERSIONS = [  //TODO (high) does it make sense to pre-fill this, if this is coming from prior user actions?
+const TEST_VERSIONS = [
     { versions: 0, update_time: "2022-01-01", steps: 10 },
     { versions: 1, update_time: "2022-01-02", steps: 20 },
 ];
@@ -34,27 +34,16 @@ describe("Attributes", () => {
         });
         expect(wrapper.find(`[itemprop='description']`).attributes("content")).toBe(TEST_ANNOTATION);
         expect(wrapper.find(`[itemprop='name']`).attributes("content")).toBe(TEST_NAME);
-        expect(wrapper.find(`#workflow-version-area > select`).exists()).toBeTruthy(); //TODO (low) does an `itemprop` need to be created in Attributes.vue (and why)?
+        expect(wrapper.find(`#workflow-version-area > select`).exists()).toBeTruthy();
 
         const name = wrapper.find("#workflow-name");
         expect(name.element.value).toBe(TEST_NAME);
         await wrapper.setProps({ name: "new_workflow_name" });
         expect(name.element.value).toBe("new_workflow_name");
-
-        const version = wrapper.findAll("#workflow-version-area > select > option");
-        console.log('version', version);
-        for (const v of version) {
-            console.log('v', v);
-            console.log('v.label', v.label);
-            const versionDate = (v.label).substring(versionLabel.indexOf(":") + 1, (v.label).indexOf(",")).trim();
-            expect(isDate(new Date(versionDate))).toBe(true);
-        }
-
-        const parameters = wrapper.findAll(".list-group-item"); //TODO (nit) not part of my fix, just curious: is this supposed to this exist in the code?
+        const parameters = wrapper.findAll(".list-group-item");
         expect(parameters.length).toBe(2);
         expect(parameters.at(0).text()).toBe("1: workflow_parameter_0");
         expect(parameters.at(1).text()).toBe("2: workflow_parameter_1");
-        console.log(wrapper.html()); //TODO (low) we don't need this, right?
         expect(wrapper.find("#workflow-annotation").element.value).toBe(TEST_ANNOTATION);
     });
 });

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -44,7 +44,7 @@ describe("Attributes", () => {
         const version = wrapper.findAll("#workflow-version-area > select > option");
         console.log('version', version);
         for (const v of version) {
-            console.log('v', v); {
+            console.log('v', v);
             console.log('v.label', v.label);
             const versionDate = (v.label).substring(versionLabel.indexOf(":") + 1, (v.label).indexOf(",")).trim();
             expect(isDate(new Date(versionDate))).toBe(true);

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -1,14 +1,15 @@
 import { mount, createLocalVue } from "@vue/test-utils";
 import Attributes from "./Attributes";
 import { UntypedParameters } from "./modules/parameters";
+import { isDate } from "date-fns";
 
 jest.mock("app");
 
 const TEST_ANNOTATION = "my cool annotation";
 const TEST_NAME = "workflow_name";
 const TEST_VERSIONS = [
-    { versions: 0, update_time: "2022-01-01", steps: 10 },
-    { versions: 1, update_time: "2022-01-02", steps: 20 },
+    { version: 0, update_time: "2022-01-02", steps: 10 },
+    { version: 1, update_time: "2022-03-04", steps: 20 },
 ];
 
 describe("Attributes", () => {
@@ -39,6 +40,15 @@ describe("Attributes", () => {
         expect(name.element.value).toBe(TEST_NAME);
         await wrapper.setProps({ name: "new_workflow_name" });
         expect(name.element.value).toBe("new_workflow_name");
+
+        const version = wrapper.findAllComponents(`#workflow-version-area > select > option`);
+        expect(version).toHaveLength(TEST_VERSIONS.length);
+        for (const [i,v] in TEST_VERSIONS) {
+            const versionLabel = version.at(i).text();
+            const versionDate = (versionLabel).substring(versionLabel.indexOf(":") + 1, (versionLabel).indexOf(",")).trim();
+            expect(isDate(new Date(versionDate))).toBe(true);
+        }
+
         const parameters = wrapper.findAll(".list-group-item");
         expect(parameters.length).toBe(2);
         expect(parameters.at(0).text()).toBe("1: workflow_parameter_0");

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -43,7 +43,7 @@ describe("Attributes", () => {
 
         const version = wrapper.findAllComponents(`#workflow-version-area > select > option`);
         expect(version).toHaveLength(TEST_VERSIONS.length);
-        for (const [i, v] in TEST_VERSIONS) {
+        for (let i = 0; i < version.length; i++) {
             const versionLabel = version.at(i).text();
             const versionDate = versionLabel.substring(versionLabel.indexOf(":") + 1, versionLabel.indexOf(",")).trim();
             expect(isDate(new Date(versionDate))).toBe(true);

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -34,16 +34,18 @@ describe("Attributes", () => {
         });
         expect(wrapper.find(`[itemprop='description']`).attributes("content")).toBe(TEST_ANNOTATION);
         expect(wrapper.find(`[itemprop='name']`).attributes("content")).toBe(TEST_NAME);
-        expect(wrapper.find(`#workflow-version-area`).attributes("value")); //TODO (low) does an `itemprop` need to be created in Attributes.vue (and why)?
+        expect(wrapper.find(`#workflow-version-area > select`).exists()).toBeTruthy(); //TODO (low) does an `itemprop` need to be created in Attributes.vue (and why)?
 
         const name = wrapper.find("#workflow-name");
         expect(name.element.value).toBe(TEST_NAME);
         await wrapper.setProps({ name: "new_workflow_name" });
         expect(name.element.value).toBe("new_workflow_name");
 
-        const versionArea = wrapper.find("#workflow-version-area").attributes("value"); //TODO (high) does `wrapper` = document.getElementById("workflow-version-area");
-        var version = versionArea.querySelector("select[class='custom-select']");        
+        const version = wrapper.findAll("#workflow-version-area > select > option");
+        console.log('version', version);
         for (const v of version) {
+            console.log('v', v); {
+            console.log('v.label', v.label);
             const versionDate = (v.label).substring(versionLabel.indexOf(":") + 1, (v.label).indexOf(",")).trim();
             expect(isDate(new Date(versionDate))).toBe(true);
         }

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -43,9 +43,9 @@ describe("Attributes", () => {
 
         const version = wrapper.findAllComponents(`#workflow-version-area > select > option`);
         expect(version).toHaveLength(TEST_VERSIONS.length);
-        for (const [i,v] in TEST_VERSIONS) {
+        for (const [i, v] in TEST_VERSIONS) {
             const versionLabel = version.at(i).text();
-            const versionDate = (versionLabel).substring(versionLabel.indexOf(":") + 1, (versionLabel).indexOf(",")).trim();
+            const versionDate = versionLabel.substring(versionLabel.indexOf(":") + 1, versionLabel.indexOf(",")).trim();
             expect(isDate(new Date(versionDate))).toBe(true);
         }
 

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -7,7 +7,7 @@ jest.mock("app");
 
 const TEST_ANNOTATION = "my cool annotation";
 const TEST_NAME = "workflow_name";
-const TEST_VERSION = [  //TODO (high) does it make sense to pre-fill this, if this is coming from prior user actions?
+const TEST_VERSIONS = [  //TODO (high) does it make sense to pre-fill this, if this is coming from prior user actions?
     { versions: 0, update_time: "2022-01-01", steps: 10 },
     { versions: 1, update_time: "2022-01-02", steps: 20 },
 ];

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -1,11 +1,16 @@
 import { mount, createLocalVue } from "@vue/test-utils";
 import Attributes from "./Attributes";
 import { UntypedParameters } from "./modules/parameters";
+import { isDate } from "date-fns";
 
 jest.mock("app");
 
 const TEST_ANNOTATION = "my cool annotation";
 const TEST_NAME = "workflow_name";
+const TEST_VERSION = [  //TODO (high) does it make sense to pre-fill this, if this is coming from prior user actions?
+    { versions: 0, update_time: "2022-01-01", steps: 10 },
+    { versions: 1, update_time: "2022-01-02", steps: 20 },
+];
 
 describe("Attributes", () => {
     it("test attributes", async () => {
@@ -19,7 +24,7 @@ describe("Attributes", () => {
                 name: TEST_NAME,
                 tags: ["workflow_tag_0", "workflow_tag_1"],
                 parameters: untypedParameters,
-                versions: ["workflow_version_0"],
+                versions: TEST_VERSIONS,
                 annotation: TEST_ANNOTATION,
             },
             stubs: {
@@ -29,15 +34,25 @@ describe("Attributes", () => {
         });
         expect(wrapper.find(`[itemprop='description']`).attributes("content")).toBe(TEST_ANNOTATION);
         expect(wrapper.find(`[itemprop='name']`).attributes("content")).toBe(TEST_NAME);
+        expect(wrapper.find(`#workflow-version-area`).attributes("value")); //TODO (low) does an `itemprop` need to be created in Attributes.vue (and why)?
 
         const name = wrapper.find("#workflow-name");
         expect(name.element.value).toBe(TEST_NAME);
         await wrapper.setProps({ name: "new_workflow_name" });
         expect(name.element.value).toBe("new_workflow_name");
-        const parameters = wrapper.findAll(".list-group-item");
+
+        const versionArea = wrapper.find("#workflow-version-area").attributes("value"); //TODO (high) does `wrapper` = document.getElementById("workflow-version-area");
+        var version = versionArea.querySelector("select[class='custom-select']");        
+        for (const v of version) {
+            const versionDate = (v.label).substring(versionLabel.indexOf(":") + 1, (v.label).indexOf(",")).trim();
+            expect(isDate(new Date(versionDate))).toBe(true);
+        }
+
+        const parameters = wrapper.findAll(".list-group-item"); //TODO (nit) not part of my fix, just curious: is this supposed to this exist in the code?
         expect(parameters.length).toBe(2);
         expect(parameters.at(0).text()).toBe("1: workflow_parameter_0");
         expect(parameters.at(1).text()).toBe("2: workflow_parameter_1");
+        console.log(wrapper.html()); //TODO (low) we don't need this, right?
         expect(wrapper.find("#workflow-annotation").element.value).toBe(TEST_ANNOTATION);
     });
 });

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -135,7 +135,10 @@ export default {
                 const current_wf = this.versions[i];
                 let update_time;
                 if (current_wf.update_time) {
-                    update_time = `${format(parseISO(current_wf.update_time, "yyyy-MM-dd", new Date()), "MMM do yyyy")}`;
+                    update_time = `${format(
+                        parseISO(current_wf.update_time, "yyyy-MM-dd", new Date()),
+                        "MMM do yyyy"
+                    )}`;
                 } else {
                     update_time = "";
                 }

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -135,7 +135,7 @@ export default {
                 const current_wf = this.versions[i];
                 let update_time;
                 if (current_wf.update_time) {
-                    update_time = `${format(parseISO(current_wf.update_time, 'yyyy-MM-dd', new Date()), "MMM do yyyy")}, `; //TODO Check Time/Milliseconds; Replace with constants for Localization
+                    update_time = `${format(parseISO(current_wf.update_time, 'yyyy-MM-dd', new Date()), "MMM do yyyy")}, `;
                 } else {
                     update_time = "";
                 }

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -135,7 +135,7 @@ export default {
                 const current_wf = this.versions[i];
                 let update_time;
                 if (current_wf.update_time) {
-                    update_time = `${format(parseISO(current_wf.update_time, 'yyyy-MM-dd', new Date()), "MMM do yyyy")}`;
+                    update_time = `${format(parseISO(current_wf.update_time, "yyyy-MM-dd", new Date()), "MMM do yyyy")}`;
                 } else {
                     update_time = "";
                 }

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -54,7 +54,7 @@
 <script>
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
 import { Services } from "components/Workflow/services";
 import Tags from "components/Common/Tags";
 import LicenseSelector from "components/License/LicenseSelector";
@@ -135,7 +135,7 @@ export default {
                 const current_wf = this.versions[i];
                 let update_time;
                 if (current_wf.update_time) {
-                    update_time = `${format(Date.parse(current_wf.update_time), "MMM do yyyy")}, `;
+                    update_time = `${format(parseISO(current_wf.update_time, 'yyyy-MM-dd', new Date()), "MMM do yyyy")}, `; //TODO Check Time/Milliseconds; Replace with constants for Localization
                 } else {
                     update_time = "";
                 }

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -135,7 +135,7 @@ export default {
                 const current_wf = this.versions[i];
                 let update_time;
                 if (current_wf.update_time) {
-                    update_time = `${format(parseISO(current_wf.update_time, 'yyyy-MM-dd', new Date()), "MMM do yyyy")}, `;
+                    update_time = `${format(parseISO(current_wf.update_time, 'yyyy-MM-dd', new Date()), "MMM do yyyy")}`;
                 } else {
                     update_time = "";
                 }


### PR DESCRIPTION
This bug (Issue: #13886) occurs because of known issues with the Safari interpreter limitation around the `Date.parse()` method. From the [JS Mozilla Guide on this method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date):
![screenshot_JS_Moz_guide_on_Date_Parse_method](https://user-images.githubusercontent.com/3672779/168158472-37c0a29e-5256-4f5b-a834-6edf504a92b3.png)

This bug is related to core JS (Object Prototype JavaScript) and browser compatibility. To avoid this bug in the future, use a JS date library to manage complexities around dates across browsers (and systems) - like the `date-fns.js` library. The fixing of this bug replaces core JS's `Date.parse()` method with `date-fns.js` library's `parseISO()` method. (note: This issue is **not** related to the switch from the `Moment.js` library to the `date-fns.js` library.)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
1. In Workflows List >> select Workflow >> "Edit" link
2. On page load in Browser Console, confirm that no error related to Date/Time occurs on **Safari** (nor in **Chrome, FF, etc**)
3. Remove a Workflow Node, confirm that no error related to Date/Time occurs on **Safari** (nor in **Chrome, FF, etc**)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
