### PR TITLE
Script to validate tours structure.

### DIFF
--- a/lib/galaxy/tours/validate.py
+++ b/lib/galaxy/tours/validate.py
@@ -1,0 +1,66 @@
+import argparse
+import sys
+
+import yaml
+from pydantic.error_wrappers import ValidationError
+
+from ._impl import (
+    get_tour_id_from_path,
+    load_tour_from_path,
+    tour_paths,
+)
+from ._schema import TourDetails
+
+DESCRIPTION = "Perform static validation of a tour."
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    args = _arg_parser().parse_args(argv)
+    target = args.target
+    validated = True
+    for tour_path in tour_paths(target):
+        tour_id = get_tour_id_from_path(tour_path)
+        message = None
+        tour = None
+        try:
+            tour = load_tour_from_path(tour_path)
+        except OSError:
+            message = f"Tour '{tour_id}' could not be loaded, error reading file."
+        except yaml.error.YAMLError:
+            message = f"Tour '{tour_id}' could not be loaded, error within file." " Please check your yaml syntax."
+        except TypeError:
+            message = (
+                f"Tour '{tour_id}' could not be loaded, error within file."
+                " Possibly spacing related. Please check your yaml syntax."
+            )
+        if tour:
+            try:
+                TourDetails(**tour)
+            except ValidationError as e:
+                message = f"Validation issue with tour data for '{tour_id}'. [{e}]"
+        if message:
+            validated = False
+            print(message)
+        else:
+            print(f"Tour {tour_id} statically validated!")
+    if not validated:
+        raise ValueError("One or more tours failed static validation.")
+
+
+def _arg_parser():
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument(
+        "target",
+        metavar="TARGET",
+        nargs="?",
+        help="tour or directories of tours to validate",
+        default="config/plugins/tours",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_tours.sh
+++ b/scripts/validate_tours.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"/..
+
+GALAXY_VIRTUAL_ENV="${GALAXY_VIRTUAL_ENV:-.venv}"
+if [ -d "$GALAXY_VIRTUAL_ENV" ]; then
+    printf "Activating virtualenv at $GALAXY_VIRTUAL_ENV\n"
+    . "$GALAXY_VIRTUAL_ENV/bin/activate"
+fi
+
+PYTHONPATH=lib:$PYTHONPATH
+export PYTHONPATH
+
+python -c "import galaxy.tours.validate; galaxy.tours.validate.main()" $*


### PR DESCRIPTION
I have two cool workflow tours, more validation that builds on this, etc.. but it all fell apart on the page reloads when using workflows. I'll revisit after progress toward single page app. This part seems ok for now though.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. ``bash scripts/validate_tours.sh``
  2. Verify it all passes.
  3. Break a tour in config/plugins/tours
  4. ``bash scripts/validate_tours.sh``
  5. Checkout error message.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
