### PR TITLE
Encode history name in tool_util.verify.interactor.get_history

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -338,7 +338,8 @@ class GalaxyInteractorApi:
 
     def get_history(self, history_name="test_history"):
         # Return the most recent non-deleted history matching the provided name
-        response = self._get(f"histories?q=name&qv={history_name}&order=update_time")
+        filters = urllib.parse.urlencode({"q": "name", "qv": history_name, "order": "update_time"})
+        response = self._get(f"histories?{filters}")
         try:
             return response.json()[-1]
         except IndexError:


### PR DESCRIPTION
get_history is failing to find the history if it has a weird name. This change is to urlencode the history_name so that it can be found.

(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
