### PR TITLE
Enable change datatype in bulk

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/OperationErrorDialog.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/OperationErrorDialog.vue
@@ -54,6 +54,10 @@ export default {
             if (this.operationError && this.operationError.result) {
                 return [...new Set(this.operationError.result.errors.map((e) => e.error))];
             }
+            const response_error = this.operationError?.errorMessage?.response?.data?.err_msg;
+            if (response_error) {
+                return [response_error];
+            }
             return [];
         },
         errorMessage() {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -47,9 +47,9 @@
             <b-dropdown-item v-b-modal:change-dbkey-of-selected-content data-description="change database build">
                 <span v-localize>Change Database/Build</span>
             </b-dropdown-item>
-            <!-- <b-dropdown-item v-b-modal:change-datatype-of-selected-content data-description="change data type">
+            <b-dropdown-item v-b-modal:change-datatype-of-selected-content data-description="change data type">
                 <span v-localize>Change data type</span>
-            </b-dropdown-item> -->
+            </b-dropdown-item>
             <b-dropdown-item v-b-modal:add-tags-to-selected-content data-description="add tags">
                 <span v-localize>Add tags</span>
             </b-dropdown-item>

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -128,11 +128,7 @@ def set_metadata(
 ):
     dataset_instance = _get_dataset_by_id(hda_manager, ldda_manager, dataset_id, model_class)
     if overwrite:
-        for name, spec in dataset_instance.metadata.spec.items():
-            # We need to be careful about the attributes we are resetting
-            if name not in ["name", "info", "dbkey", "base_name"]:
-                if spec.get("default"):
-                    setattr(dataset_instance.metadata, name, spec.unwrap(spec.get("default")))
+        hda_manager.overwrite_metadata(dataset_instance)
     try:
         dataset_instance.datatype.set_meta(dataset_instance)
         dataset_instance.set_peek()

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -121,6 +121,7 @@ def set_metadata(
                 if spec.get("default"):
                     setattr(dataset.metadata, name, spec.unwrap(spec.get("default")))
     dataset.datatype.set_meta(dataset)
+    dataset.set_peek()
     sa_session.flush()
 
 

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -120,8 +120,13 @@ def set_metadata(
             if name not in ["name", "info", "dbkey", "base_name"]:
                 if spec.get("default"):
                     setattr(dataset.metadata, name, spec.unwrap(spec.get("default")))
-    dataset.datatype.set_meta(dataset)
-    dataset.set_peek()
+    try:
+        dataset.datatype.set_meta(dataset)
+        dataset.set_peek()
+        dataset.dataset.state = dataset.dataset.states.OK
+    except Exception:
+        log.info(f"Setting metadata failed on {model_class} {dataset.id}: {str(e)}")
+        dataset.dataset.state = dataset.dataset.states.FAILED_METADATA
     sa_session.flush()
 
 

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -100,13 +100,18 @@ def set_job_metadata(
 
 @galaxy_task(action="set dataset association metadata")
 def set_metadata(
-    hda_manager: HDAManager, ldda_manager: LDDAManager, dataset_id, model_class="HistoryDatasetAssociation"
+    hda_manager: HDAManager,
+    ldda_manager: LDDAManager,
+    sa_session: galaxy_scoped_session,
+    dataset_id,
+    model_class="HistoryDatasetAssociation",
 ):
     if model_class == "HistoryDatasetAssociation":
         dataset = hda_manager.by_id(dataset_id)
     elif model_class == "LibraryDatasetDatasetAssociation":
         dataset = ldda_manager.by_id(dataset_id)
     dataset.datatype.set_meta(dataset)
+    sa_session.flush()
 
 
 @galaxy_task(bind=True)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -99,7 +99,7 @@ def set_job_metadata(
     )
 
 
-@galaxy_task(action="set or detect dataset datatype")
+@galaxy_task(action="set or detect dataset datatype and updates metadata")
 def change_datatype(
     hda_manager: HDAManager,
     ldda_manager: LDDAManager,
@@ -115,6 +115,7 @@ def change_datatype(
         datatype = sniff.guess_ext(path, datatypes_registry.sniff_order)
     datatypes_registry.change_datatype(dataset_instance, datatype)
     sa_session.flush()
+    set_metadata(hda_manager, ldda_manager, sa_session, dataset_id, model_class)
 
 
 @galaxy_task(action="set dataset association metadata")
@@ -127,9 +128,9 @@ def set_metadata(
     overwrite: bool = True,
 ):
     dataset_instance = _get_dataset_by_id(hda_manager, ldda_manager, dataset_id, model_class)
-    if overwrite:
-        hda_manager.overwrite_metadata(dataset_instance)
     try:
+        if overwrite:
+            hda_manager.overwrite_metadata(dataset_instance)
         dataset_instance.datatype.set_meta(dataset_instance)
         dataset_instance.set_peek()
         dataset_instance.dataset.state = dataset_instance.dataset.states.OK

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -827,7 +827,7 @@ class HistoryContentItemOperation(str, Enum):
     delete = "delete"
     undelete = "undelete"
     purge = "purge"
-    # change_datatype = "change_datatype"
+    change_datatype = "change_datatype"
     change_dbkey = "change_dbkey"
     add_tags = "add_tags"
     remove_tags = "remove_tags"

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -29,7 +29,6 @@ from galaxy.celery.tasks import materialize as materialize_task
 from galaxy.celery.tasks import (
     prepare_dataset_collection_download,
     prepare_history_content_download,
-    set_metadata,
     write_history_content_to,
 )
 from galaxy.managers import (
@@ -1615,10 +1614,7 @@ class HistoryItemOperator:
             self.hda_manager.ensure_can_change_datatype(item)
             self.hda_manager.ensure_can_set_metadata(item)
             item.dataset.state = item.dataset.states.SETTING_METADATA
-            # Chain tasks using immutable signature to avoid messing with dependency injection
-            change_datatype_task = change_datatype.si(dataset_id=item.id, datatype=params.datatype)
-            set_metadata_task = set_metadata.si(dataset_id=item.id)
-            (change_datatype_task | set_metadata_task).delay()
+            change_datatype.delay(dataset_id=item.id, datatype=params.datatype)
 
     def _change_dbkey(self, item: HistoryItemModel, params: ChangeDbkeyOperationParams):
         if isinstance(item, HistoryDatasetAssociation):

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1555,9 +1555,9 @@ class HistoryItemOperator:
             HistoryContentItemOperation.delete: lambda item, params, trans: self._delete(item),
             HistoryContentItemOperation.undelete: lambda item, params, trans: self._undelete(item),
             HistoryContentItemOperation.purge: lambda item, params, trans: self._purge(item, trans),
-            # HistoryContentItemOperation.change_datatype: lambda item, params, trans: self._change_datatype(
-            #     item, params
-            # ),
+            HistoryContentItemOperation.change_datatype: lambda item, params, trans: self._change_datatype(
+                item, params
+            ),
             HistoryContentItemOperation.change_dbkey: lambda item, params, trans: self._change_dbkey(item, params),
             HistoryContentItemOperation.add_tags: lambda item, params, trans: self._add_tags(item, trans.user, params),
             HistoryContentItemOperation.remove_tags: lambda item, params, trans: self._remove_tags(

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1615,6 +1615,7 @@ class HistoryItemOperator:
     ):
         if isinstance(item, HistoryDatasetAssociation):
             self._ensure_can_change_hda_datatype(item)
+            item.dataset.state = item.dataset.states.SETTING_METADATA
             self._set_hda_datatype(item, params.datatype, trans)
             set_metadata.delay(dataset_id=item.id)
 

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1616,7 +1616,7 @@ class HistoryItemOperator:
             if params.datatype == "auto":  # Trigger job to auto-detect datatype
                 self.hda_manager.set_metadata(trans, item, overwrite=True)
             else:
-                set_metadata.delay(self.hda_manager, None, dataset_id=item.id)
+                set_metadata.delay(dataset_id=item.id)
 
     def _change_dbkey(self, item: HistoryItemModel, params: ChangeDbkeyOperationParams):
         if isinstance(item, HistoryDatasetAssociation):

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1253,6 +1253,10 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             }
             bulk_operation_result = self._apply_bulk_operation(history_id, payload)
             self._assert_bulk_success(bulk_operation_result, expected_success_count=num_datasets)
+
+            # Wait for celery tasks to finish
+            self.dataset_populator.wait_for_history(history_id)
+
             history_contents = self._get_history_contents(history_id, query="?v=dev&keys=extension,data_type,metadata")
             for item in history_contents:
                 assert item["extension"] == "tabular"
@@ -1327,6 +1331,10 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             }
             bulk_operation_result = self._apply_bulk_operation(history_id, payload)
             self._assert_bulk_success(bulk_operation_result, expected_success_count=len(dataset_ids))
+
+            # Wait for celery tasks to finish
+            self.dataset_populator.wait_for_history(history_id)
+
             history_contents = self._get_history_contents(history_id, query="?v=dev&keys=extension,data_type,metadata")
             # Should be detected as `tabular` and set the metadata correctly
             for item in history_contents:


### PR DESCRIPTION
Closes #14033

This enables back the `Change datatype` bulk operation and tries to set the metadata for each dataset when doing so.

## TODO
- [x] Add API tests
- [x] Regenerate metadata in the *correct way*

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
