### PR TITLE
Rename master_api_key to bootstrap_admin_api_key

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -274,11 +274,10 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         return provided_key.user
 
     def check_bootstrap_admin_api_key(self, api_key):
-        bootstrap_admin_api_key = getattr(self.app.config, "bootstrap_admin_api_key", None)
-        if not bootstrap_admin_api_key:
+        if not self.app.config.bootstrap_admin_api_key:
             return False
         # Hash keys to make them the same size, so we can do safe comparison.
-        bootstrap_hash = hashlib.sha256(util.smart_str(bootstrap_admin_api_key)).hexdigest()
+        bootstrap_hash = hashlib.sha256(util.smart_str(self.app.config.bootstrap_admin_api_key)).hexdigest()
         provided_hash = hashlib.sha256(util.smart_str(api_key)).hexdigest()
         return util.safe_str_cmp(bootstrap_hash, provided_hash)
 


### PR DESCRIPTION
... with backward compatibility and deprecation warning. 

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
