### PR TITLE
Fix overlapping method/var name in domain validation

### DIFF
--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -71,7 +71,7 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, v
     message = validate_email_str(email)
     if not message and validate_domain:
         domain = extract_domain(email)
-        message = validate_domain(domain)
+        message = validate_domain_resolves(domain)
 
     if (
         not message
@@ -97,8 +97,8 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, v
     return message
 
 
-def validate_domain(domain):
-    message = None
+def validate_domain_resolves(domain):
+    message = ""
     try:
         socket.gethostbyname(domain)
     except socket.gaierror:

--- a/test/unit/data/security/test_validate_user_input.py
+++ b/test/unit/data/security/test_validate_user_input.py
@@ -1,6 +1,6 @@
 from galaxy.security.validate_user_input import (
     extract_domain,
-    validate_domain,
+    validate_domain_resolves,
     validate_email_str,
     validate_publicname_str,
 )
@@ -20,8 +20,8 @@ def test_extract_base_domain():
 
 
 def test_validate_domain():
-    assert validate_domain("example.org") is None
-    assert validate_domain("this is an invalid domain!") is not None
+    assert validate_domain_resolves("example.org") == ""
+    assert validate_domain_resolves("this is an invalid domain!") != ""
 
 
 def test_validate_username():


### PR DESCRIPTION
Fix for error while registering users when activation is enabled:

```pytb
Traceback (most recent call last):
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/web/framework/decorators.py", line 337, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/webapps/galaxy/controllers/user.py", line 269, in create
    user, message = self.user_manager.register(trans, **_filtered_registration_params_dict(payload))
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/managers/users.py", line 92, in register
    validate_email(trans, email, validate_domain=validate_domain),
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/security/validate_user_input.py", line 74, in validate_email
    message = validate_domain(domain)
```

Broken in #12482.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Enable user activation
  2. Attempt to register an account
  3. Boom

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
