### PR TITLE
[22.05] Specify time as datetime object in job queries

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import typing
+from datetime import datetime
 
 from boltons.iterutils import remap
 from pydantic import (
@@ -107,7 +108,7 @@ class JobManager:
 
         def build_and_apply_filters(query, objects, filter_func):
             if objects is not None:
-                if isinstance(objects, str):
+                if isinstance(objects, str) or isinstance(objects, datetime):
                     query = query.filter(filter_func(objects))
                 elif isinstance(objects, list):
                     t = []

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1110,7 +1110,7 @@ class JobIndexQueryPayload(Model):
     tool_ids: Optional[List[str]] = None
     tool_ids_like: Optional[List[str]] = None
     date_range_min: Optional[datetime] = None
-    date_range_max: Optional[str] = None
+    date_range_max: Optional[datetime] = None
     history_id: Optional[DecodedDatabaseIdField] = None
     workflow_id: Optional[DecodedDatabaseIdField] = None
     invocation_id: Optional[DecodedDatabaseIdField] = None

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1109,7 +1109,7 @@ class JobIndexQueryPayload(Model):
     user_id: Optional[DecodedDatabaseIdField] = None
     tool_ids: Optional[List[str]] = None
     tool_ids_like: Optional[List[str]] = None
-    date_range_min: Optional[str] = None
+    date_range_min: Optional[datetime] = None
     date_range_max: Optional[str] = None
     history_id: Optional[DecodedDatabaseIdField] = None
     workflow_id: Optional[DecodedDatabaseIdField] = None

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -5,6 +5,7 @@ API operations on a jobs.
 """
 
 import logging
+from datetime import datetime
 from typing import (
     Any,
     Dict,
@@ -98,13 +99,13 @@ ToolIdLikeQueryParam: Optional[str] = Query(
     description="Limit listing of jobs to those that match one of the included tool ID sql-like patterns. If none, all are returned",
 )
 
-DateRangeMinQueryParam: Optional[str] = Query(
+DateRangeMinQueryParam: Optional[datetime] = Query(
     default=None,
     title="Date Range Minimum",
     description="Limit listing of jobs to those that are updated after specified date (e.g. '2014-01-01')",
 )
 
-DateRangeMaxQueryParam: Optional[str] = Query(
+DateRangeMaxQueryParam: Optional[datetime] = Query(
     default=None,
     title="Date Range Maximum",
     description="Limit listing of jobs to those that are updated before specified date (e.g. '2014-01-01')",
@@ -186,8 +187,8 @@ class FastAPIJobs:
         view: JobIndexViewEnum = ViewQueryParam,
         tool_id: Optional[str] = ToolIdQueryParam,
         tool_id_like: Optional[str] = ToolIdLikeQueryParam,
-        date_range_min: Optional[str] = DateRangeMinQueryParam,
-        date_range_max: Optional[str] = DateRangeMaxQueryParam,
+        date_range_min: Optional[datetime] = DateRangeMinQueryParam,
+        date_range_max: Optional[datetime] = DateRangeMaxQueryParam,
         history_id: Optional[EncodedDatabaseIdField] = HistoryIdQueryParam,
         workflow_id: Optional[EncodedDatabaseIdField] = WorkflowIdQueryParam,
         invocation_id: Optional[EncodedDatabaseIdField] = InvocationIdQueryParam,

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -82,14 +82,14 @@ class JobsApiTestCase(ApiTestCase, TestsTools):
 
     @uses_test_history(require_new=True)
     def test_index_date_filter(self, history_id):
-        self.__history_with_new_dataset(history_id)
         two_weeks_ago = (datetime.datetime.utcnow() - datetime.timedelta(14)).isoformat()
         last_week = (datetime.datetime.utcnow() - datetime.timedelta(7)).isoformat()
         next_week = (datetime.datetime.utcnow() + datetime.timedelta(7)).isoformat()
         today = datetime.datetime.utcnow().isoformat()
         tomorrow = (datetime.datetime.utcnow() + datetime.timedelta(1)).isoformat()
+        self.__history_with_new_dataset(history_id)
 
-        jobs = self.__jobs_index(data={"date_range_min": today[0:10], "date_range_max": tomorrow[0:10]})
+        jobs = self.__jobs_index(data={"date_range_min": today, "date_range_max": tomorrow})
         assert len(jobs) > 0
         today_job_id = jobs[0]["id"]
 


### PR DESCRIPTION
I worked together with @davelopez on #14094 and he was able to reproduce it using an SQLite database. Specifying the time as a datetime object seems to fix it, we didn't investigate in detail why. Please feel free to add any more details @davelopez :laughing:.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
