### PR TITLE
Fix currently failing client tests

### DIFF
--- a/client/src/components/History/Content/ContentItem.test.js
+++ b/client/src/components/History/Content/ContentItem.test.js
@@ -15,6 +15,8 @@ describe("ContentItem", () => {
                     id: "item_id",
                     some_data: "some_data",
                     tags: ["tag1", "tag2", "tag3"],
+                    deleted: false,
+                    visible: true,
                 },
                 id: 1,
                 isDataset: true,


### PR DESCRIPTION
Currently the jest test for content items throw a missing prop error, this PR fixes this by providing the missing props in the test.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
