### PR TITLE
Drop update_time from JobStateHistory

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -106,7 +106,6 @@ from typing_extensions import Protocol
 
 import galaxy.exceptions
 import galaxy.model.metadata
-import galaxy.model.orm.now
 import galaxy.model.tags
 import galaxy.security.passwords
 import galaxy.util

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2037,7 +2037,6 @@ class JobStateHistory(Base, RepresentById):
 
     id = Column(Integer, primary_key=True)
     create_time = Column(DateTime, default=now)
-    update_time = Column(DateTime, default=now, onupdate=now)
     job_id = Column(Integer, ForeignKey("job.id"), index=True)
     state = Column(String(64), index=True)
     info = Column(TrimmedString(255))

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/186d4835587b_drop_job_state_history_update_time_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/186d4835587b_drop_job_state_history_update_time_.py
@@ -1,0 +1,32 @@
+"""drop job_state_history.update_time column
+
+Revision ID: 186d4835587b
+Revises: 6a67bf27e6a6
+Create Date: 2022-06-01 17:50:22.629894
+
+"""
+from alembic import op
+from sqlalchemy import (
+    Column,
+    DateTime,
+)
+
+from galaxy.model.migrations.util import drop_column
+from galaxy.model.orm.now import now
+
+# revision identifiers, used by Alembic.
+revision = "186d4835587b"
+down_revision = "6a67bf27e6a6"
+branch_labels = None
+depends_on = None
+
+table_name = "job_state_history"
+column_name = "update_time"
+
+
+def upgrade():
+    drop_column(table_name, column_name)
+
+
+def downgrade():
+    op.add_column(table_name, Column("update_time", DateTime, default=now, onupdate=now))

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
@@ -20,7 +20,7 @@ down_revision = "e7b6dcb09efd"
 branch_labels = None
 depends_on = None
 
-# database object names user in this revision
+# database object names used in this revision
 table_name = "workflow"
 column_name = "source_metadata"
 

--- a/test/unit/data/model/mapping/test_gxy_model_mapping.py
+++ b/test/unit/data/model/mapping/test_gxy_model_mapping.py
@@ -2805,16 +2805,13 @@ class TestJobStateHistory(BaseTest):
     def test_columns(self, session, cls_, job):
         state, info = job.state, job.info
         create_time = now()
-        update_time = create_time + timedelta(hours=1)
         obj = cls_(job)
         obj.create_time = create_time
-        obj.update_time = update_time
 
         with dbcleanup(session, obj) as obj_id:
             stored_obj = get_stored_obj(session, cls_, obj_id)
             assert stored_obj.id == obj_id
             assert stored_obj.create_time == create_time
-            assert stored_obj.update_time == update_time
             assert stored_obj.job_id == job.id
             assert stored_obj.state == state
             assert stored_obj.info == info


### PR DESCRIPTION
Ref #13992 
Reason: column unnecessary; discussed at meeting in Montpellier.

NOTE: Downgrading will not restore the column data, obviously. Instead, the column values will be null. However, given that the table is a log of events, the "update" data is neither referenced, nor needed. (currently, the difference between create_time and update_time is a few microseconds).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
