### PR TITLE
[22.01] fix `startswith` attribute of `<options>`

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3937,7 +3937,7 @@ exclusively use ``filter``s to populate options.
 * ``from_dataset`` - The options for the select list are dynamically obtained
   from input dataset selected for the tool from the current history.
 * ``from_file`` - The options for the select list are dynamically obtained from
-  a file. This mechanis is discourage in favor of the more generic
+  a file. This mechanism is discouraged in favor of the more generic
   ``from_data_table``.
 * ``from_parameter`` - The options for the select list are dynamically obtained
   from a parameter.
@@ -4013,6 +4013,10 @@ Starting from Galaxy v21.01, ``meta_file_key`` can be used together with
 medadata file that the ``meta_file_key`` implies, instead of the dataset
 itself.
 
+Note that in any case only the first mega byte of the referred dataset (or file)
+is considered. Lines starting with ``#`` are ignored. By using the ``startswith``
+attribute also lines starting with other strings can be ignored.
+
 ```xml
 <param name="input" type="data" format="maf" label="MAF File"/>
 <param name="species" type="select" optional="False" label="Select species for the input dataset" multiple="True">
@@ -4087,7 +4091,7 @@ used to generate dynamic options.
     </xs:sequence>
     <xs:attribute name="from_dataset" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Determine options from the dataset given in the referred input parameter. If 'meta_file_key' is given, the options are determined from the data in the metadata file of the input.</xs:documentation>
+        <xs:documentation xml:lang="en">Determine options from (the first MB of) the dataset given in the referred input parameter. If 'meta_file_key' is given, the options are determined from (the first MB of) the data in the metadata file of the input.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="from_file" type="xs:string">
@@ -4117,12 +4121,17 @@ used to generate dynamic options.
     </xs:attribute>
     <xs:attribute name="startswith" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Ignore lines starting with the given character.</xs:documentation>
+        <xs:documentation xml:lang="en">Ignore lines starting with the given string.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="meta_file_key" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">Works with from_dataset only. See [docs](#from-dataset)</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="separator" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Split tabular data with this character (default is tab)</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -645,7 +645,7 @@ class DynamicOptions:
         rval = []
         field_count = None
         for line in reader:
-            if line.startswith('#') or (self.line_startswith and not line.startswith(self.line_startswith)):
+            if line.startswith("#") or (self.line_startswith and line.startswith(self.line_startswith)):
                 continue
             line = line.rstrip("\n\r")
             if line:

--- a/test/functional/tools/options_from_metadata_file.xml
+++ b/test/functional/tools/options_from_metadata_file.xml
@@ -38,7 +38,7 @@ echo '${species_2}' >> '${output}'
     <test>
       <param name="input" value="3.maf" ftype="maf"/>
       <param name="species" value="hg17,canFam1"/>
-      <param name="species_comma" value="hg17,chr7"/>
+      <param name="species_comma" value="hg17&#009;chr7"/>
       <param name="input_2">
         <collection type="list">
           <element name="e1" value="3.maf"/>

--- a/test/functional/tools/options_from_metadata_file.xml
+++ b/test/functional/tools/options_from_metadata_file.xml
@@ -38,7 +38,7 @@ echo '${species_2}' >> '${output}'
     <test>
       <param name="input" value="3.maf" ftype="maf"/>
       <param name="species" value="hg17,canFam1"/>
-      <param name="species,comma" value="hg17,chr7"/>
+      <param name="species_comma" value="hg17,chr7"/>
       <param name="input_2">
         <collection type="list">
           <element name="e1" value="3.maf"/>

--- a/test/functional/tools/options_from_metadata_file.xml
+++ b/test/functional/tools/options_from_metadata_file.xml
@@ -1,19 +1,30 @@
 <tool id="options_from_metadata_file" name="Test for options from dataset metadata file" version="1.0.0" profile="21.01">
   <command><![CDATA[
 echo '${species}' > '${output}';
+echo '${species_comma}' >> '${output}';
 echo '${species_2}' >> '${output}'
   ]]></command>
   <inputs>
     <param name="input" type="data" format="maf" label="MAF File"/>
+    <!-- test meta_file_key to define options-->
     <param name="species" type="select" optional="false" label="Select species for the input dataset" multiple="true">
-        <options from_dataset="input" meta_file_key="species_chromosomes" >
-            <column name="name" index="0"/>
-            <column name="value" index="0"/>
+        <options from_dataset="input" meta_file_key="species_chromosomes">
+          <column name="name" index="0"/>
+          <column name="value" index="0"/>
         </options>
     </param>
-    <param name="input_2" type="data_collection" collection_type="list" format="maf" label="MAF Collection" multiple="true" />
+    <!-- test meta_file_key in combination with separator to define options
+         (since the metadata file does not contain commas each line gets an option)-->
+    <param name="species_comma" type="select" optional="false" label="Select species for the input dataset">
+        <options from_dataset="input" meta_file_key="species_chromosomes" separator=",">
+          <column name="name" index="0"/>
+          <column name="value" index="0"/>
+        </options>
+    </param>
+    <!-- test meta_file_key referring a collection to define options-->
+    <param name="input_2" type="data_collection" collection_type="list" format="maf" label="MAF Collection" multiple="true"/>
     <param name="species_2" type="select" optional="false" label="Select species for the input dataset" multiple="true">
-        <options from_dataset="input_2" meta_file_key="species_chromosomes" >
+        <options from_dataset="input_2" meta_file_key="species_chromosomes">
             <column name="name" index="0"/>
             <column name="value" index="0"/>
             <filter type="unique_value" name="unique_param" column="0"/>
@@ -21,23 +32,25 @@ echo '${species_2}' >> '${output}'
     </param>
   </inputs>
   <outputs>
-    <data format="txt" name="output" />
+    <data format="txt" name="output"/>
   </outputs>
   <tests>
     <test>
-      <param name="input" value="3.maf" ftype="maf" />
-      <param name="species" value="hg17,canFam1" />
+      <param name="input" value="3.maf" ftype="maf"/>
+      <param name="species" value="hg17,canFam1"/>
+      <param name="species,comma" value="hg17,chr7"/>
       <param name="input_2">
         <collection type="list">
-          <element name="e1" value="3.maf" />
-          <element name="e2" value="4.maf" />
+          <element name="e1" value="3.maf"/>
+          <element name="e2" value="4.maf"/>
         </collection>
       </param>
-      <param name="species_2" value="panTro1,rn3,bosTau2" />
+      <param name="species_2" value="panTro1,rn3,bosTau2"/>
       <output name="output" ftype="txt">
         <assert_contents>
-          <has_line line="hg17,canFam1" />
-          <has_line line="panTro1,rn3,bosTau2" />
+          <has_line line="hg17,canFam1"/>
+          <has_line line="hg17__tc__chr7"/>
+          <has_line line="panTro1,rn3,bosTau2"/>
         </assert_contents>
       </output>
     </test>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -53,6 +53,7 @@
   <tool file="filter_param_value_ref_attribute.xml" />
   <tool file="filter_static_regexp.xml" />
   <tool file="select_from_dataset.xml" />
+  <tool file="select_from_csvdataset.xml" />
   <tool file="select_from_dataset_optional.xml" />
   <tool file="dbkey_filter_input.xml" />
   <tool file="dbkey_filter_multi_input.xml" />

--- a/test/functional/tools/select_from_csvdataset.xml
+++ b/test/functional/tools/select_from_csvdataset.xml
@@ -1,0 +1,40 @@
+<tool id="select_from_csvdataset" name="select_from_csvdataset" version="0.1.0">
+    <description>Create dynamic options from CSV data sets</description>
+    <command><![CDATA[
+echo select_single '$select_single' > '$output'
+    ]]></command>
+    <inputs>
+        <param name="single" type="data" format="csv" label="single"/>
+        <param name="select_single" type="select" label="select_single">
+            <options from_dataset="single" separator="," startswith="Transaction_date">
+                <column name="name" index="1"/>
+                <column name="value" index="2"/>
+                <validator type="no_options" message="No data is available in single" />
+            </options>
+        </param>
+    </inputs>
+
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+
+    <tests>
+        <!-- test that csv can be selected, i.e. if the separator attribute of <options> works-->
+        <test>
+            <param name="single" value="1.csv" />
+            <param name="select_single" value="Product1" />
+            <output name="output">
+                <assert_contents>
+                    <has_text text="select_single 1200" />    
+                </assert_contents>
+            </output>
+        </test>
+        <!-- test that data from "comment" lines can not be selected, i.e. if the startswith attribute of <options> works-->
+        <test expect_failure="true">
+            <param name="single" value="1.csv" />
+            <param name="select_single" value="Product" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>


### PR DESCRIPTION
as documented in the xsd (seems that this bug was there since the beginning).

If desired we can backport the fix also to older releases.

additionally:

- fix https://github.com/galaxyproject/galaxy/issues/14324, i.e. document the `separator` attribute of options
- doc that only 1MB is used and lines starting with `#` are always ignored

While working on the tests I noticed that it is impossible to select options in tests for `multiple="true"` parameters if the option values contain `,`. For static options this is no problem (because tool devs can control the values) but it might be for dynamic options. Is this worth opening an issue? 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
