### PR TITLE
Add history update time to Beta History

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -1,6 +1,7 @@
 <template>
     <div v-if="history.size" class="history-size my-1 d-flex justify-content-between">
         <b-button
+            v-b-tooltip.hover
             title="Access Dashboard"
             variant="link"
             size="sm"
@@ -11,6 +12,7 @@
         </b-button>
         <b-button-group>
             <b-button
+                v-b-tooltip.hover
                 title="Show active"
                 variant="link"
                 size="sm"
@@ -21,6 +23,7 @@
             </b-button>
             <b-button
                 v-if="history.contents_active.deleted"
+                v-b-tooltip.hover
                 title="Show deleted"
                 variant="link"
                 size="sm"
@@ -31,6 +34,7 @@
             </b-button>
             <b-button
                 v-if="history.contents_active.hidden"
+                v-b-tooltip.hover
                 title="Show hidden"
                 variant="link"
                 size="sm"
@@ -39,6 +43,15 @@
                 <icon icon="lock" />
                 <span>{{ history.contents_active.hidden }}</span>
             </b-button>
+            <b-button
+                v-b-tooltip.hover
+                :title="'Last updated ' + diffToNow"
+                variant="link"
+                size="sm"
+                class="rounded-0 text-decoration-none"
+                @click="reloadContents()">
+                <span :class="reloadButtonCls" />
+            </b-button>
         </b-button-group>
     </div>
 </template>
@@ -46,6 +59,7 @@
 <script>
 import { backboneRoute } from "components/plugins/legacyNavigation";
 import prettyBytes from "pretty-bytes";
+import { formatDistanceToNowStrict } from "date-fns";
 
 export default {
     filters: {
@@ -55,6 +69,18 @@ export default {
     },
     props: {
         history: { type: Object, required: true },
+        lastChecked: { type: Date, default: null },
+    },
+    data() {
+        return {
+            diffToNow: 0,
+            reloadButtonCls: "fa fa-sync",
+        };
+    },
+    mounted() {
+        this.updateTime();
+        // update every second
+        setInterval(this.updateTime.bind(this), 1000);
     },
     methods: {
         onDashboard() {
@@ -62,6 +88,16 @@ export default {
         },
         setFilter(newFilterText) {
             this.$emit("update:filter-text", newFilterText);
+        },
+        updateTime() {
+            this.diffToNow = formatDistanceToNowStrict(this.lastChecked, { addSuffix: true, includeSeconds: true });
+        },
+        async reloadContents() {
+            this.$emit("reloadContents");
+            this.reloadButtonCls = "fa fa-sync fa-spin";
+            setTimeout(() => {
+                this.reloadButtonCls = "fa fa-sync";
+            }, 1000);
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -36,7 +36,11 @@
                     <section v-if="!showAdvanced">
                         <HistoryDetails :history="history" @update:history="$emit('updateHistory', $event)" />
                         <HistoryMessages :history="history" />
-                        <HistoryCounter :history="history" :filter-text.sync="filterText" />
+                        <HistoryCounter
+                            :history="history"
+                            :last-checked="lastChecked"
+                            :filter-text.sync="filterText"
+                            @reloadContents="reloadContents" />
                         <HistoryOperations
                             :history="history"
                             :show-selection="showSelection"
@@ -135,6 +139,7 @@ import HistorySelectionOperations from "./HistoryOperations/SelectionOperations"
 import HistorySelectionStatus from "./HistoryOperations/SelectionStatus";
 import SelectionChangeWarning from "./HistoryOperations/SelectionChangeWarning";
 import OperationErrorDialog from "./HistoryOperations/OperationErrorDialog";
+import { rewatchHistory } from "store/historyStore/model/watchHistory";
 
 export default {
     components: {
@@ -190,6 +195,10 @@ export default {
         isProcessing() {
             return this.operationRunning >= this.history.update_time;
         },
+        /** @returns {Date} */
+        lastChecked() {
+            return this.$store.getters.getLastCheckedTime();
+        },
     },
     watch: {
         queryKey() {
@@ -228,6 +237,9 @@ export default {
         onUnhide(item) {
             this.setInvisible(item);
             updateContentFields(item, { visible: true });
+        },
+        reloadContents() {
+            rewatchHistory();
         },
         setInvisible(item) {
             Vue.set(this.invisible, item.hid, true);

--- a/client/src/store/historyStore/historyItemsStore.js
+++ b/client/src/store/historyStore/historyItemsStore.js
@@ -17,6 +17,7 @@ const state = {
     itemKey: "hid",
     latestCreateTime: new Date(),
     totalMatchesCount: undefined,
+    lastCheckedTime: new Date(),
 };
 
 const getters = {
@@ -38,6 +39,7 @@ const getters = {
         },
     getLatestCreateTime: (state) => () => state.latestCreateTime,
     getTotalMatchesCount: (state) => () => state.totalMatchesCount,
+    getLastCheckedTime: (state) => () => state.lastCheckedTime,
 };
 
 const getQueryString = (filterText) => {
@@ -76,6 +78,9 @@ const mutations = {
                 }
             }
         });
+    },
+    setLastCheckedTime: (state, { checkForUpdate }) => {
+        state.lastCheckedTime = checkForUpdate;
     },
     saveQueryStats: (state, { stats }) => {
         state.totalMatchesCount = stats.total_matches;

--- a/client/src/store/historyStore/model/watchHistory.js
+++ b/client/src/store/historyStore/model/watchHistory.js
@@ -13,6 +13,8 @@ import { getGalaxyInstance } from "app";
 const limit = 1000;
 const throttlePeriod = 3000;
 
+let watchTimeout = null;
+
 // last time the history has changed
 let lastUpdateTime = null;
 
@@ -23,6 +25,8 @@ export async function watchHistory() {
     // get current history
     const history = await getCurrentHistoryFromServer();
     const historyId = history.id;
+    const checkForUpdate = new Date();
+    store.commit("setLastCheckedTime", { checkForUpdate });
 
     // continue if the history update time has changed
     if (!lastUpdateTime || lastUpdateTime < history.update_time) {
@@ -58,7 +62,14 @@ export async function watchHistory() {
             });
         }
     }
-    setTimeout(() => {
+    watchTimeout = setTimeout(() => {
         watchHistory();
     }, throttlePeriod);
+}
+
+export function rewatchHistory() {
+    if (watchTimeout) {
+        clearTimeout(watchTimeout);
+        watchHistory();
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/13951.
Last updated/refreshed time is displayed in `HistoryCounter`:
![image](https://user-images.githubusercontent.com/78516064/172446124-768b4af6-c204-49e4-8b5b-845e04664670.png)

What it looks like after refreshed, with annotations, filters etc.:

https://user-images.githubusercontent.com/78516064/172495777-56ec9469-9ef7-4677-bd88-bdc1541cd3ea.mov


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
