### PR TITLE
[21.09] Fix rule builder input with integer values

### DIFF
--- a/client/src/components/Upload/RulesInput.vue
+++ b/client/src/components/Upload/RulesInput.vue
@@ -129,7 +129,11 @@ export default {
                 .get(
                     `${getAppRoot()}api/histories/${
                         Galaxy.currHistoryPanel.model.id
-                    }/contents/${selectedDatasetId}/display`
+                    }/contents/${selectedDatasetId}/display`,
+                    // The Rule builder expects strings, we should not parse the respone to the default JSON type
+                    {
+                        responseType: "text",
+                    }
                 )
                 .then((response) => {
                     this.sourceContent = response.data;


### PR DESCRIPTION
Upload a dataset with the only content being
`123`. Go to the upload module, select the `Rule-based` tab.
Select `Load tabular data from: History Dataset` and select
the dataset you just uploaded. Without this fix you'd see
```
vue.runtime.esm.js?2b0e:1897 TypeError: selection.content.split is not a function
    at createCollectionViaRules (RuleBasedCollectionCreatorModal.js?46f9:63:1)
    at child.buildCollection (history-view-edit.js?0c85:387:1)
    at VueComponent._buildSelection (RulesInput.vue?5e16:199:1)
    at VueComponent._eventBuild (RulesInput.vue?5e16:164:1)
    at invokeWithErrorHandling (vue.runtime.esm.js?2b0e:1863:1)
    at HTMLButtonElement.invoker (vue.runtime.esm.js?2b0e:2184:1)
    at original._wrapper (vue.runtime.esm.js?2b0e:6961:1)
```
That because `selection.content` is an integer value.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Upload a dataset with the only content being
`123`. Go to the upload module, select the `Rule-based` tab.
Select `Load tabular data from: History Dataset` and select
the dataset you just uploaded. Without this fix you'd see
```
vue.runtime.esm.js?2b0e:1897 TypeError: selection.content.split is not a function
    at createCollectionViaRules (RuleBasedCollectionCreatorModal.js?46f9:63:1)
    at child.buildCollection (history-view-edit.js?0c85:387:1)
    at VueComponent._buildSelection (RulesInput.vue?5e16:199:1)
    at VueComponent._eventBuild (RulesInput.vue?5e16:164:1)
    at invokeWithErrorHandling (vue.runtime.esm.js?2b0e:1863:1)
    at HTMLButtonElement.invoker (vue.runtime.esm.js?2b0e:2184:1)
    at original._wrapper (vue.runtime.esm.js?2b0e:6961:1)
```
That because `selection.content` is an integer value.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
