### PR TITLE
Remove fabric as a dependency for Galaxy.

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -61,7 +61,6 @@ docopt==0.6.2
 docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 ecdsa==0.17.0; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 edam-ontology==1.25.2
-fabric3==1.14.post1
 fastapi-utils==0.2.1; python_version >= "3.6" and python_version < "4.0"
 fastapi==0.78.0; python_full_version >= "3.6.1"
 fluent-logger==0.10.0; python_version >= "3.5"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -51,7 +51,6 @@ docopt==0.6.2
 docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 ecdsa==0.17.0; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 edam-ontology==1.25.2
-fabric3==1.14.post1
 fastapi-utils==0.2.1; python_version >= "3.6" and python_version < "4.0"
 fastapi==0.78.0; python_full_version >= "3.6.1"
 fs==2.4.16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ cwltool = "==3.1.20211107152837"
 dictobj = "*"
 docutils = "!=0.17, !=0.17.1"
 edam-ontology = "*"
-Fabric3 = "*"
 fastapi = ">=0.68.2, !=0.69.0, !=0.70.0, !=0.70.1"  # https://github.com/tiangolo/fastapi/issues/4041
 fastapi-utils = "*"
 fs = "*"


### PR DESCRIPTION
No longer needed after galaxy_install package was removed.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. I mean if none of the tests fail... it must be fine right? 😆 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
