### PR TITLE
Restore Tour List View as Vue Component [PR for issue #13796]

### DIFF
--- a/client/src/components/Tour/Tour.test.js
+++ b/client/src/components/Tour/Tour.test.js
@@ -1,0 +1,30 @@
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import TourList from "./TourList.vue";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import flushPromises from "flush-promises";
+
+const localVue = getLocalVue();
+const TEST_TOUR_URI = "/api/tours";
+
+jest.mock("app");
+
+describe("Tour", () => {
+    let axiosMock;
+    let wrapper;
+
+    beforeEach(async () => {
+        axiosMock = new MockAdapter(axios);
+        axiosMock.onGet(TEST_TOUR_URI).reply(200, [{ id: "foo", writable: false }]);
+        wrapper = shallowMount(TourList, {
+            propsData: {},
+            localVue,
+        });
+        await flushPromises();
+    });
+
+    it("test tours", async () => {
+        expect(wrapper.find("#tourList").exists()).toBeTruthy();
+    });
+});

--- a/client/src/components/Tour/TourList.vue
+++ b/client/src/components/Tour/TourList.vue
@@ -1,0 +1,80 @@
+<template>
+    <div class="ui-thumbnails">
+        <h2>Galaxy Tours</h2>
+        <p>
+            This page presents a list of interactive tours available on this Galaxy server. Select any tour to get
+            started (and remember, you can click 'End Tour' at any time).
+        </p>
+        <h4>Tours</h4>
+        <div v-if="error" class="alert alert-danger">{{ error }}</div>
+        <div v-else>
+            <DelayedInput class="mb-3" :query="search" :placeholder="searchTours" :delay="0" @change="onSearch" />
+            <div v-for="tour in tours" :key="tour.id">
+                <ul v-if="match(tour)" id="tourList" class="list-group">
+                    <li class="list-group-item">
+                        <a :href="`${root}tours/${tour.id}`"> {{ tour.name || tour.id }} </a>&nbsp;&minus;&nbsp;
+                        {{ tour.description }}
+                        <span
+                            v-for="(tag, index) in tour.tags"
+                            :key="index"
+                            class="badge badge-primary text-capitalize">
+                            {{ tag }}
+                        </span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import _l from "utils/localization";
+import { getAppRoot } from "onload/loadConfig";
+import axios from "axios";
+import DelayedInput from "components/Common/DelayedInput";
+
+export default {
+    components: {
+        DelayedInput,
+    },
+    data() {
+        return {
+            tours: [],
+            search: "",
+            error: null,
+            searchTours: _l("search tours"),
+        };
+    },
+    created() {
+        this.root = getAppRoot();
+        const api = `${this.root}api/tours`;
+        axios
+            .get(api)
+            .then((response) => {
+                this.tours = response.data;
+            })
+            .catch((e) => {
+                this.error = this._errorMessage(e);
+            });
+    },
+    methods: {
+        onSearch(newValue) {
+            this.search = newValue;
+        },
+        match(tour) {
+            const query = this.search.toLowerCase();
+            return (
+                !query ||
+                (tour.id && tour.id.toLowerCase().includes(query)) ||
+                (tour.name && tour.name.toLowerCase().includes(query)) ||
+                (tour.description && tour.description.toLowerCase().includes(query)) ||
+                (tour.tags && tour.tags.join().toLowerCase().includes(query))
+            );
+        },
+        _errorMessage(e) {
+            const message = e && e.response && e.response.data && e.response.data.err_msg;
+            return message || "Request failed for an unknown reason.";
+        },
+    },
+};
+</script>

--- a/client/src/components/Tour/TourList.vue
+++ b/client/src/components/Tour/TourList.vue
@@ -29,6 +29,7 @@
 
 <script>
 import _l from "utils/localization";
+import { getAppRoot } from "onload/loadConfig";
 import { urlData } from "utils/url";
 import DelayedInput from "components/Common/DelayedInput";
 
@@ -45,6 +46,8 @@ export default {
         };
     },
     created() {
+        this.root = getAppRoot();
+
         urlData({ url: `api/tours` })
             .then((response) => {
                 this.tours = response;

--- a/client/src/components/Tour/TourList.vue
+++ b/client/src/components/Tour/TourList.vue
@@ -29,8 +29,7 @@
 
 <script>
 import _l from "utils/localization";
-import { getAppRoot } from "onload/loadConfig";
-import axios from "axios";
+import { urlData } from "utils/url";
 import DelayedInput from "components/Common/DelayedInput";
 
 export default {
@@ -46,16 +45,9 @@ export default {
         };
     },
     created() {
-        this.root = getAppRoot();
-        const api = `${this.root}api/tours`;
-        axios
-            .get(api)
-            .then((response) => {
-                this.tours = response.data;
-            })
-            .catch((e) => {
-                this.error = this._errorMessage(e);
-            });
+        urlData({ url: `api/tours` }).then((response) => {
+            this.tours = response;
+        });
     },
     methods: {
         onSearch(newValue) {

--- a/client/src/components/Tour/TourList.vue
+++ b/client/src/components/Tour/TourList.vue
@@ -47,13 +47,12 @@ export default {
     },
     created() {
         this.root = getAppRoot();
-
         urlData({ url: `api/tours` })
             .then((response) => {
                 this.tours = response;
             })
             .catch((error) => {
-                this.error = this._errorMessage(error);
+                this.error = error;
             });
     },
     methods: {
@@ -69,10 +68,6 @@ export default {
                 (tour.description && tour.description.toLowerCase().includes(query)) ||
                 (tour.tags && tour.tags.join().toLowerCase().includes(query))
             );
-        },
-        _errorMessage(e) {
-            const message = e && e.response && e.response.data && e.response.data.err_msg;
-            return message || "Request failed for an unknown reason.";
         },
     },
 };

--- a/client/src/components/Tour/TourList.vue
+++ b/client/src/components/Tour/TourList.vue
@@ -45,9 +45,13 @@ export default {
         };
     },
     created() {
-        urlData({ url: `api/tours` }).then((response) => {
-            this.tours = response;
-        });
+        urlData({ url: `api/tours` })
+            .then((response) => {
+                this.tours = response;
+            })
+            .catch((error) => {
+                this.error = this._errorMessage(error);
+            });
     },
     methods: {
         onSearch(newValue) {

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -68,6 +68,7 @@ export const getAnalysisRouter = (Galaxy) => {
             "(/)login/confirm": "show_new_user_confirmation",
             "(/)tools/view": "show_tools_view",
             "(/)tools/json": "show_tools_json",
+            "(/)tours": "show_tours_default",
             "(/)tours(/)(:tour_id)": "show_tours",
             "(/)user(/)": "show_user",
             "(/)user(/)cloud_auth": "show_cloud_auth",
@@ -147,11 +148,17 @@ export const getAnalysisRouter = (Galaxy) => {
 
         show_tours: function (tour_id) {
             this.home();
-            if (tour_id === "list" || !tour_id) {
+
+            if (tour_id === "list") {
                 this._display_vue_helper(TourList);
             } else {
                 runTour(tour_id);
             }
+        },
+
+        show_tours_default: function () {
+            this.home();
+            this._display_vue_helper(TourList);
         },
 
         show_new_user_confirmation: function () {

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -68,7 +68,7 @@ export const getAnalysisRouter = (Galaxy) => {
             "(/)login/confirm": "show_new_user_confirmation",
             "(/)tools/view": "show_tools_view",
             "(/)tools/json": "show_tools_json",
-            "(/)tours": "show_tours_default",
+            "(/)tours": "show_tours_list",
             "(/)tours(/)(:tour_id)": "show_tours",
             "(/)user(/)": "show_user",
             "(/)user(/)cloud_auth": "show_cloud_auth",
@@ -148,15 +148,10 @@ export const getAnalysisRouter = (Galaxy) => {
 
         show_tours: function (tour_id) {
             this.home();
-
-            if (tour_id === "list") {
-                this._display_vue_helper(TourList);
-            } else {
-                runTour(tour_id);
-            }
+            runTour(tour_id);
         },
 
-        show_tours_default: function () {
+        show_tours_list: function () {
             this.home();
             this._display_vue_helper(TourList);
         },

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -23,6 +23,7 @@ import DatasetList from "components/Dataset/DatasetList";
 import { getUserPreferencesModel } from "components/User/UserPreferencesModel";
 import CustomBuilds from "components/User/CustomBuilds";
 import { runTour } from "components/Tour/runTour";
+import TourList from "components/Tour/TourList";
 import GridView from "mvc/grid/grid-view";
 import GridShared from "mvc/grid/grid-shared";
 import JobDetails from "components/JobInformation/JobDetails";
@@ -146,7 +147,9 @@ export const getAnalysisRouter = (Galaxy) => {
 
         show_tours: function (tour_id) {
             this.home();
-            if (tour_id) {
+            if (tour_id === "list" || !tour_id) {
+                this._display_vue_helper(TourList);
+            } else {
                 runTour(tour_id);
             }
         },

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -202,7 +202,7 @@ export function fetchMenu(options = {}) {
             },
             {
                 title: _l("Interactive Tours"),
-                url: "tours/list",
+                url: "tours",
                 target: "__use_router__",
             },
             {

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -201,6 +201,11 @@ export function fetchMenu(options = {}) {
                 target: "_blank",
             },
             {
+                title: _l("Interactive Tours"),
+                url: "tours/list",
+                target: "__use_router__",
+            },
+            {
                 title: _l("Introduction to Galaxy"),
                 url: "welcome/new",
             },


### PR DESCRIPTION
### Changes
1. **Overview.** This feature (Issue: https://github.com/galaxyproject/galaxy/issues/13796) was previously a static html-js template converted to Vue format. 
2. **Search Feature.** Originally, the search feature searched by Tour Tag. Now, the search feature searches by Tour Tag, Tour Name, Tour Description using a keyword "phrase" search.
3. **Routing.** The link to the page was added in the "Help" submenu. Also, to retain SEO credit in search engines, the original url `/tours` was used in addition to standard format for list pages `/tours/list`.

_Code Background:_
* _Prior to Vueification, this other js file was removed from the "Help" submenu and deleted in this commit ([~1317b](https://github.com/galaxyproject/galaxy/commit/23f150917665a232dbc180a376be2d977de1317b)) from [this PR](https://github.com/galaxyproject/galaxy/pull/13778)._
* _During Vueification, this jointly-assigned issue was only partially addressed in [this previously PR](https://github.com/tcollins2011/galaxy/pull/1)._

### Screens

Before (http://127.0.0.1:8080/tours):
![Greenshot 2022-05-27 09 07 04](https://user-images.githubusercontent.com/3672779/170705304-7976c9cb-c5d0-4ffa-962f-a999b63756fa.png)

After / Changes (http://127.0.0.1:8080/tours):
![Greenshot 2022-05-27 09 06 41](https://user-images.githubusercontent.com/3672779/170705308-a003603b-5bf3-4ac7-ae92-19c3520ad091.png)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
