### PR TITLE
Interactivetool doc/sample tweaks.

### DIFF
--- a/config/galaxy.yml.interactivetools
+++ b/config/galaxy.yml.interactivetools
@@ -1,7 +1,7 @@
 gravity:
   gx_it_proxy:
     enable: true
-    proxy_port: 4002
+    port: 4002
 galaxy:
   interactivetools_enable: true
   # outputs_to_working_directory will provide you with a better level of isolation. It is highly recommended to set

--- a/doc/source/admin/special_topics/interactivetools.rst
+++ b/doc/source/admin/special_topics/interactivetools.rst
@@ -65,7 +65,7 @@ Set these values in `galaxy.yml`:
           # ...
           gx_it_proxy:
             enable: true
-            proxy_port: 4002
+            port: 4002
         galaxy:
           # ...
           interactivetools_enable: true

--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -128,7 +128,8 @@
     <tool file="phenotype_association/ldtools.xml" />
     <tool file="phenotype_association/master2pg.xml" />
   </section>
-  <!--section id="interactivetools" name="Interactive tools">
+  <!--
+  <section id="interactivetools" name="Interactive tools">
     <tool file="interactive/codingSnps.xml" />
     <tool file="interactive/interactivetool_askomics.xml" />
     <tool file="interactive/interactivetool_bam_iobio.xml" />
@@ -138,5 +139,6 @@
     <tool file="interactive/interactivetool_jupyter_notebook.xml" />
     <tool file="interactive/interactivetool_neo4j.xml" />
     <tool file="interactive/interactivetool_phinch.xml" />
-  </section-->
+  </section>
+  -->
 </toolbox>


### PR DESCRIPTION
In the `galaxy.yml.sample` file the `gx_it_proxy` port is referred to as simply `port`, but in the minimal config sample it is referred to as `proxy_port`.  If it *should* be `proxy_port`, then we should fix `galaxy.yml.sample` instead of this PR.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
