### PR TITLE
Updated `_generate_invocation_bco` to output a valid IEEE-2791-2020 object

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1014,7 +1014,7 @@ class WorkflowsAPIController(
             bco_license = workflow.license
 
         # pull in the creator_metadata info from workflow if it exists
-        reviewers = []
+        reviewers: list = []
         contributors = []
         if workflow.creator_metadata:
             for creator in workflow.creator_metadata:
@@ -1027,7 +1027,7 @@ class WorkflowsAPIController(
                         contributor['email'] = creator['email']
                     if 'identifier' in creator:
                         contributor['orcid'] = creator['identifier']
-                    
+
                     contributors.append(contributor)
 
         encoded_workflow_id = trans.security.encode_id(stored_workflow.id)
@@ -1035,7 +1035,7 @@ class WorkflowsAPIController(
         dict_workflow = json.loads(self.workflow_dict(trans, encoded_workflow_id))
 
         spec_version = kwd.get("spec_version", "https://w3id.org/ieee/ieee-2791-schema/2791object.json")
-        
+
         for i, w in enumerate(reversed(stored_workflow.workflows)):
             if workflow == w:
                 current_version = i
@@ -1197,7 +1197,7 @@ class WorkflowsAPIController(
                     "galaxy_url": url_for("/", qualified=True),
                     "galaxy_version": VERSION,
                     # TODO:
-                    # Extend this definition to include more information that is significan for a galaxy workflow/invocation? 
+                    # Extend this definition to include more information that is significan for a galaxy workflow/invocation?
                     # 'aws_estimate': aws_estimate,
                     # 'job_metrics': metrics
                 },

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1009,7 +1009,7 @@ class WorkflowsAPIController(
         stored_workflow = workflow.stored_workflow
 
         # pull in the license info from workflow if it exists
-        bco_license = ''
+        bco_license = ""
         if workflow.license:
             bco_license = workflow.license
 
@@ -1018,15 +1018,15 @@ class WorkflowsAPIController(
         contributors = []
         if workflow.creator_metadata:
             for creator in workflow.creator_metadata:
-                if creator['class'] == 'Person':
+                if creator["class"] == "Person":
                     contributor = {}
-                    contributor['contribution'] = ['contributedBy']
-                    if 'name' in creator:
-                        contributor['name'] = creator['name']
-                    if 'email' in creator:
-                        contributor['email'] = creator['email']
-                    if 'identifier' in creator:
-                        contributor['orcid'] = creator['identifier']
+                    contributor["contribution"] = ["contributedBy"]
+                    if "name" in creator:
+                        contributor["name"] = creator["name"]
+                    if "email" in creator:
+                        contributor["email"] = creator["email"]
+                    if "identifier" in creator:
+                        contributor["orcid"] = creator["identifier"]
 
                     contributors.append(contributor)
 
@@ -1042,7 +1042,7 @@ class WorkflowsAPIController(
 
         provenance_domain = {
             "name": workflow.name,
-            "version": str(current_version) + '.0',
+            "version": str(current_version) + ".0",
             "review": reviewers,
             "created": workflow_invocation.create_time.isoformat(),
             "modified": workflow_invocation.update_time.isoformat(),

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1018,15 +1018,17 @@ class WorkflowsAPIController(
         dict_workflow = json.loads(self.workflow_dict(trans, encoded_workflow_id))
 
         spec_version = kwd.get("spec_version", "https://w3id.org/ieee/ieee-2791-schema/2791object.json")
-
+        
         for i, w in enumerate(reversed(stored_workflow.workflows)):
             if workflow == w:
                 current_version = i
 
+        import pdb; pdb.set_trace()
+
         contributors = []
         for contributing_user in contributing_users:
             contributor = {
-                "orcid": kwd.get("xref", []),
+                "orcid": kwd.get("xref", ''),
                 "name": contributing_user.username,
                 "affiliation": "",
                 "contribution": ["authoredBy"],
@@ -1035,24 +1037,11 @@ class WorkflowsAPIController(
             contributors.append(contributor)
 
         reviewers = []
-        for reviewer in reviewing_users:
-            reviewer = {
-                "status": "approved",
-                "reviewer_comment": "",
-                "date": workflow_invocation.update_time.isoformat(),
-                "reviewer": {
-                    "orcid": kwd.get("orcid", []),
-                    "name": contributing_user.username,
-                    "affiliation": "",
-                    "contribution": "curatedBy",
-                    "email": contributing_user.email,
-                },
-            }
-            reviewers.append(reviewer)
+
 
         provenance_domain = {
             "name": workflow.name,
-            "version": current_version,
+            "version": str(current_version) + '.0',
             "review": reviewers,
             "derived_from": url_for("workflow", id=encoded_workflow_id, qualified=True),
             "created": workflow_invocation.create_time.isoformat(),
@@ -1189,22 +1178,17 @@ class WorkflowsAPIController(
             try:
                 for k, v in inv_step.workflow_step.tool_inputs.items():
                     param, value, step = k, v, inv_step.workflow_step.order_index
-                    parametric_domain.append({"param": param, "value": value, "step": step})
+                    parametric_domain.append({"param": str(param), "value": str(value), "step": str(step)})
             except Exception:
                 continue
 
         execution_domain = {
-            "script_access_type": "a_galaxy_workflow",
-            "script": [url_for("workflows", encoded_workflow_id=encoded_workflow_id, qualified=True)],
+            "script": [{"uri": {"uri": url_for("workflows", encoded_workflow_id=encoded_workflow_id, qualified=True)}}],
             "script_driver": "Galaxy",
             "software_prerequisites": software_prerequisites,
-            "external_data_endpoints": [
-                {"name": "Access to Galaxy", "url": url_for("/", qualified=True)},
-                kwd.get("external_data_endpoints"),
-            ],
+            "external_data_endpoints": [{"name": "Access to Galaxy", "url": url_for("/", qualified=True)}],
             "environment_variables": kwd.get("environment_variables", {}),
         }
-
         extension = [
             {
                 "extension_schema": "https://raw.githubusercontent.com/biocompute-objects/extension_domain/6d2cd8482e6075746984662edcf78b57d3d38065/galaxy/galaxy_extension.json",
@@ -1219,8 +1203,8 @@ class WorkflowsAPIController(
         ]
 
         error_domain = {
-            "empirical_error": kwd.get("empirical_error", []),
-            "algorithmic_error": kwd.get("algorithmic_error", []),
+            "empirical_error": kwd.get("empirical_error", {}),
+            "algorithmic_error": kwd.get("algorithmic_error", {}),
         }
 
         bco_dict = {

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1023,8 +1023,6 @@ class WorkflowsAPIController(
             if workflow == w:
                 current_version = i
 
-        import pdb; pdb.set_trace()
-
         contributors = []
         for contributing_user in contributing_users:
             contributor = {

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1489,7 +1489,6 @@ class BaseWorkflowPopulator(BasePopulator):
         api_asserts.assert_has_keys(bco["description_domain"], "keywords", "xref", "platform", "pipeline_steps")
         api_asserts.assert_has_keys(
             bco["execution_domain"],
-            "script_access_type",
             "script",
             "script_driver",
             "software_prerequisites",


### PR DESCRIPTION
Updated `_generate_invocation_bco` in `lib/galaxy/webapps/galaxy/api/workflows.py` to output a valid [IEEE-2791-2020 object](https://w3id.org/ieee/ieee-2791-schema/2791object.json). Also removed the automatic capture of user information and replaced it with user supplied information from the Workflow Editor (`creator_metadata`) and added `license` from workflow to BCO. 

This PR is a result of discussions from https://github.com/galaxyproject/galaxy/pull/12174 (with @mvdbeek @dannon and @nsoranzo) which has been closed. The changes here are only for the API and the UI will be in another PR later. 

## How to test the changes
(Select all options that apply)
- [x] I've **updated** the appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
  - `WorkflowsApiTestCase::test_export_invocation_bco`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
