### PR TITLE
Update/restore collection progress bar/13743

### DIFF
--- a/client/src/components/History/Content/Collection/CollectionDescription.test.js
+++ b/client/src/components/History/Content/Collection/CollectionDescription.test.js
@@ -1,6 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import CollectionDescription from "./CollectionDescription";
+import { JobStateSummary } from "./JobStateSummary";
 
 const localVue = getLocalVue();
 
@@ -8,9 +9,11 @@ describe("CollectionDescription", () => {
     let wrapper;
 
     beforeEach(() => {
+        const jss = new JobStateSummary();
         wrapper = mount(CollectionDescription, {
             propsData: {
                 collectionType: "list",
+                jobStateSummary: jss,
             },
             localVue,
         });

--- a/client/src/components/History/Content/Collection/CollectionDescription.vue
+++ b/client/src/components/History/Content/Collection/CollectionDescription.vue
@@ -1,12 +1,20 @@
 <template>
-    <h6 class="description mt-1">
-        a {{ collectionLabel }} with {{ elementCount }}<b>{{ homogeneousDatatype }}</b> {{ pluralizedItem }}
-    </h6>
+    <div>
+        <h6 class="description mt-1">
+            a {{ collectionLabel }} with {{ elementCount }}<b>{{ homogeneousDatatype }}</b> {{ pluralizedItem }}
+        </h6>
+        <CollectionProgress :summary.sync="jobState" />
+    </div>
 </template>
 
 <script>
+import CollectionProgress from "./CollectionProgress";
+import { JobStateSummary } from "./JobStateSummary";
+
 export default {
+    components: { CollectionProgress },
     props: {
+        collection: { type: Object, required: true },
         collectionType: { type: String, required: true },
         elementCount: { type: Number, required: false, default: undefined },
         elementsDatatypes: { type: Array, required: false, default: () => [] },
@@ -22,6 +30,9 @@ export default {
         };
     },
     computed: {
+        jobState() {
+            return new JobStateSummary(this.collection);
+        },
         /**@return {String} */
         collectionLabel() {
             return this.labels[this.collectionType] || "nested list";

--- a/client/src/components/History/Content/Collection/CollectionDescription.vue
+++ b/client/src/components/History/Content/Collection/CollectionDescription.vue
@@ -3,7 +3,7 @@
         <h6 class="description mt-1">
             a {{ collectionLabel }} with {{ elementCount }}<b>{{ homogeneousDatatype }}</b> {{ pluralizedItem }}
         </h6>
-        <CollectionProgress :summary.sync="jobState" />
+        <CollectionProgress :summary="jobStateSummary" />
     </div>
 </template>
 
@@ -14,7 +14,7 @@ import { JobStateSummary } from "./JobStateSummary";
 export default {
     components: { CollectionProgress },
     props: {
-        collection: { type: Object, required: true },
+        jobStateSummary: { type: JobStateSummary, required: true },
         collectionType: { type: String, required: true },
         elementCount: { type: Number, required: false, default: undefined },
         elementsDatatypes: { type: Array, required: false, default: () => [] },
@@ -30,9 +30,6 @@ export default {
         };
     },
     computed: {
-        jobState() {
-            return new JobStateSummary(this.collection);
-        },
         /**@return {String} */
         collectionLabel() {
             return this.labels[this.collectionType] || "nested list";

--- a/client/src/components/History/Content/Collection/CollectionProgress.test.js
+++ b/client/src/components/History/Content/Collection/CollectionProgress.test.js
@@ -1,0 +1,58 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import CollectionProgress from "./CollectionProgress";
+import { JobStateSummary } from "./JobStateSummary";
+
+const localVue = getLocalVue();
+
+describe("CollectionProgress", () => {
+    let wrapper;
+
+    it("should display the correct number of items", async () => {
+        const dsc = { job_state_summary: { all_jobs: 3, running: 3 }, populated_state: {} };
+        const jobStateSummary = new JobStateSummary(dsc);
+        wrapper = mount(CollectionProgress, {
+            propsData: {
+                summary: jobStateSummary,
+            },
+            localVue,
+        });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find(".progress").find(".progress-bar-striped").text()).toBe("3");
+    });
+
+    it("should correctly display states", async () => {
+        const dsc = { job_state_summary: { all_jobs: 5, running: 3, failed: 1, ok: 1 }, populated_state: {} };
+        const jobStateSummary = new JobStateSummary(dsc);
+        wrapper = mount(CollectionProgress, {
+            propsData: {
+                summary: jobStateSummary,
+            },
+            localVue,
+        });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find(".progress").find(".progress-bar-striped").text()).toBe("3");
+        expect(wrapper.find(".progress").find(".bg-success").text()).toBe("1");
+        expect(wrapper.find(".progress").find(".bg-danger").text()).toBe("1");
+    });
+
+    it("should update as dataset states change", async () => {
+        const dsc = { job_state_summary: { all_jobs: 3, running: 3 }, populated_state: {} };
+        let jobStateSummary = new JobStateSummary(dsc);
+        wrapper = mount(CollectionProgress, {
+            propsData: {
+                summary: jobStateSummary,
+            },
+            localVue,
+        });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find(".progress").find(".progress-bar-striped").text()).toBe("3");
+        dsc["job_state_summary"]["ok"] = 2;
+        dsc["job_state_summary"]["running"] = 1;
+        jobStateSummary = new JobStateSummary(dsc);
+        await wrapper.setProps({ summary: jobStateSummary });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find(".progress").find(".progress-bar-striped").text()).toBe("1");
+        expect(wrapper.find(".progress").find(".bg-success").text()).toBe("2");
+    });
+});

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -32,13 +32,13 @@ export default {
             return this.summary.get("running");
         },
         errorJobs() {
-            const failed = this.summary.get("failed") ? this.summary.get("failed") : 0;
-            const error = this.summary.get("error") ? this.summary.get("error") : 0;
+            const failed = this.summary.get("failed") || 0;
+            const error = this.summary.get("error") || 0;
             return failed + error;
         },
         waitingJobs() {
-            const queued = this.summary.get("queued") ? this.summary.get("queued") : 0;
-            const waiting = this.summary.get("waiting") ? this.summary.get("waiting") : 0;
+            const queued = this.summary.get("queued") || 0;
+            const waiting = this.summary.get("waiting") || 0;
             return queued + waiting;
         },
     },

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -32,12 +32,14 @@ export default {
             return this.summary.get("running");
         },
         errorJobs() {
-            const { failed = 0, error = 0 } = this.summary;
+            const failed = this.summary.get("failed") ? this.summary.get("failed") : 0;
+            const error = this.summary.get("error") ? this.summary.get("error") : 0;
             return failed + error;
         },
         waitingJobs() {
-            const { waiting = 0, queued = 0 } = this.summary;
-            return waiting + queued;
+            const queued = this.summary.get("queued") ? this.summary.get("queued") : 0;
+            const waiting = this.summary.get("waiting") ? this.summary.get("waiting") : 0;
+            return queued + waiting;
         },
     },
 };

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -1,0 +1,44 @@
+<!-- Job state progress bar for a collection. There's another similar component
+at components/JobStates/CollectionJobStates but it relies on the backbone data
+model, so probably has to go eventually.-->
+<template>
+    <div>
+        <b-progress v-if="maxJobs && runningJobs" :max="maxJobs" height="1em" show-value>
+            <b-progress-bar v-if="errorJobs" :value="errorJobs" variant="danger"></b-progress-bar>
+            <b-progress-bar v-if="okJobs" :value="okJobs" variant="success"></b-progress-bar>
+            <b-progress-bar v-if="runningJobs" :value="runningJobs" variant="info" animated></b-progress-bar>
+            <b-progress-bar v-if="waitingJobs" :value="waitingJobs" variant="dark" animated></b-progress-bar>
+        </b-progress>
+    </div>
+</template>
+<script>
+import { JobStateSummary } from "./JobStateSummary";
+
+export default {
+    props: {
+        summary: { type: JobStateSummary, required: true },
+    },
+    computed: {
+        hasRunningJobs() {
+            return this.summary && this.summary.get("running") > 0;
+        },
+        maxJobs() {
+            return this.summary.get("all_jobs");
+        },
+        okJobs() {
+            return this.summary.get("ok");
+        },
+        runningJobs() {
+            return this.summary.get("running");
+        },
+        errorJobs() {
+            const { failed = 0, error = 0 } = this.summary;
+            return failed + error;
+        },
+        waitingJobs() {
+            const { waiting = 0, queued = 0 } = this.summary;
+            return waiting + queued;
+        },
+    },
+};
+</script>

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -44,3 +44,15 @@ export default {
     },
 };
 </script>
+
+<style scoped>
+.progress-bar {
+    border: 1px solid black;
+}
+.progress > .bg-success {
+    color: black
+}
+.progress > .bg-danger {
+    color: black
+}
+</style>

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -50,9 +50,9 @@ export default {
     border: 1px solid black;
 }
 .progress > .bg-success {
-    color: black
+    color: black;
 }
 .progress > .bg-danger {
-    color: black
+    color: black;
 }
 </style>

--- a/client/src/components/History/Content/Collection/JobStateSummary.js
+++ b/client/src/components/History/Content/Collection/JobStateSummary.js
@@ -1,0 +1,81 @@
+/**
+ * Read-only class takes raw data and applies some rules
+ * to determine an amalgam state for a collection.
+ *
+ * Logic stolen from job-state-model.js and hdca-li.js
+ */
+import { STATES } from "../model/states";
+
+const NON_TERMINAL_STATES = [STATES.NEW, STATES.WAITING, STATES.QUEUED, STATES.RUNNING];
+const ERROR_STATES = [STATES.ERROR, STATES.DELETED];
+
+export class JobStateSummary extends Map {
+    constructor(dsc = {}) {
+        const { job_state_summary = {}, populated_state = null } = dsc;
+        super(Object.entries(job_state_summary));
+        this.populated_state = populated_state;
+    }
+
+    hasJobs(key) {
+        return this.has(key) ? this.get(key) > 0 : false;
+    }
+
+    // any of the passed states has jobs > 0
+    anyHasJobs(...states) {
+        return states.some((s) => this.hasJobs(s));
+    }
+
+    get state() {
+        if (this.jobCount) {
+            if (this.isErrored) {
+                return STATES.ERROR;
+            }
+            if (this.isRunning) {
+                return STATES.RUNNING;
+            }
+            if (this.isNew) {
+                return STATES.LOADING;
+            }
+            if (this.isTerminal) {
+                return STATES.OK;
+            }
+            return STATES.QUEUED;
+        }
+        return this.populated_state;
+    }
+
+    // Flags
+
+    get isNew() {
+        return !this.populated_state || this.populated_state == STATES.NEW;
+    }
+
+    get isErrored() {
+        return this.populated_state == STATES.ERROR || this.anyHasJobs(...ERROR_STATES);
+    }
+
+    get isTerminal() {
+        if (this.isNew) {
+            return false;
+        }
+        return !this.anyHasJobs(...NON_TERMINAL_STATES);
+    }
+
+    get isRunning() {
+        return this.hasJobs(STATES.RUNNING);
+    }
+
+    // Counts
+
+    get jobCount() {
+        return this.get("all_jobs");
+    }
+
+    get errorCount() {
+        return this.get(STATES.ERROR);
+    }
+
+    get runningCount() {
+        return this.get(STATES.RUNNING);
+    }
+}

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -31,7 +31,7 @@
                     <span class="content-title name">{{ name }}</span>
                     <CollectionDescription
                         v-if="!isDataset"
-                        :collection="item"
+                        :job-state-summary="jobState"
                         :collection-type="item.collection_type"
                         :element-count="item.element_count"
                         :elements-datatypes="item.elements_datatypes" />
@@ -73,6 +73,7 @@ import CollectionDescription from "./Collection/CollectionDescription";
 import ContentOptions from "./ContentOptions";
 import DatasetDetails from "./Dataset/DatasetDetails";
 import { updateContentFields } from "components/History/model/queries";
+import { JobStateSummary } from "./Collection/JobStateSummary";
 
 export default {
     components: {
@@ -92,6 +93,9 @@ export default {
         selectable: { type: Boolean, default: false },
     },
     computed: {
+        jobState() {
+            return new JobStateSummary(this.item);
+        },
         contentId() {
             return `dataset-${this.item.id}`;
         },

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -31,6 +31,7 @@
                     <span class="content-title name">{{ name }}</span>
                     <CollectionDescription
                         v-if="!isDataset"
+                        :collection="item"
                         :collection-type="item.collection_type"
                         :element-count="item.element_count"
                         :elements-datatypes="item.elements_datatypes" />

--- a/client/src/components/History/CurrentCollection/CollectionDetails.vue
+++ b/client/src/components/History/CurrentCollection/CollectionDetails.vue
@@ -8,6 +8,7 @@
         <template v-slot:name>
             <h3 v-short="dsc.name || 'Collection'" data-description="collection name display" />
             <CollectionDescription
+                :collection="dsc"
                 :collection-type="dsc.collection_type"
                 :element-count="dsc.element_count"
                 :elements-datatypes="dsc.elements_datatypes" />

--- a/client/src/components/History/CurrentCollection/CollectionDetails.vue
+++ b/client/src/components/History/CurrentCollection/CollectionDetails.vue
@@ -8,7 +8,7 @@
         <template v-slot:name>
             <h3 v-short="dsc.name || 'Collection'" data-description="collection name display" />
             <CollectionDescription
-                :collection="dsc"
+                :job-state-summary="jobState"
                 :collection-type="dsc.collection_type"
                 :element-count="dsc.element_count"
                 :elements-datatypes="dsc.elements_datatypes" />
@@ -20,6 +20,7 @@
 import short from "components/directives/v-short";
 import Details from "components/History/Layout/Details";
 import CollectionDescription from "components/History/Content/Collection/CollectionDescription";
+import { JobStateSummary } from "components/History/Content/Collection/JobStateSummary";
 
 export default {
     components: {
@@ -32,6 +33,11 @@ export default {
     props: {
         dsc: { type: Object, required: true },
         writeable: { type: Boolean, required: true },
+    },
+    computed: {
+        jobState() {
+            return new JobStateSummary(this.dsc);
+        },
     },
 };
 </script>


### PR DESCRIPTION
I added the collection progress bar into the new history, to address issue #13743 

![Screenshot from 2022-05-24 16-28-12](https://user-images.githubusercontent.com/26912553/170126395-239f7a22-63f9-429b-981f-2d1a8979b435.png)
![Screenshot from 2022-05-24 16-27-20](https://user-images.githubusercontent.com/26912553/170126403-6cb0fe92-3609-4f62-a3a2-5df21068e1b7.png)

Readability improved screenshot 
![Screenshot from 2022-05-27 15-51-11](https://user-images.githubusercontent.com/26912553/171452942-3e16600e-8341-40c4-8fa2-2cb8f707b694.png)


## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run a slower tool over a collection, such as "Concatenate datasets (with sleep)" and/or choose a large collection
  2. View the collection progress bar


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
