### PR TITLE
[22.05] Avoid ``FileNotFoundError`` when Dataset is purged, but HDA is not

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -151,7 +151,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             raise web.httpexceptions.HTTPNotFound(f"Invalid reference dataset id: {str(hda_id)}.")
         if not self._can_access_dataset(trans, data):
             return trans.show_error_message("You are not allowed to access this dataset")
-        if data.purged:
+        if data.purged or data.dataset.purged:
             return trans.show_error_message("The dataset you are attempting to view has been purged.")
         elif data.deleted and not (trans.user_is_admin or (data.history and trans.get_user() == data.history.user)):
             return trans.show_error_message("The dataset you are attempting to view has been deleted.")


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/share/issue/dadaa8d6b70042a29e9a946ffdd2b5af/:
```
FileNotFoundError: [Errno 2] No such file or directory: ''
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 29, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 166, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 251, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 590, in display_by_username_and_slug
    first_chunk = dataset.datatype.get_chunk(trans, dataset, 0)
  File "galaxy/datatypes/tabular.py", line 107, in get_chunk
    with compression_utils.get_fileobj(dataset.file_name) as f:
  File "galaxy/util/compression_utils.py", line 66, in get_fileobj
    return get_fileobj_raw(filename, mode, compressed_formats)[1]
  File "galaxy/util/compression_utils.py", line 126, in get_fileobj_raw
    return compressed_format, open(filename, mode, encoding="utf-8")
```

I think that might be an inconsistency from one of the old versions of the cleanup scripts, but pretty cheap to deal with here. Cause either the dataset is purged, and we display a nice error, or we'll have to load the dataset anyway to display it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
