### PR TITLE
[22.05] Fix ReviewCleanupDialog state in Storage Dashboard

### DIFF
--- a/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.test.js
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.test.js
@@ -36,7 +36,11 @@ const FAKE_OPERATION = () => {
 };
 
 async function mountReviewCleanupDialogWith(operation, totalItems = EXPECTED_TOTAL_ITEMS) {
-    const wrapper = mount(ReviewCleanupDialog, { propsData: { operation, totalItems, show: true } }, localVue);
+    const wrapper = mount(
+        ReviewCleanupDialog,
+        { propsData: { operation, totalItems, show: true, modalStatic: true } },
+        localVue
+    );
     await flushPromises();
     return wrapper;
 }

--- a/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
@@ -1,5 +1,11 @@
 <template>
-    <b-modal id="review-cleanup-dialog" v-model="showDialog" title-tag="h2" centered static @show="onShowModal">
+    <b-modal
+        id="review-cleanup-dialog"
+        v-model="showDialog"
+        title-tag="h2"
+        :static="modalStatic"
+        centered
+        @show="onShowModal">
         <template v-slot:modal-title>
             {{ title }}
             <span class="text-primary h3">{{ totalItems }}<span v-if="rowLimitReached">+</span> items</span>
@@ -98,6 +104,10 @@ export default {
             type: Boolean,
             required: false,
         },
+        modalStatic: {
+            type: Boolean,
+            required: false,
+        },
     },
     data() {
         return {
@@ -185,6 +195,9 @@ export default {
         },
     },
     watch: {
+        operation() {
+            this.currentPage = 1;
+        },
         totalItems(newVal) {
             this.totalRows = newVal;
         },


### PR DESCRIPTION
Fixes #14267

The `static` property of the modal was true, making it keep the contents of the first plugin that was opening it. The static property is now only used in testing to make the component render correctly during testing.
Also now it makes sure that we display the first page whenever a different plugin opens the dialog.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #14267
  - It should now correctly display the histories (or the datasets) in the review table corresponding to each plugin.

![fix_dashboard_dialog](https://user-images.githubusercontent.com/46503462/177527330-8e8248ec-36b8-4c90-b5bf-5e5143aeb1be.gif)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
