### PR TITLE
[22.05] Shift 'queued' state lower in priority in collection status.

### DIFF
--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -83,4 +83,4 @@ export const STATES = {
 /** We want to display a single state for a dataset collection whose elements may have mixed states.
  * This list is ordered from highest to lowest priority. If any element is in error state the whole collection should be in error.
  */
-export const HIERARCHICAL_COLLECTION_JOB_STATES = ["error", "failed", "queued", "upload", "paused", "running", "new"];
+export const HIERARCHICAL_COLLECTION_JOB_STATES = ["error", "failed", "upload", "paused", "running", "queued", "new"];


### PR DESCRIPTION
Anything but 'new' is higher than it now.  Fixes https://github.com/galaxyproject/galaxy/issues/14199

## How to test the changes?
(Select all options that apply)
- [ ] Instructions for manual testing are as follows:
  1. See linked ticket.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
