### PR TITLE
Update color scheme collection progress bar

### DIFF
--- a/client/src/components/History/Content/Collection/CollectionProgress.test.js
+++ b/client/src/components/History/Content/Collection/CollectionProgress.test.js
@@ -18,7 +18,7 @@ describe("CollectionProgress", () => {
             localVue,
         });
         await wrapper.vm.$nextTick();
-        expect(wrapper.find(".progress").find(".progress-bar-striped").text()).toBe("3");
+        expect(wrapper.find(".progress").find(".bg-warning").text()).toBe("3");
     });
 
     it("should correctly display states", async () => {
@@ -31,7 +31,7 @@ describe("CollectionProgress", () => {
             localVue,
         });
         await wrapper.vm.$nextTick();
-        expect(wrapper.find(".progress").find(".progress-bar-striped").text()).toBe("3");
+        expect(wrapper.find(".progress").find(".bg-warning").text()).toBe("3");
         expect(wrapper.find(".progress").find(".bg-success").text()).toBe("1");
         expect(wrapper.find(".progress").find(".bg-danger").text()).toBe("1");
     });
@@ -46,13 +46,13 @@ describe("CollectionProgress", () => {
             localVue,
         });
         await wrapper.vm.$nextTick();
-        expect(wrapper.find(".progress").find(".progress-bar-striped").text()).toBe("3");
+        expect(wrapper.find(".progress").find(".bg-warning").text()).toBe("3");
         dsc["job_state_summary"]["ok"] = 2;
         dsc["job_state_summary"]["running"] = 1;
         jobStateSummary = new JobStateSummary(dsc);
         await wrapper.setProps({ summary: jobStateSummary });
         await wrapper.vm.$nextTick();
-        expect(wrapper.find(".progress").find(".progress-bar-striped").text()).toBe("1");
+        expect(wrapper.find(".progress").find(".bg-warning").text()).toBe("1");
         expect(wrapper.find(".progress").find(".bg-success").text()).toBe("2");
     });
 });

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -44,4 +44,3 @@ export default {
     },
 };
 </script>
-

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -2,7 +2,7 @@
 at components/JobStates/CollectionJobStates but it relies on the backbone data
 model, so probably has to go eventually.-->
 <template>
-    <div>
+    <div class="collection-progress">
         <b-progress v-if="maxJobs && runningJobs" :max="maxJobs" height="1em" show-value>
             <b-progress-bar v-if="errorJobs" :value="errorJobs" variant="danger"></b-progress-bar>
             <b-progress-bar v-if="okJobs" :value="okJobs" variant="success"></b-progress-bar>
@@ -45,20 +45,3 @@ export default {
 };
 </script>
 
-<style scoped>
-.progress {
-    border: 1px solid black;
-}
-.progress > .bg-success {
-    color: #38504a;
-}
-.progress > .bg-danger {
-    color: #512c3c;
-}
-.progress > .bg-warning {
-    color: #564136;
-}
-.progress > .bg-secondary {
-    color: #2c3143;
-}
-</style>

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -3,11 +3,11 @@ at components/JobStates/CollectionJobStates but it relies on the backbone data
 model, so probably has to go eventually.-->
 <template>
     <div class="collection-progress">
-        <b-progress v-if="maxJobs && runningJobs" :max="maxJobs" height="1em" show-value>
-            <b-progress-bar v-if="errorJobs" :value="errorJobs" variant="danger"></b-progress-bar>
-            <b-progress-bar v-if="okJobs" :value="okJobs" variant="success"></b-progress-bar>
-            <b-progress-bar v-if="runningJobs" :value="runningJobs" variant="warning"></b-progress-bar>
-            <b-progress-bar v-if="waitingJobs" :value="waitingJobs" variant="secondary"></b-progress-bar>
+        <b-progress v-if="maxJobs && runningJobs" :max="maxJobs" show-value>
+            <b-progress-bar v-if="errorJobs" :value="errorJobs" variant="danger" />
+            <b-progress-bar v-if="okJobs" :value="okJobs" variant="success" />
+            <b-progress-bar v-if="runningJobs" :value="runningJobs" variant="warning" />
+            <b-progress-bar v-if="waitingJobs" :value="waitingJobs" variant="secondary" />
         </b-progress>
     </div>
 </template>
@@ -19,9 +19,6 @@ export default {
         summary: { type: JobStateSummary, required: true },
     },
     computed: {
-        hasRunningJobs() {
-            return this.summary && this.summary.get("running") > 0;
-        },
         maxJobs() {
             return this.summary.get("all_jobs");
         },

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -6,8 +6,8 @@ model, so probably has to go eventually.-->
         <b-progress v-if="maxJobs && runningJobs" :max="maxJobs" height="1em" show-value>
             <b-progress-bar v-if="errorJobs" :value="errorJobs" variant="danger"></b-progress-bar>
             <b-progress-bar v-if="okJobs" :value="okJobs" variant="success"></b-progress-bar>
-            <b-progress-bar v-if="runningJobs" :value="runningJobs" variant="info" animated></b-progress-bar>
-            <b-progress-bar v-if="waitingJobs" :value="waitingJobs" variant="dark" animated></b-progress-bar>
+            <b-progress-bar v-if="runningJobs" :value="runningJobs" variant="warning"></b-progress-bar>
+            <b-progress-bar v-if="waitingJobs" :value="waitingJobs" variant="secondary"></b-progress-bar>
         </b-progress>
     </div>
 </template>
@@ -46,13 +46,19 @@ export default {
 </script>
 
 <style scoped>
-.progress-bar {
+.progress {
     border: 1px solid black;
 }
 .progress > .bg-success {
-    color: black;
+    color: #38504a;
 }
 .progress > .bg-danger {
-    color: black;
+    color: #512c3c;
+}
+.progress > .bg-warning {
+    color: #564136;
+}
+.progress > .bg-secondary {
+    color: #2c3143;
 }
 </style>

--- a/client/src/style/scss/collection.scss
+++ b/client/src/style/scss/collection.scss
@@ -50,3 +50,21 @@
         overflow-y: auto;
     }
 }
+
+.collection-progress {
+    .progress  {
+        border: 1px solid black;
+        .bg-success {
+            color: $state-success-text;
+        }
+        .bg-danger {
+            color: $state-danger-text;
+        }
+        .bg-warning {
+            color: $state-warning-text;
+        }
+        .bg-secondary {
+            color: $state-secondary-text;
+        }
+    }
+}

--- a/client/src/style/scss/collection.scss
+++ b/client/src/style/scss/collection.scss
@@ -53,7 +53,8 @@
 
 .collection-progress {
     .progress {
-        border: 1px solid black;
+        border: $border-default;
+        border-color: $brand-primary;
         .bg-success {
             color: $state-success-text;
         }

--- a/client/src/style/scss/collection.scss
+++ b/client/src/style/scss/collection.scss
@@ -52,7 +52,7 @@
 }
 
 .collection-progress {
-    .progress  {
+    .progress {
         border: 1px solid black;
         .bg-success {
             color: $state-success-text;

--- a/client/src/style/scss/collection.scss
+++ b/client/src/style/scss/collection.scss
@@ -54,18 +54,9 @@
 .collection-progress {
     .progress {
         border: $border-default;
-        border-color: $brand-primary;
-        .bg-success {
-            color: $state-success-text;
-        }
-        .bg-danger {
-            color: $state-danger-text;
-        }
-        .bg-warning {
-            color: $state-warning-text;
-        }
-        .bg-secondary {
-            color: $state-secondary-text;
+        border-color: $text-muted;
+        .progress-bar {
+            color: $text-muted;
         }
     }
 }

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -79,8 +79,6 @@ $state-success-text: theme-color-level("success", $alert-color-level);
 $state-success-bg: theme-color-level("success", $alert-bg-level);
 $state-success-border: theme-color-level("success", $alert-border-level);
 
-$state-secondary-text: theme-color-level("secondary", $alert-color-level);
-
 // Fonts and sizes
 $font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -79,7 +79,7 @@ $state-success-text: theme-color-level("success", $alert-color-level);
 $state-success-bg: theme-color-level("success", $alert-bg-level);
 $state-success-border: theme-color-level("success", $alert-border-level);
 
-$state-secondary-text: theme-color-level("secondary",$alert-color-level);
+$state-secondary-text: theme-color-level("secondary", $alert-color-level);
 
 // Fonts and sizes
 $font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif,

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -79,6 +79,8 @@ $state-success-text: theme-color-level("success", $alert-color-level);
 $state-success-bg: theme-color-level("success", $alert-bg-level);
 $state-success-border: theme-color-level("success", $alert-border-level);
 
+$state-secondary-text: theme-color-level("secondary",$alert-color-level);
+
 // Fonts and sizes
 $font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";


### PR DESCRIPTION
Changing color scheme to more closely match Galaxy's colors
![Screenshot from 2022-06-07 18-49-03](https://user-images.githubusercontent.com/26912553/172496304-703fcc1e-8a56-40e1-9aeb-4d05c2d45624.png)

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Run a slower tool over a collection, such as "Concatenate datasets (with sleep)" and/or choose a large collection
  2. View the collection progress bar

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
