### PR TITLE
JobWrapper: use correct fail method

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1793,7 +1793,7 @@ class MinimalJobWrapper(HasResourceParameters):
                     else:
                         # Prior to fail we need to set job.state
                         job.set_state(final_job_state)
-                        return self.fail(f"Job {job.id}'s output dataset(s) could not be read")
+                        return fail(f"Job {job.id}'s output dataset(s) could not be read")
 
         job_context = ExpressionContext(dict(stdout=job.stdout, stderr=job.stderr))
         if extended_metadata:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1793,7 +1793,7 @@ class MinimalJobWrapper(HasResourceParameters):
                     else:
                         # Prior to fail we need to set job.state
                         job.set_state(final_job_state)
-                        return fail(f"Job {job.id}'s output dataset(s) could not be read")
+                        return self.fail(f"Job {job.id}'s output dataset(s) could not be read")
 
         job_context = ExpressionContext(dict(stdout=job.stdout, stderr=job.stderr))
         if extended_metadata:

--- a/test/functional/tools/strict_shell.xml
+++ b/test/functional/tools/strict_shell.xml
@@ -1,6 +1,8 @@
 <tool id="strict_shell" name="strict_shell" version="1.0.0">
     <command strict="true" detect_errors="exit_code"><![CDATA[
-echo "Hello" > '$out_file1';
+#if $exit_code == "0"
+    echo "Hello" > '$out_file1';
+#end if
 sh -c 'exit $exit_code';
 sh -c 'exit 0'
     ]]></command>

--- a/test/functional/tools/strict_shell_default_off.xml
+++ b/test/functional/tools/strict_shell_default_off.xml
@@ -1,8 +1,10 @@
 <tool id="strict_shell_default_off" name="strict_shell_default_off" version="1.0.0">
     <command detect_errors="exit_code"><![CDATA[
-echo 'Hello' > '$out_file1'
-; sh -c 'exit $exit_code'
-; sh -c 'exit 0'
+#if $exit_code == "0"
+    echo 'Hello' > '$out_file1';
+#end if
+sh -c 'exit $exit_code';
+sh -c 'exit 0'
     ]]></command>
     <inputs>
         <param name="exit_code" type="integer" value="0" label="exit code"/>

--- a/test/functional/tools/strict_shell_profile.xml
+++ b/test/functional/tools/strict_shell_profile.xml
@@ -1,8 +1,10 @@
 <tool id="strict_shell_profile" name="strict_shell_profile" version="1.0.0" profile="20.09">
     <command detect_errors="exit_code"><![CDATA[
-echo 'Hello' > '$out_file1'
-; sh -c 'exit $exit_code'
-; sh -c 'exit 0'
+#if $exit_code == 0
+    echo 'Hello' > '$out_file1';
+#end if
+sh -c 'exit $exit_code';
+sh -c 'exit 0'
     ]]></command>
     <inputs>
         <param name="exit_code" type="integer" value="0" label="exit code"/>

--- a/test/integration/test_job_outputs_to_working_directory.py
+++ b/test/integration/test_job_outputs_to_working_directory.py
@@ -17,5 +17,5 @@ class JobOutputsToWorkingDirectoryIntegrationInstance(integration_util.Integrati
 instance = integration_util.integration_module_instance(JobOutputsToWorkingDirectoryIntegrationInstance)
 
 test_tools = integration_util.integration_tool_runner(
-    ["output_format", "output_empty_work_dir", "collection_creates_pair_from_work_dir"]
+    ["output_format", "output_empty_work_dir", "collection_creates_pair_from_work_dir", "strict_shell_profile"]
 )


### PR DESCRIPTION
if the JobWrapper.fail method is called directly exit code (etc)
are lost.

fixes https://github.com/galaxyproject/galaxy/issues/14206

not sure why this error popped up now, probably a change in
tool verification ..?

For fixing the IUC CI job we probably need to backport this .. is 22.01 sufficient?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
