### PR TITLE
[22.05] Fix ``GET /api/whoami`` when ``last_password_change`` is NULL

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -189,7 +189,7 @@ class UserModel(Model):
     email: str = Field(title="Email", description="User email")
     active: bool = Field(title="Active", description="User is active")
     deleted: bool = Field(title="Deleted", description="User is deleted")
-    last_password_change: datetime = Field(title="Last password change", description="")
+    last_password_change: Optional[datetime] = Field(title="Last password change", description="")
     model_class: str = ModelClassField(USER_MODEL_CLASS_NAME)
 
 


### PR DESCRIPTION
Fix the following traceback:

```
  File "/srv/galaxy/.venv/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 867, in run
    result = context.run(func, *args)
  File "/srv/galaxy/lib/galaxy/webapps/galaxy/api/configuration.py", line 53, in whoami
    return _user_to_model(trans.user, trans.security)
  File "/srv/galaxy/lib/galaxy/webapps/galaxy/api/configuration.py", line 123, in _user_to_model
    return UserModel(**user.to_dict(view="element", value_mapper={"id": security.encode_id})) if user else None
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for UserModel
last_password_change
  none is not an allowed value (type=type_error.none.not_allowed)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
