### PR TITLE
Fix ``test_application_stack_post_fork`` unit test

### DIFF
--- a/lib/galaxy/web_stack/__init__.py
+++ b/lib/galaxy/web_stack/__init__.py
@@ -199,6 +199,7 @@ class GunicornApplicationStack(ApplicationStack):
     postfork_functions: List[Callable] = []
     # Will be set to True by external hook
     late_postfork_event = threading.Event()
+    late_postfork_thread: threading.Thread
 
     @classmethod
     def register_postfork_function(cls, f, *args, **kwargs):
@@ -222,8 +223,8 @@ class GunicornApplicationStack(ApplicationStack):
     def late_postfork(cls):
         # We can't run postfork functions immediately, because this is before the gunicorn `post_fork` hook runs,
         # and we depend on the `post_fork` hook to set a worker id.
-        t = threading.Thread(target=cls.run_postfork)
-        t.start()
+        cls.late_postfork_thread = threading.Thread(target=cls.run_postfork)
+        cls.late_postfork_thread.start()
 
     def log_startup(self):
         msg = [f"Galaxy server instance '{self.config.server_name}' is running"]


### PR DESCRIPTION
Make the late postfork thread a class attribute, and explicitly wait for it in the test. Fix test failure where the postfork thread was
executed after the test finished.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
