### PR TITLE
add doc and linting for test output compare attribute

### DIFF
--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -15,8 +15,8 @@ def check_compare_attribs(element, lint_ctx, test_idx):
         "sort": ["diff", "re_match", "re_match_multiline"],
         "lines_diff": ["diff", "re_match", "contains"],
         "decompress": ["diff"],
-        "delta": ["diff"],
-        "delta_frac": ["diff"],
+        "delta": ["sim_size"],
+        "delta_frac": ["sim_size"],
     }
     compare = element.get("compare", "diff")
     for attrib in COMPARE_COMPATIBILITY:

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -21,7 +21,9 @@ def check_compare_attribs(element, lint_ctx, test_idx):
     compare = element.get("compare", "diff")
     for attrib in COMPARE_COMPATIBILITY:
         if attrib in element.attrib and compare not in COMPARE_COMPATIBILITY[attrib]:
-            lint_ctx.error(f'Test {test_idx}: Attribute {attrib} is incompatible with compare="{compare}".', node=element)
+            lint_ctx.error(
+                f'Test {test_idx}: Attribute {attrib} is incompatible with compare="{compare}".', node=element
+            )
 
 
 def lint_tests(tool_xml, lint_ctx):

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -370,6 +370,7 @@ def files_re_match(file1, file2, attributes=None):
     )
     if attributes.get("sort", False):
         history_data.sort()
+        local_file.sort()
     lines_diff = int(attributes.get("lines_diff", 0))
     line_diff_count = 0
     diffs = []
@@ -403,6 +404,7 @@ def files_re_match_multiline(file1, file2, attributes=None):
             local_file = fh.read()
     if attributes.get("sort", False):
         history_data.sort()
+        local_file.sort()
     history_data = join_char.join(history_data)
     # lines_diff not applicable to multiline matching
     assert re.match(local_file, history_data, re.MULTILINE), "Multiline Regular expression did not match data file"

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -404,7 +404,6 @@ def files_re_match_multiline(file1, file2, attributes=None):
             local_file = fh.read()
     if attributes.get("sort", False):
         history_data.sort()
-        local_file.sort()
     history_data = join_char.join(history_data)
     # lines_diff not applicable to multiline matching
     assert re.match(local_file, history_data, re.MULTILINE), "Multiline Regular expression did not match data file"

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1582,6 +1582,29 @@ temporary file, which will either be compared with the file named in the
 ``file`` attribute value or checked against assertions made by a child
 ``assert_contents`` tag to verify that the tool is functionally correct.
 
+Different methods can be chosen for the comparison with the local file specified
+by ``file`` using the ``compare`` attribute:
+
+- ``diff``: uses diff to compare the history data set and the file provided by
+  ``file``. Compressed files are decompressed before the compariopm if
+  ``decompress`` is set to ``true``. BAM files are converted to SAM before the
+  comparision and for pdf some special rules are implemented. The number of
+  allowed differences can be set with ``lines_diff``.  If ``sort="true"`` history
+  and local data is sorted before the comparison.
+- ``re_match``: each line of the history data set is compared to the regular
+  expression specified in the corresponding line of the ``file``. The allowed
+  number of non matching lines can be set with ``lines_diff`` and the history
+  dataset can be sorted if ``sort`` is set to ``true``.
+- ``re_match_multiline``: it is checked if the history data sets matches the
+  multi line regular expression given in ``file``. The history dataset is sorted
+  before the comparison if the ``sort`` atrribute is set to ``true``.
+- ``contains``: check if each line in ``file`` is contained in the history data set.
+  The allowed number of lines that are not contained in the history dataset
+  can be set with ``lines_diff``.
+- ``sim_size``: compares the size of the history dataset and the ``file`` subject to
+  the values of the ``delta`` and ``delta_frac`` attributes. Note that a ``has_size``
+  content assertion should be preferred, because this avoids storing the test file.
+
         ]]></xs:documentation>
     </xs:annotation>
     <xs:sequence>
@@ -1631,9 +1654,13 @@ data type. If these do not match, the test will fail.
     </xs:attribute>
     <xs:attribute name="sort" type="PermissiveBoolean">
       <xs:annotation>
-        <xs:documentation xml:lang="en">This flag causes the lines of the output
-to be sorted before they are compared to the expected output. This could be
-useful for non-deterministic output.</xs:documentation>
+        <xs:documentation xml:lang="en"><![CDATA[
+
+Applies only if ``compare`` is ``diff``, ``re_match`` or ``re_match_multiline``. This flag causes the lines of the history data set
+to be sorted before the comparison. In case of ``diff`` also the local file is sorted. This could be
+useful for non-deterministic output.
+
+]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="value" type="xs:string">
@@ -1668,7 +1695,7 @@ it may be inconvenient to upload the entiry file and this can be used instead.
     </xs:attribute>
     <xs:attribute name="lines_diff" type="xs:integer">
       <xs:annotation>
-        <xs:documentation xml:lang="en">If ``compare`` is set to ``diff``, the number of lines of difference to allow (each line with a modification is a line added and a line removed so this counts as two lines).</xs:documentation>
+        <xs:documentation xml:lang="en">Applies only if ``compare`` is set to ``diff``, ``re_match``, and ``contains``. If ``compare`` is set to ``diff``, the number of lines of difference to allow (each line with a modification is a line added and a line removed so this counts as two lines).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="decompress" type="PermissiveBoolean">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1594,9 +1594,9 @@ by ``file`` using the ``compare`` attribute:
 - ``re_match``: each line of the history data set is compared to the regular
   expression specified in the corresponding line of the ``file``. The allowed
   number of non matching lines can be set with ``lines_diff`` and the history
-  and local dataset is sorted if ``sort`` is set to ``true``.
+  dataset is sorted if ``sort`` is set to ``true``.
 - ``re_match_multiline``: it is checked if the history data sets matches the
-  multi line regular expression given in ``file``. The history and local datasets are sorted
+  multi line regular expression given in ``file``. The history dataset is sorted
   before the comparison if the ``sort`` atrribute is set to ``true``.
 - ``contains``: check if each line in ``file`` is contained in the history data set.
   The allowed number of lines that are not contained in the history dataset

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1594,9 +1594,9 @@ by ``file`` using the ``compare`` attribute:
 - ``re_match``: each line of the history data set is compared to the regular
   expression specified in the corresponding line of the ``file``. The allowed
   number of non matching lines can be set with ``lines_diff`` and the history
-  dataset can be sorted if ``sort`` is set to ``true``.
+  and local dataset is sorted if ``sort`` is set to ``true``.
 - ``re_match_multiline``: it is checked if the history data sets matches the
-  multi line regular expression given in ``file``. The history dataset is sorted
+  multi line regular expression given in ``file``. The history and local datasets are sorted
   before the comparison if the ``sort`` atrribute is set to ``true``.
 - ``contains``: check if each line in ``file`` is contained in the history data set.
   The allowed number of lines that are not contained in the history dataset

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1656,8 +1656,7 @@ data type. If these do not match, the test will fail.
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
 
-Applies only if ``compare`` is ``diff``, ``re_match`` or ``re_match_multiline``. This flag causes the lines of the history data set
-to be sorted before the comparison. In case of ``diff`` also the local file is sorted. This could be
+Applies only if ``compare`` is ``diff``, ``re_match`` or ``re_match_multiline``. This flag causes the lines of the history data set to be sorted before the comparison. In case of ``diff`` and ``re_match`` also the local file is sorted. This could be
 useful for non-deterministic output.
 
 ]]></xs:documentation>

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1632,7 +1632,7 @@ def test_tests_expect_num_outputs_filter(lint_ctx):
 
 def test_tests_compare_attrib_incompatibility(lint_ctx):
     tool_source = get_xml_tool_source(TESTS_COMPARE_ATTRIB_INCOMPATIBILITY)
-    run_lint(lint_ctx, tests.lint_tsts, tool_source)
+    run_lint(lint_ctx, tests.lint_tests, tool_source)
     assert 'Test 1: Attribute decompress is incompatible with compare="re_match".' in lint_ctx.error_messages
     assert 'Test 1: Attribute sort is incompatible with compare="contains".' in lint_ctx.error_messages
     assert not lint_ctx.info_messages

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -763,6 +763,28 @@ TESTS_EXPECT_NUM_OUTPUTS_FILTER = """
 </tool>
 """
 
+TESTS_COMPARE_ATTRIB_INCOMPATIBILITY = """
+<tool>
+    <outputs>
+        <data name="data_name"/>
+        <collection name="collection_name" type="list:list"/>
+    </outputs>
+    <tests>
+        <test>
+            <output name="data_name" compare="re_match" decompress="true"/>
+            <output_collection name="collection_name">
+                <element compare="contains" sort="true" />
+            </output_collection>
+        </test>
+        <test>
+            <output name="data_name" compare="diff" lines_diff="2"/>
+            <output_collection name="collection_name">
+                <element compare="contains" lines_diff="2" />
+            </output_collection>
+        </test>
+    </tests>
+</tool>"""
+
 # tool xml for xml_order linter
 XML_ORDER = """
 <tool>
@@ -1606,6 +1628,17 @@ def test_tests_expect_num_outputs_filter(lint_ctx):
     assert "Test should specify 'expect_num_outputs' if outputs have filters" in lint_ctx.warn_messages
     assert len(lint_ctx.warn_messages) == 1
     assert len(lint_ctx.error_messages) == 0
+
+
+def test_tests_compare_attrib_incompatibility(lint_ctx):
+    tool_source = get_xml_tool_source(TESTS_COMPARE_ATTRIB_INCOMPATIBILITY)
+    run_lint(lint_ctx, tests.lint_tsts, tool_source)
+    assert 'Test 1: Attribute decompress is incompatible with compare="re_match".' in lint_ctx.error_messages
+    assert 'Test 1: Attribute sort is incompatible with compare="contains".' in lint_ctx.error_messages
+    assert not lint_ctx.info_messages
+    assert len(lint_ctx.valid_messages) == 1
+    assert not lint_ctx.warn_messages
+    assert len(lint_ctx.error_messages) == 2
 
 
 def test_xml_order(lint_ctx):

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1633,8 +1633,14 @@ def test_tests_expect_num_outputs_filter(lint_ctx):
 def test_tests_compare_attrib_incompatibility(lint_ctx):
     tool_source = get_xml_tool_source(TESTS_COMPARE_ATTRIB_INCOMPATIBILITY)
     run_lint(lint_ctx, tests.lint_tsts, tool_source)
-    assert 'Test 1: Attribute decompress is incompatible with compare="re_match".' in lint_ctx.error_messages
-    assert 'Test 1: Attribute sort is incompatible with compare="contains".' in lint_ctx.error_messages
+    assert (
+        'Test 1: Attribute decompress is incompatible with compare="re_match".'
+        in lint_ctx.error_messages
+    )
+    assert (
+        'Test 1: Attribute sort is incompatible with compare="contains".'
+        in lint_ctx.error_messages
+    )
     assert not lint_ctx.info_messages
     assert len(lint_ctx.valid_messages) == 1
     assert not lint_ctx.warn_messages

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1633,14 +1633,8 @@ def test_tests_expect_num_outputs_filter(lint_ctx):
 def test_tests_compare_attrib_incompatibility(lint_ctx):
     tool_source = get_xml_tool_source(TESTS_COMPARE_ATTRIB_INCOMPATIBILITY)
     run_lint(lint_ctx, tests.lint_tsts, tool_source)
-    assert (
-        'Test 1: Attribute decompress is incompatible with compare="re_match".'
-        in lint_ctx.error_messages
-    )
-    assert (
-        'Test 1: Attribute sort is incompatible with compare="contains".'
-        in lint_ctx.error_messages
-    )
+    assert 'Test 1: Attribute decompress is incompatible with compare="re_match".' in lint_ctx.error_messages
+    assert 'Test 1: Attribute sort is incompatible with compare="contains".' in lint_ctx.error_messages
     assert not lint_ctx.info_messages
     assert len(lint_ctx.valid_messages) == 1
     assert not lint_ctx.warn_messages


### PR DESCRIPTION
Since I needed to look this up in the sources I thought some additional docs might be nice. 

Changed `re_match` such that now both files are sorted. Might be more convenient for the tool developer, because keeping the local file unsorted makes no sense anyway.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
