### PR TITLE
Fix minor empty History Filter bug

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryFilters/filterConversion.js
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/filterConversion.js
@@ -34,7 +34,7 @@ export function getFilterText(filterSettings) {
     let newFilterText = "";
     Object.entries(filterSettings).forEach(([key, value]) => {
         const skipDefault = hasDefaults && normalized[key] !== undefined;
-        if (!skipDefault && value !== undefined) {
+        if (!skipDefault && ((normalized[key] !== undefined && value !== undefined) || value)) {
             if (newFilterText) {
                 newFilterText += " ";
             }

--- a/client/src/components/History/CurrentHistory/HistoryFilters/filterConversion.js
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/filterConversion.js
@@ -34,7 +34,7 @@ export function getFilterText(filterSettings) {
     let newFilterText = "";
     Object.entries(filterSettings).forEach(([key, value]) => {
         const skipDefault = hasDefaults && normalized[key] !== undefined;
-        if (!skipDefault && ((normalized[key] !== undefined && value !== undefined) || value)) {
+        if (!skipDefault && value !== undefined && value !== "") {
             if (newFilterText) {
                 newFilterText += " ";
             }

--- a/client/src/components/History/CurrentHistory/HistoryFilters/filterConversion.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/filterConversion.test.js
@@ -30,6 +30,7 @@ describe("test filtering helpers to convert settings to filter text", () => {
             "visible:": defaultFilters.visible,
             "other:": "other",
             "anything:": undefined,
+            "value:": "",
         };
         expect(getFilterText(settings)).toBe("other:other");
         settings["visible:"] = !defaultFilters.visible;


### PR DESCRIPTION
New history: if a filter was empty in the advanced search filters (e.g.: `name:""`), it would make it to the `filterText`. That bug has been fixed. Before and after below:
### Bug:

https://user-images.githubusercontent.com/78516064/174313257-e6714507-3bb7-4360-8c56-7ecc54a1b019.mov

### Fixed:

https://user-images.githubusercontent.com/78516064/174313275-2051764c-2431-47f0-82a5-20959700c8e3.mov


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
