### PR TITLE
[22.05] External OIDC doesn't work on client side

### DIFF
--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -160,7 +160,7 @@ export default {
         submitOIDCLogin(idp) {
             const rootUrl = getAppRoot();
             axios
-                .post(`${rootUrl}authnz/${idp}/login`)
+                .get(`${rootUrl}authnz/${idp}/login`)
                 .then((response) => {
                     if (response.data.redirect_uri) {
                         window.location = response.data.redirect_uri;


### PR DESCRIPTION
External OIDC doesn't work on the client side because the endpoint is not a POST but a GET endpoint, https://github.com/galaxyproject/galaxy/blob/9143dd7ca46d150ebfb26febbe187979f682da51/lib/galaxy/webapps/galaxy/controllers/authnz.py#L76.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Setup external OIDC
  2. Click the button for external OIDC
  3. Notice that Galaxy gives a HTTP 400 error in the browser

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
