### PR TITLE
[22.01] Adapt byte content for StreamingResponse

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -2,7 +2,10 @@
 API operations on the contents of a history dataset.
 """
 import logging
-from io import IOBase
+from io import (
+    BytesIO,
+    IOBase,
+)
 from typing import (
     Any,
     cast,
@@ -259,6 +262,8 @@ class FastAPIDatasets:
                 return FileResponse(file_name, headers=headers)
         elif isinstance(display_data, ZipstreamWrapper):
             return StreamingResponse(display_data.response(), headers=headers)
+        elif isinstance(display_data, bytes):
+            return StreamingResponse(BytesIO(display_data), headers=headers)
         return StreamingResponse(display_data, headers=headers)
 
     @router.get(


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14156

```
TypeError: 'bytes' object is not an iterator
  File "starlette/middleware/base.py", line 69, in __call__
    await response(scope, receive, send)
  File "starlette/responses.py", line 260, in __call__
    await wrap(partial(self.listen_for_disconnect, receive))
  File "anyio/_backends/_asyncio.py", line 662, in __aexit__
    raise exceptions[0]
  File "starlette/responses.py", line 256, in wrap
    await func()
  File "starlette/responses.py", line 245, in stream_response
    async for chunk in self.body_iterator:
  File "starlette/middleware/base.py", line 58, in body_stream
    raise app_exc
  File "starlette/middleware/base.py", line 36, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "starlette/exceptions.py", line 93, in __call__
    raise exc
  File "starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "starlette/routing.py", line 266, in handle
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 68, in app
    await response(scope, receive, send)
  File "starlette/responses.py", line 260, in __call__
    await wrap(partial(self.listen_for_disconnect, receive))
  File "anyio/_backends/_asyncio.py", line 662, in __aexit__
    raise exceptions[0]
  File "starlette/responses.py", line 256, in wrap
    await func()
  File "starlette/responses.py", line 245, in stream_response
    async for chunk in self.body_iterator:
  File "starlette/concurrency.py", line 63, in iterate_in_threadpool
    yield await anyio.to_thread.run_sync(_next, iterator)
  File "anyio/to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "starlette/concurrency.py", line 53, in _next
    return next(iterator)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Generate a HTML file with a tool that is on the sanitization list and go to /api/histories/{history_id}/contents/{history_content_id}/display

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
