### PR TITLE
[22.05] Keep current history details on list of histories update

### DIFF
--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -32,7 +32,14 @@ const mutations = {
         Vue.delete(state.histories, doomed.id);
     },
     setHistories(state, newHistories = []) {
+        const currentHistoryId = state.currentHistoryId;
+        const currentHistory = state.histories[currentHistoryId];
         const newMap = newHistories.reduce((acc, h) => ({ ...acc, [h.id]: h }), {});
+        if (currentHistory) {
+            // The incoming history list contains less information than the current history
+            // so we restore the existing current history since it gets updated regularly anyway
+            newMap[currentHistoryId] = currentHistory;
+        }
         Vue.set(state, "histories", newMap);
     },
     setHistoriesLoading(state, isLoading) {


### PR DESCRIPTION
Follow up on https://github.com/galaxyproject/galaxy/pull/14347#issuecomment-1190806596

The incoming list of histories contains only summary information for all of them and the current history has additional details that we want to preserve.
Also, since the current history gets updated regularly, there is no harm in skipping the update from the incoming list just to make sure the current doesn't get overwritten.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
