### PR TITLE
Beta History: allow search datasets by name tag using `#`

### DIFF
--- a/client/src/store/historyStore/model/filtering.test.js
+++ b/client/src/store/historyStore/model/filtering.test.js
@@ -54,7 +54,7 @@ describe("filtering", () => {
             expect(queryDict["update_time-lt"]).toBe(1640995200);
             expect(queryDict["state-eq"]).toBe("success");
             expect(queryDict["extension-eq"]).toBe("ext");
-            expect(queryDict["tag"]).toBe("first");
+            expect(queryDict["tag-contains"]).toBe("first");
             expect(queryDict["deleted"]).toBe(false);
             expect(queryDict["visible"]).toBe(true);
         });
@@ -105,5 +105,12 @@ describe("filtering", () => {
         filterTexts.forEach((filterText, index) => {
             expect(toAlias(getFilters(filterTexts[index]))).toEqual(parsedFilterSettings);
         });
+    });
+    test("named tag (hash) conversion", () => {
+        const filters = getFilters("tag=#test");
+        expect(filters[0][0]).toBe("tag");
+        expect(filters[0][1]).toBe("#test");
+        const queryDict = getQueryDict("tag=#test");
+        expect(queryDict["tag-contains"]).toBe("name:test");
     });
 });


### PR DESCRIPTION
Fixes #13873

Also, allow search by `contains` instead of `equals` tag name match

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Follow instructions on #13873

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
