### PR TITLE
[WIP] Implement abstractions to annotate non-sharable datasets & objectstores.

### DIFF
--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.test.js
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.test.js
@@ -10,14 +10,17 @@ const localVue = getLocalVue();
 
 const TEST_STORAGE_API_RESPONSE_WITHOUT_ID = {
     object_store_id: null,
+    private: false,
 };
 const TEST_STORAGE_API_RESPONSE_WITH_ID = {
     object_store_id: "foobar",
+    private: false,
 };
 const TEST_STORAGE_API_RESPONSE_WITH_NAME = {
     object_store_id: "foobar",
     name: "my cool storage",
     description: "My cool **markdown**",
+    private: true,
 };
 const TEST_DATASET_ID = "1";
 const TEST_STORAGE_URL = `/api/datasets/${TEST_DATASET_ID}/storage`;
@@ -46,9 +49,6 @@ describe("Dataset Storage", () => {
         wrapper = shallowMount(DatasetStorage, {
             propsData: { datasetId: TEST_DATASET_ID },
             localVue,
-            stubs: {
-                "loading-span": true,
-            },
         });
     }
 
@@ -102,6 +102,7 @@ describe("Dataset Storage", () => {
         expect(byIdSpan.length).toBe(1);
         const byNameSpan = wrapper.findAll(".display-os-by-name");
         expect(byNameSpan.length).toBe(0);
+        expect(wrapper.find("object-store-restriction-span-stub").props("isPrivate")).toBeFalsy();
     });
 
     it("test dataset storage with object store name", async () => {
@@ -116,6 +117,7 @@ describe("Dataset Storage", () => {
         expect(byIdSpan.length).toBe(0);
         const byNameSpan = wrapper.findAll(".display-os-by-name");
         expect(byNameSpan.length).toBe(1);
+        expect(wrapper.find("object-store-restriction-span-stub").props("isPrivate")).toBeTruthy();
     });
 
     afterEach(() => {

--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
@@ -18,13 +18,17 @@
         <div v-else>
             <p>
                 This dataset is stored in
-                <span v-if="storageInfo.name" class="display-os-by-name">
-                    a Galaxy object store named <b>{{ storageInfo.name }}</b>
+                <span class="display-os-by-name" v-if="storageInfo.name">
+                    a Galaxy <object-store-restriction-span :is-private="isPrivate" /> object store named
+                    <b>{{ storageInfo.name }}</b>
                 </span>
-                <span v-else-if="storageInfo.object_store_id" class="display-os-by-id">
-                    a Galaxy object store with id <b>{{ storageInfo.object_store_id }}</b>
+                <span class="display-os-by-id" v-else-if="storageInfo.object_store_id">
+                    a Galaxy <object-store-restriction-span :is-private="isPrivate" /> object store with id
+                    <b>{{ storageInfo.object_store_id }}</b>
                 </span>
-                <span v-else class="display-os-default"> the default configured Galaxy object store </span>.
+                <span class="display-os-default" v-else>
+                    the default configured Galaxy <object-store-restriction-span :is-private="isPrivate" /> object store </span
+                >.
             </p>
             <div v-html="descriptionRendered"></div>
         </div>
@@ -37,10 +41,12 @@ import { getAppRoot } from "onload/loadConfig";
 import LoadingSpan from "components/LoadingSpan";
 import MarkdownIt from "markdown-it";
 import { errorMessageAsString } from "utils/simple-error";
+import ObjectStoreRestrictionSpan from "./ObjectStoreRestrictionSpan";
 
 export default {
     components: {
         LoadingSpan,
+        ObjectStoreRestrictionSpan,
     },
     props: {
         datasetId: {
@@ -79,6 +85,9 @@ export default {
                 return null;
             }
             return rootSources[0].source_uri;
+        },
+        isPrivate() {
+            return this.storageInfo.private;
         },
     },
     created() {

--- a/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.test.js
+++ b/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.test.js
@@ -1,0 +1,27 @@
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import ObjectStoreRestrictionSpan from "./ObjectStoreRestrictionSpan";
+
+const localVue = getLocalVue();
+
+describe("ObjectStoreRestrictionSpan", () => {
+    let wrapper;
+
+    it("should render info about private storage if isPrivate", () => {
+        wrapper = shallowMount(ObjectStoreRestrictionSpan, {
+            propsData: { isPrivate: true },
+            localVue,
+        });
+        expect(wrapper.find(".stored-how").text()).toBe("private");
+        expect(wrapper.find(".stored-how").attributes("title")).toBeTruthy();
+    });
+
+    it("should render info about unrestricted storage if not isPrivate", () => {
+        wrapper = shallowMount(ObjectStoreRestrictionSpan, {
+            propsData: { isPrivate: false },
+            localVue,
+        });
+        expect(wrapper.find(".stored-how").text()).toBe("unrestricted");
+        expect(wrapper.find(".stored-how").attributes("title")).toBeTruthy();
+    });
+});

--- a/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.vue
+++ b/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.vue
@@ -1,0 +1,38 @@
+<template>
+    <span class="stored-how" v-b-tooltip.hover :title="title">{{ text }}</span>
+</template>
+
+<script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+Vue.use(BootstrapVue);
+
+export default {
+    props: {
+        isPrivate: {
+            // private is reserved word
+            type: Boolean,
+        },
+    },
+    computed: {
+        text() {
+            return this.isPrivate ? "private" : "unrestricted";
+        },
+        title() {
+            if (this.isPrivate) {
+                return "This dataset is stored on storage restricted to a single user. It can not be shared, pubished, or added to Galaxy data libraries.";
+            } else {
+                return "This dataset is stored on unrestricted storage. With sufficient Galaxy permissions, this dataset can be published, shared, or added to Galaxy data libraries.";
+            }
+        },
+    },
+};
+</script>
+
+<style scoped>
+/* Give visual indication of mouseover info */
+.stored-how {
+    text-decoration-line: underline;
+    text-decoration-style: dashed;
+}
+</style>

--- a/client/src/mvc/library/library-model.js
+++ b/client/src/mvc/library/library-model.js
@@ -174,7 +174,7 @@ var HistoryContents = Backbone.Collection.extend({
         this.id = options.id;
     },
     url: function () {
-        return `${this.urlRoot + this.id}/contents`;
+        return `${this.urlRoot + this.id}/contents?sharable=true`;
     },
     model: HistoryItem,
 });

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -341,7 +341,7 @@ class JobContext(BaseJobContext):
         trans.app.security_agent.copy_library_permissions(trans, ld, ldda)
         # Copy the current user's DefaultUserPermissions to the new LibraryDatasetDatasetAssociation.dataset
         trans.app.security_agent.set_all_dataset_permissions(
-            ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user)
+            ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user), flush=False, new=True
         )
         library_folder.add_library_dataset(ld, genome_build=ldda.dbkey)
         trans.sa_session.add(library_folder)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1584,6 +1584,8 @@ class MinimalJobWrapper(HasResourceParameters):
 
         object_store_populator = ObjectStorePopulator(self.app, job.user)
         object_store_id = self.get_destination_configuration("object_store_id", None)
+        require_sharable = job.requires_sharable_storage(self.app.security_agent)
+
         if object_store_id:
             object_store_populator.object_store_id = object_store_id
 
@@ -1595,7 +1597,7 @@ class MinimalJobWrapper(HasResourceParameters):
         # afterward. State below needs to happen the same way.
         for dataset_assoc in job.output_datasets + job.output_library_datasets:
             dataset = dataset_assoc.dataset
-            object_store_populator.set_object_store_id(dataset)
+            object_store_populator.set_object_store_id(dataset, require_sharable=require_sharable)
 
         job.object_store_id = object_store_populator.object_store_id
         self._setup_working_directory(job=job)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -172,6 +172,7 @@ JOB_METRIC_SCALE = 7
 # Tags that get automatically propagated from inputs to outputs when running jobs.
 AUTO_PROPAGATED_TAGS = ["name"]
 YIELD_PER_ROWS = 100
+CANNOT_SHARE_PRIVATE_DATASET_MESSAGE = "Attempting to share a non-sharable dataset."
 
 
 if TYPE_CHECKING:
@@ -1469,6 +1470,19 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             params_dict[name] = value
         job_attrs["params"] = params_dict
         return job_attrs
+
+    def requires_sharable_storage(self, security_agent):
+        # An easy optimization would be to calculate this in galaxy.tools.actions when the
+        # job is created and all the output permissions are already known. Having to reload
+        # these permissions in the job code shouldn't strictly be needed.
+
+        requires_sharing = False
+        for dataset_assoc in self.output_datasets + self.output_library_datasets:
+            if not security_agent.dataset_is_private_to_a_user(dataset_assoc.dataset.dataset):
+                requires_sharing = True
+                break
+
+        return requires_sharing
 
     def to_dict(self, view="collection", system_details=False):
         if view == "admin_job_list":
@@ -2979,7 +2993,14 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         visible = galaxy.util.string_as_bool_or_none(kwds.get("visible", None))
         if visible is not None:
             query = query.filter(content_class.visible == visible)
+        if "object_store_ids" in kwds:
+            if content_class == HistoryDatasetAssociation:
+                query = query.join(content_class.dataset).filter(
+                    Dataset.table.c.object_store_id.in_(kwds.get("object_store_ids"))
+                )
+            # else ignoring object_store_ids on HDCAs...
         if "ids" in kwds:
+            assert "object_store_ids" not in kwds
             ids = kwds["ids"]
             max_in_filter_length = kwds.get("max_in_filter_length", MAX_IN_FILTER_LENGTH)
             if len(ids) < max_in_filter_length:
@@ -3485,14 +3506,27 @@ class Dataset(Base, StorableObject, Serializable, _HasTable):
     def in_ready_state(self):
         return self.state in self.ready_states
 
+    @property
+    def sharable(self):
+        """Return True if placed into an objectstore not labeled as ``private``."""
+        if self.external_filename:
+            return True
+        else:
+            object_store = self._assert_object_store_set()
+            return not object_store.is_private(self)
+
+    def ensure_sharable(self):
+        if not self.sharable:
+            raise Exception(CANNOT_SHARE_PRIVATE_DATASET_MESSAGE)
+
     def get_file_name(self):
         if self.purged:
             log.warning(f"Attempt to get file name of purged dataset {self.id}")
             return ""
         if not self.external_filename:
-            assert self.object_store is not None, f"Object Store has not been initialized for dataset {self.id}"
-            if self.object_store.exists(self):
-                file_name = self.object_store.get_filename(self)
+            object_store = self._assert_object_store_set()
+            if object_store.exists(self):
+                file_name = object_store.get_filename(self)
             else:
                 file_name = ""
             if not file_name and self.state not in (self.states.NEW, self.states.QUEUED):
@@ -3512,6 +3546,10 @@ class Dataset(Base, StorableObject, Serializable, _HasTable):
             self.external_filename = filename
 
     file_name = property(get_file_name, set_file_name)
+
+    def _assert_object_store_set(self):
+        assert self.object_store is not None, f"Object Store has not been initialized for dataset {self.id}"
+        return self.object_store
 
     def get_extra_files_path(self):
         # Unlike get_file_name - external_extra_files_path is not backed by an
@@ -4553,6 +4591,9 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         """
         Copy this HDA to a library optionally replacing an existing LDDA.
         """
+        if not self.dataset.sharable:
+            raise Exception("Attempting to share a non-sharable dataset.")
+
         if replace_dataset:
             # The replace_dataset param ( when not None ) refers to a LibraryDataset that
             #   is being replaced with a new version.

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -42,6 +42,7 @@ from galaxy.util.sleeper import Sleeper
 NO_SESSION_ERROR_MESSAGE = (
     "Attempted to 'create' object store entity in configuration with no database session present."
 )
+DEFAULT_PRIVATE = False
 
 log = logging.getLogger(__name__)
 
@@ -104,6 +105,9 @@ class ObjectStore(metaclass=abc.ABCMeta):
 
         This method will create a proper directory structure for
         the file if the directory does not already exist.
+
+        The method returns the concrete objectstore the supplied object is stored
+        in.
         """
         raise NotImplementedError()
 
@@ -244,6 +248,19 @@ class ObjectStore(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
+    def is_private(self, obj):
+        """Return True iff supplied object is stored in private ConcreteObjectStore."""
+
+    def object_store_ids(self, private=None):
+        """Return IDs of all concrete object stores - either private ones or non-private ones.
+
+        This should just return an empty list for non-DistributedObjectStore object stores,
+        i.e. concrete objectstores and the HierarchicalObjectStore since these do not
+        use the object_store_id column for objects (Galaxy Datasets).
+        """
+        return []
+
+    @abc.abstractmethod
     def get_store_usage_percent(self):
         """Return the percentage indicating how full the store is."""
         raise NotImplementedError()
@@ -317,10 +334,11 @@ class BaseObjectStore(ObjectStore):
         extra_dirs = []
         for extra_dir_type, extra_dir_path in self.extra_dirs.items():
             extra_dirs.append({"type": extra_dir_type, "path": extra_dir_path})
+        store_type = self.store_type
         return {
             "config": config_to_dict(self.config),
             "extra_dirs": extra_dirs,
-            "type": self.store_type,
+            "type": store_type,
         }
 
     def _get_object_id(self, obj):
@@ -377,6 +395,16 @@ class BaseObjectStore(ObjectStore):
     def get_store_by(self, obj, **kwargs):
         return self._invoke("get_store_by", obj, **kwargs)
 
+    def is_private(self, obj):
+        return self._invoke("is_private", obj)
+
+    @classmethod
+    def parse_private_from_config_xml(clazz, config_xml):
+        private = DEFAULT_PRIVATE
+        if config_xml is not None:
+            private = asbool(config_xml.attrib.get("private", DEFAULT_PRIVATE))
+        return private
+
 
 class ConcreteObjectStore(BaseObjectStore):
     """Subclass of ObjectStore for stores that don't delegate (non-nested).
@@ -404,9 +432,12 @@ class ConcreteObjectStore(BaseObjectStore):
         self.store_by = config_dict.get("store_by", None) or getattr(config, "object_store_store_by", "id")
         self.name = config_dict.get("name", None)
         self.description = config_dict.get("description", None)
+        # Annotate this as true to prevent sharing of data.
+        self.private = config_dict.get("private", DEFAULT_PRIVATE)
 
     def to_dict(self):
         rval = super().to_dict()
+        rval["private"] = self.private
         rval["store_by"] = self.store_by
         rval["name"] = self.name
         rval["description"] = self.description
@@ -421,6 +452,9 @@ class ConcreteObjectStore(BaseObjectStore):
     def _get_store_by(self, obj):
         return self.store_by
 
+    def _is_private(self, obj):
+        return self.private
+
 
 class DiskObjectStore(ConcreteObjectStore):
     """
@@ -433,7 +467,7 @@ class DiskObjectStore(ConcreteObjectStore):
     >>> file_path=tempfile.mkdtemp()
     >>> obj = Bunch(id=1)
     >>> s = DiskObjectStore(Bunch(umask=0o077, jobs_directory=file_path, new_file_path=file_path, object_store_check_old_style=False), dict(files_dir=file_path))
-    >>> s.create(obj)
+    >>> o = s.create(obj)
     >>> s.exists(obj)
     True
     >>> assert s.get_filename(obj) == file_path + '/000/dataset_1.dat'
@@ -480,6 +514,7 @@ class DiskObjectStore(ConcreteObjectStore):
                     extra_dirs.append({"type": e.get("type"), "path": e.get("path")})
 
         config_dict["extra_dirs"] = extra_dirs
+        config_dict["private"] = BaseObjectStore.parse_private_from_config_xml(config_xml)
         return config_dict
 
     def to_dict(self):
@@ -619,6 +654,7 @@ class DiskObjectStore(ConcreteObjectStore):
             if not dir_only:
                 open(path, "w").close()  # Should be rb?
                 umask_fix_perms(path, self.config.umask, 0o666)
+        return self
 
     def _empty(self, obj, **kwargs):
         """Override `ObjectStore`'s stub by checking file size on disk."""
@@ -753,7 +789,8 @@ class NestedObjectStore(BaseObjectStore):
 
     def _create(self, obj, **kwargs):
         """Create a backing file in a random backend."""
-        random.choice(list(self.backends.values())).create(obj, **kwargs)
+        objectstore = random.choice(list(self.backends.values()))
+        return objectstore.create(obj, **kwargs)
 
     def _empty(self, obj, **kwargs):
         """For the first backend that has this `obj`, determine if it is empty."""
@@ -791,6 +828,9 @@ class NestedObjectStore(BaseObjectStore):
 
     def _get_concrete_store_description_markdown(self, obj):
         return self._call_method("_get_concrete_store_description_markdown", obj, None, False)
+
+    def _is_private(self, obj):
+        return self._call_method("_is_private", obj, ObjectNotFound, True)
 
     def _get_store_by(self, obj):
         return self._call_method("_get_store_by", obj, None, False)
@@ -966,25 +1006,28 @@ class DistributedObjectStore(NestedObjectStore):
 
     def _create(self, obj, **kwargs):
         """The only method in which obj.object_store_id may be None."""
-        if obj.object_store_id is None or not self._exists(obj, **kwargs):
-            if obj.object_store_id is None or obj.object_store_id not in self.backends:
+        object_store_id = obj.object_store_id
+        if object_store_id is None or not self._exists(obj, **kwargs):
+            if object_store_id is None or object_store_id not in self.backends:
                 try:
-                    obj.object_store_id = random.choice(self.weighted_backend_ids)
+                    object_store_id = random.choice(self.weighted_backend_ids)
+                    obj.object_store_id = object_store_id
                 except IndexError:
                     raise ObjectInvalid(
                         "objectstore.create, could not generate "
-                        "obj.object_store_id: %s, kwargs: %s" % (str(obj), str(kwargs))
+                        "object_store_id: %s, kwargs: %s" % (str(obj), str(kwargs))
                     )
                 log.debug(
-                    "Selected backend '%s' for creation of %s %s"
-                    % (obj.object_store_id, obj.__class__.__name__, obj.id)
+                    "Selected backend '%s' for creation of %s %s" % (object_store_id, obj.__class__.__name__, obj.id)
                 )
             else:
                 log.debug(
                     "Using preferred backend '%s' for creation of %s %s"
-                    % (obj.object_store_id, obj.__class__.__name__, obj.id)
+                    % (object_store_id, obj.__class__.__name__, obj.id)
                 )
-            self.backends[obj.object_store_id].create(obj, **kwargs)
+            return self.backends[object_store_id].create(obj, **kwargs)
+        else:
+            return self.backends[object_store_id]
 
     def _call_method(self, method, obj, default, default_is_exception, **kwargs):
         object_store_id = self.__get_store_id_for(obj, **kwargs)
@@ -1020,6 +1063,14 @@ class DistributedObjectStore(NestedObjectStore):
                     return id
         return None
 
+    def object_store_ids(self, private=None):
+        object_store_ids = []
+        for backend_id, backend in self.backends.items():
+            object_store_ids.extend(backend.object_store_ids(private=private))
+            if backend.private is private or private is None:
+                object_store_ids.append(backend_id)
+        return object_store_ids
+
 
 class HierarchicalObjectStore(NestedObjectStore):
 
@@ -1037,22 +1088,33 @@ class HierarchicalObjectStore(NestedObjectStore):
         super().__init__(config, config_dict)
 
         backends: Dict[int, ObjectStore] = {}
+        is_private = config_dict.get("private", DEFAULT_PRIVATE)
         for order, backend_def in enumerate(config_dict["backends"]):
+            backend_is_private = backend_def.get("private")
+            if backend_is_private is not None:
+                assert (
+                    is_private == backend_is_private
+                ), "The private attribute must be defined on the HierarchicalObjectStore and not contained concrete objectstores."
             backends[order] = build_object_store_from_config(config, config_dict=backend_def, fsmon=fsmon)
 
         self.backends = backends
+        self.private = is_private
 
     @classmethod
     def parse_xml(clazz, config_xml):
         backends_list = []
+        is_private = BaseObjectStore.parse_private_from_config_xml(config_xml)
         for backend in sorted(config_xml.find("backends"), key=lambda b: int(b.get("order"))):
             store_type = backend.get("type")
             objectstore_class, _ = type_to_object_store_class(store_type)
             backend_config_dict = objectstore_class.parse_xml(backend)
+            backend_config_dict["private"] = is_private
             backend_config_dict["type"] = store_type
             backends_list.append(backend_config_dict)
 
-        return {"backends": backends_list}
+        config_dict = {"backends": backends_list}
+        config_dict["private"] = is_private
+        return config_dict
 
     def to_dict(self):
         as_dict = super().to_dict()
@@ -1061,6 +1123,7 @@ class HierarchicalObjectStore(NestedObjectStore):
             backend_as_dict = backend.to_dict()
             backends.append(backend_as_dict)
         as_dict["backends"] = backends
+        as_dict["private"] = self.private
         return as_dict
 
     def _exists(self, obj, **kwargs):
@@ -1072,7 +1135,13 @@ class HierarchicalObjectStore(NestedObjectStore):
 
     def _create(self, obj, **kwargs):
         """Call the primary object store."""
-        self.backends[0].create(obj, **kwargs)
+        return self.backends[0].create(obj, **kwargs)
+
+    def _is_private(self, obj):
+        # Unlink the DistributedObjectStore - the HierarchicalObjectStore does not use
+        # object_store_id - so all the contained object stores need to define is_private
+        # the same way.
+        return self.private
 
 
 def type_to_object_store_class(store, fsmon=False):
@@ -1238,16 +1307,19 @@ class ObjectStorePopulator:
         self.object_store_id = None
         self.user = user
 
-    def set_object_store_id(self, data):
-        self.set_dataset_object_store_id(data.dataset)
+    def set_object_store_id(self, data, require_sharable=False):
+        self.set_dataset_object_store_id(data.dataset, require_sharable=require_sharable)
 
-    def set_dataset_object_store_id(self, dataset):
+    def set_dataset_object_store_id(self, dataset, require_sharable=True):
         # Create an empty file immediately.  The first dataset will be
         # created in the "default" store, all others will be created in
         # the same store as the first.
         dataset.object_store_id = self.object_store_id
         try:
-            self.object_store.create(dataset)
+            ensure_non_private = require_sharable
+            concrete_store = self.object_store.create(dataset, ensure_non_private=ensure_non_private)
+            if concrete_store.private and require_sharable:
+                raise Exception("Attempted to create shared output datasets in objectstore with sharing disabled")
         except ObjectInvalid:
             raise Exception("Unable to create output dataset: object store is full")
         self.object_store_id = dataset.object_store_id  # these will be the same thing after the first output

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -77,6 +77,7 @@ def parse_config_xml(config_xml):
                 "path": staging_path,
             },
             "extra_dirs": extra_dirs,
+            "private": ConcreteObjectStore.parse_private_from_config_xml(config_xml),
         }
     except Exception:
         # Toss it back up after logging, we can't continue loading at this point.

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -609,6 +609,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
                 rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
                 open(os.path.join(self.staging_path, rel_path), "w").close()
                 self._push_to_os(rel_path, from_string="")
+        return self
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -108,6 +108,7 @@ def parse_config_xml(config_xml):
                 "path": staging_path,
             },
             "extra_dirs": extra_dirs,
+            "private": DiskObjectStore.parse_private_from_config_xml(config_xml),
         }
     except Exception:
         # Toss it back up after logging, we can't continue loading at this point.
@@ -538,6 +539,7 @@ class IRODSObjectStore(DiskObjectStore, CloudConfigMixin):
                 open(os.path.join(self.staging_path, rel_path), "w").close()
                 self._push_to_irods(rel_path, from_string="")
         log.debug("irods_pt _create: %s", ipt_timer)
+        return self
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -77,6 +77,7 @@ def parse_config_xml(config_xml):
             log.error(msg)
             raise Exception(msg)
         r["extra_dirs"] = [{k: e.get(k) for k in attrs} for e in extra_dirs]
+        r["private"] = ConcreteObjectStore.parse_private_from_config_xml(config_xml)
         if "job_work" not in (d["type"] for d in r["extra_dirs"]):
             msg = f'No value for {tag}:type="job_work" in XML tree'
             log.error(msg)
@@ -297,6 +298,7 @@ class PithosObjectStore(ConcreteObjectStore):
                 new_file = os.path.join(self.staging_path, rel_path)
                 open(new_file, "w").close()
                 self.pithos.upload_from_string(rel_path, "")
+        return self
 
     def _empty(self, obj, **kwargs):
         """

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -105,6 +105,7 @@ def parse_config_xml(config_xml):
                 "path": staging_path,
             },
             "extra_dirs": extra_dirs,
+            "private": ConcreteObjectStore.parse_private_from_config_xml(config_xml),
         }
     except Exception:
         # Toss it back up after logging, we can't continue loading at this point.
@@ -621,6 +622,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
                 rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
                 open(os.path.join(self.staging_path, rel_path), "w").close()
                 self._push_to_os(rel_path, from_string="")
+        return self
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -140,7 +140,7 @@ def __new_history_upload(trans, uploaded_dataset, history=None, state=None):
     trans.sa_session.flush()
     history.add_dataset(hda, genome_build=uploaded_dataset.dbkey, quota=False)
     permissions = trans.app.security_agent.history_get_default_permissions(history)
-    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions)
+    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions, new=True, flush=False)
     trans.sa_session.flush()
     return hda
 
@@ -211,7 +211,7 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
     else:
         # Copy the current user's DefaultUserPermissions to the new LibraryDatasetDatasetAssociation.dataset
         trans.app.security_agent.set_all_dataset_permissions(
-            ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user)
+            ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user), new=True
         )
         folder.add_library_dataset(ld, genome_build=uploaded_dataset.dbkey)
         trans.sa_session.add(folder)

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -199,6 +199,11 @@ def get_legacy_index_query_params(
         description="Whether to return visible or hidden datasets only. Leave unset for both.",
         deprecated=True,
     ),
+    sharable: Optional[bool] = Query(
+        default=None,
+        title="Sharable",
+        description="Whether to return only sharable or not sharable datasets. Leave unset for both.",
+    ),
 ) -> LegacyHistoryContentsIndexParams:
     """This function is meant to be used as a dependency to render the OpenAPI documentation
     correctly"""
@@ -208,6 +213,7 @@ def get_legacy_index_query_params(
         details=details,
         deleted=deleted,
         visible=visible,
+        sharable=sharable,
     )
 
 
@@ -217,6 +223,7 @@ def parse_legacy_index_query_params(
     details: Optional[str] = None,
     deleted: Optional[bool] = None,
     visible: Optional[bool] = None,
+    sharable: Optional[bool] = None,
     **_,  # Additional params are ignored
 ) -> LegacyHistoryContentsIndexParams:
     """Parses (legacy) query parameters for the history contents `index` operation
@@ -242,6 +249,7 @@ def parse_legacy_index_query_params(
         ids=id_list,
         deleted=deleted,
         visible=visible,
+        sharable=sharable,
         dataset_details=dataset_details,
     )
 

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -325,7 +325,12 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             permission_disable = True
             permission_inputs = list()
             if trans.user:
-                if data.dataset.actions:
+                if not data.dataset.sharable:
+                    permission_message = "The dataset is stored on private storage to you and cannot be shared."
+                    permission_inputs.append(
+                        {"name": "not_sharable", "type": "hidden", "label": permission_message, "readonly": True}
+                    )
+                elif data.dataset.actions:
                     in_roles = {}
                     for action, roles in trans.app.security_agent.get_permissions(data.dataset).items():
                         in_roles[action.action] = [trans.security.encode_id(role.id) for role in roles]

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -100,6 +100,9 @@ class DatasetStorageDetails(Model):
     )
     hashes: List[dict] = Field(description="The file contents hashes associated with the supplied dataset instance.")
     sources: List[dict] = Field(description="The file sources associated with the supplied dataset instance.")
+    sharable: bool = Field(
+        description="Is this dataset sharable.",
+    )
 
 
 class DatasetInheritanceChainEntry(Model):
@@ -354,6 +357,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         sources = [s.to_dict() for s in dataset.sources]
         return DatasetStorageDetails(
             object_store_id=object_store_id,
+            sharable=dataset.sharable,
             name=name,
             description=description,
             percent_used=percent_used,

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -61,6 +61,7 @@ from galaxy.model import (
     User,
 )
 from galaxy.model.security import GalaxyRBACAgent
+from galaxy.objectstore import BaseObjectStore
 from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
@@ -153,6 +154,11 @@ class LegacyHistoryContentsIndexParams(Model):
     dataset_details: Optional[DatasetDetailsType]
     deleted: Optional[bool]
     visible: Optional[bool]
+    sharable: Optional[bool] = Field(
+        default=None,
+        title="Sharable",
+        description="Whether to return only sharable or not sharable datasets. Leave unset for both.",
+    )
 
 
 class HistoryContentsIndexJobsSummaryParams(Model):
@@ -263,6 +269,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def __init__(
         self,
         security: IdEncodingHelper,
+        object_store: BaseObjectStore,
         history_manager: histories.HistoryManager,
         history_contents_manager: HistoryContentsManager,
         hda_manager: hdas.HDAManager,
@@ -292,6 +299,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         self.item_operator = HistoryItemOperator(self.hda_manager, self.hdca_manager, self.dataset_collection_manager)
         self.short_term_storage_allocator = short_term_storage_allocator
         self.genomes_manager = genomes_manager
+        self.object_store = object_store
 
     def index(
         self,
@@ -1113,6 +1121,13 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         ids = legacy_params_dict.get("ids")
         if ids:
             legacy_params_dict["ids"] = self.decode_ids(ids)
+
+        object_store_ids = None
+        sharable = legacy_params.sharable
+        if sharable is not None:
+            object_store_ids = self.object_store.object_store_ids(private=not sharable)
+            if object_store_ids:
+                legacy_params_dict["object_store_ids"] = object_store_ids
         contents = history.contents_iter(**legacy_params_dict)
         items = [
             self._serialize_legacy_content_item(trans, content, legacy_params_dict.get("dataset_details"))

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -182,7 +182,7 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
 
     def test_hda_security(self):
-        element_identifiers = self.dataset_collection_populator.pair_identifiers(self.history_id)
+        element_identifiers = self.dataset_collection_populator.pair_identifiers(self.history_id, wait=True)
         self.dataset_populator.make_private(self.history_id, element_identifiers[0]["id"])
         with self._different_user():
             history_id = self.dataset_populator.new_history()

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -591,4 +591,5 @@ class LibrariesApiTestCase(ApiTestCase):
         hda_id = self.dataset_populator.new_dataset(history_id, content=content, wait=wait)["id"]
         payload = {"from_hda_id": hda_id, "create_type": "file", "folder_id": folder_id}
         ld = self._post(f"libraries/{folder_id}/contents", payload)
+        ld.raise_for_status()
         return ld

--- a/test/integration/objectstore/test_private_handling.py
+++ b/test/integration/objectstore/test_private_handling.py
@@ -1,0 +1,51 @@
+"""Integration tests for mixing store_by."""
+
+import string
+
+from galaxy_test.base import api_asserts
+from ._base import BaseObjectStoreIntegrationTestCase
+
+PRIVATE_OBJECT_STORE_CONFIG_TEMPLATE = string.Template(
+    """<?xml version="1.0"?>
+<object_store type="disk" id="primary" private="true">
+    <files_dir path="${temp_directory}/files1"/>
+    <extra_dir type="temp" path="${temp_directory}/tmp1"/>
+    <extra_dir type="job_work" path="${temp_directory}/job_working_directory1"/>
+</object_store>
+"""
+)
+
+TEST_INPUT_FILES_CONTENT = "1 2 3"
+
+
+class PrivatePreventsSharingObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["new_user_dataset_access_role_default_private"] = True
+        cls._configure_object_store(PRIVATE_OBJECT_STORE_CONFIG_TEMPLATE, config)
+
+    def test_both_types(self):
+        """Test each object store configures files correctly."""
+        with self.dataset_populator.test_history() as history_id:
+            hda = self.dataset_populator.new_dataset(history_id, content=TEST_INPUT_FILES_CONTENT, wait=True)
+            content = self.dataset_populator.get_history_dataset_content(history_id, hda["id"])
+            assert content.startswith(TEST_INPUT_FILES_CONTENT)
+            response = self.dataset_populator.make_public_raw(history_id, hda["id"])
+            assert response.status_code != 200
+            api_asserts.assert_error_message_contains(response, "Attempting to share a non-sharable dataset.")
+
+
+class PrivateCannotWritePublicDataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["new_user_dataset_access_role_default_private"] = False
+        cls._configure_object_store(PRIVATE_OBJECT_STORE_CONFIG_TEMPLATE, config)
+
+    def test_both_types(self):
+        with self.dataset_populator.test_history() as history_id:
+            response = self.dataset_populator.new_dataset_request(
+                history_id, content=TEST_INPUT_FILES_CONTENT, wait=True, assert_ok=False
+            )
+            job = response.json()["jobs"][0]
+            final_state = self.dataset_populator.wait_for_job(job["id"])
+            assert final_state == "error"

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -35,6 +35,7 @@ skip_if_not_postgres_base = pytest.mark.skipif(
     not os.environ.get("GALAXY_TEST_UNIT_MAPPING_URI_POSTGRES_BASE"),
     reason="GALAXY_TEST_UNIT_MAPPING_URI_POSTGRES_BASE not set",
 )
+PRIVATE_OBJECT_STORE_ID = "my_private_data"
 
 
 class BaseModelTestCase(unittest.TestCase):
@@ -153,8 +154,12 @@ class MappingTests(BaseModelTestCase):
         assert history.get_display_name() == "Hello₩◎ґʟⅾ"
 
     def test_hda_to_library_dataset_dataset_association(self):
-        u = model.User(email="mary@example.com", password="password")
-        hda = model.HistoryDatasetAssociation(name="hda_name")
+        model = self.model
+        u = self.model.User(email="mary@example.com", password="password")
+        h1 = model.History(name="History 1", user=u)
+        hda = model.HistoryDatasetAssociation(
+            name="hda_name", create_dataset=True, history=h1, sa_session=model.session
+        )
         self.persist(hda)
         trans = collections.namedtuple("trans", "user")
         target_folder = model.LibraryFolder(name="library_folder")
@@ -179,6 +184,23 @@ class MappingTests(BaseModelTestCase):
         assert len(new_ldda.library_dataset.expired_datasets) == 1
         assert new_ldda.library_dataset.expired_datasets[0] == ldda
         assert target_folder.item_count == 1
+
+    def test_hda_to_library_dataset_dataset_association_fails_if_private(self):
+        model = self.model
+        u = model.User(email="mary2@example.com", password="password")
+        h1 = model.History(name="History 1", user=u)
+        hda = model.HistoryDatasetAssociation(
+            name="hda_name", create_dataset=True, history=h1, sa_session=model.session
+        )
+        hda.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self.persist(hda)
+        trans = collections.namedtuple("trans", "user")
+        target_folder = model.LibraryFolder(name="library_folder")
+        with pytest.raises(Exception):
+            hda.to_library_dataset_dataset_association(
+                trans=trans(user=u),
+                target_folder=target_folder,
+            )
 
     def test_tags(self):
         TAG_NAME = "Test Tag"
@@ -594,8 +616,8 @@ class MappingTests(BaseModelTestCase):
         self.persist(u, h1, expunge=False)
 
         d1 = self.new_hda(h1, name="1")
-        d2 = self.new_hda(h1, name="2", visible=False)
-        d3 = self.new_hda(h1, name="3", deleted=True)
+        d2 = self.new_hda(h1, name="2", visible=False, object_store_id="foobar")
+        d3 = self.new_hda(h1, name="3", deleted=True, object_store_id="three_store")
         d4 = self.new_hda(h1, name="4", visible=False, deleted=True)
 
         self.session().flush()
@@ -609,8 +631,11 @@ class MappingTests(BaseModelTestCase):
         self.assertEqual(contents_iter_names(), ["1", "2", "3", "4"])
         assert contents_iter_names(deleted=False) == ["1", "2"]
         assert contents_iter_names(visible=True) == ["1", "3"]
+        assert contents_iter_names(visible=True, object_store_ids=["three_store"]) == ["3"]
         assert contents_iter_names(visible=False) == ["2", "4"]
         assert contents_iter_names(deleted=True, visible=False) == ["4"]
+        assert contents_iter_names(deleted=False, object_store_ids=["foobar"]) == ["2"]
+        assert contents_iter_names(deleted=False, object_store_ids=["foobar2"]) == []
 
         assert contents_iter_names(ids=[d1.id, d2.id, d3.id, d4.id]) == ["1", "2", "3", "4"]
         assert contents_iter_names(ids=[d1.id, d2.id, d3.id, d4.id], max_in_filter_length=1) == ["1", "2", "3", "4"]
@@ -966,6 +991,77 @@ class MappingTests(BaseModelTestCase):
         h._next_hid(n=3)
         assert h.hid_counter == 5
 
+    def test_cannot_make_private_objectstore_dataset_public(self):
+        security_agent = GalaxyRBACAgent(self.model)
+        u_from, u_to, _ = self._three_users("cannot_make_private_public")
+
+        h = self.model.History(name="History for Prevent Sharing", user=u_from)
+        d1 = self.model.HistoryDatasetAssociation(
+            extension="txt", history=h, create_dataset=True, sa_session=self.model.session
+        )
+        self.persist(h, d1)
+
+        d1.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self._make_private(security_agent, u_from, d1)
+
+        with pytest.raises(Exception) as exec_info:
+            self._make_owned(security_agent, u_from, d1)
+        assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
+
+    def test_cannot_make_private_objectstore_dataset_shared(self):
+        security_agent = GalaxyRBACAgent(self.model)
+        u_from, u_to, _ = self._three_users("cannot_make_private_shared")
+
+        h = self.model.History(name="History for Prevent Sharing", user=u_from)
+        d1 = self.model.HistoryDatasetAssociation(
+            extension="txt", history=h, create_dataset=True, sa_session=self.model.session
+        )
+        self.persist(h, d1)
+
+        d1.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self._make_private(security_agent, u_from, d1)
+
+        with pytest.raises(Exception) as exec_info:
+            security_agent.privately_share_dataset(d1.dataset, [u_to])
+        assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
+
+    def test_cannot_set_dataset_permisson_on_private(self):
+        security_agent = GalaxyRBACAgent(self.model)
+        u_from, u_to, _ = self._three_users("cannot_set_permissions_on_private")
+
+        h = self.model.History(name="History for Prevent Sharing", user=u_from)
+        d1 = self.model.HistoryDatasetAssociation(
+            extension="txt", history=h, create_dataset=True, sa_session=self.model.session
+        )
+        self.persist(h, d1)
+
+        d1.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self._make_private(security_agent, u_from, d1)
+
+        role = security_agent.get_private_user_role(u_to, auto_create=True)
+        access_action = security_agent.permitted_actions.DATASET_ACCESS.action
+
+        with pytest.raises(Exception) as exec_info:
+            security_agent.set_dataset_permission(d1.dataset, {access_action: [role]})
+        assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
+
+    def test_cannot_make_private_dataset_public(self):
+        security_agent = GalaxyRBACAgent(self.model)
+        u_from, u_to, u_other = self._three_users("cannot_make_private_dataset_public")
+
+        h = self.model.History(name="History for Annotation", user=u_from)
+        d1 = self.model.HistoryDatasetAssociation(
+            extension="txt", history=h, create_dataset=True, sa_session=self.model.session
+        )
+        self.persist(h, d1)
+
+        d1.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self._make_private(security_agent, u_from, d1)
+
+        with pytest.raises(Exception) as exec_info:
+            security_agent.make_dataset_public(d1.dataset)
+        assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
+
     def _three_users(self, suffix):
         email_from = f"user_{suffix}e1@example.com"
         email_to = f"user_{suffix}e2@example.com"
@@ -982,18 +1078,26 @@ class MappingTests(BaseModelTestCase):
         access_action = security_agent.permitted_actions.DATASET_ACCESS.action
         manage_action = security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS.action
         permissions = {access_action: [role], manage_action: [role]}
-        security_agent.set_all_dataset_permissions(hda.dataset, permissions)
+        self._set_permissions(security_agent, hda.dataset, permissions)
 
     def _make_owned(self, security_agent, user, hda):
         role = security_agent.get_private_user_role(user, auto_create=True)
         manage_action = security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS.action
         permissions = {manage_action: [role]}
-        security_agent.set_all_dataset_permissions(hda.dataset, permissions)
+        self._set_permissions(security_agent, hda.dataset, permissions)
+
+    def _set_permissions(self, security_agent, dataset, permissions):
+        # TODO: refactor set_all_dataset_permissions to actually throw an exception :|
+        error = security_agent.set_all_dataset_permissions(dataset, permissions)
+        if error:
+            raise Exception(error)
 
     def new_hda(self, history, **kwds):
-        return history.add_dataset(
-            model.HistoryDatasetAssociation(create_dataset=True, sa_session=self.model.session, **kwds)
-        )
+        object_store_id = kwds.pop("object_store_id", None)
+        hda = self.model.HistoryDatasetAssociation(create_dataset=True, sa_session=self.model.session, **kwds)
+        if object_store_id is not None:
+            hda.dataset.object_store_id = object_store_id
+        return history.add_dataset(hda)
 
 
 @skip_if_not_postgres_base
@@ -1050,6 +1154,12 @@ class MockObjectStore:
 
     def update_from_file(self, *arg, **kwds):
         pass
+
+    def is_private(self, object):
+        if object.object_store_id == PRIVATE_OBJECT_STORE_ID:
+            return True
+        else:
+            return False
 
 
 def get_suite():


### PR DESCRIPTION
Sketched out so far:
- Allow marking objectstores (in either XML or YAML) as ``private`` - indicating datasets stored in them should not be shared.
- Add ``sharable`` property to ``model.Dataset`` that checks its ``object_store_id`` against the configured object store to determine if it is not stored in a ``private`` objectstore.
- Add abstraction to ``security_agent`` to check if a dataset is restricted to a single user and augment ``galaxy.jobs.JobWrapper._set_object_store_ids`` and ``ObjectStorePopulator`` to prevent jobs that might create non-private datasets in private objectstores.
- Model/security layer prevents copying non-sharable dataset into libraries or attaching private sharing roles to them.
- The edit metadata form will display a message that the dataset is unsharable on the permissions page.
- Integration test case to ensure cannot upload public datasets to a private objectstore.
- Integration test case to ensure cannot modify access permissions of datasets stored in private objectstores.
- Expose information about whether objectstores are privateObjectStore metadata display (#10233). 

Left to do:
- Test case to verify library sets can't be uploaded to private objectstores.
- Test case to verify private object stores operate appropriately with dynamically discovered collection datasets. (past @jmchilton had this in his notes - not sure exactly what his concern was).

xrefs:
- Previous versions of this PR:
   - https://github.com/galaxyproject/galaxy/pull/10840
   - https://github.com/jmchilton/galaxy/tree/sharable_data_mid2205 
- The Nate white paper on related things (https://docs.google.com/document/d/1TQCbQxwLLijKHl_sZgTDQCpNXX2jejJQBljVrNslOvA/edit)
- Implementing quotas per objectstore #10221 
- Per-user objectstore configurations #4840 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
