### PR TITLE
[22.05] Fix History dataset database entry overflow

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -2,7 +2,7 @@
     <DatasetProvider :id="dataset.id" v-slot="{ loading, result }" auto-refresh>
         <div v-if="!loading" class="dataset">
             <div class="p-2 details not-loading">
-                <div class="summary">
+                <div class="summary text-nowrap">
                     <div v-if="stateText" class="mb-1">{{ stateText }}</div>
                     <div v-else-if="result.misc_blurb" class="blurb">
                         <span class="value">{{ result.misc_blurb }}</span>

--- a/client/src/style/scss/dataset.scss
+++ b/client/src/style/scss/dataset.scss
@@ -213,6 +213,12 @@
                     font-weight: bold;
                 }
             }
+            .dbkey {
+                .value {
+                    white-space: normal;
+                    overflow-wrap: break-word;
+                }
+            }
             .datatype .value:after {
                 content: ",";
                 @extend %help-text;


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14227. History database value would overflow, now fixed it so that it wraps onto the next line:
| **Before** | **After** |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/78516064/177407529-0dcfad66-aa95-4276-80d1-d04546814964.png) | ![image](https://user-images.githubusercontent.com/78516064/177407681-0c98d0c7-bc63-4f3a-a409-3298b10f4f32.png) |

**Another idea:**
Instead, I could just `overflow-wrap` the value like below:
![image](https://user-images.githubusercontent.com/78516064/177407781-1f560571-c25e-4b43-af13-b9c0a2b963c4.png)
That would mean only one line would be added to the code in this PR (in `dataset.scss`)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
