### PR TITLE
[22.05] Attempt to use epoch of client build time for cache busting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib/galaxy.egg-info
 lib/galaxy/web/framework/static/maps
 lib/galaxy/web/framework/static/scripts
 lib/galaxy/web/framework/static/style
+lib/galaxy/web/framework/meta.json
 
 # Database stuff
 /database/

--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
     "date-fns-tz": "^1.3.3",
     "decode-uri-component": "^0.2.0",
     "dom-to-image": "^2.6.0",
+    "dumpmeta-webpack-plugin": "^0.2.0",
     "elkjs": "^0.7.1",
     "file-saver": "^2.0.5",
     "flush-promises": "^1.0.2",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -5,6 +5,7 @@ const VueLoaderPlugin = require("vue-loader/lib/plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const DuplicatePackageCheckerPlugin = require("@cerner/duplicate-package-checker-webpack-plugin");
+const { DumpMetaPlugin } = require("dumpmeta-webpack-plugin");
 
 const scriptsBase = path.join(__dirname, "src");
 const testsBase = path.join(__dirname, "tests");
@@ -200,6 +201,14 @@ module.exports = (env = {}, argv = {}) => {
                 filename: "[name].css",
             }),
             new DuplicatePackageCheckerPlugin(),
+            new DumpMetaPlugin({
+                filename: path.join(__dirname, "../lib/galaxy/web/framework/meta.json"),
+                prepare: (stats) => ({
+                    // add any other information you need to dump
+                    hash: stats.hash,
+                    epoch: Date.now(),
+                }),
+            }),
         ],
         devServer: {
             client: {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -25,6 +25,8 @@ const modulesExcludedFromLibs = [
     "citeproc",
 ].join("|");
 
+const buildDate = new Date();
+
 module.exports = (env = {}, argv = {}) => {
     // environment name based on -d, -p, webpack flag
     const targetEnv = process.env.NODE_ENV == "production" || argv.mode == "production" ? "production" : "development";
@@ -194,7 +196,7 @@ module.exports = (env = {}, argv = {}) => {
             }),
             new webpack.DefinePlugin({
                 __targetEnv__: JSON.stringify(targetEnv),
-                __buildTimestamp__: JSON.stringify(new Date().toISOString()),
+                __buildTimestamp__: JSON.stringify(buildDate.toISOString()),
             }),
             new VueLoaderPlugin(),
             new MiniCssExtractPlugin({
@@ -206,7 +208,7 @@ module.exports = (env = {}, argv = {}) => {
                 prepare: (stats) => ({
                     // add any other information you need to dump
                     hash: stats.hash,
-                    epoch: Date.now(),
+                    epoch: Date.parse(buildDate),
                 }),
             }),
         ],

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3855,6 +3855,13 @@ dot-case@^3.0.4:
     no-case "^3.0.4"
     tslib "^2.0.3"
 
+dumpmeta-webpack-plugin@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dumpmeta-webpack-plugin/-/dumpmeta-webpack-plugin-0.2.0.tgz#c3a9da7d163ad3bb1d0373fb2c0bf5bb9b626b8f"
+  integrity sha512-9oxLTPvYVtk7HOmOq2rGQlvajCNiXtIKLInIrdNpdgzeoMMELaAsRsRBZfm6xf0JuwyBfytdJxsmtM6luTeqzA==
+  dependencies:
+    webpack ">=4.0.0 <6.0.0"
+
 duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -123,6 +123,7 @@ from galaxy.web import (
     legacy_url_for,
     url_for,
 )
+from galaxy.web.framework.base import server_starttime
 from galaxy.web.proxy import ProxyManager
 from galaxy.web.short_term_storage import (
     ShortTermStorageAllocator,
@@ -739,7 +740,7 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         self.url_for = url_for
         self.legacy_url_for = legacy_url_for
 
-        self.server_starttime = int(time.time())  # used for cachebusting
+        self.server_starttime = server_starttime  # used for cachebusting
         # Limit lifetime of tool shed repository cache to app startup
         self.tool_shed_repository_cache = None
         self.api_spec = None

--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -2,6 +2,7 @@
 A simple WSGI application/framework.
 """
 import io
+import json
 import logging
 import os
 import socket
@@ -25,11 +26,17 @@ import webob.exc as httpexceptions
 from paste.response import HeaderDict
 
 from galaxy.util import smart_str
+from galaxy.util.resources import resource_string
 
 log = logging.getLogger(__name__)
 
 #: time of the most recent server startup
 server_starttime = int(time.time())
+try:
+    meta_json = json.loads(resource_string(__package__, "meta.json"))
+    server_starttime = meta_json.get("epoch") or server_starttime
+except Exception:
+    meta_json = {}
 
 
 def __resource_with_deleted(self, member_name, collection_name, **kwargs):
@@ -567,6 +574,7 @@ __all__ = (
     "httpexceptions",
     "lazy_property",
     "routes",
+    "server_starttime",
     "walk_controller_modules",
     "WebApplication",
 )


### PR DESCRIPTION
Store webpack build hash in `meta.json` file, and use that to setup the cache busting.
This should prevent clients from unnecessarily reloading client bundles when the server restarts and/or when individual workers finish booting at staggered intervals.
This became more important with usegalaxy.org not forking off workers from a preloaded master (so all workers would have the same starttime), instead all workers have a distinct starttime.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Rebuild the client, start your instance, check that the `v=1234567890` value that is appended to the requested bundles remains the same between restarts.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
