### PR TITLE
fix two bugs in mulled container building

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -529,7 +529,7 @@ def best_search_result(
         hits = sorted(hits, key=lambda hit: hit["build_number"], reverse=True)
         hits = sorted(hits, key=lambda hit: packaging.version.parse(hit["version"]), reverse=True)
     except commands.CommandLineException as e:
-        log.error("Could not execute: '%s'\n%s", e.command, e)
+        log.error(f"Could not execute: '{e.command}'\n{e}")
         hits = []
 
     if len(hits) == 0:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -246,14 +246,14 @@ def mull_targets(
             bind_path = channel[7:]
             binds.append(f"{bind_path}:{bind_path}")
 
-    channels = ",".join(channels)
+    channels_str = ",".join(channels)
     target_str = ",".join(map(conda_build_target_str, targets))
     bind_str = ",".join(binds)
     involucro_args = [
         "-f",
         f"{DIRNAME}/invfile.lua",
         "-set",
-        f"CHANNELS={channels}",
+        f"CHANNELS={channels_str}",
         "-set",
         f"TARGETS={target_str}",
         "-set",

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -332,8 +332,11 @@ def v2_image_name(targets, image_build=None, name_override=None):
 
 def get_file_from_recipe_url(url):
     """Downloads file at url and returns tarball"""
-    r = requests.get(url, timeout=MULLED_SOCKET_TIMEOUT)
-    return tarfile.open(mode="r:bz2", fileobj=BytesIO(r.content))
+    if url.startswith("file://"):
+        return tarfile.open(mode="r:bz2", name=url[7:])
+    else:
+        r = requests.get(url, timeout=MULLED_SOCKET_TIMEOUT)
+        return tarfile.open(mode="r:bz2", fileobj=BytesIO(r.content))
 
 
 def split_container_name(name):


### PR DESCRIPTION
respecting conda channels on disk: follow up on https://github.com/galaxyproject/galaxy/pull/13755

- CondaInDockerContext needs the list of channels and not the joined str
- get_file_from_recipe should use local data

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
