### PR TITLE
Rename test to accurately describe the code it tests [improves content of new tutorial]

### DIFF
--- a/test/unit/data/security/test_validate_user_input.py
+++ b/test/unit/data/security/test_validate_user_input.py
@@ -32,7 +32,7 @@ def test_validate_username():
     assert validate_publicname_str("test user") != ""
 
 
-def test_validate_email():
+def test_validate_email_str():
     assert validate_email_str("test@foo.com") == ""
     assert validate_email_str("test-dot.user@foo.com") == ""
     assert validate_email_str("test-plus+user@foo.com") == ""


### PR DESCRIPTION
This is a tiny change, but I need it for the new Writing Tests tutorial.

The test targets the logic in `validate_email_str`, not `validate_email`. The tutorial will include tests for the `validate_email` function; renaming this will help eliminate possible confusion.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
