### PR TITLE
Update tpv rule module name and constrain version

### DIFF
--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -798,14 +798,14 @@
             <!-- Pick next available server and resubmit if an unknown error occurs -->
             <resubmit condition="unknown_error and attempt &lt;= 3" destination="galaxycloudrunner" />
         </destination>
-        <destination id="vortex_dispatcher" runner="dynamic">
+        <destination id="tpv_dispatcher" runner="dynamic">
             <!-- Demonstrates how to use total-perspective-vortex, which enables dynamic destination
             selection for entities (Tools, Users, Groups) based on a configurable yaml file.
             See: https://total-perspective-vortex.readthedocs.io/ for documentation. -->
             <param id="type">python</param>
             <param id="function">map_tool_to_destination</param>
-            <param id="rules_module">vortex.rules</param>
-            <param id="vortex_config_files">https://raw.githubusercontent.com/galaxyproject/total-perspective-vortex/main/tests/fixtures/mapping-sample.yml</param>
+            <param id="rules_module">tpv.rules</param>
+            <param id="tpv_config_files">https://raw.githubusercontent.com/galaxyproject/total-perspective-vortex/main/tests/fixtures/mapping-sample.yml</param>
         </destination>
         <destination id="docker_dispatch" runner="dynamic">
             <!-- Follow dynamic destination type will send all tool's that

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -194,7 +194,7 @@ class ConditionalDependencies:
         return "galaxycloudrunner.rules" in self.job_rule_modules
 
     def check_total_perspective_vortex(self):
-        return "vortex.rules" in self.job_rule_modules
+        return "tpv.rules" in self.job_rule_modules
 
     def check_pbs_python(self):
         return "galaxy.jobs.runners.pbs:PBSJobRunner" in self.job_runners

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -12,7 +12,7 @@ python-ldap==3.4.0
 python-pam
 galaxycloudrunner
 pkce
-total-perspective-vortex
+total-perspective-vortex<2
 
 # For file sources plugins
 fs.webdavfs>=0.4.2  # type: webdav

--- a/test/unit/app/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/app/jobs/job_conf.sample_advanced.yml
@@ -748,17 +748,17 @@ execution:
       fallback_destination: local
       # Pick next available server and resubmit if an unknown error occurs
       # resubmit: {condition: 'unknown_error and attempt <= 3', environment: galaxycloudrunner}
-    vortex_dispatcher:
+    tpv_dispatcher:
       runner: dynamic
       # Demonstrates how to use total-perspective-vortex, which enables dynamic destination
       # selection for entities (Tools, Users, Groups) based on a configurable yaml file.
       # See: https://total-perspective-vortex.readthedocs.io/ for documentation.
       type: python
       function: map_tool_to_destination
-      rules_module: vortex.rules
-      vortex_config_files:
+      rules_module: tpv.rules
+      tpv_config_files:
         - https://raw.githubusercontent.com/galaxyproject/total-perspective-vortex/main/tests/fixtures/mapping-sample.yml
-        # - config/vortex_rules_local.yml
+        # - config/tpv_rules_local.yml
 
     docker_dispatch:
       runner: dynamic


### PR DESCRIPTION
This PR does some major refactoring prior to release to make naming more consistent.
Also constrains TPV version to <2 in case of future breaking changes.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
