### PR TITLE
[22.05] Once committed to a plugin rebuild, stage old hash…

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -121,6 +121,13 @@ function buildPlugins(callback, forceRebuild) {
                                     shell: true,
                                 }
                             ).status === 0;
+                        if (!skipBuild) {
+                            // Hash exists and is outdated, triggering a rebuild.
+                            // Stage current hash to .orig for debugging and to
+                            // force a plugin rebuild in the event of a failure
+                            // (i.e. -- we're committed to a new build of this plugin).
+                            fs.renameSync(hashFilePath, `${hashFilePath}.orig`)
+                        }
                     } else {
                         console.log(`No build hashfile detected for ${pluginName}, generating now.`);
                     }


### PR DESCRIPTION
…  to preserve it and force a rebuild in the event of failure/bail/etc.

xref #14147 

## How to test the changes?
(Select all options that apply)
- [ ] Instructions for manual testing are as follows:
  1. Set a plugin build hash to an oudated build, observe staging to .orig and successful rebuild.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
