### PR TITLE
[22.05] Tool search backend bug fixes

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3049,10 +3049,8 @@
 ~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Boosts are used to customize this instance's toolbox search. The
-    higher the boost, the more importance the scoring algorithm gives
-    to the given field.  Section refers to the tool group in the tool
-    panel.  Rest of the fields are tool's attributes.
+    In tool search, a query match against a tool's name text will
+    receive this score multiplier.
 :Default: ``20.0``
 :Type: float
 
@@ -3062,7 +3060,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    If a search query exactly matches a tool name, the score will be
+    If a search query matches a tool name exactly, the score will be
     multiplied by this factor.
 :Default: ``10.0``
 :Type: float
@@ -3073,10 +3071,9 @@
 ~~~~~~~~~~~~~~~~~
 
 :Description:
-    Boosts are used to customize this instance's toolbox search. The
-    higher the boost, the more importance the scoring algorithm gives
-    to the given field.  Section refers to the tool group in the tool
-    panel.  Rest of the fields are tool's attributes.
+    In tool search, a query match against a tool's ID text will
+    receive this score multiplier. The query must be an exact match
+    against ID in order to be counted as a match.
 :Default: ``20.0``
 :Type: float
 
@@ -3086,10 +3083,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Boosts are used to customize this instance's toolbox search. The
-    higher the boost, the more importance the scoring algorithm gives
-    to the given field.  Section refers to the tool group in the tool
-    panel.  Rest of the fields are tool's attributes.
+    In tool search, a query match against a tool's section text will
+    receive this score multiplier.
 :Default: ``3.0``
 :Type: float
 
@@ -3099,10 +3094,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Boosts are used to customize this instance's toolbox search. The
-    higher the boost, the more importance the scoring algorithm gives
-    to the given field.  Section refers to the tool group in the tool
-    panel.  Rest of the fields are tool's attributes.
+    In tool search, a query match against a tool's description text
+    will receive this score multiplier.
 :Default: ``8.0``
 :Type: float
 
@@ -3112,10 +3105,8 @@
 ~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Boosts are used to customize this instance's toolbox search. The
-    higher the boost, the more importance the scoring algorithm gives
-    to the given field.  Section refers to the tool group in the tool
-    panel.  Rest of the fields are tool's attributes.
+    In tool search, a query match against a tool's label text will
+    receive this score multiplier.
 :Default: ``1.0``
 :Type: float
 
@@ -3125,11 +3116,9 @@
 ~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    A stub is parsed from the GUID as "owner/repo/tool_id". Boosts are
-    used to customize this instance's toolbox search. The higher the
-    boost, the more importance the scoring algorithm gives to the
-    given field.  Section refers to the tool group in the tool panel.
-    Rest of the fields are tool's attributes.
+    A stub is parsed from the GUID as "owner/repo/tool_id". In tool
+    search, a query match against a tool's stub text will receive this
+    score multiplier.
 :Default: ``2.0``
 :Type: float
 
@@ -3139,11 +3128,9 @@
 ~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Boosts are used to customize this instance's toolbox search. The
-    higher the boost, the more importance the scoring algorithm gives
-    to the given field.  Section refers to the tool group in the tool
-    panel.  Rest of the fields are tool's attributes.
-:Default: ``1``
+    In tool search, a query match against a tool's help text will
+    receive this score multiplier.
+:Default: ``1.0``
 :Type: float
 
 
@@ -3154,9 +3141,9 @@
 :Description:
     The lower this parameter, the greater the diminishing reward for
     term frequency in the help text. A higher K1 increases the level
-    of reward for additional occurences of a term. The default will
-    provide a small increase in score for the first, second and third
-    occurrence and then little reward thereafter.
+    of reward for additional occurences of a term. The default value
+    will provide a slight increase in score for the first, second and
+    third occurrence and little reward thereafter.
 :Default: ``0.5``
 :Type: float
 
@@ -3166,8 +3153,8 @@
 ~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Limits the number of results in toolbox search.  Can be used to
-    tweak how many results will appear.
+    Limits the number of results in toolbox search. Use to set the
+    maximum number of tool search results to display.
 :Default: ``20``
 :Type: int
 
@@ -3177,10 +3164,11 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Disabling this will prevent partial matching on tool names (not
-    recommended). Enable/ disable Ngram-search for tools. It makes
-    tool search results tolerant for spelling mistakes in the query by
-    dividing the query into multiple ngrams and search for each ngram.
+    Disabling this will prevent partial matches on tool names.
+    Enable/disable Ngram-search for tools. It makes tool search
+    results tolerant for spelling mistakes in the query, and will also
+    match query substrings e.g. "genome" will match "genomics" or
+    "metagenome".
 :Default: ``true``
 :Type: bool
 
@@ -3190,7 +3178,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Set minimum size of ngrams
+    Set minimum character length of ngrams
 :Default: ``3``
 :Type: int
 
@@ -3200,7 +3188,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Set maximum size of ngrams
+    Set maximum character length of ngrams
 :Default: ``4``
 :Type: int
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3053,7 +3053,18 @@
     higher the boost, the more importance the scoring algorithm gives
     to the given field.  Section refers to the tool group in the tool
     panel.  Rest of the fields are tool's attributes.
-:Default: ``9.0``
+:Default: ``20.0``
+:Type: float
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``tool_name_exact_multiplier``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    If a search query exactly matches a tool name, the score will be
+    multiplied by this factor.
+:Default: ``10.0``
 :Type: float
 
 
@@ -3066,7 +3077,7 @@
     higher the boost, the more importance the scoring algorithm gives
     to the given field.  Section refers to the tool group in the tool
     panel.  Rest of the fields are tool's attributes.
-:Default: ``9.0``
+:Default: ``20.0``
 :Type: float
 
 
@@ -3092,7 +3103,7 @@
     higher the boost, the more importance the scoring algorithm gives
     to the given field.  Section refers to the tool group in the tool
     panel.  Rest of the fields are tool's attributes.
-:Default: ``2.0``
+:Default: ``8.0``
 :Type: float
 
 
@@ -3114,11 +3125,12 @@
 ~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Boosts are used to customize this instance's toolbox search. The
-    higher the boost, the more importance the scoring algorithm gives
-    to the given field.  Section refers to the tool group in the tool
-    panel.  Rest of the fields are tool's attributes.
-:Default: ``5.0``
+    A stub is parsed from the GUID as "owner/repo/tool_id". Boosts are
+    used to customize this instance's toolbox search. The higher the
+    boost, the more importance the scoring algorithm gives to the
+    given field.  Section refers to the tool group in the tool panel.
+    Rest of the fields are tool's attributes.
+:Default: ``2.0``
 :Type: float
 
 
@@ -3131,6 +3143,20 @@
     higher the boost, the more importance the scoring algorithm gives
     to the given field.  Section refers to the tool group in the tool
     panel.  Rest of the fields are tool's attributes.
+:Default: ``1``
+:Type: float
+
+
+~~~~~~~~~~~~~~~~~~~~~~
+``tool_help_bm25f_k1``
+~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The lower this parameter, the greater the diminishing reward for
+    term frequency in the help text. A higher K1 increases the level
+    of reward for additional occurences of a term. The default will
+    provide a small increase in score for the first, second and third
+    occurrence and then little reward thereafter.
 :Default: ``0.5``
 :Type: float
 
@@ -3151,9 +3177,10 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Enable/ disable Ngram-search for tools. It makes tool search
-    results tolerant for spelling mistakes in the query by dividing
-    the query into multiple ngrams and search for each ngram
+    Disabling this will prevent partial matching on tool names (not
+    recommended). Enable/ disable Ngram-search for tools. It makes
+    tool search results tolerant for spelling mistakes in the query by
+    dividing the query into multiple ngrams and search for each ngram.
 :Default: ``true``
 :Type: bool
 
@@ -3176,6 +3203,18 @@
     Set maximum size of ngrams
 :Default: ``4``
 :Type: int
+
+
+~~~~~~~~~~~~~~~~~~~~~
+``tool_ngram_factor``
+~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Ngram matched scores will be multiplied by this factor. Should
+    always be below 1, because an ngram match is a partial match of a
+    search term.
+:Default: ``0.2``
+:Type: float
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1569,13 +1569,17 @@ galaxy:
   # higher the boost, the more importance the scoring algorithm gives to
   # the given field.  Section refers to the tool group in the tool
   # panel.  Rest of the fields are tool's attributes.
-  #tool_name_boost: 9.0
+  #tool_name_boost: 20.0
+
+  # If a search query exactly matches a tool name, the score will be
+  # multiplied by this factor.
+  #tool_name_exact_multiplier: 10.0
 
   # Boosts are used to customize this instance's toolbox search. The
   # higher the boost, the more importance the scoring algorithm gives to
   # the given field.  Section refers to the tool group in the tool
   # panel.  Rest of the fields are tool's attributes.
-  #tool_id_boost: 9.0
+  #tool_id_boost: 20.0
 
   # Boosts are used to customize this instance's toolbox search. The
   # higher the boost, the more importance the scoring algorithm gives to
@@ -1587,7 +1591,7 @@ galaxy:
   # higher the boost, the more importance the scoring algorithm gives to
   # the given field.  Section refers to the tool group in the tool
   # panel.  Rest of the fields are tool's attributes.
-  #tool_description_boost: 2.0
+  #tool_description_boost: 8.0
 
   # Boosts are used to customize this instance's toolbox search. The
   # higher the boost, the more importance the scoring algorithm gives to
@@ -1595,25 +1599,34 @@ galaxy:
   # panel.  Rest of the fields are tool's attributes.
   #tool_label_boost: 1.0
 
-  # Boosts are used to customize this instance's toolbox search. The
-  # higher the boost, the more importance the scoring algorithm gives to
-  # the given field.  Section refers to the tool group in the tool
-  # panel.  Rest of the fields are tool's attributes.
-  #tool_stub_boost: 5.0
+  # A stub is parsed from the GUID as "owner/repo/tool_id". Boosts are
+  # used to customize this instance's toolbox search. The higher the
+  # boost, the more importance the scoring algorithm gives to the given
+  # field.  Section refers to the tool group in the tool panel.  Rest of
+  # the fields are tool's attributes.
+  #tool_stub_boost: 2.0
 
   # Boosts are used to customize this instance's toolbox search. The
   # higher the boost, the more importance the scoring algorithm gives to
   # the given field.  Section refers to the tool group in the tool
   # panel.  Rest of the fields are tool's attributes.
-  #tool_help_boost: 0.5
+  #tool_help_boost: 1
+
+  # The lower this parameter, the greater the diminishing reward for
+  # term frequency in the help text. A higher K1 increases the level of
+  # reward for additional occurences of a term. The default will provide
+  # a small increase in score for the first, second and third occurrence
+  # and then little reward thereafter.
+  #tool_help_bm25f_k1: 0.5
 
   # Limits the number of results in toolbox search.  Can be used to
   # tweak how many results will appear.
   #tool_search_limit: 20
 
-  # Enable/ disable Ngram-search for tools. It makes tool search results
-  # tolerant for spelling mistakes in the query by dividing the query
-  # into multiple ngrams and search for each ngram
+  # Disabling this will prevent partial matching on tool names (not
+  # recommended). Enable/ disable Ngram-search for tools. It makes tool
+  # search results tolerant for spelling mistakes in the query by
+  # dividing the query into multiple ngrams and search for each ngram.
   #tool_enable_ngram_search: true
 
   # Set minimum size of ngrams
@@ -1621,6 +1634,11 @@ galaxy:
 
   # Set maximum size of ngrams
   #tool_ngram_maxsize: 4
+
+  # Ngram matched scores will be multiplied by this factor. Should
+  # always be below 1, because an ngram match is a partial match of a
+  # search term.
+  #tool_ngram_factor: 0.2
 
   # Set tool test data directory. The test framework sets this value to
   # 'test-data,https://github.com/galaxyproject/galaxy-test-data.git'

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1565,74 +1565,62 @@ galaxy:
   # Available formats are currently 'zip', 'gz', and 'bz2'.
   #disable_library_comptypes: null
 
-  # Boosts are used to customize this instance's toolbox search. The
-  # higher the boost, the more importance the scoring algorithm gives to
-  # the given field.  Section refers to the tool group in the tool
-  # panel.  Rest of the fields are tool's attributes.
+  # In tool search, a query match against a tool's name text will
+  # receive this score multiplier.
   #tool_name_boost: 20.0
 
-  # If a search query exactly matches a tool name, the score will be
+  # If a search query matches a tool name exactly, the score will be
   # multiplied by this factor.
   #tool_name_exact_multiplier: 10.0
 
-  # Boosts are used to customize this instance's toolbox search. The
-  # higher the boost, the more importance the scoring algorithm gives to
-  # the given field.  Section refers to the tool group in the tool
-  # panel.  Rest of the fields are tool's attributes.
+  # In tool search, a query match against a tool's ID text will receive
+  # this score multiplier. The query must be an exact match against ID
+  # in order to be counted as a match.
   #tool_id_boost: 20.0
 
-  # Boosts are used to customize this instance's toolbox search. The
-  # higher the boost, the more importance the scoring algorithm gives to
-  # the given field.  Section refers to the tool group in the tool
-  # panel.  Rest of the fields are tool's attributes.
+  # In tool search, a query match against a tool's section text will
+  # receive this score multiplier.
   #tool_section_boost: 3.0
 
-  # Boosts are used to customize this instance's toolbox search. The
-  # higher the boost, the more importance the scoring algorithm gives to
-  # the given field.  Section refers to the tool group in the tool
-  # panel.  Rest of the fields are tool's attributes.
+  # In tool search, a query match against a tool's description text will
+  # receive this score multiplier.
   #tool_description_boost: 8.0
 
-  # Boosts are used to customize this instance's toolbox search. The
-  # higher the boost, the more importance the scoring algorithm gives to
-  # the given field.  Section refers to the tool group in the tool
-  # panel.  Rest of the fields are tool's attributes.
+  # In tool search, a query match against a tool's label text will
+  # receive this score multiplier.
   #tool_label_boost: 1.0
 
-  # A stub is parsed from the GUID as "owner/repo/tool_id". Boosts are
-  # used to customize this instance's toolbox search. The higher the
-  # boost, the more importance the scoring algorithm gives to the given
-  # field.  Section refers to the tool group in the tool panel.  Rest of
-  # the fields are tool's attributes.
+  # A stub is parsed from the GUID as "owner/repo/tool_id". In tool
+  # search, a query match against a tool's stub text will receive this
+  # score multiplier.
   #tool_stub_boost: 2.0
 
-  # Boosts are used to customize this instance's toolbox search. The
-  # higher the boost, the more importance the scoring algorithm gives to
-  # the given field.  Section refers to the tool group in the tool
-  # panel.  Rest of the fields are tool's attributes.
-  #tool_help_boost: 1
+  # In tool search, a query match against a tool's help text will
+  # receive this score multiplier.
+  #tool_help_boost: 1.0
 
   # The lower this parameter, the greater the diminishing reward for
   # term frequency in the help text. A higher K1 increases the level of
-  # reward for additional occurences of a term. The default will provide
-  # a small increase in score for the first, second and third occurrence
-  # and then little reward thereafter.
+  # reward for additional occurences of a term. The default value will
+  # provide a slight increase in score for the first, second and third
+  # occurrence and little reward thereafter.
   #tool_help_bm25f_k1: 0.5
 
-  # Limits the number of results in toolbox search.  Can be used to
-  # tweak how many results will appear.
+  # Limits the number of results in toolbox search. Use to set the
+  # maximum number of tool search results to display.
   #tool_search_limit: 20
 
-  # Disabling this will prevent partial matching on tool names (not
-  # recommended). Enable/ disable Ngram-search for tools. It makes tool
-  # search results tolerant for spelling mistakes in the query by
-  # dividing the query into multiple ngrams and search for each ngram.
+  # Disabling this will prevent partial matches on tool names.
+  # Enable/disable Ngram-search for tools. It makes tool search results
+  # tolerant for spelling mistakes in the query, and will also match
+  # query substrings e.g. "genome" will match "genomics" or
+  # "metagenome".
   #tool_enable_ngram_search: true
 
-  # Set minimum size of ngrams
+  # Set minimum character length of ngrams
   #tool_ngram_minsize: 3
 
-  # Set maximum size of ngrams
+  # Set maximum character length of ngrams
   #tool_ngram_maxsize: 4
 
   # Ngram matched scores will be multiplied by this factor. Should

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2206,7 +2206,7 @@ mapping:
 
       tool_name_boost:
         type: float
-        default: 9.0
+        default: 20.0
         required: false
         reloadable: true
         desc: |
@@ -2215,9 +2215,18 @@ mapping:
           given field.  Section refers to the tool group in the tool panel.  Rest of
           the fields are tool's attributes.
 
+      tool_name_exact_multiplier:
+        type: float
+        default: 10.0
+        required: false
+        reloadable: true
+        desc: |
+          If a search query exactly matches a tool name, the score will be
+          multiplied by this factor.
+
       tool_id_boost:
         type: float
-        default: 9.0
+        default: 20.0
         required: false
         reloadable: true
         desc: |
@@ -2239,7 +2248,7 @@ mapping:
 
       tool_description_boost:
         type: float
-        default: 2.0
+        default: 8.0
         required: false
         reloadable: true
         desc: |
@@ -2261,7 +2270,19 @@ mapping:
 
       tool_stub_boost:
         type: float
-        default: 5.0
+        default: 2.0
+        required: false
+        reloadable: true
+        desc: |
+          A stub is parsed from the GUID as "owner/repo/tool_id".
+          Boosts are used to customize this instance's toolbox search.
+          The higher the boost, the more importance the scoring algorithm gives to the
+          given field.  Section refers to the tool group in the tool panel.  Rest of
+          the fields are tool's attributes.
+
+      tool_help_boost:
+        type: float
+        default: 1
         required: false
         reloadable: true
         desc: |
@@ -2270,16 +2291,17 @@ mapping:
           given field.  Section refers to the tool group in the tool panel.  Rest of
           the fields are tool's attributes.
 
-      tool_help_boost:
+      tool_help_bm25f_k1:
         type: float
         default: 0.5
         required: false
         reloadable: true
         desc: |
-          Boosts are used to customize this instance's toolbox search.
-          The higher the boost, the more importance the scoring algorithm gives to the
-          given field.  Section refers to the tool group in the tool panel.  Rest of
-          the fields are tool's attributes.
+          The lower this parameter, the greater the diminishing reward for
+          term frequency in the help text. A higher K1 increases the level
+          of reward for additional occurences of a term. The default will
+          provide a small increase in score for the first, second and third
+          occurrence and then little reward thereafter.
 
       tool_search_limit:
         type: int
@@ -2296,10 +2318,12 @@ mapping:
         required: false
         reloadable: true
         desc: |
+          Disabling this will prevent partial matching on tool names
+          (not recommended).
           Enable/ disable Ngram-search for tools. It makes tool
           search results tolerant for spelling mistakes in the query
           by dividing the query into multiple ngrams and search for
-          each ngram
+          each ngram.
 
       tool_ngram_minsize:
         type: int
@@ -2316,6 +2340,15 @@ mapping:
         reloadable: true
         desc: |
           Set maximum size of ngrams
+
+      tool_ngram_factor:
+        type: float
+        default: 0.2
+        required: false
+        reloadable: true
+        desc: |
+          Ngram matched scores will be multiplied by this factor. Should always
+          be below 1, because an ngram match is a partial match of a search term.
 
       tool_test_data_directories:
         type: str

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2282,7 +2282,7 @@ mapping:
 
       tool_help_boost:
         type: float
-        default: 1
+        default: 1.0
         required: false
         reloadable: true
         desc: |

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2210,10 +2210,8 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Boosts are used to customize this instance's toolbox search.
-          The higher the boost, the more importance the scoring algorithm gives to the
-          given field.  Section refers to the tool group in the tool panel.  Rest of
-          the fields are tool's attributes.
+          In tool search, a query match against a tool's name text will receive
+          this score multiplier.
 
       tool_name_exact_multiplier:
         type: float
@@ -2221,7 +2219,7 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          If a search query exactly matches a tool name, the score will be
+          If a search query matches a tool name exactly, the score will be
           multiplied by this factor.
 
       tool_id_boost:
@@ -2230,10 +2228,9 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Boosts are used to customize this instance's toolbox search.
-          The higher the boost, the more importance the scoring algorithm gives to the
-          given field.  Section refers to the tool group in the tool panel.  Rest of
-          the fields are tool's attributes.
+          In tool search, a query match against a tool's ID text will receive
+          this score multiplier. The query must be an exact match against ID
+          in order to be counted as a match.
 
       tool_section_boost:
         type: float
@@ -2241,10 +2238,8 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Boosts are used to customize this instance's toolbox search.
-          The higher the boost, the more importance the scoring algorithm gives to the
-          given field.  Section refers to the tool group in the tool panel.  Rest of
-          the fields are tool's attributes.
+          In tool search, a query match against a tool's section text will
+          receive this score multiplier.
 
       tool_description_boost:
         type: float
@@ -2252,10 +2247,8 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Boosts are used to customize this instance's toolbox search.
-          The higher the boost, the more importance the scoring algorithm gives to the
-          given field.  Section refers to the tool group in the tool panel.  Rest of
-          the fields are tool's attributes.
+          In tool search, a query match against a tool's description text will
+          receive this score multiplier.
 
       tool_label_boost:
         type: float
@@ -2263,10 +2256,8 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Boosts are used to customize this instance's toolbox search.
-          The higher the boost, the more importance the scoring algorithm gives to the
-          given field.  Section refers to the tool group in the tool panel.  Rest of
-          the fields are tool's attributes.
+          In tool search, a query match against a tool's label text will
+          receive this score multiplier.
 
       tool_stub_boost:
         type: float
@@ -2275,10 +2266,8 @@ mapping:
         reloadable: true
         desc: |
           A stub is parsed from the GUID as "owner/repo/tool_id".
-          Boosts are used to customize this instance's toolbox search.
-          The higher the boost, the more importance the scoring algorithm gives to the
-          given field.  Section refers to the tool group in the tool panel.  Rest of
-          the fields are tool's attributes.
+          In tool search, a query match against a tool's stub text will receive
+          this score multiplier.
 
       tool_help_boost:
         type: float
@@ -2286,10 +2275,8 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Boosts are used to customize this instance's toolbox search.
-          The higher the boost, the more importance the scoring algorithm gives to the
-          given field.  Section refers to the tool group in the tool panel.  Rest of
-          the fields are tool's attributes.
+          In tool search, a query match against a tool's help text will receive
+          this score multiplier.
 
       tool_help_bm25f_k1:
         type: float
@@ -2299,9 +2286,9 @@ mapping:
         desc: |
           The lower this parameter, the greater the diminishing reward for
           term frequency in the help text. A higher K1 increases the level
-          of reward for additional occurences of a term. The default will
-          provide a small increase in score for the first, second and third
-          occurrence and then little reward thereafter.
+          of reward for additional occurences of a term. The default value will
+          provide a slight increase in score for the first, second and third
+          occurrence and little reward thereafter.
 
       tool_search_limit:
         type: int
@@ -2309,8 +2296,8 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Limits the number of results in toolbox search.  Can be used to tweak how many
-          results will appear.
+          Limits the number of results in toolbox search. Use to set the
+          maximum number of tool search results to display.
 
       tool_enable_ngram_search:
         type: bool
@@ -2318,12 +2305,11 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Disabling this will prevent partial matching on tool names
-          (not recommended).
-          Enable/ disable Ngram-search for tools. It makes tool
-          search results tolerant for spelling mistakes in the query
-          by dividing the query into multiple ngrams and search for
-          each ngram.
+          Disabling this will prevent partial matches on tool names.
+          Enable/disable Ngram-search for tools. It makes tool
+          search results tolerant for spelling mistakes in the query, and will
+          also match query substrings e.g. "genome" will match "genomics" or
+          "metagenome".
 
       tool_ngram_minsize:
         type: int
@@ -2331,7 +2317,7 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Set minimum size of ngrams
+          Set minimum character length of ngrams
 
       tool_ngram_maxsize:
         type: int
@@ -2339,7 +2325,7 @@ mapping:
         required: false
         reloadable: true
         desc: |
-          Set maximum size of ngrams
+          Set maximum character length of ngrams
 
       tool_ngram_factor:
         type: float

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -237,7 +237,6 @@ class ToolPanelViewSearch:
                 add_doc_kwds = self._create_doc(
                     tool=tool,
                     index_help=index_help,
-                    config=toolbox.app.config,
                 )
                 # Add tool document to index (or overwrite if existing)
                 writer.update_document(**add_doc_kwds)
@@ -293,7 +292,6 @@ class ToolPanelViewSearch:
         self,
         tool,
         index_help: bool = True,
-        config: GalaxyAppConfiguration = None,
     ) -> Dict[str, str]:
         def clean(string):
             """Remove hyphens as they are Whoosh wildcards."""

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -67,6 +67,24 @@ CanConvertToFloat = Union[str, int, float]
 CanConvertToInt = Union[str, int, float]
 
 
+def get_or_create_index(index_dir, schema):
+    """Get or create a reference to the index."""
+    if not os.path.exists(index_dir):
+        os.makedirs(index_dir)
+    if index.exists_in(index_dir):
+        idx = index.open_dir(index_dir)
+        if idx.schema == schema:
+            return idx
+    log.warning(
+        f"Index at '{index_dir}' uses outdated schema, creating a"
+        " new index")
+
+    # Delete the old index and return a new index reference
+    shutil.rmtree(index_dir)
+    os.makedirs(index_dir)
+    return index.create_in(index_dir, schema=schema)
+
+
 class ToolBoxSearch:
     """Support searching across all fixed panel views in a toolbox.
 
@@ -181,20 +199,7 @@ class ToolPanelViewSearch:
 
     def _index_setup(self) -> index.Index:
         """Get or create a reference to the index."""
-        if not os.path.exists(self.index_dir):
-            os.makedirs(self.index_dir)
-        if index.exists_in(self.index_dir):
-            idx = index.open_dir(self.index_dir)
-            if idx.schema == self.schema:
-                return idx
-        log.warning(
-            f"Index at '{self.index_dir}' uses outdated schema, creating a"
-            " new index")
-
-        # Delete the old index and return a new index reference
-        shutil.rmtree(self.index_dir)
-        os.makedirs(self.index_dir)
-        return index.create_in(self.index_dir, schema=self.schema)
+        return get_or_create_index()
 
     def build_index(
         self,

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -245,7 +245,7 @@ class ToolPanelViewSearch:
             f"Toolbox index of panel {self.panel_view_id}"
             f" finished {execution_timer}")
 
-    def _get_tools_to_remove(self, tool_cache):
+    def _get_tools_to_remove(self, tool_cache) -> list:
         """Return list of tool IDs to be removed from index."""
         tool_ids_to_remove = (
             self.indexed_tool_ids - set(tool_cache._tool_paths_by_id.keys())
@@ -263,7 +263,7 @@ class ToolPanelViewSearch:
 
         return tool_ids_to_remove
 
-    def _get_tool_list(self, toolbox, tool_cache) -> tuple:
+    def _get_tool_list(self, toolbox, tool_cache) -> list:
         """Return list of tools to add and remove from index."""
         tools_to_index = []
 

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -323,4 +323,4 @@ class ToolPanelViewSearch:
         ]))
         # !!! -------------------------------------------------------------
 
-        return [hit["id"] for hit in hits]
+        return [hit["id"] for hit in hits[:config.tool_search_limit]]

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -284,9 +284,7 @@ class ToolPanelViewSearch:
         def clean(string):
             """Remove hyphens as they are Whoosh wildcards."""
             if "-" in string:
-                return (" ").join(
-                    token.text for token in self.rex(to_unicode(tool.name))
-                )
+                return (" ").join(token.text for token in self.rex(to_unicode(tool.name)))
             else:
                 return string
 
@@ -298,11 +296,7 @@ class ToolPanelViewSearch:
             "id_exact": to_unicode(tool.id),
             "name": clean(tool.name),
             "description": to_unicode(tool.description),
-            "section": to_unicode(
-                tool.get_panel_section()[1]
-                if len(tool.get_panel_section()) == 2
-                else ""
-            ),
+            "section": to_unicode(tool.get_panel_section()[1] if len(tool.get_panel_section()) == 2 else ""),
             "help": to_unicode(""),
         }
         if tool.guid:

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -315,7 +315,7 @@ class ToolPanelViewSearch:
             x[0] for x in hits.top_n
         ][:config.tool_search_limit]
 
-        log.info(pprint.pformat([
+        log.debug(pprint.pformat([
             {
                 'score': score,
                 'details': hit['id'],

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -199,7 +199,7 @@ class ToolPanelViewSearch:
 
     def _index_setup(self) -> index.Index:
         """Get or create a reference to the index."""
-        return get_or_create_index()
+        return get_or_create_index(self.index_dir, self.schema)
 
     def build_index(
         self,

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -31,6 +31,7 @@ from whoosh.qparser import (
 )
 from whoosh.scoring import (
     BM25F,
+    Frequency,
     MultiWeighting,
 )
 from whoosh.writing import AsyncWriter
@@ -213,13 +214,13 @@ class ToolPanelViewSearch:
         # Change field boosts for searcher
         self.searcher = self.index.searcher(
             weighting=MultiWeighting(
-                BM25F(),
-                old_id=BM25F(old_id_B=float(tool_id_boost)),
-                name=BM25F(name_B=float(tool_name_boost)),
-                section=BM25F(section_B=float(tool_section_boost)),
-                description=BM25F(description_B=float(tool_description_boost)),
-                labels=BM25F(labels_B=float(tool_label_boost)),
-                stub=BM25F(stub_B=float(tool_stub_boost)),
+                Frequency(),
+                # name=Frequency(name_B=float(tool_name_boost)),
+                # old_id=Frequency(old_id_B=float(tool_id_boost)),
+                # section=Frequency(section_B=float(tool_section_boost)),
+                # description=Frequency(description_B=float(tool_description_boost)),
+                # labels=Frequency(labels_B=float(tool_label_boost)),
+                # stub=Frequency(stub_B=float(tool_stub_boost)),
                 help=BM25F(help_B=float(tool_help_boost)),
             )
         )

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -1,8 +1,28 @@
 """
-Module for building and searching the index of tools
-installed within this Galaxy. Before changing index-building
-or searching related parts it is deeply recommended to read
-through the library docs at https://whoosh.readthedocs.io.
+Module for building and searching the index of installed tools.
+
+Before changing index-building or searching related parts it is highly
+recommended to read the docs at https://whoosh.readthedocs.io.
+
+Schema - this is how we define the index, both for building and searching. A
+    field is created for each data element that we want to add e.g. tool name,
+    tool ID, description. The type of field and its attributes define how
+    entries for that field will be indexed and ultimately how they can be
+    searched. Score weighting (boost) is added here on a per-field bases, to
+    allow matches to important fields like "name" to receive a higher score.
+
+Tokenizers - these take an attribute (e.g. name) and parse it into "tokens" to
+    be stored in the index. Can be done in many ways for different search
+    functionality. For example, the IDTokenizer creates one token for an entire
+    entry, resulting in an index field that requires a full-field match. The
+    default tokenizer will break an entry into words, so that single word
+    matches are possible.
+
+Filters - various filters are available for processing content as the index is
+    built. A StopFilter removes common articles 'a', 'for', 'and' etc. A
+    StemmingFilter removes suffixes from words to create a 'base work' e.g.
+    stemming -> stem; opened -> open; philosophy -> philosoph.
+
 """
 import logging
 import os

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -342,7 +342,7 @@ class ToolPanelViewSearch:
     def search(
         self,
         q: str,
-        config: GalaxyAppConfiguration = None,
+        config: GalaxyAppConfiguration,
     ) -> List[str]:
         """Perform search on the in-memory index."""
         # Change field boosts for searcher

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -185,6 +185,10 @@ class ToolPanelViewSearch:
                 if latest_version and latest_version.hidden:
                     continue
             tool_ids_to_remove.add(indexed_tool_id)
+
+        JSON_INDEX = '/tmp/tool_search_index.json'
+        index_data = {}
+
         with AsyncWriter(self.index) as writer:
             for tool_id in tool_ids_to_remove:
                 writer.delete_by_term("id", tool_id)
@@ -210,6 +214,12 @@ class ToolPanelViewSearch:
                         config=toolbox.app.config,
                     )
                     writer.update_document(**add_doc_kwds)
+                    index_data[tool_id] = add_doc_kwds
+
+        with open(JSON_INDEX, 'w') as f:
+            import json
+            json.dump(index_data, f)
+
         log.debug(f"Toolbox index of panel {self.panel_view_id} finished {execution_timer}")
 
     def _create_doc(

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -261,7 +261,7 @@ class ToolPanelViewSearch:
                     continue
             tool_ids_to_remove.add(indexed_tool_id)
 
-        return tool_ids_to_remove
+        return list(tool_ids_to_remove)
 
     def _get_tool_list(self, toolbox, tool_cache) -> list:
         """Return list of tools to add and remove from index."""

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -42,9 +42,9 @@ from whoosh import (
 from whoosh.fields import (
     ID,
     KEYWORD,
+    NGRAMWORDS,
     Schema,
     TEXT,
-    NGRAMWORDS,
 )
 from whoosh.qparser import (
     MultifieldParser,
@@ -57,9 +57,9 @@ from whoosh.scoring import (
 )
 from whoosh.writing import AsyncWriter
 
+from galaxy.config import GalaxyAppConfiguration
 from galaxy.util import ExecutionTimer
 from galaxy.web.framework.helpers import to_unicode
-from galaxy.config import GalaxyAppConfiguration
 
 log = logging.getLogger(__name__)
 
@@ -146,9 +146,7 @@ class ToolPanelViewSearch:
             # eligible for massive score boosting. A secondary ngram or text
             # field for name is added below
             "name_exact": TEXT(
-                field_boost=(
-                    config.tool_name_boost * config.tool_name_exact_multiplier
-                ),
+                field_boost=(config.tool_name_boost * config.tool_name_exact_multiplier),
                 analyzer=analysis.IDTokenizer() | analysis.LowercaseFilter(),
             ),
             # The owner/repo/tool_id parsed from the GUID
@@ -161,9 +159,7 @@ class ToolPanelViewSearch:
                 analyzer=analysis.StemmingAnalyzer(),
             ),
             # Help text parsed from the tool XML
-            "help": TEXT(
-                field_boost=config.tool_help_boost, analyzer=analysis.StemmingAnalyzer()
-            ),
+            "help": TEXT(field_boost=config.tool_help_boost, analyzer=analysis.StemmingAnalyzer()),
             "labels": KEYWORD(field_boost=float(config.tool_label_boost)),
         }
 
@@ -173,9 +169,7 @@ class ToolPanelViewSearch:
                     "name": NGRAMWORDS(
                         minsize=config.tool_ngram_minsize,
                         maxsize=config.tool_ngram_maxsize,
-                        field_boost=(
-                            float(config.tool_name_boost) * config.tool_ngram_factor
-                        ),
+                        field_boost=(float(config.tool_name_boost) * config.tool_ngram_factor),
                     ),
                 }
             )
@@ -228,16 +222,13 @@ class ToolPanelViewSearch:
                 # Add tool document to index (or overwrite if existing)
                 writer.update_document(**add_doc_kwds)
 
-        log.debug(
-            f"Toolbox index of panel {self.panel_view_id}"
-            f" finished {execution_timer}"
-        )
+        log.debug(f"Toolbox index of panel {self.panel_view_id}" f" finished {execution_timer}")
 
     def _get_tools_to_remove(self, tool_cache) -> list:
         """Return list of tool IDs to be removed from index."""
-        tool_ids_to_remove = (
-            self.indexed_tool_ids - set(tool_cache._tool_paths_by_id.keys())
-        ).union(tool_cache._removed_tool_ids)
+        tool_ids_to_remove = (self.indexed_tool_ids - set(tool_cache._tool_paths_by_id.keys())).union(
+            tool_cache._removed_tool_ids
+        )
 
         for indexed_tool_id in self.indexed_tool_ids:
             indexed_tool = tool_cache.get_tool_by_id(indexed_tool_id)

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -110,10 +110,17 @@ class ToolPanelViewSearch:
         config: GalaxyAppConfiguration,
         index_help: bool = True
     ):
+        """Build the schema and validate against the index."""
         schema_conf = {
             # The ID field is currently not searchable!?
             # Can't fix, spent hours trying
             'id': ID(stored=True, unique=True),
+            'id_exact': TEXT(
+                field_boost=(
+                    config.tool_id_boost
+                    * config.tool_name_exact_multiplier),
+                analyzer=analysis.IDTokenizer() | analysis.LowercaseFilter(),
+            ),
             'name': TEXT(
                 field_boost=(
                     config.tool_name_boost
@@ -227,6 +234,7 @@ class ToolPanelViewSearch:
             return {}
         add_doc_kwds = {
             "id": to_unicode(tool_id),
+            "id_exact": to_unicode(tool_id),
             "description": to_unicode(tool.description),
             "section": to_unicode(
                 tool.get_panel_section()[1]
@@ -282,6 +290,7 @@ class ToolPanelViewSearch:
         )
         fields = [
             "id",
+            "id_exact",
             "name",
             "description",
             "section",

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -185,9 +185,6 @@ class ToolPanelViewSearch:
                     continue
             tool_ids_to_remove.add(indexed_tool_id)
 
-        JSON_INDEX = '/tmp/tool_search_index.json'
-        index_data = {}
-
         with AsyncWriter(self.index) as writer:
             for tool_id in tool_ids_to_remove:
                 writer.delete_by_term("id", tool_id)
@@ -213,11 +210,7 @@ class ToolPanelViewSearch:
                         config=toolbox.app.config,
                     )
                     writer.update_document(**add_doc_kwds)
-                    index_data[tool_id] = add_doc_kwds
 
-        with open(JSON_INDEX, 'w') as f:
-            import json
-            json.dump(index_data, f)
         log.debug(
             f"Toolbox index of panel {self.panel_view_id}"
             f" finished {execution_timer}")

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -76,8 +76,7 @@ def get_or_create_index(index_dir, schema):
         if idx.schema == schema:
             return idx
     log.warning(
-        f"Index at '{index_dir}' uses outdated schema, creating a"
-        " new index")
+        f"Index at '{index_dir}' uses outdated schema, creating a new index")
 
     # Delete the old index and return a new index reference
     shutil.rmtree(index_dir)

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -48,6 +48,7 @@ from whoosh.fields import (
 )
 from whoosh.qparser import (
     MultifieldParser,
+    OrGroup,
 )
 from whoosh.scoring import (
     BM25F,
@@ -318,6 +319,7 @@ class ToolPanelViewSearch:
         self.parser = MultifieldParser(
             fields,
             schema=self.schema,
+            group=OrGroup,  # We need OR grouping to match StopList phrases
         )
         cleaned_query = " ".join(
             token.text for token in self.rex(q.lower())

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -257,11 +257,7 @@ class ToolPanelViewSearch:
 
         for tool_id in tool_cache._new_tool_ids - self.indexed_tool_ids:
             tool = toolbox.get_tool(tool_id)
-            if (
-                tool
-                and tool.is_latest_version
-                and toolbox.panel_has_tool(tool, self.panel_view_id)
-            ):
+            if tool and tool.is_latest_version and toolbox.panel_has_tool(tool, self.panel_view_id):
                 if tool.hidden:
                     # Check if there is an older tool we can return
                     if tool.lineage:

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -244,32 +244,11 @@ class ToolsService(ServiceBase):
         :return type: dict
         """
         panel_view = view or self.config.default_panel_view
-        tool_name_boost = self.config.tool_name_boost
-        tool_id_boost = self.config.tool_id_boost
-        tool_section_boost = self.config.tool_section_boost
-        tool_description_boost = self.config.tool_description_boost
-        tool_label_boost = self.config.tool_label_boost
-        tool_stub_boost = self.config.tool_stub_boost
-        tool_help_boost = self.config.tool_help_boost
-        tool_search_limit = self.config.tool_search_limit
-        tool_enable_ngram_search = self.config.tool_enable_ngram_search
-        tool_ngram_minsize = self.config.tool_ngram_minsize
-        tool_ngram_maxsize = self.config.tool_ngram_maxsize
 
         results = self.toolbox_search.search(
             q=q,
             panel_view=panel_view,
-            tool_name_boost=tool_name_boost,
-            tool_id_boost=tool_id_boost,
-            tool_section_boost=tool_section_boost,
-            tool_description_boost=tool_description_boost,
-            tool_label_boost=tool_label_boost,
-            tool_stub_boost=tool_stub_boost,
-            tool_help_boost=tool_help_boost,
-            tool_search_limit=tool_search_limit,
-            tool_enable_ngram_search=tool_enable_ngram_search,
-            tool_ngram_minsize=tool_ngram_minsize,
-            tool_ngram_maxsize=tool_ngram_maxsize,
+            config=self.config,
         )
         return results
 


### PR DESCRIPTION
This is an overhaul of the Whoosh backend for tool search, as part of the GCC2022 CoFest (working with Tyler Collins @tcollins2011), addressing issues mentioned in #14028.

Tool search had a number of bugs that have been fixed. Tool search has been greatly improved as a result:

1. Fix boosting so that it actually works (currently boost values are passed to the `BM25F` scorer B param which makes no sense)
1. Convert all fields (except `help`) from `BM25F` to `Frequency` scoring algorithm (simpler, these are small fields)
1. Remove wildcard expansion of search queries (far too generous)
1. Remove hacky `_search_ngrams` method and implement ngram search properly on the name field only
1. Implement stem searching on the `help` field (discarding common articles "and" "for" "a" etc)
1. Index `id` field properly (can not be searched against currently)
1. Delete the old Whoosh index if the schema (i.e. code) has changed at runtime (prevent weird bugs when building on top of an old schema)
1. General refactoring for readability
1. Add debug logging to report match scoring
1. Add new config params `tool_ngram_factor`, `tool_name_exact_multiplier`
1. Access config params through `toolbox` object rather than numerous positional arguments
1. Refactor calls to `ToolBoxSearch.search()` to pass `config` reference as argument instead of individual config params

## Outstanding queries
1. How to commit changes to git modules? Should we just leave these?
    - `galaxy-tool-search/lib/galaxy/webapps/galaxy/api/tools.py`
    - `galaxy-tool-search//lib/galaxy/config/schemas/config_schema.yml`
2. There is an ongoing issue with the UI (Vue) code re-ordering and messing up the API results - be sure to check the order of the `/api/tools/q=query` response in the browser's network tab if a search result still looks strange after applying this diff.

## How to test
We are still working on updating unit tests for this PR.

Our "test harness" for developing these fixes is [available here](https://github.com/neoformit/galaxy-tool-search-test). It is useful for validating changes to the code.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

Tool search results on Galaxy main vs EU (where code has been patched with this PR):
![image](https://user-images.githubusercontent.com/42562517/180622650-90499f53-cf55-43d9-a968-8e5db704acd6.png)
