### PR TITLE
[22.05] Fix a bug in PCA artifact staging that prevents a plugin rebuild.

### DIFF
--- a/config/plugins/visualizations/PCA_3Dplot/package.json
+++ b/config/plugins/visualizations/PCA_3Dplot/package.json
@@ -8,6 +8,6 @@
         "d3": "^7.4.4"
     },
     "scripts": {
-        "build": "mkdir static/dist && cp node_modules/pca-js/pca.min.js node_modules/plotly.js/dist/plotly.min.js node_modules/d3/dist/d3.min.js static/dist"
+        "build": "mkdir -p static/dist && cp node_modules/pca-js/pca.min.js node_modules/plotly.js/dist/plotly.min.js node_modules/d3/dist/d3.min.js static/dist"
     }
 }


### PR DESCRIPTION
Without `-p` mkdir will error out if the path exists, killing the build.

## How to test the changes?
(Select all options that apply)

- [x] Instructions for manual testing are as follows:
  1. `yarn run gulp pluginsRebuild` and watch for PCA.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
