### PR TITLE
[22.01] Fix enable_account_interface option hiding too much

### DIFF
--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -13,7 +13,7 @@ export const getUserPreferencesModel = (user_id) => {
             url: `api/users/${user_id}/information/inputs`,
             icon: "fa-user",
             redirect: "user",
-            shouldRender: !config.use_remote_user && config.enable_account_interface,
+            shouldRender: !config.use_remote_user,
         },
         password: {
             title: _l("Change Password"),

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -9,7 +9,9 @@ export const getUserPreferencesModel = (user_id) => {
         information: {
             title: _l("Manage Information"),
             id: "edit-preferences-information",
-            description: _l("Edit your email, addresses and custom parameters or change your public name."),
+            description: config.enable_account_interface
+                ? _l("Edit your email, addresses and custom parameters or change your public name.")
+                : _l("Edit your custom parameters."),
             url: `api/users/${user_id}/information/inputs`,
             icon: "fa-user",
             redirect: "user",

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -69,7 +69,7 @@ export const getUserPreferencesModel = (user_id) => {
             icon: "fa-cloud",
             submitTitle: "Create a new Key",
             submitIcon: "fa-check",
-            shouldRender: config.enable_account_interface,
+            shouldRender: true,
         },
         toolbox_filters: {
             title: _l("Manage Toolbox Filters"),

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -341,59 +341,82 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         email = user.email
         username = user.username
         inputs = list()
-        inputs.append({
-            'id': 'email_input',
-            'name': 'email',
-            'type': 'text',
-            'label': 'Email address',
-            'value': email,
-            'help': 'If you change your email address you will receive an activation link in the new mailbox and you have to activate your account by visiting it.'})
-        if trans.webapp.name == 'galaxy':
-            inputs.append({
-                'id': 'name_input',
-                'name': 'username',
-                'type': 'text',
-                'label': 'Public name',
-                'value': username,
-                'help': 'Your public name is an identifier that will be used to generate addresses for information you share publicly. Public names must be at least three characters in length and contain only lower-case letters, numbers, and the "-" character.'})
-            info_form_models = self.get_all_forms(trans, filter=dict(deleted=False), form_type=trans.app.model.FormDefinition.types.USER_INFO)
+        user_info = {
+            "email": email,
+            "username": username,
+        }
+        is_galaxy_app = trans.webapp.name == "galaxy"
+        if trans.app.config.enable_account_interface or not is_galaxy_app:
+            inputs.append(
+                {
+                    "id": "email_input",
+                    "name": "email",
+                    "type": "text",
+                    "label": "Email address",
+                    "value": email,
+                    "help": "If you change your email address you will receive an activation link in the new mailbox and you have to activate your account by visiting it.",
+                }
+            )
+        if is_galaxy_app:
+            if trans.app.config.enable_account_interface:
+                inputs.append(
+                    {
+                        "id": "name_input",
+                        "name": "username",
+                        "type": "text",
+                        "label": "Public name",
+                        "value": username,
+                        "help": 'Your public name is an identifier that will be used to generate addresses for information you share publicly. Public names must be at least three characters in length and contain only lower-case letters, numbers, and the "-" character.',
+                    }
+                )
+            info_form_models = self.get_all_forms(
+                trans, filter=dict(deleted=False), form_type=trans.app.model.FormDefinition.types.USER_INFO
+            )
             if info_form_models:
                 info_form_id = trans.security.encode_id(user.values.form_definition.id) if user.values else None
                 info_field = {
-                    'type': 'conditional',
-                    'name': 'info',
-                    'cases': [],
-                    'test_param': {
-                        'name': 'form_id',
-                        'label': 'User type',
-                        'type': 'select',
-                        'value': info_form_id,
-                        'help': '',
-                        'data': []
-                    }
+                    "type": "conditional",
+                    "name": "info",
+                    "cases": [],
+                    "test_param": {
+                        "name": "form_id",
+                        "label": "User type",
+                        "type": "select",
+                        "value": info_form_id,
+                        "help": "",
+                        "data": [],
+                    },
                 }
                 for f in info_form_models:
                     values = None
                     if info_form_id == trans.security.encode_id(f.id) and user.values:
                         values = user.values.content
                     info_form = f.to_dict(user=user, values=values, security=trans.security)
-                    info_field['test_param']['data'].append({'label': info_form['name'], 'value': info_form['id']})
-                    info_field['cases'].append({'value': info_form['id'], 'inputs': info_form['inputs']})
+                    info_field["test_param"]["data"].append({"label": info_form["name"], "value": info_form["id"]})
+                    info_field["cases"].append({"value": info_form["id"], "inputs": info_form["inputs"]})
                 inputs.append(info_field)
 
-            address_inputs = [{'type': 'hidden', 'name': 'id', 'hidden': True}]
-            for field in AddressField.fields():
-                address_inputs.append({'type': 'text', 'name': field[0], 'label': field[1], 'help': field[2]})
-            address_repeat = {'title': 'Address', 'name': 'address', 'type': 'repeat', 'inputs': address_inputs, 'cache': []}
-            address_values = [address.to_dict(trans) for address in user.addresses]
-            for address in address_values:
-                address_cache = []
-                for input in address_inputs:
-                    input_copy = input.copy()
-                    input_copy['value'] = address.get(input['name'])
-                    address_cache.append(input_copy)
-                address_repeat['cache'].append(address_cache)
-            inputs.append(address_repeat)
+            if trans.app.config.enable_account_interface:
+                address_inputs = [{"type": "hidden", "name": "id", "hidden": True}]
+                for field in AddressField.fields():
+                    address_inputs.append({"type": "text", "name": field[0], "label": field[1], "help": field[2]})
+                address_repeat = {
+                    "title": "Address",
+                    "name": "address",
+                    "type": "repeat",
+                    "inputs": address_inputs,
+                    "cache": [],
+                }
+                address_values = [address.to_dict(trans) for address in user.addresses]
+                for address in address_values:
+                    address_cache = []
+                    for input in address_inputs:
+                        input_copy = input.copy()
+                        input_copy["value"] = address.get(input["name"])
+                        address_cache.append(input_copy)
+                    address_repeat["cache"].append(address_cache)
+                inputs.append(address_repeat)
+                user_info["addresses"] = [address.to_dict(trans) for address in user.addresses]
 
             # Build input sections for extra user preferences
             extra_user_pref = self._build_extra_user_pref_inputs(trans, self._get_extra_user_preferences(trans), user)
@@ -401,15 +424,29 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                 inputs.append(item)
         else:
             if user.active_repositories:
-                inputs.append(dict(id='name_input', name='username', label='Public name:', type='hidden', value=username, help='You cannot change your public name after you have created a repository in this tool shed.'))
+                inputs.append(
+                    dict(
+                        id="name_input",
+                        name="username",
+                        label="Public name:",
+                        type="hidden",
+                        value=username,
+                        help="You cannot change your public name after you have created a repository in this tool shed.",
+                    )
+                )
             else:
-                inputs.append(dict(id='name_input', name='username', label='Public name:', type='text', value=username, help='Your public name provides a means of identifying you publicly within this tool shed. Public names must be at least three characters in length and contain only lower-case letters, numbers, and the "-" character. You cannot change your public name after you have created a repository in this tool shed.'))
-        return {
-            'email': email,
-            'username': username,
-            'addresses': [address.to_dict(trans) for address in user.addresses],
-            'inputs': inputs,
-        }
+                inputs.append(
+                    dict(
+                        id="name_input",
+                        name="username",
+                        label="Public name:",
+                        type="text",
+                        value=username,
+                        help='Your public name provides a means of identifying you publicly within this tool shed. Public names must be at least three characters in length and contain only lower-case letters, numbers, and the "-" character. You cannot change your public name after you have created a repository in this tool shed.',
+                    )
+                )
+        user_info["inputs"] = inputs
+        return user_info
 
     @expose_api
     def set_information(self, trans, id, payload=None, **kwd):


### PR DESCRIPTION
Fixes #13418

Setting `enable_account_interface: false` will now make the server return all the configurable user inputs except for `username`, `email`, and `address` instead of completely hiding the `Manage Information` section in the user preferences.

It also makes the `Manage Cloud Authorization` **visible always**. I'm not 100% sure if this is intended, if not we can drop 50c1c89d2b57b22609917e0263e2d4780449b151

I'm targeting 22.05 but let me know if I should target an older version for the fix.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Change `enable_account_interface` in the galaxy.yml config file and restart Galaxy.
  - Login to Galaxy and go to User Preferences -> Manage Information
  - Observe you can now edit other user custom parameters.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
