### PR TITLE
[22.05] Optimize History watcher to request detailed information only for expanded items

### DIFF
--- a/client/src/store/historyStore/model/watchHistory.js
+++ b/client/src/store/historyStore/model/watchHistory.js
@@ -58,12 +58,9 @@ export async function watchHistoryOnce(store) {
             v: "dev",
             view: "detailed",
         };
-        const paramsString = Object.entries(params)
-            .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
-            .join("&");
-        const url = `api/histories/${historyId}/contents?${paramsString}`;
+        const url = `api/histories/${historyId}/contents`;
         lastRequestDate = new Date();
-        const payload = await urlData({ url });
+        const payload = await urlData({ url, params });
         // show warning that not all changes have been obtained
         if (payload && payload.length == limit) {
             console.debug(`Reached limit of monitored changes (limit=${limit}).`);

--- a/client/src/utils/url.js
+++ b/client/src/utils/url.js
@@ -2,11 +2,12 @@ import axios from "axios";
 import { getAppRoot } from "onload/loadConfig";
 import { rethrowSimple } from "utils/simple-error";
 
-export async function urlData({ url, headers }) {
+export async function urlData({ url, headers, params }) {
     try {
         console.debug("Requesting data from: ", url);
         headers = headers || {};
-        const { data } = await axios.get(`${getAppRoot()}${url}`, { headers });
+        params = params || {};
+        const { data } = await axios.get(`${getAppRoot()}${url}`, { headers, params });
         return data;
     } catch (e) {
         rethrowSimple(e);


### PR DESCRIPTION
This is an attempt to reduce the performance impact of *Stack 1* in https://github.com/galaxyproject/galaxy/issues/14322#issuecomment-1184670268

Instead of requesting detailed information for all the updated items in the current history we now request the basic summary information and the details only for those items that are currently expanded in the history panel.

The impact is more notorious when dealing with large bulk operations that may update more than 1000 items in a single request. For example:

**Scenario**
We have a History with 1000 datasets and 2 of those are expanded in the history panel. Then we change the dbkey of the entire history in bulk. The history watcher will request 1000 items which is the current limit:
- **Before** this fix the content's request takes around 10 seconds
- **After** the fix the content's request takes around 1 second

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Run a bulk operation targeting more than 1k items.
  - Observe the response time with different numbers of expanded items in the history panel

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
