### PR TITLE
[23.0] Validate a file exists before deletion

### DIFF
--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -653,7 +653,8 @@ class FileParameter(MetadataParameter):
                 # directory. Correct.
                 file_name = path_rewriter(file_name)
             mf.update_from_file(file_name)
-            os.unlink(file_name)
+            if os.path.exists(file_name):
+                os.unlink(file_name)
             value = mf.id
         return value
 


### PR DESCRIPTION
While uploading vcf.gz files directly to a data library this file may not always exist and attempting to unlink it will cause failure while uploading. 

```
Traceback (most recent call last):
  File "[PATH]/galaxy/lib/galaxy/jobs/runners/__init__.py", line 546, in _finish_or_resubmit_job
    job_wrapper.finish(tool_stdout, tool_stderr, exit_code, check_output_detected_state=check_output_detected_state, job_stdout=job_stdout, job_stderr=job_stderr)
  File "[PATH]/galaxy/lib/galaxy/jobs/__init__.py", line 1765, in finish
    output_name, dataset, job, context, final_job_state, remote_metadata_directory
  File "[PATH]/galaxy/lib/galaxy/jobs/__init__.py", line 1619, in _finish_dataset
    self.external_output_metadata.load_metadata(dataset, output_name, self.sa_session, working_directory=self.working_directory, remote_metadata_directory=remote_metadata_directory)
  File "[PATH]/galaxy/lib/galaxy/metadata/__init__.py", line 211, in load_metadata
    self._load_metadata_from_path(dataset, metadata_output_path, working_directory, remote_metadata_directory)
  File "[PATH]/galaxy/lib/galaxy/metadata/__init__.py", line 82, in _load_metadata_from_path
    dataset.metadata.from_JSON_dict(metadata_output_path, path_rewriter=path_rewriter)
  File "[PATH]/galaxy/lib/galaxy/model/metadata.py", line 229, in from_JSON_dict
    value = param.from_external_value(external_value, dataset, **from_ext_kwds)
  File "[PATH]/galaxy/lib/galaxy/model/metadata.py", line 634, in from_external_value
    extra_dir='_metadata_files',
FileNotFoundError: [Errno 2] No such file or directory: '[PATH]/job_working_dir/001/686/1686184/metadata/metadata_temp_file_g2cvocqu'
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
