### PR TITLE
[22.05] Fix: skip setting metadata on deferred datasets when changing datatype in bulk

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -129,6 +129,8 @@ def set_metadata(
 ):
     dataset_instance = _get_dataset_by_id(hda_manager, ldda_manager, dataset_id, model_class)
     try:
+        if dataset_instance.has_deferred_data:
+            return  # Skip setting metadata on deferred datasets
         if overwrite:
             hda_manager.overwrite_metadata(dataset_instance)
         dataset_instance.datatype.set_meta(dataset_instance)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -19,6 +19,7 @@ from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import Registry as DatatypesRegistry
 from galaxy.jobs import MinimalJobWrapper
 from galaxy.managers.collections import DatasetCollectionManager
+from galaxy.managers.datasets import DatasetAssociationManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
 from galaxy.managers.markdown_util import generate_branded_pdf
@@ -109,7 +110,12 @@ def change_datatype(
     datatype: str,
     model_class: str = "HistoryDatasetAssociation",
 ):
-    dataset_instance = _get_dataset_by_id(hda_manager, ldda_manager, dataset_id, model_class)
+    manager = _get_dataset_manager(hda_manager, ldda_manager, model_class)
+    dataset_instance = manager.by_id(dataset_id)
+    can_change_datatype = manager.ensure_can_change_datatype(dataset_instance, raiseException=False)
+    if not can_change_datatype:
+        log.info(f"Changing datatype is not allowed for {model_class} {dataset_instance.id}")
+        return
     if datatype == "auto":
         path = dataset_instance.dataset.file_name
         datatype = sniff.guess_ext(path, datatypes_registry.sniff_order)
@@ -127,10 +133,13 @@ def set_metadata(
     model_class: str = "HistoryDatasetAssociation",
     overwrite: bool = True,
 ):
-    dataset_instance = _get_dataset_by_id(hda_manager, ldda_manager, dataset_id, model_class)
+    manager = _get_dataset_manager(hda_manager, ldda_manager, model_class)
+    dataset_instance = manager.by_id(dataset_id)
+    can_set_metadata = manager.ensure_can_set_metadata(dataset_instance, raiseException=False)
+    if not can_set_metadata:
+        log.info(f"Setting metadata is not allowed for {model_class} {dataset_instance.id}")
+        return
     try:
-        if dataset_instance.has_deferred_data:
-            return  # Skip setting metadata on deferred datasets
         if overwrite:
             hda_manager.overwrite_metadata(dataset_instance)
         dataset_instance.datatype.set_meta(dataset_instance)
@@ -142,17 +151,15 @@ def set_metadata(
     sa_session.flush()
 
 
-def _get_dataset_by_id(
-    hda_manager: HDAManager, ldda_manager: LDDAManager, dataset_id: int, model_class: str = "HistoryDatasetAssociation"
-) -> model.DatasetInstance:
-    dataset: model.DatasetInstance
+def _get_dataset_manager(
+    hda_manager: HDAManager, ldda_manager: LDDAManager, model_class: str = "HistoryDatasetAssociation"
+) -> DatasetAssociationManager:
     if model_class == "HistoryDatasetAssociation":
-        dataset = hda_manager.by_id(dataset_id)
+        return hda_manager
     elif model_class == "LibraryDatasetDatasetAssociation":
-        dataset = ldda_manager.by_id(dataset_id)
+        return ldda_manager
     else:
-        raise NotImplementedError(f"Cannot set metadata for model_class {model_class}")
-    return dataset
+        raise NotImplementedError(f"Cannot find manager for model_class {model_class}")
 
 
 @galaxy_task(bind=True)

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -382,17 +382,23 @@ class DatasetAssociationManager(
             rval["modify_item_roles"] = modify_item_role_list
         return rval
 
-    def ensure_can_change_datatype(self, dataset: model.DatasetInstance):
+    def ensure_can_change_datatype(self, dataset: model.DatasetInstance, raiseException: bool = True) -> bool:
         if not dataset.datatype.is_datatype_change_allowed():
+            if not raiseException:
+                return False
             raise exceptions.InsufficientPermissionsException(
                 f'Changing datatype "{dataset.extension}" is not allowed.'
             )
+        return True
 
-    def ensure_can_set_metadata(self, dataset: model.DatasetInstance):
+    def ensure_can_set_metadata(self, dataset: model.DatasetInstance, raiseException: bool = True) -> bool:
         if not dataset.ok_to_edit_metadata():
+            if not raiseException:
+                return False
             raise exceptions.ItemAccessibilityException(
                 "This dataset is currently being used as input or output. You cannot change datatype until the jobs have completed or you have canceled them."
             )
+        return True
 
     def detect_datatype(self, trans, dataset_assoc):
         """Sniff and assign the datatype to a given dataset association (ldda or hda)"""

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1621,8 +1621,9 @@ class HistoryItemOperator:
         if isinstance(item, HistoryDatasetAssociation):
             self.hda_manager.ensure_can_change_datatype(item)
             self.hda_manager.ensure_can_set_metadata(item)
-            item.dataset.state = item.dataset.states.SETTING_METADATA
-            trans.sa_session.flush()
+            if not item.has_deferred_data:
+                item.dataset.state = item.dataset.states.SETTING_METADATA
+                trans.sa_session.flush()
             change_datatype.delay(dataset_id=item.id, datatype=params.datatype)
 
     def _change_dbkey(self, item: HistoryItemModel, params: ChangeDbkeyOperationParams):

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1621,10 +1621,18 @@ class HistoryItemOperator:
         if isinstance(item, HistoryDatasetAssociation):
             self.hda_manager.ensure_can_change_datatype(item)
             self.hda_manager.ensure_can_set_metadata(item)
-            if not item.has_deferred_data:
-                item.dataset.state = item.dataset.states.SETTING_METADATA
+            is_deferred = item.has_deferred_data
+            item.dataset.state = item.dataset.states.SETTING_METADATA
+            trans.sa_session.flush()
+            if is_deferred:
+                if params.datatype == "auto":  # if `auto` just keep the original guessed datatype
+                    item.update()  # TODO: remove this `update` when we can properly track the operation results to notify the history
+                else:
+                    trans.app.datatypes_registry.change_datatype(item, params.datatype)
+                item.dataset.state = item.dataset.states.DEFERRED
                 trans.sa_session.flush()
-            change_datatype.delay(dataset_id=item.id, datatype=params.datatype)
+            else:
+                change_datatype.delay(dataset_id=item.id, datatype=params.datatype)
 
     def _change_dbkey(self, item: HistoryItemModel, params: ChangeDbkeyOperationParams):
         if isinstance(item, HistoryDatasetAssociation):

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1274,7 +1274,9 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             assert details["state"] == "deferred"
             assert details["extension"] == "bed"
             assert details["data_type"] == "galaxy.datatypes.interval.Bed"
-            assert details["metadata_columns"]
+            assert "metadata_columns" in details
+            assert "metadata_delimiter" in details
+            assert "metadata_comment_lines" in details
 
             new_datatype = "txt"
             payload = {
@@ -1287,16 +1289,15 @@ class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
             bulk_operation_result = self._apply_bulk_operation(history_id, payload)
             self._assert_bulk_success(bulk_operation_result, expected_success_count=1)
 
-            # Wait for celery tasks to finish
-            time.sleep(2)  # I don't like this at all, is there another way to wait for celery here?
-
             history_contents = self._get_history_contents(history_id, query="?v=dev&view=detailed")
             for item in history_contents:
                 assert item["state"] == "deferred"
                 assert item["extension"] == "txt"
                 assert item["data_type"] == "galaxy.datatypes.data.Text"
-                # Should keep or discard old metadata?
+                # It should discard old metadata
                 assert "metadata_columns" not in item
+                assert "metadata_delimiter" not in item
+                assert "metadata_comment_lines" not in item
 
     @skip_without_tool("cat_data_and_sleep")
     def test_bulk_datatype_change_errors(self):


### PR DESCRIPTION
Fixes #14096 

When running the *Change datatype* operation in bulk, changing the data type on a deferred dataset seems ok as long as we don't alter the state of the dataset. Generating the metadata doesn't work because the dataset is not materialized so we skip it.

I'm not completely sure this is the correct fix, so suggestions are greatly welcome.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  1. Create one or more deferred dataset
  2. Run the `Change datatype` operation from the selection menu on them
  3. The state of the dataset should still be deferred

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
