### PR TITLE
[22.01] Fix histories API URL building

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -469,9 +469,9 @@ class HistorySerializer(sharable.SharableModelSerializer, deletable.PurgableSeri
             'nice_size': lambda item, key, **context: item.disk_nice_size,
             'state': self.serialize_history_state,
 
-            'url': lambda item, key, **context: self.url_for('history', id=self.app.security.encode_id(item.id)),
+            'url': lambda item, key, **context: self.url_for('history', id=self.app.security.encode_id(item.id), context=context),
             'contents_url': lambda item, key, **context: self.url_for('history_contents',
-                                                           history_id=self.app.security.encode_id(item.id)),
+                                                           history_id=self.app.security.encode_id(item.id), context=context),
 
             'empty': lambda item, key, **context: (len(item.datasets) + len(item.dataset_collections)) <= 0,
             'count': lambda item, key, **context: len(item.datasets),

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -188,6 +188,7 @@ class FastAPIHistories:
 
     @router.get(
         '/api/histories/{id}',
+        name="history",
         summary='Returns the history with the given ID.',
     )
     def show(

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -77,6 +77,15 @@ class HistoriesApiTestCase(ApiTestCase, BaseHistories):
         self._assert_has_keys(state_details, *states)
         self._assert_has_keys(state_ids, *states)
 
+    def test_show_history_returns_expected_urls(self):
+        # This test can be dropped when the URL attributes become deprecated
+        history_id = self._create_history("TestHistoryForUrls")["id"]
+        show_response = self._show(history_id)
+        self._assert_has_key(show_response, 'id', 'url', 'contents_url')
+
+        assert show_response["url"] == f"/api/histories/{history_id}"
+        assert show_response["contents_url"] == f"/api/histories/{history_id}/contents"
+
     def test_show_most_recently_used(self):
         history_id = self._create_history("TestHistoryRecent")["id"]
         show_response = self._get("histories/most_recently_used").json()


### PR DESCRIPTION
Fixes #14185

When using FastAPI, we need to call `url_builder` to generate the correct API URL instead of the legacy `url_for`. Also, the `name` of the endpoint must match the provided name when calling `url_builder`.
Here we were missing the request context that provides this functionality and the name of the endpoint for `/api/histories/{id}`.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
