### PR TITLE
[22.05] Replace old storage FAQ in preferences

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -70,13 +70,13 @@
             </b-row>
         </ConfigProvider>
         <p class="mt-2">
-            {{ titleYouAreUsing }} <strong>{{ diskUsage }}</strong> {{ titleOfDiskSpace }}
-            <span v-html="quotaUsageString"></span>
-            {{ titleIsYourUsage }}
-            <a href="https://galaxyproject.org/learn/managing-datasets/" target="_blank"
-                ><b v-localize>documentation</b></a
-            >
-            {{ titleForTipsOnHow }}
+            You are using <strong>{{ diskUsage }}</strong> of disk space in this Galaxy instance.
+            <span v-if="enableQuotas">
+                Your disk quota is: <strong>{{ diskQuota }}</strong
+                >.
+            </span>
+            Is your usage more than expected? Review your
+            <b-link :href="storageDashboardUrl">Storage Dashboard</b-link>.
         </p>
     </b-container>
 </template>
@@ -114,7 +114,8 @@ export default {
         return {
             email: "",
             diskUsage: "",
-            quotaUsageString: "",
+            diskQuota: "",
+            storageDashboardUrl: `${getAppRoot()}storage`,
             baseUrl: `${getAppRoot()}user`,
             messageVariant: null,
             message: null,
@@ -122,10 +123,6 @@ export default {
             nameState: null,
             deleteError: "",
             submittedNames: [],
-            titleYouAreUsing: _l("You are using"),
-            titleOfDiskSpace: _l("of disk space in this Galaxy instance."),
-            titleIsYourUsage: _l("Is your usage more than expected? See the"),
-            titleForTipsOnHow: _l("for tips on how to find all of the data in your account."),
             titleLoggedInAs: _l("You are logged in as"),
         };
     },
@@ -170,9 +167,7 @@ export default {
         axios.get(`${getAppRoot()}api/users/${this.userId}`).then((response) => {
             this.email = response.data.email;
             this.diskUsage = response.data.nice_total_disk_usage;
-            this.quotaUsageString = this.enableQuotas
-                ? `Your disk quota is: <strong>${response.data.quota}</strong>.`
-                : "";
+            this.diskQuota = response.data.quota;
         });
     },
     methods: {


### PR DESCRIPTION
Fixes #14268

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to User -> Preferences
  - The message at the bottom should link to the new Storage Dashboard.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
