### PR TITLE
[22.05] Add ``SuppressNoResponseReturnedMiddleware``

### DIFF
--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -14,6 +14,7 @@ from starlette.responses import (
 
 from galaxy.version import VERSION
 from galaxy.webapps.base.api import (
+    add_empty_response_middleware,
     add_exception_handler,
     add_request_id_middleware,
     include_all_package_routers,
@@ -176,6 +177,7 @@ def initialize_fast_app(gx_wsgi_webapp, gx_app):
     wsgi_handler = WSGIMiddleware(gx_wsgi_webapp)
     gx_app.haltables.append(("WSGI Middleware threadpool", wsgi_handler.executor.shutdown))
     app.mount("/", wsgi_handler)
+    add_empty_response_middleware(app)
     if gx_app.config.galaxy_url_prefix != "/":
         parent_app = FastAPI()
         parent_app.mount(gx_app.config.galaxy_url_prefix, app=app)

--- a/lib/galaxy/webapps/reports/fast_app.py
+++ b/lib/galaxy/webapps/reports/fast_app.py
@@ -2,6 +2,7 @@ from a2wsgi import WSGIMiddleware
 from fastapi import FastAPI
 
 from galaxy.webapps.base.api import (
+    add_empty_response_middleware,
     add_exception_handler,
     add_request_id_middleware,
     include_all_package_routers,
@@ -22,4 +23,5 @@ def initialize_fast_app(gx_webapp):
     include_all_package_routers(app, "galaxy.webapps.reports.api")
     wsgi_handler = WSGIMiddleware(gx_webapp)
     app.mount("/", wsgi_handler)
+    add_empty_response_middleware(app)
     return app

--- a/lib/tool_shed/webapp/fast_app.py
+++ b/lib/tool_shed/webapp/fast_app.py
@@ -2,6 +2,7 @@ from a2wsgi import WSGIMiddleware
 from fastapi import FastAPI
 
 from galaxy.webapps.base.api import (
+    add_empty_response_middleware,
     add_exception_handler,
     add_request_id_middleware,
     include_all_package_routers,
@@ -20,6 +21,7 @@ def initialize_fast_app(gx_webapp, tool_shed_app):
     wsgi_handler = WSGIMiddleware(gx_webapp)
     tool_shed_app.haltables.append(("WSGI Middleware threadpool", wsgi_handler.executor.shutdown))
     app.mount("/", wsgi_handler)
+    add_empty_response_middleware(app)
     return app
 
 

--- a/test/unit/webapps/test_middleware_empty_response.py
+++ b/test/unit/webapps/test_middleware_empty_response.py
@@ -1,0 +1,119 @@
+import asyncio
+import contextlib
+import threading
+import time
+from typing import Optional
+
+import pytest
+import requests
+import uvicorn
+from fastapi import status
+from fastapi.applications import FastAPI
+from requests import ReadTimeout
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from galaxy.util import sockets
+from galaxy.webapps.base.api import add_empty_response_middleware
+
+error_encountered: Optional[str] = None
+error_handled = False
+
+
+@pytest.fixture()
+def reset_global_vars():
+    global error_encountered
+    global error_handled
+    error_encountered = None
+    error_handled = False
+
+
+class SomeMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        try:
+            return await call_next(request)
+        except Exception as e:
+            global error_encountered
+            error_encountered = str(e)
+            raise
+
+
+class OuterMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        global error_handled
+        error_handled = True
+        return response
+
+
+class Server(uvicorn.Server):
+    """Uvicorn server in a thread.
+
+    https://stackoverflow.com/a/66589593
+    """
+
+    def install_signal_handlers(self):
+        pass
+
+    @contextlib.contextmanager
+    def run_in_thread(self):
+        thread = threading.Thread(target=self.run)
+        thread.start()
+        try:
+            while not self.started:
+                time.sleep(1e-3)
+            yield
+        finally:
+            self.should_exit = True
+            thread.join()
+
+
+def setup_fastAPI(add_middleware=True):
+    app = FastAPI()
+    # Looks weird, but we need at least 2 middlewares based on BaseHTTPMiddleware to trigger this.
+    # xref https://github.com/encode/starlette/discussions/1527#discussion-3893922
+    app.add_middleware(SomeMiddleware)
+    app.add_middleware(SomeMiddleware)
+    if add_middleware:
+        add_empty_response_middleware(app)
+    app.add_middleware(OuterMiddleware)
+
+    @app.get("/")
+    async def index():
+        await asyncio.sleep(1)
+        return
+
+    return app
+
+
+def test_client_disconnect_with_middleware(reset_global_vars):
+    app = setup_fastAPI()
+    port = sockets.unused_port()
+    server = Server(config=uvicorn.Config(app=app, host="127.0.0.1", port=port))
+    with server.run_in_thread():
+        try:
+            requests.get(f"http://127.0.0.1:{port}/", timeout=0.1)
+        except ReadTimeout:
+            pass
+
+    assert error_encountered == "No response returned."
+    assert error_handled
+
+
+def test_client_disconnect_raises_error_without_middleware(reset_global_vars):
+    app = setup_fastAPI(add_middleware=False)
+    port = sockets.unused_port()
+    server = Server(config=uvicorn.Config(app=app, host="127.0.0.1", port=port))
+    with server.run_in_thread():
+        try:
+            requests.get(f"http://127.0.0.1:{port}/", timeout=0.1)
+        except ReadTimeout:
+            pass
+
+    assert error_encountered == "No response returned."
+    try:
+        assert not error_handled
+    except AssertionError:
+        raise Exception(
+            "add_empty_response_middleware not required anymore, bug likely fixed upstream. You can revert https://github.com/galaxyproject/galaxy/pull/14202"
+        )


### PR DESCRIPTION
Fixes noisy exceptions when client has disconnected,e .g
https://sentry.galaxyproject.org/share/issue/8c46339f05c94f6a8c85c44bc71aea6a/
:
```
WouldBlock: null
  File "anyio/streams/memory.py", line 94, in receive
    return self.receive_nowait()
  File "anyio/streams/memory.py", line 89, in receive_nowait
    raise WouldBlock
EndOfStream: null
  File "starlette/middleware/base.py", line 43, in call_next
    message = await recv_stream.receive()
  File "anyio/streams/memory.py", line 114, in receive
    raise EndOfStream
RuntimeError: No response returned.
  File "uvicorn/protocols/http/h11_impl.py", line 366, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "uvicorn/middleware/proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
  File "fastapi/applications.py", line 269, in __call__
    await super().__call__(scope, receive, send)
  File "starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "starlette_context/middleware/raw_middleware.py", line 96, in __call__
    await self.app(scope, receive, send_wrapper)
  File "starlette/middleware/base.py", line 68, in __call__
    response = await self.dispatch_func(request, call_next)
  File "galaxy/webapps/galaxy/fast_app.py", line 119, in add_send_file_header
    response = await call_next(request)
  File "starlette/middleware/base.py", line 47, in call_next
    raise RuntimeError("No response returned.")
```
on `/api/histories/14a1ba6a16ee6e2c/contents/bulk`.


Fix is from https://stackoverflow.com/a/72677699/19426046

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
