### PR TITLE
Fix flaky test_workflow_delete selenium test

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -507,6 +507,9 @@ workflows:
     pager_page_previous: '.gx-workflows-grid-pager .gx-grid-pager-prev button'
     pager_page_active: '.gx-workflows-grid-pager .gx-grid-pager-page.active button'
     run_button: '[data-workflow-run*="${id}"]'
+    workflow_with_name:
+      type: xpath
+      selector: '//span[@class="workflow-dropdown-name" and text() = "${workflow_name}"]'
 
   create:
     selectors:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1250,6 +1250,7 @@ class NavigatesGalaxy(HasDriver):
         alert = self.driver.switch_to.alert
         alert.send_keys(new_name)
         alert.accept()
+        self.components.workflows.workflow_with_name(workflow_name=new_name).wait_for_visible()
 
     @retry_during_transitions
     def workflow_index_name(self, workflow_index=0):


### PR DESCRIPTION
Should fix:
```
_______________ WorkflowManagementTestCase.test_workflow_delete ________________
self = <galaxy_test.selenium.test_workflow_management.WorkflowManagementTestCase testMethod=test_workflow_delete>
    @selenium_test
    def test_workflow_delete(self):
        self.workflow_index_open()
        self._workflow_import_from_url()
        self.workflow_index_rename("fordelete")
        self._assert_showing_n_workflows(1)
>       self.workflow_index_click_option("Delete")
lib/galaxy_test/selenium/test_workflow_management.py:158: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lib/galaxy/selenium/navigates_galaxy.py:1277: in workflow_index_click_option
    if not self.select_dropdown_item(option_title):
lib/galaxy/selenium/navigates_galaxy.py:1271: in select_dropdown_item
    if option_title in menu_option.text:
.venv/lib/python3.7/site-packages/selenium/webdriver/remote/webelement.py:85: in text
    return self._execute(Command.GET_ELEMENT_TEXT)['value']
.venv/lib/python3.7/site-packages/selenium/webdriver/remote/webelement.py:773: in _execute
    return self._parent.execute(command, params)
.venv/lib/python3.7/site-packages/selenium/webdriver/remote/webdriver.py:430: in execute
    self.error_handler.check_response(response)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <selenium.webdriver.remote.errorhandler.ErrorHandler object at 0x7f9d1e82ce50>
response = {'status': 404, 'value': '{"value":{"error":"stale element reference","message":"stale element reference: element is n...\\n#19 0x5603b5880788 \\u003Cunknown>\\n#20 0x5603b589af1d \\u003Cunknown>\\n#21 0x7f387b623609 \\u003Cunknown>\\n"}}'}
```

I think the problem is that we didn't wait for the component to update.
If you put a break at  https://github.com/mvdbeek/galaxy/blob/8a5f45737d30e586a74505ba5c8499be6dc1494c/lib/galaxy_test/selenium/test_workflow_management.py#L158 you'll still see the old workflow name. In the test we open the menu to click delete, but if the component updates right then we get the stale element error.

Now we're waiting for (and verifying) the name change.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
