### PR TITLE
[WIP] Allow router to reactively control the masthead.

### DIFF
--- a/client/src/components/Masthead/Masthead.test.js
+++ b/client/src/components/Masthead/Masthead.test.js
@@ -81,7 +81,6 @@ describe("Masthead.vue", () => {
                 hidden: true,
             },
         ];
-        const initialActiveTab = "shared";
 
         // window manager assumes this is a Backbone collection - mock that out.
         tabs.add = (x) => {
@@ -93,10 +92,16 @@ describe("Masthead.vue", () => {
             windowManager,
         };
 
+        const mastheadOptions = {
+            activeTab: "shared",
+        };
+        const config = {};
+
         wrapper = mount(Masthead, {
             propsData: {
                 mastheadState,
-                initialActiveTab,
+                mastheadOptions,
+                config,
             },
             store,
             localVue,

--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -11,7 +11,7 @@
                 v-show="!(tab.hidden === undefined ? false : tab.hidden)"
                 :key="`tab-${idx}`"
                 :tab="tab"
-                :active-tab="activeTab" />
+                :active="tab.id == activeTab" />
             <masthead-item :tab="windowTab" :toggle="windowToggle" @click="onWindowToggle" />
         </b-navbar-nav>
         <quota-meter />
@@ -55,23 +55,20 @@ export default {
             type: String,
             default: null,
         },
-        initialActiveTab: {
-            type: String,
-            default: null,
-        },
         mastheadState: {
             type: Object,
             default: null,
         },
-        menuOptions: {
+        config: {
             type: Object,
-            default: null,
+            required: true,
+        },
+        mastheadOptions: {
+            required: true,
         },
     },
     data() {
         return {
-            activeTab: this.initialActiveTab,
-            baseTabs: [],
             extensionTabs: [],
             windowTab: this.mastheadState.windowManager.getTab(),
             windowToggle: false,
@@ -85,21 +82,27 @@ export default {
             }
             return brandTitle;
         },
+        baseTabs() {
+            if (this.config) {
+                return fetchMenu(this.config, this.mastheadOptions);
+            } else {
+                return [];
+            }
+        },
         tabs() {
             const tabs = [].concat(this.baseTabs, this.extensionTabs);
             return tabs.map(this._tabToJson);
         },
+        activeTab() {
+            return this.mastheadOptions.activeTab;
+        },
     },
     created() {
-        this.baseTabs = fetchMenu(this.menuOptions);
         loadWebhookMenuItems(this.extensionTabs);
     },
     methods: {
         addItem(item) {
             this.tabs.push(item);
-        },
-        highlight(activeTab) {
-            this.activeTab = activeTab;
         },
         onWindowToggle() {
             this.windowToggle = !this.windowToggle;

--- a/client/src/components/Masthead/MastheadItem.test.js
+++ b/client/src/components/Masthead/MastheadItem.test.js
@@ -21,14 +21,14 @@ describe("MastheadItem.vue", () => {
         return shallowMount(MastheadItem, {
             propsData: {
                 tab,
-                activeTab: active,
+                active: active,
             },
             localVue,
         });
     }
 
     it("should render active tab with menus", async () => {
-        active = "mytab";
+        active = true;
         menu = true;
         wrapper = m();
         expect(wrapper.vm.classes.active).toBe(true);
@@ -36,7 +36,7 @@ describe("MastheadItem.vue", () => {
     });
 
     it("should render inactive tabs without menus", async () => {
-        active = "othertab";
+        active = false;
         menu = false;
         wrapper = m();
         expect(wrapper.vm.classes.active).toBe(false);

--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -74,9 +74,9 @@ export default {
             type: Boolean,
             default: false,
         },
-        activeTab: {
-            type: String,
-            default: null,
+        active: {
+            type: Boolean,
+            default: false,
         },
     },
     computed: {
@@ -87,9 +87,8 @@ export default {
             return `Please <a href="${getAppRoot()}login">log in or register</a> to use this feature.`;
         },
         classes() {
-            const isActiveTab = this.tab.id == this.activeTab;
             return Object.fromEntries([
-                ["active", isActiveTab],
+                ["active", this.active],
                 [this.tab.cls, true],
             ]);
         },

--- a/client/src/components/Masthead/initMasthead.js
+++ b/client/src/components/Masthead/initMasthead.js
@@ -5,7 +5,7 @@
 import { MastheadState, mountMasthead } from "../../layout/masthead";
 import $ from "jquery";
 
-export function initMasthead(config, container) {
+export function initMasthead(Galaxy, config, container) {
     console.log("initMasthead");
 
     const $masthead = $("#masthead");
@@ -15,7 +15,7 @@ export function initMasthead(config, container) {
     } else {
         if (container) {
             const mastheadState = new MastheadState();
-            mountMasthead(container, config, mastheadState);
+            mountMasthead(container, Galaxy, config, mastheadState);
         }
     }
 }

--- a/client/src/entry/analysis/App.vue
+++ b/client/src/entry/analysis/App.vue
@@ -11,7 +11,8 @@
                 :brand-link="staticUrlToPrefixed(config.logo_url)"
                 :brand-image="staticUrlToPrefixed(config.logo_src)"
                 :brand-image-secondary="staticUrlToPrefixed(config.logo_src_secondary)"
-                :menu-options="config" />
+                :masthead-options="mastheadOptions"
+                :config="config" />
             <alert
                 v-if="config.message_box_visible && config.message_box_content"
                 id="messagebox"
@@ -48,6 +49,7 @@ export default {
     components: {
         Masthead,
     },
+    props: ["mastheadOptions"],
     data() {
         return {
             config: getGalaxyInstance().config,

--- a/client/src/entry/analysis/index.js
+++ b/client/src/entry/analysis/index.js
@@ -5,12 +5,43 @@ import App from "./App.vue";
 import store from "store";
 import { getRouter } from "./router";
 
+function buildReactiveMastheadOptions(Galaxy) {
+    const props = {
+        defaultEnableAdmin: {
+            default: Galaxy.user.get("is_admin"),
+        },
+        defaultEnableInteractiveTools: {
+            default: Galaxy.config.interactivetools_enable,
+        },
+        defaultEnableVisualizations: {
+            default: Galaxy.config.visualizations_visible,
+        },
+    };
+    const data = {
+        enableAdmin: props.defaultEnableAdmin,
+        enableInteractiveTools: props.defaultEnableInteractiveTools,
+        enableVisualizations: props.defaultEnableVisualizations,
+        activeTab: null,
+    };
+    const methods = {
+        reset() {
+            this.enableAdmin = this.defaultEnableAdmin;
+            this.enableInteractiveTools = this.defaultEnableInteractiveTools;
+            this.enableVisualizations = this.defaultEnableVisualizations;
+            this.activeTab = null;
+        },
+    };
+    const vm = new Vue({ props, methods, data });
+    return vm;
+}
+
 addInitialization((Galaxy) => {
     console.log("App setup");
-    const router = getRouter(Galaxy);
+    const mastheadOptions = buildReactiveMastheadOptions(Galaxy);
+    const router = getRouter(Galaxy, mastheadOptions);
     new Vue({
         el: "#app",
-        render: (h) => h(App),
+        render: (createElement) => createElement(App, { props: { mastheadOptions } }),
         router: router,
         store: store,
     });

--- a/client/src/entry/analysis/routes/admin-routes.js
+++ b/client/src/entry/analysis/routes/admin-routes.js
@@ -1,4 +1,5 @@
 import { getGalaxyInstance } from "app";
+import { MASTHEAD_TAB_ID } from "layout/masthead";
 
 import Admin from "entry/analysis/modules/Admin";
 import Home from "components/admin/Home";
@@ -25,6 +26,7 @@ export default [
     {
         path: "/admin",
         component: Admin,
+        masthead: { activeTab: MASTHEAD_TAB_ID.ADMIN },
         children: [
             {
                 path: "",

--- a/client/src/entry/analysis/routes/library-routes.js
+++ b/client/src/entry/analysis/routes/library-routes.js
@@ -5,11 +5,13 @@ import LibraryFolderDatasetPermissions from "components/Libraries/LibraryFolder/
 import LibraryFolderPermissions from "components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions";
 import LibraryDataset from "components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset";
 import LibraryPermissions from "components/Libraries/LibraryPermissions/LibraryPermissions";
+import { MASTHEAD_TAB_ID } from "layout/masthead";
 
 export default [
     {
         path: "/libraries",
         component: Base,
+        masthead: { activeTab: MASTHEAD_TAB_ID.SHARED },
         children: [
             { path: "", component: LibrariesList },
             {

--- a/client/src/entry/router.js
+++ b/client/src/entry/router.js
@@ -1,0 +1,73 @@
+// A VueRouter tailored to Galaxy entry points.
+// Currently:
+// - Provides interaction with getAppRoot to implicitly supply base.
+// - Adds declarative masthead logic.
+// - Handles confirmation logic in locations with confirmation set.
+// - Emits router-push event to app.
+// - Avoids console warning on NavigationDuplicated events.
+
+import Vue from "vue";
+import VueRouter from "vue-router";
+import { getAppRoot } from "onload/loadConfig";
+
+Vue.use(VueRouter);
+
+// patches $router.push() to trigger an event and hide duplication warnings
+const originalPush = VueRouter.prototype.push;
+VueRouter.prototype.push = function push(location) {
+    // verify if confirmation is required
+    console.debug("VueRouter - push: ", location);
+    if (this.confirmation) {
+        if (confirm("There are unsaved changes which will be lost.")) {
+            this.confirmation = undefined;
+        } else {
+            return;
+        }
+    }
+    // always emit event when a route is pushed
+    this.app.$emit("router-push");
+    // avoid console warning when user clicks to revisit same route
+    return originalPush.call(this, location).catch((err) => {
+        if (err.name !== "NavigationDuplicated") {
+            throw err;
+        }
+    });
+};
+
+export function getGalaxyRouter(routerOptions, mastheadOptions = null) {
+    routerOptions.base = routerOptions.base || getAppRoot();
+
+    function storeGalaxyOptionsToMetaOnArray(definesRoutes, defaultMastheadOptions = null) {
+        for (const definesRoute of definesRoutes || []) {
+            storeGalaxyOptionsToMeta(definesRoute, defaultMastheadOptions);
+        }
+    }
+
+    function storeGalaxyOptionsToMeta(definesRoute, defaultMastheadOptions = null) {
+        definesRoute = definesRoute || [];
+        if (definesRoute.masthead || defaultMastheadOptions) {
+            console.log("in here with masthead options...");
+            definesRoute.meta = definesRoute.meta || {};
+            definesRoute.meta.masthead = definesRoute.masthead || defaultMastheadOptions;
+        }
+        storeGalaxyOptionsToMetaOnArray(definesRoute.children, definesRoute.masthead);
+    }
+
+    storeGalaxyOptionsToMetaOnArray(routerOptions.routes);
+
+    const router = new VueRouter(routerOptions);
+    if (mastheadOptions) {
+        router.beforeEach((to, from, next) => {
+            mastheadOptions.reset();
+            for (const [key, value] of Object.entries(to.meta?.masthead || {})) {
+                if (key in mastheadOptions.$data) {
+                    Vue.set(mastheadOptions, key, value);
+                } else {
+                    console.warn(`Unknown masthead option ${key} encountered in route`);
+                }
+            }
+            next();
+        });
+    }
+    return router;
+}

--- a/client/src/layout/masthead.js
+++ b/client/src/layout/masthead.js
@@ -3,6 +3,17 @@ import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload/loadConfig";
 import Masthead from "../components/Masthead/Masthead";
 import { mountVueComponent } from "../utils/mountVueComponent";
+import Vue from "vue";
+
+export const MASTHEAD_TAB_ID = Object.freeze({
+    SHARED: "shared",
+    ADMIN: "admin",
+    HELP: "help",
+    USER: "user",
+    ANALYSIS: "analysis",
+    WORKFLOW: "workflow",
+    VISUALIZATION: "visualization",
+});
 
 export class MastheadState {
     // Used to be a Backbone View - not pretty but keep all window wide listeners,
@@ -22,18 +33,52 @@ function staticUrlToPrefixed(appRoot, url) {
     return url?.startsWith("/") ? `${appRoot}${url.substring(1)}` : url;
 }
 
-export function mountMasthead(el, options, mastheadState) {
+function buildReactiveMastheadOptions(Galaxy = null, config = null) {
+    Galaxy = Galaxy || getGalaxyInstance();
+    config = config || Galaxy.config;
+    const props = {
+        defaultEnableAdmin: {
+            default: Galaxy.user.get("is_admin"),
+        },
+        defaultEnableInteractiveTools: {
+            default: config.interactivetools_enable,
+        },
+        defaultEnableVisualizations: {
+            default: config.visualizations_visible,
+        },
+    };
+    const data = {
+        enableAdmin: props.defaultEnableAdmin,
+        enableInteractiveTools: props.defaultEnableInteractiveTools,
+        enableVisualizations: props.defaultEnableVisualizations,
+        activeTab: null,
+    };
+    const methods = {
+        reset() {
+            this.enableAdmin = this.defaultEnableAdmin;
+            this.enableInteractiveTools = this.defaultEnableInteractiveTools;
+            this.enableVisualizations = this.defaultEnableVisualizations;
+            this.activeTab = null;
+        },
+    };
+    const vm = new Vue({ props, methods, data });
+    return vm;
+}
+
+export function mountMasthead(el, Galaxy, config, mastheadState) {
     const appRoot = getAppRoot();
+    const mastheadOptions = buildReactiveMastheadOptions(Galaxy, config);
     return mountVueComponent(Masthead)(
         {
             el: el,
             mastheadState: mastheadState,
-            displayGalaxyBrand: options.display_galaxy_brand,
-            brand: options.brand,
-            brandLink: staticUrlToPrefixed(appRoot, options.logo_url),
-            brandImage: staticUrlToPrefixed(appRoot, options.logo_src),
-            brandImageSecondary: staticUrlToPrefixed(appRoot, options.logo_src_secondary),
-            menuOptions: options,
+            displayGalaxyBrand: config.display_galaxy_brand,
+            brand: config.brand,
+            brandLink: staticUrlToPrefixed(appRoot, config.logo_url),
+            brandImage: staticUrlToPrefixed(appRoot, config.logo_src),
+            brandImageSecondary: staticUrlToPrefixed(appRoot, config.logo_src_secondary),
+            config: config,
+            mastheadOptions: mastheadOptions,
         },
         el
     );

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { getGalaxyInstance } from "app";
 import _l from "utils/localization";
+import { MASTHEAD_TAB_ID } from "./masthead";
 
 const POST_LOGOUT_URL = "root/login?is_logout_redirect=true";
 
@@ -55,14 +56,14 @@ export function userLogoutClient() {
     window.top.location.href = `${galaxy.root}${POST_LOGOUT_URL}`;
 }
 
-export function fetchMenu(options = {}) {
+export function fetchMenu(config, mastheadOptions) {
     const Galaxy = getGalaxyInstance();
     const menu = [];
     //
     // Analyze data tab.
     //
     menu.push({
-        id: "analysis",
+        id: MASTHEAD_TAB_ID.ANALYSIS,
         url: "",
         tooltip: _l("Tools and Current History"),
         icon: "fa-home",
@@ -72,7 +73,7 @@ export function fetchMenu(options = {}) {
     // Workflow tab.
     //
     menu.push({
-        id: "workflow",
+        id: MASTHEAD_TAB_ID.WORKFLOW,
         title: _l("Workflow"),
         tooltip: _l("Chain tools into workflows"),
         disabled: !Galaxy.user.id,
@@ -83,34 +84,32 @@ export function fetchMenu(options = {}) {
     //
     // Visualization tab.
     //
-    if (Galaxy.config.visualizations_visible) {
-        if (Galaxy.config.visualizations_visible) {
-            menu.push({
-                id: "visualization",
-                title: _l("Visualize"),
-                tooltip: _l("Visualize datasets"),
-                disabled: !Galaxy.user.id,
-                url: "visualizations",
-                target: "__use_router__",
-            });
-        }
+    if (mastheadOptions.enableVisualizations) {
+        menu.push({
+            id: MASTHEAD_TAB_ID.VISUALIZATION,
+            title: _l("Visualize"),
+            tooltip: _l("Visualize datasets"),
+            disabled: !Galaxy.user.id,
+            url: "visualizations",
+            target: "__use_router__",
+        });
     }
 
     //
     // 'Shared Items' or Libraries tab.
     //
-    if (Galaxy.config.single_user) {
+    if (config.single_user) {
         // Single user can still use libraries, especially as we may grow that
         // functionality as a representation for external data.  The rest is
         // hidden though.
         menu.push({
             title: _l("Data Libraries"),
             url: "libraries",
-            id: "libraries",
+            id: MASTHEAD_TAB_ID.SHARED,
         });
     } else {
         menu.push({
-            id: "shared",
+            id: MASTHEAD_TAB_ID.SHARED,
             title: _l("Shared Data"),
             url: "javascript:void(0)",
             tooltip: _l("Access published resources"),
@@ -146,9 +145,9 @@ export function fetchMenu(options = {}) {
     //
     // Admin.
     //
-    if (Galaxy.user.get("is_admin")) {
+    if (mastheadOptions.enableAdmin) {
         menu.push({
-            id: "admin",
+            id: MASTHEAD_TAB_ID.ADMIN,
             title: _l("Admin"),
             url: "admin",
             tooltip: _l("Administer this Galaxy"),
@@ -160,38 +159,38 @@ export function fetchMenu(options = {}) {
     // Help tab.
     //
     const helpTab = {
-        id: "help",
+        id: MASTHEAD_TAB_ID.HELP,
         title: _l("Help"),
         url: "javascript:void(0)",
         tooltip: _l("Support, contact, and community"),
         menu: [
             {
                 title: _l("Galaxy Help"),
-                url: options.helpsite_url,
+                url: config.helpsite_url,
                 target: "_blank",
-                hidden: !options.helpsite_url,
+                hidden: !config.helpsite_url,
             },
             {
                 title: _l("Support"),
-                url: options.support_url,
+                url: config.support_url,
                 target: "_blank",
-                hidden: !options.support_url,
+                hidden: !config.support_url,
             },
             {
                 title: _l("Videos"),
-                url: options.screencasts_url,
+                url: config.screencasts_url,
                 target: "_blank",
-                hidden: !options.screencasts_url,
+                hidden: !config.screencasts_url,
             },
             {
                 title: _l("Community Hub"),
-                url: options.wiki_url,
+                url: config.wiki_url,
                 target: "_blank",
-                hidden: !options.wiki_url,
+                hidden: !config.wiki_url,
             },
             {
                 title: _l("How to Cite Galaxy"),
-                url: options.citation_url,
+                url: config.citation_url,
                 target: "_blank",
             },
             {
@@ -210,9 +209,9 @@ export function fetchMenu(options = {}) {
             },
             {
                 title: _l("Terms and Conditions"),
-                url: options.terms_url,
+                url: config.terms_url,
                 target: "_blank",
-                hidden: !options.terms_url,
+                hidden: !config.terms_url,
             },
         ],
     };
@@ -223,9 +222,9 @@ export function fetchMenu(options = {}) {
     //
     let userTab = {};
     if (!Galaxy.user.id) {
-        if (options.allow_user_creation) {
+        if (config.allow_user_creation) {
             userTab = {
-                id: "user",
+                id: MASTHEAD_TAB_ID.USER,
                 title: _l("Login or Register"),
                 cls: "loggedout-only",
                 url: "login",
@@ -233,7 +232,7 @@ export function fetchMenu(options = {}) {
             };
         } else {
             userTab = {
-                id: "user",
+                id: MASTHEAD_TAB_ID.USER,
                 title: _l("Login"),
                 cls: "loggedout-only",
                 tooltip: _l("Login"),
@@ -242,7 +241,7 @@ export function fetchMenu(options = {}) {
         }
     } else {
         userTab = {
-            id: "user",
+            id: MASTHEAD_TAB_ID.USER,
             title: _l("User"),
             cls: "loggedin-only",
             url: "javascript:void(0)",
@@ -268,7 +267,7 @@ export function fetchMenu(options = {}) {
                 {
                     title: _l("Logout"),
                     onclick: userLogout,
-                    hidden: Galaxy.config.single_user,
+                    hidden: config.single_user,
                 },
                 {
                     title: _l("Datasets"),
@@ -284,7 +283,7 @@ export function fetchMenu(options = {}) {
                     title: _l("Histories shared with me"),
                     url: "histories/list_shared",
                     target: "__use_router__",
-                    hidden: Galaxy.config.single_user,
+                    hidden: config.single_user,
                 },
                 {
                     title: _l("Pages"),
@@ -298,14 +297,14 @@ export function fetchMenu(options = {}) {
                 },
             ],
         };
-        if (Galaxy.config.visualizations_visible) {
+        if (mastheadOptions.enableVisualizations) {
             userTab.menu.push({
                 title: _l("Visualizations"),
                 url: "visualizations/list",
                 target: "__use_router__",
             });
         }
-        if (Galaxy.config.interactivetools_enable) {
+        if (mastheadOptions.enableInteractiveTools) {
             userTab.menu.push({ divider: true });
             userTab.menu.push({
                 title: _l("Active InteractiveTools"),

--- a/client/src/layout/page.js
+++ b/client/src/layout/page.js
@@ -59,7 +59,7 @@ const View = Backbone.View.extend({
             this.$masthead.remove();
             this.$center.css("top", 0);
         } else {
-            this.masthead = mountMasthead(this.$masthead[0], this.config, mastheadState);
+            this.masthead = mountMasthead(this.$masthead[0], Galaxy, this.config, mastheadState);
         }
         this.$center.append(this.center.$el);
         this.$el.append(this.modal.$el);

--- a/templates/webapps/galaxy/galaxy.masthead.mako
+++ b/templates/webapps/galaxy/galaxy.masthead.mako
@@ -39,7 +39,7 @@
                 console.log("galaxy.masthead.mako", "initialize masthead");
                 let options = ${h.dumps(masthead_config)};
                 const container = document.getElementById("masthead");
-                window.bundleEntries.initMasthead(options, container);
+                window.bundleEntries.initMasthead(galaxy, options, container);
             });
         } else {
             console.log("galaxy.masthead.mako", "Detected embedding, not initializing masthead");


### PR DESCRIPTION
The goal here is to replace the hacks in the workflow centric UI where we want a completely different masthead depending on the router we're rendering. This just sets up the plumbing though and uses restoring the highlight of the current masthead tab selected from older Galaxies with the new version of the masthead.

I talked to @mvdbeek and he thought dropping the highlighted tab was a regression. If instead we want it to no be highlighted, I can drop that but I would still like to get the core refactoring in for the downstream work ideally.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Click around the UI and see the current tab is selected again. Here is an older Galaxy (http://huttenhower.sph.harvard.edu/galaxy/) that used to do this as well.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
