### PR TITLE
[22.05] Add purged dataset badge

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -41,7 +41,13 @@
                     <span>:</span>
                     <span class="content-title name">{{ name }}</span>
                 </span>
+                <span v-if="item.purged" class="align-self-start btn-group p-1">
+                    <b-badge variant="secondary" title="This dataset has been permanently deleted">
+                        <icon icon="burn" /> Purged
+                    </b-badge>
+                </span>
                 <ContentOptions
+                    v-else
                     :is-dataset="isDataset"
                     :is-deleted="item.deleted"
                     :is-history-item="isHistoryItem"

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -51,7 +51,6 @@
                     :is-dataset="isDataset"
                     :is-deleted="item.deleted"
                     :is-history-item="isHistoryItem"
-                    :is-purged="item.purged"
                     :is-visible="item.visible"
                     :state="state"
                     @delete="$emit('delete')"

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -26,7 +26,6 @@
             title="Delete"
             size="sm"
             variant="link"
-            :disabled="isPurged"
             @click.stop="$emit('delete')">
             <icon icon="trash" />
         </b-button>
@@ -36,7 +35,6 @@
             title="Undelete"
             size="sm"
             variant="link"
-            :disabled="isPurged"
             @click.stop="$emit('undelete')">
             <icon icon="trash-restore" />
         </b-button>
@@ -58,34 +56,27 @@ export default {
         isDataset: { type: Boolean, required: true },
         isDeleted: { type: Boolean, default: false },
         isHistoryItem: { type: Boolean, required: true },
-        isPurged: { type: Boolean, default: false },
         isVisible: { type: Boolean, default: true },
         state: { type: String, default: "" },
     },
     computed: {
         displayButtonTitle() {
-            if (this.isPurged) {
-                return "Cannot display datasets removed from disk.";
-            }
             if (this.displayDisabled) {
                 return "This dataset is not yet viewable.";
             }
             return "Display";
         },
         displayDisabled() {
-            return this.isPurged || ["discarded", "new", "upload"].includes(this.state);
+            return ["discarded", "new", "upload"].includes(this.state);
         },
         editButtonTitle() {
-            if (this.isPurged) {
-                return "Cannot edit attributes of datasets removed from disk.";
-            }
             if (this.editDisabled) {
                 return "This dataset is not yet editable.";
             }
             return "Edit attributes";
         },
         editDisabled() {
-            return this.isPurged || ["discarded", "new", "upload", "queued", "running", "waiting"].includes(this.state);
+            return ["discarded", "new", "upload", "queued", "running", "waiting"].includes(this.state);
         },
     },
 };


### PR DESCRIPTION
Fixes #14230

This should make it more evident that the dataset has been purged as a simple first iteration, we can refine the style down the road.

### Before
![image](https://user-images.githubusercontent.com/46503462/177009895-3d39dc4d-9db2-45ff-afa2-94cecc1a802e.png)


### After
![image](https://user-images.githubusercontent.com/46503462/177009781-3fced709-94a7-4891-a330-751876a4a32a.png)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
   - Purge any dataset in your history.
   - Go to `Show deleted` or apply the `deleted:true` search filter.
   - You should see a clear indication that the dataset is purged.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
