### PR TITLE
Only set job state if state is not None

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1351,7 +1351,8 @@ class BaseDirectoryImportModelStore(ModelImportStore):
         raw_state = job_attrs.get("state")
         if force_terminal and raw_state and raw_state not in model.Job.terminal_states:
             raw_state = model.Job.states.ERROR
-        imported_job.set_state(raw_state)
+        if raw_state:
+            imported_job.set_state(raw_state)
 
     def _read_list_if_exists(self, file_name, required=False):
         file_name = os.path.join(self.archive_dir, file_name)


### PR DESCRIPTION
Should fix the occasional error, as in
```
def get_state():
        response = state_func()
        assert response.status_code == 200, f"Failed to fetch state update while waiting. [{response.content}]"
        state_response = response.json()
        state = state_response["state"]
        if state in skip_states:
            return None
        else:
            if assert_ok:
>               assert state in ok_states, f"Final state - {state} - not okay. Full response: {state_response}"
E               AssertionError: Final state - None - not okay. Full response: {'model_class': 'Job', 'id': 'f3f73e481f432006', 'state': None, 'exit_code': 0, 'update_time': '2022-06-03T09:26:55.724962', 'create_time': '2022-06-03T09:26:49.352078', 'galaxy_version': '22.05', 'command_version': None, 'tool_id': '__DATA_FETCH__', 'history_id': '529fd61ab1c6cc36', 'params': {'request_version': '"1"', 'request_json': '"{\\"targets\\": [{\\"destination\\": {\\"type\\": \\"hdca\\", \\"object_id\\": 1}, \\"collection_type\\": \\"list:paired\\", \\"name\\": \\"Test Dataset Collection\\", \\"elements\\": [{\\"name\\": \\"test0\\", \\"elements\\": [{\\"name\\": \\"forward\\", \\"src\\": \\"pasted\\", \\"paste_content\\": \\"TestData123\\", \\"hashes\\": [], \\"purge_source\\": false}, {\\"name\\": \\"reverse\\", \\"src\\": \\"pasted\\", \\"paste_content\\": \\"TestData123\\", \\"hashes\\": [], \\"purge_source\\": false}]}]}], \\"check_content\\": true}"', 'file_count': '"0"', 'files': '[]', 'paramfile': 'null'}, 'inputs': {}, 'outputs': {'__new_primary_file_unnamed output|test0:forward__': {'id': 'd9abeb98649a6a7e', 'src': 'hda', 'uuid': 'f0c314e8-98e4-4[622](https://github.com/galaxyproject/galaxy/runs/6723181056?check_suite_focus=true#step:15:623)-9a37-0e81bb9aa268'}, '__new_primary_file_unnamed output|test0:reverse__': {'id': 'f3f73e481f432006', 'src': 'hda', 'uuid': '5ccdc60f-2435-4c19-8da5-b73bead05fef'}}, 'output_collections': {'output0': {'id': 'adb5f5c93f827949', 'src': 'hdca'}}, 'command_line': "python '/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/tools/data_fetch.py' --galaxy-root '/home/runner/work/galaxy/galaxy/galaxy root' --datatypes-registry '/tmp/tmpsg5fixj6/tmph52birz6/tmplbz0dfqz/database/job_working_directory_yyo9a66e/000/4/registry.xml' --request-version '1' --request '/tmp/tmpsg5fixj6/tmph52birz6/tmplbz0dfqz/database/job_working_directory_yyo9a66e/000/4/configs/tmpsr_k_m1m'", 'tool_stdout': '', 'tool_stderr': '', 'job_stdout': '', 'job_stderr': '', 'stderr': '', 'stdout': '', 'job_messages': [], 'dependencies': []}
```

Not sure how this can happen, but we should never be setting the state to None.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
