### PR TITLE
Fix the swift integration tests that are using some minio container

### DIFF
--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -40,7 +40,7 @@ def start_minio(container_name):
         "--rm",
         "minio/minio:latest",
         "server",
-        "/tmp/data",
+        "/data",
     ]
     subprocess.check_call(minio_start_args)
 


### PR DESCRIPTION
The minio container yields an error with /tmp/data. Maybe that fixes the integration tests?

```
bag@bag:~$ docker run -p 9000:9000 -i -t  minio/minio:latest server /tmp/data
Formatting 1st pool, 1 set(s), 1 drives per set.

API: SYSTEM()
Time: 09:05:06 UTC 06/03/2022
Error: Disk `/tmp/data` is part of root disk, will not be used (*errors.errorString)
       8: internal/logger/logger.go:278:logger.LogIf()
       7: cmd/erasure-sets.go:1243:cmd.markRootDisksAsDown()
       6: cmd/format-erasure.go:798:cmd.initFormatErasure()
       5: cmd/prepare-storage.go:198:cmd.connectLoadInitFormats()
       4: cmd/prepare-storage.go:282:cmd.waitForFormatErasure()
       3: cmd/erasure-server-pool.go:66:cmd.newErasureServerPools()
       2: cmd/server-main.go:668:cmd.newObjectLayer()
       1: cmd/server-main.go:518:cmd.serverMain()
Formatting 1st pool, 1 set(s), 1 drives per set.
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
