### PR TITLE
Misc fixes 2022-06-28

### DIFF
--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -49,8 +49,6 @@ jobs:
       run: rsync -av --remove-source-files --exclude .git galaxy-test-data/ 'galaxy root/test-data/'
     - name: Install planemo
       run: pip install planemo
-    - name: Install jq
-      run: sudo apt-get install jq
     - name: Determine converters to check
       run: |
         ls 'galaxy root'/lib/galaxy/datatypes/converters/*xml | grep -v -f 'galaxy root'/lib/galaxy/datatypes/converters/.tt_skip > tool_list.txt
@@ -67,16 +65,17 @@ jobs:
     - name: Run tests
       run: |
         mkdir -p json_output
+        EXIT_CODE=0
         mapfile -t TOOL_ARRAY < tool_list.txt
         for CONVERTER in "${TOOL_ARRAY[@]}"; do
           json=$(mktemp -u -p json_output --suff .json)
-          planemo test --test_output_json "$json" --galaxy_python_version ${{ matrix.python-version }} --galaxy_root 'galaxy root' "$CONVERTER" || true
+          planemo test --test_output_json "$json" --galaxy_python_version ${{ matrix.python-version }} --galaxy_root 'galaxy root' "$CONVERTER" || EXIT_CODE=$?
         done
         planemo merge_test_reports json_output/*.json tool_test_output.json
         planemo test_reports tool_test_output.json --test_output tool_test_output.html
-        if jq '.["tests"][]["data"]["status"]' tool_test_output.json | grep -v "success"; then
+        if [ "$EXIT_CODE" -ne 0 ]; then
           echo "Unsuccessful tests found, inspect the 'Converter test results' artifact for details."
-          exit 1
+          exit $EXIT_CODE
         fi
     - uses: actions/upload-artifact@v3
       if: failure()

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -566,6 +566,7 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
         self.installed_repository_manager = self._register_singleton(
             InstalledRepositoryManager, InstalledRepositoryManager(self)
         )
+        self.dynamic_tool_manager = self._register_singleton(DynamicToolManager)
         self._configure_datatypes_registry(
             self.installed_repository_manager,
             use_converters=use_converters,
@@ -612,7 +613,6 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         self.test_data_resolver = self._register_singleton(
             TestDataResolver, TestDataResolver(file_dirs=self.config.tool_test_data_directories)
         )
-        self.dynamic_tool_manager = self._register_singleton(DynamicToolManager)
         self.api_keys_manager = self._register_singleton(ApiKeyManager)
 
         # Tool Data Tables

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -185,7 +185,7 @@ else:
     _HasTable = object
 
 
-def get_uuid(uuid: Optional[Union[UUID, str]] = None):
+def get_uuid(uuid: Optional[Union[UUID, str]] = None) -> UUID:
     if isinstance(uuid, UUID):
         return uuid
     if not uuid:

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -99,6 +99,7 @@ class MinimalManagerApp(MinimalApp):
     job_config: "JobConfiguration"
     job_manager: Any  # galaxy.jobs.manager.JobManager
     job_metrics: "JobMetrics"
+    dynamic_tool_manager: Any  # 'galaxy.managers.tools.DynamicToolManager'
 
     @property
     def is_job_handler(self) -> bool:
@@ -141,7 +142,6 @@ class StructuredApp(MinimalManagerApp):
     library_folder_manager: Any  # 'galaxy.managers.folders.FolderManager'
     library_manager: Any  # 'galaxy.managers.libraries.LibraryManager'
     role_manager: Any  # 'galaxy.managers.roles.RoleManager'
-    dynamic_tool_manager: Any  # 'galaxy.managers.tools.DynamicToolManager'
     data_provider_registry: Any  # 'galaxy.visualization.data_providers.registry.DataProviderRegistry'
     tool_data_tables: "ToolDataTableManager"
     genomes: Any  # 'galaxy.visualization.genomes.Genomes'

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -58,7 +58,7 @@ def output_properties(
     path: Optional[str] = None,
     content: Optional[bytes] = None,
     basename=None,
-    pseduo_location=False,
+    pseudo_location=False,
 ) -> OutputPropertiesType:
     checksum = hashlib.sha1()
     properties: OutputPropertiesType = {"class": "File", "checksum": "", "size": 0}
@@ -83,12 +83,12 @@ def output_properties(
     properties["checksum"] = f"sha1${checksum.hexdigest()}"
     properties["size"] = filesize
     set_basename_and_derived_properties(properties, basename)
-    _handle_pseudo_location(properties, pseduo_location)
+    _handle_pseudo_location(properties, pseudo_location)
     return properties
 
 
-def _handle_pseudo_location(properties, pseduo_location):
-    if pseduo_location:
+def _handle_pseudo_location(properties, pseudo_location):
+    if pseudo_location:
         properties["location"] = properties["basename"]
 
 
@@ -436,7 +436,7 @@ def output_to_cwl_json(
     get_metadata,
     get_dataset,
     get_extra_files,
-    pseduo_location=False,
+    pseudo_location=False,
 ):
     """Convert objects in a Galaxy history into a CWL object.
 
@@ -459,7 +459,7 @@ def output_to_cwl_json(
             metadata,
         )
         return output_to_cwl_json(
-            element_output, get_metadata, get_dataset, get_extra_files, pseduo_location=pseduo_location
+            element_output, get_metadata, get_dataset, get_extra_files, pseudo_location=pseudo_location
         )
 
     output_metadata = galaxy_output.metadata
@@ -486,7 +486,7 @@ def output_to_cwl_json(
 
             if file_or_directory == "File":
                 dataset_dict = get_dataset(output_metadata)
-                properties = output_properties(pseduo_location=pseduo_location, **dataset_dict)
+                properties = output_properties(pseudo_location=pseudo_location, **dataset_dict)
                 basename = properties["basename"]
                 extra_files = get_extra_files(output_metadata)
                 found_index = False
@@ -512,7 +512,7 @@ def output_to_cwl_json(
                             if extra_file_class == "File":
                                 ec = get_dataset(output_metadata, filename=path)
                                 ec["basename"] = extra_file_basename
-                                ec_properties = output_properties(pseduo_location=pseduo_location, **ec)
+                                ec_properties = output_properties(pseudo_location=pseudo_location, **ec)
                             elif extra_file_class == "Directory":
                                 ec_properties = {}
                                 ec_properties["class"] = "Directory"
@@ -540,7 +540,7 @@ def output_to_cwl_json(
                             if extra_file_class == "File":
                                 ec = get_dataset(output_metadata, filename=path)
                                 ec["basename"] = ec_basename
-                                ec_properties = output_properties(pseduo_location=pseduo_location, **ec)
+                                ec_properties = output_properties(pseudo_location=pseudo_location, **ec)
                             elif extra_file_class == "Directory":
                                 ec_properties = {}
                                 ec_properties["class"] = "Directory"
@@ -568,7 +568,7 @@ def output_to_cwl_json(
                         path = extra_file["path"]
                         ec = get_dataset(output_metadata, filename=path)
                         ec["basename"] = os.path.basename(path)
-                        ec_properties = output_properties(pseduo_location=pseduo_location, **ec)
+                        ec_properties = output_properties(pseudo_location=pseudo_location, **ec)
                         listing.append(ec_properties)
 
             if secondary_files:

--- a/lib/galaxy_test/driver/uses_shed.py
+++ b/lib/galaxy_test/driver/uses_shed.py
@@ -127,7 +127,7 @@ class UsesShed:
             )
         except AssertionError as e:
             if "Error attempting to retrieve installation information from tool shed" in unicodify(e):
-                pytest.skip("Toolshed '%s' unavailable" % tool_shed_url)
+                pytest.skip(f"Toolshed '{tool_shed_url}' unavailable")
             raise
 
     def uninstall_repository(self, owner, name, changeset, tool_shed_url="https://toolshed.g2.bx.psu.edu"):

--- a/packages/test_base/setup.cfg
+++ b/packages/test_base/setup.cfg
@@ -31,8 +31,6 @@ version = 22.5.0.dev0
 [options]
 include_package_data = True
 install_requires =
-    galaxy-app
-    galaxy-data
     galaxy-tool-util
     galaxy-util
     bioblend

--- a/packages/test_driver/setup.cfg
+++ b/packages/test_driver/setup.cfg
@@ -32,15 +32,14 @@ version = 22.5.0.dev0
 include_package_data = True
 install_requires =
     galaxy-app
+    galaxy-config
     galaxy-data
     galaxy-test-base
     galaxy-tool-util
     galaxy-util
     galaxy-webapps
-    galaxy-web-framework
     nose
     pytest
-    PyYAML
 packages = find:
 python_requires = >=3.7
 

--- a/test/integration/test_data_manager.py
+++ b/test/integration/test_data_manager.py
@@ -8,11 +8,11 @@ from galaxy_test.base.populators import (
     DatasetPopulator,
     skip_if_toolshed_down,
 )
-from galaxy_test.base.uses_shed import (
+from galaxy_test.driver import integration_util
+from galaxy_test.driver.uses_shed import (
     CONDA_AUTO_INSTALL_JOB_TIMEOUT,
     UsesShed,
 )
-from galaxy_test.driver import integration_util
 
 FETCH_TOOL_ID = "toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.3"
 FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT = {

--- a/test/integration/test_data_manager_refgenie.py
+++ b/test/integration/test_data_manager_refgenie.py
@@ -5,11 +5,11 @@ import string
 from nose.plugins.skip import SkipTest
 
 from galaxy_test.base.populators import DatasetPopulator
-from galaxy_test.base.uses_shed import (
+from galaxy_test.driver import integration_util
+from galaxy_test.driver.uses_shed import (
     CONDA_AUTO_INSTALL_JOB_TIMEOUT,
     UsesShed,
 )
-from galaxy_test.driver import integration_util
 
 FETCH_TOOL_ID = "toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.3"
 FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT = {

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -2,8 +2,8 @@ import os
 from collections import namedtuple
 
 from galaxy_test.base.populators import DatasetPopulator
-from galaxy_test.base.uses_shed import UsesShed
 from galaxy_test.driver import integration_util
+from galaxy_test.driver.uses_shed import UsesShed
 from tool_shed.util import hg_util
 
 REPO_TYPE = namedtuple("REPO_TYPE", "name owner changeset")

--- a/test/integration/test_shed_tool_tests.py
+++ b/test/integration/test_shed_tool_tests.py
@@ -1,8 +1,8 @@
 import os
 
 from galaxy_test.base.populators import skip_if_toolshed_down
-from galaxy_test.base.uses_shed import UsesShed
 from galaxy_test.driver import integration_util
+from galaxy_test.driver.uses_shed import UsesShed
 
 
 class ToolShedToolTestIntegrationTestCase(integration_util.IntegrationTestCase, UsesShed):

--- a/test/integration/test_workflow_invocation.py
+++ b/test/integration/test_workflow_invocation.py
@@ -4,8 +4,8 @@ from galaxy_test.base.populators import (
     DatasetPopulator,
     WorkflowPopulator,
 )
-from galaxy_test.base.uses_shed import UsesShed
 from galaxy_test.driver import integration_util
+from galaxy_test.driver.uses_shed import UsesShed
 
 
 class WorkflowInvocationTestCase(integration_util.IntegrationTestCase, UsesShed):

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -15,13 +15,13 @@ from galaxy.model import (
 )
 from galaxy.workflow.refactor.schema import RefactorActionExecutionMessageTypeEnum
 from galaxy_test.base.populators import WorkflowPopulator
-from galaxy_test.base.uses_shed import UsesShed
 from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_NESTED_RUNTIME_PARAMETER,
     WORKFLOW_NESTED_SIMPLE,
     WORKFLOW_NESTED_WITH_MULTIPLE_VERSIONS_TOOL,
 )
 from galaxy_test.driver import integration_util
+from galaxy_test.driver.uses_shed import UsesShed
 
 REFACTORING_SIMPLE_TEST = """
 class: GalaxyWorkflow

--- a/test/integration_selenium/test_workflow_repository_tool_update.py
+++ b/test/integration_selenium/test_workflow_repository_tool_update.py
@@ -1,4 +1,4 @@
-from galaxy_test.base.uses_shed import UsesShed
+from galaxy_test.driver.uses_shed import UsesShed
 from .framework import (
     selenium_test,
     SeleniumIntegrationTestCase,


### PR DESCRIPTION
Taking out some self-contained fixes from https://github.com/galaxyproject/galaxy/pull/12909 and https://github.com/galaxyproject/galaxy/pull/13909:

- Fix `pseduo_location` typo.
- Add `dynamic_tool_manager` to `MinimalManagerApp` (needed for CWL).
- Add more type annotations.
- Move `uses_shed.py` to `galaxy_test.driver` to break circular dependency between galaxy-test-base and galaxy-test-driver packages.
- Fail "Run tests" step of Converter CI tests for any planemo test failure (not only failed tool tests)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
