### PR TITLE
[22.01] Fixes for the tus resumable upload command line script

### DIFF
--- a/scripts/resumable_upload.py
+++ b/scripts/resumable_upload.py
@@ -1,4 +1,4 @@
-import json
+#!/usr/bin/env python3
 import os
 
 import click
@@ -42,22 +42,21 @@ def upload_file(url, path, api_key, history_id, file_type='auto', dbkey='?', fil
     # Extract session from created upload URL
     session_id = uploader.url.rsplit('/', 1)[1]
     payload = {
-        'history_id': history_id,
-        'targets': json.dumps([
-            {
-                "destination": {"type": "hdas"},
-                "elements": [
-                    {
-                        "src": "files",
-                        "ext": file_type,
-                        "dbkey": dbkey,
-                        "name": filename
-                    }
-                ]
-            }
-        ]),
+        "history_id": history_id,
+        "targets":
+            [
+                {
+                    "destination": {"type": "hdas"},
+                    "elements": [{"src": "files", "ext": file_type, "dbkey": dbkey, "name": filename}],
+                }
+            ],
+        "files_0|file_data": {"session_id": session_id, "name": filename},
     }
-    response = requests.post(f"{url}{SUBMISSION_ENDPOINT}", data=payload, files={'files_0|file_data': json.dumps({"session_id": session_id})}, headers=headers)
+    response = requests.post(
+        f"{url}{SUBMISSION_ENDPOINT}",
+        json=payload,
+        headers=headers,
+    )
     response.raise_for_status()
 
 


### PR DESCRIPTION
Prior to this change, it would upload the data and then submit the tool with a stringified session ID that would become the actual dataset content, ignoring the uploaded data.

Resumable upload functionality is already tested, just not this script directly.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run the script
  2. Observe valid uploads

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
