### PR TITLE
Fix mypy reexport error for testfixtures

### DIFF
--- a/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
+++ b/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
@@ -2,7 +2,7 @@ import logging
 import os
 import unittest
 
-from testfixtures import log_capture
+from testfixtures.logcapture import log_capture
 
 import galaxy.jobs.dynamic_tool_destination as dt
 from galaxy.jobs.dynamic_tool_destination import map_tool_to_destination


### PR DESCRIPTION
Fix this mypy error for the galaxy-app package:

```
tests/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py:5: error:
Module "testfixtures" does not explicitly export attribute "log_capture";
implicit reexport disabled  [attr-defined]
    from testfixtures import log_capture
    ^
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
