### PR TITLE
Disallow indexing of the /training-materials/ proxy used for "Tutorial Mode"

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow: /display?
 Disallow: /display_as?
+Disallow: /training-material/


### PR DESCRIPTION
Google search results are polluted currently with usegalaxy.*'s proxying of the training materials. I didn't know this until a user shared a `usegalaxy.be/training-material/` link to us, at which point some googling showed those results quite high. Many of the big galaxies are deploying the proxy route which let's us do awful, but useful, things, so I think we need to deploy this robots.txt everywhere.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
