### PR TITLE
[22.05] Put revoke for canceling upload task behind ``enable_celery_tasks`` flag

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -1198,7 +1198,7 @@ class JobHandlerStopQueue(Monitors):
 
 
 class DefaultJobDispatcher:
-    def __init__(self, app):
+    def __init__(self, app: MinimalManagerApp):
         self.app = app
         self.job_runners = self.app.job_config.get_job_runner_plugins(self.app.config.server_name)
         # Once plugins are loaded, all job destinations that were created from
@@ -1260,7 +1260,7 @@ class DefaultJobDispatcher:
         # The runner name is not set until the job has started.
         # If we're stopping a task, then the runner_name may be
         # None, in which case it hasn't been scheduled.
-        if job.tool_id == "__DATA_FETCH__":
+        if self.app.config.enable_celery_tasks and job.tool_id == "__DATA_FETCH__":
             from galaxy.celery import celery_app
 
             celery_app.control.revoke(job.job_runner_external_id)


### PR DESCRIPTION
If you're not using celery tasks and you cancel an upload job you're seeing https://sentry.galaxyproject.org/share/issue/afd03606fbf742468a8e5c28bcddf9c4/:
```
ConnectionRefusedError: [Errno 111] Connection refused
  File "kombu/connection.py", line 446, in _reraise_as_library_errors
    yield
  File "kombu/connection.py", line 433, in _ensure_connection
    return retry_over_time(
  File "kombu/utils/functional.py", line 312, in retry_over_time
    return fun(*args, **kwargs)
  File "kombu/connection.py", line 877, in _connection_factory
    self._connection = self._establish_connection()
  File "kombu/connection.py", line 812, in _establish_connection
    conn = self.transport.establish_connection()
  File "kombu/transport/pyamqp.py", line 201, in establish_connection
    conn.connect()
  File "amqp/connection.py", line 323, in connect
    self.transport.connect()
  File "amqp/transport.py", line 129, in connect
    self._connect(self.host, self.port, self.connect_timeout)
  File "amqp/transport.py", line 184, in _connect
    self.sock.connect(sa)
OperationalError: [Errno 111] Connection refused
  File "galaxy/jobs/handler.py", line 1097, in monitor
    self.monitor_step()
  File "galaxy/jobs/handler.py", line 1180, in monitor_step
    self.dispatcher.stop(job, job_wrapper)
  File "galaxy/jobs/handler.py", line 1266, in stop
    celery_app.control.revoke(job.job_runner_external_id)
  File "celery/app/control.py", line 496, in revoke
    return self.broadcast('revoke', destination=destination, arguments={
  File "celery/app/control.py", line 741, in broadcast
    return self.mailbox(conn)._broadcast(
  File "kombu/pidbox.py", line 328, in _broadcast
    chan = channel or self.connection.default_channel
  File "kombu/connection.py", line 895, in default_channel
    self._ensure_connection(**conn_opts)
  File "kombu/connection.py", line 433, in _ensure_connection
    return retry_over_time(
  File "contextlib.py", line 131, in __exit__
    self.gen.throw(type, value, traceback)
  File "kombu/connection.py", line 450, in _reraise_as_library_errors
    raise ConnectionError(str(exc)) from exc
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
