### PR TITLE
[22.05] Upgrade FastAPI to 0.79.0

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -62,7 +62,7 @@ docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (
 ecdsa==0.17.0; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 edam-ontology==1.25.2
 fastapi-utils==0.2.1; python_version >= "3.6" and python_version < "4.0"
-fastapi==0.78.0; python_full_version >= "3.6.1"
+fastapi==0.79.0; python_full_version >= "3.6.1"
 fluent-logger==0.10.0; python_version >= "3.5"
 fonttools==4.33.3; python_version >= "3.7"
 fs==2.4.16

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -52,7 +52,7 @@ docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (
 ecdsa==0.17.0; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 edam-ontology==1.25.2
 fastapi-utils==0.2.1; python_version >= "3.6" and python_version < "4.0"
-fastapi==0.78.0; python_full_version >= "3.6.1"
+fastapi==0.79.0; python_full_version >= "3.6.1"
 fs==2.4.16
 funcsigs==1.0.2
 future==0.18.2; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")

--- a/lib/galaxy/webapps/openapi/utils.py
+++ b/lib/galaxy/webapps/openapi/utils.py
@@ -32,7 +32,6 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.openapi.constants import (
     METHODS_WITH_BODY,
     REF_PREFIX,
-    STATUS_CODES_WITH_NO_BODY,
 )
 from fastapi.openapi.models import OpenAPI
 from fastapi.params import (
@@ -44,6 +43,7 @@ from fastapi.utils import (
     deep_dict_update,
     generate_operation_id_for_path,
     get_model_definitions,
+    is_body_allowed_for_status_code,
 )
 from pydantic import BaseModel
 from pydantic.fields import (
@@ -266,7 +266,7 @@ def get_openapi_path(
             operation.setdefault("responses", {}).setdefault(status_code, {})[
                 "description"
             ] = route.response_description
-            if route_response_media_type and route.status_code not in STATUS_CODES_WITH_NO_BODY:
+            if route_response_media_type and is_body_allowed_for_status_code(route.status_code):
                 response_schema = {"type": "string"}
                 if lenient_issubclass(current_response_class, JSONResponse):
                     if route.response_field:


### PR DESCRIPTION
Fixes `RuntimeError: Response content longer than Content-Length`

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
