### PR TITLE
Support phylocanvas autobuild

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -27,6 +27,7 @@ const STATIC_PLUGIN_BUILD_IDS = [
     "openlayers",
     "openseadragon",
     "PCA_3Dplot",
+    "phylocanvas",
     "pv",
     "nora",
     "venn",


### PR DESCRIPTION
Script source was modified in https://github.com/galaxyproject/galaxy/commit/43e80d1fcf2a0dd88ba84b944acb8eb84e5ba944#diff-c229ddee85f39b240685419b1135baa89e10fa68f3896bafc67bc84664378992L1 and the artifacts were dropped, but it was never added to autobuild.

This is causing it to currently fail on new or updated Galaxy installs.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Upload a newick file and visualize it.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
