### PR TITLE
Add text to history import/switch buttons

### DIFF
--- a/templates/webapps/galaxy/history/display.mako
+++ b/templates/webapps/galaxy/history/display.mako
@@ -20,9 +20,15 @@
     switch_url = h.url_for( controller='history', action='switch_to_history', hist_id=encoded_history_id )
 %>
     %if not user_is_owner:
-        <a href="javascript:void(0)" class="history-copy-link btn btn-secondary float-right" title="Import this history">Import</a>
+        <a href="javascript:void(0)" class="history-copy-link btn btn-secondary float-right" title="Import this history">
+             Import 
+            <span class="fa fa-plus"></span>
+        </a>
     %else:
-        <a href="${switch_url}" class="btn btn-secondary fa fa-exchange float-right" title="${_('Switch to this history')}"></a>
+        <a href="${switch_url}" class="btn btn-secondary float-right" title="${_('Switch to this history')}">
+             Switch 
+            <span class="fa fa-exchange"></span>
+        </a>
     %endif
 </%def>
 

--- a/templates/webapps/galaxy/history/display.mako
+++ b/templates/webapps/galaxy/history/display.mako
@@ -21,13 +21,13 @@
 %>
     %if not user_is_owner:
         <a href="javascript:void(0)" class="history-copy-link btn btn-secondary float-right" title="Import this history">
-             Import 
             <span class="fa fa-plus"></span>
+            Import
         </a>
     %else:
         <a href="${switch_url}" class="btn btn-secondary float-right" title="${_('Switch to this history')}">
-             Switch 
             <span class="fa fa-exchange"></span>
+            Switch
         </a>
     %endif
 </%def>


### PR DESCRIPTION
As requested by @hexylena in https://github.com/galaxyproject/galaxy/pull/13946#issuecomment-1141181728:
> That said, just having 'Import' written is a huge improvement, but the switch icon has the same sort of issue.
> 
> 1. Could we do `import +`, and `switch <>`, using both the name + icon for the buttons?

I have added `Import` and `Switch` to the buttons:
![image](https://user-images.githubusercontent.com/78516064/171676393-1e387f87-da2b-4e8c-a27f-1a67dc99822e.png)     ![image](https://user-images.githubusercontent.com/78516064/171676264-e7d32746-a6af-4a5b-9355-8ae3d7129f06.png)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
