### PR TITLE
Add documentation how to avoid data modification by tools

### DIFF
--- a/doc/source/admin/index.rst
+++ b/doc/source/admin/index.rst
@@ -11,6 +11,7 @@ This documentation is in the midst of being ported and unified based on resource
    config
    config_logging
    production
+   security
    nginx
    apache
    scaling

--- a/doc/source/admin/production.md
+++ b/doc/source/admin/production.md
@@ -167,7 +167,7 @@ Note that the tool only knows the paths to inputs and outputs, but if using the 
 There are three approaches to protect Galaxy against this:
 
 - Use different credentials for running tools. This can be configured using the ``real_system_username`` config variable.
-- Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
+- Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will execute in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
 - Use pulsar to stage inputs and outputs
 
 More information on pulsar configuration can be found in the [job configuration](jobs.md) documentation, and the other two are explained in [using a compute cluster](cluster.md).

--- a/doc/source/admin/production.md
+++ b/doc/source/admin/production.md
@@ -152,26 +152,6 @@ To get started with setting up local data, please see [Data Integration](https:/
 
 File sizes have grown very large thanks to rapidly advancing sequencer technology, and it is not always practical to upload these files through the browser. Thankfully, a simple solution is to allow Galaxy users to upload them via FTP and import those files in to their histories. Configuration for FTP is explained on the [File Upload via FTP](special_topics/ftp.md) page.
 
-### Protect Galaxy against data loss due to misbehaving tools
-
-Tools have access to the paths of input and output data sets which are stored in
-``file_path`` and by default the credentials used for running tools are the same
-as for running Galaxy. Thus its possible that tools modify data in Galaxy's
-``file_path``. Examples for such changes are:
-
-- Creation of additional files, e.g. indices, which is a problem for cleaning up data, because Galaxy does not know about these files.
-- Removal of input or output files of the tools. This will create problems with other tools using these data sets (note that most tool repositories use CI tests to to avoid this, but the problem may still occur).
-
-Note that the tool only knows the paths to inputs and outputs, but if using the default configuration for other paths (e.g. configuration directory) also these paths are easily accessible.
-
-There are three approaches to protect Galaxy against this:
-
-- Use different credentials for running tools. This can be configured using the ``real_system_username`` config variable.
-- Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will execute in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
-- Use pulsar to stage inputs and outputs
-
-More information on pulsar configuration can be found in the [job configuration](jobs.md) documentation, and the other two are explained in [using a compute cluster](cluster.md).
-
 ## Advanced configuration
 
 ### Load balancing and web application scaling

--- a/doc/source/admin/production.md
+++ b/doc/source/admin/production.md
@@ -159,7 +159,7 @@ Tools have access to the paths of input and output data sets which are stored in
 as for running Galaxy. Thus its possible that tools modify data in Galaxy's
 ``file_path``. Examples for such changes are:
 
-- Addition of additional files, e.g. indices, which is a problem for cleaning up data, because Galaxy does not know about these files.
+- Creation of additional files, e.g. indices, which is a problem for cleaning up data, because Galaxy does not know about these files.
 - Removal of input or output files of the tools. This will create problems with other tools using these data sets (note that most tool repositories use CI tests to to avoid this, but the problem may still occur).
 
 Note that the tool only knows the paths to inputs and outputs, but if using the default configuration for other paths (e.g. configuration directory) also these paths are easily accessible.
@@ -170,7 +170,7 @@ There are three approaches to protect Galaxy against this:
 - Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
 - Use pulsar to stage inputs and outputs
 
-For both more information can be found in the [job configuration](jobs.md) documentatiion and see also [using a compute cluster](cluster.md).
+More information on pulsar configuration can be found in the [job configuration](jobs.md) documentation, and the other two are explained in [using a compute cluster](cluster.md).
 
 ## Advanced configuration
 

--- a/doc/source/admin/production.md
+++ b/doc/source/admin/production.md
@@ -152,6 +152,25 @@ To get started with setting up local data, please see [Data Integration](https:/
 
 File sizes have grown very large thanks to rapidly advancing sequencer technology, and it is not always practical to upload these files through the browser. Thankfully, a simple solution is to allow Galaxy users to upload them via FTP and import those files in to their histories. Configuration for FTP is explained on the [File Upload via FTP](special_topics/ftp.md) page.
 
+### Protect Galaxy against data loss due to misbehaving tools
+
+Tools have access to the paths of input and output data sets which are stored in
+``file_path`` and by default the credentials used for running tools are the same
+as for running Galaxy. Thus its possible that tools modify data in Galaxy's
+``file_path``. Examples for such changes are:
+
+- Addition of additional files, e.g. indices, which is a problem for cleaning up data, because Galaxy does not know about these files.
+- Removal of input or output files of the tools. This will create problems with other tools using these data sets (note that most tool repositories use CI tests to to avoid this, but the problem may still occur).
+
+Note that the tool only knows the paths to inputs and outputs, but if using the default configuration for other paths (e.g. configuration directory) also these paths are easily accessible.
+
+There are two approaches to protect Galaxy against this:
+
+- Use different credentials for running tools. This can be configured using the ``real_system_username`` config variable.
+- Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
+
+For both more information can be found in the [job configuration](jobs.md) documentatiion and see also [using a compute cluster](cluster.md).
+
 ## Advanced configuration
 
 ### Load balancing and web application scaling

--- a/doc/source/admin/production.md
+++ b/doc/source/admin/production.md
@@ -164,10 +164,11 @@ as for running Galaxy. Thus its possible that tools modify data in Galaxy's
 
 Note that the tool only knows the paths to inputs and outputs, but if using the default configuration for other paths (e.g. configuration directory) also these paths are easily accessible.
 
-There are two approaches to protect Galaxy against this:
+There are three approaches to protect Galaxy against this:
 
 - Use different credentials for running tools. This can be configured using the ``real_system_username`` config variable.
 - Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
+- Use pulsar to stage inputs and outputs
 
 For both more information can be found in the [job configuration](jobs.md) documentatiion and see also [using a compute cluster](cluster.md).
 

--- a/doc/source/admin/security.md
+++ b/doc/source/admin/security.md
@@ -4,18 +4,18 @@
 
 Tools have access to the paths of input and output data sets which are stored in
 ``file_path`` and by default the credentials used for running tools are the same
-as for running Galaxy. Thus its possible that tools modify data in Galaxy's
-``file_path``. Examples for such changes are:
+as for running Galaxy. Thus it is possible that a tool modifies data in Galaxy's
+``file_path``. Examples of such potential changes are:
 
 - Creation of additional files, e.g. indices, which is a problem for cleaning up data, because Galaxy does not know about these files.
-- Removal of input or output files of the tools. This will create problems with other tools using these data sets (note that most tool repositories use CI tests to to avoid this, but the problem may still occur).
+- Removal of tool input or output files. This will create problems with other tools using these datasets (note that most tool repositories use CI tests to to avoid this, but the problem may still occur).
 
-Note that the tool only knows the paths to inputs and outputs, but if using the default configuration for other paths (e.g. configuration directory) also these paths are easily accessible.
+Note that a tool only knows the paths to its inputs and outputs, but if using the default configuration for other paths (e.g. the configuration directory) also these paths can be calculated and accessed.
 
-There are three approaches to protect Galaxy against this:
+There are three approaches to protect Galaxy against these risks:
 
 - Use different credentials for running tools. This can be configured using the ``real_system_username`` config variable.
 - Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will execute in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
-- Use pulsar to stage inputs and outputs
+- Use [Pulsar](https://pulsar.readthedocs.io/) to stage inputs and outputs.
 
 More information on pulsar configuration can be found in the [job configuration](jobs.md) documentation, and the other two are explained in [using a compute cluster](cluster.md).

--- a/doc/source/admin/security.md
+++ b/doc/source/admin/security.md
@@ -1,0 +1,21 @@
+# Security considerations
+
+### Protect Galaxy against data loss due to misbehaving tools
+
+Tools have access to the paths of input and output data sets which are stored in
+``file_path`` and by default the credentials used for running tools are the same
+as for running Galaxy. Thus its possible that tools modify data in Galaxy's
+``file_path``. Examples for such changes are:
+
+- Creation of additional files, e.g. indices, which is a problem for cleaning up data, because Galaxy does not know about these files.
+- Removal of input or output files of the tools. This will create problems with other tools using these data sets (note that most tool repositories use CI tests to to avoid this, but the problem may still occur).
+
+Note that the tool only knows the paths to inputs and outputs, but if using the default configuration for other paths (e.g. configuration directory) also these paths are easily accessible.
+
+There are three approaches to protect Galaxy against this:
+
+- Use different credentials for running tools. This can be configured using the ``real_system_username`` config variable.
+- Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will execute in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
+- Use pulsar to stage inputs and outputs
+
+More information on pulsar configuration can be found in the [job configuration](jobs.md) documentation, and the other two are explained in [using a compute cluster](cluster.md).


### PR DESCRIPTION
While working on https://github.com/galaxyproject/galaxy/pull/14235 I thought this might be a nice addition to the docs. 

Not entirely sure if `real_system_username` will work for non DRMAA job runners?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
