### PR TITLE
[22.05] Fix logic around tool favorites for anonymous users.

### DIFF
--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -65,7 +65,7 @@
                         <span class="fa fa-star-o" />
                     </b-button>
                     <b-button
-                        v-else
+                        v-else-if="showRemoveFavorite"
                         v-b-tooltip.hover
                         role="button"
                         title="Remove from Favorites"
@@ -176,8 +176,14 @@ export default {
         versions() {
             return this.options.versions;
         },
+        hasUser() {
+            return !this.user.isAnonymous;
+        },
         showAddFavorite() {
-            return !!this.user.email && !this.isFavorite;
+            return this.hasUser && !this.isFavorite;
+        },
+        showRemoveFavorite() {
+            return this.hasUser && !this.showAddFavorite;
         },
         showVersions() {
             return this.versions && this.versions.length > 1;


### PR DESCRIPTION
It shouldn't just be add or remove - I think they shouldn't be shown at all if an anonymous user is using the form.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. View tool form with and without logging in and verify the improved logic.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
