### PR TITLE
column label renaming for clarity

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -79,7 +79,7 @@ class PageListGrid(grids.Grid):
                 lambda item: dict(action="display_by_username_and_slug", username=item.user.username, slug=item.slug)
             ),
         ),
-        URLColumn("Public URL"),
+        URLColumn("Directory"),
         grids.OwnerAnnotationColumn(
             "Annotation",
             key="annotation",

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -79,7 +79,7 @@ class PageListGrid(grids.Grid):
                 lambda item: dict(action="display_by_username_and_slug", username=item.user.username, slug=item.slug)
             ),
         ),
-        URLColumn("Directory"),
+        URLColumn("Permalink"),
         grids.OwnerAnnotationColumn(
             "Annotation",
             key="annotation",


### PR DESCRIPTION
Column label renamed for clarity from "Public URL" to "Permalink" (linked to Github issue #14000):

![Greenshot 2022-06-10 09 57 48](https://user-images.githubusercontent.com/3672779/173081760-812289b4-c4fb-4bef-b1ea-77ad8cfb8f6c.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.


