### PR TITLE
Beta History: fix reset selection

### DIFF
--- a/client/src/components/History/Content/SelectedItems.js
+++ b/client/src/components/History/Content/SelectedItems.js
@@ -70,12 +70,15 @@ export default {
         reset() {
             this.items = new Map();
             this.allSelected = false;
+        },
+        cancelSelection() {
             this.showSelection = false;
         },
     },
     watch: {
         scopeKey(newKey, oldKey) {
             if (newKey !== oldKey) {
+                this.cancelSelection();
                 this.reset();
             }
         },

--- a/client/src/components/History/Content/SelectedItems.test.js
+++ b/client/src/components/History/Content/SelectedItems.test.js
@@ -64,6 +64,17 @@ describe("History SelectedItems", () => {
         expectSelectionDisabled();
     });
 
+    it("should discard (but not disable) the current selection on `reset`", async () => {
+        const numberOfExpectedItems = 3;
+        await selectSomeItemsManually(numberOfExpectedItems);
+        expect(slotProps.selectionSize).toBe(numberOfExpectedItems);
+
+        await resetSelection();
+
+        expect(slotProps.selectionSize).toBe(0);
+        expectSelectionEnabled();
+    });
+
     describe("Query Selection Mode", () => {
         it("is considered a query selection when we select `all items` and the query contains more items than we have currently loaded", async () => {
             const expectedTotalItemsInQuery = 100;
@@ -169,6 +180,12 @@ describe("History SelectedItems", () => {
         const { setSelected } = slotProps;
         expect(setSelected).toBeInstanceOf(Function);
         await setSelected(item, false);
+    }
+
+    async function resetSelection() {
+        const { resetSelection } = slotProps;
+        expect(resetSelection).toBeInstanceOf(Function);
+        resetSelection();
     }
 
     async function selectAllItemsInCurrentQuery(loadedItems) {


### PR DESCRIPTION
Reset selection should unselect everything but not disable selection.

I guess I messed up the fix from #13858 resolving a merge conflict. Here are the changes again including a test that should have been included from the beginning, sorry :pray: 


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
