### PR TITLE
[22.05] Don't hit object store when getting size

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -190,7 +190,7 @@ class DatasetSerializer(base.ModelSerializer[DatasetManager], deletable.Purgable
             "extra_files_path": self.serialize_extra_files_path,
             "permissions": self.serialize_permissions,
             "total_size": lambda item, key, **context: int(item.get_total_size()),
-            "file_size": lambda item, key, **context: int(item.get_size()),
+            "file_size": lambda item, key, **context: int(item.get_size(calculate_size=False)),
         }
         self.serializers.update(serializers)
 
@@ -522,9 +522,9 @@ class _UnflattenedMetadataDatasetAssociationSerializer(base.ModelSerializer[T], 
             "extra_files_path": self._proxy_to_dataset(serializer=self.dataset_serializer.serialize_extra_files_path),
             "permissions": self._proxy_to_dataset(serializer=self.dataset_serializer.serialize_permissions),
             # TODO: do the sizes proxy accurately/in the same way?
-            "size": lambda item, key, **context: int(item.get_size()),
+            "size": lambda item, key, **context: int(item.get_size(calculate_size=False)),
             "file_size": lambda item, key, **context: self.serializers["size"](item, key, **context),
-            "nice_size": lambda item, key, **context: item.get_size(nice_size=True),
+            "nice_size": lambda item, key, **context: item.get_size(nice_size=True, calculate_size=False),
             # common to lddas and hdas - from mapping.py
             "copied_from_history_dataset_association_id": self.serialize_id,
             "copied_from_library_dataset_dataset_association_id": self.serialize_id,

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -242,7 +242,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         rval["deleted"] = ld.deleted
         rval["folder_id"] = f"F{rval['folder_id']}"
         rval["full_path"] = full_path
-        rval["file_size"] = util.nice_size(int(ldda.get_size()))
+        rval["file_size"] = util.nice_size(int(ldda.get_size(calculate_size=False)))
         rval["date_uploaded"] = ldda.create_time.isoformat()
         rval["update_time"] = ldda.update_time.isoformat()
         rval["can_user_modify"] = trans.user_is_admin or trans.app.security_agent.can_modify_library_item(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3568,18 +3568,21 @@ class Dataset(Base, StorableObject, Serializable, _HasTable):
         else:
             return self.object_store.size(self)
 
-    def get_size(self, nice_size=False):
+    def get_size(self, nice_size=False, calculate_size=True):
         """Returns the size of the data on disk"""
         if self.file_size:
             if nice_size:
                 return galaxy.util.nice_size(self.file_size)
             else:
                 return self.file_size
-        else:
+        elif calculate_size:
+            # Hopefully we only reach this branch in sessionless mode
             if nice_size:
                 return galaxy.util.nice_size(self._calculate_size())
             else:
                 return self._calculate_size()
+        else:
+            return self.file_size or 0
 
     def set_size(self, no_extra_files=False):
         """Sets the size of the data on disk.
@@ -4018,11 +4021,11 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
         self.clear_associated_files()
         _get_datatypes_registry().change_datatype(self, new_ext)
 
-    def get_size(self, nice_size=False):
+    def get_size(self, nice_size=False, calculate_size=True):
         """Returns the size of the data on disk"""
         if nice_size:
-            return galaxy.util.nice_size(self.dataset.get_size())
-        return self.dataset.get_size()
+            return galaxy.util.nice_size(self.dataset.get_size(calculate_size=calculate_size))
+        return self.dataset.get_size(calculate_size=calculate_size)
 
     def set_size(self, **kwds):
         """Sets and gets the size of the data on disk"""

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -357,7 +357,9 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
         trans.sa_session.flush()
 
         rval = trans.security.encode_all_ids(library_dataset.to_dict())
-        nice_size = util.nice_size(int(library_dataset.library_dataset_dataset_association.get_size()))
+        nice_size = util.nice_size(
+            int(library_dataset.library_dataset_dataset_association.get_size(calculate_size=False))
+        )
         rval["file_size"] = nice_size
         rval["update_time"] = library_dataset.update_time.strftime("%Y-%m-%d %I:%M %p")
         rval["deleted"] = library_dataset.deleted

--- a/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
@@ -128,7 +128,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
                         current_user_roles, content_item.library_dataset_dataset_association.dataset
                     )
                 )
-                raw_size = int(content_item.library_dataset_dataset_association.get_size())
+                raw_size = int(content_item.library_dataset_dataset_association.get_size(calculate_size=False))
                 nice_size = util.nice_size(raw_size)
                 update_time = content_item.library_dataset_dataset_association.update_time.isoformat()
 


### PR DESCRIPTION
I am a little uncertain about this, but size should be set once. This is part of stack 1 in https://github.com/galaxyproject/galaxy/issues/14322 (although it's certainly not the only issue within the route there).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
