### PR TITLE
Update window manager margin

### DIFF
--- a/client/src/style/scss/windows.scss
+++ b/client/src/style/scss/windows.scss
@@ -1,7 +1,6 @@
 .winbox {
     border-radius: $border-radius-base;
-    margin-top: 4rem;
-    margin-left: 1rem;
+    margin-top: 3rem;
 }
 
 .winbox.min {


### PR DESCRIPTION
When testing https://github.com/galaxyproject/galaxy/pull/13922, I saw that the window manager cannot be dragged right to the top and left of the browser window and overflows on the right side (most noticeable when maximizing)

![Screenshot from 2022-06-17 15-55-30](https://user-images.githubusercontent.com/32272674/174312615-0f2b7902-6e26-4725-bfda-5465ccdd2e53.png)

After this small adjustment to the CSS

![Screenshot from 2022-06-17 15-54-37](https://user-images.githubusercontent.com/32272674/174312609-97b5236e-e891-44a2-9a42-c685567fd34d.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open the window manager and drag around

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
