### PR TITLE
[22.05] Drop dataset error controller method

### DIFF
--- a/client/src/mvc/dataset/dataset-model.js
+++ b/client/src/mvc/dataset/dataset-model.js
@@ -75,7 +75,7 @@ var DatasetAssociation = Backbone.Model.extend(BASE_MVC.LoggableMixin).extend(
                     display: `datasets/${id}/display/?preview=True`,
                     edit: `datasets/edit?dataset_id=${id}`,
                     download: `api/datasets/${id}/display${this._downloadQueryParameters()}`,
-                    report_error: `dataset/errors?id=${id}`,
+                    report_error: `datasets/error?dataset_id=${id}`,
                     rerun: `tool_runner/rerun?id=${id}`,
                     show_params: `datasets/${id}/details`,
                     visualization: "visualization",

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -10,7 +10,6 @@ from markupsafe import escape
 
 from galaxy import (
     datatypes,
-    model,
     util,
     web,
 )
@@ -87,16 +86,6 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         return (allow_admin and trans.user_is_admin) or trans.app.security_agent.can_access_dataset(
             roles, dataset_association.dataset
         )
-
-    @web.expose
-    def errors(self, trans, id):
-        hda = trans.sa_session.query(model.HistoryDatasetAssociation).get(self.decode_id(id))
-
-        if not hda or not self._can_access_dataset(trans, hda):
-            return trans.show_error_message(
-                "Either this dataset does not exist or you do not have permission to access it."
-            )
-        return trans.fill_template("dataset/errors.mako", hda=hda)
 
     @web.expose
     def stdout(self, trans, dataset_id=None, **kwargs):


### PR DESCRIPTION
The mako is gone, this is all client-side. Also updates the link
generated in the legacy history. Fixes
https://sentry.galaxyproject.org/share/issue/99796552da0246ae982c33e2559fb1f7/:
```
TopLevelLookupException: Can't locate template for uri 'dataset/errors.mako'
  File "uvicorn/protocols/http/h11_impl.py", line 366, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "uvicorn/middleware/proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
  File "fastapi/applications.py", line 269, in __call__
    await super().__call__(scope, receive, send)
  File "starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "starlette/middleware/base.py", line 69, in __call__
    await response(scope, receive, send)
  File "starlette/responses.py", line 260, in __call__
    await wrap(partial(self.listen_for_disconnect, receive))
  File "anyio/_backends/_asyncio.py", line 662, in __aexit__
    raise exceptions[0]
  File "starlette/responses.py", line 256, in wrap
    await func()
  File "starlette/responses.py", line 245, in stream_response
    async for chunk in self.body_iterator:
  File "starlette/middleware/base.py", line 58, in body_stream
    raise app_exc
  File "starlette/middleware/base.py", line 36, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "starlette_context/middleware/raw_middleware.py", line 96, in __call__
    await self.app(scope, receive, send_wrapper)
  File "starlette/middleware/base.py", line 69, in __call__
    await response(scope, receive, send)
  File "starlette/responses.py", line 260, in __call__
    await wrap(partial(self.listen_for_disconnect, receive))
  File "anyio/_backends/_asyncio.py", line 662, in __aexit__
    raise exceptions[0]
  File "starlette/responses.py", line 256, in wrap
    await func()
  File "starlette/responses.py", line 245, in stream_response
    async for chunk in self.body_iterator:
  File "starlette/middleware/base.py", line 58, in body_stream
    raise app_exc
  File "starlette/middleware/base.py", line 36, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "starlette/middleware/base.py", line 69, in __call__
    await response(scope, receive, send)
  File "starlette/responses.py", line 260, in __call__
    await wrap(partial(self.listen_for_disconnect, receive))
  File "anyio/_backends/_asyncio.py", line 662, in __aexit__
    raise exceptions[0]
  File "starlette/responses.py", line 256, in wrap
    await func()
  File "starlette/responses.py", line 245, in stream_response
    async for chunk in self.body_iterator:
  File "starlette/middleware/base.py", line 58, in body_stream
    raise app_exc
  File "starlette/middleware/base.py", line 36, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "starlette/exceptions.py", line 93, in __call__
    raise exc
  File "starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "starlette/routing.py", line 418, in handle
    await self.app(scope, receive, send)
  File "a2wsgi/wsgi.py", line 140, in __call__
    return await responder(scope, receive, send)
  File "a2wsgi/wsgi.py", line 179, in __call__
    raise self.exc_info[0].with_traceback(
  File "galaxy/web/framework/middleware/error.py", line 165, in __call__
    app_iter = self.application(environ, sr_checker)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 29, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 159, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 244, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 99, in errors
    return trans.fill_template("dataset/errors.mako", hda=hda)
  File "galaxy/webapps/base/webapp.py", line 1095, in fill_template
    return self.fill_template_mako(filename, **kwargs)
  File "galaxy/webapps/base/webapp.py", line 1099, in fill_template_mako
    template = template_lookup.get_template(filename)
  File "mako/lookup.py", line 254, in get_template
    raise exceptions.TopLevelLookupException(
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
