### PR TITLE
Improve handling of non-existent or uninitialized database when running upgrade script

### DIFF
--- a/lib/galaxy/model/migrations/scripts.py
+++ b/lib/galaxy/model/migrations/scripts.py
@@ -253,6 +253,12 @@ class LegacyScripts:
                 elif self.database == "install":
                     self.argv.append("tsi@head")
 
+    def get_db_url(self):
+        if self.database in ["galaxy", self.DEFAULT_DB_ARG]:
+            return self.gxy_url
+        elif self.database == "install":
+            return self.tsi_url
+
     def _rename_arg(self, old_name, new_name) -> None:
         pos = self.argv.index(old_name)
         self.argv[pos] = new_name

--- a/lib/galaxy/model/migrations/scripts.py
+++ b/lib/galaxy/model/migrations/scripts.py
@@ -168,7 +168,7 @@ class LegacyScripts:
     def __init__(self, argv: List[str], cwd: Optional[str] = None) -> None:
         self.argv = argv
         self.cwd = cwd or os.getcwd()
-        self._database = None  # Do not assign default value: `None` means we don't know yet.
+        self._database: Optional[str] = None  # Do not assign default value: `None` means we don't know yet.
 
     @property
     def database(self):

--- a/lib/galaxy/model/migrations/scripts.py
+++ b/lib/galaxy/model/migrations/scripts.py
@@ -120,7 +120,13 @@ class LegacyScripts:
     def __init__(self, argv: List[str], cwd: Optional[str] = None) -> None:
         self.argv = argv
         self.cwd = cwd or os.getcwd()
-        self.database = self.DEFAULT_DB_ARG
+        self._database = None  # Do not assign default value: `None` means we don't know yet.
+
+    @property
+    def database(self):
+        if self._database is None:
+            raise LegacyScriptsException("Attempt to access identifier of database before processing the script arguments")
+        return self._database
 
     def run(self) -> None:
         """
@@ -147,8 +153,9 @@ class LegacyScripts:
         If last argument is a valid database name, pop and assign it; otherwise assign default.
         """
         arg = self.argv[-1]
+        self._database = self.DEFAULT_DB_ARG
         if arg in ["galaxy", "install"]:
-            self.database = self.argv.pop()
+            self._database = self.argv.pop()
 
     def rename_config_argument(self) -> None:
         """

--- a/scripts/manage_db_adapter.py
+++ b/scripts/manage_db_adapter.py
@@ -25,12 +25,15 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pa
 from galaxy.model.migrations.scripts import (
     invoke_alembic,
     LegacyScripts,
+    verify_database_is_initialized,
 )
 
 
 def run():
     ls = LegacyScripts(sys.argv, os.getcwd())
     ls.run()
+    db_url = ls.get_db_url()
+    verify_database_is_initialized(db_url)
     invoke_alembic()
 
 

--- a/test/unit/data/model/migrations/test_scripts.py
+++ b/test/unit/data/model/migrations/test_scripts.py
@@ -145,3 +145,15 @@ class TestLegacyScripts:
         argv = ["caller", "--alembic-config", "path-to-alembic", "downgrade"]
         with pytest.raises(LegacyScriptsException):
             LegacyScripts(argv).convert_args()
+
+    def test_access_database_id(self):
+        db = "galaxy"
+        argv = ["caller", "--alembic-config", "path-to-alembic", "upgrade", db]
+        ls = LegacyScripts(argv)
+        ls.run()
+        assert ls.database == db
+
+    def test_access_database_id_before_processing_script_args_raises_error(self):
+        argv = ["caller", "--alembic-config", "path-to-alembic", "upgrade"]
+        with pytest.raises(LegacyScriptsException):
+            LegacyScripts(argv).database

--- a/test/unit/data/model/migrations/test_scripts.py
+++ b/test/unit/data/model/migrations/test_scripts.py
@@ -1,8 +1,13 @@
+import random
+
 import pytest
 
 from galaxy.model.migrations.scripts import (
+    DatabaseDoesNotExistError,
+    DatabaseNotInitializedError,
     LegacyScripts,
     LegacyScriptsException,
+    verify_database_is_initialized,
 )
 
 
@@ -157,3 +162,13 @@ class TestLegacyScripts:
         argv = ["caller", "--alembic-config", "path-to-alembic", "upgrade"]
         with pytest.raises(LegacyScriptsException):
             LegacyScripts(argv).database
+
+    def test_verify_database_is_init_raises_error_if_no_database(self):
+        nonexistant_path = str(random.random())[2:]
+        db_url = f"sqlite:////{nonexistant_path}"
+        with pytest.raises(DatabaseDoesNotExistError):
+            verify_database_is_initialized(db_url)
+
+    def test_verify_database_is_init_raises_error_if_database_not_initialized(self, sqlite_memory_url):
+        with pytest.raises(DatabaseNotInitializedError):
+            verify_database_is_initialized(sqlite_memory_url)


### PR DESCRIPTION
Fixes #14276.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
1. Delete the sqlite database (the default one or the one set in galaxy.yml)
2. Run ./manage_db.sh upgrade: observe db-not-exists error
3. touch file for sqlite db or create a  new postgres db (do not initialize!) and update galaxy.yml to point to it
4. Run ./manage_db.sh upgrade: observe db-not-initialized error
5. Run create_db.sh or update galaxy.yml to point to an initialized database.
6. Run ./manage_db.sh upgrade: observe no error.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
