### PR TITLE
[22.05] Fix handling + encoding of spaces in tool names

### DIFF
--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -138,7 +138,7 @@
                         if (tool_id === "upload1" || tool_id === "upload") {
                             document.getElementById("tool-panel-upload-button").click();
                         } else {
-                            Galaxy.router.push("/", { tool_id: tool_id });
+                            Galaxy.router.push("/", { tool_id: encodeURI(tool_id) });
                         }
                         removeOverlay();
                     });


### PR DESCRIPTION
@dannon would love your eyes on this if possible.

Previously we (correct me if I'm wrong)

- automatically replaced spaces with +s when loading tools, e.g. via router
- and required tools with ` ` in their ID use properly % encoded spaces.

@shiltemann was testing a new tutorial via the gtn webhook and noticed that `Remove beginning1` was not loading, it errored out on "No such tool Remove+beginning1". So I've opened this PR to uri encode the tool ID to avoid this situation, leaving `+`s alone, but encoding ` ` as `%20`. 

This doesn't feel like the right solution really, but I'm not sure what is, I feel like we've made a number of changes to this over time and they all have subtle oddities. Should `Remove beginning1` and `Remove+beginning1`  and `Remove%20beginning1` all be equivalent? It seems a lot of libraries do that interchangeably so, maybe it makes sense to treat all three of those values equivalently and we can test for that?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
