### PR TITLE
[21.09] Fix missing biotools package

### DIFF
--- a/packages/tool_util/setup.py
+++ b/packages/tool_util/setup.py
@@ -31,6 +31,7 @@ TEST_DIR = 'tests'
 PACKAGES = [
     'galaxy',
     'galaxy.tool_util',
+    'galaxy.tool_util.biotools',
     'galaxy.tool_util.client',
     'galaxy.tool_util.cwl',
     'galaxy.tool_util.deps',


### PR DESCRIPTION
I had missed this in my last PR.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
