### PR TITLE
[22.05] Add Deleted histories plugin for DiskUsage dashboard

### DIFF
--- a/client/src/components/User/DiskUsage/Management/Cleanup/categories.js
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/categories.js
@@ -1,5 +1,12 @@
 import _l from "utils/localization";
-import { cleanupDatasets, fetchDiscardedDatasets, fetchDiscardedDatasetsSummary } from "../services";
+import {
+    cleanupDatasets,
+    fetchDiscardedDatasets,
+    fetchDiscardedDatasetsSummary,
+    cleanupHistories,
+    fetchDiscardedHistories,
+    fetchDiscardedHistoriesSummary,
+} from "../services";
 
 export const cleanupCategories = [
     {
@@ -16,6 +23,18 @@ export const cleanupCategories = [
                 fetchSummary: fetchDiscardedDatasetsSummary,
                 fetchItems: fetchDiscardedDatasets,
                 cleanupItems: cleanupDatasets,
+            },
+            {
+                id: "deleted_histories",
+                name: _l("Deleted histories"),
+                description: _l(
+                    "When you delete a history it's not immediately removed from the disk (so you can recover it later)." +
+                        " But this means it's still taking space until you permanently delete it." +
+                        " Here you can quickly find and remove those histories to free up some space"
+                ),
+                fetchSummary: fetchDiscardedHistoriesSummary,
+                fetchItems: fetchDiscardedHistories,
+                cleanupItems: cleanupHistories,
             },
         ],
     },

--- a/client/src/components/User/DiskUsage/Management/services.js
+++ b/client/src/components/User/DiskUsage/Management/services.js
@@ -9,6 +9,7 @@ const isDeleted = "q=deleted-eq&qv=True";
 const isNotPurged = "q=purged-eq&qv=False";
 const maxItemsToFetch = 500;
 const discardedDatasetsQueryParams = `${isDataset}&${isDeleted}&${isNotPurged}&limit=${maxItemsToFetch}`;
+const discardedHistoriesQueryParams = `&${isDeleted}&${isNotPurged}&limit=${maxItemsToFetch}`;
 
 /**
  * Calculates the total amount of bytes that can be cleaned by permanently removing
@@ -99,6 +100,72 @@ export async function cleanupDatasets(datasets) {
             (partial_sum, item) => partial_sum + (erroredIds.includes(item.id) ? 0 : datasetsTable[item.id].size),
             0
         );
+    } catch (error) {
+        result.errorMessage = error;
+    }
+    return result;
+}
+
+export async function fetchDiscardedHistoriesSummary() {
+    const summaryKeys = "size";
+    const url = `${getAppRoot()}api/histories?keys=${summaryKeys}&${discardedHistoriesQueryParams}`;
+    try {
+        const { data } = await axios.get(url);
+        const totalSizeInBytes = data.reduce((partial_sum, item) => partial_sum + item.size, 0);
+        return new CleanableSummary({
+            totalSize: totalSizeInBytes,
+            totalItems: data.length,
+        });
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}
+
+export async function fetchDiscardedHistories(options = {}) {
+    let params = "";
+    if (options.sortBy) {
+        const sortPostfix = options.sortDesc ? "-dsc" : "-asc";
+        params += `order=${options.sortBy}${sortPostfix}&`;
+    }
+    if (options.limit) {
+        params += `limit=${options.limit}&`;
+    }
+    if (options.offset) {
+        params += `offset=${options.offset}&`;
+    }
+    const url = `${getAppRoot()}api/histories?keys=${datasetKeys}&${discardedHistoriesQueryParams}&${params}`;
+    try {
+        const { data } = await axios.get(url);
+        return data;
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}
+
+async function purgeHistory(historyId) {
+    const payload = {
+        purge: true,
+    };
+    const url = `${getAppRoot()}api/histories/${historyId}`;
+    try {
+        const { data } = await axios.delete(url, { data: payload });
+        return data;
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}
+
+export async function cleanupHistories(histories) {
+    const result = new CleanupResult();
+    const historiesTable = histories.reduce((acc, item) => ((acc[item.id] = item), acc), {});
+    // TODO: Promise.all() and do this in parallel?  Or add a bulk delete endpoint?
+    try {
+        for (const history of histories) {
+            const requestResult = await purgeHistory(history.id);
+            console.debug(requestResult);
+            result.totalFreeBytes += historiesTable[history.id].size;
+            result.totalItemCount += 1;
+        }
     } catch (error) {
         result.errorMessage = error;
     }

--- a/client/src/components/User/DiskUsage/Management/services.js
+++ b/client/src/components/User/DiskUsage/Management/services.js
@@ -9,6 +9,8 @@ const isDeleted = "q=deleted-eq&qv=True";
 const isNotPurged = "q=purged-eq&qv=False";
 const maxItemsToFetch = 500;
 const discardedDatasetsQueryParams = `${isDataset}&${isDeleted}&${isNotPurged}&limit=${maxItemsToFetch}`;
+
+const historyKeys = "id,name,size,update_time";
 const discardedHistoriesQueryParams = `&${isDeleted}&${isNotPurged}&limit=${maxItemsToFetch}`;
 
 /**
@@ -133,7 +135,7 @@ export async function fetchDiscardedHistories(options = {}) {
     if (options.offset) {
         params += `offset=${options.offset}&`;
     }
-    const url = `${getAppRoot()}api/histories?keys=${datasetKeys}&${discardedHistoriesQueryParams}&${params}`;
+    const url = `${getAppRoot()}api/histories?keys=${historyKeys}&${discardedHistoriesQueryParams}&${params}`;
     try {
         const { data } = await axios.get(url);
         return data;


### PR DESCRIPTION
Was requested by @jennaj that we go ahead and allow history purge in the new storage dashboard as well; had reports of users being confused by *not* being able to see deleted histories in here.  This is a quick first pass at a plugin for that.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. See history management dashboard, purge a couple deleted histories.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
