### PR TITLE
[22.05] Sort histories in history switcher by most recently updated

### DIFF
--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -17,6 +17,7 @@
             :selectable="true"
             :sort-by.sync="sortBy"
             :sort-desc.sync="sortDesc"
+            :sort-compare="currentFirstSortCompare"
             select-mode="single"
             selected-variant="success"
             @row-selected="switchToHistory"
@@ -95,6 +96,17 @@ export default {
         onFiltered(filteredItems) {
             this.totalRows = filteredItems.length;
             this.currentPage = 1;
+        },
+        /** Make the current history appear always first when sorting. */
+        currentFirstSortCompare(a, b, key, sortDesc) {
+            if (a.id == this.currentHistoryId) {
+                return sortDesc ? 1 : -1;
+            } else if (b.id == this.currentHistoryId) {
+                return sortDesc ? -1 : 1;
+            } else {
+                // Fallback to default sorting
+                return false;
+            }
         },
     },
 };

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -15,6 +15,8 @@
             :per-page="perPage"
             :current-page="currentPage"
             :selectable="true"
+            :sort-by.sync="sortBy"
+            :sort-desc.sync="sortDesc"
             select-mode="single"
             selected-variant="success"
             @row-selected="switchToHistory"
@@ -58,6 +60,8 @@ export default {
             filter: null,
             currentPage: 1,
             totalRows: 0,
+            sortBy: "update_time",
+            sortDesc: true,
         };
     },
     computed: {


### PR DESCRIPTION
Fixes #14297

The current history will always appear at the top, regardless of column sorting.

![switch_histories_current_top](https://user-images.githubusercontent.com/46503462/178337600-b5fe98ab-98ce-40af-ab2c-f568cc3d94c9.gif)


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
