### PR TITLE
[22.05] Check for app_name and link_name before unquoting

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -702,6 +702,10 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         **kwds,
     ):
         """Access to external display applications"""
+        if None in [app_name, link_name]:
+            return trans.show_error_message("A display application name and link name must be provided.")
+        app_name = unquote_plus(app_name)
+        link_name = unquote_plus(link_name)
         # Build list of parameters to pass in to display application logic (app_kwds)
         app_kwds = {}
         for name, value in dict(kwds).items():  # clone kwds because we remove stuff as we go.
@@ -723,10 +727,6 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         else:
             user_roles = []
         # Decode application name and link name
-        app_name = unquote_plus(app_name)
-        link_name = unquote_plus(link_name)
-        if None in [app_name, link_name]:
-            return trans.show_error_message("A display application name and link name must be provided.")
         if self._can_access_dataset(trans, data, additional_roles=user_roles):
             msg = []
             preparable_steps = []


### PR DESCRIPTION
Should fix
https://sentry.galaxyproject.org/share/issue/f20a1d47fab04ca8bca7a657d81fb568/:
```
AttributeError: 'NoneType' object has no attribute 'replace'
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 29, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 159, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 244, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/web/framework/decorators.py", line 138, in set_nocache_headers
    return func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 738, in display_application
    link_name = unquote_plus(link_name)
  File "urllib/parse.py", line 777, in unquote_plus
    string = string.replace('+', ' ')
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
