### PR TITLE
[22.05] Avoid loading expensive properties for all histories

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -8,7 +8,7 @@
             class="rounded-0 text-decoration-none"
             @click="onDashboard">
             <icon icon="database" />
-            <span>{{ history.size | niceFileSize }}</span>
+            <span>{{ historySize | niceFileSize }}</span>
         </b-button>
         <b-button-group>
             <b-button
@@ -19,10 +19,10 @@
                 class="rounded-0 text-decoration-none"
                 @click="setFilter('')">
                 <span class="fa fa-map-marker" />
-                <span>{{ history.contents_active.active }}</span>
+                <span>{{ numItemsActive }}</span>
             </b-button>
             <b-button
-                v-if="history.contents_active.deleted"
+                v-if="numItemsDeleted"
                 v-b-tooltip.hover
                 title="Show deleted"
                 variant="link"
@@ -30,10 +30,10 @@
                 class="rounded-0 text-decoration-none"
                 @click="setFilter('deleted:true')">
                 <icon icon="trash" />
-                <span>{{ history.contents_active.deleted }}</span>
+                <span>{{ numItemsDeleted }}</span>
             </b-button>
             <b-button
-                v-if="history.contents_active.hidden"
+                v-if="numItemsHidden"
                 v-b-tooltip.hover
                 title="Show hidden"
                 variant="link"
@@ -41,7 +41,7 @@
                 class="rounded-0 text-decoration-none"
                 @click="setFilter('visible:false')">
                 <icon icon="eye-slash" />
-                <span>{{ history.contents_active.hidden }}</span>
+                <span>{{ numItemsHidden }}</span>
             </b-button>
             <b-button
                 v-b-tooltip.hover
@@ -60,6 +60,7 @@
 import { backboneRoute } from "components/plugins/legacyNavigation";
 import prettyBytes from "pretty-bytes";
 import { formatDistanceToNowStrict } from "date-fns";
+import { usesDetailedHistoryMixin } from "./usesDetailedHistoryMixin.js";
 
 export default {
     filters: {
@@ -67,6 +68,7 @@ export default {
             return prettyBytes(rawSize);
         },
     },
+    mixins: [usesDetailedHistoryMixin],
     props: {
         history: { type: Object, required: true },
         lastChecked: { type: Date, default: null },

--- a/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
@@ -13,16 +13,16 @@
             <b-dropdown-text id="history-op-all-content">
                 <span v-localize>With entire history...</span>
             </b-dropdown-text>
-            <b-dropdown-item v-if="history.contents_active.active" data-description="copy datasets" @click="onCopy">
+            <b-dropdown-item v-if="numItemsActive" data-description="copy datasets" @click="onCopy">
                 <span v-localize>Copy Datasets</span>
             </b-dropdown-item>
-            <b-dropdown-item v-if="history.contents_active.hidden" v-b-modal:show-all-hidden-content>
+            <b-dropdown-item v-if="numItemsHidden" v-b-modal:show-all-hidden-content>
                 <span v-localize>Unhide All Hidden Content</span>
             </b-dropdown-item>
-            <b-dropdown-item v-if="history.contents_active.hidden" v-b-modal:delete-all-hidden-content>
+            <b-dropdown-item v-if="numItemsHidden" v-b-modal:delete-all-hidden-content>
                 <span v-localize>Delete All Hidden Content</span>
             </b-dropdown-item>
-            <b-dropdown-item v-if="history.contents_active.deleted" v-b-modal:purge-all-deleted-content>
+            <b-dropdown-item v-if="numItemsDeleted" v-b-modal:purge-all-deleted-content>
                 <span v-localize>Purge All Deleted Content</span>
             </b-dropdown-item>
         </b-dropdown>
@@ -43,8 +43,10 @@
 <script>
 import { unhideAllHiddenContent, deleteAllHiddenContent, purgeAllDeletedContent } from "components/History/model/crud";
 import { iframeRedirect } from "components/plugins/legacyNavigation";
+import { usesDetailedHistoryMixin } from "../usesDetailedHistoryMixin.js";
 
 export default {
+    mixins: [usesDetailedHistoryMixin],
     props: {
         history: { type: Object, required: true },
     },

--- a/client/src/components/History/CurrentHistory/usesDetailedHistoryMixin.js
+++ b/client/src/components/History/CurrentHistory/usesDetailedHistoryMixin.js
@@ -1,0 +1,24 @@
+/**
+ * VueJS mixin exposing extended properties for a history in a safe way.
+ * If the values haven't been loaded yet the computed properties will return 0 instead of undefined.
+ */
+export const usesDetailedHistoryMixin = {
+    computed: {
+        /** The total size in bytes of the sum of all the items in this history. */
+        historySize() {
+            return this.history.size || 0;
+        },
+        /** The number of items currently active (usable). */
+        numItemsActive() {
+            return this.history.contents_active?.active || 0;
+        },
+        /** The number of items deleted and/or purged. */
+        numItemsDeleted() {
+            return this.history.contents_active?.deleted || 0;
+        },
+        /** The number of items hidden. */
+        numItemsHidden() {
+            return this.history.contents_active?.hidden || 0;
+        },
+    },
+};

--- a/client/src/components/providers/UserHistories.js
+++ b/client/src/components/providers/UserHistories.js
@@ -47,8 +47,10 @@ export default {
         // when user changes reload histories
         user: {
             immediate: true,
-            handler() {
-                this.loadHistories();
+            handler(newVal, oldVal) {
+                if (oldVal?.id != newVal?.id) {
+                    this.loadHistories();
+                }
             },
         },
 

--- a/client/src/store/historyStore/model/queries.js
+++ b/client/src/store/historyStore/model/queries.js
@@ -39,6 +39,14 @@ function formData(fields = {}) {
  */
 const stdHistoryParams = {
     view: "summary",
+};
+
+/**
+ * Extended history request parameters.
+ * Retrieves additional details which are usually more "expensive".
+ */
+const extendedHistoryParams = {
+    view: "summary",
     keys: "size,contents_active",
 };
 
@@ -58,7 +66,7 @@ export async function getHistoryList() {
  */
 export async function getHistoryById(id) {
     const path = `api/histories/${id}`;
-    const response = await axios.get(prependPath(path), { params: stdHistoryParams });
+    const response = await axios.get(prependPath(path), { params: extendedHistoryParams });
     const props = doResponse(response);
     return new History(props);
 }


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/issues/14322#issuecomment-1184670268

The `size` and `contents_active` properties are more expensive than the summary properties and don't need to be loaded for all histories, just for the current history or for particular histories that we want the extra details.

Requires #14349 because otherwise, reloading all the histories multiple times will overwrite the current history losing the extended properties (`size` and `contents_active`) retrieved when the current history was set.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
