### PR TITLE
Add Workflow Invocation Tabs

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
@@ -1,14 +1,10 @@
 <template>
     <div v-if="invocation">
-        <div v-if="Object.keys(invocation.input_step_parameters).length">
-            <details class="invocation-parameters-details">
-                <summary><b>Parameters</b></summary>
+        <b-tabs lazy>
+            <b-tab v-if="Object.keys(invocation.input_step_parameters).length" title="Parameters">
                 <parameter-step :parameters="Object.values(invocation.input_step_parameters)" />
-            </details>
-        </div>
-        <div v-if="Object.keys(invocation.inputs).length">
-            <details class="invocation-inputs-details">
-                <summary><b>Inputs</b></summary>
+            </b-tab>
+            <b-tab v-if="Object.keys(invocation.inputs).length" title="Inputs">
                 <div
                     v-for="(input, key) in invocation.inputs"
                     :key="input.id"
@@ -16,29 +12,20 @@
                     <b>{{ dataInputStepLabel(key, input) }}</b>
                     <generic-history-item :item-id="input.id" :item-src="input.src" />
                 </div>
-            </details>
-        </div>
-        <div v-if="Object.keys(invocation.outputs).length">
-            <details class="invocation-outputs-details">
-                <summary><b>Outputs</b></summary>
+            </b-tab>
+            <b-tab v-if="Object.keys(invocation.outputs).length" title="Outputs">
                 <div v-for="(output, key) in invocation.outputs" :key="output.id">
                     <b>{{ key }}:</b>
                     <generic-history-item :item-id="output.id" :item-src="output.src" />
                 </div>
-            </details>
-        </div>
-        <div v-if="Object.keys(invocation.output_collections).length">
-            <details class="invocation-output-collections-details">
-                <summary><b>Output Collections</b></summary>
+            </b-tab>
+            <b-tab v-if="Object.keys(invocation.output_collections).length" title="Output Collections">
                 <div v-for="(output, key) in invocation.output_collections" :key="output.id">
                     <b>{{ key }}:</b>
                     <generic-history-item :item-id="output.id" :item-src="output.src" />
                 </div>
-            </details>
-        </div>
-        <div v-if="workflow">
-            <details v-if="workflow" class="invocation-steps-details">
-                <summary><b>Steps</b></summary>
+            </b-tab>
+            <b-tab v-if="workflow" title="Steps">
                 <workflow-invocation-step
                     v-for="step in Object.values(workflow.steps)"
                     :key="step.id"
@@ -46,8 +33,8 @@
                     :ordered-steps="orderedSteps"
                     :workflow="workflow"
                     :workflow-step="step" />
-            </details>
-        </div>
+            </b-tab>
+        </b-tabs>
     </div>
 </template>
 <script>
@@ -66,11 +53,8 @@ export default {
     },
     props: {
         invocation: {
+            type: Object,
             required: true,
-        },
-        invocationAndJobTerminal: {
-            required: true,
-            type: Boolean,
         },
     },
     computed: {

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationExportOptions.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationExportOptions.vue
@@ -1,13 +1,10 @@
 <template>
     <b-card-group deck>
-        <b-card title="BioCompute Object" class="mb-2">
-            <p>BioCompute Object description...</p>
-            <a class="bco-json" :href="bcoJSON"><b>Download</b></a>
+        <b-card title="BioCompute Object" class="export-plugin-card">
+            <p>Learn more about <a href="https://biocomputeobject.org/" target="_blank">BioCompute Objects</a>.</p>
+            <a class="bco-json" :href="bcoDownloadLink"><b>Download</b></a>
         </b-card>
-        <!-- <b-card title="RO-Crate">
-                <p>RO-Crate description...</p>
-                <a class="bco-json" :href="bcoJSON"><b>Download</b></a>
-            </b-card> -->
+        <!-- Add more export plugins here -->
     </b-card-group>
 </template>
 
@@ -21,7 +18,7 @@ export default {
         },
     },
     computed: {
-        bcoJSON: function () {
+        bcoDownloadLink: function () {
             return `${getAppRoot()}api/invocations/${this.invocationId}/biocompute/download`;
         },
     },

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationExportOptions.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationExportOptions.vue
@@ -1,0 +1,29 @@
+<template>
+    <b-card-group deck>
+        <b-card title="BioCompute Object" class="mb-2">
+            <p>BioCompute Object description...</p>
+            <a class="bco-json" :href="bcoJSON"><b>Download</b></a>
+        </b-card>
+        <!-- <b-card title="RO-Crate">
+                <p>RO-Crate description...</p>
+                <a class="bco-json" :href="bcoJSON"><b>Download</b></a>
+            </b-card> -->
+    </b-card-group>
+</template>
+
+<script>
+import { getAppRoot } from "onload/loadConfig";
+export default {
+    props: {
+        invocationId: {
+            type: String,
+            required: true,
+        },
+    },
+    computed: {
+        bcoJSON: function () {
+            return `${getAppRoot()}api/invocations/${this.invocationId}/biocompute/download`;
+        },
+    },
+};
+</script>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
@@ -34,16 +34,6 @@ describe("WorkflowInvocationState.vue with terminal invocation", () => {
     it("determines that invocation and job states are terminal", async () => {
         expect(wrapper.vm.invocationAndJobTerminal).toBeTruthy();
     });
-
-    it("displays report links", async () => {
-        expect(wrapper.find(".invocation-pdf-link").exists()).toBeTruthy();
-        expect(wrapper.find(".invocation-report-link").exists()).toBeTruthy();
-        expect(wrapper.find(".bco-json").exists()).toBeTruthy();
-    });
-
-    it("doesn't show cancel invocation button", async () => {
-        expect(wrapper.find(".cancel-workflow-scheduling").exists()).toBeFalsy();
-    });
 });
 
 describe("WorkflowInvocationState.vue with no invocation", () => {
@@ -76,15 +66,5 @@ describe("WorkflowInvocationState.vue with no invocation", () => {
 
     it("determines that invocation and job states are not terminal", async () => {
         expect(wrapper.vm.invocationAndJobTerminal).toBeFalsy();
-    });
-
-    it("does not display report links", async () => {
-        expect(wrapper.find(".invocation-pdf-link").exists()).toBeFalsy();
-        expect(wrapper.find(".invocation-report-link").exists()).toBeFalsy();
-        expect(wrapper.find(".bco-json").exists()).toBeFalsy();
-    });
-
-    it("shows cancel invocation button", async () => {
-        expect(wrapper.find(".cancel-workflow-scheduling").exists()).toBeTruthy();
     });
 });

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -14,9 +14,9 @@
                 :invocation="invocation"
                 :invocation-and-job-terminal="invocationAndJobTerminal" />
         </b-tab>
-        <b-tab title="Workflow Overview">
+        <!-- <b-tab title="Workflow Overview">
             <p>TODO: Insert readonly version of workflow editor here</p>
-        </b-tab>
+        </b-tab> -->
         <b-tab title="Export">
             <div v-if="invocationAndJobTerminal">
                 <workflow-invocation-export-options :invocation-id="invocation.id" />

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.test.js
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.test.js
@@ -1,0 +1,82 @@
+import WorkflowInvocationSummary from "./WorkflowInvocationSummary";
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import Vuex from "vuex";
+import invocationData from "../Workflow/test/json/invocation.json";
+
+const invocationJobsSummaryById = {
+    id: "d9833097445452b0",
+    model: "WorkflowInvocation",
+    states: {},
+    populated_state: "ok",
+};
+
+const mockComputed = {
+    getInvocationJobsSummaryById: () => () => invocationJobsSummaryById,
+};
+
+const localVue = getLocalVue();
+
+describe("WorkflowInvocationSummary.vue with terminal invocation", () => {
+    let wrapper;
+    let propsData;
+
+    beforeEach(async () => {
+        propsData = {
+            invocation: invocationData,
+            invocationAndJobTerminal: true,
+            invocationSchedulingTerminal: true,
+        };
+        wrapper = shallowMount(WorkflowInvocationSummary, {
+            propsData,
+            computed: mockComputed,
+            localVue,
+        });
+    });
+
+    it("displays report links", async () => {
+        expect(wrapper.find(".invocation-pdf-link").exists()).toBeTruthy();
+        expect(wrapper.find(".invocation-report-link").exists()).toBeTruthy();
+    });
+
+    it("doesn't show cancel invocation button", async () => {
+        expect(wrapper.find(".cancel-workflow-scheduling").exists()).toBeFalsy();
+    });
+});
+
+describe("WorkflowInvocationSummary.vue with invocation scheduling running", () => {
+    let wrapper;
+    let propsData;
+    let store;
+    let actions;
+
+    beforeEach(async () => {
+        actions = {
+            fetchInvocationForId: jest.fn(),
+            fetchInvocationJobsSummaryForId: jest.fn(),
+        };
+        store = new Vuex.Store({
+            actions,
+        });
+        propsData = {
+            invocation: invocationData,
+            invocationAndJobTerminal: false,
+            invocationSchedulingTerminal: false,
+        };
+        wrapper = shallowMount(WorkflowInvocationSummary, {
+            store,
+            propsData,
+            computed: mockComputed,
+            localVue,
+        });
+    });
+
+    it("does not display report links", async () => {
+        expect(wrapper.find(".invocation-pdf-link").exists()).toBeFalsy();
+        expect(wrapper.find(".invocation-report-link").exists()).toBeFalsy();
+    });
+
+    it("shows cancel invocation button", async () => {
+        expect(wrapper.find(".cancel-workflow-scheduling").exists()).toBeTruthy();
+    });
+});

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
@@ -1,0 +1,153 @@
+<template>
+    <div class="mb-3 workflow-invocation-state-component">
+        <div v-if="invocationAndJobTerminal">
+            <span>
+                <a class="invocation-report-link" :href="invocationLink">
+                    <b>View Report {{ indexStr }}</b>
+                </a>
+                <a
+                    v-b-tooltip
+                    class="fa fa-print ml-1 invocation-pdf-link"
+                    :href="invocationPdfLink"
+                    title="Download PDF" />
+            </span>
+        </div>
+        <div v-else>
+            <span class="fa fa-spinner fa-spin" />
+            <span>Invocation {{ indexStr }}...</span>
+            <span
+                v-if="!invocationSchedulingTerminal"
+                v-b-tooltip.hover
+                class="fa fa-times cancel-workflow-scheduling"
+                title="Cancel scheduling of workflow invocation"
+                @click="onCancel"></span>
+        </div>
+        <progress-bar v-if="!stepCount" note="Loading step state summary..." :loading="true" class="steps-progress" />
+        <progress-bar
+            v-else-if="invocationState == 'cancelled'"
+            note="Invocation scheduling cancelled - expected jobs and outputs may not be generated."
+            :error-count="1"
+            class="steps-progress" />
+        <progress-bar
+            v-else-if="invocationState == 'failed'"
+            note="Invocation scheduling failed - Galaxy administrator may have additional details in logs."
+            :error-count="1"
+            class="steps-progress" />
+        <progress-bar
+            v-else
+            :note="stepStatesStr"
+            :total="stepCount"
+            :ok-count="stepStates.scheduled"
+            :loading="!invocationSchedulingTerminal"
+            class="steps-progress" />
+        <progress-bar
+            :note="jobStatesStr"
+            :total="jobCount"
+            :ok-count="okCount"
+            :running-count="runningCount"
+            :new-count="newCount"
+            :error-count="errorCount"
+            :loading="!invocationAndJobTerminal"
+            class="jobs-progress" />
+    </div>
+</template>
+<script>
+import { getRootFromIndexLink } from "onload";
+import mixin from "components/JobStates/mixin";
+import ProgressBar from "components/ProgressBar";
+
+import { mapGetters } from "vuex";
+
+const getUrl = (path) => getRootFromIndexLink() + path;
+
+export default {
+    components: {
+        ProgressBar,
+    },
+    mixins: [mixin],
+    props: {
+        invocation: {
+            type: Object,
+            required: true,
+        },
+        invocationAndJobTerminal: {
+            type: Boolean,
+            required: true,
+        },
+        invocationSchedulingTerminal: {
+            type: Boolean,
+            required: true,
+        },
+        jobStatesSummary: {
+            type: Object,
+            required: false,
+            default: null,
+        },
+        index: {
+            type: Number,
+            required: false,
+            default: null,
+        },
+    },
+    data() {
+        return {
+            stepStatesInterval: null,
+            jobStatesInterval: null,
+        };
+    },
+    computed: {
+        ...mapGetters(["getInvocationById", "getInvocationJobsSummaryById"]),
+        invocationId() {
+            return this.invocation?.id;
+        },
+        indexStr() {
+            if (this.index == null) {
+                return "";
+            } else {
+                return `${this.index + 1}`;
+            }
+        },
+        invocationState: function () {
+            return this.invocation?.state || "new";
+        },
+        stepCount: function () {
+            return this.invocation?.steps.length;
+        },
+        stepStates: function () {
+            const stepStates = {};
+            if (!this.invocation) {
+                return {};
+            }
+            for (const step of this.invocation.steps) {
+                if (!stepStates[step.state]) {
+                    stepStates[step.state] = 1;
+                } else {
+                    stepStates[step.state] += 1;
+                }
+            }
+            return stepStates;
+        },
+        invocationLink: function () {
+            return getUrl(`workflows/invocations/report?id=${this.invocationId}`);
+        },
+        invocationPdfLink: function () {
+            return getUrl(`api/invocations/${this.invocationId}/report.pdf`);
+        },
+        stepStatesStr: function () {
+            return `${this.stepStates.scheduled || 0} of ${this.stepCount} steps successfully scheduled.`;
+        },
+        jobStatesStr: function () {
+            let jobStr = `${this.jobStatesSummary?.numTerminal() || 0} of ${this.jobCount} jobs complete`;
+            if (!this.invocationSchedulingTerminal) {
+                jobStr += " (total number of jobs will change until all steps fully scheduled)";
+            }
+            return `${jobStr}.`;
+        },
+    },
+    methods: {
+        onCancel() {
+            this.$emit("invocation-cancelled");
+        },
+    },
+};
+</script>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -655,24 +655,29 @@ invocations:
     toggle_invocation_details: '.toggle-invocation-details'
     progress_steps_note: '.workflow-invocation-state-component .steps-progress .progressNote'
     progress_jobs_note: '.workflow-invocation-state-component .jobs-progress .progressNote'
-    input_details: '.workflow-invocation-state-component .invocation-inputs-details'
-    input_details_title: '.workflow-invocation-state-component .invocation-inputs-details [data-label="${label}"]'
-    input_details_name:  '.workflow-invocation-state-component .invocation-inputs-details [data-label="${label}"] .name'
 
-    steps_details: '.workflow-invocation-state-component .invocation-steps-details'
-    step_title: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .step-title'
-    step_details: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .portlet-operations'
-    step_output_collection: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-output-collection-details'
-    step_output_collection_toggle: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-output-collection-details .name'
+    invocation_tab:
+      type: xpath
+      selector: '//a[text()="${label}"]'
+    invocation_details_tab:
+      type: xpath
+      selector: '//a[text()="${label}"]'
+    input_details_title: '[data-label="${label}"]'
+    input_details_name: '[data-label="${label}"] .name'
+
+    step_title: '[data-step="${order_index}"] .step-title'
+    step_details: '[data-step="${order_index}"] .portlet-operations'
+    step_output_collection: '[data-step="${order_index}"] .invocation-step-output-collection-details'
+    step_output_collection_toggle: '[data-step="${order_index}"] .invocation-step-output-collection-details .name'
     step_output_collection_element_identifier:
       type: xpath
       selector: '//span[@class="content-title name"][text()="${element_identifier}"]'
-    step_output_collection_element_datatype: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-output-collection-details .datatype .value'
-    step_job_details: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details'
-    step_job_table: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details table'
-    step_job_table_rows: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details table tbody tr'
-    step_job_information: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details table tbody .b-table-details .info_data_table'
-    step_job_information_tool_id: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details table tbody .b-table-details .info_data_table #galaxy-tool-id'
+    step_output_collection_element_datatype: '[data-step="${order_index}"] .invocation-step-output-collection-details .datatype .value'
+    step_job_details: '[data-step="${order_index}"] .invocation-step-job-details'
+    step_job_table: '[data-step="${order_index}"] .invocation-step-job-details table'
+    step_job_table_rows: '[data-step="${order_index}"] .invocation-step-job-details table tbody tr'
+    step_job_information: '[data-step="${order_index}"] .invocation-step-job-details table tbody .b-table-details .info_data_table'
+    step_job_information_tool_id: '[data-step="${order_index}"] .invocation-step-job-details table tbody .b-table-details .info_data_table #galaxy-tool-id'
 
 tour:
   popover:

--- a/lib/galaxy_test/selenium/test_workflow_invocation_details.py
+++ b/lib/galaxy_test/selenium/test_workflow_invocation_details.py
@@ -43,11 +43,12 @@ class WorkflowInvocationDetailsTestCase(SeleniumTestCase):
         assert_progress_steps_note_contains("3 of 3 steps successfully scheduled.")
         assert "2 of 2 jobs complete." in invocations.progress_jobs_note.wait_for_visible().text
 
-        invocations.input_details.wait_for_and_click()
+        invocations.invocation_tab(label="Details").wait_for_and_click()
+        invocations.invocation_details_tab(label="Inputs").wait_for_and_click()
         invocations.input_details_title(label="text_input").wait_for_visible()
         assert "Test_Dataset" in invocations.input_details_name(label="text_input").wait_for_visible().text
 
-        invocations.steps_details.wait_for_and_click()
+        invocations.invocation_details_tab(label="Steps").wait_for_and_click()
         assert "Step 1: text_input" in invocations.step_title(order_index="0").wait_for_visible().text
         assert "Step 2: split_up" in invocations.step_title(order_index="1").wait_for_visible().text
         assert "Step 3: paired" in invocations.step_title(order_index="2").wait_for_visible().text


### PR DESCRIPTION
Closes #14029

Most changes are refactorings to split the WorkflowInvocationState component into individual components.

### New Export tab
Also, there is now a dedicated `Export` tab where we can place all the different kinds of invocation export integrations with additional information. These *export cards* can also contain the UI from #13920 or just link you to the dedicated export page.

![image](https://user-images.githubusercontent.com/46503462/173798038-133f165b-d53f-4771-a40f-d135a266a85e.png)

Currently, only BioCompute Object is available, @HadleyKing, feel free to suggest a different description, right now is just a link pointing to https://biocomputeobject.org/

---

- [x] TODO: adapt selenium tests that may break

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Run a workflow or go to http://127.0.0.1:8081/workflows/invocations
  - The information is now displayed on tabs.
  
    ![wf_invocation_tabs_pr](https://user-images.githubusercontent.com/46503462/173603436-affbcd2d-c965-4e4b-b2b0-2fd880d72dcf.gif)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
