### PR TITLE
[22.05] Increase contrast of Beta label (accessibility) in Storage Dashboard

### DIFF
--- a/client/src/components/User/DiskUsage/Management/StorageManager.vue
+++ b/client/src/components/User/DiskUsage/Management/StorageManager.vue
@@ -3,7 +3,7 @@
         <b-container fluid>
             <b-link to="StorageDashboard">{{ goBackText }}</b-link>
             <h2 class="text-center my-3">
-                <b>{{ title }}</b> <sup class="text-secondary">(Beta)</sup>
+                <b>{{ title }}</b> <sup class="text-beta">(Beta)</sup>
             </h2>
 
             <b-row class="justify-content-md-center">
@@ -102,3 +102,8 @@ export default {
     },
 };
 </script>
+<style lang="css" scoped>
+.text-beta {
+    color: #717273;
+}
+</style>


### PR DESCRIPTION
Fixes #14298

For some unknown reason, the default `text-secondary` in Bootstrap doesn't have enough contrast on white background. Thanks @hexylena for noticing.

### Before
![image](https://user-images.githubusercontent.com/46503462/178282184-d769f34d-a2d2-429d-bae5-46b698c7ea1d.png)


### After
![image](https://user-images.githubusercontent.com/46503462/178281853-9f96181e-b020-45c0-b637-e010ea692697.png)


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
