### PR TITLE
[22.05] History edit attributes tweaks

### DIFF
--- a/client/src/components/History/Layout/Details.vue
+++ b/client/src/components/History/Layout/Details.vue
@@ -22,6 +22,7 @@
         <!-- edit form, change title, annotation, or tags -->
         <div v-else class="mt-3" data-description="edit form">
             <b-input
+                ref="name"
                 v-model="localProps.name"
                 class="mb-2"
                 placeholder="Name"
@@ -66,6 +67,7 @@
 import { mapGetters } from "vuex";
 import short from "components/directives/v-short";
 import { StatelessTags } from "components/Tags";
+import Vue from "vue";
 
 export default {
     components: {
@@ -102,6 +104,12 @@ export default {
                 annotation: this.annotation,
                 tags: this.tags,
             };
+            // After dom update, focus on input
+            Vue.nextTick(() => {
+                if (this.$refs.name) {
+                    this.$refs.name.focus();
+                }
+            });
         },
     },
 };

--- a/client/src/components/History/Layout/Details.vue
+++ b/client/src/components/History/Layout/Details.vue
@@ -21,7 +21,7 @@
 
         <!-- edit form, change title, annotation, or tags -->
         <div v-else class="mt-3" data-description="edit form">
-            <b-textarea
+            <b-input
                 v-model="localProps.name"
                 class="mb-2"
                 placeholder="Name"

--- a/client/src/components/History/Layout/Details.vue
+++ b/client/src/components/History/Layout/Details.vue
@@ -29,6 +29,7 @@
                 trim
                 max-rows="4"
                 data-description="name input"
+                @keyup.enter="onSave"
                 @keyup.esc="onToggle" />
             <b-textarea
                 v-if="showAnnotation"

--- a/client/src/components/History/Layout/Details.vue
+++ b/client/src/components/History/Layout/Details.vue
@@ -67,7 +67,6 @@
 import { mapGetters } from "vuex";
 import short from "components/directives/v-short";
 import { StatelessTags } from "components/Tags";
-import Vue from "vue";
 
 export default {
     components: {
@@ -105,7 +104,7 @@ export default {
                 tags: this.tags,
             };
             // After dom update, focus on input
-            Vue.nextTick(() => {
+            this.$nextTick(() => {
                 if (this.$refs.name) {
                     this.$refs.name.focus();
                 }

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1589,7 +1589,11 @@ class NavigatesGalaxy(HasDriver):
         if self.is_beta_history():
             editable_text_input_element.clear()
         editable_text_input_element.send_keys(new_name)
-        self.send_enter(editable_text_input_element)
+        if not self.is_beta_history():
+            # in the new history 'enter' submits the change, which we don't want
+            # to automatically do here since we may edit other fields prior to
+            # submitting
+            self.send_enter(editable_text_input_element)
         return editable_text_input_element
 
     def history_panel_name_input(self):


### PR DESCRIPTION
fixes https://github.com/galaxyproject/galaxy/issues/14095

Single line history title, autofocuses on edit, and enter will save.

![image](https://user-images.githubusercontent.com/155398/175314680-caf05a8f-f23e-491c-a2bf-c62f20f99109.png)

Draft while I tinker with options for focus/save.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
