### PR TITLE
Make columns types an empty list for empty tabular data 

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -556,13 +556,14 @@ class Tabular(TabularData):
                             comment_lines = None  # type: ignore [assignment]
                         break
                     i += 1
-
+        print(column_types)
         # we error on the larger number of columns
         # first we pad our column_types by using data from first line
         if len(first_line_column_types) > len(column_types):
             for column_type in first_line_column_types[len(column_types) :]:
                 column_types.append(column_type)
         # Now we fill any unknown (None) column_types with data from first line
+        print(column_types)
         for i in range(len(column_types)):
             if column_types[i] is None:
                 if len(first_line_column_types) <= i or first_line_column_types[i] is None:

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -450,18 +450,18 @@ class Tabular(TabularData):
         column_type_compare_order = list(column_type_set_order)  # Order to compare column types
         column_type_compare_order.reverse()
 
-        def type_overrules_type(column_type1, column_type2):
-            if column_type1 is None or column_type1 == column_type2:
+        def type_overrules_type(new_column_type, old_column_type):
+            if new_column_type is None or new_column_type == old_column_type:
                 return False
-            if column_type2 is None:
+            if old_column_type is None:
                 return True
             for column_type in column_type_compare_order:
-                if column_type1 == column_type:
+                if new_column_type == column_type:
                     return True
-                if column_type2 == column_type:
+                if old_column_type == column_type:
                     return False
             # neither column type was found in our ordered list, this cannot happen
-            raise ValueError(f"Tried to compare unknown column types: {column_type1} and {column_type2}")
+            raise ValueError(f"Tried to compare unknown column types: {new_column_type} and {old_column_type}")
 
         def is_int(column_text):
             # Don't allow underscores in numeric literals (PEP 515)
@@ -508,7 +508,7 @@ class Tabular(TabularData):
         comment_lines = 0
         column_names = None
         column_types: List = []
-        first_line_column_types = [default_column_type]  # default value is one column of type str
+        first_line_column_types = []
         if dataset.has_data():
             # NOTE: if skip > num_check_lines, we won't detect any metadata, and will use default
             with compression_utils.get_fileobj(dataset.get_file_name()) as dataset_fh:
@@ -556,14 +556,13 @@ class Tabular(TabularData):
                             comment_lines = None  # type: ignore [assignment]
                         break
                     i += 1
-        print(column_types)
+
         # we error on the larger number of columns
         # first we pad our column_types by using data from first line
         if len(first_line_column_types) > len(column_types):
             for column_type in first_line_column_types[len(column_types) :]:
                 column_types.append(column_type)
         # Now we fill any unknown (None) column_types with data from first line
-        print(column_types)
         for i in range(len(column_types)):
             if column_types[i] is None:
                 if len(first_line_column_types) <= i or first_line_column_types[i] is None:

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -22,3 +22,18 @@ def test_tabular_set_meta_large_file():
         assert dataset.metadata.columns == 2
         assert dataset.metadata.delimiter == "\t"
         assert not hasattr(dataset.metadata, "column_names")
+
+
+def test_tabular_set_meta_empty():
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.file_name = test_file.name
+        Tabular().set_meta(dataset)
+        # data and comment lines are not stored if more than MAX_DATA_LINES
+        assert dataset.metadata.data_lines == 0
+        assert dataset.metadata.comment_lines == 0
+        assert dataset.metadata.column_types == []
+        assert dataset.metadata.columns == 0
+        assert dataset.metadata.delimiter == "\t"
+        assert not hasattr(dataset.metadata, "column_names")

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -25,15 +25,90 @@ def test_tabular_set_meta_large_file():
 
 
 def test_tabular_set_meta_empty():
+    """
+    empty file
+    """
     with tempfile.NamedTemporaryFile(mode="w") as test_file:
         test_file.flush()
         dataset = MockDataset(id=1)
-        dataset.file_name = test_file.name
+        dataset.set_file_name(test_file.name)
         Tabular().set_meta(dataset)
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines == 0
         assert dataset.metadata.comment_lines == 0
         assert dataset.metadata.column_types == []
         assert dataset.metadata.columns == 0
+        assert dataset.metadata.delimiter == "\t"
+        assert not hasattr(dataset.metadata, "column_names")
+
+
+def test_tabular_set_meta_nearly_empty():
+    """
+    file just containing a single new line
+    - empty lines are treated as comments
+    """
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        test_file.write("\n")
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        Tabular().set_meta(dataset)
+        # data and comment lines are not stored if more than MAX_DATA_LINES
+        assert dataset.metadata.data_lines == 0
+        assert dataset.metadata.comment_lines == 1
+        assert dataset.metadata.column_types == []
+        assert dataset.metadata.columns == 0
+        assert dataset.metadata.delimiter == "\t"
+        assert not hasattr(dataset.metadata, "column_names")
+
+
+def test_tabular_column_types():
+    """
+    file just containing a single new line
+    - empty lines are treated as comments
+    """
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        # 1st line has special treatment which we want to ignore in this test
+        test_file.write("\t\t\t\t\n")
+        # note that the 1st column of this line will be detected as None
+        # but this is overwritten by the default column type (str) after
+        # checking all lines
+        test_file.write("\tstr\t23\t42.00\ta,b,c\n")
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        Tabular().set_meta(dataset)
+        # data and comment lines are not stored if more than MAX_DATA_LINES
+        assert dataset.metadata.data_lines == 2
+        assert dataset.metadata.comment_lines == 0
+        assert dataset.metadata.column_types == ["str", "str", "int", "float", "list"]
+        assert dataset.metadata.columns == 5
+        assert dataset.metadata.delimiter == "\t"
+        assert not hasattr(dataset.metadata, "column_names")
+
+
+def test_tabular_column_types_override():
+    """
+    check that guessed column types can be improved
+    by the types guessed for later lines
+    overwriting is only possible in the following order None -> int -> float -> list -> str
+
+    also check that more columns can be added by later lines
+    """
+    with tempfile.NamedTemporaryFile(mode="w") as test_file:
+        # 1st line has special treatment which we want to ignore in this test
+        test_file.write("\t\t\t\t\n")
+        # note that the first column in detected as None which can be overwritten by int
+        test_file.write("\t23\t42.00\ta,b,c\tstr\n")
+        test_file.write("23\t42.0\t23,42.0\tstr\t42\tanother column\n")
+        test_file.flush()
+        dataset = MockDataset(id=1)
+        dataset.set_file_name(test_file.name)
+        Tabular().set_meta(dataset)
+        # data and comment lines are not stored if more than MAX_DATA_LINES
+        assert dataset.metadata.data_lines == 3
+        assert dataset.metadata.comment_lines == 0
+        assert dataset.metadata.column_types == ["int", "float", "list", "str", "str", "str"]
+        assert dataset.metadata.columns == 6
         assert dataset.metadata.delimiter == "\t"
         assert not hasattr(dataset.metadata, "column_names")

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -32,7 +32,7 @@ def test_tabular_set_meta_empty():
         test_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
-        Tabular().set_meta(dataset)
+        Tabular().set_meta(dataset)  # type: ignore [arg-type]
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines == 0
         assert dataset.metadata.comment_lines == 0
@@ -52,7 +52,7 @@ def test_tabular_set_meta_nearly_empty():
         test_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
-        Tabular().set_meta(dataset)
+        Tabular().set_meta(dataset)  # type: ignore [arg-type]
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines == 0
         assert dataset.metadata.comment_lines == 1
@@ -77,7 +77,7 @@ def test_tabular_column_types():
         test_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
-        Tabular().set_meta(dataset)
+        Tabular().set_meta(dataset)  # type: ignore [arg-type]
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines == 2
         assert dataset.metadata.comment_lines == 0
@@ -104,7 +104,7 @@ def test_tabular_column_types_override():
         test_file.flush()
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
-        Tabular().set_meta(dataset)
+        Tabular().set_meta(dataset)  # type: ignore [arg-type]
         # data and comment lines are not stored if more than MAX_DATA_LINES
         assert dataset.metadata.data_lines == 3
         assert dataset.metadata.comment_lines == 0

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -15,3 +15,10 @@ def test_tabular_set_meta_large_file():
         dataset = MockDataset(id=1)
         dataset.set_file_name(test_file.name)
         Tabular().set_meta(dataset)  # type: ignore [arg-type]
+        # data and comment lines are not stored if more than MAX_DATA_LINES
+        assert dataset.metadata.data_lines is None
+        assert dataset.metadata.comment_lines is None
+        assert dataset.metadata.column_types == ["str", "str"]
+        assert dataset.metadata.columns == 2
+        assert dataset.metadata.delimiter == "\t"
+        assert not hasattr(dataset.metadata, "column_names")

--- a/test/unit/data/datatypes/test_tabular.py
+++ b/test/unit/data/datatypes/test_tabular.py
@@ -64,7 +64,7 @@ def test_tabular_set_meta_nearly_empty():
 
 def test_tabular_column_types():
     """
-    file just containing a single new line
+    file containing a single containing only tab characters terminated with a new line character
     - empty lines are treated as comments
     """
     with tempfile.NamedTemporaryFile(mode="w") as test_file:

--- a/test/unit/data/datatypes/util.py
+++ b/test/unit/data/datatypes/util.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Optional
 
 from galaxy.datatypes.sniff import get_test_fname
+from galaxy.util.bunch import Bunch
 from galaxy.util.hash_util import md5_hash_file
 
 
@@ -20,7 +21,7 @@ class MockDatasetDataset:
         self.file_name_ = file_name
 
 
-class MockMetadata:
+class MockMetadata(Bunch):
     file_name_: Optional[str] = None
 
     def get_file_name(self, sync_cache=True):


### PR DESCRIPTION
- show number of columns https://github.com/galaxyproject/galaxy/issues/13258
  - [ ] could also be `rows x cols` (I.e. drop the words lines and columns) for compacter display
  - [x]  empty files currently get `0 lines 1 colums`?
    - [ ] @dannon mentioned that this is because there are tables with enormous numbers of columns (but I don't see this breaking since there is only a max no of lines limit, or?)
       - [ ] there is a 1MB limit in the line number estimation function, but the number of columns is taken from the properties filled by `set_meta` which reads `MAX_LINES` .. question is if we can assume that `set_meta` runs before `set_peek`?
    - [x] guess we should fix this and cover this with a test for `Tabular.set_meta` .. should this be an inline unit test or another way
    - [ ] not entirely sure if fix is 100% correct, since files with a single empty column are now also 0 column files. this is because the tabular datatype assumes empty lines as comments which are not used to determine empty columns
- shorter display of estimated number of lines https://github.com/galaxyproject/galaxy/issues/6506
  - [ ] also thought if K, M, G... suffixes might be nicer


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
