### PR TITLE
Clear history refresh timeout for snappier operations in new history

### DIFF
--- a/client/src/components/History/adapters/HistoryPanelProxy.js
+++ b/client/src/components/History/adapters/HistoryPanelProxy.js
@@ -56,7 +56,8 @@ export class HistoryPanelProxy {
         watchHistory();
     }
     refreshContents() {
-        // to be removed after disabling legacy history
+        // to be removed after disabling legacy history, present to provide uniform interface
+        // with History Panel Backbone View.
     }
     loadCurrentHistory() {
         store.dispatch("history/loadCurrentHistory");

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -572,6 +572,7 @@ import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import axios from "axios";
 import _l from "utils/localization";
+import { refreshContentsWrapper } from "utils/data";
 import HotTable from "@handsontable/vue";
 import UploadUtils from "mvc/upload/upload-utils";
 import JobStatesModel from "mvc/history/job-states-model";
@@ -1313,10 +1314,7 @@ export default {
             this.mapping.splice(index, 1);
         },
         refreshAndWait(response) {
-            const Galaxy = getGalaxyInstance();
-            if (Galaxy && Galaxy.currHistoryPanel) {
-                Galaxy.currHistoryPanel.refreshContents();
-            }
+            refreshContentsWrapper();
             this.waitOnJob(response);
         },
         waitOnJob(response) {
@@ -1332,9 +1330,7 @@ export default {
                         "Unknown error encountered while running your upload job, this could be a server issue or a problem with the upload definition.";
                     this.doFullJobCheck(jobId);
                 } else {
-                    const Galaxy = getGalaxyInstance();
-                    const history = Galaxy && Galaxy.currHistoryPanel && Galaxy.currHistoryPanel.model;
-                    history.refresh && history.refresh();
+                    refreshContentsWrapper();
                     this.oncreate();
                 }
             };

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -91,6 +91,7 @@
 import { getGalaxyInstance } from "app";
 import { getToolFormData, updateToolFormData, submitJob } from "./services";
 import { allowCachedJobs } from "./utilities";
+import { refreshContentsWrapper } from "utils/data";
 import ToolCard from "./ToolCard";
 import ButtonSpinner from "components/Common/ButtonSpinner";
 import CurrentUser from "components/providers/CurrentUser";
@@ -274,7 +275,6 @@ export default {
                 return;
             }
             this.showExecuting = true;
-            const Galaxy = getGalaxyInstance();
             const jobDef = {
                 history_id: historyId,
                 tool_id: this.formConfig.id,
@@ -296,9 +296,7 @@ export default {
             submitJob(jobDef).then(
                 (jobResponse) => {
                     this.showExecuting = false;
-                    if (Galaxy.currHistoryPanel) {
-                        Galaxy.currHistoryPanel.refreshContents();
-                    }
+                    refreshContentsWrapper();
                     if (jobResponse.produces_entry_points) {
                         this.showEntryPoints = true;
                         this.entryPoints = jobResponse.jobs;

--- a/client/src/components/Upload/Collection.vue
+++ b/client/src/components/Upload/Collection.vue
@@ -120,6 +120,7 @@
 import _l from "utils/localization";
 import _ from "underscore";
 import { getGalaxyInstance } from "app";
+import { refreshContentsWrapper } from "utils/data";
 import UploadRow from "mvc/upload/collection/collection-row";
 import UploadBoxMixin from "./UploadBoxMixin";
 import { uploadModelsToPayload } from "./helpers";
@@ -250,8 +251,7 @@ export default {
             const outputs = incoming.outputs || incoming.data.outputs || {};
             it.set({ percentage: 100, status: "success", outputs });
             this._updateStateForSuccess(it);
-            const Galaxy = getGalaxyInstance();
-            Galaxy.currHistoryPanel.refreshContents();
+            refreshContentsWrapper();
         },
 
         _eventBuild: function () {

--- a/client/src/components/Upload/Composite.vue
+++ b/client/src/components/Upload/Composite.vue
@@ -61,7 +61,7 @@
 <script>
 import _l from "utils/localization";
 import _ from "underscore";
-import { getGalaxyInstance } from "app";
+import { refreshContentsWrapper } from "utils/data";
 import UploadRow from "mvc/upload/composite/composite-row";
 import UploadBoxMixin from "./UploadBoxMixin";
 import { uploadModelsToPayload } from "./helpers";
@@ -193,11 +193,10 @@ export default {
 
         /** Refresh success state */
         _eventSuccess: function (message) {
-            const Galaxy = getGalaxyInstance();
             this.collection.each((it) => {
                 it.set("status", "success");
             });
-            Galaxy.currHistoryPanel.refreshContents();
+            refreshContentsWrapper();
         },
 
         /** Refresh error state */

--- a/client/src/components/Upload/UploadBoxMixin.js
+++ b/client/src/components/Upload/UploadBoxMixin.js
@@ -6,11 +6,10 @@ import UploadExtension from "mvc/upload/upload-extension";
 import UploadModel from "mvc/upload/upload-model";
 import UploadWrapper from "./UploadWrapper";
 import { defaultNewFileName, uploadModelsToPayload } from "./helpers";
-import { getGalaxyInstance } from "app";
 import UploadFtp from "mvc/upload/upload-ftp";
 import LazyLimited from "mvc/lazy/lazy-limited";
 import { findExtension } from "./utils";
-import { filesDialog } from "utils/data";
+import { filesDialog, refreshContentsWrapper } from "utils/data";
 import { getAppRoot } from "onload";
 import { UploadQueue } from "utils/uploadbox";
 import axios from "axios";
@@ -195,8 +194,7 @@ export default {
             this.counterAnnounce--;
             this.counterSuccess++;
             this._updateStateForCounters();
-            const Galaxy = getGalaxyInstance();
-            Galaxy.currHistoryPanel.refreshContents();
+            refreshContentsWrapper();
         },
         /** A new file has been dropped/selected through the uploadbox plugin */
         _eventAnnounce: function (index, file) {

--- a/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -25,6 +25,7 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex";
 import { WorkflowInvocationState } from "components/WorkflowInvocationState";
 import Webhooks from "mvc/webhooks";
 import { getAppRoot } from "onload/loadConfig";
@@ -50,6 +51,7 @@ export default {
         };
     },
     computed: {
+        ...mapGetters("history", ["currentHistoryId"]),
         timesExecuted() {
             return this.invocations.length;
         },
@@ -67,13 +69,7 @@ export default {
             if (this.invocations.length < 1) {
                 return false;
             }
-            const Galaxy = getGalaxyInstance();
-            return (
-                (this.invocations[0].history_id &&
-                    Galaxy.currHistoryPanel &&
-                    Galaxy.currHistoryPanel.model.id != this.invocations[0].history_id) ||
-                false
-            );
+            return (this.invocations[0].history_id && this.currentHistoryId != this.invocations[0].history_id) || false;
         },
     },
     mounted() {

--- a/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -69,7 +69,7 @@ export default {
             if (this.invocations.length < 1) {
                 return false;
             }
-            return (this.invocations[0].history_id && this.currentHistoryId != this.invocations[0].history_id) || false;
+            return this.invocations[0].history_id && this.currentHistoryId != this.invocations[0].history_id;
         },
     },
     mounted() {

--- a/client/src/store/historyStore/model/watchHistory.js
+++ b/client/src/store/historyStore/model/watchHistory.js
@@ -22,6 +22,8 @@ let lastUpdateTime = null;
 let lastRequestDate = new Date();
 
 export async function watchHistory() {
+    // "Reset" watchTimeout so we don't queue up watchHistory calls in rewatchHistory.
+    watchTimeout = null;
     // get current history
     const history = await getCurrentHistoryFromServer();
     const historyId = history.id;

--- a/client/src/utils/data.js
+++ b/client/src/utils/data.js
@@ -9,6 +9,7 @@ import { uploadModelsToPayload } from "components/Upload/helpers";
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload/loadConfig";
 import { submitUpload } from "utils/uploadbox";
+import { rewatchHistory } from "store/historyStore/model/watchHistory";
 
 // This should be moved more centrally (though still hanging off Galaxy for
 // external use?), and populated from the store; just using this as a temporary
@@ -85,8 +86,6 @@ function _mountSelectionDialog(clazz, options) {
  * TODO: This should live somewhere else.
  */
 export function create(options) {
-    const Galaxy = getGalaxyInstance();
-    const history_panel = Galaxy.currHistoryPanel;
     async function getHistory() {
         if (!options.history_id) {
             return getCurrentGalaxyHistory();
@@ -97,9 +96,7 @@ export function create(options) {
         submitUpload({
             url: `${getAppRoot()}api/tools/fetch`,
             success: (response) => {
-                if (history_panel) {
-                    history_panel.refreshContents();
-                }
+                refreshContentsWrapper();
                 if (options.success) {
                     options.success(response);
                 }
@@ -110,4 +107,12 @@ export function create(options) {
             },
         });
     });
+}
+
+export function refreshContentsWrapper() {
+    const Galaxy = getGalaxyInstance();
+    // Legacy Panel Interface. no-op if using new history
+    Galaxy?.currHistoryPanel?.refreshContents();
+    // Will not do anything in legacy interface
+    rewatchHistory();
 }

--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -43,22 +43,27 @@ def stream_url_to_str(
 
 
 def stream_url_to_file(
-    path: str, file_sources: Optional["ConfiguredFileSources"] = None, prefix: str = "gx_file_stream"
+    path: str,
+    file_sources: Optional["ConfiguredFileSources"] = None,
+    prefix: str = "gx_file_stream",
+    dir: Optional[str] = None,
 ) -> str:
     temp_name: str
     if file_sources and file_sources.looks_like_uri(path):
         file_source_path = file_sources.get_file_source_path(path)
-        with tempfile.NamedTemporaryFile(prefix=prefix, delete=False) as temp:
+        with tempfile.NamedTemporaryFile(prefix=prefix, delete=False, dir=dir) as temp:
             temp_name = temp.name
         file_source_path.file_source.realize_to(file_source_path.path, temp_name)
     elif path.startswith("base64://"):
-        with tempfile.NamedTemporaryFile(prefix=prefix, delete=False) as temp:
+        with tempfile.NamedTemporaryFile(prefix=prefix, delete=False, dir=dir) as temp:
             temp_name = temp.name
             temp.write(base64.b64decode(path[len("base64://") :]))
             temp.flush()
     else:
         page = urllib.request.urlopen(path, timeout=DEFAULT_SOCKET_TIMEOUT)  # page will be .close()ed in stream_to_file
-        temp_name = stream_to_file(page, prefix=prefix, source_encoding=get_charset_from_http_headers(page.headers))
+        temp_name = stream_to_file(
+            page, prefix=prefix, source_encoding=get_charset_from_http_headers(page.headers), dir=dir
+        )
     return temp_name
 
 

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -499,7 +499,7 @@ def _has_src_to_path(upload_config, item, is_dataset=False) -> Tuple[str, str]:
         if name is None:
             name = url.split("/")[-1]
     elif src == "pasted":
-        path = stream_to_file(StringIO(item["paste_content"]))
+        path = stream_to_file(StringIO(item["paste_content"]), dir=upload_config.working_directory)
         if name is None:
             name = "Pasted Entry"
     else:


### PR DESCRIPTION
We had a bunch of strategically placed explicit refresh operations, e.g. when submitting tools, workflows, uploads, etc. This restores them for the new history and fixes https://github.com/galaxyproject/galaxy/issues/13731.
It also fixes a minor bug in https://github.com/galaxyproject/galaxy/pull/13989 that could lead to a buildup of requests.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

You can test that the request buildup is fixed by manually by delaying the response in
https://github.com/galaxyproject/galaxy/blob/928bb4b4622f57c1fb8d8eecbe4cc9b260e5aab0/lib/galaxy/webapps/galaxy/controllers/history.py#L999
and hitting the refresh button a bunch of times. In the network tab you'll see the requests piling up with this fix, while with the fix there's just one request pending.

To make it really clear that the history is getting updated e.g. on upload, set https://github.com/mvdbeek/galaxy/blob/f9bd234d5a9cf598cd198428c37b9aa80c9cef7b/client/src/store/historyStore/model/watchHistory.js#L14 to a high value and see that newly uploaded datasets immediately appear in the history.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
