### PR TITLE
Fix unlimited quota display in Storage Dashboard

### DIFF
--- a/client/src/components/User/DiskUsage/Quota/QuotaUsageBar.vue
+++ b/client/src/components/User/DiskUsage/Quota/QuotaUsageBar.vue
@@ -7,7 +7,8 @@
             {{ storageSourceText }}
         </h2>
         <h3>
-            <b>{{ quotaUsage.niceTotalDiskUsage }}</b> of {{ quotaUsage.niceQuota }} used
+            <b>{{ quotaUsage.niceTotalDiskUsage }}</b>
+            <span v-if="quotaHasLimit"> of {{ quotaUsage.niceQuota }}</span> used
         </h3>
         <span v-if="quotaHasLimit" class="quota-percent-text">
             {{ quotaUsage.quotaPercent }}{{ percentOfDiskQuotaUsedText }}

--- a/client/src/components/User/DiskUsage/Quota/QuotaUsageSummary.test.js
+++ b/client/src/components/User/DiskUsage/Quota/QuotaUsageSummary.test.js
@@ -19,6 +19,7 @@ const FAKE_QUOTA_USAGES_LIST = [
     {
         sourceLabel: "Unlimited source",
         quotaInBytes: null,
+        isUnlimited: true,
     },
 ];
 
@@ -40,5 +41,23 @@ describe("QuotaUsageSummary.vue", () => {
         const expectedNumberOfBars = FAKE_QUOTA_USAGES_LIST.length;
 
         expect(wrapper.findAll("quotausagebar-stub").length).toBe(expectedNumberOfBars);
+    });
+
+    it("should display `unlimited` quota when all sources are unlimited", async () => {
+        const FAKE_UNLIMITED_QUOTA_USAGES = [
+            {
+                sourceLabel: "Unlimited source 1",
+                quotaInBytes: null,
+                isUnlimited: true,
+            },
+            {
+                sourceLabel: "Unlimited source 2",
+                quotaInBytes: null,
+                isUnlimited: true,
+            },
+        ];
+        const wrapper = mountQuotaUsageSummaryWith(FAKE_UNLIMITED_QUOTA_USAGES);
+        const summaryText = wrapper.find("h2").text();
+        expect(summaryText).toContain("unlimited");
     });
 });

--- a/client/src/components/User/DiskUsage/Quota/QuotaUsageSummary.vue
+++ b/client/src/components/User/DiskUsage/Quota/QuotaUsageSummary.vue
@@ -1,12 +1,19 @@
 <template>
     <div class="quota-summary">
         <div class="text-center my-5">
-            <h2>
-                You've got <b>{{ niceTotalQuota }}</b> of total disk quota
-            </h2>
-            <h4>
-                {{ quotaSummaryDescription }}
-            </h4>
+            <div v-if="allSourcesUnlimited">
+                <h2>You've got <b>unlimited</b> disk quota</h2>
+                <h4 v-localize>All your storage sources have unlimited disk space. Enjoy!</h4>
+            </div>
+            <div v-else>
+                <h2>
+                    You've got <b> {{ niceTotalQuota }} </b> of total disk quota
+                </h2>
+                <h4 v-localize>
+                    This is the maximum disk space that you can use across all your storage sources. Unlimited storage
+                    sources are not taken into account
+                </h4>
+            </div>
         </div>
 
         <div v-for="quotaUsage in quotaUsages" :key="quotaUsage.sourceLabel">
@@ -16,7 +23,6 @@
 </template>
 
 <script>
-import _l from "utils/localization";
 import { bytesToString } from "utils/utils";
 import QuotaUsageBar from "./QuotaUsageBar";
 
@@ -30,14 +36,6 @@ export default {
             required: true,
         },
     },
-    data() {
-        return {
-            quotaSummaryDescription: _l(
-                "This is the maximum disk space that you can use across all your storage sources." +
-                    " Unlimited storage sources are not taken into account"
-            ),
-        };
-    },
     computed: {
         /** @returns {Number} */
         totalQuota() {
@@ -47,6 +45,11 @@ export default {
         /** @returns {String} */
         niceTotalQuota() {
             return bytesToString(this.totalQuota, true);
+        },
+        /** @returns {Boolean} */
+        allSourcesUnlimited() {
+            const allUnlimited = this.quotaUsages.every((usage) => usage.isUnlimited);
+            return allUnlimited;
         },
     },
 };


### PR DESCRIPTION
Fixes #14083

Now when all user's storage sources are `unlimited` the summary text will be more explicit.

![image](https://user-images.githubusercontent.com/46503462/174314082-02a2b721-1968-440f-89f6-bf290c159623.png)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
