### PR TITLE
[22.01] Fix collection download for BAM native files

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -421,8 +421,10 @@ class BamNative(CompressedArchive, _BamOrSam):
         file_paths = []
         rel_paths.append(f"{name or dataset.file_name}.{dataset.extension}")
         file_paths.append(dataset.file_name)
-        rel_paths.append(f"{name or dataset.file_name}.{dataset.extension}.bai")
-        file_paths.append(dataset.metadata.bam_index.file_name)
+        # We may or may not have a bam index file (BamNative doesn't have it, but also index generation may have failed)
+        if dataset.metadata.bam_index:
+            rel_paths.append(f"{name or dataset.file_name}.{dataset.extension}.bai")
+            file_paths.append(dataset.metadata.bam_index.file_name)
         return zip(file_paths, rel_paths)
 
     def groom_dataset_content(self, file_name):


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/organizations/galaxy/issues/85033/?project=3&query=is%3Aunresolved&statsPeriod=14d:
```
AttributeError: 'NoneType' object has no attribute 'file_name'
  File "galaxy/webapps/galaxy/services/history_contents.py", line 482, in get_dataset_collection_archive_for_download
    return self.__stream_dataset_collection(trans, dataset_collection_instance)
  File "galaxy/webapps/galaxy/services/history_contents.py", line 503, in __stream_dataset_collection
    archive = hdcas.stream_dataset_collection(
  File "galaxy/managers/hdcas.py", line 37, in stream_dataset_collection
    write_dataset_collection(dataset_collection_instance, archive)
  File "galaxy/managers/hdcas.py", line 46, in write_dataset_collection
    for file_path, relpath in hda.datatype.to_archive(dataset=hda, name=name):
  File "galaxy/datatypes/binary.py", line 535, in to_archive
    file_paths.append(dataset.metadata.bam_index.file_name)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
Upload an unsorted bam data, build a collection and try downloading that collection

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
