### PR TITLE
Prevent user from closing the rule builder modal when clicking outside of it

### DIFF
--- a/client/src/components/Collections/RuleBasedCollectionCreatorModal.js
+++ b/client/src/components/Collections/RuleBasedCollectionCreatorModal.js
@@ -16,6 +16,8 @@ function ruleBasedCollectionCreatorModal(elements, elementsType, importType, opt
         title = _l("Build Rules for Uploading Collections");
     }
     options.title = title;
+    // Prevents user from accidentally closing the modal by clicking outside the bounds
+    options.closing_events = false;
     const { promise, showEl } = collectionCreatorModalSetup(options);
     return import(/* webpackChunkName: "ruleCollectionBuilder" */ "components/RuleCollectionBuilder.vue").then(
         (module) => {

--- a/client/src/components/Collections/common/modal.js
+++ b/client/src/components/Collections/common/modal.js
@@ -16,14 +16,14 @@ export function collectionCreatorModalSetup(options, Galaxy = null) {
         };
     });
     const showEl = function (el) {
-        let close_event = options.closing_events === undefined || options.closing_events
+        const close_event = options.closing_events === undefined || options.closing_events;
         modal.show({
             title: options.title || _l("Create a collection"),
             body: el,
             width: "85%",
             height: "100%",
             xlarge: true,
-            closing_events: close_event
+            closing_events: close_event,
         });
     };
     return { promise, options, showEl };

--- a/client/src/components/Collections/common/modal.js
+++ b/client/src/components/Collections/common/modal.js
@@ -16,13 +16,14 @@ export function collectionCreatorModalSetup(options, Galaxy = null) {
         };
     });
     const showEl = function (el) {
+        let close_event = options.closing_events === undefined || options.closing_events
         modal.show({
             title: options.title || _l("Create a collection"),
             body: el,
             width: "85%",
             height: "100%",
             xlarge: true,
-            closing_events: true,
+            closing_events: close_event
         });
     };
     return { promise, options, showEl };


### PR DESCRIPTION
Fix for #13382 
Added an option to Rule Builder to prevent accidental clicking outside of the modal from closing Rule Builder Modal only.





https://user-images.githubusercontent.com/26912553/174333558-ffe2ed6a-865e-42a8-ae69-e34e1ede2ae1.mp4






## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Open Rule Builder
  2. Try to click outside of the modal
  3. Note that the modal doesn't close
  4. Click Cancel to close the modal

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
