### PR TITLE
Improve robustness of test_exit_code_127 k8s test

### DIFF
--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import re
-import shlex
 import subprocess
 import tempfile
 
@@ -28,6 +27,7 @@ from galaxy.datatypes.sniff import (
 )
 from galaxy.util import (
     nice_size,
+    shlex_join,
     string_as_bool,
     unicodify,
 )
@@ -219,7 +219,7 @@ class Ipynb(Json):
                 ofilename = dataset.file_name
                 log.exception(
                     'Command "%s" failed. Could not convert the Jupyter Notebook to HTML, defaulting to plain text.',
-                    " ".join(map(shlex.quote, cmd)),
+                    shlex_join(cmd),
                 )
             return open(ofilename, mode="rb"), headers
 

--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import re
-import shlex
 import shutil
 import sys
 import tempfile
@@ -18,6 +17,7 @@ import packaging.version
 from galaxy.util import (
     commands,
     listify,
+    shlex_join,
     smart_str,
     which,
 )
@@ -237,7 +237,7 @@ class CondaContext(installable.InstallableContext):
         env = {}
         if self.condarc_override:
             env["CONDARC"] = self.condarc_override
-        cmd_string = " ".join(map(shlex.quote, cmd))
+        cmd_string = shlex_join(cmd)
         kwds = dict()
         try:
             if stdout_path:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -12,7 +12,6 @@ Build a mulled image with:
 import json
 import logging
 import os
-import shlex
 import shutil
 import stat
 import string
@@ -31,6 +30,7 @@ from galaxy.tool_util.deps.docker_util import command_list as docker_command_lis
 from galaxy.util import (
     commands,
     safe_makedirs,
+    shlex_join,
     unicodify,
 )
 from ._cli import arg_parser
@@ -301,7 +301,7 @@ def mull_targets(
             involucro_args.insert(6, "-set")
             involucro_args.insert(7, f"TEST_BINDS={','.join(test_bind)}")
     cmd = involucro_context.build_command(involucro_args)
-    print(f"Executing: {' '.join(shlex.quote(_) for _ in cmd)}")
+    print(f"Executing: {shlex_join(cmd)}")
     if dry_run:
         return 0
     ensure_installed(involucro_context, True)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -13,6 +13,7 @@ import json
 import os
 import random
 import re
+import shlex
 import shutil
 import smtplib
 import stat
@@ -76,6 +77,12 @@ from .path import (  # noqa: F401
     safe_makedirs,
     safe_relpath,
 )
+
+try:
+    shlex_join = shlex.join  # type: ignore[attr-defined]
+except AttributeError:
+    # Python < 3.8
+    shlex_join = lambda split_command: " ".join(map(shlex.quote, split_command))  # noqa: E731
 
 inflector = Inflector()
 

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -82,7 +82,9 @@ try:
     shlex_join = shlex.join  # type: ignore[attr-defined]
 except AttributeError:
     # Python < 3.8
-    shlex_join = lambda split_command: " ".join(map(shlex.quote, split_command))  # noqa: E731
+    def shlex_join(split_command):
+        return " ".join(map(shlex.quote, split_command))
+
 
 inflector = Inflector()
 

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -365,7 +365,7 @@ def external_chown(path, pwent, external_chown_script, description="file"):
 
         cmd = shlex.split(external_chown_script)
         cmd.extend([path, pwent[0], str(pwent[3])])
-        log.debug(f"Changing ownership of {path} with: {' '.join(map(shlex.quote, cmd))}")
+        log.debug(f"Changing ownership of {path} with: '{galaxy.util.shlex_join(cmd)}'")
         galaxy.util.commands.execute(cmd)
         return True
     except galaxy.util.commands.CommandLineException as e:

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -4,7 +4,6 @@
 import collections
 import json
 import os
-import shlex
 import string
 import subprocess
 import tempfile
@@ -328,7 +327,7 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         p = subprocess.run(log_cmd, capture_output=True, text=True)
         if p.returncode:
             raise Exception(
-                f"Command '{shlex.join(log_cmd)}' failed with exit code: {p.returncode}.\nstdout: {p.stdout}\nstderr: {p.stderr}"
+                f"Command '{' '.join(log_cmd)}' failed with exit code: {p.returncode}.\nstdout: {p.stdout}\nstderr: {p.stderr}"
             )
         output = p.stdout
         EXPECTED_STDOUT = "The bool is not true"

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -335,7 +335,7 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
                 if allow_wait and "is waiting to start" in p.stderr:
                     return None
                 raise Exception(
-                    f"Command '{shlex_join}' failed with exit code: {p.returncode}.\nstdout: {p.stdout}\nstderr: {p.stderr}"
+                    f"Command '{shlex_join(log_cmd)}' failed with exit code: {p.returncode}.\nstdout: {p.stdout}\nstderr: {p.stderr}"
                 )
             return p.stdout
 

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -323,7 +323,7 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         self._wait_for_external_state(sa_session=sa_session, job=job, expected=app.model.Job.states.RUNNING)
 
         external_id = job.job_runner_external_id
-        output = unicodify(subprocess.check_output(["kubectl", "logs", "-l" f"job-name={external_id}"]))
+        output = unicodify(subprocess.check_output(["kubectl", "logs", "-l", f"job-name={external_id}"]))
         EXPECTED_STDOUT = "The bool is not true"
         EXPECTED_STDERR = "The bool is very not true"
         assert EXPECTED_STDOUT in output

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -325,7 +325,7 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
 
         external_id = job.job_runner_external_id
         log_cmd = ["kubectl", "logs", "-l", f"job-name={external_id}"]
-        p = subprocess.run(log_cmd)
+        p = subprocess.run(log_cmd, capture_output=True, text=True)
         if p.returncode:
             raise Exception(
                 f"Command '{shlex.join(log_cmd)}' failed with exit code: {p.returncode}.\nstdout: {p.stdout}\nstderr: {p.stderr}"

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -4,6 +4,7 @@
 import collections
 import json
 import os
+import shlex
 import string
 import subprocess
 import tempfile
@@ -323,7 +324,13 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         self._wait_for_external_state(sa_session=sa_session, job=job, expected=app.model.Job.states.RUNNING)
 
         external_id = job.job_runner_external_id
-        output = unicodify(subprocess.check_output(["kubectl", "logs", "-l", f"job-name={external_id}"]))
+        log_cmd = ["kubectl", "logs", "-l", f"job-name={external_id}"]
+        p = subprocess.run(log_cmd)
+        if p.returncode:
+            raise Exception(
+                f"Command '{shlex.join(log_cmd)}' failed with exit code: {p.returncode}.\nstdout: {p.stdout}\nstderr: {p.stderr}"
+            )
+        output = p.stdout
         EXPECTED_STDOUT = "The bool is not true"
         EXPECTED_STDERR = "The bool is very not true"
         assert EXPECTED_STDOUT in output


### PR DESCRIPTION
Maybe fixes
https://github.com/galaxyproject/galaxy/runs/6941388460?check_suite_focus=true#step:14:909,
but seems like a good change on its own.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
