### PR TITLE
[22.01] Fix local version switching

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -45,7 +45,7 @@
                         itemtype="https://schema.org/CreativeWork">
                         <template v-slot:body>
                             <FormDisplay
-                                :id="formConfig.id"
+                                :id="toolId"
                                 :inputs="formConfig.inputs"
                                 :validation-scroll-to="validationScrollTo"
                                 @onChange="onChange"
@@ -184,6 +184,12 @@ export default {
     computed: {
         toolName() {
             return this.formConfig.name;
+        },
+        toolId() {
+            // ensure version is included in tool id, otherwise form inputs are
+            // not re-rendered when versions change.
+            const { id, version } = this.formConfig;
+            return id.endsWith(version) ? id : `${id}/${version}`;
         },
         tooltip() {
             return `Execute: ${this.formConfig.name} (${this.formConfig.version})`;


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14311.
Problem is that we use `:key` in
https://github.com/mvdbeek/galaxy/blob/9e4563d9eb5d8f38a48e1f01466d4fcd1fc66502/client/src/components/Form/FormDisplay.vue#L3,
so that doesn't re-render when the tool id doesn't change (which is the
case for local tools, but not toolshed tools).


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Switch versions in a local tool and make sure tool parameter changes are reflected in the UI.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
