### PR TITLE
[22.05] Fix importing whole folders as datasets

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -31,12 +31,6 @@ SerializationKeysQueryParam: Optional[str] = Query(
     description="Comma-separated list of keys to be passed to the serializer",
 )
 
-SerializationDefaultViewQueryParam: Optional[str] = Query(
-    None,
-    title="Default View",
-    description="The item view that will be used in case no particular view was specified.",
-)
-
 FilterQueryQueryParam: Optional[List[str]] = Query(
     default=None,
     title="Filter Query",
@@ -67,9 +61,8 @@ def parse_serialization_params(
 def query_serialization_params(
     view: Optional[str] = SerializationViewQueryParam,
     keys: Optional[str] = SerializationKeysQueryParam,
-    default_view: Optional[str] = SerializationDefaultViewQueryParam,
 ) -> SerializationParams:
-    return parse_serialization_params(view=view, keys=keys, default_view=default_view, format=format)
+    return parse_serialization_params(view=view, keys=keys)
 
 
 def get_value_filter_query_params(

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -587,7 +587,7 @@ class FastAPIHistoryContents:
         ),
         serialization_params: SerializationParams = Depends(query_serialization_params),
         payload: CreateHistoryContentPayload = Body(...),
-    ) -> AnyHistoryContentItem:
+    ) -> Union[AnyHistoryContentItem, List[AnyHistoryContentItem]]:
         """Create a new `HDA` or `HDCA` in the given History."""
         payload.type = type or payload.type
         return self.service.create(trans, history_id, payload, serialization_params)

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -511,7 +511,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         history_id: EncodedDatabaseIdField,
         payload: CreateHistoryContentPayload,
         serialization_params: SerializationParams,
-    ) -> AnyHistoryContentItem:
+    ) -> Union[AnyHistoryContentItem, List[AnyHistoryContentItem]]:
         """
         Create a new HDA or HDCA.
 
@@ -520,6 +520,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         """
         history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
 
+        serialization_params.default_view = "detailed"
         history_content_type = payload.type
         if history_content_type == HistoryContentType.dataset:
             source = payload.source
@@ -1334,7 +1335,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
                     history, add_to_history=True
                 )
                 hda_dict = self.hda_serializer.serialize_to_view(
-                    hda, user=trans.user, trans=trans, default_view="detailed", **serialization_params.dict()
+                    hda, user=trans.user, trans=trans, **serialization_params.dict()
                 )
                 rval.append(hda_dict)
         else:
@@ -1368,7 +1369,6 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             return None
 
         trans.sa_session.flush()
-        serialization_params.default_view = "detailed"
         return self.hda_serializer.serialize_to_view(hda, user=trans.user, trans=trans, **serialization_params.dict())
 
     def __create_hda_from_ldda(self, trans, history: History, ldda_id: EncodedDatabaseIdField):
@@ -1465,7 +1465,6 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
 
         # if the consumer specified keys or view, use the secondary serializer
         if serialization_params.view or serialization_params.keys:
-            serialization_params.default_view = "detailed"
             return self.hdca_serializer.serialize_to_view(
                 dataset_collection_instance, user=trans.user, trans=trans, **serialization_params.dict()
             )

--- a/lib/galaxy_test/api/test_folders.py
+++ b/lib/galaxy_test/api/test_folders.py
@@ -1,10 +1,14 @@
-from galaxy_test.base.populators import LibraryPopulator
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    LibraryPopulator,
+)
 from ._framework import ApiTestCase
 
 
 class FoldersApiTestCase(ApiTestCase):
     def setUp(self):
         super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.library_populator = LibraryPopulator(self.galaxy_interactor)
         self.library = self.library_populator.new_library("FolderTestsLibrary")
 
@@ -77,6 +81,17 @@ class FoldersApiTestCase(ApiTestCase):
         self._assert_status_code_is(undelete_response, 200)
         undeleted_folder = undelete_response.json()
         assert undeleted_folder["deleted"] is False
+
+    def test_import_folder_to_history(self):
+        library, response = self.library_populator.fetch_single_url_to_folder()
+        dataset = self.library_populator.get_library_contents_with_path(library["id"], "/4.bed")
+        with self.dataset_populator.test_history() as history_id:
+            create_data = {"source": "library_folder", "content": dataset["folder_id"]}
+            create_response = self._post(f"histories/{history_id}/contents", create_data, json=True)
+            create_response.raise_for_status()
+            datasets = create_response.json()
+            assert len(datasets) == 1
+            assert datasets[0]["name"] == "4.bed"
 
     def test_update_deleted_raise_403(self):
         folder = self._create_folder("Test Update Deleted Folder")

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -10,14 +10,12 @@ from galaxy.model.unittest_utils.store_fixtures import (
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
+    FILE_URL,
     LibraryPopulator,
     skip_if_github_down,
     skip_without_asgi,
 )
 from ._framework import ApiTestCase
-
-FILE_URL = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed"
-FILE_MD5 = "37b59762b59fff860460522d271bc111"
 
 
 class LibrariesApiTestCase(ApiTestCase):
@@ -268,37 +266,14 @@ class LibrariesApiTestCase(ApiTestCase):
         assert dataset["file_size"] == 61, dataset
 
     def test_fetch_single_url_to_folder(self):
-        library, response = self._fetch_single_url_to_folder()
+        library, response = self.library_populator.fetch_single_url_to_folder()
         dataset = self.library_populator.get_library_contents_with_path(library["id"], "/4.bed")
         assert dataset["file_size"] == 61, dataset
 
     def test_fetch_single_url_with_invalid_datatype(self):
-        _, response = self._fetch_single_url_to_folder("xxx", assert_ok=False)
+        _, response = self.library_populator.fetch_single_url_to_folder("xxx", assert_ok=False)
         self._assert_status_code_is(response, 400)
         assert response.json()["err_msg"] == "Requested extension 'xxx' unknown, cannot upload dataset."
-
-    def _fetch_single_url_to_folder(self, file_type="auto", assert_ok=True):
-        history_id, library, destination = self._setup_fetch_to_folder("single_url")
-        items = [
-            {
-                "src": "url",
-                "url": FILE_URL,
-                "MD5": FILE_MD5,
-                "ext": file_type,
-            }
-        ]
-        targets = [
-            {
-                "destination": destination,
-                "items": items,
-            }
-        ]
-        payload = {
-            "history_id": history_id,  # TODO: Shouldn't be needed :(
-            "targets": targets,
-            "validate_hashes": True,
-        }
-        return library, self.dataset_populator.fetch(payload, assert_ok=assert_ok)
 
     def test_legacy_upload_unknown_datatype(self):
         library = self.library_populator.new_private_library("ForLegacyUpload")

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -94,6 +94,9 @@ from galaxy.util.resources import resource_string
 from . import api_asserts
 from .api import ApiTestInteractor
 
+FILE_URL = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed"
+FILE_MD5 = "37b59762b59fff860460522d271bc111"
+
 CWL_TOOL_DIRECTORY = os.path.join(galaxy_root_path, "test", "functional", "tools", "cwl_tools")
 
 # Simple workflow that takes an input and call cat wrapper on it.
@@ -2157,6 +2160,29 @@ class LibraryPopulator:
         data = dict(name=name)
         create_response = self.galaxy_interactor.post("libraries", data=data, admin=True, json=True)
         return create_response.json()
+
+    def fetch_single_url_to_folder(self, file_type="auto", assert_ok=True):
+        history_id, library, destination = self.setup_fetch_to_folder("single_url")
+        items = [
+            {
+                "src": "url",
+                "url": FILE_URL,
+                "MD5": FILE_MD5,
+                "ext": file_type,
+            }
+        ]
+        targets = [
+            {
+                "destination": destination,
+                "items": items,
+            }
+        ]
+        payload = {
+            "history_id": history_id,  # TODO: Shouldn't be needed :(
+            "targets": targets,
+            "validate_hashes": True,
+        }
+        return library, self.dataset_populator.fetch(payload, assert_ok=assert_ok)
 
     def get_permissions(
         self,


### PR DESCRIPTION
And remove `default_view` query parameter parsing. That was never meant
to be definable via the API, users were meant to set the view, and the
controller code sets the appropriate default_view.

Fixes
https://sentry.galaxyproject.org/share/issue/e26374bcf34f4ac0aed92c343c5a1fe6/:

```

App Only

Full

Raw
WouldBlock: null
  File "anyio/streams/memory.py", line 94, in receive
    return self.receive_nowait()
  File "anyio/streams/memory.py", line 89, in receive_nowait
    raise WouldBlock
EndOfStream: null
  File "starlette/middleware/base.py", line 43, in call_next
    message = await recv_stream.receive()
  File "anyio/streams/memory.py", line 114, in receive
    raise EndOfStream
TypeError: serialize_to_view() got multiple values for keyword argument 'default_view'
  File "starlette/middleware/base.py", line 68, in __call__
    response = await self.dispatch_func(request, call_next)
  File "galaxy/webapps/galaxy/fast_app.py", line 103, in add_x_frame_options
    response = await call_next(request)
  File "starlette/middleware/base.py", line 46, in call_next
    raise app_exc
  File "starlette/middleware/base.py", line 36, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "starlette/exceptions.py", line 93, in __call__
    raise exc
  File "starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "starlette/routing.py", line 266, in handle
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 65, in app
    response = await func(request)
  File "fastapi/routing.py", line 227, in app
    raw_response = await run_endpoint_function(
  File "fastapi/routing.py", line 162, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "starlette/concurrency.py", line 41, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "anyio/to_thread.py", line 31, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "anyio/_backends/_asyncio.py", line 937, in run_sync_in_worker_thread
    return await future
  File "anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "galaxy/webapps/galaxy/api/history_contents.py", line 593, in create
    return self.service.create(trans, history_id, payload, serialization_params)
  File "galaxy/webapps/galaxy/services/history_contents.py", line 527, in create
    return self.__create_datasets_from_library_folder(trans, history, payload, serialization_params)
  File "galaxy/webapps/galaxy/services/history_contents.py", line 1336, in __create_datasets_from_library_folder
    hda_dict = self.hda_serializer.serialize_to_view(
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
