### PR TITLE
[21.09] fix JobWrapper: use correct fail method

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1696,7 +1696,7 @@ class JobWrapper(HasResourceParameters):
                     else:
                         # Prior to fail we need to set job.state
                         job.set_state(final_job_state)
-                        return self.fail(f"Job {job.id}'s output dataset(s) could not be read")
+                        return fail(f"Job {job.id}'s output dataset(s) could not be read")
 
         job_context = ExpressionContext(dict(stdout=job.stdout, stderr=job.stderr))
         if extended_metadata:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1697,6 +1697,12 @@ class JobWrapper(HasResourceParameters):
                         # Prior to fail we need to set job.state
                         job.set_state(final_job_state)
                         return fail(f"Job {job.id}'s output dataset(s) could not be read")
+        else:
+            # check existence of outputs (tools may delete outputs)
+            for dataset_path in self.get_output_fnames():
+                if not os.path.exists(dataset_path.real_path):
+                    job.set_state(final_job_state)
+                    return fail(f"Job {job.id}'s output dataset(s) could not be read")
 
         job_context = ExpressionContext(dict(stdout=job.stdout, stderr=job.stderr))
         if extended_metadata:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2011,6 +2011,8 @@ class JobWrapper(HasResourceParameters):
 
         results = []
         for da in job.output_datasets + job.output_library_datasets:
+            if da.purged:
+                continue
             da_false_path = dataset_path_rewriter.rewrite_dataset_path(da.dataset, 'output')
             mutable = da.dataset.dataset.external_filename is None
             dataset_path = DatasetPath(da.dataset.dataset.id, da.dataset.file_name, false_path=da_false_path, mutable=mutable)

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -273,7 +273,7 @@ def set_metadata_portable():
             external_filename = unnamed_id_to_path.get(dataset_instance_id, dataset_filename_override)
             if not os.path.exists(external_filename):
                 matches = glob.glob(external_filename)
-                assert len(matches) == 1, f"More than one file matched by output glob '{external_filename}'"
+                assert len(matches) == 1, f"{len(matches)} file matched by output glob '{external_filename}', should be 1"
                 external_filename = matches[0]
                 assert safe_contains(tool_job_working_directory, external_filename), f"Cannot collect output '{external_filename}' from outside of working directory"
                 created_from_basename = os.path.relpath(external_filename, os.path.join(tool_job_working_directory, 'working'))

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -214,6 +214,8 @@
   <tool file="interactivetool_simple.xml" />
   <tool file="interactivetool_two_entry_points.xml" />
   <tool file="converter_target_datatype.xml" />
+  
+  <tool file="tool_deleting_output.xml" />
 
   <!-- Tools interesting only for building up test workflows. -->
 

--- a/test/functional/tools/tool_deleting_output.xml
+++ b/test/functional/tools/tool_deleting_output.xml
@@ -1,6 +1,6 @@
 <tool id="tool_deleting_output" name="tool_deleting_output" version="0.1.0" license="AFL-3.0" profile="21.09">
     <command><![CDATA[
-rm '$out_file1' || true && ## alle sure that this does not fail.
+rm '$out_file1' || true && ## ensure that this does not fail.
 exit $exit_code
     ]]></command>
     <inputs>
@@ -18,8 +18,8 @@ exit $exit_code
         </test>
     </tests>
     <help><![CDATA[
-        This tool tests what happens if the underlying program removes the output data set,
-        it should fail independent of the exit code and the exit code should be correctly checked.
+        This tool tests what happens if the underlying program removes the output data set:
+        the job should fail independent of the exit code and the exit code should be correctly checked.
 
         With outputs_to_working_directory this provoked https://github.com/galaxyproject/galaxy/issues/14206
     ]]></help>

--- a/test/functional/tools/tool_deleting_output.xml
+++ b/test/functional/tools/tool_deleting_output.xml
@@ -1,6 +1,6 @@
 <tool id="tool_deleting_output" name="tool_deleting_output" version="0.1.0" license="AFL-3.0" profile="21.09">
     <command><![CDATA[
-rm '$out_file1' &&
+rm '$out_file1';  ## don't use && since otherwise the framework test fails 
 exit $exit_code
     ]]></command>
     <inputs>

--- a/test/functional/tools/tool_deleting_output.xml
+++ b/test/functional/tools/tool_deleting_output.xml
@@ -12,11 +12,6 @@ exit $exit_code
     <tests>
         <test expect_exit_code="0" expect_failure="true">
             <param name="exit_code" value="0"/>
-            <!-- <output name="out_file1">
-                <assert_contents>
-                    <has_size value="0"/>
-                </assert_contents>
-            </output> -->
         </test>
         <test expect_exit_code="1" expect_failure="true">
             <param name="exit_code" value="1"/>

--- a/test/functional/tools/tool_deleting_output.xml
+++ b/test/functional/tools/tool_deleting_output.xml
@@ -1,6 +1,6 @@
 <tool id="tool_deleting_output" name="tool_deleting_output" version="0.1.0" license="AFL-3.0" profile="21.09">
     <command><![CDATA[
-rm '$out_file1';  ## don't use && since otherwise the framework test fails 
+rm '$out_file1' || true && ## alle sure that this does not fail.
 exit $exit_code
     ]]></command>
     <inputs>

--- a/test/functional/tools/tool_deleting_output.xml
+++ b/test/functional/tools/tool_deleting_output.xml
@@ -1,0 +1,31 @@
+<tool id="tool_deleting_output" name="tool_deleting_output" version="0.1.0" license="AFL-3.0" profile="21.09">
+    <command><![CDATA[
+rm '$out_file1' &&
+exit $exit_code
+    ]]></command>
+    <inputs>
+        <param name="exit_code" type="integer" value="0"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test expect_exit_code="0" expect_failure="true">
+            <param name="exit_code" value="0"/>
+            <!-- <output name="out_file1">
+                <assert_contents>
+                    <has_size value="0"/>
+                </assert_contents>
+            </output> -->
+        </test>
+        <test expect_exit_code="1" expect_failure="true">
+            <param name="exit_code" value="1"/>
+        </test>
+    </tests>
+    <help><![CDATA[
+        This tool tests what happens if the underlying program removes the output data set,
+        it should fail independent of the exit code and the exit code should be correctly checked.
+
+        With outputs_to_working_directory this provoked https://github.com/galaxyproject/galaxy/issues/14206
+    ]]></help>
+</tool>

--- a/test/integration/test_job_outputs_to_working_directory.py
+++ b/test/integration/test_job_outputs_to_working_directory.py
@@ -15,4 +15,4 @@ class JobOutputsToWorkingDirectoryIntegrationInstance(integration_util.Integrati
 
 instance = integration_util.integration_module_instance(JobOutputsToWorkingDirectoryIntegrationInstance)
 
-test_tools = integration_util.integration_tool_runner(["output_format", "output_empty_work_dir", "collection_creates_pair_from_work_dir"])
+test_tools = integration_util.integration_tool_runner(["output_format", "output_empty_work_dir", "collection_creates_pair_from_work_dir", "tool_deleting_output"])


### PR DESCRIPTION
Add a test case and fix the job wrapper.

Since recently planemo was changed to use `outputs_to_working_directory` this branch of the code was used which used the wrong fail method. The consequence was that exit code, etc was lost. 

fixes https://github.com/galaxyproject/galaxy/issues/14206

supersedes https://github.com/galaxyproject/galaxy/pull/14210

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
