### PR TITLE
Fail selenium test if browser console logs error

### DIFF
--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -96,6 +96,9 @@ describe("Invocations.vue", () => {
                 propsData,
                 computed: {
                     getWorkflowNameByInstanceId: (state) => (id) => "workflow name",
+                    getStoredWorkflowIdByInstanceId: (state) => (id) => {
+                        return "workflowId";
+                    },
                     getWorkflowByInstanceId: (state) => (id) => {
                         return { id: "workflowId" };
                     },

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -65,7 +65,10 @@
                 <UtcDate :date="data.value" mode="elapsed" />
             </template>
             <template v-slot:cell(execute)="data">
-                <WorkflowRunButton :id="getWorkflowByInstanceId(data.item.workflow_id).id" :root="root" />
+                <WorkflowRunButton
+                    :id="getStoredWorkflowIdByInstanceId(data.item.workflow_id)"
+                    :root="root"
+                    v-if="getStoredWorkflowIdByInstanceId(data.item.workflow_id)" />
             </template>
         </b-table>
         <b-pagination
@@ -122,7 +125,7 @@ export default {
         };
     },
     computed: {
-        ...mapGetters(["getWorkflowNameByInstanceId", "getWorkflowByInstanceId"]),
+        ...mapGetters(["getWorkflowNameByInstanceId", "getWorkflowByInstanceId", "getStoredWorkflowIdByInstanceId"]),
         ...mapGetters("history", ["getHistoryById", "getHistoryNameById"]),
         title() {
             let title = `Workflow Invocations`;

--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -38,7 +38,7 @@ export var DatasetListItemView = _super.extend(
             if (attributes.logger) {
                 this.logger = this.model.logger = attributes.logger;
             }
-            this.log(`${this}.initialize:`, attributes);
+            this.log(`${this}.initialize:`, attributes.model);
             _super.prototype.initialize.call(this, attributes);
 
             /** where should pages from links be displayed? (default to new tab/window) */

--- a/client/src/store/workflowStore.js
+++ b/client/src/store/workflowStore.js
@@ -18,6 +18,10 @@ const getters = {
             return "...";
         }
     },
+    getStoredWorkflowIdByInstanceId: (state) => (workflowId) => {
+        const storedWorkflow = state.workflowsByInstanceId[workflowId];
+        return storedWorkflow?.id;
+    },
 };
 
 const actions = {

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -438,7 +438,7 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin, Use
 class SeleniumTestCase(FunctionalTestCase, TestWithSeleniumMixin):
     galaxy_driver_class = GalaxyTestDriver
     ACCEPTABLE_LOG_LEVELS = ("DEBUG", "INFO", "WARNING")
-    IGNORE_ERRORS = ("favicon", "xkcd", "phdcomics")
+    IGNORE_ERRORS = ("favicon", "xkcd", "phdcomics", "Failed to load resource")
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Fails like this:

```
self = <galaxy_test.selenium.test_workflow_invocation_details.WorkflowInvocationDetailsTestCase testMethod=test_job_details>

    def raise_exception_on_console_error(self):
        error_logs = "\n".join(self.get_error_messages())
        if error_logs:
>           raise Exception(f"console logged following errors:\n {error_logs}")
E           Exception: console logged following errors:
E            webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js 622:14 "[Vue warn]: Error in render: \"TypeError: Cannot read properties of undefined (reading 'id')\"\n\nfound in\n\n---> \u003CBTable>\n       \u003CInvocations> at src/components/Workflow/Invocations.vue\n         \u003CCurrentUser>\n           \u003CRoot>"
E           webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js 1898:12 TypeError: Cannot read properties of undefined (reading 'id')
E               at fn (webpack-internal:///./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib/index.js??vue-loader-options!./src/components/Workflow/Invocations.vue?vue&type=template&id=07e45a23&scoped=true&:276:27)
E               at normalized (webpack-internal:///./node_modules/vue/dist/vue.runtime.esm.js:2605:37)
E               at normalizeSlot (webpack-internal:///./node_modules/bootstrap-vue/esm/utils/normalize-slot.js:59:71)
E               at VueComponent.normalizeSlot (webpack-internal:///./node_modules/bootstrap-vue/esm/mixins/normalize-slot.js:32:88)
E               at VueComponent.renderTbodyRowCell (webpack-internal:///./node_modules/bootstrap-vue/esm/components/table/helpers/mixin-tbody-row.js:215:41)
E               at eval (webpack-internal:///./node_modules/bootstrap-vue/esm/components/table/helpers/mixin-tbody-row.js:248:23)
E               at Array.map (<anonymous>)
E               at VueComponent.renderTbodyRow (webpack-internal:///./node_modules/bootstrap-vue/esm/components/table/helpers/mixin-tbody-row.js:247:25)
E               at eval (webpack-internal:///./node_modules/bootstrap-vue/esm/components/table/helpers/mixin-tbody.js:210:28)
E               at Array.forEach (<anonymous>)

lib/galaxy_test/selenium/framework.py:464: Exception
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
