### PR TITLE
[22.01] Improve robustness of tus upload and calculation of progress

### DIFF
--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -47,7 +47,7 @@ function tusUpload(data, index, tusEndpoint, cnf) {
             const status = err.originalResponse?.getStatus();
             if (status == 403) {
                 console.error(`Failed because of missing authorization: ${err}`);
-                cnf.error(error);
+                cnf.error(err);
             } else {
                 // 🎵 Never gonna give you up 🎵
                 console.log(`Failed because: ${err}\n, will retry in 10 seconds`);

--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -39,16 +39,25 @@ function tusUpload(data, index, tusEndpoint, cnf) {
     console.debug(`Starting chunked upload for ${file.name} [chunkSize=${chunkSize}].`);
     const upload = new tus.Upload(file, {
         endpoint: tusEndpoint,
+        retryDelays: [0, 3000, 10000],
         fingerprint: buildFingerprint(cnf),
         chunkSize: chunkSize,
         metadata: data.payload,
-        onError: function (error) {
-            console.log("Failed because: " + error);
-            cnf.error(error);
+        onError: function (err) {
+            const status = err.originalResponse?.getStatus();
+            if (status == 403) {
+                console.error(`Failed because of missing authorization: ${err}`);
+                cnf.error(error);
+            } else {
+                // 🎵 Never gonna give you up 🎵
+                console.log(`Failed because: ${err}\n, will retry in 10 seconds`);
+
+                setTimeout(() => startTusUpload(upload), 10000);
+            }
         },
-        onProgress: function (bytesUploaded, bytesTotal) {
-            var percentage = ((bytesUploaded / bytesTotal) * 100).toFixed(2);
-            console.log(bytesUploaded, bytesTotal, percentage + "%");
+        onChunkComplete: function (chunkSize, bytesAccepted, bytesTotal) {
+            const percentage = ((bytesAccepted / bytesTotal) * 100).toFixed(2);
+            console.log(bytesAccepted, bytesTotal, percentage + "%");
             cnf.progress(percentage);
         },
         onSuccess: function () {
@@ -62,6 +71,10 @@ function tusUpload(data, index, tusEndpoint, cnf) {
             tusUpload(data, index + 1, tusEndpoint, cnf);
         },
     });
+    startTusUpload(upload);
+}
+
+function startTusUpload(upload) {
     // Check if there are any previous uploads to continue.
     upload.findPreviousUploads().then(function (previousUploads) {
         // Found previous uploads so we select the first one.


### PR DESCRIPTION
We now don't let the upload fail at all and instead retry indefinitely.
The progress report is also more accurate as we only report the progress
of individual chunks that have been confirmed by the server.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

Upload a large file or use the throttling control in your browser, restart the galaxy server and/or toggle network connectivity, and see that when the connection returns uploads continue without error.  

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
