### PR TITLE
[22.05] Small speedup by using cache_ok on MetadataType

### DIFF
--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -326,6 +326,8 @@ class MetadataType(JSONType):
     writes in JSON.
     """
 
+    cache_ok = True
+
     def process_bind_param(self, value, dialect):
         if value is not None:
             if MAX_METADATA_VALUE_SIZE is not None:


### PR DESCRIPTION
Trying to reduce the load on web-05 while we only have a single vm ...

Silences:
```
/Users/mvandenb/src/galaxy/lib/galaxy/model/__init__.py:6158: SAWarning: TypeDecorator MetadataType() will not produce a cache key because the ``cache_ok`` attribute is not set to True.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this type object's state is safe to use in a cache key, or False to disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)
```

which is odd, because `MetadataType` inherits from `JSONType`, which has
cache_ok set to True.

Second call with cache_ok = True:
```
         85871 function calls (84569 primitive calls) in 0.337 seconds

   Ordered by: cumulative time
   List reduced from 891 to 89 due to restriction <0.1>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       10    0.000    0.000    0.229    0.023 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2898(_iter)
       10    0.000    0.000    0.229    0.023 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/session.py:1563(execute)
       10    0.000    0.000    0.225    0.023 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py:1617(_execute_20)
       10    0.000    0.000    0.225    0.023 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/elements.py:321(_execute_on_connection)
       10    0.000    0.000    0.225    0.023 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py:1449(_execute_clauseelement)
        1    0.000    0.000    0.219    0.219 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:112(contents)
        1    0.000    0.000    0.219    0.219 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:238(_union_of_contents)
       10    0.000    0.000    0.215    0.022 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py:1694(_execute_context)
       10    0.000    0.000    0.214    0.021 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/default.py:731(do_execute)
       10    0.213    0.021    0.214    0.021 {method 'execute' of 'psycopg2.extensions.cursor' objects}
        3    0.000    0.000    0.211    0.070 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2752(all)
        1    0.000    0.000    0.164    0.164 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:430(_subcontainer_id_map)
        1    0.000    0.000    0.097    0.097 /Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/services/history_contents.py:1166(<listcomp>)
       21    0.001    0.000    0.097    0.005 /Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/services/history_contents.py:1218(_serialize_content_item)
       21    0.000    0.000    0.078    0.004 /Users/mvandenb/src/galaxy/lib/galaxy/managers/base.py:745(serialize_to_view)
    51/21    0.001    0.000    0.077    0.004 /Users/mvandenb/src/galaxy/lib/galaxy/managers/base.py:671(serialize)
        5    0.000    0.000    0.056    0.011 /Users/mvandenb/src/galaxy/lib/galaxy/managers/hdcas.py:333(serialize_elements_datatypes)
        5    0.000    0.000    0.056    0.011 /Users/mvandenb/src/galaxy/lib/galaxy/model/__init__.py:6152(dataset_dbkeys_and_extensions_summary)
        1    0.000    0.000    0.039    0.039 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:414(_contained_id_map)
       47    0.000    0.000    0.031    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/api/__init__.py:167(__call__)
       47    0.000    0.000    0.031    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/starlette/applications.py:119(url_path_for)
       47    0.010    0.000    0.031    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/starlette/routing.py:598(url_path_for)
        5    0.000    0.000    0.029    0.006 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2895(__iter__)
       20    0.000    0.000    0.027    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/loading.py:135(chunks)
       10    0.000    0.000    0.023    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:390(_raw_all_rows)
     6484    0.011    0.000    0.021    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/starlette/routing.py:242(url_path_for)
       10    0.000    0.000    0.020    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/cursor.py:1803(_fetchall_impl)
       10    0.000    0.000    0.020    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/cursor.py:975(fetchall)
       15    0.000    0.000    0.020    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/cursor.py:1893(_soft_close)
       10    0.000    0.000    0.019    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py:1126(close)
       10    0.000    0.000    0.019    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/pool/base.py:1113(close)
       10    0.000    0.000    0.019    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/pool/base.py:965(_checkin)
       10    0.000    0.000    0.019    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/pool/base.py:682(_finalize_fairy)
       10    0.000    0.000    0.019    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/pool/base.py:980(_reset)
       16    0.000    0.000    0.019    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/hdas.py:457(serialize)
       10    0.000    0.000    0.019    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/default.py:681(do_rollback)
       10    0.019    0.002    0.019    0.002 {method 'rollback' of 'psycopg2.extensions.connection' objects}
        5    0.000    0.000    0.019    0.004 /Users/mvandenb/src/galaxy/lib/galaxy/model/__init__.py:5617(_get_nested_collection_attributes)
       16    0.000    0.000    0.019    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/datasets.py:662(serialize)
  288/238    0.000    0.000    0.018    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/util/langhelpers.py:1110(__get__)
        1    0.000    0.000    0.017    0.017 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:122(contents_count)
        3    0.000    0.000    0.016    0.005 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:395(_allrows)
        3    0.000    0.000    0.016    0.005 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:1691(_fetchall_impl)
    24/23    0.000    0.000    0.015    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:720(columns)
       23    0.000    0.000    0.015    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:1642(_populate_column_collection)
       16    0.000    0.000    0.015    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/hdas.py:432(<lambda>)
       25    0.001    0.000    0.013    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/base.py:1291(_populate_separate_keys)
       22    0.000    0.000    0.013    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:693(_generate_fromclause_column_proxies)
       21    0.000    0.000    0.013    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/base.py:639(url_for)
        1    0.000    0.000    0.012    0.012 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:3107(count)
        2    0.000    0.000    0.012    0.006 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:288(_union_of_contents_query)
        2    0.000    0.000    0.012    0.006 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:1363(all)
        2    0.000    0.000    0.012    0.006 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:1283(_fetchall_impl)
      167    0.001    0.000    0.011    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/schema.py:2041(_make_proxy)
      176    0.000    0.000    0.011    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:694(<genexpr>)
        2    0.000    0.000    0.009    0.005 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2847(one)
       10    0.000    0.000    0.009    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/elements.py:496(_compile_w_cache)
      167    0.003    0.000    0.009    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/schema.py:1163(__init__)
       10    0.000    0.000    0.009    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/util/langhelpers.py:1192(oneshot)
       10    0.000    0.000    0.009    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/traversals.py:330(_generate_cache_key)
       10    0.000    0.000    0.009    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/traversals.py:276(_generate_cache_key)
   456/10    0.004    0.000    0.008    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/traversals.py:159(_gen_cache_key)
     6437    0.007    0.000    0.008    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/starlette/routing.py:34(__init__)
       21    0.000    0.000    0.008    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:381(iterrows)
        5    0.000    0.000    0.007    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:357(statement)
        1    0.000    0.000    0.007    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:1335(_from_self)
        1    0.000    0.000    0.007    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:466(subquery)
        1    0.000    0.000    0.007    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:3304(_compile_state)
        1    0.000    0.000    0.007    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:603(create_for_statement)
      483    0.004    0.000    0.006    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/coercions.py:112(expect)
    46/32    0.000    0.000    0.006    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/traversals.py:264(<listcomp>)
        8    0.000    0.000    0.006    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:334(_apply_orm_filter)
        1    0.000    0.000    0.006    0.006 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:770(_setup_for_generate)
        8    0.000    0.000    0.006    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2938(column_descriptions)
        8    0.000    0.000    0.006    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:2280(_column_descriptions)
       17    0.000    0.000    0.005    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:1378(_adapt_clause)
       17    0.000    0.000    0.005    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/visitors.py:790(replacement_traverse)
       17    0.000    0.000    0.005    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/visitors.py:820(clone)
       17    0.000    0.000    0.005    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:1382(replace)
       17    0.000    0.000    0.005    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/util.py:849(replace)
        9    0.000    0.000    0.005    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:2418(to_compile_state)
       17    0.000    0.000    0.005    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/util.py:829(_corresponding_column)
      139    0.001    0.000    0.005    0.000 /Users/mvandenb/src/galaxy/lib/galaxy/security/idencoding.py:33(encode_id)
       17    0.000    0.000    0.005    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:193(corresponding_column)
        1    0.000    0.000    0.005    0.005 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:130(contents_query)
        8    0.000    0.000    0.005    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:913(_create_entities_collection)
        1    0.000    0.000    0.005    0.005 /Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/services/history_contents.py:1271(_get_history)
      144    0.001    0.000    0.005    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:2797(_for_columns)
        1    0.000    0.000    0.005    0.005 /Users/mvandenb/src/galaxy/lib/galaxy/managers/secured.py:35(get_accessible)
```

Second call without cache_ok = False:
```
         113293 function calls (111484 primitive calls) in 0.391 seconds

   Ordered by: cumulative time
   List reduced from 1039 to 104 due to restriction <0.1>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       10    0.000    0.000    0.271    0.027 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2898(_iter)
       10    0.000    0.000    0.271    0.027 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/session.py:1563(execute)
       10    0.000    0.000    0.266    0.027 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py:1617(_execute_20)
       10    0.000    0.000    0.266    0.027 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/elements.py:321(_execute_on_connection)
       10    0.000    0.000    0.266    0.027 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py:1449(_execute_clauseelement)
        1    0.000    0.000    0.214    0.214 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:112(contents)
        1    0.000    0.000    0.214    0.214 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:238(_union_of_contents)
       10    0.000    0.000    0.212    0.021 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py:1694(_execute_context)
       10    0.000    0.000    0.209    0.021 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/default.py:731(do_execute)
       10    0.209    0.021    0.209    0.021 {method 'execute' of 'psycopg2.extensions.cursor' objects}
        3    0.000    0.000    0.206    0.069 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2752(all)
        1    0.000    0.000    0.155    0.155 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:430(_subcontainer_id_map)
        1    0.000    0.000    0.148    0.148 /Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/services/history_contents.py:1166(<listcomp>)
       21    0.001    0.000    0.148    0.007 /Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/services/history_contents.py:1218(_serialize_content_item)
       21    0.000    0.000    0.128    0.006 /Users/mvandenb/src/galaxy/lib/galaxy/managers/base.py:745(serialize_to_view)
    51/21    0.001    0.000    0.128    0.006 /Users/mvandenb/src/galaxy/lib/galaxy/managers/base.py:671(serialize)
        5    0.000    0.000    0.106    0.021 /Users/mvandenb/src/galaxy/lib/galaxy/managers/hdcas.py:333(serialize_elements_datatypes)
        5    0.000    0.000    0.106    0.021 /Users/mvandenb/src/galaxy/lib/galaxy/model/__init__.py:6152(dataset_dbkeys_and_extensions_summary)
        5    0.000    0.000    0.073    0.015 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2895(__iter__)
       10    0.000    0.000    0.054    0.005 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/elements.py:496(_compile_w_cache)
        6    0.000    0.000    0.044    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:603(create_for_statement)
        5    0.000    0.000    0.044    0.009 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/elements.py:554(_compiler)
        5    0.000    0.000    0.044    0.009 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/compiler.py:690(__init__)
        5    0.000    0.000    0.044    0.009 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/compiler.py:408(__init__)
        1    0.000    0.000    0.044    0.044 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:414(_contained_id_map)
        5    0.000    0.000    0.044    0.009 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/compiler.py:485(process)
    235/5    0.000    0.000    0.044    0.009 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/visitors.py:71(_compiler_dispatch)
        5    0.000    0.000    0.044    0.009 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/compiler.py:3237(visit_select)
        6    0.000    0.000    0.040    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:770(_setup_for_generate)
       20    0.000    0.000    0.036    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/loading.py:135(chunks)
        5    0.000    0.000    0.035    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/base.py:486(create_for_statement)
        5    0.000    0.000    0.033    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:1513(_legacy_join)
       27    0.000    0.000    0.033    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:1675(_join_left_to_right)
       47    0.000    0.000    0.032    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/api/__init__.py:167(__call__)
       47    0.000    0.000    0.032    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/starlette/applications.py:119(url_path_for)
       47    0.011    0.000    0.032    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/starlette/routing.py:598(url_path_for)
       10    0.000    0.000    0.031    0.003 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:390(_raw_all_rows)
  421/355    0.001    0.000    0.031    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/util/langhelpers.py:1110(__get__)
       10    0.000    0.000    0.029    0.003 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/cursor.py:1803(_fetchall_impl)
       10    0.000    0.000    0.029    0.003 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/cursor.py:975(fetchall)
       15    0.000    0.000    0.029    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/cursor.py:1893(_soft_close)
       10    0.000    0.000    0.028    0.003 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py:1126(close)
       10    0.000    0.000    0.028    0.003 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/pool/base.py:1113(close)
       10    0.000    0.000    0.028    0.003 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/pool/base.py:965(_checkin)
       10    0.000    0.000    0.028    0.003 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/pool/base.py:682(_finalize_fairy)
       10    0.000    0.000    0.028    0.003 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/pool/base.py:980(_reset)
    36/35    0.000    0.000    0.028    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:720(columns)
       10    0.000    0.000    0.028    0.003 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/default.py:681(do_rollback)
       10    0.028    0.003    0.028    0.003 {method 'rollback' of 'psycopg2.extensions.connection' objects}
        1    0.000    0.000    0.026    0.026 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:122(contents_count)
       27    0.000    0.000    0.024    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:1776(_join_determine_implicit_left_side)
       27    0.000    0.000    0.024    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/util.py:122(find_left_clause_to_join_from)
       37    0.001    0.000    0.022    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/base.py:1291(_populate_separate_keys)
     6484    0.012    0.000    0.022    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/starlette/routing.py:242(url_path_for)
        1    0.000    0.000    0.020    0.020 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:3107(count)
       16    0.000    0.000    0.019    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/hdas.py:457(serialize)
        5    0.000    0.000    0.018    0.004 /Users/mvandenb/src/galaxy/lib/galaxy/model/__init__.py:5617(_get_nested_collection_attributes)
       16    0.000    0.000    0.018    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/datasets.py:662(serialize)
      287    0.001    0.000    0.018    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:193(corresponding_column)
       23    0.000    0.000    0.015    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:1642(_populate_column_collection)
      287    0.006    0.000    0.015    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/base.py:1351(corresponding_column)
        2    0.000    0.000    0.015    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2847(one)
        3    0.000    0.000    0.014    0.005 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:395(_allrows)
        3    0.000    0.000    0.014    0.005 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:1691(_fetchall_impl)
       16    0.000    0.000    0.014    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/hdas.py:432(<lambda>)
       21    0.000    0.000    0.014    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:381(iterrows)
       21    0.000    0.000    0.014    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/base.py:639(url_for)
       30    0.001    0.000    0.013    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:1257(_joincond_scan_left_right)
        2    0.000    0.000    0.013    0.007 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:1363(all)
        2    0.000    0.000    0.013    0.006 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:1283(_fetchall_impl)
       22    0.000    0.000    0.013    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:693(_generate_fromclause_column_proxies)
        2    0.000    0.000    0.013    0.006 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:288(_union_of_contents_query)
       12    0.000    0.000    0.012    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:1122(_populate_column_collection)
      270    0.000    0.000    0.012    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/schema.py:2355(get_referent)
      167    0.001    0.000    0.012    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/schema.py:2041(_make_proxy)
        1    0.000    0.000    0.011    0.011 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2867(scalar)
      176    0.000    0.000    0.011    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:694(<genexpr>)
       10    0.000    0.000    0.009    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/util/langhelpers.py:1192(oneshot)
       10    0.000    0.000    0.009    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/traversals.py:330(_generate_cache_key)
       10    0.000    0.000    0.009    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/traversals.py:276(_generate_cache_key)
   451/10    0.005    0.000    0.009    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/traversals.py:159(_gen_cache_key)
       20    0.000    0.000    0.009    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:1241(_can_join)
      167    0.003    0.000    0.009    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/schema.py:1163(__init__)
  788/537    0.002    0.000    0.009    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/util/langhelpers.py:1181(__get__)
        1    0.000    0.000    0.009    0.009 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:1335(_from_self)
        5    0.000    0.000    0.009    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:357(statement)
        1    0.000    0.000    0.008    0.008 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:466(subquery)
        1    0.000    0.000    0.008    0.008 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:3304(_compile_state)
     6437    0.007    0.000    0.008    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/starlette/routing.py:34(__init__)
        2    0.000    0.000    0.008    0.004 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:551(_only_one_row)
        4    0.000    0.000    0.008    0.002 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:1680(_fetchone_impl)
       14    0.000    0.000    0.008    0.001 {built-in method builtins.next}
      741    0.004    0.000    0.007    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/coercions.py:112(expect)
        8    0.000    0.000    0.007    0.001 /Users/mvandenb/src/galaxy/lib/galaxy/managers/history_contents.py:334(_apply_orm_filter)
    46/32    0.000    0.000    0.007    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/traversals.py:264(<listcomp>)
        8    0.000    0.000    0.007    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/query.py:2938(column_descriptions)
        8    0.000    0.000    0.007    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:2280(_column_descriptions)
        5    0.000    0.000    0.007    0.001 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/compiler.py:3507(_compose_select_body)
       14    0.000    0.000    0.007    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:2418(to_compile_state)
      278    0.001    0.000    0.007    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/selectable.py:1134(<genexpr>)
       17    0.000    0.000    0.006    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:1378(_adapt_clause)
       17    0.000    0.000    0.006    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/visitors.py:790(replacement_traverse)
        1    0.000    0.000    0.006    0.006 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/result.py:1173(one)
      154    0.001    0.000    0.006    0.000 /Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/orm/context.py:2797(_for_columns)
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
