### PR TITLE
Beta History: Display history counter always

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="history.size" class="history-size my-1 d-flex justify-content-between">
+    <div class="history-size my-1 d-flex justify-content-between">
         <b-button
             v-b-tooltip.hover
             title="Access Dashboard"


### PR DESCRIPTION
This makes the HistoryCounter always visible in the Beta History.

Without this change:

![history_counts](https://user-images.githubusercontent.com/46503462/173631857-fe1a67e8-5439-4f47-8351-741e621a5533.gif)



## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Create a new history
  - The counter should be visible
    
    ![image](https://user-images.githubusercontent.com/46503462/173632018-64569cdd-3df9-419c-b43a-62a09a73732e.png)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
