### PR TITLE
[22.05] Add release tag to client-submitted sentry events

### DIFF
--- a/client/src/onload/globalInits/initSentry.js
+++ b/client/src/onload/globalInits/initSentry.js
@@ -8,10 +8,12 @@ import * as Sentry from "@sentry/browser";
  */
 export const initSentry = (galaxy, config) => {
     console.log("initSentry");
-
     if (config.sentry) {
         const { sentry_dsn_public, email } = config.sentry;
-        const release = `${config.version_major}.${config.version_minor}`;
+        let release = galaxy.config.version_major;
+        if (galaxy.config.version_minor) {
+            release += `.${galaxy.config.version_minor}`;
+        }
         Sentry.init({
             dsn: sentry_dsn_public,
             release: release,

--- a/client/src/onload/globalInits/initSentry.js
+++ b/client/src/onload/globalInits/initSentry.js
@@ -11,7 +11,11 @@ export const initSentry = (galaxy, config) => {
 
     if (config.sentry) {
         const { sentry_dsn_public, email } = config.sentry;
-        Sentry.init({ dsn: sentry_dsn_public });
+        const release = `${config.version_major}.${config.version_minor}`;
+        Sentry.init({
+            dsn: sentry_dsn_public,
+            release: release,
+        });
         if (email) {
             Sentry.configureScope((scope) => {
                 scope.setUser({


### PR DESCRIPTION
Correctly tags client-submitted sentry events to a particular release.  I want to iterate on this and actually build this into the client, but right now the source of truth for the galaxy version is tied to a single python file.

## How to test the changes?
(Select all options that apply)
- [ ] Instructions for manual testing are as follows:
  1. Configure sentry locally for testing, add an error in the client.  Note it gets tagged with the appropriate release.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
