### PR TITLE
Allow sort order for sort_by to be reversed

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4666,10 +4666,10 @@ In both cases the desired metadata is selected by ``key``.
 
 The ``static_value`` and ``regexp`` filters can be inverted by setting ``keep`` to true.
 
-* ``add_value``: add an option with a given ``name`` and ``value`` to the options. By default the new option is appended, with ``index`` the insertion position can be specified.
-* ``remove_value``: remove a value from the options. Either specified explicitly with ``value``, the value of another input specifified with ``ref``, or the metatdata ``key`` of another input ``meta_ref``.
+* ``add_value``: add an option with a given ``name`` and ``value`` to the options. By default, the new option is appended, with ``index`` the insertion position can be specified.
+* ``remove_value``: remove a value from the options. Either specified explicitly with ``value``, the value of another input specified with ``ref``, or the metadata ``key`` of another input ``meta_ref``.
 * ``unique_value``: remove options that have duplicate entries in the given ``column``.
-* ``sort_by``: sort options by the entries of a given ``column``.
+* ``sort_by``: sort options by the entries of a given ``column``. If ``reverse_sort_order`` is set to ``true``, reverse sort order from ascending to descending.
 * ``multiple_splitter``: split the entries of the specified ``column``(s) in the referenced file using a ``separator``. Thereby the number of columns is increased.
 
 ### Examples
@@ -4856,6 +4856,13 @@ added to the end of the list.</xs:documentation>
         <xs:documentation xml:lang="en">Only used when ``type`` is
 ``remove_value``. Dataset to look for the value of metadata ``key`` to remove
 from the list.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="reverse_sort_order" type="xs:boolean" default="false">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Used when ``type`` is ``sort_by``, if set to
+        ``true`` it will reverse the sort order from ascending to descending. Default
+        is ``false``.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -516,9 +516,10 @@ class SortByColumnFilter(Filter):
         column = elem.get("column", None)
         assert column is not None, "Required 'column' attribute missing from filter"
         self.column = d_option.column_spec_to_index(column)
+        self.reverse = elem.get("reverse_sort_order", False)
 
     def filter_options(self, options, trans, other_values):
-        return sorted(options, key=lambda x: x[self.column])
+        return sorted(options, key=lambda x: x[self.column], reverse=self.reverse)
 
 
 filter_types = dict(

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -516,7 +516,7 @@ class SortByColumnFilter(Filter):
         column = elem.get("column", None)
         assert column is not None, "Required 'column' attribute missing from filter"
         self.column = d_option.column_spec_to_index(column)
-        self.reverse = elem.get("reverse_sort_order", False)
+        self.reverse = string_as_bool(elem.get("reverse_sort_order", "False"))
 
     def filter_options(self, options, trans, other_values):
         return sorted(options, key=lambda x: x[self.column], reverse=self.reverse)


### PR DESCRIPTION
Options can currently be specified with `from_data_table`. These options can be sorted by using `sort_by` with a column specified to sort on. Currently sort order cannot be specified. This PR adds a `reverse_sort_order` attribute to the `<filter>` element that is used by the SortByColumnFilter.

The specific use case for this comes from the nextclade and pangolin data managers. These DMs manage a growing collection of databases where the most recent database should be the default selection. With the current Galaxy, the sort order shows the earlier (i.e. smallest date in ISO-8601) first. This simple PR will allow the tools to show the most recent database first.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

I have tested manually with a self-written tool (tool XML below), but I don't know the test framework well enough to write a test for this functionality. Assistance in this regard is appreciated.

``` xml
<tool id="sort_order" name="Sort Order" version="0.1.0+galaxy0" profile="21.05">
    <requirements>
    </requirements>
    <command detect_errors="exit_code"><![CDATA[
        echo '$inputs'
    ]]></command>
    <inputs>
        <param type="data" name="input_table" format="tabular" label="Input table"/>
        <param type="select" name="sortable" label="Sortable">
            <options from_dataset="input_table">
                <column name="name" index="0"/>
                <column name="value" index="0"/>
                <filter type="sort_by" column="0"/>
            </options>
        </param>
        <param type="select" name="reverse_sortable" label="Reverse Sortable">
            <options from_dataset="input_table">
                <column name="name" index="0"/>
                <column name="value" index="0"/>
                <filter type="sort_by" column="0" reverse_sort_order="true" />
            </options>
        </param>
    </inputs>
    <outputs>
    </outputs>
    <help><![CDATA[
        TODO: Fill in help.
    ]]></help>
</tool>
```
## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
