### PR TITLE
[22.05] Fix tool search config defaults

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -252,7 +252,7 @@ class ToolsService(ServiceBase):
         tool_stub_boost = self.config.get("tool_stub_boost", 5)
         tool_help_boost = self.config.get("tool_help_boost", 0.5)
         tool_search_limit = self.config.get("tool_search_limit", 20)
-        tool_enable_ngram_search = self.config.get("tool_enable_ngram_search", False)
+        tool_enable_ngram_search = self.config.tool_enable_ngram_search
         tool_ngram_minsize = self.config.get("tool_ngram_minsize", 3)
         tool_ngram_maxsize = self.config.get("tool_ngram_maxsize", 4)
 

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -244,17 +244,17 @@ class ToolsService(ServiceBase):
         :return type: dict
         """
         panel_view = view or self.config.default_panel_view
-        tool_name_boost = self.config.get("tool_name_boost", 9)
-        tool_id_boost = self.config.get("tool_id_boost", 9)
-        tool_section_boost = self.config.get("tool_section_boost", 3)
-        tool_description_boost = self.config.get("tool_description_boost", 2)
-        tool_label_boost = self.config.get("tool_label_boost", 1)
-        tool_stub_boost = self.config.get("tool_stub_boost", 5)
-        tool_help_boost = self.config.get("tool_help_boost", 0.5)
-        tool_search_limit = self.config.get("tool_search_limit", 20)
+        tool_name_boost = self.config.tool_name_boost
+        tool_id_boost = self.config.tool_id_boost
+        tool_section_boost = self.config.tool_section_boost
+        tool_description_boost = self.config.tool_description_boost
+        tool_label_boost = self.config.tool_label_boost
+        tool_stub_boost = self.config.tool_stub_boost
+        tool_help_boost = self.config.tool_help_boost
+        tool_search_limit = self.config.tool_search_limit
         tool_enable_ngram_search = self.config.tool_enable_ngram_search
-        tool_ngram_minsize = self.config.get("tool_ngram_minsize", 3)
-        tool_ngram_maxsize = self.config.get("tool_ngram_maxsize", 4)
+        tool_ngram_minsize = self.config.tool_ngram_minsize
+        tool_ngram_maxsize = self.config.tool_ngram_maxsize
 
         results = self.toolbox_search.search(
             q=q,


### PR DESCRIPTION
Default schema is:

```
      tool_enable_ngram_search:
        type: bool
        default: true
        required: false
        reloadable: true
        desc: |
          Enable/ disable Ngram-search for tools. It makes tool
          search results tolerant for spelling mistakes in the query
          by dividing the query into multiple ngrams and search for
          each ngram
```

But since we use `config.get` to access the value, we don't get any of the actual schema defaults.  We just get whatever was in the actual galaxy configuration dictionary as it is on disk, which in this case is not defined.

`config.tool_enable_ngram_search` is `True`
`config.get('tool_enable_ngram_search', False)` is `False`

@jdavcs is going to write up a followup issue for trying to audit the rest of the uses of this, but everything should probably be swapped over to the 'new' config access style.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
