### PR TITLE
[22.05] Place progressbar below collection name, allow full width

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -46,12 +46,6 @@
                     <span class="id hid">{{ id }}</span>
                     <span>:</span>
                     <span class="content-title name">{{ name }}</span>
-                    <CollectionDescription
-                        v-if="!isDataset"
-                        :job-state-summary="jobState"
-                        :collection-type="item.collection_type"
-                        :element-count="item.element_count"
-                        :elements-datatypes="item.elements_datatypes" />
                 </span>
                 <ContentOptions
                     :is-dataset="isDataset"
@@ -67,6 +61,13 @@
                     @unhide="$emit('unhide')" />
             </div>
         </div>
+        <CollectionDescription
+            v-if="!isDataset"
+            class="px-2 pb-2"
+            :job-state-summary="jobState"
+            :collection-type="item.collection_type"
+            :element-count="item.element_count"
+            :elements-datatypes="item.elements_datatypes" />
         <StatelessTags
             v-if="!tagsDisabled || hasTags"
             class="alltags p-1"


### PR DESCRIPTION
Resolves #14135.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/2105447/174829849-4b6e2f75-fc64-4c9c-a9fd-2edfebc5df9c.png">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
