### PR TITLE
[22.05] Move `Show Histories Side-by-Side` menu entry below histories count

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -42,6 +42,14 @@
                         <span v-else>You have {{ histories.length }} histories.</span>
                     </b-dropdown-text>
 
+                    <b-dropdown-item
+                        v-if="!currentUser.isAnonymous"
+                        data-description="switch to multi history view"
+                        @click="redirect('/history/view_multiple')">
+                        <Icon fixed-width class="mr-1" icon="columns" />
+                        <span v-localize>Show Histories Side-by-Side</span>
+                    </b-dropdown-item>
+
                     <b-dropdown-divider></b-dropdown-divider>
 
                     <b-dropdown-item v-if="!currentUser.isAnonymous" v-b-modal:copy-history-modal>
@@ -73,14 +81,6 @@
                         @click="backboneRoute('/histories/show_structure')">
                         <Icon fixed-width icon="code-branch" class="mr-1" />
                         <span v-localize>Show Structure</span>
-                    </b-dropdown-item>
-
-                    <b-dropdown-item
-                        v-if="!currentUser.isAnonymous"
-                        data-description="switch to multi history view"
-                        @click="redirect('/history/view_multiple')">
-                        <Icon fixed-width class="mr-1" icon="columns" />
-                        <span v-localize>Show Histories Side-by-Side</span>
                     </b-dropdown-item>
 
                     <template v-if="!currentUser.isAnonymous">


### PR DESCRIPTION
Just a suggestion, feel free to close.

The `Show Histories Side-by-Side` option is not strictly related to the current history, while it feels more natural to have it just near the histories count at the top of the menu.

## Before
![image](https://user-images.githubusercontent.com/46503462/176219314-526e6e49-5172-4cda-920e-45abe576d837.png)


## After
![image](https://user-images.githubusercontent.com/46503462/176218613-464b1a7f-3025-4403-8dc5-84c1e9348391.png)


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
