### PR TITLE
[22.05] Fix unhashable type in history contents API

### DIFF
--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -40,6 +40,9 @@ class BaseDatabaseIdField:
     def __repr__(self):
         return f"DatabaseID ({super().__repr__()})"
 
+    def __hash__(self) -> int:
+        return hash(self)
+
 
 class DecodedDatabaseIdField(int, BaseDatabaseIdField):
     @classmethod

--- a/test/unit/webapps/api/test_id_fields.py
+++ b/test/unit/webapps/api/test_id_fields.py
@@ -37,3 +37,21 @@ def test_decoded_database_id_field(security: IdEncodingHelper):
     decoded_id = 1
     id_model = EncodedIdModel(id=decoded_id)
     assert id_model.id == security.encode_id(decoded_id)
+
+
+def test_decoded_id_hash(security: IdEncodingHelper):
+    id_a = 1
+    id_b = 2
+    model_a = DecodedIdModel(id=security.encode_id(id_a))
+    model_b = DecodedIdModel(id=security.encode_id(id_b))
+    model_same_1 = DecodedIdModel(id=security.encode_id(id_a))
+    assert hash(model_a.id) != hash(model_b.id)
+    assert hash(model_a.id) == hash(model_same_1.id)
+
+
+def test_encoded_id_hash(security: IdEncodingHelper):
+    model_a = EncodedIdModel(id=1)
+    model_b = EncodedIdModel(id=2)
+    model_same_a = EncodedIdModel(id=1)
+    assert hash(model_a.id) != hash(model_b.id)
+    assert hash(model_a.id) == hash(model_same_a.id)


### PR DESCRIPTION
Fixes #14387

<del>I couldn't reproduce #14387, but the issue looks like using `Set` here will require `EncodedDatabaseId` to be hashable.
Using a simple list will work just fine since this query parameter is parsed manually anyway and converted to a Set just to avoid duplicates while maintaining retro-compatibility with the legacy API and supporting multiple ways of defining it.</del>

`BaseDatabaseIdField` should be hashable now.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
