### PR TITLE
Enable CORS for tus uploads.

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1382,6 +1382,7 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
             "upload_path": urljoin(f"{application_stack.config.galaxy_url_prefix}/", "api/upload/resumable_upload"),
             "tmp_dir": application_stack.config.tus_upload_store or application_stack.config.new_file_path,
             "max_size": application_stack.config.maximum_upload_file_size,
+            "allowed_origin_hostnames": application_stack.config.allowed_origin_hostnames
         },
     )
     # X-Forwarded-Host handling


### PR DESCRIPTION
Requires: https://github.com/mvdbeek/tusfilter/pull/1

Adds CORS handling to TUS uploads.

TODO: Consider adding separate config setting for uploads `allowed_upload_origin_hostnames`, that could be made looser than other settings (e.g. `'*'`), with fall back to `allowed_origin_hostnames`, so that other Browser-based applications are able to upload datasets.

Example application is GiN (Galaxy in Notebooks), which can upload datasets from a User's computer to Galaxy via JS in a Jupyter Notebook: data is sent from user's computer directly to Galaxy, using credentials provided to GiN. Otherwise, datasets would need to be transferred from User's computer to Jupyter server, then sent e.g. via python/CURL/etc, to the Galaxy server, in order to get around CORS.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
