### PR TITLE
[22.05] Generate the headers handson table uses to avoid missing header issue

### DIFF
--- a/client/src/components/RuleBuilder/SavedRulesSelector.vue
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.vue
@@ -13,7 +13,7 @@
                 :key="index"
                 v-b-tooltip.hover.right
                 class="rule-link dropdown-item saved-rule-item"
-                :title="formatPreview(session.rule, index)"
+                :title="formatPreview(session.rule)"
                 @click="$emit('update-rules', session.rule)"
                 >Saved rule from
                 <UtcDate :date="session.dateTime" mode="elapsed" />
@@ -39,14 +39,13 @@ export default {
             type: Array,
             required: true,
         },
-        ruleColHeaders: {
-            type: Array,
-            required: true,
-        },
     },
     data: function () {
         return {
             savedRulesMenu: _l("Recently used rules"),
+            // Get the 61 character values for ASCII 65 (A) to 126 (~), which is how handson table labels its columns
+            // This ensures the handson table headers are available for passing to the display method in formatPreview
+            hotHeaders: [... new Array(61).keys()].map(i => String.fromCharCode(i + 65))
         };
     },
     computed: {
@@ -58,7 +57,7 @@ export default {
         },
     },
     methods: {
-        formatPreview(savedRuleJson, index) {
+        formatPreview(savedRuleJson) {
             let prettyString = "";
             let delim = "";
             let numOfPreviewedRules = 0;
@@ -67,7 +66,7 @@ export default {
                 if (numOfPreviewedRules == 5) {
                     return prettyString;
                 } else {
-                    prettyString += delim + RULES[element.type].display(element, this.ruleColHeaders[index]);
+                    prettyString += delim + RULES[element.type].display(element, this.hotHeaders);
                     prettyString = prettyString.slice(0, -1);
                     delim = ", ";
                     numOfPreviewedRules++;

--- a/client/src/components/RuleBuilder/SavedRulesSelector.vue
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.vue
@@ -45,7 +45,7 @@ export default {
             savedRulesMenu: _l("Recently used rules"),
             // Get the 61 character values for ASCII 65 (A) to 126 (~), which is how handson table labels its columns
             // This ensures the handson table headers are available for passing to the display method in formatPreview
-            hotHeaders: [... new Array(61).keys()].map(i => String.fromCharCode(i + 65))
+            hotHeaders: [...new Array(61).keys()].map((i) => String.fromCharCode(i + 65)),
         };
     },
     computed: {
@@ -67,7 +67,7 @@ export default {
                     return prettyString;
                 } else {
                     prettyString += delim + RULES[element.type].display(element, this.hotHeaders);
-                    prettyString = prettyString.slice(0, -1);
+                    prettyString = prettyString.trim();
                     delim = ", ";
                     numOfPreviewedRules++;
                 }

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -339,7 +339,6 @@
                                 <saved-rules-selector
                                     ref="savedRulesSelector"
                                     :saved-rules="savedRules"
-                                    :rule-col-headers="colHeadersPerRule"
                                     @update-rules="restoreRules" />
                             </span>
                             <div v-if="jaggedData" class="rule-warning">


### PR DESCRIPTION
Fix for #14175 

I added a const with column headers that HOT uses [A, B, C, D] to account for the fact that they are not available when the user is trying to display the tooltip from previous rules.  
Also replaced a slice with a trim.

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Create a few rules with the Rule Builder
  2. Click on the SavedRuleSelector icon 
  3. Note that the tool tip preview looks accurate,

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
