### PR TITLE
[22.05] Avoid race condition in disk object store delete

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -653,9 +653,11 @@ class DiskObjectStore(ConcreteObjectStore):
             if entire_dir and (extra_dir or obj_dir):
                 shutil.rmtree(path)
                 return True
-            if self._exists(obj, **kwargs):
-                os.remove(path)
-                return True
+            os.remove(path)
+            return True
+        except FileNotFoundError:
+            # Absolutely possible that a delete request races, but that's "fine".
+            return True
         except OSError as ex:
             log.critical(f"{self.__get_filename(obj, **kwargs)} delete error {ex}")
         return False


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/share/issue/f48a997e238e46519b67d455ac9bf8bd/:
```
/corral4/main/objects/b/e/1/dataset_be145ee3-580b-48c3-8a40-e55929d3bb81.dat delete error [Errno 2] No such file or directory: '/corral4/main/objects/b/e/1/dataset_be145ee3-580b-48c3-8a40-e55929d3bb81.dat'
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
