### PR TITLE
[22.05] Send composite datasets directly to tusUpload

### DIFF
--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -102,7 +102,9 @@ export function submitUpload(config) {
     }
     const tusEndpoint = `${getAppRoot()}api/upload/resumable_upload/`;
 
-    if (isPasted(data)) {
+    if (hasFiles(data) || isComposite(data)) {
+        return tusUpload(data.files, 0, data, tusEndpoint, cnf);
+    } else {
         if (data.targets.length && data.targets[0].elements.length) {
             const pasted = data.targets[0].elements[0];
             if (isUrl(pasted)) {
@@ -113,13 +115,15 @@ export function submitUpload(config) {
                 return tusUpload([blob], 0, data, tusEndpoint, cnf);
             }
         }
-    } else {
-        return tusUpload(data.files, 0, data, tusEndpoint, cnf);
     }
 }
 
-function isPasted(data) {
-    return !data.files.length;
+function hasFiles(data) {
+    return data.files.length;
+}
+
+function isComposite(data) {
+    return data.targets.length && data.targets[0].items && data.targets[0].items[0].composite;
 }
 
 function isUrl(pasted_item) {


### PR DESCRIPTION
Fixes #14125.

If the data contains a file or is a composite dataset, send it directly to tusUpload(), otherwise attempt to handle the pasted content on the client depending on what that pasted content is.

I couldn't figure out a way to handle the parts of a composite dataset on the client depending on what they are. A composite dataset may consist of any combination of a file, a pasted url(s), and pasted non-url content (unlikely, but not impossible). Any files are stored at `data.files` and are already handled by tus - so no problem there. Any non-file items are stored in the `data.targets[0].target.items[0].composite.items` array and are identified as: `src=pasted` for non-url pasted content and `src=url` for url pasted content. I tried iterating over this array and handling each item separately - which, of course, resulted in 3 separate composite datasets. So, I've opted for the simple solution: if it has files or is a composite dataset, don't try to handle pasted content with tus.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
