### PR TITLE
Support stop_job param in query string

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -713,6 +713,12 @@ class FastAPIHistoryContents:
             description="When deleting a dataset collection, whether to also delete containing datasets.",
             deprecated=True,
         ),
+        stop_job: Optional[bool] = Query(
+            default=False,
+            title="Stop Job",
+            description="Whether to stop the creating job if all outputs of the job have been deleted.",
+            deprecated=True,
+        ),
         payload: DeleteHistoryContentPayload = Body(None),
     ):
         """
@@ -725,6 +731,7 @@ class FastAPIHistoryContents:
             payload = DeleteHistoryContentPayload()
         payload.purge = payload.purge or purge is True
         payload.recursive = payload.recursive or recursive is True
+        payload.stop_job = payload.stop_job or stop_job is True
         rval = self.service.delete(
             trans,
             id=id,

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -338,6 +338,13 @@ class DatasetsApiTestCase(ApiTestCase):
 
     @skip_without_tool("cat_data_and_sleep")
     def test_delete_cancels_job(self):
+        self._run_cancel_job(use_query_params=False)
+
+    @skip_without_tool("cat_data_and_sleep")
+    def test_delete_cancels_job_with_query_params(self):
+        self._run_cancel_job(use_query_params=True)
+
+    def _run_cancel_job(self, use_query_params=False):
         hda_id = self.dataset_populator.new_dataset(self.history_id)["id"]
         inputs = {
             "input1": {"src": "hda", "id": hda_id},
@@ -355,7 +362,9 @@ class DatasetsApiTestCase(ApiTestCase):
         assert job_details["state"] in ("new", "queued", "running"), job_details
 
         # Use stop_job to cancel the creating job
-        delete_response = self.dataset_populator.delete_dataset(self.history_id, output_hda_id, stop_job=True)
+        delete_response = self.dataset_populator.delete_dataset(
+            self.history_id, output_hda_id, stop_job=True, use_query_params=use_query_params
+        )
         self._assert_status_code_is_ok(delete_response)
         deleted_hda = delete_response.json()
         assert deleted_hda["deleted"], deleted_hda

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -597,9 +597,13 @@ class BaseDatasetPopulator(BasePopulator):
         purge: bool = False,
         stop_job: bool = False,
         wait_for_purge: bool = False,
+        use_query_params: bool = False,
     ) -> Response:
         dataset_url = f"histories/{history_id}/contents/{content_id}"
-        delete_response = self._delete(dataset_url, {"purge": purge, "stop_job": stop_job}, json=True)
+        if use_query_params:
+            delete_response = self._delete(f"{dataset_url}?purge={purge}&stop_job={stop_job}")
+        else:
+            delete_response = self._delete(dataset_url, {"purge": purge, "stop_job": stop_job}, json=True)
         delete_response.raise_for_status()
         if wait_for_purge and delete_response.status_code == 202:
             return self.wait_for_purge(history_id, content_id)


### PR DESCRIPTION
Fixes jobs not stopping in user interface when all outputs are deleted.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
