### PR TITLE
Fix run client dev server in Gitpod

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -207,7 +207,11 @@ module.exports = (env = {}, argv = {}) => {
                     errors: true,
                     warnings: false,
                 },
+                webSocketURL: {
+                    port: process.env.GITPOD_WORKSPACE_ID ? 443 : undefined,
+                },
             },
+            allowedHosts: process.env.GITPOD_WORKSPACE_ID ? "all" : "auto",
             devMiddleware: {
                 publicPath: "/static/dist",
             },


### PR DESCRIPTION
This PR fixes the `Invalid Host header` error and client HMR when running `client-dev-server` in Gitpod.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open repo using [this](https://gitpod.io/#https://github.com/galaxyproject/galaxy) or open this pr using [this](https://gitpod.io/#https://github.com/galaxyproject/galaxy/pull/14111) in Gitpod
  2. Run `make client-dev-server`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
