### PR TITLE
[22.01] Correct IMPLICITLY_REQUIRED_TOOL_FILES for some tools

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -222,20 +222,20 @@ IMPLICITLY_REQUIRED_TOOL_FILES: Dict[str, Dict] = {
     # "foobar": {"required": REQUIRE_FULL_DIRECTORY}
     # if no version is specified, all versions without explicit RequiredFiles will be selected
     "circos": {"required": REQUIRE_FULL_DIRECTORY},
-    "cp_image_math": {"required": {"includes": [{"path": "cp_common_functions.py", "path_type": "literal"}]}},
-    "enumerate_charges": {"required": {"includes": [{"path": "site_substructures.smarts", "path_type": "literal"}]}},
+    "cp_image_math": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
+    "enumerate_charges": {"required": REQUIRE_FULL_DIRECTORY},
     "fasta_compute_length": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
     "fasta_concatenate0": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
     "filter_tabular": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
     "flanking_features_1": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
     "gops_intersect_1": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
     "gops_subtract_1": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
-    "maxquant": {"required": {"includes": [{"path": "mqparam.py", "path_type": "literal"}]}},
-    "maxquant_mqpar": {"required": {"includes": [{"path": "mqparam.py", "path_type": "literal"}]}},
+    "maxquant": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
+    "maxquant_mqpar": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
     "query_tabular": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
     "shasta": {"required": {"includes": [{"path": "configs/*", "path_type": "glob"}]}},
     "sqlite_to_tabular": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
-    "sucos_max_score": {"required": {"includes": [{"path": "utils.py", "path_type": "literal"}]}},
+    "sucos_max_score": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
 }
 
 


### PR DESCRIPTION
IMPLICITLY_REQUIRED_TOOL_FILES contains records of required files for some tools where not all of the scripts required for running the jobs can be automatically detected from the wrapper.  Some of these entries are incorrect:  'required' needs to cover all required scripts, including those that were previously being automatically detected.   This change is needed in order to be able to run older versions of maxquant etc on pulsar.