### PR TITLE
Fix padding in history content items

### DIFF
--- a/client/src/components/History/Content/ContentItem.test.js
+++ b/client/src/components/History/Content/ContentItem.test.js
@@ -60,5 +60,7 @@ describe("ContentItem", () => {
         expect(wrapper.emitted()["update:selected"][1][0]).toBe(false);
         expect(wrapper.classes()).toEqual(expect.arrayContaining(["alert-info"]));
         expect(selector.attributes("data-icon")).toBe("check-square");
+        await wrapper.setProps({ item: { tags: [] } });
+        expect(wrapper.find(".alltags").exists()).toBe(false);
     });
 });

--- a/client/src/components/History/Content/ContentItem.test.js
+++ b/client/src/components/History/Content/ContentItem.test.js
@@ -1,8 +1,14 @@
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import ContentItem from "./ContentItem";
+import { updateContentFields } from "components/History/model/queries";
+
+jest.mock("components/History/model/queries");
 
 const localVue = getLocalVue();
+
+// mock queries
+updateContentFields.mockImplementation(async () => {});
 
 describe("ContentItem", () => {
     let wrapper;
@@ -10,7 +16,7 @@ describe("ContentItem", () => {
     beforeEach(() => {
         wrapper = mount(ContentItem, {
             propsData: {
-                expandDataset: false,
+                expandDataset: true,
                 item: {
                     id: "item_id",
                     some_data: "some_data",
@@ -20,12 +26,16 @@ describe("ContentItem", () => {
                 },
                 id: 1,
                 isDataset: true,
-                isHistoryItem: false,
+                isHistoryItem: true,
                 name: "name",
                 selected: false,
                 selectable: false,
             },
             localVue,
+            stubs: {
+                DatasetDetails: true,
+                vueTagsInput: false,
+            },
         });
     });
 
@@ -40,6 +50,14 @@ describe("ContentItem", () => {
             await tags.at(i).find(".tag-name").trigger("click");
             expect(wrapper.emitted()["tag-click"][i][0]).toBe(`tag${i + 1}`);
         }
+        // close all tags
+        for (let i = 0; i < 3; i++) {
+            const tagRemover = wrapper.find(".ti-icon-close");
+            await tagRemover.trigger("click");
+            expect(wrapper.emitted()["tag-change"][i][1]).not.toContain(`tag${i + 1}`);
+        }
+        await wrapper.setProps({ isHistoryItem: false, item: { tags: [] } });
+        expect(wrapper.find(".alltags").exists()).toBe(false);
         // expansion button
         const $el = wrapper.find(".cursor-pointer");
         $el.trigger("click");
@@ -60,7 +78,5 @@ describe("ContentItem", () => {
         expect(wrapper.emitted()["update:selected"][1][0]).toBe(false);
         expect(wrapper.classes()).toEqual(expect.arrayContaining(["alert-info"]));
         expect(selector.attributes("data-icon")).toBe("check-square");
-        await wrapper.setProps({ item: { tags: [] } });
-        expect(wrapper.find(".alltags").exists()).toBe(false);
     });
 });

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -51,8 +51,8 @@
         </div>
         <StatelessTags
             v-if="!tagsDisabled || hasTags"
-            v-model="tags"
             class="alltags p-1"
+            :value="tags"
             :use-toggle-link="false"
             :disabled="tagsDisabled"
             @tag-click="onTagClick"
@@ -168,6 +168,7 @@ export default {
             }
         },
         onTags(newTags) {
+            this.$emit("tag-change", this.item, newTags);
             updateContentFields(this.item, { tags: newTags });
         },
         onTagClick(tag) {

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -50,10 +50,11 @@
             </div>
         </div>
         <StatelessTags
+            v-if="!tagsDisabled || tags.length > 0"
             v-model="tags"
-            :class="tagsCls"
+            class="alltags p-1"
             :use-toggle-link="false"
-            :disabled="!expandDataset || !isHistoryItem"
+            :disabled="tagsDisabled"
             @tag-click="onTagClick"
             @input="onTags" />
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
@@ -125,8 +126,8 @@ export default {
         tags() {
             return this.item.tags;
         },
-        tagsCls() {
-            return { "p-1 alltags": this.item.tags.length > 0 };
+        tagsDisabled() {
+            return !this.expandDataset || !this.isHistoryItem;
         },
     },
     methods: {

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -65,8 +65,7 @@
 </template>
 
 <script>
-import { getAppRoot } from "onload";
-import { backboneRoute, useGalaxy, iframeRedirect } from "components/plugins/legacyNavigation";
+import { backboneRoute, iframeAdd } from "components/plugins/legacyNavigation";
 import { StatelessTags } from "components/Tags";
 import { STATES } from "./model/states";
 import CollectionDescription from "./Collection/CollectionDescription";
@@ -142,18 +141,8 @@ export default {
             }
         },
         onDisplay() {
-            const id = this.item.id;
-            useGalaxy((Galaxy) => {
-                const url = `${getAppRoot()}datasets/${id}/display/?preview=True`;
-                if (Galaxy.frame && Galaxy.frame.active) {
-                    Galaxy.frame.add({
-                        title: this.name,
-                        url: url,
-                    });
-                } else {
-                    iframeRedirect(url);
-                }
-            });
+            const url = `datasets/${this.item.id}/display/?preview=True`;
+            iframeAdd({ path: url, title: this.name });
         },
         onDragStart(evt) {
             evt.dataTransfer.dropEffect = "move";

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -126,7 +126,7 @@ export default {
             return this.item.tags;
         },
         tagsCls() {
-            return { "p-1 alltags" : this.item.tags.length > 0 };
+            return { "p-1 alltags": this.item.tags.length > 0 };
         },
     },
     methods: {

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -50,7 +50,7 @@
             </div>
         </div>
         <StatelessTags
-            v-if="!tagsDisabled || tags.length > 0"
+            v-if="!tagsDisabled || hasTags"
             v-model="tags"
             class="alltags p-1"
             :use-toggle-link="false"
@@ -107,6 +107,9 @@ export default {
         },
         contentState() {
             return STATES[this.state] && STATES[this.state];
+        },
+        hasTags() {
+            return this.tags && this.tags.length > 0;
         },
         hasStateIcon() {
             return this.contentState && this.contentState.icon;

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -49,14 +49,13 @@
                     @unhide="$emit('unhide')" />
             </div>
         </div>
-        <div class="p-1 alltags">
-            <StatelessTags
-                v-model="tags"
-                :use-toggle-link="false"
-                :disabled="!expandDataset || !isHistoryItem"
-                @tag-click="onTagClick"
-                @input="onTags" />
-        </div>
+        <StatelessTags
+            v-model="tags"
+            :class="tagsCls"
+            :use-toggle-link="false"
+            :disabled="!expandDataset || !isHistoryItem"
+            @tag-click="onTagClick"
+            @input="onTags" />
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->
         <div class="detail-animation-wrapper" :class="expandDataset ? '' : 'collapsed'">
             <DatasetDetails v-if="expandDataset" :dataset="item" @edit="onEdit" />
@@ -125,6 +124,9 @@ export default {
         },
         tags() {
             return this.item.tags;
+        },
+        tagsCls() {
+            return { "p-1 alltags" : this.item.tags.length > 0 };
         },
     },
     methods: {

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -99,6 +99,7 @@
                                         :selected="isSelected(item)"
                                         :selectable="showSelection"
                                         @tag-click="onTagClick"
+                                        @tag-change="onTagChange"
                                         @update:expand-dataset="setExpanded(item, $event)"
                                         @update:selected="setSelected(item, $event)"
                                         @view-collection="$emit('view-collection', item)"
@@ -230,6 +231,9 @@ export default {
         },
         setInvisible(item) {
             Vue.set(this.invisible, item.hid, true);
+        },
+        onTagChange(item, newTags) {
+            item.tags = newTags;
         },
         onTagClick(tag) {
             if (this.filterText == "tag=" + tag) {


### PR DESCRIPTION
Fixes various issues, particularly the padding for untagged history items by ensuring that the tag component is only rendered if needed. Contains an additional preliminary fix to populate the tag label when new tags are being added which avoids empty tags waiting for a server response. Also contains changes to increase test coverage of tag handling and removal.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
