### PR TITLE
Fix jest test warnings for saved rules and markdown test

### DIFF
--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.test.js
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.test.js
@@ -75,7 +75,7 @@ describe("History Text Dataset Display", () => {
 
     it("should render header with embedded true", async () => {
         expect(wrapper.find(".card-header").exists()).toBe(true);
-        await wrapper.setData({ embedded: true });
+        await wrapper.setProps({ embedded: true });
         expect(wrapper.find(".card-header").exists()).toBe(false);
     });
 

--- a/client/src/components/RuleBuilder/SavedRulesSelector.test.js
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.test.js
@@ -48,9 +48,10 @@ describe("SavedRulesSelector", () => {
             ],
         };
         const ruleHeaders = ["A"];
+        const dateTime = new Date().toISOString();
         await wrapper.setProps({
             user: "test_user",
-            savedRules: [{ rule: JSON.stringify(testRules) }],
+            savedRules: [{ dateTime: dateTime, rule: JSON.stringify(testRules) }],
             ruleColHeaders: [ruleHeaders],
         });
         const sessions = wrapper.findAll("div.dropdown-menu > a.saved-rule-item");

--- a/client/src/components/RuleBuilder/SavedRulesSelector.vue
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.vue
@@ -10,7 +10,7 @@
         <div class="dropdown-menu" role="menu">
             <a
                 v-for="(session, index) in sortSavedRules"
-                :key="session.dateTime"
+                :key="index"
                 v-b-tooltip.hover.right
                 class="rule-link dropdown-item saved-rule-item"
                 :title="formatPreview(session.rule, index)"


### PR DESCRIPTION
Minor fix for two jest test cases which currently throw console errors when running `make client-watch`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
