### PR TITLE
Use imports instead of variable assignment for galaxy.util.Element

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -55,13 +55,11 @@ except ImportError:
 LXML_AVAILABLE = True
 try:
     from lxml import etree
-
-    Element = etree._Element
+    from lxml.etree import _Element as Element
 except ImportError:
     LXML_AVAILABLE = False
     import xml.etree.ElementTree as etree  # type: ignore[assignment,no-redef]
-
-    Element = etree.Element
+    from xml.etree.ElementTree import Element  # noqa: F401  # type: ignore[assignment,no-redef]
 
 try:
     import docutils.core as docutils_core


### PR DESCRIPTION
Seems to help with
```
tox -e mypy
mypy installed: attrs==21.4.0,flake8==4.0.1,flake8-bugbear==22.4.25,importlib-metadata==4.2.0,mccabe==0.6.1,mypy==0.961,mypy-extensions==0.4.3,pycodestyle==2.8.0,pyflakes==2.4.0,tomli==2.0.1,typed-ast==1.5.4,types-bleach==5.0.2,types-boto==2.49.15,types-contextvars==2.4.6,types-cryptography==3.3.21,types-dataclasses==0.6.5,types-docutils==0.18.3,types-Markdown==3.3.28,types-paramiko==2.10.0,types-pkg-resources==0.1.3,types-python-dateutil==2.8.17,types-PyYAML==6.0.8,types-requests==2.27.30,types-six==1.16.16,types-urllib3==1.26.15,typing_extensions==4.2.0,zipp==3.8.0
mypy run-test-pre: PYTHONHASHSEED='3759038334'
mypy run-test: commands[0] | mypy test lib
lib/galaxy/util/xml_macros.py:29: error: Variable "galaxy.util.Element" is not valid as a type
[valid-type]
        macros: Dict[str, List[Element]] = {}
                               ^
lib/galaxy/util/xml_macros.py:29: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
lib/galaxy/util/xml_macros.py:36: error: Element? has no attribute "get"  [attr-defined]
            tokens[m.get("name")] = m.text or ""
                   ^
lib/galaxy/util/xml_macros.py:36: error: Element? has no attribute "text"  [attr-defined]
            tokens[m.get("name")] = m.text or ""
                                    ^
lib/galaxy/util/xml_macros.py:42: error: Element? has no attribute "get"  [attr-defined]
            macro_dict[m.get("name")] = XmlMacroDef(m)
                       ^
Found 4 errors in 1 file (checked 1460 source files)
ERROR: InvocationError for command /Users/mvandenb/src/galaxy/.tox/mypy/bin/mypy test lib (exited with code 1)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
