### PR TITLE
[22.01] Fix contains_collection check for empty root collections

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5811,6 +5811,9 @@ class HistoryDatasetCollectionAssociation(
         """Checks to see that the indicated collection is a member of the
         hdca by using a recursive CTE sql query to find the collection's parents
         and checking to see if any of the parents are associated with this hdca"""
+        if collection_id == self.collection_id:
+            # collection_id is root collection
+            return True
 
         sa_session = object_session(self)
         DCE = DatasetCollectionElement

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -240,7 +240,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
 
         # check to make sure the dsc is part of the validated hdca
         decoded_parent_id = self.decode_id(parent_id)
-        if parent_id != hdca_id and not hdca.contains_collection(decoded_parent_id):
+        if not hdca.contains_collection(decoded_parent_id):
             raise exceptions.ObjectNotFound('Requested dataset collection is not contained within indicated history content')
 
         # retrieve contents

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -358,6 +358,14 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         assert len(offset_contents) == 1
         assert offset_contents[0]['element_index'] == 1
 
+    def test_collection_contents_empty_root(self):
+        hdca = self.dataset_collection_populator.create_list_in_history(self.history_id, contents=[]).json()
+        assert hdca["elements"] == []
+        root_contents_url = hdca["contents_url"]
+        response = self._get(root_contents_url)
+        response.raise_for_status()
+        assert response.json() == []
+
     def test_get_suitable_converters_single_datatype(self):
         response = self.dataset_collection_populator.upload_collection(self.history_id, "list:paired", elements=[
             {


### PR DESCRIPTION
Comparing hdca_id with parent_id is just wrong, as hdca_id is the id for
a `HistoryDatasetCollectionAssociation`, while `parent_id` is the id for
a `DatasetCollection`. This happened to work regardless of the first if
check if the root collection contains at least one DCE, but that won't
work for collections without elements.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
