### PR TITLE
[22.01] Remove tus uploads during fetch data job

### DIFF
--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -19,6 +19,14 @@ function submitPayload(payload, cnf) {
         });
 }
 
+function buildFingerprint(cnf) {
+    async function customFingerprint(file, options) {
+        return ["tus-br", file.name, file.type, file.size, file.lastModified, cnf.data.history_id].join("-");
+    }
+
+    return customFingerprint;
+}
+
 function tusUpload(data, index, tusEndpoint, cnf) {
     const startTime = performance.now();
     const chunkSize = cnf.chunkSize;
@@ -31,6 +39,7 @@ function tusUpload(data, index, tusEndpoint, cnf) {
     console.debug(`Starting chunked upload for ${file.name} [chunkSize=${chunkSize}].`);
     const upload = new tus.Upload(file, {
         endpoint: tusEndpoint,
+        fingerprint: buildFingerprint(cnf),
         chunkSize: chunkSize,
         metadata: data.payload,
         onError: function (error) {

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -502,6 +502,11 @@ class UploadConfig:
         if purge_source:
             try:
                 shutil.move(path, new_path)
+                # Drop .info file if it exists
+                try:
+                    os.remove(f"{path}.info")
+                except FileNotFoundError:
+                    pass
             except OSError as e:
                 # We may not have permission to remove converted_path
                 if e.errno != errno.EACCES:

--- a/lib/galaxy/webapps/galaxy/api/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/api/_fetch_util.py
@@ -185,6 +185,7 @@ def validate_and_normalize_targets(trans, payload):
             item["in_place"] = run_as_real_user
         elif src == "files":
             item["in_place"] = run_as_real_user
+            item["purge_source"] = True
 
         # Small disagreement with traditional uploads - we purge less by default since whether purging
         # happens varies based on upload options in non-obvious ways.


### PR DESCRIPTION
Since the fingerprint isn't necessarily unique across all users I've also added the history id to the fingerprint, so we're not removing the dataset of another user. It seems necessary to remove files in relatively short intervals on usegalaxy.eu to avoid  a large set of files in the tus upload store.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
