### PR TITLE
[22.05] Prevent iframe from interfering with drop events

### DIFF
--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -52,6 +52,11 @@ export default {
             modalShow: false,
         };
     },
+    watch: {
+        modalShow() {
+            this.setIframeEvents(this.modalShow);
+        },
+    },
     mounted() {
         this.show();
         // handles subsequent external requests to re-open a re-used modal
@@ -69,6 +74,15 @@ export default {
                 this.$root.$emit("uploadResult", result);
             }
             this.hide();
+        },
+        /** Disable mouse events in iframe to prevent interference with uploader drop box */
+        setIframeEvents(disableEvents) {
+            const element = document.getElementById("galaxy_main");
+            if (element) {
+                element.style["pointer-events"] = disableEvents ? "none" : "auto";
+            } else {
+                console.warn("UploadModal::setIframeEvents - `galaxy_main` not found.");
+            }
         },
     },
 };


### PR DESCRIPTION
Fixes #14228. Currently the iframe behind the uploader, although being covered, interferes with the drag and drop event handlers assigned to the uploader box. This PR remedies this issue by disabling mouse events for the covered iframe when the upload box is visible.

Solution suggested in https://stackoverflow.com/questions/49203501/how-to-prevent-an-iframe-from-stealing-drop-event-from-parent-container.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
