### PR TITLE
[21.09] Fix dataset controller actions (delete, purge, unhide)

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -726,14 +726,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         id = None
         try:
             id = self.decode_id(dataset_id)
-            hda = trans.sa_session.query(self.app.model.HistoryDatasetAssociation).get(id)
-            assert hda, f'Invalid HDA: {id}'
-            # Walk up parent datasets to find the containing history
-            topmost_parent = hda
-            while topmost_parent.parent:
-                topmost_parent = topmost_parent.parent
-            assert topmost_parent in trans.history.datasets, "Data does not belong to current history"
-            # Mark deleted and cleanup
+            hda = self.hda_manager.get_owned(id, trans.user, current_history=trans.history)
             hda.mark_deleted()
             hda.clear_associated_files()
             trans.log_event(f"Dataset id {str(id)} marked as deleted")
@@ -753,17 +746,8 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         id = None
         try:
             id = self.decode_id(dataset_id)
-            history = trans.get_history()
-            hda = trans.sa_session.query(self.app.model.HistoryDatasetAssociation).get(id)
-            assert hda and hda.undeletable, f'Invalid HDA: {id}'
-            # Walk up parent datasets to find the containing history
-            topmost_parent = hda
-            while topmost_parent.parent:
-                topmost_parent = topmost_parent.parent
-            assert topmost_parent in history.datasets, "Data does not belong to current history"
-            # Mark undeleted
-            hda.mark_undeleted()
-            trans.sa_session.flush()
+            item = self.hda_manager.get_owned(id, trans.user, current_history=trans.history)
+            self.hda_manager.undelete(item)
             trans.log_event(f"Dataset id {str(id)} has been undeleted")
         except Exception:
             msg = f'HDA undeletion failed (encoded: {dataset_id}, decoded: {id})'
@@ -776,22 +760,13 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
     def _unhide(self, trans, dataset_id):
         try:
             id = self.decode_id(dataset_id)
-        except Exception:
-            return False
-        history = trans.get_history()
-        hda = trans.sa_session.query(self.app.model.HistoryDatasetAssociation).get(id)
-        if hda:
-            # Walk up parent datasets to find the containing history
-            topmost_parent = hda
-            while topmost_parent.parent:
-                topmost_parent = topmost_parent.parent
-            assert topmost_parent in history.datasets, "Data does not belong to current history"
-            # Mark undeleted
-            hda.mark_unhidden()
+            item = self.hda_manager.get_owned(id, trans.user, current_history=trans.history)
+            item.mark_unhidden()
             trans.sa_session.flush()
             trans.log_event(f"Dataset id {str(id)} has been unhidden")
             return True
-        return False
+        except Exception:
+            return False
 
     def _purge(self, trans, dataset_id):
         message = None


### PR DESCRIPTION
We don't have a parent property anymore.
That's been broken since 21.09.
Fixes
https://sentry.galaxyproject.org/organizations/galaxy/issues/4971/?project=3&query=is%3Aunresolved&statsPeriod=14d:

```
AttributeError: 'HistoryDatasetAssociation' object has no attribute 'parent'
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 897, in _undelete
    while topmost_parent.parent:
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
