### PR TITLE
More explicit History Import button

### DIFF
--- a/templates/webapps/galaxy/history/display.mako
+++ b/templates/webapps/galaxy/history/display.mako
@@ -20,9 +20,9 @@
     switch_url = h.url_for( controller='history', action='switch_to_history', hist_id=encoded_history_id )
 %>
     %if not user_is_owner:
-        <a href="javascript:void(0)" class="history-copy-link btn btn-secondary fa fa-plus float-right" title="Import history"></a>
+        <a href="javascript:void(0)" class="history-copy-link btn btn-secondary float-right" title="Import this history">Import</a>
     %else:
-        <a href="${switch_url}" class="btn btn-secondary fa fa-plus float-right" title="${_('Switch to this history')}"></a>
+        <a href="${switch_url}" class="btn btn-secondary fa fa-exchange float-right" title="${_('Switch to this history')}"></a>
     %endif
 </%def>
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/13419. Changed history import button so that it says `Import` instead of being just a `+` icon. When the history is owned by the current user, replaced the `+` button with `switch to history` button. Before and after below:
### Before
| Import history     | Switch to this history |
| ----------- | ----------- |
|   ![image](https://user-images.githubusercontent.com/78516064/169589927-8449f298-ff53-406d-b4ff-906ef1d3b510.png)   |  ![image](https://user-images.githubusercontent.com/78516064/169590278-89c79457-9355-4c26-84da-1f706ce873e2.png)    |

### After
| Import history     | Switch to this history |
| ----------- | ----------- |
|   ![image](https://user-images.githubusercontent.com/78516064/169590831-44572e36-d148-43be-a00a-57ad6d29c0b7.png)   |  ![image](https://user-images.githubusercontent.com/78516064/169590896-b5dff069-9de0-4667-ba77-8684c31a0671.png)    |

## Other ideas

* https://github.com/galaxyproject/galaxy/issues/13419#issuecomment-1046661993
  We could use `primary-action` but i feel it doesn't look great:
  ![image](https://user-images.githubusercontent.com/78516064/169591741-96161083-fb6d-4a0e-bad8-b39498f04eec.png)
* Place import button in line with the History title:
  ![image](https://user-images.githubusercontent.com/78516064/169592259-ad684583-8ed3-417d-83c0-2b28af684547.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
