### PR TITLE
[22.01] Drop exception catching when querying db for session

### DIFF
--- a/lib/galaxy/security/idencoding.py
+++ b/lib/galaxy/security/idencoding.py
@@ -99,8 +99,13 @@ class IdEncodingHelper:
 
     def decode_guid(self, session_key):
         # Session keys are strings
-        decoded_session_key = codecs.decode(session_key, 'hex')
-        return unicodify(self.id_cipher.decrypt(decoded_session_key)).lstrip('!')
+        try:
+            decoded_session_key = codecs.decode(session_key, "hex")
+            return unicodify(self.id_cipher.decrypt(decoded_session_key)).lstrip("!")
+        except TypeError:
+            raise galaxy.exceptions.MalformedId(f"Malformed guid '{session_key}' specified, unable to decode.")
+        except ValueError:
+            raise galaxy.exceptions.MalformedId(f"Wrong guid '{session_key}' specified, unable to decode.")
 
     def get_new_guid(self):
         # Generate a unique, high entropy 128 bit random number


### PR DESCRIPTION
Should fix users getting logged out if a OperationalError occurs and they get a
new session because of the too-wide exception handling.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Put an "occasional exception" into the `get_session_from_session_key` handling and see that you remain logged in in your instance, e.g with:
```
if random.choice([True, False]):
    raise Exception("bad luck")
```

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
