### PR TITLE
Recommend rebasing PRs over merging the target branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,34 @@ https://help.github.com/en/github/getting-started-with-github/git-and-github-lea
    automatically started by GitHub using e.g. Travis CI.
 
 10. Your pull request will be handled according to [some
-   rules](doc/source/project/organization.rst#handling-pull-requests).
+    rules](doc/source/project/organization.rst#handling-pull-requests).
+
+11. If, before your pull request is merged, conflicts arise between your branch
+    and the target branch (because other commits were pushed to the target
+    branch), you need to either:
+
+    1) [rebase your branch](https://git-scm.com/docs/git-rebase) on top of the
+       target branch, or
+    2) merge the target branch into your branch.
+
+    We recommend the first approach (i.e. rebasing) because it produces cleaner
+    git histories, which are easier to bisect. If your branch is called
+    `feature_branch` and your target branch is `dev`, you can rebase your branch
+    with the following commands:
+
+    ```
+    $ git checkout feature_branch
+    $ git pull
+    $ git fetch upstream
+    $ git rebase upstream/dev
+    ```
+
+    Once you have resolved the conflicts in all commits of your branch, you can
+    force-push the rebased branch to update the pull request:
+
+    ```
+    $ git push --force
+    ```
 
 ## Style guidelines
 


### PR DESCRIPTION
A clean git histories is easier to bisect in case of issues.

Discussed during the latest committers meeting.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
