### PR TITLE
[22.05] Fix: make tag filtering case insensitive

### DIFF
--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -122,9 +122,9 @@ class TaggableFilterMixin:
                 if ":" not in val:
                     # We require an exact match and the tag to look for has no user_value,
                     # so we can't just concatenate user_tname, ':' and user_vale
-                    cond = target_model.table.c.user_tname == val
+                    cond = target_model.table.c.user_tname.ilike(val)
                 else:
-                    cond = column == val
+                    cond = column.ilike(val)
             else:
                 cond = column.contains(val, autoescape=True)
             return sql.expression.and_(model_class.table.c.id == getattr(target_model.table.c, id_column), cond)

--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -7,7 +7,10 @@ Mixins for Taggable model managers and serializers.
 import logging
 from typing import Type
 
-from sqlalchemy import sql
+from sqlalchemy import (
+    func,
+    sql,
+)
 
 from galaxy import model
 from galaxy.model.tags import GalaxyTagHandler
@@ -118,15 +121,16 @@ class TaggableFilterMixin:
             target_model = getattr(model, f"{class_name}TagAssociation")
             id_column = f"{target_model.table.name.rsplit('_tag_association')[0]}_id"
             column = target_model.table.c.user_tname + ":" + target_model.table.c.user_value
+            lower_val = val.lower()  # Ignore case
             if op == "eq":
-                if ":" not in val:
+                if ":" not in lower_val:
                     # We require an exact match and the tag to look for has no user_value,
                     # so we can't just concatenate user_tname, ':' and user_vale
-                    cond = target_model.table.c.user_tname.ilike(val)
+                    cond = func.lower(target_model.table.c.user_tname) == lower_val
                 else:
-                    cond = column.ilike(val)
+                    cond = func.lower(column) == lower_val
             else:
-                cond = column.contains(val, autoescape=True)
+                cond = func.lower(column).contains(lower_val, autoescape=True)
             return sql.expression.and_(model_class.table.c.id == getattr(target_model.table.c, id_column), cond)
 
         return _create_tag_filter


### PR DESCRIPTION
Fixes #14099

I'm not sure if this was a bug or a feature, but filtering tags was case-sensitive in the API and seems to have been like that since a long time ago.

This PR makes the tag filter case insensitive.

![fix_tag_case_search](https://user-images.githubusercontent.com/46503462/174771489-4fdd15ec-7270-4486-bd49-d6309fba73ea.gif)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Follow steps on #14099

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
