### PR TITLE
[22.05] HistoryFilters datepicker fix: date now shows up in field

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -97,7 +97,7 @@ export default {
             create_time_gt: "",
             create_time_lt: "",
         };
-    }, 
+    },
     computed: {
         filterSettings() {
             return toAlias(getFilters(this.filterText));

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -51,21 +51,13 @@
             <small class="mt-1">Filter by creation time:</small>
             <b-form-group class="m-0">
                 <b-input-group>
-                    <b-form-input v-model="filterSettings['create_time>']" size="sm" placeholder="created after" />
+                    <b-form-input v-model="create_time_gt" size="sm" placeholder="created after" />
                     <b-input-group-append>
-                        <b-form-datepicker
-                            v-model="filterSettings['create_time>']"
-                            reset-button
-                            button-only
-                            size="sm" />
+                        <b-form-datepicker v-model="create_time_gt" reset-button button-only size="sm" />
                     </b-input-group-append>
-                    <b-form-input v-model="filterSettings['create_time<']" size="sm" placeholder="created before" />
+                    <b-form-input v-model="create_time_lt" size="sm" placeholder="created before" />
                     <b-input-group-append>
-                        <b-form-datepicker
-                            v-model="filterSettings['create_time<']"
-                            reset-button
-                            button-only
-                            size="sm" />
+                        <b-form-datepicker v-model="create_time_lt" reset-button button-only size="sm" />
                     </b-input-group-append>
                 </b-input-group>
             </b-form-group>
@@ -100,6 +92,12 @@ export default {
         filterText: { type: String, default: null },
         showAdvanced: { type: Boolean, default: false },
     },
+    data() {
+        return {
+            create_time_gt: "",
+            create_time_lt: "",
+        };
+    }, 
     computed: {
         filterSettings() {
             return toAlias(getFilters(this.filterText));
@@ -118,12 +116,20 @@ export default {
             return Object.keys(STATES);
         },
     },
+    watch: {
+        filterSettings() {
+            this.create_time_gt = this.filterSettings["create_time>"];
+            this.create_time_lt = this.filterSettings["create_time<"];
+        },
+    },
     methods: {
         onOption(name, value) {
             this.filterSettings[name] = value;
         },
         onSearch() {
             this.onToggle();
+            this.filterSettings["create_time>"] = this.create_time_gt;
+            this.filterSettings["create_time<"] = this.create_time_lt;
             this.updateFilter(getFilterText(this.filterSettings));
         },
         onToggle() {


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14165. Previously, date wouldn't show up in the textbox when selected from the datepicker because `filterSettings` is a `computed` property.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
