### PR TITLE
[22.05] Show job progress bar while there are non-terminal jobs, declutter text

### DIFF
--- a/client/src/components/History/Content/Collection/CollectionDescription.vue
+++ b/client/src/components/History/Content/Collection/CollectionDescription.vue
@@ -3,7 +3,7 @@
         <h6 class="description mt-1">
             a {{ collectionLabel }} with {{ elementCount }}<b>{{ homogeneousDatatype }}</b> {{ pluralizedItem }}
         </h6>
-        <CollectionProgress v-if="jobStateSummary.size !=0" :summary="jobStateSummary" />
+        <CollectionProgress v-if="jobStateSummary.size != 0" :summary="jobStateSummary" />
     </div>
 </template>
 

--- a/client/src/components/History/Content/Collection/CollectionDescription.vue
+++ b/client/src/components/History/Content/Collection/CollectionDescription.vue
@@ -3,7 +3,7 @@
         <h6 class="description mt-1">
             a {{ collectionLabel }} with {{ elementCount }}<b>{{ homogeneousDatatype }}</b> {{ pluralizedItem }}
         </h6>
-        <CollectionProgress :summary="jobStateSummary" />
+        <CollectionProgress v-if="jobStateSummary.size !=0" :summary="jobStateSummary" />
     </div>
 </template>
 

--- a/client/src/components/History/Content/Collection/CollectionProgress.test.js
+++ b/client/src/components/History/Content/Collection/CollectionProgress.test.js
@@ -18,7 +18,7 @@ describe("CollectionProgress", () => {
             localVue,
         });
         await wrapper.vm.$nextTick();
-        expect(wrapper.find(".progress").find(".bg-warning").text()).toBe("3");
+        expect(wrapper.find(".progress").find(".bg-warning").attributes("aria-valuenow")).toBe("3");
     });
 
     it("should correctly display states", async () => {
@@ -31,9 +31,9 @@ describe("CollectionProgress", () => {
             localVue,
         });
         await wrapper.vm.$nextTick();
-        expect(wrapper.find(".progress").find(".bg-warning").text()).toBe("3");
-        expect(wrapper.find(".progress").find(".bg-success").text()).toBe("1");
-        expect(wrapper.find(".progress").find(".bg-danger").text()).toBe("1");
+        expect(wrapper.find(".progress").find(".bg-warning").attributes("aria-valuenow")).toBe("3");
+        expect(wrapper.find(".progress").find(".bg-success").attributes("aria-valuenow")).toBe("1");
+        expect(wrapper.find(".progress").find(".bg-danger").attributes("aria-valuenow")).toBe("1");
     });
 
     it("should update as dataset states change", async () => {
@@ -46,13 +46,26 @@ describe("CollectionProgress", () => {
             localVue,
         });
         await wrapper.vm.$nextTick();
-        expect(wrapper.find(".progress").find(".bg-warning").text()).toBe("3");
+        expect(wrapper.find(".progress").find(".bg-warning").attributes("aria-valuenow")).toBe("3");
         dsc["job_state_summary"]["ok"] = 2;
         dsc["job_state_summary"]["running"] = 1;
         jobStateSummary = new JobStateSummary(dsc);
         await wrapper.setProps({ summary: jobStateSummary });
         await wrapper.vm.$nextTick();
-        expect(wrapper.find(".progress").find(".bg-warning").text()).toBe("1");
-        expect(wrapper.find(".progress").find(".bg-success").text()).toBe("2");
+        expect(wrapper.find(".progress").find(".bg-warning").attributes("aria-valuenow")).toBe("1");
+        expect(wrapper.find(".progress").find(".bg-success").attributes("aria-valuenow")).toBe("2");
+    });
+
+    it("should be visible when all jobs are queued", async () => {
+        const dsc = { job_state_summary: { all_jobs: 3, queued: 3 }, populated_state: {} };
+        const jobStateSummary = new JobStateSummary(dsc);
+        wrapper = mount(CollectionProgress, {
+            propsData: {
+                summary: jobStateSummary,
+            },
+            localVue,
+        });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find(".progress").find(".bg-secondary").attributes("aria-valuenow")).toBe("3");
     });
 });

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -6,24 +6,24 @@ model, so probably has to go eventually.-->
         <b-progress v-if="!summary.isTerminal" :max="summary.jobCount">
             <b-progress-bar
                 v-if="summary.errorCount"
+                v-b-tooltip.hover="summary.errorCountText"
                 :value="summary.errorCount"
-                variant="danger"
-                v-b-tooltip.hover="summary.errorCount" />
+                variant="danger" />
             <b-progress-bar
                 v-if="summary.okCount"
+                v-b-tooltip.hover="summary.okCountText"
                 :value="summary.okCount"
-                variant="success"
-                v-b-tooltip.hover="summary.okCount" />
+                variant="success" />
             <b-progress-bar
                 v-if="summary.runningCount"
+                v-b-tooltip.hover="summary.runningCountText"
                 :value="summary.runningCount"
-                variant="warning"
-                v-b-tooltip.hover="summary.runningCount" />
+                variant="warning" />
             <b-progress-bar
                 v-if="summary.waitingCount"
+                v-b-tooltip.hover="summary.waitingCountText"
                 :value="summary.waitingCount"
-                variant="secondary"
-                v-b-tooltip.hover="summary.waitingCount" />
+                variant="secondary" />
         </b-progress>
     </div>
 </template>

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -3,11 +3,15 @@ at components/JobStates/CollectionJobStates but it relies on the backbone data
 model, so probably has to go eventually.-->
 <template>
     <div class="collection-progress">
-        <b-progress v-if="maxJobs && runningJobs" :max="maxJobs" show-value>
-            <b-progress-bar v-if="errorJobs" :value="errorJobs" variant="danger" />
-            <b-progress-bar v-if="okJobs" :value="okJobs" variant="success" />
-            <b-progress-bar v-if="runningJobs" :value="runningJobs" variant="warning" />
-            <b-progress-bar v-if="waitingJobs" :value="waitingJobs" variant="secondary" />
+        <b-progress v-if="maxJobs != okJobs + errorJobs" :max="maxJobs">
+            <b-progress-bar v-if="errorJobs" :value="errorJobs" variant="danger" v-b-tooltip.hover="errorJobs" />
+            <b-progress-bar v-if="okJobs" :value="okJobs" variant="success" v-b-tooltip.hover="okJobs" />
+            <b-progress-bar v-if="runningJobs" :value="runningJobs" variant="warning" v-b-tooltip.hover="runningJobs" />
+            <b-progress-bar
+                v-if="waitingJobs"
+                :value="waitingJobs"
+                variant="secondary"
+                v-b-tooltip.hover="waitingJobs" />
         </b-progress>
     </div>
 </template>

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -35,12 +35,14 @@ export default {
         errorJobs() {
             const failed = this.summary.get("failed") || 0;
             const error = this.summary.get("error") || 0;
-            return failed + error;
+            const discarded = this.summary.get("discarded") || 0;
+            return failed + error + discarded;
         },
         waitingJobs() {
             const queued = this.summary.get("queued") || 0;
             const waiting = this.summary.get("waiting") || 0;
-            return queued + waiting;
+            const paused = this.summary.get("paused") || 0;
+            return queued + waiting + paused;
         },
     },
 };

--- a/client/src/components/History/Content/Collection/CollectionProgress.vue
+++ b/client/src/components/History/Content/Collection/CollectionProgress.vue
@@ -3,15 +3,27 @@ at components/JobStates/CollectionJobStates but it relies on the backbone data
 model, so probably has to go eventually.-->
 <template>
     <div class="collection-progress">
-        <b-progress v-if="maxJobs != okJobs + errorJobs" :max="maxJobs">
-            <b-progress-bar v-if="errorJobs" :value="errorJobs" variant="danger" v-b-tooltip.hover="errorJobs" />
-            <b-progress-bar v-if="okJobs" :value="okJobs" variant="success" v-b-tooltip.hover="okJobs" />
-            <b-progress-bar v-if="runningJobs" :value="runningJobs" variant="warning" v-b-tooltip.hover="runningJobs" />
+        <b-progress v-if="!summary.isTerminal" :max="summary.jobCount">
             <b-progress-bar
-                v-if="waitingJobs"
-                :value="waitingJobs"
+                v-if="summary.errorCount"
+                :value="summary.errorCount"
+                variant="danger"
+                v-b-tooltip.hover="summary.errorCount" />
+            <b-progress-bar
+                v-if="summary.okCount"
+                :value="summary.okCount"
+                variant="success"
+                v-b-tooltip.hover="summary.okCount" />
+            <b-progress-bar
+                v-if="summary.runningCount"
+                :value="summary.runningCount"
+                variant="warning"
+                v-b-tooltip.hover="summary.runningCount" />
+            <b-progress-bar
+                v-if="summary.waitingCount"
+                :value="summary.waitingCount"
                 variant="secondary"
-                v-b-tooltip.hover="waitingJobs" />
+                v-b-tooltip.hover="summary.waitingCount" />
         </b-progress>
     </div>
 </template>
@@ -21,29 +33,6 @@ import { JobStateSummary } from "./JobStateSummary";
 export default {
     props: {
         summary: { type: JobStateSummary, required: true },
-    },
-    computed: {
-        maxJobs() {
-            return this.summary.get("all_jobs");
-        },
-        okJobs() {
-            return this.summary.get("ok");
-        },
-        runningJobs() {
-            return this.summary.get("running");
-        },
-        errorJobs() {
-            const failed = this.summary.get("failed") || 0;
-            const error = this.summary.get("error") || 0;
-            const discarded = this.summary.get("discarded") || 0;
-            return failed + error + discarded;
-        },
-        waitingJobs() {
-            const queued = this.summary.get("queued") || 0;
-            const waiting = this.summary.get("waiting") || 0;
-            const paused = this.summary.get("paused") || 0;
-            return queued + waiting + paused;
-        },
     },
 };
 </script>

--- a/client/src/components/History/Content/Collection/JobStateSummary.js
+++ b/client/src/components/History/Content/Collection/JobStateSummary.js
@@ -6,8 +6,8 @@
  */
 import { STATES } from "../model/states";
 
-const NON_TERMINAL_STATES = ["new", "waiting", "queued", "running"];
-const ERROR_STATES = ["error", "discarded"];
+const NON_TERMINAL_STATES = ["new", "waiting", "queued", "running", "resubmitted", "upload"];
+const ERROR_STATES = ["error", "discarded", "deleted"];
 
 export class JobStateSummary extends Map {
     constructor(dsc = {}) {
@@ -76,7 +76,12 @@ export class JobStateSummary extends Map {
     }
 
     get errorCount() {
-        return (this.get("error") || 0) + (this.get("failed") || 0) + (this.get("discarded") || 0);
+        return (
+            (this.get("error") || 0) +
+            (this.get("failed") || 0) +
+            (this.get("discarded") || 0) +
+            (this.get("deleted") || 0)
+        );
     }
 
     get runningCount() {

--- a/client/src/components/History/Content/Collection/JobStateSummary.js
+++ b/client/src/components/History/Content/Collection/JobStateSummary.js
@@ -79,7 +79,6 @@ export class JobStateSummary extends Map {
         return (
             (this.get("error") || 0) +
             (this.get("failed") || 0) +
-            (this.get("discarded") || 0) +
             (this.get("deleted") || 0)
         );
     }

--- a/client/src/components/History/Content/Collection/JobStateSummary.js
+++ b/client/src/components/History/Content/Collection/JobStateSummary.js
@@ -6,8 +6,8 @@
  */
 import { STATES } from "../model/states";
 
-const NON_TERMINAL_STATES = [STATES.NEW, STATES.WAITING, STATES.QUEUED, STATES.RUNNING];
-const ERROR_STATES = [STATES.ERROR, STATES.DISCARDED];
+const NON_TERMINAL_STATES = ["new", "waiting", "queued", "running"];
+const ERROR_STATES = ["error", "discarded"];
 
 export class JobStateSummary extends Map {
     constructor(dsc = {}) {
@@ -28,18 +28,18 @@ export class JobStateSummary extends Map {
     get state() {
         if (this.jobCount) {
             if (this.isErrored) {
-                return STATES.ERROR;
+                return STATES.error;
             }
             if (this.isRunning) {
-                return STATES.RUNNING;
+                return STATES.running;
             }
             if (this.isNew) {
-                return STATES.LOADING;
+                return STATES.loading;
             }
             if (this.isTerminal) {
-                return STATES.OK;
+                return STATES.ok;
             }
-            return STATES.QUEUED;
+            return STATES.queued;
         }
         return this.populated_state;
     }
@@ -47,11 +47,11 @@ export class JobStateSummary extends Map {
     // Flags
 
     get isNew() {
-        return !this.populated_state || this.populated_state == STATES.NEW;
+        return !this.populated_state || this.populated_state == STATES.new;
     }
 
     get isErrored() {
-        return this.populated_state == STATES.ERROR || this.anyHasJobs(...ERROR_STATES);
+        return this.populated_state == STATES.error || this.anyHasJobs(...ERROR_STATES);
     }
 
     get isTerminal() {
@@ -62,20 +62,28 @@ export class JobStateSummary extends Map {
     }
 
     get isRunning() {
-        return this.hasJobs(STATES.RUNNING);
+        return this.hasJobs(STATES.running);
     }
 
     // Counts
+
+    get okCount() {
+        return this.get("ok");
+    }
 
     get jobCount() {
         return this.get("all_jobs");
     }
 
     get errorCount() {
-        return this.get(STATES.ERROR);
+        return (this.get("error") || 0) + (this.get("failed") || 0) + (this.get("discarded") || 0);
     }
 
     get runningCount() {
-        return this.get(STATES.RUNNING);
+        return this.get("running");
+    }
+
+    get waitingCount() {
+        return (this.get("queued") || 0) + (this.get("waiting") || 0) + (this.get("paused") || 0);
     }
 }

--- a/client/src/components/History/Content/Collection/JobStateSummary.js
+++ b/client/src/components/History/Content/Collection/JobStateSummary.js
@@ -71,19 +71,39 @@ export class JobStateSummary extends Map {
         return this.get("ok");
     }
 
+    get okCountText() {
+        return `${this.okCount} OK`;
+    }
+
     get jobCount() {
         return this.get("all_jobs");
+    }
+
+    get jobCountText() {
+        return `${this.jobCount} Total Jobs`;
     }
 
     get errorCount() {
         return (this.get("error") || 0) + (this.get("failed") || 0) + (this.get("deleted") || 0);
     }
 
+    get errorCountText() {
+        return `${this.errorCount} Error`;
+    }
+
     get runningCount() {
         return this.get("running");
     }
 
+    get runningCountText() {
+        return `${this.runningCount} Running`;
+    }
+
     get waitingCount() {
         return (this.get("queued") || 0) + (this.get("waiting") || 0) + (this.get("paused") || 0);
+    }
+
+    get waitingCountText() {
+        return `${this.waitingCount} Waiting`;
     }
 }

--- a/client/src/components/History/Content/Collection/JobStateSummary.js
+++ b/client/src/components/History/Content/Collection/JobStateSummary.js
@@ -7,7 +7,7 @@
 import { STATES } from "../model/states";
 
 const NON_TERMINAL_STATES = [STATES.NEW, STATES.WAITING, STATES.QUEUED, STATES.RUNNING];
-const ERROR_STATES = [STATES.ERROR, STATES.DELETED];
+const ERROR_STATES = [STATES.ERROR, STATES.DISCARDED];
 
 export class JobStateSummary extends Map {
     constructor(dsc = {}) {

--- a/client/src/components/History/Content/Collection/JobStateSummary.js
+++ b/client/src/components/History/Content/Collection/JobStateSummary.js
@@ -76,11 +76,7 @@ export class JobStateSummary extends Map {
     }
 
     get errorCount() {
-        return (
-            (this.get("error") || 0) +
-            (this.get("failed") || 0) +
-            (this.get("deleted") || 0)
-        );
+        return (this.get("error") || 0) + (this.get("failed") || 0) + (this.get("deleted") || 0);
     }
 
     get runningCount() {

--- a/client/src/components/History/Content/Collection/JobStateSummary.js
+++ b/client/src/components/History/Content/Collection/JobStateSummary.js
@@ -7,7 +7,7 @@
 import { STATES } from "../model/states";
 
 const NON_TERMINAL_STATES = ["new", "waiting", "queued", "running", "resubmitted", "upload"];
-const ERROR_STATES = ["error", "discarded", "deleted"];
+const ERROR_STATES = ["error", "failed", "deleted"];
 
 export class JobStateSummary extends Map {
     constructor(dsc = {}) {


### PR DESCRIPTION
To fix #14131  and #14136 
I moved the value of the items to tooltips, and set the progress bar to only be visible when there are items that are not in a terminal state (ok/error)

I've also made some updates out of the code reveiw for #14146 

https://user-images.githubusercontent.com/26912553/174950469-55489fe6-3169-4ebd-a23b-6d35ad1db01c.mp4

Also fixing #14203 

https://user-images.githubusercontent.com/26912553/176948293-6617f186-c6ed-4bd8-94bb-b5aead1dfde0.mp4




## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] Instructions for manual testing are as follows:
  1. Run a slower tool over a collection, such as "Concatenate datasets (with sleep)" and/or choose a large collection
  2. View the collection progress bar
  3. Note that the numbers no longer appear over the states, and instead are visible in a tooltip
  4. With a nested collection, click into the collection and see that the CollectionProgressBar does not populate for the child collections that do not have a jobStateSummary.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
