### PR TITLE
[22.01] Use INFO log level for irods

### DIFF
--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -30,6 +30,7 @@ IRODS_IMPORT_MESSAGE = ('The Python irods package is required to use this featur
 # 1 MB
 CHUNK_SIZE = 2**20
 log = logging.getLogger(__name__)
+logging.getLogger("irods.connection").setLevel(logging.INFO)  # irods logging generates gigabytes of logs
 
 
 def _config_xml_error(tag):


### PR DESCRIPTION
We've run out of disk space on usegalaxy.org due to these log messages.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
