### PR TITLE
[22.05] Fix bulk operations visibility

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/OperationErrorDialog.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/OperationErrorDialog.vue
@@ -1,8 +1,8 @@
 <template>
     <b-modal
         v-model="show"
-        title="Something went wrong..."
-        header-text-variant="danger"
+        :title="title"
+        :header-text-variant="titleVariant"
         title-tag="h2"
         scrollable
         ok-only
@@ -59,6 +59,12 @@ export default {
                 return [response_error];
             }
             return [];
+        },
+        title() {
+            return this.isPartialSuccess ? "Some items could not be processed" : "Something went wrong...";
+        },
+        titleVariant() {
+            return this.isPartialSuccess ? "warning" : "danger";
         },
         errorMessage() {
             return this.operationError?.errorMessage?.message;

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -93,6 +93,13 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find(option).exists()).toBe(false);
             });
 
+            it("should display 'permanently delete' option always", async () => {
+                const option = '[data-description="purge option"]';
+                expect(wrapper.find(option).exists()).toBe(true);
+                await wrapper.setProps({ filterText: "deleted:true" });
+                expect(wrapper.find(option).exists()).toBe(true);
+            });
+
             it("should display 'undelete' option only on deleted items", async () => {
                 const option = '[data-description="undelete option"]';
                 expect(wrapper.find(option).exists()).toBe(false);

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -24,6 +24,9 @@ const TASKS_CONFIG = {
     enable_celery_tasks: true,
 };
 
+const getPurgedContentSelection = () => new Map([["FAKE_ID", { purged: true }]]);
+const getNonPurgedContentSelection = () => new Map([["FAKE_ID", { purged: false }]]);
+
 async function mountSelectionOperationsWrapper(config) {
     const wrapper = shallowMount(
         SelectionOperations,
@@ -102,27 +105,30 @@ describe("History Selection Operations", () => {
 
             it("should display 'undelete' option only on deleted and non-purged items", async () => {
                 const option = '[data-description="undelete option"]';
-                const ONE_PURGED_SELECTED = new Map([["FAKE_ID", { purged: true }]]);
-                const ONE_NON_PURGED_SELECTED = new Map([["FAKE_ID", { purged: false }]]);
                 expect(wrapper.find(option).exists()).toBe(false);
                 await wrapper.setProps({
                     filterText: "deleted:true",
-                    contentSelection: ONE_NON_PURGED_SELECTED,
+                    contentSelection: getNonPurgedContentSelection(),
                 });
                 expect(wrapper.find(option).exists()).toBe(true);
+            });
 
-                // In manual selection mode, if all selected items are purged we don't allow undeleting
+            it("should not display 'undelete' when is manual selection mode and all selected items are purged", async () => {
+                const option = '[data-description="undelete option"]';
                 await wrapper.setProps({
                     filterText: "deleted:true",
-                    contentSelection: ONE_PURGED_SELECTED,
+                    contentSelection: getPurgedContentSelection(),
                     isQuerySelection: false,
                 });
                 expect(wrapper.find(option).exists()).toBe(false);
+            });
 
+            it("should display 'undelete' option when is query selection mode and filtering by deleted", async () => {
+                const option = '[data-description="undelete option"]';
                 // In query selection mode we don't know if some items may not be purged, so we allow to undelete
                 await wrapper.setProps({
                     filterText: "deleted:true",
-                    contentSelection: ONE_PURGED_SELECTED,
+                    contentSelection: getPurgedContentSelection(),
                     isQuerySelection: true,
                 });
                 expect(wrapper.find(option).exists()).toBe(true);

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -100,10 +100,31 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 
-            it("should display 'undelete' option only on deleted items", async () => {
+            it("should display 'undelete' option only on deleted and non-purged items", async () => {
                 const option = '[data-description="undelete option"]';
+                const ONE_PURGED_SELECTED = new Map([["FAKE_ID", { purged: true }]]);
+                const ONE_NON_PURGED_SELECTED = new Map([["FAKE_ID", { purged: false }]]);
                 expect(wrapper.find(option).exists()).toBe(false);
-                await wrapper.setProps({ filterText: "deleted:true" });
+                await wrapper.setProps({
+                    filterText: "deleted:true",
+                    contentSelection: ONE_NON_PURGED_SELECTED,
+                });
+                expect(wrapper.find(option).exists()).toBe(true);
+
+                // In manual selection mode, if all selected items are purged we don't allow undeleting
+                await wrapper.setProps({
+                    filterText: "deleted:true",
+                    contentSelection: ONE_PURGED_SELECTED,
+                    isQuerySelection: false,
+                });
+                expect(wrapper.find(option).exists()).toBe(false);
+
+                // In query selection mode we don't know if some items may not be purged, so we allow to undelete
+                await wrapper.setProps({
+                    filterText: "deleted:true",
+                    contentSelection: ONE_PURGED_SELECTED,
+                    isQuerySelection: true,
+                });
                 expect(wrapper.find(option).exists()).toBe(true);
             });
 

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -28,7 +28,7 @@
                 <b-dropdown-item v-else v-b-modal:delete-selected-content data-description="delete option">
                     <span v-localize>Delete</span>
                 </b-dropdown-item>
-                <b-dropdown-item v-if="!showDeleted" v-b-modal:purge-selected-content data-description="purge option">
+                <b-dropdown-item v-b-modal:purge-selected-content data-description="purge option">
                     <span v-localize>Delete (permanently)</span>
                 </b-dropdown-item>
                 <b-dropdown-divider v-if="showBuildOptions" />

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -20,12 +20,12 @@
                     <span v-localize>Hide</span>
                 </b-dropdown-item>
                 <b-dropdown-item
-                    v-if="showDeleted"
+                    v-if="canUndeleteSelection"
                     v-b-modal:restore-selected-content
                     data-description="undelete option">
                     <span v-localize>Undelete</span>
                 </b-dropdown-item>
-                <b-dropdown-item v-else v-b-modal:delete-selected-content data-description="delete option">
+                <b-dropdown-item v-if="!showDeleted" v-b-modal:delete-selected-content data-description="delete option">
                     <span v-localize>Delete</span>
                 </b-dropdown-item>
                 <b-dropdown-item v-b-modal:purge-selected-content data-description="purge option">
@@ -209,6 +209,17 @@ export default {
         },
         noTagsSelected() {
             return this.selectedTags.length === 0;
+        },
+        canUndeleteSelection() {
+            return this.showDeleted && (this.isQuerySelection || !this.areAllSelectedPurged);
+        },
+        areAllSelectedPurged() {
+            for (const item of this.contentSelection.values()) {
+                if (Object.prototype.hasOwnProperty.call(item, "purged") && !item["purged"]) {
+                    return false;
+                }
+            }
+            return true;
         },
     },
     watch: {

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1122,7 +1122,7 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             # collections don't have a `purged` attribute but they should be marked deleted on purge
             assert purged_collection["deleted"] is True
 
-            # Un-deleting a purged dataset should not have any effect
+            # Un-deleting a purged dataset should not have any effect and raise an error
             payload = {
                 "operation": "undelete",
                 "items": [
@@ -1134,7 +1134,10 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             }
             bulk_operation_result = self._apply_bulk_operation(history_id, payload)
             history_contents = self._get_history_contents(history_id)
-            self._assert_bulk_success(bulk_operation_result, 1)
+            assert bulk_operation_result["success_count"] == 0
+            assert len(bulk_operation_result["errors"]) == 1
+            error = bulk_operation_result["errors"][0]
+            assert error["item"]["id"] == datasets_ids[0]
             purged_dataset = self._get_dataset_with_id_from_history_contents(history_contents, datasets_ids[0])
             assert purged_dataset["deleted"] is True
             assert purged_dataset["purged"] is True


### PR DESCRIPTION
Fixes #14107

- The `Permanently delete` option now appears always.
- The `Undelete` option now is hidden when using manual selection (in query selection we cannot know if there would be non-purged datasets selected) and all items are purged.

**Note**: Trying to purge or undelete a purged dataset will now raise an error in the API. This will probably trigger more error dialogs in the client due to *partial success* but it will make it easier to detect when the history will actually change after an operation so we can stop the `Processing...` message correctly.

![fix_bulk_ops_visibility](https://user-images.githubusercontent.com/46503462/174632456-6f3e782e-8bcf-4239-83d3-1ee252c4c8c7.gif)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Follow instructions on #14107

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
