### PR TITLE
Add test case for setting unsettable metadata

### DIFF
--- a/test/functional/tools/metadata.xml
+++ b/test/functional/tools/metadata.xml
@@ -5,7 +5,9 @@ cp '$input.extra_files_path'/* '$output_copy_of_input.extra_files_path' &&
 echo '$input.metadata.base_name' > '$output_of_input_metadata'
     ]]></command>
     <inputs>
-        <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
+        <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth.">
+            <validator type="expression" message="Wrong metadata">value.metadata.base_name == 'Example Metadata'</validator>
+        </param>
     </inputs>
     <outputs>
         <data name="output_of_input_metadata" format="txt" />

--- a/test/functional/tools/metadata2.xml
+++ b/test/functional/tools/metadata2.xml
@@ -1,0 +1,30 @@
+<tool id="metadata2" name="metadata2" version="1.0.0">
+    <command><![CDATA[
+echo 'columns $input.metadata.columns' > '$output_of_input_metadata' &&
+echo 'column_types $input.metadata.column_types' >> '$output_of_input_metadata' &&
+echo 'column_names $input.metadata.column_names' >> '$output_of_input_metadata'
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" format="tabular" label="Tabular Dataset"/>
+    </inputs>
+    <outputs>
+        <data name="output_of_input_metadata" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="1.tabular" ftype="tabular" >
+                <metadata name="columns" value="2" />
+                <metadata name="column_names" value="1,2,3" />
+                <metadata name="column_types" value="str,int,str" />
+            </param>
+            <!-- This ouptut tests setting input metadata above -->
+            <output name="output_of_input_metadata" ftype="txt">
+                <assert_contents>
+                    <has_line line="columns: 2" />
+                    <has_line line="column_names: 1,2,3" />
+                    <has_line line="column_types: str,int,str" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -64,6 +64,7 @@
   <tool file="unicode_stream.xml" />
   <tool file="vcf_bgzip.xml" />
   <tool file="metadata.xml" />
+  <tool file="metadata2.xml" />
   <tool file="metadata_bam.xml" />
   <tool file="metadata_bcf.xml" />
   <tool file="metadata_biom1.xml" />


### PR DESCRIPTION
Input parameter validators allow to check for metadata. For tabular data checking `columns`, `column_names` seems particularly useful to restrict possible inputs. 

This may work in Galaxy (no idea if it does), but in order to use this in Galaxy tool tests one would need to be able to set this metadata elements. But this seems only possible if `set_in_upload=True` is enabled in the metadata definition of the datatype, like here: https://github.com/galaxyproject/galaxy/blob/1e122858abb7f15320cc36c9166e44fc90083e82/lib/galaxy/datatypes/assembly.py#L135

Given that `set_in_upload` is only set approx. a dozed times this features is more or less unusable in tool tests. 

This seems analogous to https://github.com/galaxyproject/galaxy/pull/12709 where I argued that it should be possible to upload arbitrary datatypes in tool tests, while still forbidding users to upload datatypes for which `display_in_upload="true"` is not set. 

Ideas how to enable this in tool tests are very welcome. 

There is of course the additional problem how to set `list` metadata like `column_names` in tests.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
