### PR TITLE
Fix composite datatypes with ``substitute_name_with_metadata``

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -792,20 +792,13 @@ class Data(metaclass=DataMeta):
         kwds["is_binary"] = is_binary
         kwds["to_posix_lines"] = to_posix_lines
         kwds["space_to_tab"] = space_to_tab
-        return Bunch(**kwds)
+
+        composite_file = Bunch(**kwds)
+        return composite_file
 
     def add_composite_file(self, name, **kwds):
         # self.composite_files = self.composite_files.copy()
         self.composite_files[name] = self.__new_composite_file(name, **kwds)
-
-    def __substitute_composite_key(self, key, composite_file, dataset=None):
-        if composite_file.substitute_name_with_metadata:
-            if dataset:
-                meta_value = str(dataset.metadata.get(composite_file.substitute_name_with_metadata))
-            else:
-                meta_value = self.spec[composite_file.substitute_name_with_metadata].default  # type: ignore
-            return key % meta_value
-        return key
 
     @property
     def writable_files(self):
@@ -813,6 +806,14 @@ class Data(metaclass=DataMeta):
         if self.composite_type != "auto_primary_file":
             files[self.primary_file_name] = self.__new_composite_file(self.primary_file_name)
         for key, value in self.get_composite_files().items():
+            files[key] = value
+        return files
+
+    def get_writable_files_for_dataset(self, dataset):
+        files = {}
+        if self.composite_type != "auto_primary_file":
+            files[self.primary_file_name] = self.__new_composite_file(self.primary_file_name)
+        for key, value in self.get_composite_files(dataset).items():
             files[key] = value
         return files
 

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -393,9 +393,14 @@ class Registry:
                                     "description": description,
                                     "description_url": description_url,
                                 }
-                                composite_files = datatype_instance.composite_files
+                                composite_files = datatype_instance.get_composite_files()
                                 if composite_files:
-                                    datatype_info_dict["composite_files"] = [_.dict() for _ in composite_files.values()]
+                                    _composite_files = []
+                                    for name, composite_file in composite_files.items():
+                                        _composite_file = composite_file.dict()
+                                        _composite_file["name"] = name
+                                        _composite_files.append(_composite_file)
+                                    datatype_info_dict["composite_files"] = _composite_files
                                 self.datatype_info_dicts.append(datatype_info_dict)
 
                                 for auto_compressed_type in auto_compressed_types:

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -161,18 +161,27 @@ def _fetch_target(upload_config: "UploadConfig", target):
         composite = item.pop("composite", None)
         if datatype and datatype.composite_type:
             composite_type = datatype.composite_type
-            writable_files = datatype.writable_files
             assert composite_type == "auto_primary_file", "basic composite uploads not yet implemented"
 
             # get_composite_dataset_name finds dataset name from basename of contents
             # and such but we're not implementing that here yet. yagni?
             # also need name...
+            metadata = {
+                composite_file.substitute_name_with_metadata: datatype.metadata_spec[
+                    composite_file.substitute_name_with_metadata
+                ].default
+                for composite_file in datatype.composite_files.values()
+                if composite_file.substitute_name_with_metadata
+            }
             name = item.get("name") or "Composite Dataset"
-            dataset_bunch = Bunch(
+            metadata["base_name"] = name
+            dataset = Bunch(
                 name=name,
+                metadata=metadata,
             )
+            writable_files = datatype.get_writable_files_for_dataset(dataset)
             primary_file = stream_to_file(
-                StringIO(datatype.generate_primary_file(dataset_bunch)),
+                StringIO(datatype.generate_primary_file(dataset)),
                 prefix="upload_auto_primary_file",
                 dir=upload_config.working_directory,
             )
@@ -189,7 +198,7 @@ def _fetch_target(upload_config: "UploadConfig", target):
             }
             _copy_and_validate_simple_attributes(item, rval)
             composite_items = composite.get("elements", [])
-            keys = [value.name for value in writable_files.values()]
+            keys = list(writable_files.keys())
             composite_item_idx = 0
             for composite_item in composite_items:
                 if composite_item_idx >= len(keys):

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -435,6 +435,24 @@ class ToolsUploadTestCase(ApiTestCase):
             }
         }
         inputs, datsets = stage_inputs(self.galaxy_interactor, history_id, job, use_path_paste=False)
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+
+    @skip_without_datatype("velvet")
+    @uses_test_history(require_new=False)
+    def test_composite_datatype_pbed_stage_fetch(self, history_id):
+        job = {
+            "input1": {
+                "class": "File",
+                "format": "pbed",
+                "composite_data": [
+                    "test-data/rgenetics.bim",
+                    "test-data/rgenetics.bed",
+                    "test-data/rgenetics.fam",
+                ],
+            }
+        }
+        inputs, datsets = stage_inputs(self.galaxy_interactor, history_id, job, use_path_paste=False)
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
 
     @skip_without_datatype("velvet")
     @uses_test_history(require_new=False)
@@ -453,6 +471,7 @@ class ToolsUploadTestCase(ApiTestCase):
         inputs, datsets = stage_inputs(
             self.galaxy_interactor, history_id, job, use_path_paste=False, use_fetch_api=False
         )
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
 
     @skip_without_datatype("velvet")
     @uses_test_history(require_new=False)


### PR DESCRIPTION
And also fixes the display name of the composite element:

Before:
<img width="1080" alt="Screenshot 2022-06-10 at 21 11 24" src="https://user-images.githubusercontent.com/6804901/173134321-ab0a8cae-7ee7-4e8e-aa99-06748e8459fb.png">


After:
<img width="870" alt="Screenshot 2022-06-10 at 21 08 44" src="https://user-images.githubusercontent.com/6804901/173134225-076978ea-45e1-4e27-b2ec-c3f785bf407d.png">


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
