### PR TITLE
Fix disable change datatype bulk without celery

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -4,6 +4,7 @@ import MockAdapter from "axios-mock-adapter";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "jest/helpers";
 import SelectionOperations from "./SelectionOperations.vue";
+import MockConfigProvider from "components/providers/MockConfigProvider";
 
 const localVue = getLocalVue();
 
@@ -16,154 +17,191 @@ const BULK_ERROR_RESPONSE = {
     errors: [{ error: "Error reason", item: { history_content_type: "dataset", id: "dataset_id" } }],
 };
 
+const NO_TASKS_CONFIG = {
+    enable_celery_tasks: false,
+};
+const TASKS_CONFIG = {
+    enable_celery_tasks: true,
+};
+
+async function mountSelectionOperationsWrapper(config) {
+    const wrapper = shallowMount(
+        SelectionOperations,
+        {
+            propsData: {
+                history: FAKE_HISTORY,
+                filterText: "",
+                contentSelection: new Map(),
+                selectionSize: 1,
+                isQuerySelection: false,
+                totalItemsInQuery: 5,
+            },
+            stubs: {
+                ConfigProvider: MockConfigProvider(config),
+            },
+        },
+        localVue
+    );
+    await flushPromises();
+    return wrapper;
+}
+
 describe("History Selection Operations", () => {
     let axiosMock;
     let wrapper;
 
-    beforeEach(async () => {
-        axiosMock = new MockAdapter(axios);
-        wrapper = shallowMount(
-            SelectionOperations,
-            {
-                propsData: {
-                    history: FAKE_HISTORY,
-                    filterText: "",
-                    contentSelection: new Map(),
-                    selectionSize: 1,
-                    isQuerySelection: false,
-                    totalItemsInQuery: 5,
-                },
-            },
-            localVue
-        );
-        await flushPromises();
+    describe("With Celery Enabled", () => {
+        beforeEach(async () => {
+            axiosMock = new MockAdapter(axios);
+            wrapper = await mountSelectionOperationsWrapper(TASKS_CONFIG);
+            await flushPromises();
+        });
+
+        afterEach(() => {
+            axiosMock.restore();
+        });
+
+        describe("Dropdown Menu", () => {
+            it("should not render if there is nothing selected", async () => {
+                await wrapper.setProps({ selectionSize: 0 });
+                expect(wrapper.html()).toBe("");
+            });
+
+            it("should display the total number of items to apply the operation", async () => {
+                await wrapper.setProps({ selectionSize: 10 });
+                expect(wrapper.find('[data-description="selected count"]').text()).toContain("10");
+            });
+
+            it("should display 'hide' option only on visible items", async () => {
+                const option = '[data-description="hide option"]';
+                expect(wrapper.find(option).exists()).toBe(true);
+                await wrapper.setProps({ filterText: "visible:false" });
+                expect(wrapper.find(option).exists()).toBe(false);
+            });
+
+            it("should display 'unhide' option only on hidden items", async () => {
+                const option = '[data-description="unhide option"]';
+                expect(wrapper.find(option).exists()).toBe(false);
+                await wrapper.setProps({ filterText: "visible:false" });
+                expect(wrapper.find(option).exists()).toBe(true);
+            });
+
+            it("should display 'delete' option only on non-deleted items", async () => {
+                const option = '[data-description="delete option"]';
+                expect(wrapper.find(option).exists()).toBe(true);
+                await wrapper.setProps({ filterText: "deleted:true" });
+                expect(wrapper.find(option).exists()).toBe(false);
+            });
+
+            it("should display 'undelete' option only on deleted items", async () => {
+                const option = '[data-description="undelete option"]';
+                expect(wrapper.find(option).exists()).toBe(false);
+                await wrapper.setProps({ filterText: "deleted:true" });
+                expect(wrapper.find(option).exists()).toBe(true);
+            });
+
+            it("should display collection building options only on visible and non-deleted items", async () => {
+                const buildListOption = '[data-description="build list"]';
+                const buildPairOption = '[data-description="build pair"]';
+                const buildListOfPairsOption = '[data-description="build list of pairs"]';
+                expect(wrapper.find(buildListOption).exists()).toBe(true);
+                expect(wrapper.find(buildPairOption).exists()).toBe(true);
+                expect(wrapper.find(buildListOfPairsOption).exists()).toBe(true);
+                await wrapper.setProps({ filterText: "visible:false" });
+                expect(wrapper.find(buildListOption).exists()).toBe(false);
+                expect(wrapper.find(buildPairOption).exists()).toBe(false);
+                expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
+                await wrapper.setProps({ filterText: "deleted:true" });
+                expect(wrapper.find(buildListOption).exists()).toBe(false);
+                expect(wrapper.find(buildPairOption).exists()).toBe(false);
+                expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
+            });
+        });
+
+        describe("Operation Run", () => {
+            it("should emit event to disable selection", async () => {
+                axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_SUCCESS_RESPONSE);
+
+                expect(wrapper.emitted()).not.toHaveProperty("update:show-selection");
+                wrapper.vm.hideSelected();
+                await flushPromises();
+                expect(wrapper.emitted()).toHaveProperty("update:show-selection");
+                expect(wrapper.emitted()["update:show-selection"][0][0]).toBe(false);
+            });
+
+            it("should update operation-running state when running any operation that succeeds", async () => {
+                axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_SUCCESS_RESPONSE);
+
+                expect(wrapper.emitted()).not.toHaveProperty("update:operation-running");
+                wrapper.vm.hideSelected();
+                await flushPromises();
+                expect(wrapper.emitted()).toHaveProperty("update:operation-running");
+
+                const operationRunningEvents = wrapper.emitted("update:operation-running");
+                expect(operationRunningEvents).toHaveLength(1);
+                // The event sets the current History update time for waiting until the next history update
+                expect(operationRunningEvents[0]).toEqual([FAKE_HISTORY.update_time]);
+            });
+
+            it("should update operation-running state to null when the operation fails", async () => {
+                axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(400);
+
+                expect(wrapper.emitted()).not.toHaveProperty("update:operation-running");
+                wrapper.vm.hideSelected();
+                await flushPromises();
+                expect(wrapper.emitted()).toHaveProperty("update:show-selection");
+
+                const operationRunningEvents = wrapper.emitted("update:operation-running");
+                // We expect 2 events, one before running the operation and another one after completion
+                expect(operationRunningEvents).toHaveLength(2);
+                // The first event sets the current History update time for waiting until the next history update
+                expect(operationRunningEvents[0]).toEqual([FAKE_HISTORY.update_time]);
+                // The second is null to signal that we shouldn't wait for a history change anymore since the operation has failed
+                expect(operationRunningEvents[1]).toEqual([null]);
+            });
+
+            it("should emit operation error event when the operation fails", async () => {
+                axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(400);
+
+                expect(wrapper.emitted()).not.toHaveProperty("operation-error");
+                wrapper.vm.hideSelected();
+                await flushPromises();
+                expect(wrapper.emitted()).toHaveProperty("operation-error");
+            });
+
+            it("should emit operation error event with the result when any item fail", async () => {
+                axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_ERROR_RESPONSE);
+
+                expect(wrapper.emitted()).not.toHaveProperty("operation-error");
+                wrapper.vm.hideSelected();
+                await flushPromises();
+                expect(wrapper.emitted()).toHaveProperty("operation-error");
+
+                const operationErrorEvents = wrapper.emitted("operation-error");
+                expect(operationErrorEvents).toHaveLength(1);
+                const errorEvent = operationErrorEvents[0][0];
+                expect(errorEvent).toHaveProperty("result");
+                expect(errorEvent.result).toEqual(BULK_ERROR_RESPONSE);
+            });
+        });
     });
 
-    afterEach(() => {
-        axiosMock.restore();
-    });
-
-    describe("Dropdown Menu", () => {
-        it("should not render if there is nothing selected", async () => {
-            await wrapper.setProps({ selectionSize: 0 });
-            expect(wrapper.html()).toBe("");
-        });
-
-        it("should display the total number of items to apply the operation", async () => {
-            await wrapper.setProps({ selectionSize: 10 });
-            expect(wrapper.find('[data-description="selected count"]').text()).toContain("10");
-        });
-
-        it("should display 'hide' option only on visible items", async () => {
-            const option = '[data-description="hide option"]';
-            expect(wrapper.find(option).exists()).toBe(true);
-            await wrapper.setProps({ filterText: "visible:false" });
-            expect(wrapper.find(option).exists()).toBe(false);
-        });
-
-        it("should display 'unhide' option only on hidden items", async () => {
-            const option = '[data-description="unhide option"]';
-            expect(wrapper.find(option).exists()).toBe(false);
-            await wrapper.setProps({ filterText: "visible:false" });
-            expect(wrapper.find(option).exists()).toBe(true);
-        });
-
-        it("should display 'delete' option only on non-deleted items", async () => {
-            const option = '[data-description="delete option"]';
-            expect(wrapper.find(option).exists()).toBe(true);
-            await wrapper.setProps({ filterText: "deleted:true" });
-            expect(wrapper.find(option).exists()).toBe(false);
-        });
-
-        it("should display 'undelete' option only on deleted items", async () => {
-            const option = '[data-description="undelete option"]';
-            expect(wrapper.find(option).exists()).toBe(false);
-            await wrapper.setProps({ filterText: "deleted:true" });
-            expect(wrapper.find(option).exists()).toBe(true);
-        });
-
-        it("should display collection building options only on visible and non-deleted items", async () => {
-            const buildListOption = '[data-description="build list"]';
-            const buildPairOption = '[data-description="build pair"]';
-            const buildListOfPairsOption = '[data-description="build list of pairs"]';
-            expect(wrapper.find(buildListOption).exists()).toBe(true);
-            expect(wrapper.find(buildPairOption).exists()).toBe(true);
-            expect(wrapper.find(buildListOfPairsOption).exists()).toBe(true);
-            await wrapper.setProps({ filterText: "visible:false" });
-            expect(wrapper.find(buildListOption).exists()).toBe(false);
-            expect(wrapper.find(buildPairOption).exists()).toBe(false);
-            expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
-            await wrapper.setProps({ filterText: "deleted:true" });
-            expect(wrapper.find(buildListOption).exists()).toBe(false);
-            expect(wrapper.find(buildPairOption).exists()).toBe(false);
-            expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
-        });
-    });
-
-    describe("Operation Run", () => {
-        it("should emit event to disable selection", async () => {
-            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_SUCCESS_RESPONSE);
-
-            expect(wrapper.emitted()).not.toHaveProperty("update:show-selection");
-            wrapper.vm.hideSelected();
+    describe("With Celery Disabled", () => {
+        beforeEach(async () => {
+            axiosMock = new MockAdapter(axios);
+            wrapper = await mountSelectionOperationsWrapper(NO_TASKS_CONFIG);
             await flushPromises();
-            expect(wrapper.emitted()).toHaveProperty("update:show-selection");
-            expect(wrapper.emitted()["update:show-selection"][0][0]).toBe(false);
         });
 
-        it("should update operation-running state when running any operation that succeeds", async () => {
-            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_SUCCESS_RESPONSE);
-
-            expect(wrapper.emitted()).not.toHaveProperty("update:operation-running");
-            wrapper.vm.hideSelected();
-            await flushPromises();
-            expect(wrapper.emitted()).toHaveProperty("update:operation-running");
-
-            const operationRunningEvents = wrapper.emitted("update:operation-running");
-            expect(operationRunningEvents).toHaveLength(1);
-            // The event sets the current History update time for waiting until the next history update
-            expect(operationRunningEvents[0]).toEqual([FAKE_HISTORY.update_time]);
+        afterEach(() => {
+            axiosMock.restore();
         });
 
-        it("should update operation-running state to null when the operation fails", async () => {
-            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(400);
-
-            expect(wrapper.emitted()).not.toHaveProperty("update:operation-running");
-            wrapper.vm.hideSelected();
-            await flushPromises();
-            expect(wrapper.emitted()).toHaveProperty("update:show-selection");
-
-            const operationRunningEvents = wrapper.emitted("update:operation-running");
-            // We expect 2 events, one before running the operation and another one after completion
-            expect(operationRunningEvents).toHaveLength(2);
-            // The first event sets the current History update time for waiting until the next history update
-            expect(operationRunningEvents[0]).toEqual([FAKE_HISTORY.update_time]);
-            // The second is null to signal that we shouldn't wait for a history change anymore since the operation has failed
-            expect(operationRunningEvents[1]).toEqual([null]);
-        });
-
-        it("should emit operation error event when the operation fails", async () => {
-            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(400);
-
-            expect(wrapper.emitted()).not.toHaveProperty("operation-error");
-            wrapper.vm.hideSelected();
-            await flushPromises();
-            expect(wrapper.emitted()).toHaveProperty("operation-error");
-        });
-
-        it("should emit operation error event with the result when any item fail", async () => {
-            axiosMock.onPut(BULK_OPERATIONS_ENDPOINT).reply(200, BULK_ERROR_RESPONSE);
-
-            expect(wrapper.emitted()).not.toHaveProperty("operation-error");
-            wrapper.vm.hideSelected();
-            await flushPromises();
-            expect(wrapper.emitted()).toHaveProperty("operation-error");
-
-            const operationErrorEvents = wrapper.emitted("operation-error");
-            expect(operationErrorEvents).toHaveLength(1);
-            const errorEvent = operationErrorEvents[0][0];
-            expect(errorEvent).toHaveProperty("result");
-            expect(errorEvent.result).toEqual(BULK_ERROR_RESPONSE);
+        describe("Dropdown Menu", () => {
+            it("should hide `Change data type` option", async () => {
+                const option = '[data-description="change data type"]';
+                expect(wrapper.find(option).exists()).toBe(false);
+            });
         });
     });
 });

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -31,7 +31,7 @@
                 <b-dropdown-item v-if="!showDeleted" v-b-modal:purge-selected-content data-description="purge option">
                     <span v-localize>Delete (permanently)</span>
                 </b-dropdown-item>
-                <b-dropdown-divider />
+                <b-dropdown-divider v-if="showBuildOptions" />
                 <b-dropdown-item v-if="showBuildOptions" data-description="build list" @click="buildDatasetList">
                     <span v-localize>Build Dataset List</span>
                 </b-dropdown-item>

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -1,62 +1,73 @@
 <template>
     <section v-if="hasSelection">
-        <b-dropdown text="Selection" size="sm" variant="primary" data-description="selected content menu">
-            <template v-slot:button-content>
-                <span v-if="selectionMatchesQuery" data-test-id="all-filter-selected">
-                    All <b>{{ totalItemsInQuery }}</b> selected
-                </span>
-                <span v-else data-test-id="num-active-selected">
-                    <b>{{ selectionSize }}</b> of {{ totalItemsInQuery }} selected
-                </span>
-            </template>
-            <b-dropdown-text>
-                <span v-localize data-description="selected count">With {{ numSelected }} selected...</span>
-            </b-dropdown-text>
-            <b-dropdown-item v-if="showHidden" v-b-modal:show-selected-content data-description="unhide option">
-                <span v-localize>Unhide</span>
-            </b-dropdown-item>
-            <b-dropdown-item v-else v-b-modal:hide-selected-content data-description="hide option">
-                <span v-localize>Hide</span>
-            </b-dropdown-item>
-            <b-dropdown-item v-if="showDeleted" v-b-modal:restore-selected-content data-description="undelete option">
-                <span v-localize>Undelete</span>
-            </b-dropdown-item>
-            <b-dropdown-item v-else v-b-modal:delete-selected-content data-description="delete option">
-                <span v-localize>Delete</span>
-            </b-dropdown-item>
-            <b-dropdown-item v-if="!showDeleted" v-b-modal:purge-selected-content data-description="purge option">
-                <span v-localize>Delete (permanently)</span>
-            </b-dropdown-item>
-            <b-dropdown-divider />
-            <b-dropdown-item v-if="showBuildOptions" data-description="build list" @click="buildDatasetList">
-                <span v-localize>Build Dataset List</span>
-            </b-dropdown-item>
-            <b-dropdown-item v-if="showBuildOptions" data-description="build pair" @click="buildDatasetPair">
-                <span v-localize>Build Dataset Pair</span>
-            </b-dropdown-item>
-            <b-dropdown-item v-if="showBuildOptions" data-description="build list of pairs" @click="buildListOfPairs">
-                <span v-localize>Build List of Dataset Pairs</span>
-            </b-dropdown-item>
-            <b-dropdown-item
-                v-if="showBuildOptions"
-                data-description="build collection from rules"
-                @click="buildCollectionFromRules">
-                <span v-localize>Build Collection from Rules</span>
-            </b-dropdown-item>
-            <b-dropdown-divider />
-            <b-dropdown-item v-b-modal:change-dbkey-of-selected-content data-description="change database build">
-                <span v-localize>Change Database/Build</span>
-            </b-dropdown-item>
-            <b-dropdown-item v-b-modal:change-datatype-of-selected-content data-description="change data type">
-                <span v-localize>Change data type</span>
-            </b-dropdown-item>
-            <b-dropdown-item v-b-modal:add-tags-to-selected-content data-description="add tags">
-                <span v-localize>Add tags</span>
-            </b-dropdown-item>
-            <b-dropdown-item v-b-modal:remove-tags-from-selected-content data-description="remove tags">
-                <span v-localize>Remove tags</span>
-            </b-dropdown-item>
-        </b-dropdown>
+        <ConfigProvider v-slot="{ config }">
+            <b-dropdown text="Selection" size="sm" variant="primary" data-description="selected content menu">
+                <template v-slot:button-content>
+                    <span v-if="selectionMatchesQuery" data-test-id="all-filter-selected">
+                        All <b>{{ totalItemsInQuery }}</b> selected
+                    </span>
+                    <span v-else data-test-id="num-active-selected">
+                        <b>{{ selectionSize }}</b> of {{ totalItemsInQuery }} selected
+                    </span>
+                </template>
+                <b-dropdown-text>
+                    <span v-localize data-description="selected count">With {{ numSelected }} selected...</span>
+                </b-dropdown-text>
+                <b-dropdown-item v-if="showHidden" v-b-modal:show-selected-content data-description="unhide option">
+                    <span v-localize>Unhide</span>
+                </b-dropdown-item>
+                <b-dropdown-item v-else v-b-modal:hide-selected-content data-description="hide option">
+                    <span v-localize>Hide</span>
+                </b-dropdown-item>
+                <b-dropdown-item
+                    v-if="showDeleted"
+                    v-b-modal:restore-selected-content
+                    data-description="undelete option">
+                    <span v-localize>Undelete</span>
+                </b-dropdown-item>
+                <b-dropdown-item v-else v-b-modal:delete-selected-content data-description="delete option">
+                    <span v-localize>Delete</span>
+                </b-dropdown-item>
+                <b-dropdown-item v-if="!showDeleted" v-b-modal:purge-selected-content data-description="purge option">
+                    <span v-localize>Delete (permanently)</span>
+                </b-dropdown-item>
+                <b-dropdown-divider />
+                <b-dropdown-item v-if="showBuildOptions" data-description="build list" @click="buildDatasetList">
+                    <span v-localize>Build Dataset List</span>
+                </b-dropdown-item>
+                <b-dropdown-item v-if="showBuildOptions" data-description="build pair" @click="buildDatasetPair">
+                    <span v-localize>Build Dataset Pair</span>
+                </b-dropdown-item>
+                <b-dropdown-item
+                    v-if="showBuildOptions"
+                    data-description="build list of pairs"
+                    @click="buildListOfPairs">
+                    <span v-localize>Build List of Dataset Pairs</span>
+                </b-dropdown-item>
+                <b-dropdown-item
+                    v-if="showBuildOptions"
+                    data-description="build collection from rules"
+                    @click="buildCollectionFromRules">
+                    <span v-localize>Build Collection from Rules</span>
+                </b-dropdown-item>
+                <b-dropdown-divider />
+                <b-dropdown-item v-b-modal:change-dbkey-of-selected-content data-description="change database build">
+                    <span v-localize>Change Database/Build</span>
+                </b-dropdown-item>
+                <b-dropdown-item
+                    v-if="config.enable_celery_tasks"
+                    v-b-modal:change-datatype-of-selected-content
+                    data-description="change data type">
+                    <span v-localize>Change data type</span>
+                </b-dropdown-item>
+                <b-dropdown-item v-b-modal:add-tags-to-selected-content data-description="add tags">
+                    <span v-localize>Add tags</span>
+                </b-dropdown-item>
+                <b-dropdown-item v-b-modal:remove-tags-from-selected-content data-description="remove tags">
+                    <span v-localize>Remove tags</span>
+                </b-dropdown-item>
+            </b-dropdown>
+        </ConfigProvider>
 
         <b-modal id="hide-selected-content" title="Hide Selected Content?" title-tag="h2" @ok="hideSelected">
             <p v-localize>Really hide {{ numSelected }} content items?</p>
@@ -146,6 +157,7 @@ import { checkFilter, getQueryDict } from "store/historyStore/model/filtering";
 import { GenomeProvider, DatatypesProvider } from "components/providers";
 import SingleItemSelector from "components/SingleItemSelector";
 import { StatelessTags } from "components/Tags";
+import ConfigProvider from "components/providers/ConfigProvider";
 
 export default {
     components: {
@@ -153,6 +165,7 @@ export default {
         DatatypesProvider,
         SingleItemSelector,
         StatelessTags,
+        ConfigProvider,
     },
     props: {
         history: { type: Object, required: true },


### PR DESCRIPTION
Fixes #14079

When Celery is disabled on the server the `Change data type` option does not appear anymore.

![image](https://user-images.githubusercontent.com/46503462/174276138-5d8996be-05fd-44bd-bca8-9dacef5e3e1d.png)

Thank you @cat-bro for reporting! and @mvdbeek for suggesting the solution!

Also hides one of the dropdown dividers associated with collection building when we can't build collections based on the filters. Thank you @guerler for noticing!

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
