### PR TITLE
[WIP] ensure that Singularity doesn't run with HOME=/root

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -637,11 +637,11 @@ class MulledSingularityContainerResolver(SingularityCliContainerResolver, Mulled
             homedir = os.environ.get("HOME")
             if homedir and not (os.access(homedir, os.R_OK) and os.access(homedir, os.X_OK)):
                 galaxy_homedir = os.environ.get("GALAXY_HOME")
-                if galaxy_homedir is not None:
+                if galaxy_homedir:
                     homedir = galaxy_homedir
                 else:
                     homedir = "/tmp"
-            shell(cmds=cmds)
+            shell(cmds=cmds, env={'HOME': homedir})
             self.cache_directory.invalidate_cache()
 
     def __str__(self):

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -633,6 +633,14 @@ class MulledSingularityContainerResolver(SingularityCliContainerResolver, Mulled
             cmds = container.build_mulled_singularity_pull_command(
                 cache_directory=self.cache_directory.path, namespace=self.namespace
             )
+            # when Galaxy runs in Docker with uswgi, HOME remains set to /root, this is a workaround for that case
+            homedir = os.environ.get('HOME')
+            if homedir is not None and not (base) ubuntu@composer2:~/docker-galaxy-stable/compose$ _OK)):
+                galaxy_homedir = os.environ.get('GALAXY_HOME')
+                if galaxy_homedir is not None:
+                    homedir = galaxy_homedir
+                else:
+                    homedir = '/tmp'
             shell(cmds=cmds)
             self.cache_directory.invalidate_cache()
 

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -635,7 +635,7 @@ class MulledSingularityContainerResolver(SingularityCliContainerResolver, Mulled
             )
             # when Galaxy runs in Docker with uswgi, HOME remains set to /root, this is a workaround for that case
             homedir = os.environ.get("HOME")
-            if homedir is not None and not (os.access(homedir, os.R_OK) and os.access(homedir, os.X_OK)):
+            if homedir and not (os.access(homedir, os.R_OK) and os.access(homedir, os.X_OK)):
                 galaxy_homedir = os.environ.get("GALAXY_HOME")
                 if galaxy_homedir is not None:
                     homedir = galaxy_homedir

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -634,13 +634,13 @@ class MulledSingularityContainerResolver(SingularityCliContainerResolver, Mulled
                 cache_directory=self.cache_directory.path, namespace=self.namespace
             )
             # when Galaxy runs in Docker with uswgi, HOME remains set to /root, this is a workaround for that case
-            homedir = os.environ.get('HOME')
-            if homedir is not None and not (base) ubuntu@composer2:~/docker-galaxy-stable/compose$ _OK)):
-                galaxy_homedir = os.environ.get('GALAXY_HOME')
+            homedir = os.environ.get("HOME")
+            if homedir is not None and not (os.access(homedir, os.R_OK) and os.access(homedir, os.X_OK)):
+                galaxy_homedir = os.environ.get("GALAXY_HOME")
                 if galaxy_homedir is not None:
                     homedir = galaxy_homedir
                 else:
-                    homedir = '/tmp'
+                    homedir = "/tmp"
             shell(cmds=cmds)
             self.cache_directory.invalidate_cache()
 


### PR DESCRIPTION
When Galaxy is run in Docker, it starts uwsgi and passes the `--uid` and `--gid` flags to make the daemon process drop privileges. This leaves the HOME environment variable unchanged, so typically HOME=/root. In this case, when `singularity build` runs, it looks in for the `$HOME/.docker/config.json` file which fails if HOME is inaccessible. The result is that the container does not get built and cached and rather gets rebuilt every time a tool runs.

This PR addresses that case by looking for an inaccessible HOME directory and choosing an alternative - either the value in GALAXY_HOME or /tmp.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run [Dockerize Galaxy](https://github.com/bgruening/docker-galaxy-stable) in docker-compose mode with Singularity support
  2. Install a tool (e.g. minimap2)
  3. Run an analysis
  4. Check the Singularity container cache directory. It should contain a new container file for the minimap2 tool (before this PR it would contain nothing)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
