### PR TITLE
[22.05] Fix dataset link copy

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -62,22 +62,20 @@
 <script>
 import { legacyNavigationMixin } from "components/plugins/legacyNavigation";
 import { copy as sendToClipboard } from "utils/clipboard";
-import { absPath, prependPath } from "utils/redirect";
+import { absPath } from "utils/redirect";
+import { downloadUrlMixin } from "./mixins.js";
 import DatasetDownload from "./DatasetDownload";
 
 export default {
     components: {
         DatasetDownload,
     },
-    mixins: [legacyNavigationMixin],
+    mixins: [legacyNavigationMixin, downloadUrlMixin],
     props: {
         item: { type: Object, required: true },
         showHighlight: { type: Boolean, default: false },
     },
     computed: {
-        downloadUrl() {
-            return prependPath(`api/datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
-        },
         showDownloads() {
             return !this.item.purged && ["ok", "failed_metadata", "error"].includes(this.item.state);
         },

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -62,7 +62,7 @@
 <script>
 import { legacyNavigationMixin } from "components/plugins/legacyNavigation";
 import { copy as sendToClipboard } from "utils/clipboard";
-import { absPath } from "utils/redirect";
+import { absPath, prependPath } from "utils/redirect";
 import DatasetDownload from "./DatasetDownload";
 
 export default {
@@ -75,6 +75,9 @@ export default {
         showHighlight: { type: Boolean, default: false },
     },
     computed: {
+        downloadUrl() {
+            return prependPath(`api/datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
+        },
         showDownloads() {
             return !this.item.purged && ["ok", "failed_metadata", "error"].includes(this.item.state);
         },

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -36,15 +36,14 @@
 
 <script>
 import { prependPath } from "utils/redirect";
+import { downloadUrlMixin } from "./mixins.js";
 
 export default {
+    mixins: [downloadUrlMixin],
     props: {
         item: { type: Object, required: true },
     },
     computed: {
-        downloadUrl() {
-            return prependPath(`api/datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
-        },
         hasMetaFiles() {
             return this.metaFiles && this.metaFiles.length > 0;
         },

--- a/client/src/components/History/Content/Dataset/DatasetDownload.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDownload.vue
@@ -1,10 +1,10 @@
 <template>
     <b-dropdown
         v-if="hasMetaFiles"
+        v-b-tooltip.top.hover
         dropup
         no-caret
         no-flip
-        v-b-tooltip.top.hover
         size="sm"
         variant="link"
         toggle-class="text-decoration-none"

--- a/client/src/components/History/Content/Dataset/mixins.js
+++ b/client/src/components/History/Content/Dataset/mixins.js
@@ -1,0 +1,10 @@
+import { prependPath } from "utils/redirect";
+
+/* VueJS mixin with dataset downloadUrl */
+export const downloadUrlMixin = {
+    computed: {
+        downloadUrl() {
+            return prependPath(`api/datasets/${this.item.id}/display?to_ext=${this.item.extension}`);
+        },
+    },
+};


### PR DESCRIPTION
Fixes dataset link copy being `undefined` as reported by Anton on slack.

![image](https://user-images.githubusercontent.com/155398/175351194-a92acd0a-0454-4c89-b823-a786e2b00b14.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Click link button and verify generated url.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
