### PR TITLE
[22.05] Fix `FilesDialog` navigation back when a file source shows an error

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -4,7 +4,7 @@
         :options-show="optionsShow"
         :modal-show="modalShow"
         :hide-modal="() => (modalShow = false)"
-        :back-func="load"
+        :back-func="goBack"
         :undo-show="undoShow">
         <template v-slot:search>
             <data-dialog-search v-model="filter" />
@@ -329,6 +329,10 @@ export default {
                         this.errorMessage = errorMessage;
                     });
             }
+        },
+        goBack() {
+            // Loading without a record navigates back one level
+            this.load();
         },
         parseItemFileMode(item) {
             const result = {


### PR DESCRIPTION
Fixes #14178

After displaying an error in any of the file sources, when going back, the load function was *magically* passed an `event` object as the argument instead of no arguments causing unexpected behaviors.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow instructions in #14178
  - The root folders shouldn't be selectable now

    ![fix_files_dialog_go_back](https://user-images.githubusercontent.com/46503462/175607560-5c1ccc85-204c-47fe-a27f-b519912ce6cb.gif)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
