### PR TITLE
Use standard date format in library folder contents

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -159,11 +159,7 @@
                     </div>
                 </template>
                 <template v-slot:cell(update_time)="row">
-                    <UtcDate
-                        v-if="row.item.update_time"
-                        :date="row.item.update_time"
-                        custom-format="'YYYY-MM-DD- HH:mm a'"
-                        mode="elapsed" />
+                    <UtcDate v-if="row.item.update_time" :date="row.item.update_time" mode="elapsed" />
                 </template>
                 <template v-slot:cell(is_unrestricted)="row">
                     <font-awesome-icon v-if="row.item.is_unrestricted" title="Unrestricted dataset" icon="globe" />

--- a/client/src/components/UtcDate.vue
+++ b/client/src/components/UtcDate.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import { formatDistanceToNow, parse, parseISO } from "date-fns";
+import { formatDistanceToNow, parseISO } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 
 export default {
@@ -24,10 +24,6 @@ export default {
             type: String,
             default: "date", // or elapsed
         },
-        customFormat: {
-            type: String,
-            default: undefined,
-        },
     },
     computed: {
         elapsedTime: function () {
@@ -37,12 +33,8 @@ export default {
             return this.parsedDate.toISOString();
         },
         parsedDate: function () {
-            if (this.customFormat !== undefined) {
-                return parse(this.date, this.customFormat, new Date());
-            } else {
-                // assume ISO format date, except in Galaxy this won't have TZinfo -- it will always be Zulu
-                return parseISO(`${this.date}Z`);
-            }
+            // assume ISO format date, except in Galaxy this won't have TZinfo -- it will always be Zulu
+            return parseISO(`${this.date}Z`);
         },
         pretty: function () {
             return `${formatInTimeZone(this.parsedDate, "Etc/Zulu", "eeee MMM do H:mm:ss yyyy")} UTC`;

--- a/lib/galaxy/managers/cloudauthzs.py
+++ b/lib/galaxy/managers/cloudauthzs.py
@@ -67,7 +67,7 @@ class CloudAuthzsSerializer(base.ModelSerializer):
             else None,
             "last_update": lambda item, key, **context: str(item.last_update),
             "last_activity": lambda item, key, **context: str(item.last_activity),
-            "create_time": lambda item, key, **context: str(item.create_time),
+            "create_time": lambda item, key, **context: item.create_time.isoformat(),
             "description": lambda item, key, **context: str(item.description),
         }
         self.serializers.update(serializers)

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -243,8 +243,8 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         rval["folder_id"] = f"F{rval['folder_id']}"
         rval["full_path"] = full_path
         rval["file_size"] = util.nice_size(int(ldda.get_size()))
-        rval["date_uploaded"] = ldda.create_time.strftime("%Y-%m-%d %I:%M %p")
-        rval["update_time"] = ldda.update_time.strftime("%Y-%m-%d %I:%M %p")
+        rval["date_uploaded"] = ldda.create_time.isoformat()
+        rval["update_time"] = ldda.update_time.isoformat()
         rval["can_user_modify"] = trans.user_is_admin or trans.app.security_agent.can_modify_library_item(
             current_user_roles, ld
         )

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8919,8 +8919,8 @@ class PageRevision(Base, Dictifiable, RepresentById):
 
     def to_dict(self, view="element"):
         rval = super().to_dict(view=view)
-        rval["create_time"] = str(self.create_time)
-        rval["update_time"] = str(self.update_time)
+        rval["create_time"] = self.create_time.isoformat()
+        rval["update_time"] = self.update_time.isoformat()
         return rval
 
 

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -522,7 +522,7 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
         trans.sa_session.flush()
         ldda_dict = ldda.to_dict()
         rval = trans.security.encode_dict_ids(ldda_dict)
-        update_time = ldda.update_time.strftime("%Y-%m-%d %I:%M %p")
+        update_time = ldda.update_time.isoformat()
         rval["update_time"] = update_time
         return rval
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -282,7 +282,7 @@ class WorkflowsAPIController(
             trans, workflow_id, by_stored_id=not instance
         )
         return [
-            {"version": i, "update_time": str(w.update_time), "steps": len(w.steps)}
+            {"version": i, "update_time": w.update_time.isoformat(), "steps": len(w.steps)}
             for i, w in enumerate(reversed(stored_workflow.workflows))
         ]
 

--- a/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
@@ -14,7 +14,6 @@ from galaxy.webapps.galaxy.services.base import ServiceBase
 
 log = logging.getLogger(__name__)
 
-TIME_FORMAT = "%Y-%m-%d %I:%M %p"
 FOLDER_TYPE_NAME = "folder"
 FILE_TYPE_NAME = "file"
 
@@ -95,7 +94,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
         for content_item in self._load_folder_contents(trans, folders, datasets, offset, limit):
             return_item = {}
             encoded_id = trans.security.encode_id(content_item.id)
-            create_time = content_item.create_time.strftime(TIME_FORMAT)
+            create_time = str(content_item.create_time)
 
             if content_item.api_type == FOLDER_TYPE_NAME:
                 encoded_id = f"F{encoded_id}"
@@ -105,7 +104,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
                 can_manage = is_admin or (
                     trans.user and trans.app.security_agent.can_manage_library_item(current_user_roles, folder)
                 )
-                update_time = content_item.update_time.strftime(TIME_FORMAT)
+                update_time = str(content_item.update_time)
                 return_item.update(dict(can_modify=can_modify, can_manage=can_manage))
                 if content_item.description:
                     return_item.update(dict(description=content_item.description))
@@ -131,7 +130,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
                 )
                 raw_size = int(content_item.library_dataset_dataset_association.get_size())
                 nice_size = util.nice_size(raw_size)
-                update_time = content_item.library_dataset_dataset_association.update_time.strftime(TIME_FORMAT)
+                update_time = str(content_item.library_dataset_dataset_association.update_time)
 
                 library_dataset_dict = content_item.to_dict()
                 encoded_ldda_id = trans.security.encode_id(content_item.library_dataset_dataset_association.id)

--- a/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
@@ -94,7 +94,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
         for content_item in self._load_folder_contents(trans, folders, datasets, offset, limit):
             return_item = {}
             encoded_id = trans.security.encode_id(content_item.id)
-            create_time = str(content_item.create_time)
+            create_time = content_item.create_time.isoformat()
 
             if content_item.api_type == FOLDER_TYPE_NAME:
                 encoded_id = f"F{encoded_id}"
@@ -104,7 +104,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
                 can_manage = is_admin or (
                     trans.user and trans.app.security_agent.can_manage_library_item(current_user_roles, folder)
                 )
-                update_time = str(content_item.update_time)
+                update_time = content_item.update_time.isoformat()
                 return_item.update(dict(can_modify=can_modify, can_manage=can_manage))
                 if content_item.description:
                     return_item.update(dict(description=content_item.description))
@@ -130,7 +130,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
                 )
                 raw_size = int(content_item.library_dataset_dataset_association.get_size())
                 nice_size = util.nice_size(raw_size)
-                update_time = str(content_item.library_dataset_dataset_association.update_time)
+                update_time = content_item.library_dataset_dataset_association.update_time.isoformat()
 
                 library_dataset_dict = content_item.to_dict()
                 encoded_ldda_id = trans.security.encode_id(content_item.library_dataset_dataset_association.id)


### PR DESCRIPTION
Fixes the failing date parsing and is more consistent with the rest of
this API. Probably fallout from dropping moment.js in #13800 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Go to a Library folder with JS console open and see that there are no exceptions like in the screenshot:
 
![Screenshot 2022-06-13 at 11 57 23](https://user-images.githubusercontent.com/6804901/173444433-a43bc3dd-7b16-4fde-8c09-17cb4c3f3d09.png)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
