### PR TITLE
[22.05] History watch throttling -- relax when backgrounded

### DIFF
--- a/client/src/store/historyStore/model/watchHistory.js
+++ b/client/src/store/historyStore/model/watchHistory.js
@@ -11,7 +11,7 @@ import { getCurrentHistoryFromServer } from "./queries";
 import { getGalaxyInstance } from "app";
 
 const limit = 1000;
-const throttlePeriod = 3000;
+let throttlePeriod = 3000;
 
 let watchTimeout = null;
 
@@ -20,6 +20,16 @@ let lastUpdateTime = null;
 
 // last time changed history items have been requested
 let lastRequestDate = new Date();
+
+document.addEventListener("visibilitychange", function () {
+    if (document.visibilityState === "visible") {
+        // Poll every 3 seconds when visible
+        throttlePeriod = 3000;
+    } else {
+        // Poll every 60 seconds when hidden/backgrounded
+        throttlePeriod = 60000;
+    }
+});
 
 export async function watchHistoryOnce(store) {
     // "Reset" watchTimeout so we don't queue up watchHistory calls in rewatchHistory.


### PR DESCRIPTION
Quick test for slowing down polling when the tab is backgrounded, to reduce load on main (and other galaxy servers).

- [x] when foregrounded again, go ahead and immediately poll

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
