### PR TITLE
[22.05] Fix incorrect history swapping in some cases where we swap on the client but the server is never notified.

### DIFF
--- a/client/src/components/providers/UserHistories.js
+++ b/client/src/components/providers/UserHistories.js
@@ -88,7 +88,7 @@ export default {
                 deleteHistory: (history) => this.deleteHistory({ history }),
                 deleteCurrentHistory: () => this.deleteHistory({ history: this.currentHistory }),
 
-                // purge history then clearn currentHistoryId
+                // purge history then clear currentHistoryId
                 purgeHistory: (history) => this.deleteHistory({ history, purge: true }),
                 purgeCurrentHistory: () => this.deleteHistory({ history: this.currentHistory, purge: true }),
 

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -152,10 +152,8 @@ const actions = {
         commit("setCurrentHistoryId", history.id);
     },
     async setCurrentHistory({ dispatch, getters }, id) {
-        if (id !== getters.currentHistoryId) {
-            const changedHistory = await setCurrentHistoryOnServer(id);
-            dispatch("selectHistory", changedHistory);
-        }
+        const changedHistory = await setCurrentHistoryOnServer(id);
+        dispatch("selectHistory", changedHistory);
     },
     setHistory({ commit }, history) {
         commit("setHistory", history);


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14173

This does fix it, but WIP for a minute trying to track through how the delete action was mutating the store and bypassing this (but not actually notifying the server).

Since the "should the server even maintain a current history" ship has sailed, it does track though that anytime we perform the selectCurrentHistory action we should ensure the server has been notified.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
