### PR TITLE
[22.05] Fix draggable source for content items

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -1,12 +1,6 @@
 <template>
-    <div
-        :id="contentId"
-        :class="['content-item m-1 p-0 rounded', contentCls]"
-        draggable
-        :data-hid="id"
-        :data-state="state"
-        @dragstart="onDragStart">
-        <div class="p-1 cursor-pointer" @click.stop="onClick">
+    <div :id="contentId" :class="['content-item m-1 p-0 rounded', contentCls]" :data-hid="id" :data-state="state">
+        <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @click.stop="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1 font-weight-bold">
                     <span v-if="selectable" class="selector">


### PR DESCRIPTION
This was preventing copy/pasting text from dataset details.  This is identical to how the old history worked, where only the titlebar was draggable.

fixes https://github.com/galaxyproject/galaxy/issues/14174


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Drag a dataset.  Copy text out of the details.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
