### PR TITLE
[22.05] Reduce bulk operations drop-down cutting off

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -1,7 +1,7 @@
 <template>
     <section v-if="hasSelection">
         <ConfigProvider v-slot="{ config }">
-            <b-dropdown text="Selection" size="sm" variant="primary" data-description="selected content menu">
+            <b-dropdown text="Selection" size="sm" variant="primary" data-description="selected content menu" no-flip>
                 <template v-slot:button-content>
                     <span v-if="selectionMatchesQuery" data-test-id="all-filter-selected">
                         All <b>{{ totalItemsInQuery }}</b> selected


### PR DESCRIPTION
Fixes #14106

This will hopefully reduce or avoid the cutting-off when there is not much vertical space for the dropdown.
I don't know if there is some other kind of CSS sorcery that can help.

### Before
![before_fix_dropdown](https://user-images.githubusercontent.com/46503462/174637779-82db2b2d-26f9-43d3-9c42-95da6b48e9dd.gif)

### After
![after_fix_dropdown](https://user-images.githubusercontent.com/46503462/174637800-2785ede1-b4e8-41f5-a74c-16d26c896764.gif)

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Reduce the vertical space available and try to display the drop-down
  

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
