### PR TITLE
Migrate `library folder contents` API to FastAPI

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -5,7 +5,6 @@ import re
 from datetime import datetime
 from enum import Enum
 from typing import (
-    Annotated,
     Any,
     Dict,
     List,
@@ -24,7 +23,10 @@ from pydantic import (
     Json,
     UUID4,
 )
-from typing_extensions import Literal
+from typing_extensions import (
+    Annotated,
+    Literal,
+)
 
 from galaxy.model import (
     Dataset,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2539,7 +2539,7 @@ class LibraryFolderContentsIndexQueryPayload(Model):
 
 
 class LibraryFolderItemBase(Model):
-    id: EncodedDatabaseIdField
+    id: DecodedDatabaseIdField
     name: str
     type: str
     create_time: datetime = CreateTimeField
@@ -2563,7 +2563,7 @@ class FileLibraryFolderItem(LibraryFolderItemBase):
     state: Dataset.states = DatasetStateField
     file_size: str
     raw_size: int
-    ldda_id: EncodedDatabaseIdField
+    ldda_id: DecodedDatabaseIdField
     tags: str
     message: Optional[str]
 
@@ -2572,7 +2572,7 @@ AnyLibraryFolderItem = Annotated[Union[FileLibraryFolderItem, FolderLibraryFolde
 
 
 class LibraryFolderMetadata(Model):
-    parent_library_id: EncodedDatabaseIdField
+    parent_library_id: DecodedDatabaseIdField
     folder_name: str
     folder_description: str
     total_rows: int

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -2,93 +2,99 @@
 API operations on the contents of a library folder.
 """
 import logging
+from typing import Optional
 
-from galaxy import util
-from galaxy.web import (
-    expose_api,
-    expose_api_anonymous,
+from fastapi import (
+    Body,
+    Path,
+    Query,
+)
+
+from galaxy.managers.context import ProvidesUserContext
+from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import (
+    CreateLibraryFilePayload,
+    LibraryFolderContentsIndexQueryPayload,
+    LibraryFolderContentsIndexResult,
 )
 from galaxy.webapps.galaxy.services.library_folder_contents import LibraryFolderContentsService
 from . import (
-    BaseGalaxyAPIController,
     depends,
+    DependsOnTrans,
+    Router,
 )
 
 log = logging.getLogger(__name__)
 
+router = Router(tags=["data libraries folders"])
 
-class FolderContentsController(BaseGalaxyAPIController):
-    """
-    Class controls retrieval, creation and updating of folder contents.
-    """
+FolderIdPathParam: EncodedDatabaseIdField = Path(
+    ..., title="Folder ID", description="The encoded identifier of the library folder."
+)
 
+LimitQueryParam: int = Query(default=10, title="Limit", description="Maximum number of contents to return.")
+
+OffsetQueryParam: int = Query(
+    default=0,
+    title="Offset",
+    description="Return contents from this specified position. For example, if ``limit`` is set to 100 and ``offset`` to 200, contents between position 200-299 will be returned.",
+)
+
+SearchQueryParam: Optional[str] = Query(
+    default=None,
+    title="Search Text",
+    description="Used to filter the contents. Only the folders and files which name contains this text will be returned.",
+)
+
+IncludeDeletedQueryParam: Optional[bool] = Query(
+    default=False,
+    title="Include Deleted",
+    description="Returns also deleted contents. Deleted contents can only be retrieved by Administrators or users with",
+)
+
+
+@router.cbv
+class FastAPILibraryFoldersContents:
     service: LibraryFolderContentsService = depends(LibraryFolderContentsService)
 
-    @expose_api_anonymous
-    def index(self, trans, folder_id, limit=None, offset=None, search_text=None, **kwd):
+    @router.get(
+        "/api/folders/{folder_id}/contents",
+        summary="Returns a list of a folder's contents (files and sub-folders) with additional metadata about the folder.",
+        responses={
+            200: {
+                "description": "The contents of the folder that match the query parameters.",
+                "model": LibraryFolderContentsIndexResult,
+            },
+        },
+    )
+    def index(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        folder_id: EncodedDatabaseIdField = FolderIdPathParam,
+        limit: int = LimitQueryParam,
+        offset: int = OffsetQueryParam,
+        search_text: Optional[str] = SearchQueryParam,
+        include_deleted: Optional[bool] = IncludeDeletedQueryParam,
+    ):
+        """Returns a list of a folder's contents (files and sub-folders).
+
+        Additional metadata for the folder is provided in the response as a separate object containing data
+        for breadcrumb path building, permissions and other folder's details.
         """
-        GET /api/folders/{encoded_folder_id}/contents?limit={limit}&offset={offset}
+        payload = LibraryFolderContentsIndexQueryPayload(
+            limit=limit, offset=offset, search_text=search_text, include_deleted=include_deleted
+        )
+        return self.service.index(trans, folder_id, payload)
 
-        Displays a collection (list) of a folder's contents
-        (files and folders). Encoded folder ID is prepended
-        with 'F' if it is a folder as opposed to a data set
-        which does not have it. Full path is provided in
-        response as a separate object providing data for
-        breadcrumb path building.
-
-        ..example:
-            limit and offset can be combined. Skip the first two and return five:
-                '?limit=3&offset=5'
-
-        :param  folder_id: encoded ID of the folder which
-            contents should be library_dataset_dict
-        :type   folder_id: encoded string
-
-        :param  offset: offset for returned library folder datasets
-        :type   folder_id: encoded string
-
-        :param  limit: limit   for returned library folder datasets
-            contents should be library_dataset_dict
-        :type   folder_id: encoded string
-
-        :param kwd: keyword dictionary with other params
-        :type  kwd: dict
-
-        :returns: dictionary containing all items and metadata
-        :type:    dict
-
-        :raises: MalformedId, InconsistentDatabase, ObjectNotFound,
-             InternalServerError
-        """
-        include_deleted = util.asbool(kwd.get("include_deleted", False))
-        return self.service.index(trans, folder_id, limit, offset, search_text, include_deleted)
-
-    @expose_api
-    def create(self, trans, encoded_folder_id, payload, **kwd):
-        """
-        POST /api/folders/{encoded_id}/contents
-
-        Create a new library file from an HDA.
-
-        :param  encoded_folder_id:      the encoded id of the folder to import dataset(s) to
-        :type   encoded_folder_id:      an encoded id string
-        :param  payload:    dictionary structure containing:
-            :param from_hda_id:         (optional) the id of an accessible HDA to copy into the library
-            :type  from_hda_id:         encoded id
-            :param from_hdca_id:         (optional) the id of an accessible HDCA to copy into the library
-            :type  from_hdca_id:         encoded id
-            :param ldda_message:        (optional) the new message attribute of the LDDA created
-            :type   ldda_message:       str
-            :param extended_metadata:   (optional) dub-dictionary containing any extended metadata to associate with the item
-            :type  extended_metadata:   dict
-        :type   payload:    dict
-
-        :returns:   a dictionary describing the new item if ``from_hda_id`` is supplied or a list of
-                    such dictionaries describing the new items if ``from_hdca_id`` is supplied.
-        :rtype:     object
-
-        :raises:    ObjectAttributeInvalidException,
-            InsufficientPermissionsException, ItemAccessibilityException,
-            InternalServerError
-        """
-        return self.service.create(trans, encoded_folder_id, payload)
+    @router.post(
+        "/api/folders/{folder_id}/contents",
+        name="add_history_datasets_to_library",
+        summary="Creates a new library file from an existing HDA/HDCA.",
+    )
+    def create(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        folder_id: EncodedDatabaseIdField = FolderIdPathParam,
+        payload: CreateLibraryFilePayload = Body(...),
+    ):
+        return self.service.create(trans, folder_id, payload)

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -11,7 +11,7 @@ from fastapi import (
 )
 
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     CreateLibraryFilePayload,
     LibraryFolderContentsIndexQueryPayload,
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
 
 router = Router(tags=["data libraries folders"])
 
-FolderIdPathParam: EncodedDatabaseIdField = Path(
+FolderIdPathParam: DecodedDatabaseIdField = Path(
     ..., title="Folder ID", description="The encoded identifier of the library folder."
 )
 
@@ -70,7 +70,7 @@ class FastAPILibraryFoldersContents:
     def index(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        folder_id: EncodedDatabaseIdField = FolderIdPathParam,
+        folder_id: DecodedDatabaseIdField = FolderIdPathParam,
         limit: int = LimitQueryParam,
         offset: int = OffsetQueryParam,
         search_text: Optional[str] = SearchQueryParam,
@@ -94,7 +94,7 @@ class FastAPILibraryFoldersContents:
     def create(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        folder_id: EncodedDatabaseIdField = FolderIdPathParam,
+        folder_id: DecodedDatabaseIdField = FolderIdPathParam,
         payload: CreateLibraryFilePayload = Body(...),
     ):
         return self.service.create(trans, folder_id, payload)

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -34,7 +34,7 @@ from . import (
 
 log = logging.getLogger(__name__)
 
-router = Router(tags=["folders"])
+router = Router(tags=["data libraries folders"])
 
 FolderIdPathParam: EncodedDatabaseIdField = Path(
     ..., title="Folder ID", description="The encoded identifier of the library folder."

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1029,28 +1029,6 @@ def populate_api_routes(webapp, app):
         webapp, name_prefix="library_dataset_", path_prefix="/api/libraries/{library_id}/contents/{library_content_id}"
     )
 
-    # =======================
-    # ===== FOLDERS API =====
-    # =======================
-
-    webapp.mapper.connect(
-        "add_history_datasets_to_library",
-        "/api/folders/{encoded_folder_id}/contents",
-        controller="folder_contents",
-        action="create",
-        conditions=dict(method=["POST"]),
-    )
-
-    webapp.mapper.resource(
-        "content",
-        "contents",
-        controller="folder_contents",
-        name_prefix="folder_",
-        path_prefix="/api/folders/{folder_id}",
-        parent_resources=dict(member_name="folder", collection_name="folders"),
-        conditions=dict(method=["GET"]),
-    )
-
     webapp.mapper.resource("job", "jobs", path_prefix="/api")
     webapp.mapper.connect(
         "job_search", "/api/jobs/search", controller="jobs", action="search", conditions=dict(method=["POST"])

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -51,7 +51,7 @@ api_tags_metadata = [
     },
     {"name": "histories"},
     {"name": "libraries"},
-    {"name": "folders"},
+    {"name": "data libraries folders"},
     {"name": "job_lock"},
     {"name": "metrics"},
     {"name": "default"},

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -181,13 +181,13 @@ class LibrariesApiTestCase(ApiTestCase):
     def test_create_dataset_denied(self):
         url, payload = self._create_dataset_kwargs()
         with self._different_user():
-            create_response = self._post(url, payload)
+            create_response = self._post(url, payload, json=True)
             self._assert_status_code_is(create_response, 403)
 
     def test_create_dataset_bootstrap_admin_user(self):
         url, payload = self._create_dataset_kwargs()
         with self._different_user():
-            create_response = self._post(url, payload, key=self.master_api_key)
+            create_response = self._post(url, payload, key=self.master_api_key, json=True)
             self._assert_status_code_is(create_response, 400)
 
     def _create_dataset_kwargs(self):
@@ -376,7 +376,7 @@ class LibrariesApiTestCase(ApiTestCase):
         history_id = self.dataset_populator.new_history()
         hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3")["id"]
         payload = {"from_hda_id": hda_id}
-        create_response = self._post(f"folders/{folder_id}/contents", payload)
+        create_response = self._post(f"folders/{folder_id}/contents", payload, json=True)
         self._assert_status_code_is(create_response, 200)
         self._assert_has_keys(create_response.json(), "name", "id")
 
@@ -392,7 +392,7 @@ class LibrariesApiTestCase(ApiTestCase):
         history_id = self.dataset_populator.new_history()
         hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3 sub")["id"]
         payload = {"from_hda_id": hda_id}
-        create_response = self._post(f"folders/{subfolder_id}/contents", payload)
+        create_response = self._post(f"folders/{subfolder_id}/contents", payload, json=True)
         self._assert_status_code_is(create_response, 200)
         self._assert_has_keys(create_response.json(), "name", "id")
         dataset_update_time = create_response.json()["update_time"]
@@ -523,7 +523,7 @@ class LibrariesApiTestCase(ApiTestCase):
         self._assert_status_code_is(folder_response, 200)
         folder_id = folder_response.json()[0]["id"]
         payload = {"from_hdca_id": hdca_id}
-        create_response = self._post(f"folders/{folder_id}/contents", payload)
+        create_response = self._post(f"folders/{folder_id}/contents", payload, json=True)
         self._assert_status_code_is(create_response, 200)
         assert len(create_response.json()) == 2
         # Also test that anything different from a flat dataset collection list
@@ -532,7 +532,7 @@ class LibrariesApiTestCase(ApiTestCase):
             "outputs"
         ][0]["id"]
         payload = {"from_hdca_id": hdca_pair_id}
-        create_response = self._post(f"folders/{folder_id}/contents", payload)
+        create_response = self._post(f"folders/{folder_id}/contents", payload, json=True)
         self._assert_status_code_is(create_response, 501)
         assert (
             create_response.json()["err_msg"]


### PR DESCRIPTION
I'm trying to refactor and simplify the `folder_contents` API as part of a different PR and then see if I can optimize the `index` endpoint when trying to search on folders containing a large number of elements.

I've extracted these changes that focus only on migrating the current code to FastAPI for easier review.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
