### PR TITLE
[22.05] Reload histories when the user 'really' changes

### DIFF
--- a/client/src/components/providers/UserHistories.js
+++ b/client/src/components/providers/UserHistories.js
@@ -47,8 +47,10 @@ export default {
         // when user changes reload histories
         user: {
             immediate: true,
-            handler() {
-                this.loadHistories();
+            handler(newVal, oldVal) {
+                if (oldVal?.id != newVal?.id) {
+                    this.loadHistories();
+                }
             },
         },
 


### PR DESCRIPTION
Currently, when reloading the page, the user prop watcher triggers multiple full reloads of **all** the user's histories.

![image](https://user-images.githubusercontent.com/46503462/179800675-93ebda69-cb71-4833-8451-3dd4dbb12516.png)

This change will ensure that the actual reloading of histories happens only once and when the user (ID) actually changes. Hopefully, this will also contribute to reducing a bit the load as part of #14322


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
