### PR TITLE
Enhance history ContentItem buttons appearance

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :id="contentId" :class="['content-item m-1 p-0 rounded', contentCls]" :data-hid="id" :data-state="state">
+    <div :id="contentId" :class="['content-item m-1 p-0 rounded content-buttons', contentCls]" :data-hid="id" :data-state="state">
         <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @click.stop="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1 font-weight-bold">

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -1,5 +1,9 @@
 <template>
-    <div :id="contentId" :class="['content-item m-1 p-0 rounded content-buttons', contentCls]" :data-hid="id" :data-state="state">
+    <div
+        :id="contentId"
+        :class="['content-item m-1 p-0 rounded content-buttons', contentCls]"
+        :data-hid="id"
+        :data-state="state">
         <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @click.stop="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1 font-weight-bold">

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -1045,6 +1045,20 @@ a.action-button {
     @extend .btn, .active;
 }
 
+// A content button is a button in content items
+
+.content-buttons {
+    .btn:hover,
+    .btn:active,
+    .btn:focus,
+    .btn:focus-visible {
+        @extend .text-white;
+        background-color: transparent !important;
+        border-color: transparent !important;
+        box-shadow: none !important;
+    }    
+}
+
 // A menu button is a button that has an attached popup menu
 
 .menubutton {

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -1052,7 +1052,7 @@ a.action-button {
     .btn:active,
     .btn:focus,
     .btn:focus-visible {
-        @extend .text-white;
+        @extend .text-info;
         background-color: transparent !important;
         border-color: transparent !important;
         box-shadow: none !important;

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -1056,7 +1056,7 @@ a.action-button {
         background-color: transparent !important;
         border-color: transparent !important;
         box-shadow: none !important;
-    }    
+    }
 }
 
 // A menu button is a button that has an attached popup menu


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14026 . History item buttons had grey bg-color on hover, changed it to no bg-color and [blue](https://github.com/galaxyproject/galaxy/pull/14222#issuecomment-1170106443) icon color:

https://user-images.githubusercontent.com/78516064/176509083-d98b3ba6-d714-43c4-9e64-d4a23650de3c.mov

Let me know if these colors don't work, if I should bring back a different bg-color or any other ideas...
Also, this change only affects `ContentItem`s, not other areas in the panel.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
