### PR TITLE
[22.05] Mark openPBS integration test cases as xfail

### DIFF
--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -11,6 +11,8 @@ from typing import (
     NamedTuple,
 )
 
+import pytest
+
 from galaxy.security.ssh_util import generate_ssh_keys
 from galaxy_test.base.populators import skip_without_tool
 from galaxy_test.driver import integration_util
@@ -134,6 +136,7 @@ class BaseCliIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
         assert job_env.some_env == "42"
 
 
+@pytest.mark.xfail(reason="Container entrypoint occasionally fails to set default queue")
 class OpenPBSSetup:
     job_plugin = "OpenPBS"
     image = "mvdbeek/galaxy-integration-docker-images:openpbs-22.01"


### PR DESCRIPTION
I don't think our time is well-spent debugging this one.
It mostly works, but sometimes the startup fails.
This shouldn't mark the whole test suite as failed.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
