### PR TITLE
Extend docs and tests for conditional output actions

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3761,6 +3761,7 @@ Name | Description
 ``$__app__`` | The ``galaxy.app.UniverseApplication`` instance, gives access to all other configuration file variables (e.g. $__app__.config.output_size_limit). Should be used as a last resort, may go away in future releases.
 ``$__target_datatype__`` | Only available in converter tools when run internally by Galaxy. Contains the target datatype of the conversion
 
+
 Additional runtime properties are available as environment variables. Since these
 are not Cheetah variables (the values aren't available until runtime) these should likely
 be escaped with a backslash (``\``) when appearing in ``command`` or ``configfile`` elements.
@@ -5468,6 +5469,11 @@ based on inputs, as shown below:
 </data>
 ```
 
+Note that the value given in ``when`` tags needs to be the python string representation
+of the value of the referred parameter, e.g. ``True`` or ``False`` if the referred
+parameter is a boolean.
+
+
 ### Unconditional Actions and Column Names
 
 For a static file that contains a fixed number of columns, it is straight forward:
@@ -5692,7 +5698,8 @@ of this directive.
     <xs:attribute name="value" type="xs:string" use="optional">
       <xs:annotation>
         <xs:documentation xml:lang="en">Value to match conditional input value
-against.</xs:documentation>
+against. This needs to be the python string representation of the parameter value,
+e.g. ``True`` or ``False`` if the referred parameter is a boolean.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="datatype_isinstance" type="xs:string" use="optional">

--- a/test/functional/tools/output_action_change_format.xml
+++ b/test/functional/tools/output_action_change_format.xml
@@ -15,6 +15,9 @@
                 <param type="data" name="input" format="data" />
             </when>
         </conditional>
+        <section name="asection" title="A Section">
+            <param type="boolean" name="abool" truevalue="does_not_matter_for_action" falsevalue="also_irrelevant"/>
+        </section>
     </inputs>
     <outputs>
         <data name="out1" from_work_dir="out1">
@@ -26,6 +29,14 @@
                         </action>
                     </when>
                 </conditional>
+                <conditional name="asection.abool">
+                    <when value="True">
+                        <action name="dbkey" type="metadata" default="hg19"/>
+                    </when>
+                    <when value="False">
+                        <action name="dbkey" type="metadata" default="hg38"/>
+                    </when>
+                </conditional>
             </actions>
         </data>
     </outputs>
@@ -33,19 +44,23 @@
         <test>
             <param name="dispatch" value="dont" />
             <param name="input" value="simple_line.txt" />
+            <param name="abool" value="true"/>
             <output name="out1" ftype="data">
                 <assert_contents>
                     <has_line line="1&#009;2" />
                 </assert_contents>
+                <metadata name="dbkey" value="hg19" />
             </output>
         </test>
         <test>
             <param name="dispatch" value="do" />
             <param name="input" value="simple_line.txt" />
+            <param name="abool" value="false"/>
             <output name="out1" ftype="txt">
                 <assert_contents>
                     <has_line line="1&#009;2" />
                 </assert_contents>
+                <metadata name="dbkey" value="hg38" />
             </output>
         </test>
     </tests>


### PR DESCRIPTION
for the case that a boolean is referred.

In this case the python string value of the parameter value
needs to be used as the value for the when tag which might be a
bit confusing.

The test is also extended such that:

- multiple (two) conditional actions are used in one output
- referring parameters in sections

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
