### PR TITLE
[22.05] Avoid placeholder value in one more selenium selector

### DIFF
--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -164,7 +164,7 @@ history_panel:
       _: '.history-index .content-item${suffix}'
       title: '${_} .content-title'
       details: '${_} .details'
-      summary: '${_} .summary'
+      summary: '${_} .not-loading .summary'
 
       hid: '${_} .hid'
       name: '${_} .name'


### PR DESCRIPTION
Follow-up on #14198

This should fix `test_simple_execution` and `test_expanded_execution_of_simple_workflow` because of the same reason of #14198.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
