### PR TITLE
[22.05] Fix test_collection_contents_empty_root, use fetch data response

### DIFF
--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -432,7 +432,10 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         assert offset_contents[0]["element_index"] == 1
 
     def test_collection_contents_empty_root(self):
-        hdca = self.dataset_collection_populator.create_list_in_history(self.history_id, contents=[]).json()
+        create_response = self.dataset_collection_populator.create_list_in_history(
+            self.history_id, contents=[], wait=True
+        ).json()
+        hdca = create_response["output_collections"][0]
         assert hdca["elements"] == []
         root_contents_url = hdca["contents_url"]
         response = self._get(root_contents_url)


### PR DESCRIPTION
(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
