### PR TITLE
[22.05] Deleted, discarded and deferred file not found tweaks

### DIFF
--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -101,9 +101,9 @@ export default {
             return `${getAppRoot()}workflows/${this.workflow.id}/invocations`;
         },
         urlViewShared() {
-            return `${getAppRoot()}workflow/display_by_username_and_slug?username=${this.workflow.owner}&slug=${
-                this.workflow.slug
-            }`;
+            return `${getAppRoot()}workflow/display_by_username_and_slug?username=${
+                this.workflow.owner
+            }&slug=${encodeURIComponent(this.workflow.slug)}`;
         },
         readOnly() {
             return !!this.workflow.shared;

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -27,6 +27,7 @@ from galaxy.datatypes.util.gff_util import (
     parse_gff3_attributes,
     parse_gff_attributes,
 )
+from galaxy.model import DatasetInstance
 from galaxy.util import compression_utils
 from . import (
     data,
@@ -167,10 +168,11 @@ class Interval(Tabular):
                     else:
                         empty_line_count += 1
 
-    def displayable(self, dataset):
+    def displayable(self, dataset: DatasetInstance):
         try:
             return (
-                dataset.has_data()
+                not dataset.dataset.purged
+                and dataset.has_data()
                 and dataset.state == dataset.states.OK
                 and dataset.metadata.columns > 0
                 and dataset.metadata.data_lines != 0

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -34,6 +34,7 @@ from galaxy.datatypes.sniff import (
     iter_headers,
     validate_tabular,
 )
+from galaxy.model import DatasetInstance
 from galaxy.util import compression_utils
 from . import dataproviders
 
@@ -90,10 +91,11 @@ class TabularData(data.Text):
         if dataset.metadata.comment_lines:
             dataset.blurb = f"{dataset.blurb}, {util.commaify(str(dataset.metadata.comment_lines))} comments"
 
-    def displayable(self, dataset):
+    def displayable(self, dataset: DatasetInstance):
         try:
             return (
-                dataset.has_data()
+                not dataset.dataset.purged
+                and dataset.has_data()
                 and dataset.state == dataset.states.OK
                 and dataset.metadata.columns > 0
                 and dataset.metadata.data_lines != 0

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -25,6 +25,7 @@ from galaxy.managers.hdas import (
     HDAManager,
 )
 from galaxy.managers.histories import HistoryManager
+from galaxy.model import Dataset
 from galaxy.model.item_attrs import (
     UsesAnnotations,
     UsesItemRatings,
@@ -152,11 +153,17 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             return trans.show_error_message("You are not allowed to access this dataset")
         if data.purged:
             return trans.show_error_message("The dataset you are attempting to view has been purged.")
-        if data.deleted and not (trans.user_is_admin or (data.history and trans.get_user() == data.history.user)):
+        elif data.deleted and not (trans.user_is_admin or (data.history and trans.get_user() == data.history.user)):
             return trans.show_error_message("The dataset you are attempting to view has been deleted.")
-        if data.state == trans.model.Dataset.states.UPLOAD:
+        elif data.state == Dataset.states.UPLOAD:
             return trans.show_error_message(
                 "Please wait until this dataset finishes uploading before attempting to view it."
+            )
+        elif data.state == Dataset.states.DISCARDED:
+            return trans.show_error_message("The dataset you are attempting to view has been discarded.")
+        elif data.state == Dataset.states.DEFERRED:
+            return trans.show_error_message(
+                "The dataset you are attempting to view has deferred data. You can only use this dataset as input for jobs."
             )
         return data
 

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -165,6 +165,10 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             return trans.show_error_message(
                 "The dataset you are attempting to view has deferred data. You can only use this dataset as input for jobs."
             )
+        elif data.state == Dataset.states.PAUSED:
+            return trans.show_error_message(
+                "The dataset you are attempting to view is in paused state. One of the inputs for the job that creates this dataset has failed."
+            )
         return data
 
     @web.expose

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -9,6 +9,7 @@ from pydantic import (
     BaseModel,
     Extra,
     Field,
+    ValidationError,
 )
 
 from galaxy import exceptions
@@ -254,4 +255,10 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
             return result
 
         rval = [serialize_element(el) for el in contents]
-        return DatasetCollectionContentElements.parse_obj(rval)
+        try:
+            return DatasetCollectionContentElements.parse_obj(rval)
+        except ValidationError:
+            log.exception(
+                f"Serializing DatasetCollectionContentsElements failed. Collection is populated: {hdca.collection.populated}"
+            )
+            raise


### PR DESCRIPTION
See the commits for details, fixes https://sentry.galaxyproject.org/share/issue/395cb0fc507e400fb2f55048d5f7b42e/ and https://sentry.galaxyproject.org/share/issue/77cd5728ab4e4911a62db7a08a09dbee/ and a bunch more that I'm not finding now.

This should totally have more tests, but I also hope this is going to be removed soon with proper client-side rendering and reasonable API routes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Create discarded, purged and deferred datasets, and try to display them via the eye icon or go directly to the controller URLs (http://127.0.0.1:8080/datasets/${hda_id}/display/?preview=True, http://127.0.0.1:8080/u/${your_username}/d/${hda_id}). You don't want to see internal server errors there.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
