### PR TITLE
[21.09] Add missing webapp to webapp package

### DIFF
--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -131,7 +131,7 @@ class BooleanExpressionEvaluator:
         action.evaluator = evaluator
         boolOperand = TRUE | FALSE | Word(token_format or DEFAULT_TOKEN_FORMAT)
         boolOperand.setParseAction(action)
-        self.boolExpr = infixNotation(
+        self.boolExpr: ParserElement = infixNotation(
             boolOperand,
             [
                 (NOT_OP, 1, opAssoc.RIGHT, BoolNot),

--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -14,7 +14,6 @@ from typing import (
 from pyparsing import (
     alphanums,
     CaselessKeyword,
-    Forward,
     infixNotation,
     Keyword,
     opAssoc,
@@ -132,7 +131,7 @@ class BooleanExpressionEvaluator:
         action.evaluator = evaluator
         boolOperand = TRUE | FALSE | Word(token_format or DEFAULT_TOKEN_FORMAT)
         boolOperand.setParseAction(action)
-        self.boolExpr: Forward = infixNotation(
+        self.boolExpr = infixNotation(
             boolOperand,
             [
                 (NOT_OP, 1, opAssoc.RIGHT, BoolNot),

--- a/packages/app/requirements.txt
+++ b/packages/app/requirements.txt
@@ -19,4 +19,4 @@ refgenconf>=0.7.0,<0.10.0 # https://github.com/galaxyproject/galaxy/issues/11601
 Fabric3
 lagom
 fs
-whoosh
+Whoosh

--- a/packages/app/requirements.txt
+++ b/packages/app/requirements.txt
@@ -19,3 +19,4 @@ refgenconf>=0.7.0,<0.10.0 # https://github.com/galaxyproject/galaxy/issues/11601
 Fabric3
 lagom
 fs
+whoosh

--- a/packages/app/setup.py
+++ b/packages/app/setup.py
@@ -56,6 +56,7 @@ PACKAGES = [
     'galaxy.tools.data',
     'galaxy.tools.data_manager',
     'galaxy.tools.error_reports',
+    'galaxy.tools.error_reports.plugins',
     'galaxy.tools.expressions',
     'galaxy.tools.filters',
     'galaxy.tools.imp_exp',

--- a/packages/webapps/setup.py
+++ b/packages/webapps/setup.py
@@ -50,6 +50,7 @@ PACKAGES = [
     'tool_shed.tools',
     'tool_shed.util',
     'tool_shed.utility_containers',
+    'tool_shed.webapp',
     'tool_shed.webapp.api',
     'tool_shed.webapp.controllers',
     'tool_shed.webapp.framework',

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -38,10 +38,11 @@ def start_minio(container_name):
         '-d',
         '--name',
         container_name,
-        '--rm',
-        'minio/minio:latest',
-        'server',
-        '/tmp/data']
+        "--rm",
+        "minio/minio:latest",
+        "server",
+        "/data",
+    ]
     subprocess.check_call(minio_start_args)
 
 


### PR DESCRIPTION
The tool_shed.webapp module is missing, and therefore, it's not possible to import and use the IntegrationTestCase from the galaxy test driver, which tries to instantiate the UniverseApplication from the toolshed.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
