### PR TITLE
Fix ``parse_requirements_and_containers()`` for CWL and YAML tools

### DIFF
--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -5,6 +5,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Union,
 )
 
@@ -242,11 +243,8 @@ class ResourceRequirement:
         except ValueError:
             self.runtime_required = True
 
-    @staticmethod
-    def from_dict(resource_dict):
-        resource_type = next(iter(resource_dict.keys()))
-        value_or_expression = resource_dict[resource_type]
-        return ResourceRequirement(value_or_expression=value_or_expression, resource_type=resource_type)
+    def to_dict(self) -> Dict:
+        return {"resource_type": self.resource_type, "value_or_expression": self.value_or_expression}
 
     def get_value(self, runtime: Optional[Dict] = None, js_evaluator: Optional[Callable] = None):
         if self.runtime_required:
@@ -282,14 +280,11 @@ def resource_requirements_from_list(requirements) -> List[ResourceRequirement]:
     return rr
 
 
-def parse_requirements_from_dict(root_dict):
-    requirements = root_dict.get("requirements", [])
-    resource_requirements = resource_requirements_from_list(requirements)
-    containers = root_dict.get("containers", [])
+def parse_requirements_from_lists(software_requirements, containers, resource_requirements) -> Tuple:
     return (
-        ToolRequirements.from_list(requirements),
+        ToolRequirements.from_list(software_requirements),
         [ContainerDescription.from_dict(c) for c in containers],
-        resource_requirements,
+        resource_requirements_from_list(resource_requirements),
     )
 
 

--- a/lib/galaxy/tool_util/parser/cwl.py
+++ b/lib/galaxy/tool_util/parser/cwl.py
@@ -153,14 +153,10 @@ class CwlToolSource(ToolSource):
 
         software_requirements = self.tool_proxy.software_requirements()
         resource_requirements = self.tool_proxy.resource_requirements()
-        return requirements.parse_requirements_from_dict(
-            dict(
-                requirements=list(
-                    map(lambda r: {"name": r[0], "version": r[1], "type": "package"}, software_requirements)
-                ),
-                containers=containers,
-                resource_requirements=resource_requirements,
-            )
+        return requirements.parse_requirements_from_lists(
+            software_requirements=[{"name": r[0], "version": r[1], "type": "package"} for r in software_requirements],
+            containers=containers,
+            resource_requirements=resource_requirements,
         )
 
     def parse_profile(self):

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -10,6 +10,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
 )
 
 from galaxy.util.path import safe_walk
@@ -181,7 +182,7 @@ class ToolSource(metaclass=ABCMeta):
         return None
 
     @abstractmethod
-    def parse_requirements_and_containers(self):
+    def parse_requirements_and_containers(self) -> Tuple:
         """Return triple of ToolRequirement, ContainerDescription and ResourceRequirement lists."""
 
     @abstractmethod

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -89,7 +89,12 @@ class YamlToolSource(ToolSource):
         return self.root_dict.get("runtime_version", {}).get("interpreter", None)
 
     def parse_requirements_and_containers(self):
-        return requirements.parse_requirements_from_dict(self.root_dict)
+        mixed_requirements = self.root_dict.get("requirements", [])
+        return requirements.parse_requirements_from_lists(
+            software_requirements=[r for r in mixed_requirements if r.get("type") != "resource"],
+            containers=self.root_dict.get("containers", []),
+            resource_requirements=[r for r in mixed_requirements if r.get("type") == "resource"],
+        )
 
     def parse_input_pages(self):
         # All YAML tools have only one page (feature is deprecated)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -504,6 +504,7 @@ do
           report_file="run_unit_tests.html"
           test_script="pytest"
           unit_extra='--doctest-modules --ignore lib/galaxy/web/proxy/js/node_modules/ --ignore lib/tool_shed/webapp/controllers --ignore lib/galaxy/jobs/runners/chronos.py --ignore lib/tool_shed/webapp/model/migrate --ignore lib/galaxy/tools/bundled --ignore lib/galaxy_test --ignore lib/tool_shed/test --ignore lib/galaxy/model/migrations/alembic'
+          generate_cwl_conformance_tests=1
           if [ $# -gt 1 ]; then
               unit_extra="$unit_extra $2"
               shift 2

--- a/test/unit/tool_util/test_cwl.py
+++ b/test/unit/tool_util/test_cwl.py
@@ -1,0 +1,367 @@
+import json
+import os
+from uuid import uuid4
+
+import yaml
+
+from galaxy.tool_util.cwl import (
+    tool_proxy,
+    workflow_proxy,
+)
+from galaxy.tool_util.cwl.parser import (
+    _to_cwl_tool_object,
+    tool_proxy_from_persistent_representation,
+)
+from galaxy.tool_util.parser.cwl import CwlToolSource
+from galaxy.tool_util.parser.factory import get_tool_source as _get_tool_source
+from galaxy.util import galaxy_directory
+
+CWL_TOOLS_DIRECTORY = os.path.abspath(os.path.join(galaxy_directory(), "test/functional/tools/cwl_tools"))
+
+
+def get_tool_source(*args, **kwargs):
+    tool_source = _get_tool_source(*args, **kwargs)
+    if not isinstance(tool_source, CwlToolSource):
+        raise Exception(f"Returned ToolSource class '{type(tool_source)}' was not expected class 'CwlToolSource'")
+    return tool_source
+
+
+def _cwl_tool_path(path):
+    return os.path.join(CWL_TOOLS_DIRECTORY, path)
+
+
+def test_tool_proxy():
+    """Test that tool proxies load some valid tools correctly."""
+    tool_proxy(_cwl_tool_path("v1.0/v1.0/cat1-testcli.cwl"))
+    tool_proxy(_cwl_tool_path("v1.0/v1.0/cat3-tool.cwl"))
+    tool_proxy(_cwl_tool_path("v1.0/v1.0/env-tool1.cwl"))
+    tool_proxy(_cwl_tool_path("v1.0/v1.0/sorttool.cwl"))
+    tool_proxy(_cwl_tool_path("v1.0/v1.0/bwa-mem-tool.cwl"))
+    tool_proxy(_cwl_tool_path("v1.0/v1.0/parseInt-tool.cwl"))
+
+
+def test_serialize_deserialize():
+    path = _cwl_tool_path("v1.0/v1.0/cat5-tool.cwl")
+    tool = tool_proxy(path)
+    expected_uuid = tool.uuid
+    rep = tool.to_persistent_representation()
+    tool = tool_proxy_from_persistent_representation(rep)
+    assert tool.uuid == expected_uuid
+    tool.job_proxy({"file1": "/moo"}, {})
+    with open(path) as f:
+        tool_object = yaml.safe_load(f)
+    tool_object = json.loads(json.dumps(tool_object))
+    tool = _to_cwl_tool_object(tool_object=tool_object, uuid=expected_uuid)
+    assert tool.uuid == expected_uuid
+
+
+def test_serialize_deserialize_workflow_embed():
+    # Test inherited hints and requirements from workflow -> tool
+    # work here.
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/count-lines2-wf.cwl"))
+    step_proxies = proxy.step_proxies()
+    tool_proxy = step_proxies[0].tool_proxy
+    assert tool_proxy.requirements, tool_proxy.requirements
+
+
+def test_reference_proxies():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/count-lines1-wf.cwl"))
+    assert len(proxy.tool_reference_proxies()) == 2
+
+
+def test_subworkflow_parsing():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/count-lines10-wf.cwl"))
+    assert len(proxy.tool_reference_proxies()) == 2
+
+    assert len(proxy.output_labels) == 1
+    assert "count_output" in proxy.output_labels, proxy.output_labels
+
+    galaxy_workflow_dict = proxy.to_dict()
+    steps = galaxy_workflow_dict["steps"]
+    assert len(steps) == 2  # One input, one subworkflow
+
+    subworkflow_step = steps[1]
+    assert subworkflow_step["type"] == "subworkflow"
+
+
+def test_checks_is_a_tool():
+    """Test that tool proxy cannot be created for a workflow."""
+    exception = None
+    try:
+        tool_proxy(_cwl_tool_path("v1.0/v1.0/count-lines1-wf.cwl"))
+    except Exception as e:
+        exception = e
+
+    assert exception is not None
+    assert "CommandLineTool" in str(exception), str(exception)
+
+
+def test_workflow_of_files_proxy():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/count-lines1-wf.cwl"))
+    step_proxies = proxy.step_proxies()
+    assert len(step_proxies) == 2
+
+    galaxy_workflow_dict = proxy.to_dict()
+
+    assert len(proxy.runnables) == 2
+
+    assert len(galaxy_workflow_dict["steps"]) == 3
+    wc_step = galaxy_workflow_dict["steps"][1]
+    exp_step = galaxy_workflow_dict["steps"][2]
+    assert wc_step["input_connections"]
+    assert exp_step["input_connections"]
+
+
+def test_workflow_embedded_tools_proxy():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/count-lines2-wf.cwl"))
+    step_proxies = proxy.step_proxies()
+    assert len(step_proxies) == 2
+    galaxy_workflow_dict = proxy.to_dict()
+
+    assert len(proxy.runnables) == 2
+
+    assert len(galaxy_workflow_dict["steps"]) == 3
+    wc_step = galaxy_workflow_dict["steps"][1]
+    exp_step = galaxy_workflow_dict["steps"][2]
+    assert wc_step["input_connections"]
+    assert exp_step["input_connections"]
+
+
+def test_workflow_scatter():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/count-lines3-wf.cwl"))
+
+    step_proxies = proxy.step_proxies()
+    assert len(step_proxies) == 1
+
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 2
+
+    # TODO: For CWL - deactivate implicit scattering Galaxy does
+    # and force annotation in the workflow of scattering? Maybe?
+    wc_step = galaxy_workflow_dict["steps"][1]
+    assert wc_step["input_connections"]
+
+    assert "inputs" in wc_step
+    wc_inputs = wc_step["inputs"]
+    assert len(wc_inputs) == 1
+    file_input = wc_inputs[0]
+    assert file_input["scatter_type"] == "dotproduct", wc_step
+
+    assert len(wc_step["workflow_outputs"]) == 1
+
+
+def test_workflow_outputs_of_inputs():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/any-type-compat.cwl"))
+
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 3
+    input_step = galaxy_workflow_dict["steps"][0]
+
+    assert len(input_step["workflow_outputs"]) == 1
+
+
+def test_workflow_scatter_multiple_input():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/count-lines4-wf.cwl"))
+
+    step_proxies = proxy.step_proxies()
+    assert len(step_proxies) == 1
+
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 3
+
+
+def test_workflow_multiple_input_merge_flattened():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/count-lines7-wf.cwl"))
+
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 3
+
+    tool_step = galaxy_workflow_dict["steps"][2]
+    assert "inputs" in tool_step
+    inputs = tool_step["inputs"]
+    assert len(inputs) == 1
+    input = inputs[0]
+    assert input["merge_type"] == "merge_flattened"
+
+
+def test_workflow_step_value_from():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/step-valuefrom-wf.cwl"))
+
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 3
+
+    tool_step = [s for s in galaxy_workflow_dict["steps"].values() if s["label"] == "step1"][0]
+    assert "inputs" in tool_step
+    inputs = tool_step["inputs"]
+    assert len(inputs) == 1
+    assert "value_from" in inputs[0], inputs
+
+
+def test_workflow_input_without_source():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/step-valuefrom3-wf.cwl"))
+
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 3
+
+    tool_step = galaxy_workflow_dict["steps"][2]
+    assert "inputs" in tool_step
+    inputs = tool_step["inputs"]
+    assert len(inputs) == 3, inputs
+    assert inputs[2].get("value_from")
+
+
+def test_workflow_input_default():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/pass-unconnected.cwl"))
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 3
+
+    tool_step = galaxy_workflow_dict["steps"][2]
+
+    assert "inputs" in tool_step
+    inputs = tool_step["inputs"]
+    assert len(inputs) == 2, inputs
+    assert inputs[1]
+
+
+def test_search_workflow():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/search.cwl#main"))
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 5
+
+
+def test_workflow_simple_optional_input():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/io-int-optional-wf.cwl"))
+
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 2
+
+    input_step = galaxy_workflow_dict["steps"][0]
+    assert input_step["type"] == "parameter_input", input_step
+    assert input_step["tool_state"]["parameter_type"] == "field", input_step
+
+
+def test_boolean_defaults():
+    proxy = workflow_proxy(_cwl_tool_path("v1.2/tests/conditionals/cond-wf-002_nojs.cwl"))
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 3
+    bool_input = galaxy_workflow_dict["steps"][0]
+    assert bool_input["label"] == "test", bool_input
+    bool_tool_state = bool_input["tool_state"]
+    assert bool_tool_state["optional"]
+    assert bool_tool_state["default"]["value"] is False
+
+
+def test_workflow_file_optional_input():
+    proxy = workflow_proxy(_cwl_tool_path("v1.0/v1.0/count-lines11-wf.cwl"))
+
+    galaxy_workflow_dict = proxy.to_dict()
+    assert len(galaxy_workflow_dict["steps"]) == 3
+
+    input_step = galaxy_workflow_dict["steps"][0]
+    # TODO: make this File? - implemented in Galaxy now
+    assert input_step["type"] == "parameter_input", input_step
+    assert input_step["tool_state"]["optional"] is True, input_step
+
+
+def test_load_proxy_simple():
+    cat3 = _cwl_tool_path("v1.0/v1.0/cat3-tool.cwl")
+    tool_source = get_tool_source(cat3)
+
+    # Behavior was changed - too verbose?
+    # description = tool_source.parse_description()
+    # assert description == "Print the contents of a file to stdout using 'cat' running in a docker container.", description
+
+    input_sources = _inputs(tool_source)
+    assert len(input_sources) == 1
+
+    input_source = input_sources[0]
+    assert input_source.parse_help() == "The file that will be copied using 'cat'"
+    assert input_source.parse_label() == "Input File"
+
+    outputs, output_collections = tool_source.parse_outputs(None)
+    assert len(outputs) == 1
+
+    _, containers, *_ = tool_source.parse_requirements_and_containers()
+    assert len(containers) == 1
+
+
+def test_representation_id():
+    cat3 = _cwl_tool_path("v1.0/v1.0/cat3-tool.cwl")
+    with open(cat3) as f:
+        representation = yaml.safe_load(f)
+        representation["id"] = "my-cool-id"
+
+        uuid = str(uuid4())
+        proxy = tool_proxy(tool_object=representation, uuid=uuid)
+        tool_id = proxy.galaxy_id()
+        assert tool_id == uuid, tool_id
+        id_proxy = tool_proxy_from_persistent_representation(proxy.to_persistent_representation())
+        tool_id = id_proxy.galaxy_id()
+        assert tool_id == uuid, tool_id
+        assert proxy.uuid == id_proxy.uuid
+
+
+def test_env_tool1():
+    env_tool1 = _cwl_tool_path("v1.0/v1.0/env-tool1.cwl")
+    tool_source = get_tool_source(env_tool1)
+    _inputs(tool_source)
+
+
+def test_wc2_tool():
+    env_tool1 = _cwl_tool_path("v1.0/v1.0/wc2-tool.cwl")
+    tool_source = get_tool_source(env_tool1)
+    _inputs(tool_source)
+    datasets, collections = _outputs(tool_source)
+    assert len(datasets) == 1, datasets
+    output = datasets["output"]
+    assert output.format == "expression.json", output.format
+
+
+def test_optional_output():
+    optional_output2_tool1 = _cwl_tool_path("v1.0/v1.0/optional-output.cwl")
+    tool_source = get_tool_source(optional_output2_tool1)
+    datasets, collections = _outputs(tool_source)
+    assert len(datasets) == 2, datasets
+    output = datasets["optional_file"]
+    assert output.format == "expression.json", output.format
+
+
+def test_schemadef_tool():
+    tool_path = _cwl_tool_path("v1.0/v1.0/schemadef-tool.cwl")
+    tool_source = get_tool_source(tool_path)
+    _inputs(tool_source)
+
+
+def test_params_tool():
+    tool_path = _cwl_tool_path("v1.0/v1.0/params.cwl")
+    tool_source = get_tool_source(tool_path)
+    _inputs(tool_source)
+
+
+def test_tool_reload():
+    cat1_tool = _cwl_tool_path("v1.0/v1.0/cat1-testcli.cwl")
+    tool_source = get_tool_source(cat1_tool)
+    _inputs(tool_source)
+
+    # Test reloading - had a regression where this broke down.
+    cat1_tool_again = _cwl_tool_path("v1.0/v1.0/cat1-testcli.cwl")
+    tool_source = get_tool_source(cat1_tool_again)
+    _inputs(tool_source)
+
+
+def _outputs(tool_source):
+    return tool_source.parse_outputs(object())
+
+
+def _inputs(tool_source=None, path=None):
+    if tool_source is None:
+        path = _cwl_tool_path(path)
+        tool_source = get_tool_source(path)
+
+    input_pages = tool_source.parse_input_pages()
+    assert input_pages.inputs_defined
+    page_sources = input_pages.page_sources
+    assert len(page_sources) == 1
+    page_source = page_sources[0]
+    input_sources = page_source.parse_input_sources()
+    return input_sources

--- a/test/unit/tool_util/test_cwl.py
+++ b/test/unit/tool_util/test_cwl.py
@@ -281,8 +281,17 @@ def test_load_proxy_simple():
     outputs, output_collections = tool_source.parse_outputs(None)
     assert len(outputs) == 1
 
-    _, containers, *_ = tool_source.parse_requirements_and_containers()
+    software_requirements, containers, resource_requirements = tool_source.parse_requirements_and_containers()
+    assert software_requirements.to_dict() == []
     assert len(containers) == 1
+    assert containers[0].to_dict() == {
+        "identifier": "debian:stretch-slim",
+        "type": "docker",
+        "resolve_dependencies": False,
+        "shell": "/bin/sh",
+    }
+    assert len(resource_requirements) == 1
+    assert resource_requirements[0].to_dict() == {"resource_type": "ram_min", "value_or_expression": 8}
 
 
 def test_representation_id():

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -482,11 +482,17 @@ class YamlLoaderTestCase(BaseLoaderTestCase):
         assert self._tool_source.parse_action_module() is None
 
     def test_requirements(self):
-        requirements, containers, resource_requirements = self._tool_source.parse_requirements_and_containers()
-        assert requirements[0].type == "package"
-        assert requirements[0].name == "bwa"
-        assert containers[0].identifier == "awesome/bowtie"
-        assert resource_requirements[0].resource_type == "cores_min"
+        software_requirements, containers, resource_requirements = self._tool_source.parse_requirements_and_containers()
+        assert software_requirements.to_dict() == [{"name": "bwa", "type": "package", "version": "1.0.1", "specs": []}]
+        assert len(containers) == 1
+        assert containers[0].to_dict() == {
+            "identifier": "awesome/bowtie",
+            "type": "docker",
+            "resolve_dependencies": False,
+            "shell": "/bin/sh",
+        }
+        assert len(resource_requirements) == 1
+        assert resource_requirements[0].to_dict() == {"resource_type": "cores_min", "value_or_expression": 1}
 
     def test_outputs(self):
         outputs, output_collections = self._tool_source.parse_outputs(object())

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,11 @@ commands =
     unit: bash run_tests.sh -u
     # start with test here but obviously someday all of it...
     mypy: mypy test lib
+    test_galaxy_packages: make generate-cwl-conformance-tests
     test_galaxy_packages: bash packages/test.sh
-whitelist_externals = bash
+whitelist_externals =
+    bash
+    make
 passenv = 
     CI CONDA_EXE
     GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
@@ -31,6 +34,7 @@ setenv =
     check_indexes: GALAXY_SKIP_CLIENT_BUILD=1
 deps =
     lint,lint_docstring,lint_docstring_include_list,mypy: -rlib/galaxy/dependencies/pinned-lint-requirements.txt
+    test_galaxy_packages: pyyaml
     unit: mock-ssh-server
 
 [testenv:mulled]
@@ -41,7 +45,6 @@ commands = bash .ci/check_py3_compatibility.sh
 
 [testenv:check_python_dependencies]
 commands = make list-dependency-updates # someday change exit code on this.
-whitelist_externals = make
 
 [testenv:mako_count]
 commands = bash .ci/check_mako.sh


### PR DESCRIPTION
- Extract resource requirements from the correct list for CWL tools
- Don't return resource requirements in the software requirement list for YAML tools

Also:
- Move requirements methods to `ToolProxy` since they apply also to `ExpressionToolProxy`.
- Make `resource_requirements()` method also return hints.
- Make `hints_or_requirements_of_class()` method return a list and reuse it in the other methods.
- Add unit tests for CWL parsing

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
