### PR TITLE
Enhance `library folder contents` search API

### DIFF
--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -485,23 +485,16 @@ class FolderManager:
 
         return query
 
-    def build_folder_path(self, trans, folder):
+    def build_folder_path(self, trans, folder: model.LibraryFolder) -> List[Tuple[str, str]]:
         """
-        Search the path upwards recursively and load the whole route of
-        names and ids for breadcrumb building purposes.
+        Returns the folder path from root to the given folder.
 
-        :param folder: current folder for navigating up
-        :param type:   Galaxy LibraryFolder
-
-        :returns:   list consisting of full path to the library
-        :type:      list
+        The path items are tuples with the name and id of each folder for breadcrumb building purposes.
         """
-        path_to_root = []
-        # We are almost in root
-        encoded_id = trans.security.encode_id(folder.id)
-        path_to_root.append((f"F{encoded_id}", folder.name))
-        if folder.parent_id is not None:
-            # We add the current folder and traverse up one folder.
-            upper_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(folder.parent_id)
-            path_to_root.extend(self.build_folder_path(trans, upper_folder))
+        current_folder = folder
+        path_to_root = [(f"F{trans.security.encode_id(current_folder.id)}", current_folder.name)]
+        while current_folder.parent_id is not None:
+            parent_folder = trans.sa_session.query(model.LibraryFolder).get(current_folder.parent_id)
+            current_folder = parent_folder
+            path_to_root.insert(0, (f"F{trans.security.encode_id(current_folder.id)}", current_folder.name))
         return path_to_root

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -463,12 +463,20 @@ class FolderManager:
             # We check against the actual dataset and not the ldda (for now?)
             associated_dataset = aliased(model.Dataset)
             dataset_permission = aliased(model.DatasetPermissions)
+            is_public_dataset = not_(
+                sa_session.query(model.DatasetPermissions)
+                .filter(
+                    model.DatasetPermissions.dataset_id == associated_dataset.id,
+                    model.DatasetPermissions.action == access_action,
+                )
+                .exists()
+            )
             query = query.outerjoin(ldda.dataset.of_type(associated_dataset))
             query = query.outerjoin(associated_dataset.actions.of_type(dataset_permission))
             query = query.filter(
                 or_(
                     # The dataset is public
-                    not_(dataset_permission.action == access_action),
+                    is_public_dataset,
                     # The user has explicit access
                     and_(
                         dataset_permission.action == access_action,

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1146,7 +1146,7 @@ class GalaxyRBACAgent(RBACAgent):
         private_role = self.get_private_user_role(trans.user)
         access_roles = dataset.get_access_roles(self)
 
-        if len(access_roles) != 1:
+        if len(access_roles) != 1 or private_role is None:
             return False
         else:
             if access_roles[0].id == private_role.id:

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -80,6 +80,11 @@ class FastAPILibraryFoldersContents:
 
         Additional metadata for the folder is provided in the response as a separate object containing data
         for breadcrumb path building, permissions and other folder's details.
+
+        **Security note**:
+        - Accessing a library folder or sub-folder requires only access to the parent library.
+        - Deleted folders can only be accessed by admins or users with `MODIFY` permission.
+        - Datasets may be public, private or restricted (to a group of users). Listing deleted datasets has the same requirements as folders.
         """
         payload = LibraryFolderContentsIndexQueryPayload(
             limit=limit, offset=offset, search_text=search_text, include_deleted=include_deleted

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -118,22 +118,22 @@ class FolderContentsApiTestCase(ApiTestCase):
         folder_name = "Test Folder Contents Index search text"
         folder_id = self._create_folder_in_library(folder_name)
 
-        dataset_names = ["AB", "BC", "ABC"]
+        dataset_names = ["AB", "BX", "abx"]
         for name in dataset_names:
             self._create_dataset_in_folder(folder_id, name)
 
-        subfolder_names = ["Folder_A", "Folder_C"]
+        subfolder_names = ["Folder_a", "Folder_X"]
         for name in subfolder_names:
             self._create_subfolder_in(folder_id, name)
 
         all_names = dataset_names + subfolder_names
 
-        search_terms = ["A", "B", "C"]
+        search_terms = ["A", "B", "X"]
         for search_text in search_terms:
             response = self._get(f"folders/{folder_id}/contents?search_text={search_text}")
             self._assert_status_code_is(response, 200)
             contents = response.json()["folder_contents"]
-            matching_names = [name for name in all_names if search_text in name]
+            matching_names = [name for name in all_names if search_text.casefold() in name.casefold()]
             assert len(contents) == len(matching_names)
 
     def test_index_permissions_include_deleted(self):


### PR DESCRIPTION
Fixes #14180

This PR moves the database logic from the service layer to the manager (where it should live) and tries optimizing the index endpoint in the library folder contents API using a database query instead of retrieving all contents and performing manual filtering.

Includes:
- A bunch of refactorings to simplify the endpoint logic.
- Increase the test coverage.
- Make search text case insensitive.
- Search query optimization. See next section.
- Fix `dataset_is_private_to_user` raising an exception when the user is a bootstrap admin.

## Performance Optimization

### TLDR
Request time reduction from **2028.7 ms** to **87.6 ms** searching on a folder with 3000 datasets (around 20x faster) :tada:

### Details
In my local setup, I ran a simple postman test 20 times (with a delay of 100ms between requests) and measured the response time on:
```
http://127.0.0.1:8080/api/folders/F33b43b4e7093c91f/contents?include_deleted=false&limit=10&offset=0&search_text=300
```
The folder `F33b43b4e7093c91f` contains 3000 datasets (2700 non-deleted) and the `search_text=300` should yield 4 datasets as result.

On `dev` branch the response times in milliseconds were:
```json
{
  "times": [2011, 2172, 2136, 1797, 1885, 2173, 1860, 1972, 1849, 2172, 1777, 1916, 2240, 2405, 2337, 2051, 1839, 2103, 1861, 2018],
  "count": 20,
  "totalTime": 40574,
}
```
Which results in an average response time of **2028.7 ms**

On `this` branch the response times in milliseconds were:
```json
{
  "times": [74, 69, 73, 113, 69, 69, 127, 116, 87, 129, 109, 67, 68, 100, 72, 65, 66, 69, 85, 125],
  "count": 20,
  "totalTime": 1752,
}
```
Which results in an average response time of **87.6 ms** :tada: 

## TODO
- [x] Fix permission check for private and public datasets in query
- [x] Additional refactorings
- <del>Support `order by`. The client right now only orders the current page.</del> I will add this in a follow-up PR to keep the scope of this PR limited. Tracked here #14256


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to `Shared Data -> Data Libraries`
  - Find a folder with a large number of datasets
  - Try to search by entering any text

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
