### PR TITLE
[22.05] Decrease log level for tool not found

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -45,7 +45,7 @@ class ToolRunner(BaseUIController):
     @web.expose
     def index(self, trans, tool_id=None, from_noframe=None, **kwd):
         def __tool_404__():
-            log.error("index called with tool id '%s' but no such tool exists", tool_id)
+            log.debug("index called with tool id '%s' but no such tool exists", tool_id)
             trans.log_event("Tool id '%s' does not exist" % tool_id)
             trans.response.status = 404
             return trans.show_error_message("Tool '%s' does not exist." % (escape(tool_id)))


### PR DESCRIPTION
Wouldn't mind dropping the log completely either if people prefer that.

Fixes https://sentry.galaxyproject.org/share/issue/3d5a56056bcb4fe2830baaf865604be4/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
