### PR TITLE
Bulk operations: more API tests & fixes

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -759,7 +759,7 @@ class DatasetCollectionManager:
         return data, sources
 
     def __get_history_collection_instance(self, trans, id, check_ownership=False, check_accessible=True):
-        instance_id = int(trans.app.security.decode_id(id))
+        instance_id = trans.app.security.decode_id(id) if isinstance(id, str) else id
         collection_instance = trans.sa_session.query(trans.app.model.HistoryDatasetCollectionAssociation).get(
             instance_id
         )

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1390,6 +1390,8 @@ class HistoryItemOperator:
         manager.delete(item, flush=self.flush)
 
     def _undelete(self, item: HistoryItemModel):
+        if getattr(item, "purged", False):
+            return
         manager = self._get_item_manager(item)
         manager.undelete(item, flush=self.flush)
 

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -221,7 +221,7 @@ class HistoriesContentsService(ServiceBase):
         self.hda_deserializer = hda_deserializer
         self.hdca_serializer = hdca_serializer
         self.history_contents_filters = history_contents_filters
-        self.item_operator = HistoryItemOperator(self.hda_manager, self.hdca_manager)
+        self.item_operator = HistoryItemOperator(self.hda_manager, self.hdca_manager, self.dataset_collection_manager)
         self.short_term_storage_allocator = short_term_storage_allocator
 
     def index(
@@ -533,7 +533,7 @@ class HistoriesContentsService(ServiceBase):
                 history,
                 filters,
             )
-        errors = self._apply_bulk_operation(contents, payload.operation)
+        errors = self._apply_bulk_operation(contents, payload.operation, trans)
         trans.sa_session.flush()
         success_count = len(contents) - len(errors)
         return HistoryContentBulkOperationResult.construct(success_count=success_count, errors=errors)
@@ -1301,10 +1301,11 @@ class HistoriesContentsService(ServiceBase):
         self,
         contents: Iterable[HistoryItemModel],
         operation: HistoryContentItemOperation,
+        trans: ProvidesHistoryContext,
     ) -> List[BulkOperationItemError]:
         errors: List[BulkOperationItemError] = []
         for item in contents:
-            error = self._apply_operation_to_item(operation, item)
+            error = self._apply_operation_to_item(operation, item, trans)
             if error:
                 errors.append(error)
         return errors
@@ -1313,9 +1314,10 @@ class HistoriesContentsService(ServiceBase):
         self,
         operation: HistoryContentItemOperation,
         item: HistoryItemModel,
+        trans: ProvidesHistoryContext,
     ) -> Optional[BulkOperationItemError]:
         try:
-            self.item_operator.apply(operation, item)
+            self.item_operator.apply(operation, item, trans)
             return None
         except BaseException as exc:
             return BulkOperationItemError.construct(
@@ -1348,7 +1350,7 @@ class HistoriesContentsService(ServiceBase):
 
 
 class ItemOperation(Protocol):
-    def __call__(self, item: HistoryItemModel) -> None:
+    def __call__(self, item: HistoryItemModel, trans: ProvidesHistoryContext) -> None:
         ...
 
 
@@ -1359,20 +1361,22 @@ class HistoryItemOperator:
         self,
         hda_manager: hdas.HDAManager,
         hdca_manager: hdcas.HDCAManager,
+        dataset_collection_manager: DatasetCollectionManager,
     ):
         self.hda_manager = hda_manager
         self.hdca_manager = hdca_manager
+        self.dataset_collection_manager = dataset_collection_manager
         self.flush = False
         self._operation_map: Dict[HistoryContentItemOperation, ItemOperation] = {
-            HistoryContentItemOperation.hide: lambda item: self._hide(item),
-            HistoryContentItemOperation.unhide: lambda item: self._unhide(item),
-            HistoryContentItemOperation.delete: lambda item: self._delete(item),
-            HistoryContentItemOperation.undelete: lambda item: self._undelete(item),
-            HistoryContentItemOperation.purge: lambda item: self._purge(item),
+            HistoryContentItemOperation.hide: lambda item, trans: self._hide(item),
+            HistoryContentItemOperation.unhide: lambda item, trans: self._unhide(item),
+            HistoryContentItemOperation.delete: lambda item, trans: self._delete(item),
+            HistoryContentItemOperation.undelete: lambda item, trans: self._undelete(item),
+            HistoryContentItemOperation.purge: lambda item, trans: self._purge(item, trans),
         }
 
-    def apply(self, operation: HistoryContentItemOperation, item: HistoryItemModel):
-        self._operation_map[operation](item)
+    def apply(self, operation: HistoryContentItemOperation, item: HistoryItemModel, trans: ProvidesHistoryContext):
+        self._operation_map[operation](item, trans)
 
     def _get_item_manager(self, item: HistoryItemModel):
         if isinstance(item, HistoryDatasetAssociation):
@@ -1395,6 +1399,7 @@ class HistoryItemOperator:
         manager = self._get_item_manager(item)
         manager.undelete(item, flush=self.flush)
 
-    def _purge(self, item: HistoryItemModel):
-        manager = self._get_item_manager(item)
-        manager.purge(item, flush=self.flush)
+    def _purge(self, item: HistoryItemModel, trans: ProvidesHistoryContext):
+        if isinstance(item, HistoryDatasetCollectionAssociation):
+            return self.dataset_collection_manager.delete(trans, "history", item.id, recursive=True, purge=True)
+        self.hda_manager.purge(item, flush=self.flush)

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1118,6 +1118,23 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             # collections don't have a `purged` attribute but they should be marked deleted on purge
             assert purged_collection["deleted"] is True
 
+            # Un-deleting a purged dataset should not have any effect
+            payload = {
+                "operation": "undelete",
+                "items": [
+                    {
+                        "id": datasets_ids[0],
+                        "history_content_type": "dataset",
+                    },
+                ],
+            }
+            bulk_operation_result = self._apply_bulk_operation(history_id, payload)
+            history_contents = self._get_history_contents(history_id)
+            self._assert_bulk_success(bulk_operation_result, 1)
+            purged_dataset = self._get_dataset_with_id_from_history_contents(history_contents, datasets_ids[0])
+            assert purged_dataset["deleted"] is True
+            assert purged_dataset["purged"] is True
+
     def test_index_returns_expected_total_matches(self):
         with self.dataset_populator.test_history() as history_id:
             datasets_ids, collection_ids, history_contents = self._create_test_history_contents(history_id)

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1135,6 +1135,21 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             assert purged_dataset["deleted"] is True
             assert purged_dataset["purged"] is True
 
+    def test_purging_collection_should_purge_contents(self):
+        with self.dataset_populator.test_history() as history_id:
+            datasets_ids, collection_ids, history_contents = self._create_test_history_contents(history_id)
+
+            # Purge all collections
+            payload = {"operation": "purge"}
+            query = "q=history_content_type-eq&qv=dataset_collection"
+            bulk_operation_result = self._apply_bulk_operation(history_id, payload, query)
+            history_contents = self._get_history_contents(history_id)
+            self._assert_bulk_success(bulk_operation_result, len(collection_ids))
+            for item in history_contents:
+                assert item["deleted"] is True
+                if item["history_content_type"] == "dataset":
+                    assert item["purged"] is True
+
     def test_index_returns_expected_total_matches(self):
         with self.dataset_populator.test_history() as history_id:
             datasets_ids, collection_ids, history_contents = self._create_test_history_contents(history_id)


### PR DESCRIPTION
Fixes #13889

Allows purging collections (with contents) in bulk. If `celery` is enabled, each contained dataset will be purged in its own celery task. Not sure if it's interesting or worth to batch-purge all datasets (in the same collection) in just one celery task... I'm leaving it as the old history does by now.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
