### PR TITLE
Add tour requirements.

### DIFF
--- a/client/src/components/Tour/runTour.js
+++ b/client/src/components/Tour/runTour.js
@@ -121,5 +121,6 @@ export async function runTour(tourId, tourData = null) {
             },
         });
     });
-    return mountTour({ steps });
+    const requirements = tourData.requirements || [];
+    return mountTour({ steps, requirements });
 }

--- a/lib/galaxy/tours/_schema.py
+++ b/lib/galaxy/tours/_schema.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import (
     List,
     Optional,
@@ -10,10 +11,22 @@ from pydantic import (
 )
 
 
+class Requirement(str, Enum):
+    """Available types of job sources (model classes) that produce dataset collections."""
+
+    LOGGED_IN = "logged_in"
+    NEW_HISTORY = "new_history"
+    ADMIN = "admin"
+
+
 class TourCore(BaseModel):
     name: str = Field(title="Name", description="Name of tour")
     description: str = Field(title="Description", description="Tour description")
     tags: List[str] = Field(title="Tags", description="Topic topic tags")
+    requirements: List[Requirement] = Field(title="Requirements", description="Requirements to run the tour.")
+
+    class Config:
+        use_enum_values = True  # when using .dict()
 
 
 class Tour(TourCore):


### PR DESCRIPTION
Allow tours to annotate they need a logged in user, admin user, or new history.

I've noticed the existing tours sort of break down when not given a new history and it would be nice to declare tours require one to be logged in (for workflow tours) and admin (for admin tutorials).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
