### PR TITLE
Get last history list offset and restore on return

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -91,8 +91,13 @@
                                     No data found for selected filter.
                                 </b-alert>
                             </div>
-                            <Listing v-else :items="itemsLoaded" :query-key="queryKey" @scroll="onScroll">
-                                <template v-slot:item="{ item }">
+                            <Listing
+                                v-else
+                                :offset="listOffset"
+                                :items="itemsLoaded"
+                                :query-key="queryKey"
+                                @scroll="onScroll">
+                                <template v-slot:item="{ item, getOffset }">
                                     <ContentItem
                                         v-if="!invisible[item.hid]"
                                         :id="item.hid"
@@ -109,7 +114,7 @@
                                         @toggleHighlights="toggleHighlights"
                                         @update:expand-dataset="setExpanded(item, $event)"
                                         @update:selected="setSelected(item, $event)"
-                                        @view-collection="$emit('view-collection', item)"
+                                        @view-collection="$emit('view-collection', item, getOffset)"
                                         @delete="onDelete(item)"
                                         @undelete="onUndelete(item)"
                                         @unhide="onUnhide(item)" />
@@ -165,6 +170,7 @@ export default {
         OperationErrorDialog,
     },
     props: {
+        listOffset: { type: Number, default: 0 },
         history: { type: Object, required: true },
     },
     data() {

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -97,7 +97,7 @@
                                 :items="itemsLoaded"
                                 :query-key="queryKey"
                                 @scroll="onScroll">
-                                <template v-slot:item="{ item, getOffset }">
+                                <template v-slot:item="{ item, currentOffset }">
                                     <ContentItem
                                         v-if="!invisible[item.hid]"
                                         :id="item.hid"
@@ -114,7 +114,7 @@
                                         @toggleHighlights="toggleHighlights"
                                         @update:expand-dataset="setExpanded(item, $event)"
                                         @update:selected="setSelected(item, $event)"
-                                        @view-collection="$emit('view-collection', item, getOffset)"
+                                        @view-collection="$emit('view-collection', item, currentOffset)"
                                         @delete="onDelete(item)"
                                         @undelete="onUndelete(item)"
                                         @unhide="onUnhide(item)" />

--- a/client/src/components/History/Index.vue
+++ b/client/src/components/History/Index.vue
@@ -4,6 +4,7 @@
             <div v-if="currentHistory" id="current-history-panel" class="history-index">
                 <CurrentHistory
                     v-if="!breadcrumbs.length"
+                    :list-offset="listOffset"
                     :history="currentHistory"
                     v-on="handlers"
                     @view-collection="onViewCollection">
@@ -51,10 +52,12 @@ export default {
         return {
             // list of collections we have drilled down into
             breadcrumbs: [],
+            listOffset: 0,
         };
     },
     methods: {
-        onViewCollection(collection) {
+        onViewCollection(collection, getListOffset) {
+            this.listOffset = getListOffset();
             this.breadcrumbs = [...this.breadcrumbs, collection];
         },
     },

--- a/client/src/components/History/Index.vue
+++ b/client/src/components/History/Index.vue
@@ -56,8 +56,8 @@ export default {
         };
     },
     methods: {
-        onViewCollection(collection, getListOffset) {
-            this.listOffset = getListOffset();
+        onViewCollection(collection, currentOffset) {
+            this.listOffset = currentOffset;
             this.breadcrumbs = [...this.breadcrumbs, collection];
         },
     },

--- a/client/src/components/History/Layout/Listing.vue
+++ b/client/src/components/History/Layout/Listing.vue
@@ -4,11 +4,12 @@
             ref="listing"
             class="listing"
             data-key="id"
+            :offset="offset"
             :data-sources="items"
             :data-component="{}"
             @scroll="onScroll">
             <template v-slot:item="{ item }">
-                <slot name="item" :item="item" />
+                <slot name="item" :item="item" :get-offset="getOffset" />
             </template>
             <template v-slot:footer>
                 <LoadingSpan v-if="loading" class="m-2" message="Loading" />
@@ -27,6 +28,7 @@ export default {
         VirtualList,
     },
     props: {
+        offset: { type: Number, default: 0 },
         loading: { type: Boolean, default: false },
         items: { type: Array, default: null },
         queryKey: { type: String, default: null },
@@ -73,6 +75,9 @@ export default {
         onScroll() {
             const rangeStart = this.$refs.listing.range.start;
             this.$emit("scroll", rangeStart);
+        },
+        getOffset() {
+            return this.$refs.listing.getOffset();
         },
     },
 };

--- a/client/src/components/History/Layout/Listing.vue
+++ b/client/src/components/History/Layout/Listing.vue
@@ -9,7 +9,7 @@
             :data-component="{}"
             @scroll="onScroll">
             <template v-slot:item="{ item }">
-                <slot name="item" :item="item" :get-offset="getOffset" />
+                <slot name="item" :item="item" :current-offset="getOffset()" />
             </template>
             <template v-slot:footer>
                 <LoadingSpan v-if="loading" class="m-2" message="Loading" />
@@ -77,7 +77,7 @@ export default {
             this.$emit("scroll", rangeStart);
         },
         getOffset() {
-            return this.$refs.listing.getOffset();
+            return this.$refs.listing?.getOffset() || 0;
         },
     },
 };


### PR DESCRIPTION
Closes #13746

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Click on a collection in history list
  2. Back to the history list using history navigation

![Screen Recording 2022-06-21 at 19 52 59](https://user-images.githubusercontent.com/8046843/174842451-ad9d4881-063b-4d5a-a657-48bdf071570f.gif)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
