### PR TITLE
[22.05] Fix encoding Decimal values and inf/-inf

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -120,7 +120,10 @@ from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.form_builder import SelectField
-from galaxy.util.json import safe_loads
+from galaxy.util.json import (
+    safe_loads,
+    swap_inf_nan,
+)
 from galaxy.util.rules_dsl import RuleSet
 from galaxy.util.template import (
     fill_template,
@@ -2459,7 +2462,7 @@ class Tool(Dictifiable):
                 "enctype": self.enctype,
             }
         )
-        return tool_model
+        return swap_inf_nan(tool_model)
 
     def populate_model(self, request_context, inputs, state_inputs, group_inputs, other_values=None):
         """

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -9,6 +9,7 @@ from collections.abc import (
     Mapping,
     Sequence,
 )
+from decimal import Decimal
 
 from ..util import unicodify
 
@@ -22,7 +23,8 @@ from_json_string = json.loads
 
 def swap_inf_nan(val):
     """
-    This takes an arbitrary object and preps it for jsonifying safely, templating Inf/NaN.
+    This takes an arbitrary object and preps it for jsonifying safely, templating Inf/NaN and
+    casting Decimal instances as strings.
     """
     if isinstance(val, str):
         # basestring first, because it's a sequence and would otherwise get caught below.
@@ -40,6 +42,8 @@ def swap_inf_nan(val):
             return "__-Infinity__"
         else:
             return val
+    elif isinstance(val, Decimal):
+        return str(val)
     else:
         return val
 
@@ -63,12 +67,12 @@ def safe_dumps(obj, **kwargs):
     """
     This is a wrapper around dumps that encodes Infinity and NaN values.  It's a
     fairly rare case (which will be low in request volume).  Basically, we tell
-    json.dumps to blow up if it encounters Infinity/NaN, and we 'fix' it before
-    re-encoding.
+    json.dumps to blow up if it encounters Infinity/NaN, or Decimal values,
+    and we 'fix' it before re-encoding.
     """
     try:
         dumped = json.dumps(obj, allow_nan=False, **kwargs)
-    except ValueError:
+    except (ValueError, TypeError):
         obj = swap_inf_nan(obj)
         dumped = json.dumps(obj, allow_nan=False, **kwargs)
     if kwargs.get("escape_closing_tags", True):

--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -67,7 +67,7 @@ def safe_dumps(obj, **kwargs):
     """
     This is a wrapper around dumps that encodes Infinity and NaN values.  It's a
     fairly rare case (which will be low in request volume).  Basically, we tell
-    json.dumps to blow up if it encounters Infinity/NaN, or Decimal values,
+    json.dumps to blow up if it encounters Infinity/NaN, or Decimal values
     and we 'fix' it before re-encoding.
     """
     try:

--- a/test/unit/util/test_json.py
+++ b/test/unit/util/test_json.py
@@ -1,0 +1,25 @@
+from decimal import Decimal
+
+import pytest
+
+from galaxy.util.json import (
+    safe_dumps,
+    swap_inf_nan,
+)
+
+
+@pytest.mark.parametrize(
+    "val,expected_val",
+    [
+        (float("inf"), "__Infinity__"),
+        (float("-inf"), "__-Infinity__"),
+        (float("NaN"), "__NaN__"),
+        (Decimal("1"), "1"),
+    ],
+)
+def test_swap_inf_nan(val, expected_val):
+    assert swap_inf_nan(val) == expected_val
+
+
+def test_safe_dumps():
+    assert safe_dumps({"a": Decimal("0.1")}) == """{"a": "0.1"}"""


### PR DESCRIPTION
Should fix:
```
TypeError: Object of type Decimal is not JSON serializable
  File "galaxy/web/framework/decorators.py", line 341, in decorator
    rval = format_return_as_json(rval, jsonp_callback, pretty=trans.debug)
  File "galaxy/web/framework/decorators.py", line 378, in format_return_as_json
    json = safe_dumps(rval, **dumps_kwargs)
  File "galaxy/util/json.py", line 70, in safe_dumps
    dumped = json.dumps(obj, allow_nan=False, **kwargs)
  File "__init__.py", line 234, in dumps
    return cls(
  File "json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
```
and maybe https://github.com/galaxyproject/galaxy/issues/9576 ? Not sure though if we ever interpreted `__Infinity__` in the client code. A quick search through the codebase didn't show anything.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
