### PR TITLE
Small tour tweaks.

### DIFF
--- a/client/src/components/Tour/runTour.js
+++ b/client/src/components/Tour/runTour.js
@@ -103,13 +103,21 @@ export async function runTour(tourId, tourData = null) {
                     waitForElement(step.element, resolve, reject, attempts);
                 }).then(() => {
                     // pre-actions
-                    doClick(step.preclick);
+                    let preclick = step.preclick;
+                    if (preclick === true) {
+                        preclick = [step.element];
+                    }
+                    doClick(preclick);
                     doInsert(step.element, step.textinsert);
                 });
             },
             onNext: () => {
                 // post-actions
-                doClick(step.postclick);
+                let postclick = step.postclick;
+                if (postclick === true) {
+                    postclick = [step.element];
+                }
+                doClick(postclick);
             },
         });
     });

--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -1,6 +1,6 @@
 name: Galaxy UI
 description: A gentle introduction to the Galaxy User Interface
-title_default: "Welcome to Galaxy"
+title_default: Welcome to Galaxy
 tags:
   - "core"
   - "UI"
@@ -9,12 +9,9 @@ tags:
 steps:
     # 'title's will be displayed in the header of each step-container
     # If you don't specify any title, a default title is used, defined above.
-    - title: "Welcome to Galaxy"
+    - title: Welcome to Galaxy
       # 'content' is the actual text that is shown to the user
       content: "This short tour will guide you through Galaxy's user interface. You can leave the tour at any time by pressing escape."
-      # backdrop is just one of many properties you can attach to one step-container,
-      # a full reference can be found at http://bootstraptour.com/api/
-      backdrop: true
 
     # 'element' is the JQuery Selector (http://api.jquery.com/category/selectors/) of the element you want to describe
     # In this case we want to highlight the Upload button with the `.upload-button` selector
@@ -22,8 +19,7 @@ steps:
       element: ".upload-button"
       intro: "Galaxy supports many ways to get in your data. Use this button to upload your data."
       # You can trigger click() events on arbitrary elements before (preclick) or after (postclick) the element is shown
-      postclick:
-        - ".upload-button"
+      postclick: true
 
     - title: "Upload your data"
       element: "#btn-local"
@@ -46,14 +42,12 @@ steps:
     - title: "Start the upload"
       element: "#btn-start"
       intro: "Upload the data into your Galaxy history."
-      postclick:
-        - "#btn-start"
+      postclick: true
 
     - title: "Close upload/download manager"
       element: "#btn-close"
       intro: "Close the upload manager with this button or with a click outside of the manager window."
-      postclick:
-        - "#btn-close"
+      postclick: true
 
     - title: "Tools"
       element: "#left"
@@ -91,8 +85,7 @@ steps:
       element: '#execute'
       intro: "Click on 'Execute' to run your tool and send it to the compute cluster.
               Don't be afraid to test different settings in parallel. Galaxy can handle multiple runs of the same tool."
-      postclick:
-        - '#execute'
+      postclick: true
 
     - title: "History"
       element: "#right"
@@ -111,8 +104,7 @@ steps:
     - title: "Dataset information"
       element: "div.content-item .content-title"
       intro: "This is your dataset. You can get more informations and options like different visualizations by clicking on it."
-      postclick:
-        - "div.content-item .content-title"
+      postclick: true
   
     - title: "Remove dataset"
       element: "#current-history-panel div.content-item button[title='Delete']"
@@ -121,8 +113,7 @@ steps:
     - title: "Dataset information"
       element: "#current-history-panel div.content-item button[title='Dataset Details']"
       intro: "Clicking on your dataset provides you with more information regarding your dataset (e.g. filetype or size)."
-      preclick:
-        - "#current-history-panel div.content-item button[title='Dataset Details']"
+      preclick: true
 
     - title: "Re-run tool"
       element: "#current-history-panel div.content-item button[title='Run Job Again']"
@@ -131,8 +122,7 @@ steps:
     - title: "Panel collapse"
       element: "#left > div.unified-panel-footer > div.panel-collapse.left"
       intro: "To extend the view for your main Galaxy page in the middle, you can collapse the tool panel on the left hand side. Clicking the panel arrow on the right hand side, collapses the history."
-      postclick:
-        - "#left > div.unified-panel-footer > div.panel-collapse.left"
+      postclick: true
 
     - title: "Top panel"
       element: "#masthead"

--- a/config/plugins/tours/core.history.yaml
+++ b/config/plugins/tours/core.history.yaml
@@ -13,8 +13,7 @@ steps:
       intro: |
             At first we upload some data into your Galaxy history.<br>
             Use this button to upload your data.
-      postclick:
-        - ".upload-button"
+      postclick: true
 
     - title: "Upload your data"
       element: "#btn-local"
@@ -47,8 +46,7 @@ steps:
     - title: "Dataset information"
       element: "div.content-item .content-title"
       intro: "This is one of your uploaded datasets. You can get more informations and options like different visualizations by clicking on it."
-      postclick:
-        - "div.content-item .content-title"
+      postclick: true
 
     - title: "Metadata"
       element: "#current-history-panel div.content-item span.datatype"
@@ -61,26 +59,22 @@ steps:
     - element: "#current-history-panel div.content-item button[title='Dataset Details']"
       title: "Even more information"
       intro: "Get an overview of all metadata associated with your dataset by using the Information symbol."
-      preclick:
-        - "#current-history-panel div.content-item button[title='Dataset Details']"
+      preclick: true
 
     - element: "#current-history-panel div.content-item button[title='Display']"
       title: "Inspect your data"
       intro: "The eye symbol can be used to look at your data."
-      preclick:
-        - "#current-history-panel div.content-item button[title='Display']"
+      preclick: true
 
     - element: "#current-history-panel div.content-item button[title='Edit attributes']"
       title: "Edit metadata"
       intro: "With the pencil button you can edit metadata attributes of your dataset, like the associated filetype or the dataset name."
-      preclick:
-        - "#current-history-panel div.content-item button[title='Edit attributes']"
+      preclick: true
 
     - element: "#current-history-panel div.content-item button[title='Delete']"
       title: "Remove datasets"
       intro: "You can remove a dataset from the history with the cross symbol."
-      postclick:
-        - "#current-history-panel div.content-item button[title='Delete']"
+      postclick: true
 
     - element: "#current-history-panel input[data-description='filter text input']"
       title: "Filter your datasets"
@@ -92,8 +86,7 @@ steps:
       intro: |
             Galaxy datasets are only marked as deleted and can be recovered by clicking this link.
             Please note that datasets marked as deleted can be purged by your administrator at any time.
-      postclick:
-        - "#current-history-panel div.content-item button[title='Undelete']"
+      postclick: true
 
     - element: "#current-history-panel [data-description='filter text input']"
       title: "Search your History"
@@ -103,8 +96,7 @@ steps:
     - element: "#current-history-panel [title='Show history options']"
       title: "History Options"
       intro: "In the History menu you will find a lot more useful History options."
-      postclick:
-        - "#current-history-panel [title='Show history options']"
+      postclick: true
 
     - title: "Enjoy your Galaxy Histories"
       intro: "Thanks for taking this tour! Happy research with Galaxy!"

--- a/config/plugins/tours/core.history.yaml
+++ b/config/plugins/tours/core.history.yaml
@@ -16,14 +16,9 @@ steps:
       postclick: true
 
     - title: "Upload your data"
-      element: "#btn-local"
-      intro: "You can upload data from your computer."
-      postclick:
-        - "#btn-new"
-
-    - title: "Upload your data"
       element: "#btn-new"
       intro: "Copy and paste data directly into Galaxy or include URLs that lead to your data."
+      postclick: true
 
     - title: "Insert URLs"
       element: ".upload-text-content"
@@ -73,7 +68,7 @@ steps:
 
     - element: "#current-history-panel div.content-item button[title='Delete']"
       title: "Remove datasets"
-      intro: "You can remove a dataset from the history with the cross symbol."
+      intro: "You can remove a dataset from the history with the trash can symbol."
       postclick: true
 
     - element: "#current-history-panel input[data-description='filter text input']"

--- a/config/plugins/tours/core.windows.yaml
+++ b/config/plugins/tours/core.windows.yaml
@@ -11,13 +11,11 @@ steps:
 
     - element: "#tool-panel-upload-button"
       intro: "Before using the Window Manager, we will upload some tabular data."
-      postclick:
-        - "#tool-panel-upload-button"
+      postclick: true
 
     - element: "#btn-new"
       intro: "We will be using the paste feature to create a new dataset."
-      postclick:
-        - "#btn-new"
+      postclick: true
 
     - element: ".upload-text-content"
       intro: "...and paste content into the text area field."
@@ -33,8 +31,7 @@ steps:
 
     - element: ".upload-settings"
       intro: "Now, we may further configure the upload content."
-      postclick:
-        - ".upload-settings"
+      postclick: true
 
     - element: ".upload-space_to_tab"
       intro: "...by specifying that all spaces in our table should be converted into tabs."
@@ -44,26 +41,22 @@ steps:
 
     - element: "#btn-start"
       intro: "Upload the data into your Galaxy history."
-      postclick:
-        - "#btn-start"
+      postclick: true
 
     - element: "#btn-close"
       intro: "Hit the close button to close the upload dialog."
-      postclick:
-        - "#btn-close"
+      postclick: true
 
     - element: "#enable-window-manager > .nav-link"
       intro: "Clicking this button will enable Galaxy's Window Manager mode."
-      postclick:
-        - "#enable-window-manager > .nav-link"
+      postclick: true
 
     - element: "#right"
       intro: "This is your history. It contains all datasets you are currently working with including our uploaded table."
 
     - element: "#current-history-panel div.content-item button[title='Display']"
       intro: "Clicking the eye-icon usually displays a dataset in the center panel."
-      postclick:
-        - "#current-history-panel div.content-item button[title='Display']"
+      postclick: true
 
     - element: "#winbox-1"
       intro: "However while using the Window Manager, the dataset will be shown as resizable window."

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1905,7 +1905,12 @@ class NavigatesGalaxy(HasDriver):
         self.components._.messages.error.assert_absent_or_hidden()
 
     def run_tour_step(self, step, step_index, tour_callback):
+        element_str = step.get("element", None)
+
         preclick = step.get("preclick", [])
+        if preclick is True:
+            preclick = [element_str]
+
         for preclick_selector in preclick:
             print(f"(Pre)Clicking {preclick_selector}")
             self._tour_wait_for_and_click_element(preclick_selector)
@@ -1923,6 +1928,8 @@ class NavigatesGalaxy(HasDriver):
         tour_callback.handle_step(step, step_index)
 
         postclick = step.get("postclick", [])
+        if postclick is True:
+            postclick = [element_str]
         for postclick_selector in postclick:
             print(f"(Post)Clicking {postclick_selector}")
             self._tour_wait_for_and_click_element(postclick_selector)

--- a/lib/galaxy/tours/_impl.py
+++ b/lib/galaxy/tours/_impl.py
@@ -28,6 +28,11 @@ def load_tour_steps(contents_dict):
     #  Some of this can be done on the clientside.  Maybe even should?
     title_default = contents_dict.get("title_default")
     for step in contents_dict["steps"]:
+        # Remove attributes no longer used, so they are attempted to be
+        # validated.
+        if "backdrop" in step:
+            step.pop("backdrop")
+
         if "intro" in step:
             step["content"] = step.pop("intro")
         if "position" in step:

--- a/lib/galaxy/tours/_impl.py
+++ b/lib/galaxy/tours/_impl.py
@@ -24,13 +24,19 @@ def build_tours_registry(tour_directories: str):
     return ToursRegistryImpl(tour_directories)
 
 
-def load_tour_steps(contents_dict):
+def noop_warn(str):
+    pass
+
+
+def load_tour_steps(contents_dict, warn=None):
+    warn = warn or noop_warn
     #  Some of this can be done on the clientside.  Maybe even should?
     title_default = contents_dict.get("title_default")
     for step in contents_dict["steps"]:
         # Remove attributes no longer used, so they are attempted to be
         # validated.
         if "backdrop" in step:
+            warn(f"Deprecated and dropped property backdrop found in step {step}")
             step.pop("backdrop")
 
         if "intro" in step:
@@ -48,10 +54,10 @@ def get_tour_id_from_path(tour_path: Union[str, os.PathLike]) -> str:
     return os.path.splitext(filename)[0]
 
 
-def load_tour_from_path(tour_path: Union[str, os.PathLike]) -> dict:
+def load_tour_from_path(tour_path: Union[str, os.PathLike], warn=None) -> dict:
     with open(tour_path) as f:
         tour = yaml.safe_load(f)
-        load_tour_steps(tour)
+        load_tour_steps(tour, warn=warn)
     return tour
 
 

--- a/lib/galaxy/tours/_schema.py
+++ b/lib/galaxy/tours/_schema.py
@@ -1,6 +1,7 @@
 from typing import (
     List,
     Optional,
+    Union,
 )
 
 from pydantic import (
@@ -32,18 +33,14 @@ class TourStep(BaseModel):
     placement: Optional[str] = Field(
         title="Placement", description="Placement of the text box relative to the selected element"
     )
-    preclick: Optional[list] = Field(
+    preclick: Optional[Union[bool, List[str]]] = Field(
         title="Pre-click", description="Elements that receive a click() event before the step is shown"
     )
-    postclick: Optional[list] = Field(
+    postclick: Optional[Union[bool, List[str]]] = Field(
         title="Post-click", description="Elements that receive a click() event after the step is shown"
     )
     textinsert: Optional[str] = Field(
         title="Text-insert", description="Text to insert if element is a text box (e.g. tool search or upload)"
-    )
-    backdrop: Optional[bool] = Field(
-        title="Backdrop",
-        description=("Show a dark backdrop behind the popover and its element," "highlighting the current step"),
     )
 
 

--- a/lib/galaxy/tours/validate.py
+++ b/lib/galaxy/tours/validate.py
@@ -23,10 +23,14 @@ def main(argv=None):
     validated = True
     for tour_path in tour_paths(target):
         tour_id = get_tour_id_from_path(tour_path)
+
+        def warn(msg):
+            print(f"Tour '{tour_id}' warning: {msg}")
+
         message = None
         tour = None
         try:
-            tour = load_tour_from_path(tour_path)
+            tour = load_tour_from_path(tour_path, warn=warn)
         except OSError:
             message = f"Tour '{tour_id}' could not be loaded, error reading file."
         except yaml.error.YAMLError:


### PR DESCRIPTION
- Remove backdrop - it no longer does anything with popper.js.
- Reduce duplication in almost all tours by allowing preclick/postclick to just click the element specified by the step.
- Other small changes to history tour:
  - More concise upload help.
  - Icon for deleting datasets changed, updated it here.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
