### PR TITLE
Fix tag search non finding non-nametags

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -236,10 +236,10 @@ export default {
             item.tags = newTags;
         },
         onTagClick(tag) {
-            if (this.filterText == "tag=" + tag) {
+            if (this.filterText == "tag:" + tag) {
                 this.filterText = "";
             } else {
-                this.filterText = "tag=" + tag;
+                this.filterText = "tag:" + tag;
             }
         },
         onOperationError(error) {

--- a/client/src/store/historyStore/model/filtering.js
+++ b/client/src/store/historyStore/model/filtering.js
@@ -127,7 +127,7 @@ const validFilters = {
     visible: equals("visible", "visible", toBool),
     name: contains("name"),
     state: equals("state"),
-    tag: contains("tags", "tag-contains", expandNameTag),
+    tag: contains("tags", "tag", expandNameTag),
     update_time: compare("update_time", "le", toDate),
     update_time_ge: compare("update_time", "ge", toDate),
     update_time_gt: compare("update_time", "gt", toDate),

--- a/client/src/store/historyStore/model/filtering.test.js
+++ b/client/src/store/historyStore/model/filtering.test.js
@@ -69,7 +69,7 @@ describe("filtering", () => {
             expect(queryDict["update_time-lt"]).toBe(1640995200);
             expect(queryDict["state-eq"]).toBe("success");
             expect(queryDict["extension-eq"]).toBe("ext");
-            expect(queryDict["tag-contains"]).toBe("first");
+            expect(queryDict["tag"]).toBe("first");
             expect(queryDict["deleted"]).toBe(false);
             expect(queryDict["visible"]).toBe(true);
         });
@@ -127,6 +127,6 @@ describe("filtering", () => {
         expect(filters[0][0]).toBe("tag");
         expect(filters[0][1]).toBe("#test");
         const queryDict = getQueryDict("tag:#test");
-        expect(queryDict["tag-contains"]).toBe("name:test");
+        expect(queryDict["tag"]).toBe("name:test");
     });
 });


### PR DESCRIPTION
Fixed tag search not finding non-nametags.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
