### PR TITLE
[22.05] Add `queued` as acceptable state for collection states

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -90,7 +90,7 @@
 <script>
 import { backboneRoute, iframeAdd } from "components/plugins/legacyNavigation";
 import { StatelessTags } from "components/Tags";
-import { STATES } from "./model/states";
+import { STATES, STATE_REDUCE } from "./model/states";
 import CollectionDescription from "./Collection/CollectionDescription";
 import ContentOptions from "./ContentOptions";
 import DatasetDetails from "./Dataset/DatasetDetails";
@@ -150,7 +150,7 @@ export default {
         },
         state() {
             if (this.item.job_state_summary) {
-                for (const key of ["error", "failed", "paused", "upload", "running"]) {
+                for (const key of STATE_REDUCE) {
                     if (this.item.job_state_summary[key] > 0) {
                         return key;
                     }

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -90,7 +90,7 @@
 <script>
 import { backboneRoute, iframeAdd } from "components/plugins/legacyNavigation";
 import { StatelessTags } from "components/Tags";
-import { STATES, STATES_REDUCE } from "./model/states";
+import { STATES, HIERARCHICAL_COLLECTION_JOB_STATES } from "./model/states";
 import CollectionDescription from "./Collection/CollectionDescription";
 import ContentOptions from "./ContentOptions";
 import DatasetDetails from "./Dataset/DatasetDetails";
@@ -150,9 +150,9 @@ export default {
         },
         state() {
             if (this.item.job_state_summary) {
-                for (const key of STATES_REDUCE) {
-                    if (this.item.job_state_summary[key] > 0) {
-                        return key;
+                for (const state of HIERARCHICAL_COLLECTION_JOB_STATES) {
+                    if (this.item.job_state_summary[state] > 0) {
+                        return state;
                     }
                 }
                 return "ok";

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -90,7 +90,7 @@
 <script>
 import { backboneRoute, iframeAdd } from "components/plugins/legacyNavigation";
 import { StatelessTags } from "components/Tags";
-import { STATES, STATE_REDUCE } from "./model/states";
+import { STATES, STATES_REDUCE } from "./model/states";
 import CollectionDescription from "./Collection/CollectionDescription";
 import ContentOptions from "./ContentOptions";
 import DatasetDetails from "./Dataset/DatasetDetails";
@@ -150,7 +150,7 @@ export default {
         },
         state() {
             if (this.item.job_state_summary) {
-                for (const key of STATE_REDUCE) {
+                for (const key of STATES_REDUCE) {
                     if (this.item.job_state_summary[key] > 0) {
                         return key;
                     }

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -19,10 +19,15 @@ export const STATES = {
         status: "success",
         text: "No data.",
     },
-    /** the tool producing this dataset failed */
+    /** the tool producing this dataset has errored */
     error: {
         status: "danger",
         text: "An error occurred with this dataset:",
+        icon: "exclamation-triangle",
+    },
+    /** the dataset has failed */
+    failed: {
+        status: "danger",
         icon: "exclamation-triangle",
     },
     /** metadata discovery/setting failed or errored (but otherwise ok) */
@@ -78,4 +83,4 @@ export const STATES = {
 /** For collections it is necessary to reduce the available states of the collection items to a single state which
  * can be displayed to represent the collection itself. The order matters.
  */
-export const STATE_REDUCE = ["error", "failed", "queued", "upload", "running", "paused"];
+export const STATES_REDUCE = ["error", "failed", "queued", "upload", "running", "paused"];

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -74,3 +74,8 @@ export const STATES = {
         spin: true,
     },
 };
+
+/** For collections it is necessary to reduce the available states of the collection items to a single state which
+ * can be displayed to represent the collection itself. The order matters.
+ */
+export const STATE_REDUCE = ["error", "failed", "queued", "upload", "running", "paused"];

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -25,7 +25,7 @@ export const STATES = {
         text: "An error occurred with this dataset:",
         icon: "exclamation-triangle",
     },
-    /** the dataset has failed */
+    /** the job has failed, this is not a dataset but a job state used in the collection job state summary. */
     failed: {
         status: "danger",
         icon: "exclamation-triangle",

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -80,7 +80,7 @@ export const STATES = {
     },
 };
 
-/** For collections it is necessary to reduce the available states of the collection items to a single state which
- * can be displayed to represent the collection itself. The order matters.
+/** We want to display a single state for a dataset collection whose elements may have mixed states.
+ * This list is ordered from highest to lowest priority. If any element is in error state the whole collection should be in error.
  */
-export const STATES_REDUCE = ["error", "failed", "queued", "upload", "running", "paused"];
+export const HIERARCHICAL_COLLECTION_JOB_STATES = ["error", "failed", "queued", "upload", "paused", "running", "new"];

--- a/client/src/components/History/Content/model/states.test.js
+++ b/client/src/components/History/Content/model/states.test.js
@@ -1,0 +1,10 @@
+import { STATES, STATES_REDUCE } from "./states";
+
+describe("States", () => {
+    it("check if all reduced states exist and have a status set", async () => {
+        STATES_REDUCE.forEach((datasetState) => {
+            const alertState = STATES[datasetState];
+            expect(alertState.status).toBeDefined();
+        });
+    });
+});

--- a/client/src/components/History/Content/model/states.test.js
+++ b/client/src/components/History/Content/model/states.test.js
@@ -1,9 +1,9 @@
-import { STATES, STATES_REDUCE } from "./states";
+import { STATES, HIERARCHICAL_COLLECTION_JOB_STATES } from "./states";
 
 describe("States", () => {
     it("check if all reduced states exist and have a status set", async () => {
-        STATES_REDUCE.forEach((datasetState) => {
-            const alertState = STATES[datasetState];
+        HIERARCHICAL_COLLECTION_JOB_STATES.forEach((jobState) => {
+            const alertState = STATES[jobState];
             expect(alertState.status).toBeDefined();
         });
     });


### PR DESCRIPTION
Fixes #14134. Collection state in the root view are resolved by evaluating the job state summary. All states identified in the state summary are reduced by the first occurrence of a mapped dataset state. Until now `queued` was not considered in this list of states. This PR resolves this.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
