### PR TITLE
Localize workflow deletion confirmation message...

### DIFF
--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -164,7 +164,8 @@ export default {
         onDelete: function () {
             const id = this.workflow.id;
             const name = this.workflow.name;
-            if (window.confirm(`Are you sure you want to delete workflow '${name}'?`)) {
+            const confirmationMessage = this.l(`Are you sure you want to delete workflow '${name}'?`);
+            if (window.confirm(confirmationMessage)) {
                 this.services
                     .deleteWorkflow(id)
                     .then((message) => {

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -27,7 +27,7 @@ function isTestLocalized(text) {
 }
 
 expect.extend({
-    toBeLocalizationOf(received) {
+    toBeLocalized(received) {
         const pass = isTestLocalized(received);
         if (pass) {
             return {


### PR DESCRIPTION
... and unit test.

Also includes a fix for #13880 that has been sitting in a branch for a while.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
