### PR TITLE
Allow : and = as key word separators in history search?

### DIFF
--- a/client/src/store/historyStore/model/filtering.js
+++ b/client/src/store/historyStore/model/filtering.js
@@ -149,7 +149,7 @@ const validAlias = [
 
 /** Check the value of a particular filter. */
 export function checkFilter(filterText, filterName, filterValue) {
-    const re = new RegExp(`${filterName}:(\\S+)`);
+    const re = new RegExp(`${filterName}[:=](\\S+)`);
     const reMatch = re.exec(filterText);
     const testValue = reMatch ? reMatch[1] : defaultFilters[filterName];
     return toLowerNoQuotes(testValue) == toLowerNoQuotes(filterValue);
@@ -163,7 +163,7 @@ export function getFilters(filterText) {
     let hasMatches = false;
     if (matches) {
         matches.forEach((pair) => {
-            const elgRE = /(\S+)([:><])(.+)/g;
+            const elgRE = /(\S+)([:=><])(.+)/g;
             const elgMatch = elgRE.exec(pair);
             if (elgMatch) {
                 let field = elgMatch[1];

--- a/client/src/store/historyStore/model/filtering.test.js
+++ b/client/src/store/historyStore/model/filtering.test.js
@@ -1,8 +1,8 @@
 import { checkFilter, getFilters, toAlias, getQueryDict, testFilters } from "./filtering";
 
 const filterTexts = [
-    "name:'name of item' hid>10 hid<100 create-time>'2021-01-01' update-time<'2022-01-01' state:success extension:ext tag:first deleted:False visible:'TRUE'",
-    "name:'name of item' hid_gt:10 hid-lt:100 create_time-gt:'2021-01-01' update_time-lt:'2022-01-01' state:sUccEss extension:EXT tag:FirsT deleted:false visible:true",
+    "name:'name of item' hid>10 hid<100 create-time>'2021-01-01' update-time<'2022-01-01' state=success extension:ext tag:first deleted:False visible='TRUE'",
+    "name:'name of item' hid_gt:10 hid-lt:100 create_time-gt='2021-01-01' update_time-lt:'2022-01-01' state:sUccEss extension=EXT tag:FirsT deleted:false visible:true",
 ];
 describe("filtering", () => {
     test("parse default filter", () => {


### PR DESCRIPTION
In #13971 we switched completely from equal to colons and this pinpointed all spots required to change the separator including the filter panel, quick filter buttons and tests. Now that colons are the separator of choice, we can allow users to also use `=` as separator, only if they manually type a filter string. This could make it easier to adjust, since the previous history only supported `=` as separator. Thanks for pointing that out @dannon.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
