### PR TITLE
[release-testing] Rephrase 'updated' to 'refreshed' in history counter

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -45,7 +45,7 @@
             </b-button>
             <b-button
                 v-b-tooltip.hover
-                :title="'Last updated ' + diffToNow"
+                :title="'Last refreshed ' + diffToNow"
                 variant="link"
                 size="sm"
                 class="rounded-0 text-decoration-none"


### PR DESCRIPTION
Testing https://github.com/galaxyproject/galaxy/pull/13989.

I won't call this a bug, but it really confused me that the update time in the hover text never got higher than 3 seconds. I interpreted 'Last updated' as referring to the `update_time` entry in the database, i.e. last time the history was modified in some way. Then I realised the time simply refers to the refreshing of the history in the UI.

In my opinion 'refreshed' would be less ambiguous here.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
