### PR TITLE
API workflow index allow 'searching' by owner

### DIFF
--- a/lib/galaxy/model/index_filter_util.py
+++ b/lib/galaxy/model/index_filter_util.py
@@ -8,9 +8,13 @@ from sqlalchemy import (
     and_,
     or_,
 )
-from sqlalchemy.orm import InstrumentedAttribute
+from sqlalchemy.orm import (
+    aliased,
+    InstrumentedAttribute,
+)
 from sqlalchemy.sql.expression import BinaryExpression
 
+from galaxy import model
 from galaxy.util.search import (
     FilteredTerm,
     RawTextTerm,
@@ -51,3 +55,10 @@ def tag_filter(assocation_model_class, term_text, quoted: bool = False):
             return assocation_model_class.user_tname.ilike(f"%{term_text}%")
         else:
             return assocation_model_class.user_tname == term_text
+
+
+def append_user_filter(query, model_class, term: FilteredTerm):
+    alias = aliased(model.User)
+    query = query.outerjoin(model_class.user.of_type(alias))
+    query = query.filter(text_column_filter(alias.username, term))
+    return query

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1455,6 +1455,7 @@ query_tags = [
         "The workflow's tag, if the tag contains a colon an approach will be made to match the key and value of the tag separately.",
         "t",
     ),
+    IndexQueryTag("user", "The stored workflow's owner's username.", "u"),
     IndexQueryTag(
         "is:published",
         "Include only published workflows in the final result. Be sure the the query parameter `show_published` is set to `true` if to include all published workflows and not just the requesting user's.",
@@ -1468,7 +1469,7 @@ query_tags = [
 SearchQueryParam: Optional[str] = search_query_param(
     model_name="Stored Workflow",
     tags=query_tags,
-    free_text_fields=["name", "tag"],
+    free_text_fields=["name", "tag", "user"],
 )
 
 SkipStepCountsQueryParam: bool = Query(

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -589,6 +589,37 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert their_workflow_id_1 in index_ids
         assert my_workflow_id_1 not in index_ids
 
+    def test_index_owner(self):
+        my_workflow_id_1 = self.workflow_populator.simple_workflow("ownertags_m_1")
+        email_1 = f"{uuid4()}@test.com"
+        with self._different_user(email=email_1):
+            published_workflow_id_1 = self.workflow_populator.simple_workflow("ownertags_p_1", publish=True)
+            owner_1 = self._show_workflow(published_workflow_id_1)["owner"]
+
+        email_2 = f"{uuid4()}@test.com"
+        with self._different_user(email=email_2):
+            published_workflow_id_2 = self.workflow_populator.simple_workflow("ownertags_p_2", publish=True)
+
+        index_ids = self.workflow_populator.index_ids(search="is:published", show_published=True)
+        assert published_workflow_id_1 in index_ids
+        assert published_workflow_id_2 in index_ids
+        assert my_workflow_id_1 not in index_ids
+
+        index_ids = self.workflow_populator.index_ids(search=f"is:published u:{owner_1}", show_published=True)
+        assert published_workflow_id_1 in index_ids
+        assert published_workflow_id_2 not in index_ids
+        assert my_workflow_id_1 not in index_ids
+
+        index_ids = self.workflow_populator.index_ids(search=f"is:published u:'{owner_1}'", show_published=True)
+        assert published_workflow_id_1 in index_ids
+        assert published_workflow_id_2 not in index_ids
+        assert my_workflow_id_1 not in index_ids
+
+        index_ids = self.workflow_populator.index_ids(search=f"is:published {owner_1}", show_published=True)
+        assert published_workflow_id_1 in index_ids
+        assert published_workflow_id_2 not in index_ids
+        assert my_workflow_id_1 not in index_ids
+
     def test_index_parameter_invalid_combinations(self):
         # these can all be called by themselves and return 200...
         response = self._get("workflows?show_hidden=true")


### PR DESCRIPTION
I suspect this is the only backend change required to implement paginated search of the published workflows list via this index API and extensions to the current client component (https://github.com/jmchilton/galaxy/commit/e89599913f0f7d5c583f1230860f4aa12cc9af26).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
