### PR TITLE
Add workflow invocations link to email template

### DIFF
--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -55,7 +55,9 @@ class EmailAction(DefaultJobAction):
         try:
             frm = app.config.email_from
             history_id_encoded = app.security.encode_id(job.history_id)
+            invocation_id_encoded = app.security.encode_id(job.workflow_invocation_step.workflow_invocation_id)
             link = f"{app.config.galaxy_infrastructure_url}/histories/view?id={history_id_encoded}"
+            link_invocation = f"{app.config.galaxy_infrastructure_url}/workflows/invocations/report?id={invocation_id_encoded}"
             if frm is None:
                 if action.action_arguments and "host" in action.action_arguments:
                     host = action.action_arguments["host"]
@@ -66,6 +68,7 @@ class EmailAction(DefaultJobAction):
             subject = f"Galaxy job completion notification from history '{job.history.name}'"
             outdata = ",\n".join(ds.dataset.display_name() for ds in job.output_datasets)
             body = f"Your Galaxy job generating dataset(s):\n\n{outdata}\n\nis complete as of {datetime.datetime.now().strftime('%I:%M')}. Click the link below to access your data: \n{link}"
+            body += f"\n\nWorkflow Invocation Report:\n{link_invocation}"
             send_mail(frm, to, subject, body, app.config)
         except Exception as e:
             log.error("EmailAction PJA Failed, exception: %s", unicodify(e))

--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -57,7 +57,9 @@ class EmailAction(DefaultJobAction):
             history_id_encoded = app.security.encode_id(job.history_id)
             invocation_id_encoded = app.security.encode_id(job.workflow_invocation_step.workflow_invocation_id)
             link = f"{app.config.galaxy_infrastructure_url}/histories/view?id={history_id_encoded}"
-            link_invocation = f"{app.config.galaxy_infrastructure_url}/workflows/invocations/report?id={invocation_id_encoded}"
+            link_invocation = (
+                f"{app.config.galaxy_infrastructure_url}/workflows/invocations/report?id={invocation_id_encoded}"
+            )
             if frm is None:
                 if action.action_arguments and "host" in action.action_arguments:
                     host = action.action_arguments["host"]


### PR DESCRIPTION
To the existing "Galaxy job completion notification" email, added link to the Workflow Invocations Report as requested in Github #13924 issue. (Note: This PR replaces the [defunct/closed PR 14045](https://github.com/galaxyproject/galaxy/pull/14045) - see for the Reviewer comments.)

Before:
![fix_before](https://user-images.githubusercontent.com/3672779/172892214-10d07184-1fd3-4ffc-9cc3-35efd3c2e86d.png)

After:
![fix_after](https://user-images.githubusercontent.com/3672779/172892213-734ff088-a9d6-49bd-82e5-101cab7ae20c.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

