### PR TITLE
[22.05] Avoid placeholder value in selenium selectors

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -1,7 +1,7 @@
 <template>
     <DatasetProvider :id="dataset.id" v-slot="{ loading, result }" auto-refresh>
         <div v-if="!loading" class="dataset">
-            <div class="p-2 details">
+            <div class="p-2 details not-loading">
                 <div class="summary">
                     <div v-if="stateText" class="mb-1">{{ stateText }}</div>
                     <div v-else-if="result.misc_blurb" class="blurb">
@@ -33,7 +33,7 @@
                 having more standard 'placeholder' versions of pre-loaded
                 components) )
             -->
-            <div class="p-2 details">
+            <div class="p-2 details loading">
                 <div class="summary">
                     <div class="blurb">
                         <span class="value">? lines</span>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -168,10 +168,10 @@ history_panel:
 
       hid: '${_} .hid'
       name: '${_} .name'
-      blurb: '${_} .blurb .value'
-      dbkey: '${_} .dbkey .value'
-      info: '${_} .info .value'
-      peek: '${_} .dataset-peek'
+      blurb: '${_} .not-loading .blurb .value'
+      dbkey: '${_} .not-loading .dbkey .value'
+      info: '${_} .not-loading .info .value'
+      peek: '${_} .not-loading .dataset-peek'
       toolhelp_title: '${_} .toolhelp strong'
 
       # Title buttons...
@@ -682,7 +682,7 @@ invocations:
     step_output_collection_element_identifier:
       type: xpath
       selector: '//span[@class="content-title name"][text()="${element_identifier}"]'
-    step_output_collection_element_datatype: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-output-collection-details .datatype .value'
+    step_output_collection_element_datatype: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-output-collection-details .not-loading .datatype .value'
     step_job_details: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details'
     step_job_table: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details table'
     step_job_table_rows: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details table tbody tr'


### PR DESCRIPTION
Should fix a bunch of flaky selenium tests that are getting the placeholder value that was added in https://github.com/galaxyproject/galaxy/pull/13827.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
