### PR TITLE
Add support for sorting contents in data libraries

### DIFF
--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -62,7 +62,7 @@
                         class="form-control input_library_name"
                         rows="3" />
 
-                    <div v-else-if="row.item.deleted && include_deleted" class="deleted-item">{{ row.item.name }}</div>
+                    <div v-else-if="row.item.deleted && includeDeleted" class="deleted-item">{{ row.item.name }}</div>
                     <b-link v-else :to="{ path: `folders/${row.item.root_folder_id}` }">{{ row.item.name }}</b-link>
                 </template>
                 <template v-slot:cell(description)="{ item }">
@@ -212,7 +212,7 @@ export default {
             perPage: DEFAULT_PER_PAGE,
             librariesList: [],
             maxDescriptionLength: MAX_DESCRIPTION_LENGTH,
-            include_deleted: false,
+            includeDeleted: false,
             exclude_restricted: false,
             filterOn: [],
             excluded: [],
@@ -243,11 +243,11 @@ export default {
     created() {
         this.root = getAppRoot();
         this.services = new Services({ root: this.root });
-        this.loadLibraries(this.include_deleted);
+        this.loadLibraries(this.includeDeleted);
     },
     methods: {
-        loadLibraries(include_deleted = false) {
-            this.services.getLibraries(include_deleted).then((result) => (this.librariesList = result));
+        loadLibraries(includeDeleted = false) {
+            this.services.getLibraries(includeDeleted).then((result) => (this.librariesList = result));
         },
         toggleEditMode(item) {
             item.editMode = !item.editMode;
@@ -282,7 +282,7 @@ export default {
                     Toast.success("Library has been marked deleted.");
                     deletedLib.deleted = true;
                     this.toggleEditMode(deletedLib);
-                    if (!this.include_deleted) {
+                    if (!this.includeDeleted) {
                         this.hideOn("deleted", false);
                     }
                 },
@@ -301,9 +301,9 @@ export default {
             this.filter = value;
         },
         toggle_include_deleted(isDeletedIncluded) {
-            this.include_deleted = isDeletedIncluded;
-            if (this.include_deleted) {
-                this.services.getLibraries(this.include_deleted).then((result) => {
+            this.includeDeleted = isDeletedIncluded;
+            if (this.includeDeleted) {
+                this.services.getLibraries(this.includeDeleted).then((result) => {
                     this.librariesList = this.librariesList.concat(result);
                     this.$refs.libraries_list.refresh();
                 });

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -29,6 +29,7 @@
                 selectable
                 no-select-on-click
                 show-empty
+                @sort-changed="onSort"
                 @row-clicked="onRowClick">
                 <template v-slot:empty>
                     <div v-if="isBusy" class="text-center my-2">
@@ -293,7 +294,6 @@ function initialFolderState() {
         expandedMessage: [],
         folderContents: [],
         includeDeleted: false,
-        searchText: "",
         isAllSelectedMode: false,
     };
 }
@@ -323,7 +323,10 @@ export default {
         return {
             ...initialFolderState(),
             ...{
-                currentPage: null,
+                currentPage: 1,
+                sortBy: "name",
+                sortDesc: false,
+                searchText: "",
                 currentFolderId: null,
                 error: null,
                 isBusy: false,
@@ -338,12 +341,16 @@ export default {
         };
     },
     watch: {
-        perPage: {
-            handler: function (value) {
-                this.fetchFolderContents();
-            },
+        perPage() {
+            this.fetchFolderContents();
         },
         includeDeleted() {
+            this.fetchFolderContents();
+        },
+        sortBy() {
+            this.fetchFolderContents();
+        },
+        sortDesc() {
             this.fetchFolderContents();
         },
     },
@@ -362,12 +369,18 @@ export default {
             const data = initialFolderState();
             Object.keys(data).forEach((k) => (this[k] = data[k]));
         },
+        onSort(props) {
+            this.sortBy = props.sortBy;
+            this.sortDesc = props.sortDesc;
+        },
         fetchFolderContents() {
             this.setBusy(true);
             this.services
                 .getFolderContents(
                     this.currentFolderId,
                     this.includeDeleted,
+                    this.sortBy,
+                    this.sortDesc,
                     this.perPage,
                     (this.currentPage - 1) * this.perPage,
                     this.searchText

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -293,7 +293,7 @@ function initialFolderState() {
         expandedMessage: [],
         folderContents: [],
         includeDeleted: false,
-        search_text: "",
+        searchText: "",
         isAllSelectedMode: false,
     };
 }
@@ -370,7 +370,7 @@ export default {
                     this.includeDeleted,
                     this.perPage,
                     (this.currentPage - 1) * this.perPage,
-                    this.search_text
+                    this.searchText
                 )
                 .then((response) => {
                     this.folderContents = response.folder_contents;
@@ -393,7 +393,7 @@ export default {
                 });
         },
         updateSearchValue(value) {
-            this.search_text = value;
+            this.searchText = value;
             this.folderContents = [];
             this.fetchFolderContents();
         },

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -3,7 +3,7 @@
         <div>
             <FolderTopBar
                 :folder-contents="folderContents"
-                :include_deleted="include_deleted"
+                :include-deleted.sync="includeDeleted"
                 :folder_id="current_folder_id"
                 :selected="selected"
                 :metadata="folder_metadata"
@@ -292,7 +292,7 @@ function initialFolderState() {
         unselected: [],
         expandedMessage: [],
         folderContents: [],
-        include_deleted: false,
+        includeDeleted: false,
         search_text: "",
         isAllSelectedMode: false,
     };
@@ -340,8 +340,11 @@ export default {
     watch: {
         perPage: {
             handler: function (value) {
-                this.fetchFolderContents(this.include_deleted);
+                this.fetchFolderContents();
             },
+        },
+        includeDeleted() {
+            this.fetchFolderContents();
         },
     },
     created() {
@@ -353,19 +356,18 @@ export default {
             this.current_folder_id = folder_id;
             this.currentPage = page;
             this.resetData();
-            this.fetchFolderContents(this.include_deleted);
+            this.fetchFolderContents();
         },
         resetData() {
             const data = initialFolderState();
             Object.keys(data).forEach((k) => (this[k] = data[k]));
         },
-        fetchFolderContents(include_deleted = false) {
-            this.include_deleted = include_deleted;
+        fetchFolderContents() {
             this.setBusy(true);
             this.services
                 .getFolderContents(
                     this.current_folder_id,
-                    include_deleted,
+                    this.includeDeleted,
                     this.perPage,
                     (this.currentPage - 1) * this.perPage,
                     this.search_text
@@ -393,7 +395,7 @@ export default {
         updateSearchValue(value) {
             this.search_text = value;
             this.folderContents = [];
-            this.fetchFolderContents(this.include_deleted);
+            this.fetchFolderContents();
         },
         selectAllRenderedRows() {
             this.$refs.folder_content_table.items.forEach((row, index) => {
@@ -413,7 +415,7 @@ export default {
             this.$refs.folder_content_table.refresh();
         },
         refreshTableContent() {
-            this.fetchFolderContents(this.include_deleted);
+            this.fetchFolderContents();
         },
         deleteFromTable(deletedItem) {
             this.folderContents = this.folderContents.filter((element) => {

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -4,7 +4,7 @@
             <FolderTopBar
                 :folder-contents="folderContents"
                 :include-deleted.sync="includeDeleted"
-                :folder_id="current_folder_id"
+                :folder_id="currentFolderId"
                 :selected="selected"
                 :metadata="folder_metadata"
                 :unselected="unselected"
@@ -324,7 +324,7 @@ export default {
             ...initialFolderState(),
             ...{
                 currentPage: null,
-                current_folder_id: null,
+                currentFolderId: null,
                 error: null,
                 isBusy: false,
                 folder_metadata: {},
@@ -353,7 +353,7 @@ export default {
     },
     methods: {
         getFolder(folder_id, page) {
-            this.current_folder_id = folder_id;
+            this.currentFolderId = folder_id;
             this.currentPage = page;
             this.resetData();
             this.fetchFolderContents();
@@ -366,7 +366,7 @@ export default {
             this.setBusy(true);
             this.services
                 .getFolderContents(
-                    this.current_folder_id,
+                    this.currentFolderId,
                     this.includeDeleted,
                     this.perPage,
                     (this.currentPage - 1) * this.perPage,
@@ -535,7 +535,7 @@ export default {
             } else {
                 this.services.newFolder(
                     {
-                        parent_id: this.current_folder_id,
+                        parent_id: this.currentFolderId,
                         name: folder.name,
                         description: folder.description,
                     },

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -240,7 +240,7 @@ export default {
                 const selected = await this.services.getFilteredFolderContents(
                     this.folder_id,
                     this.unselected,
-                    this.$parent.search_text
+                    this.$parent.searchText
                 );
                 this.$emit("setBusy", false);
                 return selected;

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -101,11 +101,7 @@
                     </button>
                     <FolderDetails :id="folder_id" class="mr-1" :metadata="metadata" />
                     <div v-if="canDelete" class="form-check logged-dataset-manipulation mr-1">
-                        <b-form-checkbox
-                            id="checkbox-1"
-                            :checked="include_deleted"
-                            name="checkbox-1"
-                            @input="toggle_include_deleted($event)">
+                        <b-form-checkbox :checked="includeDeleted" @change="$emit('update:includeDeleted', $event)">
                             include deleted
                         </b-form-checkbox>
                     </div>
@@ -155,7 +151,7 @@ export default {
             type: String,
             required: true,
         },
-        include_deleted: {
+        includeDeleted: {
             type: Boolean,
             required: true,
         },
@@ -340,9 +336,6 @@ export default {
                 },
                 cache: true,
             });
-        },
-        toggle_include_deleted: function (value) {
-            this.$emit("fetchFolderContents", value);
         },
         updateContent: function () {
             this.$emit("fetchFolderContents");

--- a/client/src/components/Libraries/LibraryFolder/services.js
+++ b/client/src/components/Libraries/LibraryFolder/services.js
@@ -7,14 +7,23 @@ export class Services {
         this.root = options.root || getAppRoot();
     }
 
-    async getFolderContents(id, includeDeleted, limit, offset, searchText = false) {
-        const url = `${
-            this.root
-        }api/folders/${id}/contents?include_deleted=${includeDeleted}&limit=${limit}&offset=${offset}${this.getSearchQuery(
-            searchText
-        )}`;
+    async getFolderContents(folderId, includeDeleted, sortBy, sortDesc, limit, offset, searchText) {
+        const url = `${this.root}api/folders/${folderId}/contents`;
+        const config = {
+            params: {
+                include_deleted: includeDeleted,
+                sort_by: sortBy,
+                sort_desc: sortDesc,
+                limit,
+                offset,
+            },
+        };
+        searchText = searchText.trim();
+        if (searchText) {
+            config.params.search_text = searchText;
+        }
         try {
-            const response = await axios.get(url);
+            const response = await axios.get(url, config);
             return response.data;
         } catch (e) {
             rethrowSimple(e);

--- a/client/src/components/Libraries/LibraryFolder/services.js
+++ b/client/src/components/Libraries/LibraryFolder/services.js
@@ -7,11 +7,11 @@ export class Services {
         this.root = options.root || getAppRoot();
     }
 
-    async getFolderContents(id, includeDeleted, limit, offset, search_text = false) {
+    async getFolderContents(id, includeDeleted, limit, offset, searchText = false) {
         const url = `${
             this.root
         }api/folders/${id}/contents?include_deleted=${includeDeleted}&limit=${limit}&offset=${offset}${this.getSearchQuery(
-            search_text
+            searchText
         )}`;
         try {
             const response = await axios.get(url);
@@ -21,15 +21,15 @@ export class Services {
         }
     }
 
-    async getFilteredFolderContents(id, excluded, search_text) {
-        const contents = await axios.get(`${this.root}api/folders/${id}/contents?${this.getSearchQuery(search_text)}`);
+    async getFilteredFolderContents(id, excluded, searchText) {
+        const contents = await axios.get(`${this.root}api/folders/${id}/contents?${this.getSearchQuery(searchText)}`);
         return contents.data.folder_contents.filter((item) => {
             return !excluded.some((exc) => exc.id === item.id);
         });
     }
 
-    getSearchQuery(search_text) {
-        return search_text ? `&search_text=${encodeURI(search_text.trim())}` : "";
+    getSearchQuery(searchText) {
+        return searchText ? `&search_text=${encodeURI(searchText.trim())}` : "";
     }
 
     updateFolder(item, onSucess, onError) {

--- a/client/src/components/Libraries/LibraryFolder/services.js
+++ b/client/src/components/Libraries/LibraryFolder/services.js
@@ -7,10 +7,10 @@ export class Services {
         this.root = options.root || getAppRoot();
     }
 
-    async getFolderContents(id, include_deleted, limit, offset, search_text = false) {
+    async getFolderContents(id, includeDeleted, limit, offset, search_text = false) {
         const url = `${
             this.root
-        }api/folders/${id}/contents?include_deleted=${include_deleted}&limit=${limit}&offset=${offset}${this.getSearchQuery(
+        }api/folders/${id}/contents?include_deleted=${includeDeleted}&limit=${limit}&offset=${offset}${this.getSearchQuery(
             search_text
         )}`;
         try {

--- a/client/src/components/Libraries/LibraryFolder/table-fields.js
+++ b/client/src/components/Libraries/LibraryFolder/table-fields.js
@@ -16,7 +16,7 @@ export const fields = [
     {
         label: "Description",
         key: "message",
-        sortable: false,
+        sortable: true,
     },
     {
         label: "Type",
@@ -36,7 +36,7 @@ export const fields = [
     {
         label: "State",
         key: "state",
-        sortable: true,
+        sortable: false,
     },
     {
         label: "",

--- a/client/src/components/Libraries/services.js
+++ b/client/src/components/Libraries/services.js
@@ -7,8 +7,8 @@ export class Services {
         this.root = options.root || getAppRoot();
     }
 
-    async getLibraries(include_deleted = false) {
-        const url = `${this.root}api/libraries?deleted=${include_deleted}`;
+    async getLibraries(includeDeleted = false) {
+        const url = `${this.root}api/libraries?deleted=${includeDeleted}`;
         try {
             const response = await axios.get(url);
             return response.data;

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -485,23 +485,16 @@ class FolderManager:
 
         return query
 
-    def build_folder_path(self, trans, folder):
+    def build_folder_path(self, trans, folder: model.LibraryFolder) -> List[Tuple[str, str]]:
         """
-        Search the path upwards recursively and load the whole route of
-        names and ids for breadcrumb building purposes.
+        Returns the folder path from root to the given folder.
 
-        :param folder: current folder for navigating up
-        :param type:   Galaxy LibraryFolder
-
-        :returns:   list consisting of full path to the library
-        :type:      list
+        The path items are tuples with the name and id of each folder for breadcrumb building purposes.
         """
-        path_to_root = []
-        # We are almost in root
-        encoded_id = trans.security.encode_id(folder.id)
-        path_to_root.append((f"F{encoded_id}", folder.name))
-        if folder.parent_id is not None:
-            # We add the current folder and traverse up one folder.
-            upper_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(folder.parent_id)
-            path_to_root.extend(self.build_folder_path(trans, upper_folder))
+        current_folder = folder
+        path_to_root = [(f"F{trans.security.encode_id(current_folder.id)}", current_folder.name)]
+        while current_folder.parent_id is not None:
+            parent_folder = trans.sa_session.query(model.LibraryFolder).get(current_folder.parent_id)
+            current_folder = parent_folder
+            path_to_root.insert(0, (f"F{trans.security.encode_id(current_folder.id)}", current_folder.name))
         return path_to_root

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -463,12 +463,20 @@ class FolderManager:
             # We check against the actual dataset and not the ldda (for now?)
             associated_dataset = aliased(model.Dataset)
             dataset_permission = aliased(model.DatasetPermissions)
+            is_public_dataset = not_(
+                sa_session.query(model.DatasetPermissions)
+                .filter(
+                    model.DatasetPermissions.dataset_id == associated_dataset.id,
+                    model.DatasetPermissions.action == access_action,
+                )
+                .exists()
+            )
             query = query.outerjoin(ldda.dataset.of_type(associated_dataset))
             query = query.outerjoin(associated_dataset.actions.of_type(dataset_permission))
             query = query.filter(
                 or_(
                     # The dataset is public
-                    not_(dataset_permission.action == access_action),
+                    is_public_dataset,
                     # The user has explicit access
                     and_(
                         dataset_permission.action == access_action,

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1146,7 +1146,7 @@ class GalaxyRBACAgent(RBACAgent):
         private_role = self.get_private_user_role(trans.user)
         access_roles = dataset.get_access_roles(self)
 
-        if len(access_roles) != 1:
+        if len(access_roles) != 1 or private_role is None:
             return False
         else:
             if access_roles[0].id == private_role.id:

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2531,11 +2531,21 @@ class LibraryFolderCurrentPermissions(BaseModel):
     )
 
 
+class LibraryFolderContentsIndexSortByEnum(str, Enum):
+    name = "name"
+    description = "description"
+    type = "type"
+    size = "size"
+    update_time = "update_time"
+
+
 class LibraryFolderContentsIndexQueryPayload(Model):
     limit: int = 10
     offset: int = 0
     search_text: Optional[str] = None
     include_deleted: Optional[bool] = None
+    order_by: LibraryFolderContentsIndexSortByEnum = LibraryFolderContentsIndexSortByEnum.name
+    sort_desc: Optional[bool] = False
 
 
 class LibraryFolderItemBase(Model):

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -16,6 +16,7 @@ from galaxy.schema.schema import (
     CreateLibraryFilePayload,
     LibraryFolderContentsIndexQueryPayload,
     LibraryFolderContentsIndexResult,
+    LibraryFolderContentsIndexSortByEnum,
 )
 from galaxy.webapps.galaxy.services.library_folder_contents import LibraryFolderContentsService
 from . import (
@@ -52,6 +53,18 @@ IncludeDeletedQueryParam: Optional[bool] = Query(
     description="Returns also deleted contents. Deleted contents can only be retrieved by Administrators or users with",
 )
 
+SortByQueryParam: LibraryFolderContentsIndexSortByEnum = Query(
+    default=LibraryFolderContentsIndexSortByEnum.name,
+    title="Sort By",
+    description="Sort results by specified field.",
+)
+
+SortDescQueryParam: Optional[bool] = Query(
+    default=False,
+    title="Sort Descending",
+    description="Sort results in descending order.",
+)
+
 
 @router.cbv
 class FastAPILibraryFoldersContents:
@@ -75,11 +88,15 @@ class FastAPILibraryFoldersContents:
         offset: int = OffsetQueryParam,
         search_text: Optional[str] = SearchQueryParam,
         include_deleted: Optional[bool] = IncludeDeletedQueryParam,
+        order_by: LibraryFolderContentsIndexSortByEnum = SortByQueryParam,
+        sort_desc: Optional[bool] = SortDescQueryParam,
     ):
         """Returns a list of a folder's contents (files and sub-folders).
 
         Additional metadata for the folder is provided in the response as a separate object containing data
         for breadcrumb path building, permissions and other folder's details.
+
+        *Note*: When sorting, folders always have priority (they show-up before any dataset regardless of the sorting).
 
         **Security note**:
         - Accessing a library folder or sub-folder requires only access to the parent library.
@@ -87,7 +104,12 @@ class FastAPILibraryFoldersContents:
         - Datasets may be public, private or restricted (to a group of users). Listing deleted datasets has the same requirements as folders.
         """
         payload = LibraryFolderContentsIndexQueryPayload(
-            limit=limit, offset=offset, search_text=search_text, include_deleted=include_deleted
+            limit=limit,
+            offset=offset,
+            search_text=search_text,
+            include_deleted=include_deleted,
+            order_by=order_by,
+            sort_desc=sort_desc,
         )
         return self.service.index(trans, folder_id, payload)
 

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -80,6 +80,11 @@ class FastAPILibraryFoldersContents:
 
         Additional metadata for the folder is provided in the response as a separate object containing data
         for breadcrumb path building, permissions and other folder's details.
+
+        **Security note**:
+        - Accessing a library folder or sub-folder requires only access to the parent library.
+        - Deleted folders can only be accessed by admins or users with `MODIFY` permission.
+        - Datasets may be public, private or restricted (to a group of users). Listing deleted datasets has the same requirements as folders.
         """
         payload = LibraryFolderContentsIndexQueryPayload(
             limit=limit, offset=offset, search_text=search_text, include_deleted=include_deleted

--- a/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
@@ -76,9 +76,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
         tag_manager = tags.GalaxyTagHandler(trans.sa_session)
 
         folder_contents = []
-        contents, total_rows = self.folder_manager.get_contents(
-            trans, folder, payload.include_deleted, payload.search_text, payload.offset, payload.limit
-        )
+        contents, total_rows = self.folder_manager.get_contents(trans, folder, payload)
         for content_item in contents:
             if isinstance(content_item, model.LibraryFolder):
                 serialized_item = self._serialize_library_folder(user_permissions, content_item)

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -118,22 +118,22 @@ class FolderContentsApiTestCase(ApiTestCase):
         folder_name = "Test Folder Contents Index search text"
         folder_id = self._create_folder_in_library(folder_name)
 
-        dataset_names = ["AB", "BC", "ABC"]
+        dataset_names = ["AB", "BX", "abx"]
         for name in dataset_names:
             self._create_dataset_in_folder(folder_id, name)
 
-        subfolder_names = ["Folder_A", "Folder_C"]
+        subfolder_names = ["Folder_a", "Folder_X"]
         for name in subfolder_names:
             self._create_subfolder_in(folder_id, name)
 
         all_names = dataset_names + subfolder_names
 
-        search_terms = ["A", "B", "C"]
+        search_terms = ["A", "B", "X"]
         for search_text in search_terms:
             response = self._get(f"folders/{folder_id}/contents?search_text={search_text}")
             self._assert_status_code_is(response, 200)
             contents = response.json()["folder_contents"]
-            matching_names = [name for name in all_names if search_text in name]
+            matching_names = [name for name in all_names if search_text.casefold() in name.casefold()]
             assert len(contents) == len(matching_names)
 
     def test_index_permissions_include_deleted(self):


### PR DESCRIPTION
Requires #14236 and Fixes #14256 

## Before
The library folder contents could not be ordered by column, the option was there but was only reordering the currently visible page items.

![before_correct_order](https://user-images.githubusercontent.com/46503462/178991956-b95d17bc-b8d7-46f3-aabe-b6762b5dcbab.gif)

## After
The library folder contents API now supports ordering by some properties and sorting in descending or ascending order. The data libraries UI now uses the correct query to show the correct ordering when sorting by column.

![correct_order](https://user-images.githubusercontent.com/46503462/178992523-17d4a1d6-8e71-498d-8ca1-b18a5ea77b94.gif)

## Some considerations
- Folders are treated slightly differently than datasets since they don't have the same properties.
- Folders will always be shown in the first pages regardless of the ordering.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to Data Libraries
  - Navigate to a folder with multiple pages
  - Try sorting by any of the available options

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
