### PR TITLE
Allow any as value for boolean default parameters in filter text

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFiltersDefault.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFiltersDefault.vue
@@ -19,7 +19,7 @@ export default {
     data() {
         return {
             options: [
-                { text: "Any", value: null },
+                { text: "Any", value: "any" },
                 { text: "Yes", value: true },
                 { text: "No", value: false },
             ],
@@ -46,7 +46,7 @@ export default {
     methods: {
         getValue(name) {
             const value = this.settings[`${name}:`];
-            return value !== undefined ? value : null;
+            return value !== undefined ? value : "any";
         },
         onChange(name, value) {
             value = value !== null ? value : undefined;

--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -28,6 +28,15 @@ describe("filtering", () => {
         const queryDict = HistoryFilters.getQueryDict("name of item");
         expect(queryDict["name-contains"]).toBe("name of item");
     });
+    test("parse any for default parameters", () => {
+        const filters = HistoryFilters.getFilters("deleted:any");
+        expect(filters.length).toBe(0);
+        const queryDict = HistoryFilters.getQueryDict("deleted:any");
+        expect(Object.keys(queryDict).length).toBe(0);
+        const filtersAny = HistoryFilters.getFilters("name:any");
+        expect(filtersAny[0][0]).toBe("name");
+        expect(filtersAny[0][1]).toBe("any");
+    });
     test("parse check filter", () => {
         expect(HistoryFilters.checkFilter(filterTexts[0], "tag", "first")).toBe(true);
         expect(HistoryFilters.checkFilter(filterTexts[0], "tag", "second")).toBe(false);

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -250,12 +250,15 @@ export default class Filtering<T> {
         }
         // check if any default filter keys have been used
         let hasDefaults = false;
-        for (const defaultKey in this.defaultFilters) {
-            if (result[defaultKey]) {
+        Object.keys(this.defaultFilters).forEach((defaultKey) => {
+            const value = result[defaultKey];
+            if (value !== undefined) {
+                if (value == "any") {
+                    delete result[defaultKey];
+                }
                 hasDefaults = true;
-                break;
             }
-        }
+        });
         // use default filters if none of the default filters has been explicitly specified
         if (!hasDefaults && this.useDefaultFilters) {
             result = { ...result, ...this.defaultFilters };


### PR DESCRIPTION
Requires #13971. Early draft to allow `any` as value for default filter keys `deleted` and `visible` in the search field of the history. Requires tests.

Also noticed a related potentially conflicting behavior in the `delete`, and `unhide` click handling. When those icons are clicked the history item is removed regardless of the filter. Instead we might want to consider to re-evaluate the filter with the target item before removing it from the list. 

Can go to 22.09.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
