### PR TITLE
Adjust history store operations when switching between histories

### DIFF
--- a/client/src/components/History/adapters/HistoryPanelProxy.js
+++ b/client/src/components/History/adapters/HistoryPanelProxy.js
@@ -64,7 +64,7 @@ export class HistoryPanelProxy {
     }
     switchToHistory(historyId) {
         this.model.id = historyId;
-        store.dispatch("history/setCurrentHistoryId", historyId);
+        store.dispatch("history/setCurrentHistory", historyId);
     }
     async buildCollection(collectionType, selection, hideSourceItems, fromRulesInput = false) {
         let selectionContent = null;

--- a/client/src/components/providers/UserHistories.js
+++ b/client/src/components/providers/UserHistories.js
@@ -37,7 +37,7 @@ export default {
             "createNewHistory",
             "updateHistory",
             "deleteHistory",
-            "setCurrentHistoryId",
+            "setCurrentHistory",
             "setHistory",
             "loadHistories",
             "secureHistory",
@@ -73,7 +73,7 @@ export default {
                 setHistory: this.setHistory,
 
                 // select new history, basically just needs the id
-                setCurrentHistory: (h) => this.setCurrentHistoryId(h.id),
+                setCurrentHistory: (h) => this.setCurrentHistory(h.id),
 
                 // create new history then select it
                 createNewHistory: this.createNewHistory,

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -153,11 +153,8 @@ const actions = {
         commit("setHistory", history);
         commit("setCurrentHistoryId", history.id);
     },
-    async setCurrentHistoryId({ commit, dispatch, getters }, id) {
-        // Need to do 2 requests because apparently the response from "setHistory"
-        // can't be twisted to be the same as a normal lookup
+    async setCurrentHistoryId({ dispatch, getters }, id) {
         if (id !== getters.currentHistoryId) {
-            commit("setCurrentHistoryId", id);
             const changedHistory = await setCurrentHistoryOnServer(id);
             dispatch("loadHistoryById", changedHistory.id);
         }

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -98,8 +98,8 @@ const actions = {
             return dispatch("createNewHistory");
         }
     },
-    loadCurrentHistory({ dispatch }) {
-        getCurrentHistoryFromServer().then((history) => dispatch("selectHistory", history));
+    async loadCurrentHistory({ dispatch }) {
+        return getCurrentHistoryFromServer().then((history) => dispatch("selectHistory", history));
     },
     loadHistories({ commit }) {
         if (!isLoadingHistories) {

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -75,11 +75,9 @@ const getters = {
     },
 };
 
-// Holds promises for in-flight loads
-const promises = {
-    load: null,
-    byId: new Map(),
-};
+// flags to keep track of loading states
+const isLoadingHistory = new Map();
+let isLoadingHistories = false;
 
 const actions = {
     async copyHistory({ dispatch }, { history, name, copyAll }) {
@@ -95,7 +93,7 @@ const actions = {
         const deletedHistory = await deleteHistoryById(history.id, purge);
         commit("deleteHistory", deletedHistory);
         if (getters.firstHistoryId) {
-            return dispatch("setCurrentHistoryId", getters.firstHistoryId);
+            return dispatch("setCurrentHistory", getters.firstHistoryId);
         } else {
             return dispatch("createNewHistory");
         }
@@ -104,9 +102,9 @@ const actions = {
         getCurrentHistoryFromServer().then((history) => dispatch("selectHistory", history));
     },
     loadHistories({ commit }) {
-        if (!promises.load) {
+        if (!isLoadingHistories) {
             commit("setHistoriesLoading", true);
-            promises.load = getHistoryList()
+            isLoadingHistories = getHistoryList()
                 .then((list) => {
                     commit("setHistories", list);
                 })
@@ -114,31 +112,24 @@ const actions = {
                     console.warn("loadHistories error", err);
                 })
                 .finally(() => {
-                    promises.load = null;
+                    isLoadingHistories = null;
                     commit("setHistoriesLoading", false);
                 });
         }
     },
-    loadHistoryById({ commit, getters, dispatch }, id) {
-        if (!promises.byId.has(id)) {
-            // immediately set if we have something current
-            const existing = getters.getHistoryById(id);
-            if (existing) {
-                commit("setHistory", existing);
-            }
-
-            // but also check for updates
+    loadHistoryById({ dispatch }, id) {
+        if (!isLoadingHistory.has(id)) {
             const p = getHistoryById(id)
                 .then((history) => {
-                    dispatch("selectHistory", history);
+                    dispatch("setHistory", history);
                 })
                 .catch((err) => {
                     console.warn("loadHistoryById error", id, err);
                 })
                 .finally(() => {
-                    promises.byId.delete(id);
+                    isLoadingHistory.delete(id);
                 });
-            promises.byId.set(id, p);
+            isLoadingHistory.set(id, p);
         }
     },
     resetHistory({ commit }) {
@@ -153,10 +144,10 @@ const actions = {
         commit("setHistory", history);
         commit("setCurrentHistoryId", history.id);
     },
-    async setCurrentHistoryId({ dispatch, getters }, id) {
+    async setCurrentHistory({ dispatch, getters }, id) {
         if (id !== getters.currentHistoryId) {
             const changedHistory = await setCurrentHistoryOnServer(id);
-            dispatch("loadHistoryById", changedHistory.id);
+            dispatch("selectHistory", changedHistory);
         }
     },
     setHistory({ commit }, history) {

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -112,7 +112,7 @@ const actions = {
                     console.warn("loadHistories error", err);
                 })
                 .finally(() => {
-                    isLoadingHistories = null;
+                    isLoadingHistories = false;
                     commit("setHistoriesLoading", false);
                 });
         }

--- a/client/src/store/historyStore/historyStore.test.js
+++ b/client/src/store/historyStore/historyStore.test.js
@@ -1,0 +1,55 @@
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import store from "store/index";
+
+// response resource data
+let nHistories = 3;
+let currentHistory = 0;
+const histories = {};
+for (let i = 0; i < nHistories; i++) {
+    histories[i] = { id: i };
+}
+
+describe("historyStore", () => {
+    let axiosMock;
+
+    beforeEach(() => {
+        axiosMock = new MockAdapter(axios);
+        axiosMock.onGet("/history/current_history_json").reply(() => {
+            return [200, histories[currentHistory]];
+        });
+        axiosMock.onGet("/history/create_new_current").reply(() => {
+            const id = nHistories++;
+            return [200, { id: id }];
+        });
+        axiosMock.onGet("/history/set_as_current").reply((config) => {
+            const payload = config.params;
+            currentHistory = payload.id;
+            return [200, histories[payload.id]];
+        });
+        axiosMock.onGet(/api\/histories\/./).reply((config) => {
+            const historyId = config.url.charAt(config.url.length - 1);
+            return [200, histories[historyId]];
+        });
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    it("store initialization", async () => {
+        expect(store.getters["history/currentHistoryId"]).toBe(null);
+        await store.dispatch("history/loadCurrentHistory");
+        expect(store.getters["history/currentHistoryId"]).toBe(0);
+        await store.dispatch("history/loadHistoryById", 1);
+        await store.dispatch("history/loadHistoryById", 2);
+        expect(store.getters["history/currentHistoryId"]).toBe(0);
+        await store.dispatch("history/setCurrentHistory", 1);
+        expect(store.getters["history/currentHistoryId"]).toBe(1);
+        await store.dispatch("history/loadCurrentHistory");
+        expect(store.getters["history/currentHistoryId"]).toBe(1);
+        expect(store.getters["history/getHistoryById"](2).id).toBe(2);
+        await store.dispatch("history/createNewHistory");
+        expect(store.getters["history/currentHistoryId"]).toBe(3);
+    });
+});


### PR DESCRIPTION
Should resolve #14097. This PR revisits and optimizes the history store operations and the flow of commits and actions when setting and receiving the histories. Thank you so much @simonbray, for reporting this together with a very useful screencast . Can you take a look at this PR and verify that it resolves the issue you observed?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
