### PR TITLE
[22.05] Allow downloading individual metadata files in History

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -6,7 +6,7 @@
                     <span class="fa fa-bug" />
                 </b-button>
                 <b-button
-                    v-if="showDownloads"
+                    v-if="showDownloads && !metaFiles"
                     class="download-btn px-1"
                     title="Download"
                     size="sm"
@@ -14,6 +14,22 @@
                     @click.stop="onDownload">
                     <span class="fa fa-save" />
                 </b-button>
+                <b-dropdown
+                    v-if="showDownloads && metaFiles"
+                    no-caret
+                    v-b-tooltip.bottom.hover
+                    size="sm"
+                    variant="link"
+                    toggle-class="text-decoration-none"
+                    title="Download"
+                    data-description="dataset download">
+                    <template v-slot:button-content>
+                        <span class="fa fa-save"/>
+                    </template>
+                    <b-dropdown-item>
+                        You have data.
+                    </b-dropdown-item>
+                </b-dropdown>
                 <b-button
                     v-if="showDownloads"
                     class="px-1"
@@ -82,6 +98,9 @@ export default {
     computed: {
         downloadUrl() {
             return prependPath(`api/datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
+        },
+        metaFiles() {
+            return this.meta_files;
         },
         showDownloads() {
             return !this.item.purged && ["ok", "failed_metadata", "error"].includes(this.item.state);

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -5,7 +5,7 @@
                 <b-button v-if="showError" class="px-1" title="Error" size="sm" variant="link" @click.stop="onError">
                     <span class="fa fa-bug" />
                 </b-button>
-                <dataset-download v-if="showDownloads" :item="item" />
+                <dataset-download v-if="showDownloads" :item="item" @on-download="onDownload" />
                 <b-button
                     v-if="showDownloads"
                     class="px-1"
@@ -61,7 +61,6 @@
 
 <script>
 import { legacyNavigationMixin } from "components/plugins/legacyNavigation";
-import { prependPath } from "utils/redirect";
 import { copy as sendToClipboard } from "utils/clipboard";
 import { absPath } from "utils/redirect";
 import DatasetDownload from "./DatasetDownload";
@@ -102,6 +101,9 @@ export default {
         onCopyLink() {
             const msg = this.localize("Link is copied to your clipboard");
             sendToClipboard(absPath(this.downloadUrl), msg);
+        },
+        onDownload(resource) {
+            window.location.href = resource;
         },
         onError() {
             this.backboneRoute("datasets/error", { dataset_id: this.item.id });

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -5,31 +5,7 @@
                 <b-button v-if="showError" class="px-1" title="Error" size="sm" variant="link" @click.stop="onError">
                     <span class="fa fa-bug" />
                 </b-button>
-                <b-button
-                    v-if="showDownloads && !metaFiles"
-                    class="download-btn px-1"
-                    title="Download"
-                    size="sm"
-                    variant="link"
-                    @click.stop="onDownload">
-                    <span class="fa fa-save" />
-                </b-button>
-                <b-dropdown
-                    v-if="showDownloads && metaFiles"
-                    no-caret
-                    v-b-tooltip.bottom.hover
-                    size="sm"
-                    variant="link"
-                    toggle-class="text-decoration-none"
-                    title="Download"
-                    data-description="dataset download">
-                    <template v-slot:button-content>
-                        <span class="fa fa-save"/>
-                    </template>
-                    <b-dropdown-item>
-                        You have data.
-                    </b-dropdown-item>
-                </b-dropdown>
+                <dataset-download v-if="showDownloads" :item="item" />
                 <b-button
                     v-if="showDownloads"
                     class="px-1"
@@ -88,20 +64,18 @@ import { legacyNavigationMixin } from "components/plugins/legacyNavigation";
 import { prependPath } from "utils/redirect";
 import { copy as sendToClipboard } from "utils/clipboard";
 import { absPath } from "utils/redirect";
+import DatasetDownload from "./DatasetDownload";
 
 export default {
+    components: {
+        DatasetDownload,
+    },
     mixins: [legacyNavigationMixin],
     props: {
         item: { type: Object, required: true },
         showHighlight: { type: Boolean, default: false },
     },
     computed: {
-        downloadUrl() {
-            return prependPath(`api/datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
-        },
-        metaFiles() {
-            return this.meta_files;
-        },
         showDownloads() {
             return !this.item.purged && ["ok", "failed_metadata", "error"].includes(this.item.state);
         },
@@ -128,9 +102,6 @@ export default {
         onCopyLink() {
             const msg = this.localize("Link is copied to your clipboard");
             sendToClipboard(absPath(this.downloadUrl), msg);
-        },
-        onDownload() {
-            window.location.href = this.downloadUrl;
         },
         onError() {
             this.backboneRoute("datasets/error", { dataset_id: this.item.id });

--- a/client/src/components/History/Content/Dataset/DatasetDownload.test.js
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.test.js
@@ -1,0 +1,43 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import DatasetDownload from "./DatasetDownload";
+
+const localVue = getLocalVue();
+
+const items = [
+    { id: "item_id", extension: "ext", meta_files: [{ file_type: "a" }, { file_type: "b" }] },
+    { id: "item_id", extension: "ext", meta_files: [] },
+];
+
+describe("DatasetDownload", () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = mount(DatasetDownload, {
+            propsData: {
+                item: items[0],
+            },
+            localVue,
+        });
+    });
+
+    it("checks basics", async () => {
+        const dropdownItems = wrapper.findAll(".dropdown-item");
+        expect(dropdownItems.length).toBe(3);
+        expect(dropdownItems.at(0).text()).toBe("Download Dataset");
+        expect(dropdownItems.at(1).text()).toBe("Download a");
+        expect(dropdownItems.at(2).text()).toBe("Download b");
+        for (let i = 0; i < dropdownItems.length; i++) {
+            await dropdownItems.at(i).trigger("click");
+        }
+        await wrapper.setProps({ item: items[1] });
+        const foundItems = wrapper.find(".dropdown-item").exists();
+        expect(foundItems).toBe(false);
+        await wrapper.trigger("click");
+        const emitted = wrapper.emitted()["on-download"];
+        expect(emitted[0][0]).toBe(`/api/datasets/item_id/display?to_ext=ext`);
+        expect(emitted[1][0]).toBe(`/dataset/get_metadata_file?hda_id=item_id&metadata_name=a`);
+        expect(emitted[2][0]).toBe(`/dataset/get_metadata_file?hda_id=item_id&metadata_name=b`);
+        expect(emitted[3][0]).toBe(`/api/datasets/item_id/display?to_ext=ext`);
+    });
+});

--- a/client/src/components/History/Content/Dataset/DatasetDownload.test.js
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.test.js
@@ -36,8 +36,8 @@ describe("DatasetDownload", () => {
         await wrapper.trigger("click");
         const emitted = wrapper.emitted()["on-download"];
         expect(emitted[0][0]).toBe(`/api/datasets/item_id/display?to_ext=ext`);
-        expect(emitted[1][0]).toBe(`/dataset/get_metadata_file?hda_id=item_id&metadata_name=a`);
-        expect(emitted[2][0]).toBe(`/dataset/get_metadata_file?hda_id=item_id&metadata_name=b`);
+        expect(emitted[1][0]).toBe(`/api/datasets/item_id/metadata_file?metadata_file=a`);
+        expect(emitted[2][0]).toBe(`/api/datasets/item_id/metadata_file?metadata_file=b`);
         expect(emitted[3][0]).toBe(`/api/datasets/item_id/display?to_ext=ext`);
     });
 });

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -1,0 +1,46 @@
+<template>
+    <b-dropdown
+        v-if="metaFiles"
+        no-caret
+        v-b-tooltip.top.hover
+        size="sm"
+        variant="link"
+        toggle-class="text-decoration-none"
+        title="Download"
+        data-description="dataset download">
+        <template v-slot:button-content>
+            <span class="fa fa-save" />
+        </template>
+        <b-dropdown-item v-localize @click.stop="onDownload">Download Dataset</b-dropdown-item>
+    </b-dropdown>
+    <b-button v-else class="download-btn px-1" title="Download" size="sm" variant="link" @click.stop="onDownload">
+        <span class="fa fa-save" />
+    </b-button>
+</template>
+
+<script>
+import { prependPath } from "utils/redirect";
+
+export default {
+    props: {
+        item: { type: Object, required: true },
+    },
+    computed: {
+        downloadUrl() {
+            return prependPath(`api/datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
+        },
+        metaDownloadUrl() {
+            return prependPath(`dataset/get_metadata_file?hda_id=${this.item.id}&metadata_name=`);
+        },
+        metaFiles() {
+            console.log(this.item);
+            return this.item.meta_files;
+        },
+    },
+    methods: {
+        onDownload() {
+            window.location.href = this.downloadUrl;
+        },
+    },
+};
+</script>

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -1,6 +1,6 @@
 <template>
     <b-dropdown
-        v-if="metaFiles"
+        v-if="hasMetaFiles"
         no-caret
         v-b-tooltip.top.hover
         size="sm"
@@ -11,9 +11,21 @@
         <template v-slot:button-content>
             <span class="fa fa-save" />
         </template>
-        <b-dropdown-item v-localize @click.stop="onDownload">Download Dataset</b-dropdown-item>
+        <b-dropdown-item v-localize @click.stop="onDownload(downloadUrl)"> Download Dataset </b-dropdown-item>
+        <b-dropdown-item
+            v-for="(metaFile, index) of metaFiles"
+            :key="index"
+            @click.stop="onDownload(metaUrl, metaFile.file_type)">
+            Download {{ metaFile.file_type }}
+        </b-dropdown-item>
     </b-dropdown>
-    <b-button v-else class="download-btn px-1" title="Download" size="sm" variant="link" @click.stop="onDownload">
+    <b-button
+        v-else
+        class="download-btn px-1"
+        title="Download"
+        size="sm"
+        variant="link"
+        @click.stop="onDownload(downloadUrl)">
         <span class="fa fa-save" />
     </b-button>
 </template>
@@ -29,17 +41,19 @@ export default {
         downloadUrl() {
             return prependPath(`api/datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
         },
+        hasMetaFiles() {
+            return this.metaFiles && this.metaFiles.length > 0;
+        },
         metaDownloadUrl() {
             return prependPath(`dataset/get_metadata_file?hda_id=${this.item.id}&metadata_name=`);
         },
         metaFiles() {
-            console.log(this.item);
             return this.item.meta_files;
         },
     },
     methods: {
-        onDownload() {
-            window.location.href = this.downloadUrl;
+        onDownload(resource, extension = "") {
+            window.location.href = `${resource}${extension}`;
         },
     },
 };

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -1,7 +1,9 @@
 <template>
     <b-dropdown
         v-if="hasMetaFiles"
+        dropup
         no-caret
+        no-flip
         v-b-tooltip.top.hover
         size="sm"
         variant="link"
@@ -15,7 +17,7 @@
         <b-dropdown-item
             v-for="(metaFile, index) of metaFiles"
             :key="index"
-            @click.stop="onDownload(metaUrl, metaFile.file_type)">
+            @click.stop="onDownload(metaDownloadUrl, metaFile.file_type)">
             Download {{ metaFile.file_type }}
         </b-dropdown-item>
     </b-dropdown>

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -55,7 +55,7 @@ export default {
     },
     methods: {
         onDownload(resource, extension = "") {
-            window.location.href = `${resource}${extension}`;
+            this.$emit("on-download", `${resource}${extension}`);
         },
     },
 };

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -9,6 +9,7 @@
         variant="link"
         toggle-class="text-decoration-none"
         title="Download"
+        class="download-btn"
         data-description="dataset download">
         <template v-slot:button-content>
             <span class="fa fa-save" />
@@ -17,6 +18,7 @@
         <b-dropdown-item
             v-for="(metaFile, index) of metaFiles"
             :key="index"
+            :data-description="`download ${metaFile.file_type}`"
             @click.stop="onDownload(metaDownloadUrl, metaFile.file_type)">
             Download {{ metaFile.file_type }}
         </b-dropdown-item>

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -47,7 +47,7 @@ export default {
             return this.metaFiles && this.metaFiles.length > 0;
         },
         metaDownloadUrl() {
-            return prependPath(`dataset/get_metadata_file?hda_id=${this.item.id}&metadata_name=`);
+            return prependPath(`api/datasets/${this.item.id}/metadata_file?metadata_file=`);
         },
         metaFiles() {
             return this.item.meta_files;

--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -371,7 +371,9 @@ export var DatasetListItemView = _super.extend(
                         ${_.map(
                             this.model.get("meta_files"),
                             (meta_file) =>
-                                `<a class="dropdown-item" href="${urls.meta_download + meta_file.file_type}">
+                                `<a class="dropdown-item" href="${
+                                    urls.meta_download + meta_file.file_type
+                                }" data-description="download ${meta_file.file_type}">
                                     ${_l("Download")} ${meta_file.file_type}
                                 </a>`
                         )}

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -184,6 +184,7 @@ history_panel:
       download_button: '${_} .download-btn'
       info_button: '${_} .params-btn'
       alltags: '${_} .alltags .ti-tags'
+      metadata_file_download: '${_} [data-description="download ${metadata_name}"]'
 
       dataset_operations_dropdown: '${_}  .dataset-actions'
 

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -263,10 +263,18 @@ class FastAPIDatasets:
         tags=["histories"],
         response_class=FileResponse,
     )
+    @router.get(
+        "/api/datasets/{history_content_id}/metadata_file",
+        summary="Returns the metadata file associated with this history item.",
+        response_class=FileResponse,
+    )
     def get_metadata_file(
         self,
         trans=DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: Optional[EncodedDatabaseIdField] = Query(
+            default=None,
+            description="The encoded database identifier of the History.",
+        ),
         history_content_id: EncodedDatabaseIdField = DatasetIDPathParam,
         metadata_file: str = Query(
             ...,

--- a/lib/galaxy_test/selenium/test_dataset_metadata_download.py
+++ b/lib/galaxy_test/selenium/test_dataset_metadata_download.py
@@ -1,0 +1,29 @@
+from .framework import (
+    selenium_test,
+    SeleniumTestCase,
+    UsesHistoryItemAssertions,
+)
+
+FIRST_HID = 1
+
+
+class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
+    ensure_registered = True
+
+    @selenium_test
+    def test_dataset_metadata_download(self):
+        self._prepare_dataset()
+        item = self.history_panel_item_component(hid=FIRST_HID)
+        item.download_button.wait_for_and_click()
+        # For some reason the legacy history metadata drop-down is not a child of the dataset item
+        if self.is_beta_history:
+            item.metadata_file_download(metadata_name="bam_index").wait_for_and_click()
+
+    def _prepare_dataset(self):
+        self.history_panel_create_new()
+        self.perform_upload(self.get_filename("1.bam"))
+        self.history_panel_wait_for_hid_ok(FIRST_HID)
+        self.assert_item_name(FIRST_HID, "1.bam")
+
+        # Expand HDA and wait for details to show up.
+        return self.history_panel_click_item_title(hid=FIRST_HID, wait=True)


### PR DESCRIPTION
Resolves #14123. This PR restores the dropdown download option displayed when individual files can be downloaded for a single history item.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
