### PR TITLE
[22.05] Add selenium tests for uploads

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -882,6 +882,11 @@ gies:
     iframe: 'body iframe[seamless="seamless"]'
 
 upload:
+  composite:
+    selectors:
+      table: 'div#composite table.upload-table'
+      close: 'div#composite div.upload-buttons button'
+
   selectors:
     tab: '#tab-title-link-${tab}'
     ftp_add: '#btn-ftp'

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1,4 +1,4 @@
-"""A mixing that extends a HasDriver class with Galaxy-specific utilities.
+"""A mixin that extends a HasDriver class with Galaxy-specific utilities.
 
 Implementer must provide a self.build_url method to target Galaxy.
 """
@@ -741,6 +741,25 @@ class NavigatesGalaxy(HasDriver):
         self.upload_start()
 
         self.wait_for_and_click_selector("button#btn-close")
+
+    def perform_upload_of_composite_dataset_pasted_data(self, ext, paste_content):
+        self.home()
+        self.upload_start_click()
+        self.components.upload.tab(tab="composite").wait_for_and_click()
+        self.upload_set_footer_extension(ext, tab_id="composite")
+
+        table = self.components.upload.composite.table().wait_for_visible()
+        source_select_buttons = table.find_elements_by_css_selector("div.dropdown button.btn")
+        paste_buttons = table.find_elements_by_css_selector(".upload-source .dropdown-menu .dropdown-item .fa-edit")
+        textareas = table.find_elements_by_css_selector("div.upload-text-column textarea.upload-text-content")
+
+        for i in range(len(paste_content)):
+            source_select_buttons[i].click()
+            paste_buttons[i].click()
+            textareas[i].send_keys(paste_content[i])
+
+        self.upload_start(tab_id="composite")
+        self.components.upload.composite.close.wait_for_and_click()
 
     def upload_list(self, test_paths, name="test", ext=None, genome=None, hide_source_items=True):
         self._collection_upload_start(test_paths, ext, genome, "List")

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -12,6 +12,51 @@ from .framework import (
 
 class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
+    def test_upload_file(self):
+        self.perform_upload(self.get_filename("1.sam"))
+
+        self.history_panel_wait_for_hid_ok(1)
+        history_count = len(self.history_contents())
+        assert history_count == 1, "Incorrect number of items in history - expected 1, found %d" % history_count
+
+        self.history_panel_click_item_title(hid=1, wait=True)
+        self.assert_item_summary_includes(1, "28 lines")
+
+    @selenium_test
+    def test_upload_pasted_content(self):
+        pasted_content = "this is pasted"
+        self.perform_upload_of_pasted_content(pasted_content)
+
+        self.history_panel_wait_for_hid_ok(1)
+        history_count = len(self.history_contents())
+        assert history_count == 1, "Incorrect number of items in history - expected 1, found %d" % history_count
+
+    @selenium_test
+    def test_upload_pasted_url_content(self):
+        pasted_content = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/LICENSE.txt"
+        self.perform_upload_of_pasted_content(pasted_content)
+
+        self.history_panel_wait_for_hid_ok(1)
+        history_count = len(self.history_contents())
+        assert history_count == 1, "Incorrect number of items in history - expected 1, found %d" % history_count
+
+    @selenium_test
+    def test_upload_composite_dataset_pasted_data(self):
+        paste_content = ["a", "b", "c"]
+        self.perform_upload_of_composite_dataset_pasted_data("velvet", paste_content)
+
+        self.history_panel_wait_for_hid_ok(1)
+        history_count = len(self.history_contents())
+        assert history_count == 1, "Incorrect number of items in history - expected 1, found %d" % history_count
+
+        self.history_panel_click_item_title(hid=1, wait=True)
+        self.history_panel_item_view_dataset_details(1)
+        param_values = self.driver.find_elements_by_css_selector("#tool-parameters td.tool-parameter-value")
+        request_json = param_values[1].text
+        for data in paste_content:
+            assert f'"paste_content": "{data}"' in request_json
+
+    @selenium_test
     def test_upload_simplest(self):
         self.perform_upload(self.get_filename("1.sam"))
 


### PR DESCRIPTION
Follow up to #14191.

For composite datasets, this includes just one test for pasted data. I haven't figured out yet how to verify an uploaded file and downloaded content from a url in the context of a composite upload test (both have been tested manually)


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
