### PR TITLE
[22.01] Enable generating urls for WSGI routes within FastAPI routes

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -97,7 +97,10 @@ from galaxy.util.task import IntervalTask
 from galaxy.visualization.data_providers.registry import DataProviderRegistry
 from galaxy.visualization.genomes import Genomes
 from galaxy.visualization.plugins.registry import VisualizationsRegistry
-from galaxy.web import url_for
+from galaxy.web import (
+    legacy_url_for,
+    url_for,
+)
 from galaxy.web.proxy import ProxyManager
 from galaxy.web_stack import application_stack_instance, ApplicationStack
 from galaxy.webhooks import WebhooksRegistry
@@ -610,10 +613,12 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         # Inject url_for for components to more easily optionally depend
         # on url_for.
         self.url_for = url_for
+        self.legacy_url_for = legacy_url_for
 
         self.server_starttime = int(time.time())  # used for cachebusting
         # Limit lifetime of tool shed repository cache to app startup
         self.tool_shed_repository_cache = None
+        self.legacy_mapper = None
         log.info(f"Galaxy app startup finished {startup_timer}")
 
     def _shutdown_queue_worker(self):

--- a/lib/galaxy/datatypes/display_applications/application.py
+++ b/lib/galaxy/datatypes/display_applications/application.py
@@ -53,13 +53,16 @@ class DisplayApplicationLink:
 
     def get_display_url(self, data, trans):
         dataset_hash, user_hash = encode_dataset_user(trans, data, None)
-        return trans.app.url_for(controller='dataset',
-                                 action="display_application",
-                                 dataset_id=dataset_hash,
-                                 user_id=user_hash,
-                                 app_name=quote_plus(self.display_application.id),
-                                 link_name=quote_plus(self.id),
-                                 app_action=None)
+        return trans.app.legacy_url_for(
+            mapper=trans.app.legacy_mapper,
+            controller="dataset",
+            action="display_application",
+            dataset_id=dataset_hash,
+            user_id=user_hash,
+            app_name=quote_plus(self.display_application.id),
+            link_name=quote_plus(self.id),
+            app_action=None,
+        )
 
     def get_inital_values(self, data, trans):
         if self.other_values:

--- a/lib/galaxy/web/__init__.py
+++ b/lib/galaxy/web/__init__.py
@@ -2,7 +2,10 @@
 The Galaxy web application framework
 """
 
-from .framework import url_for
+from .framework import (
+    legacy_url_for,
+    url_for,
+)
 from .framework.base import httpexceptions
 from .framework.decorators import (
     do_not_cache,
@@ -25,11 +28,26 @@ from .framework.decorators import (
     require_login,
 )
 
-__all__ = ('do_not_cache', 'error', 'expose', 'expose_api',
-        'expose_api_anonymous', 'expose_api_anonymous_and_sessionless',
-        'expose_api_raw', 'expose_api_raw_anonymous',
-        'expose_api_raw_anonymous_and_sessionless',
-        'format_return_as_json', 'httpexceptions', 'json', 'json_pretty',
-        'legacy_expose_api', 'legacy_expose_api_anonymous',
-        'legacy_expose_api_raw', 'legacy_expose_api_raw_anonymous',
-        'require_admin', 'require_login', 'url_for')
+__all__ = (
+    "do_not_cache",
+    "error",
+    "expose",
+    "expose_api",
+    "expose_api_anonymous",
+    "expose_api_anonymous_and_sessionless",
+    "expose_api_raw",
+    "expose_api_raw_anonymous",
+    "expose_api_raw_anonymous_and_sessionless",
+    "format_return_as_json",
+    "httpexceptions",
+    "json",
+    "json_pretty",
+    "legacy_expose_api",
+    "legacy_expose_api_anonymous",
+    "legacy_expose_api_raw",
+    "legacy_expose_api_raw_anonymous",
+    "require_admin",
+    "require_login",
+    "legacy_url_for",
+    "url_for",
+)

--- a/lib/galaxy/web/framework/__init__.py
+++ b/lib/galaxy/web/framework/__init__.py
@@ -2,6 +2,8 @@
 Galaxy web application framework
 """
 
+from routes import request_config
+
 from . import base
 
 DEPRECATED_URL_ATTRIBUTE_MESSAGE = "*deprecated attribute, URL not filled in by server*"
@@ -17,6 +19,15 @@ def handle_url_for(*args, **kwargs) -> str:
         return base.routes.url_for(*args, **kwargs)
     except AttributeError:
         return DEPRECATED_URL_ATTRIBUTE_MESSAGE
+
+
+def legacy_url_for(mapper, *args, **kwargs) -> str:
+    """
+    Re-establishes the mapper for legacy WSGI routes.
+    """
+    rc = request_config()
+    rc.mapper = mapper
+    return base.routes.url_for(*args, **kwargs)
 
 
 url_for = handle_url_for

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -205,6 +205,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     # ==== Done
     # Indicate that all configuration settings have been provided
     webapp.finalize_config()
+    app.legacy_mapper = webapp.mapper
 
     # Wrap the webapp in some useful middleware
     if kwargs.get('middleware', True):

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
+    skip_if_github_down,
     skip_without_datatype,
     skip_without_tool,
 )
@@ -224,3 +225,16 @@ class DatasetsApiTestCase(ApiTestCase):
         archive = zipfile.ZipFile(BytesIO(response.content))
         namelist = archive.namelist()
         assert len(namelist) == 4, f"Expected 3 elements in [{namelist}]"
+
+    @skip_if_github_down
+    def test_display_application_link(self):
+        item = {
+            "src": "url",
+            "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bam",
+            "ext": "bam"
+        }
+        output = self.dataset_populator.fetch_hda(
+            self.history_id, item
+        )
+        dataset_details = self.dataset_populator.get_history_dataset_details(self.history_id, dataset=output, assert_ok=True)
+        assert "display_application/" in dataset_details["display_apps"][0]["links"][0]["href"]


### PR DESCRIPTION
Fixes the display_applications link.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
