### PR TITLE
Don't create a BGZF index when running the compressing converter

### DIFF
--- a/lib/galaxy/datatypes/converters/uncompressed_to_gz.xml
+++ b/lib/galaxy/datatypes/converters/uncompressed_to_gz.xml
@@ -1,19 +1,19 @@
 <tool id="CONVERTER_uncompressed_to_gz" name="Convert uncompressed file to compressed" hidden="true" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01">
     <macros>
-        <token name="@TOOL_VERSION@">1.11</token>
+        <token name="@TOOL_VERSION@">1.15.1</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
-        <requirement type="package" version="1.11">tabix</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">htslib</requirement>
     </requirements>
     <command><![CDATA[
-cp '$ext_config' 'galaxy.json' &&
-bgzip -@ \${GALAXY_SLOTS:-1} -ci '$input1' > '$output1'
+cp '$ext_config' galaxy.json &&
+bgzip -@ "\${GALAXY_SLOTS:-1}" -c '$input1' > '$output1'
     ]]></command>
     <configfiles>
         <configfile name="ext_config">{"output1": {
-  "name": "${input1.name+'.gz' if not $input1.name.endswith('.vcf') else $input1.name+'.bgzip'} compressed",
-  "ext": "${input1.ext+'.gz' if $input1.ext != 'vcf' else 'vcf_bgzip'}"
+  "name": "${input1.name + '.gz' if not $input1.name.endswith('.vcf') else $input1.name + '.bgzip'} compressed",
+  "ext": "${input1.ext + '.gz' if $input1.ext != 'vcf' else 'vcf_bgzip'}"
 }}</configfile>
     </configfiles>
     <inputs>


### PR DESCRIPTION
The index file is not used because it is generated again in `set_meta()` for the `VcfGz` datatype, and ignored for all others.

Additionally, the index file is currently generated alongside the input dataset, which fails when the input directory is not writeable (such as when running in a container).

Fix https://github.com/galaxyproject/galaxy/issues/13916 .

Also, replace outdated `tabix` requirement with the latest `htslib`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
