### PR TITLE
Beta History Collections: set default visible and deleted state in ContentOptions

### DIFF
--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -56,10 +56,10 @@
 export default {
     props: {
         isDataset: { type: Boolean, required: true },
-        isDeleted: { type: Boolean, required: true },
+        isDeleted: { type: Boolean, default: false },
         isHistoryItem: { type: Boolean, required: true },
         isPurged: { type: Boolean, default: false },
-        isVisible: { type: Boolean, required: true },
+        isVisible: { type: Boolean, default: true },
         state: { type: String, default: "" },
     },
     computed: {


### PR DESCRIPTION
Datasets **as collection elements** do not provide *visible* and *deleted* values and are assumed to be visible and non-deleted by default.
This should get rid of the following console errors when displaying collection contents:

```
[Vue warn]: Invalid prop: type check failed for prop "isDeleted". Expected Boolean, got Undefined 
```

```
[Vue warn]: Invalid prop: type check failed for prop "isVisible". Expected Boolean, got Undefined 
```

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Click any collection in the new History
  - Observe there is no property validation errors in the console 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
