### PR TITLE
Swap new hidden icon from 'lock' to 'eye-slash'

### DIFF
--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -47,7 +47,7 @@
             size="sm"
             variant="link"
             @click.stop="$emit('unhide')">
-            <icon icon="unlock" />
+            <icon icon="eye-slash" />
         </b-button>
     </span>
 </template>

--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -40,7 +40,7 @@
                 size="sm"
                 class="rounded-0 text-decoration-none"
                 @click="setFilter('visible:false')">
-                <icon icon="lock" />
+                <icon icon="eye-slash" />
                 <span>{{ history.contents_active.hidden }}</span>
             </b-button>
             <b-button


### PR DESCRIPTION
Swaps 'hidden' icon from lock:
![image](https://user-images.githubusercontent.com/155398/173086103-409cb32a-c270-46e8-a590-67ed3f5dd8cf.png)


To eye-slash:
![image](https://user-images.githubusercontent.com/155398/173086021-f82204f5-caf8-4e1f-8cf4-35bbcc2ca533.png)

Discussed in ui/ux group.  We also experimented with subbing in a new display icon, but decided not to pursue it -- the eye just has too much recognition as 'display' action.  "Lock" has been used as an indicator of privacy/secure data, and shouldn't be used for visibility here.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
