### PR TITLE
Fix bug: set creation_date on dataset.metadata, not dataset

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1206,7 +1206,7 @@ class Loom(H5):
                     if isinstance(loom_spec_version, bytes):
                         loom_spec_version = loom_spec_version.decode()
                 dataset.metadata.loom_spec_version = loom_spec_version
-                dataset.creation_date = loom_file.attrs.get("creation_date")
+                dataset.metadata.creation_date = loom_file.attrs.get("creation_date")
                 dataset.metadata.shape = tuple(loom_file["matrix"].shape)
 
                 tmp = list(loom_file.get("layers", {}).keys())
@@ -1343,7 +1343,7 @@ class Anndata(H5):
             dataset.metadata.description = anndata_file.attrs.get("description")
             dataset.metadata.url = anndata_file.attrs.get("url")
             dataset.metadata.doi = anndata_file.attrs.get("doi")
-            dataset.creation_date = anndata_file.attrs.get("creation_date")
+            dataset.metadata.creation_date = anndata_file.attrs.get("creation_date")
             dataset.metadata.shape = anndata_file.attrs.get("shape", dataset.metadata.shape)
             # none of the above appear to work in any dataset tested, but could be useful for
             # future AnnData datasets


### PR DESCRIPTION
This is obviously a bug: `creation_date` is a `MetadataElement`, not an attribute of a `DatasetInstance`.

Note: this was discovered as part of #14007, but it seems critical enough to be placed in a separate PR.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
