### PR TITLE
Use modern sqlalchemy query syntax in ``_get_nested_collection_attributes``

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5845,7 +5845,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         db_session = object_session(self)
         if db_session and self.id:
             statement = self._get_nested_collection_attributes(return_entities=(HistoryDatasetAssociation,))
-            return db_session.execute(statement).all()
+            return db_session.execute(statement).scalars().all()
         else:
             # Sessionless context
             instances = []


### PR DESCRIPTION
The preferred way to build queries is to construct select/update etc
statements
(https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#orm-query-is-internally-unified-with-select-update-delete-2-0-style-execution-available).

Started this because it seemed like you could avoid server side cursors
this way, even if they're globally enabled (xref
https://github.com/galaxyproject/galaxy/issues/14151#issuecomment-1165805353)
... but that's not actually the case. So now this is just refactoring.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
