### PR TITLE
[23.0] celery_extended doesn't update disk usage for work dir outputs.

### DIFF
--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -869,6 +869,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
     @uses_test_history(require_new=False)
     def test_run_cat1(self, history_id):
         # Run simple non-upload tool with an input data parameter.
+        initial_disk_usage = self.dataset_populator.total_disk_usage()
         new_dataset = self.dataset_populator.new_dataset(history_id, content="Cat1Test")
         inputs = dict(
             input1=dataset_to_param(new_dataset),
@@ -878,6 +879,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         self.assertEqual(output1_content.strip(), "Cat1Test")
+        final_disk_usage = self.dataset_populator.total_disk_usage()
+        assert final_disk_usage >= initial_disk_usage + 9 * 2
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=True)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1057,6 +1057,13 @@ class BaseDatasetPopulator(BasePopulator):
         assert "id" in role, role
         return role["id"]
 
+    def total_disk_usage(self) -> float:
+        response = self._get("users/current")
+        response.raise_for_status()
+        user_object = response.json()
+        assert "total_disk_usage" in user_object
+        return user_object["total_disk_usage"]
+
     def create_role(self, user_ids: list, description: Optional[str] = None) -> dict:
         payload = {
             "name": self.get_random_name(prefix="testpop"),

--- a/test/integration/test_metadata_strategy.py
+++ b/test/integration/test_metadata_strategy.py
@@ -1,0 +1,30 @@
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    uses_test_history,
+)
+from galaxy_test.driver.integration_util import IntegrationTestCase
+
+
+class TestDiskUsageUpdateDefault(IntegrationTestCase):
+    framework_tool_and_types = True
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    @uses_test_history(require_new=False)
+    def test_run_work_dir_glob(self, history_id):
+        # Run a tool with a work dir glob and ensure content and disk usage is updated.
+        self.dataset_populator.new_dataset(history_id, content="fwd1Test", wait=True)
+        initial_disk_usage = self.dataset_populator.total_disk_usage()
+        response = self.dataset_populator.run_tool("from_work_dir_glob", {}, history_id, assert_ok=True)
+        self.dataset_populator.wait_for_job(job_id=response["jobs"][0]["id"])
+        final_disk_usage = self.dataset_populator.total_disk_usage()
+        assert final_disk_usage == initial_disk_usage + 3
+
+
+class TestDiskUsageCeleryExtended(TestDiskUsageUpdateDefault):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["metadata_strategy"] = "celery_extended"


### PR DESCRIPTION
So far just a test case to demonstrate disk usage update for work dir outputs is broken with celery_extended - the test case works by default but fails for celery_extended. 

Discovered this working on quota stuff.

Open questions...
- [ ] True of non-work dir outputs?
- [ ] How to fix?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
