### PR TITLE
Refactor history contents API ID encoding

### DIFF
--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -57,6 +57,10 @@ class DecodedDatabaseIdField(int, BaseDatabaseIdField):
             raise ValueError("Invalid characters in encoded ID")
         return cls(cls.security.decode_id(v))
 
+    @classmethod
+    def encode(cls, v):
+        return cls.security.encode_id(v)
+
 
 class EncodedDatabaseIdField(str, BaseDatabaseIdField):
     @classmethod

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -82,7 +82,7 @@ AccessibleField: bool = Field(
     description="Whether this item is accessible to the current user due to permissions.",
 )
 
-EncodedEntityIdField: EncodedDatabaseIdField = Field(
+EntityIdField = Field(
     ...,
     title="ID",
     description="The encoded ID of this entity.",
@@ -349,7 +349,7 @@ class Visualization(Model):  # TODO annotate this model
 class HistoryItemBase(Model):
     """Basic information provided by items contained in a History."""
 
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     name: Optional[str] = Field(
         title="Name",
         description="The name of the item.",
@@ -594,7 +594,7 @@ class DCSummary(Model):
     """Dataset Collection summary information."""
 
     model_class: str = ModelClassField(DC_MODEL_CLASS_NAME)
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     create_time: datetime = CreateTimeField
     update_time: datetime = UpdateTimeField
     collection_type: CollectionType = CollectionTypeField
@@ -606,7 +606,7 @@ class DCSummary(Model):
 class HDAObject(Model):
     """History Dataset Association Object"""
 
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(HDA_MODEL_CLASS_NAME)
     state: Dataset.states = DatasetStateField
     hda_ldda: DatasetSourceType = HdaLddaField
@@ -619,7 +619,7 @@ class HDAObject(Model):
 class DCObject(Model):
     """Dataset Collection Object"""
 
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(DC_MODEL_CLASS_NAME)
     collection_type: CollectionType = CollectionTypeField
     populated: Optional[bool] = PopulatedField
@@ -631,7 +631,7 @@ class DCObject(Model):
 class DCESummary(Model):
     """Dataset Collection Element summary information."""
 
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(DCE_MODEL_CLASS_NAME)
     element_index: int = Field(
         ...,
@@ -800,7 +800,7 @@ class HistoryContentItem(Model):
         title="Content Type",
         description="The type of this item.",
     )
-    id: DecodedDatabaseIdField = EncodedEntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
 
 
 class UpdateContentItem(HistoryContentItem):
@@ -899,7 +899,7 @@ class HistorySummary(HistoryBase):
     """History summary information."""
 
     model_class: str = ModelClassField(HISTORY_MODEL_CLASS_NAME)
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     name: str = Field(
         ...,
         title="Name",
@@ -1423,7 +1423,7 @@ class JobIdResponse(BaseModel):
 
 
 class JobBaseModel(Model):
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(JOB_MODEL_CLASS_NAME)
     tool_id: str = Field(
         ...,
@@ -1464,7 +1464,7 @@ class JobImportHistoryResponse(JobBaseModel):
 
 
 class JobStateSummary(Model):
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     model: str = ModelClassField("Job")
     populated_state: DatasetCollection.populated_states = PopulatedStateField
     states: Dict[Job.states, int] = Field(
@@ -1509,7 +1509,7 @@ class JobSummary(JobBaseModel):
 
 
 class DatasetSourceId(Model):
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     src: DatasetSourceType = Field(
         ...,
         title="Source",
@@ -1643,7 +1643,7 @@ class JobFullDetails(JobDetails):
 
 
 class StoredWorkflowSummary(Model):
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: EncodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(STORED_WORKFLOW_MODEL_CLASS_NAME)
     create_time: datetime = CreateTimeField
     update_time: datetime = UpdateTimeField

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -182,6 +182,10 @@ class Model(BaseModel):
     class Config:
         use_enum_values = True  # when using .dict()
         allow_population_by_field_name = True
+        json_encoders = {
+            # This will ensure all IDs are encoded when serialized to JSON
+            DecodedDatabaseIdField: lambda v: DecodedDatabaseIdField.encode(v),
+        }
 
 
 class UserModel(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -796,7 +796,7 @@ class HistoryContentItem(Model):
         title="Content Type",
         description="The type of this item.",
     )
-    id: EncodedDatabaseIdField = EncodedEntityIdField
+    id: DecodedDatabaseIdField = EncodedEntityIdField
 
 
 class UpdateContentItem(HistoryContentItem):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -33,7 +33,7 @@ from galaxy.schema import (
     SerializationParams,
     ValueFilterQueryParams,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     AnyHistoryContentItem,
     AnyJobStateSummary,
@@ -85,13 +85,13 @@ log = logging.getLogger(__name__)
 
 router = Router(tags=["histories"])
 
-HistoryIDPathParam: EncodedDatabaseIdField = Path(..., title="History ID", description="The ID of the History.")
+HistoryIDPathParam: DecodedDatabaseIdField = Path(..., title="History ID", description="The ID of the History.")
 
-HistoryItemIDPathParam: EncodedDatabaseIdField = Path(
+HistoryItemIDPathParam: DecodedDatabaseIdField = Path(
     ..., title="History Item ID", description="The ID of the item (`HDA`/`HDCA`) contained in the history."
 )
 
-HistoryHDCAIDPathParam: EncodedDatabaseIdField = Path(
+HistoryHDCAIDPathParam: DecodedDatabaseIdField = Path(
     ..., title="History Dataset Collection ID", description="The ID of the `HDCA` contained in the history."
 )
 
@@ -229,7 +229,7 @@ def parse_legacy_index_query_params(
     else:
         content_types = [e.value for e in HistoryContentType]
 
-    id_list: Optional[List[EncodedDatabaseIdField]] = None
+    id_list: Optional[List[DecodedDatabaseIdField]] = None
     if ids:
         id_list = util.listify(ids)
         # If explicit ids given, always used detailed result.
@@ -355,7 +355,7 @@ class FastAPIHistoryContents:
     def index(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         index_params: HistoryContentsIndexParams = Depends(get_index_query_params),
         legacy_params: LegacyHistoryContentsIndexParams = Depends(get_legacy_index_query_params),
         serialization_params: SerializationParams = Depends(query_serialization_params),
@@ -388,8 +388,8 @@ class FastAPIHistoryContents:
     def show_jobs_summary(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypeQueryParam,
     ) -> AnyJobStateSummary:
         """Return detailed information about an `HDA` or `HDCAs` jobs.
@@ -417,8 +417,8 @@ class FastAPIHistoryContents:
     def show(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypeQueryParam,
         fuzzy_count: Optional[int] = Query(
             default=None,
@@ -461,8 +461,8 @@ class FastAPIHistoryContents:
     def prepare_store_download(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypeQueryParam,
         payload: StoreExportPayload = Body(...),
     ) -> AsyncFile:
@@ -480,8 +480,8 @@ class FastAPIHistoryContents:
     def write_store(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypeQueryParam,
         payload: WriteStoreToPayload = Body(...),
     ) -> AsyncTaskResultSummary:
@@ -499,7 +499,7 @@ class FastAPIHistoryContents:
     def index_jobs_summary(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         params: HistoryContentsIndexJobsSummaryParams = Depends(get_index_jobs_summary_params),
     ) -> List[AnyJobStateSummary]:
         """Return job state summary info for jobs, implicit groups jobs for collections or workflow invocations.
@@ -525,11 +525,11 @@ class FastAPIHistoryContents:
     def download_dataset_collection(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: Optional[EncodedDatabaseIdField] = Query(
+        history_id: Optional[DecodedDatabaseIdField] = Query(
             default=None,
             description="The encoded database identifier of the History.",
         ),
-        id: EncodedDatabaseIdField = HistoryHDCAIDPathParam,
+        id: DecodedDatabaseIdField = HistoryHDCAIDPathParam,
     ):
         """Download the content of a history dataset collection as a `zip` archive
         while maintaining approximate collection structure.
@@ -555,8 +555,8 @@ class FastAPIHistoryContents:
     def prepare_collection_download(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryHDCAIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryHDCAIDPathParam,
     ) -> AsyncFile:
         """The history dataset collection will be written as a `zip` archive to the
         returned short term storage object. Progress tracking this file's creation
@@ -578,7 +578,7 @@ class FastAPIHistoryContents:
     def create(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         type: Optional[HistoryContentType] = Query(
             default=None,
             title="Content Type",
@@ -599,8 +599,8 @@ class FastAPIHistoryContents:
     def update_permissions(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        dataset_id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        dataset_id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         # Using a generic Dict here as an attempt on supporting multiple aliases for the permissions params.
         payload: Dict[str, Any] = Body(
             default=...,
@@ -618,7 +618,7 @@ class FastAPIHistoryContents:
     def update_batch(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),
         payload: UpdateHistoryContentsBatchPayload = Body(...),
     ) -> HistoryContentsResult:
@@ -637,7 +637,7 @@ class FastAPIHistoryContents:
     def bulk_operation(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         filter_query_params: ValueFilterQueryParams = Depends(get_value_filter_query_params),
         payload: HistoryContentBulkOperationPayload = Body(...),
     ) -> HistoryContentBulkOperationResult:
@@ -654,8 +654,8 @@ class FastAPIHistoryContents:
     def validate(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
     ) -> dict:  # TODO: define a response?
         """Validates the metadata associated with a dataset within a History."""
         return self.service.validate(trans, history_id, id)
@@ -674,8 +674,8 @@ class FastAPIHistoryContents:
     def update(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypeQueryParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),
         payload: UpdateHistoryContentsPayload = Body(...),
@@ -697,8 +697,8 @@ class FastAPIHistoryContents:
         self,
         response: Response,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypeQueryParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),
         purge: Optional[bool] = Query(
@@ -755,7 +755,7 @@ class FastAPIHistoryContents:
     def archive(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         filename: Optional[str] = Query(
             default=None,
             description="The name that the Archive will have (defaults to history name).",
@@ -783,7 +783,7 @@ class FastAPIHistoryContents:
     def create_from_store(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),
         create_payload: CreateHistoryContentFromStore = Body(...),
     ) -> List[AnyHistoryContentItem]:
@@ -804,7 +804,7 @@ class FastAPIHistoryContents:
         request: Request,
         response: Response,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         hid: int = Path(
             ...,
             title="Target HID",
@@ -888,8 +888,8 @@ class FastAPIHistoryContents:
     def materialize_dataset(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
     ) -> AsyncTaskResultSummary:
         materializae_request = MaterializeDatasetInstanceRequest(
             history_id=history_id,
@@ -906,7 +906,7 @@ class FastAPIHistoryContents:
     def materialize_to_history(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         materialize_api_payload: MaterializeDatasetInstanceAPIRequest = Body(...),
     ) -> AsyncTaskResultSummary:
         materializae_request: MaterializeDatasetInstanceRequest = MaterializeDatasetInstanceRequest(

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -68,7 +68,7 @@ from galaxy.schema import (
     SerializationParams,
     ValueFilterQueryParams,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     AnyBulkOperationParams,
     AnyHistoryContentItem,
@@ -125,7 +125,7 @@ from galaxy.webapps.galaxy.services.base import (
 
 log = logging.getLogger(__name__)
 
-DatasetDetailsType = Union[Set[EncodedDatabaseIdField], Literal["all"]]
+DatasetDetailsType = Union[Set[DecodedDatabaseIdField], Literal["all"]]
 
 HistoryItemModel = Union[HistoryDatasetAssociation, HistoryDatasetCollectionAssociation]
 
@@ -150,7 +150,7 @@ class HistoryContentsIndexParams(Model):
 class LegacyHistoryContentsIndexParams(Model):
     """Query parameters exclusively used by the *legacy version* of `index` operation."""
 
-    ids: Optional[List[EncodedDatabaseIdField]]
+    ids: Optional[List[DecodedDatabaseIdField]]
     types: List[HistoryContentType]
     dataset_details: Optional[DatasetDetailsType]
     deleted: Optional[bool]
@@ -160,7 +160,7 @@ class LegacyHistoryContentsIndexParams(Model):
 class HistoryContentsIndexJobsSummaryParams(Model):
     """Query parameters exclusively used by the `index_jobs_summary` operation."""
 
-    ids: List[EncodedDatabaseIdField] = []
+    ids: List[DecodedDatabaseIdField] = []
     types: List[JobSourceType] = []
 
 
@@ -178,7 +178,7 @@ class CreateHistoryContentPayloadFromCopy(CreateHistoryContentPayloadBase):
         title="Source",
         description="The source of the content. Can be other history element to be copied or library elements.",
     )
-    content: Optional[EncodedDatabaseIdField] = Field(
+    content: Optional[DecodedDatabaseIdField] = Field(
         None,
         title="Content",
         description=(
@@ -202,7 +202,7 @@ class CollectionElementIdentifier(Model):
         title="Source",
         description="The source of the element.",
     )
-    id: Optional[EncodedDatabaseIdField] = Field(
+    id: Optional[DecodedDatabaseIdField] = Field(
         None,
         title="ID",
         description="The encoded ID of the element.",
@@ -298,7 +298,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def index(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         params: HistoryContentsIndexParams,
         legacy_params: LegacyHistoryContentsIndexParams,
         serialization_params: SerializationParams,
@@ -317,7 +317,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def show(
         self,
         trans,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         serialization_params: SerializationParams,
         contents_type: HistoryContentType,
         fuzzy_count: Optional[int] = None,
@@ -361,13 +361,13 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def prepare_store_download(
         self,
         trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         payload: StoreExportPayload,
         contents_type: HistoryContentType = HistoryContentType.dataset,
     ) -> AsyncFile:
         model_store_format = payload.model_store_format
         if contents_type == HistoryContentType.dataset:
-            hda = self.hda_manager.get_accessible(self.decode_id(id), trans.user)
+            hda = self.hda_manager.get_accessible(id, trans.user)
             content_id = hda.id
             content_name = hda.name
         elif contents_type == HistoryContentType.dataset_collection:
@@ -394,13 +394,13 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def write_store(
         self,
         trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         payload: WriteStoreToPayload,
         contents_type: HistoryContentType = HistoryContentType.dataset,
     ):
         ensure_celery_tasks_enabled(trans.app.config)
         if contents_type == HistoryContentType.dataset:
-            hda = self.hda_manager.get_accessible(self.decode_id(id), trans.user)
+            hda = self.hda_manager.get_accessible(id, trans.user)
             content_id = hda.id
         elif contents_type == HistoryContentType.dataset_collection:
             dataset_collection_instance = self.__get_accessible_collection(trans, id)
@@ -432,13 +432,12 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             raise exceptions.RequestParameterInvalidException(
                 f"The number of ids ({len(ids)}) and types ({len(types)}) must match."
             )
-        decoded_ids = self.decode_ids(ids)
-        return [self.encode_all_ids(job_state) for job_state in fetch_job_states(trans.sa_session, decoded_ids, types)]
+        return [self.encode_all_ids(job_state) for job_state in fetch_job_states(trans.sa_session, ids, types)]
 
     def show_jobs_summary(
         self,
         trans,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         contents_type: HistoryContentType,
     ) -> AnyJobStateSummary:
         """
@@ -458,7 +457,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         job = None
         implicit_collection_jobs = None
         if contents_type == HistoryContentType.dataset:
-            hda = self.hda_manager.get_accessible(self.decode_id(id), trans.user)
+            hda = self.hda_manager.get_accessible(id, trans.user)
             job = hda.creating_job
         elif contents_type == HistoryContentType.dataset_collection:
             dataset_collection_instance = self.__get_accessible_collection(trans, id)
@@ -471,7 +470,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         assert job is None or implicit_collection_jobs is None
         return self.encode_all_ids(summarize_jobs_to_dict(trans.sa_session, job or implicit_collection_jobs))
 
-    def get_dataset_collection_archive_for_download(self, trans, id: EncodedDatabaseIdField):
+    def get_dataset_collection_archive_for_download(self, trans, id: DecodedDatabaseIdField):
         """
         Download the content of a HistoryDatasetCollection as a tgz archive
         while maintaining approximate collection structure.
@@ -486,7 +485,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             log.exception(error_message)
             raise exceptions.InternalServerError(error_message)
 
-    def prepare_collection_download(self, trans, id: EncodedDatabaseIdField) -> AsyncFile:
+    def prepare_collection_download(self, trans, id: DecodedDatabaseIdField) -> AsyncFile:
         ensure_celery_tasks_enabled(trans.app.config)
         dataset_collection_instance = self.__get_accessible_collection(trans, id)
         archive_name = f"{dataset_collection_instance.hid}: {dataset_collection_instance.name}"
@@ -509,7 +508,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def create(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         payload: CreateHistoryContentPayload,
         serialization_params: SerializationParams,
     ) -> Union[AnyHistoryContentItem, List[AnyHistoryContentItem]]:
@@ -519,7 +518,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         ..note:
             Currently, a user can only copy an HDA from a history that the user owns.
         """
-        history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
+        history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
 
         serialization_params.default_view = "detailed"
         history_content_type = payload.type
@@ -536,11 +535,11 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def create_from_store(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         payload: CreateHistoryContentFromStore,
         serialization_params: SerializationParams,
     ) -> List[AnyHistoryContentItem]:
-        history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
+        history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
         object_tracker = self.create_objects_from_store(
             trans,
             payload,
@@ -582,7 +581,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def update_permissions(
         self,
         trans,
-        history_content_id: EncodedDatabaseIdField,
+        history_content_id: DecodedDatabaseIdField,
         payload: UpdateDatasetPermissionsPayload,
     ) -> DatasetAssociationRoles:
         """
@@ -603,9 +602,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
                     RequestParameterMissingException
         """
         payload_dict = payload.dict(by_alias=True)
-        hda = self.hda_manager.get_owned(
-            self.decode_id(history_content_id), trans.user, current_history=trans.history, trans=trans
-        )
+        hda = self.hda_manager.get_owned(history_content_id, trans.user, current_history=trans.history, trans=trans)
         assert hda is not None
         self.hda_manager.update_permissions(trans, hda, **payload_dict)
         roles = self.hda_manager.serialize_dataset_association_roles(trans, hda)
@@ -614,8 +611,8 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def update(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
-        id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         payload: Dict[str, Any],
         serialization_params: SerializationParams,
         contents_type: HistoryContentType,
@@ -641,7 +638,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def update_batch(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         payload: UpdateHistoryContentsBatchPayload,
         serialization_params: SerializationParams,
     ) -> List[AnyHistoryContentItem]:
@@ -659,15 +656,14 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         :returns:   an error object if an error occurred or a dictionary containing
                     any values that were different from the original and, therefore, updated
         """
-        history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
+        history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
         items = payload.items
-        hda_ids = []
-        hdca_ids = []
+        hda_ids: List[DecodedDatabaseIdField] = []
+        hdca_ids: List[DecodedDatabaseIdField] = []
         for item in items:
             contents_type = item.history_content_type
             if contents_type == HistoryContentType.dataset:
-                decoded_id = self.decode_id(item.id)
-                hda_ids.append(decoded_id)
+                hda_ids.append(item.id)
             else:
                 hdca_ids.append(item.id)
         payload_dict = payload.dict(exclude_unset=True)
@@ -688,11 +684,11 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def bulk_operation(
         self,
         trans: ProvidesHistoryContext,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         filter_query_params: ValueFilterQueryParams,
         payload: HistoryContentBulkOperationPayload,
     ) -> HistoryContentBulkOperationResult:
-        history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
+        history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
         filters = self.history_contents_filters.parse_query_filters(filter_query_params)
         self._validate_bulk_operation_params(payload, trans.user, trans)
         contents: List[HistoryItemModel]
@@ -712,7 +708,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         success_count = len(contents) - len(errors)
         return HistoryContentBulkOperationResult.construct(success_count=success_count, errors=errors)
 
-    def validate(self, trans, history_id: EncodedDatabaseIdField, history_content_id: EncodedDatabaseIdField):
+    def validate(self, trans, history_id: DecodedDatabaseIdField, history_content_id: DecodedDatabaseIdField):
         """
         Validates the metadata associated with a dataset within a History.
 
@@ -724,8 +720,8 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         :rtype:     dict
         :returns:   TODO
         """
-        decoded_id = self.decode_id(history_content_id)
-        history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
+        decoded_id = history_content_id
+        history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
         hda = self.hda_manager.get_owned_ids([decoded_id], history=history)[0]
         if hda:
             self.hda_manager.set_metadata(trans, hda, overwrite=True, validate=True)
@@ -734,7 +730,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def delete(
         self,
         trans,
-        id,
+        id: DecodedDatabaseIdField,
         serialization_params: SerializationParams,
         contents_type: HistoryContentType,
         payload: DeleteHistoryContentPayload,
@@ -748,14 +744,14 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             async_result = self.dataset_collection_manager.delete(
                 trans, "history", id, recursive=payload.recursive, purge=payload.purge
             )
-            return {"id": id, "deleted": True, "async_result": async_result is not None}
+            return {"id": self.encode_id(id), "deleted": True, "async_result": async_result is not None}
         else:
             raise exceptions.UnknownContentsType(f"Unknown contents type: {contents_type}")
 
     def archive(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         filter_query_params: FilterQueryParams,
         filename: Optional[str] = "",
         dry_run: Optional[bool] = True,
@@ -797,7 +793,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             return parent_names
 
         # get the history used for the contents query and check for accessibility
-        history = self.history_manager.get_accessible(trans.security.decode_id(history_id), trans.user)
+        history = self.history_manager.get_accessible(history_id, trans.user)
         archive_base_name = filename or name_to_filename(history.name)
 
         # this is the fn applied to each dataset contained in the query
@@ -865,7 +861,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def contents_near(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         serialization_params: SerializationParams,
         filter_params: HistoryContentsFilterList,
         direction: DirectionOptions,
@@ -882,9 +878,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
 
         Additional counts provided in the HTTP headers.
         """
-        history: History = self.history_manager.get_accessible(
-            self.decode_id(history_id), trans.user, current_history=trans.history
-        )
+        history: History = self.history_manager.get_accessible(history_id, trans.user, current_history=trans.history)
 
         # while polling, check to see if the history has changed
         # if it hasn't then we can short-circuit the poll request
@@ -1039,9 +1033,9 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         return min_hid, max_hid
 
     def __delete_dataset(
-        self, trans, id: EncodedDatabaseIdField, purge: bool, stop_job: bool, serialization_params: SerializationParams
+        self, trans, id: DecodedDatabaseIdField, purge: bool, stop_job: bool, serialization_params: SerializationParams
     ):
-        hda = self.hda_manager.get_owned(self.decode_id(id), trans.user, current_history=trans.history)
+        hda = self.hda_manager.get_owned(id, trans.user, current_history=trans.history)
         self.hda_manager.error_if_uploading(hda)
 
         async_result = None
@@ -1054,22 +1048,21 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         rval["async_result"] = async_result is not None
         return rval
 
-    def __update_dataset_collection(self, trans, id: EncodedDatabaseIdField, payload: Dict[str, Any]):
+    def __update_dataset_collection(self, trans, id: DecodedDatabaseIdField, payload: Dict[str, Any]):
         return self.dataset_collection_manager.update(trans, "history", id, payload)
 
     def __update_dataset(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
-        id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         payload: Dict[str, Any],
         serialization_params: SerializationParams,
     ):
         # anon user: ensure that history ids match up and the history is the current,
         #   check for uploading, and use only the subset of attribute keys manipulatable by anon users
-        decoded_id = self.decode_id(id)
-        history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
-        hda = self.__datasets_for_update(trans, history, [decoded_id], payload)[0]
+        history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
+        hda = self.__datasets_for_update(trans, history, [id], payload)[0]
         if hda:
             self.__deserialize_dataset(trans, hda, payload)
             serialization_params.default_view = "detailed"
@@ -1078,7 +1071,9 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             )
         return {}
 
-    def __datasets_for_update(self, trans, history: History, hda_ids: List[int], payload: Dict[str, Any]):
+    def __datasets_for_update(
+        self, trans, history: History, hda_ids: List[DecodedDatabaseIdField], payload: Dict[str, Any]
+    ):
         anonymous_user = not trans.user_is_admin and trans.user is None
         if anonymous_user:
             anon_allowed_payload = {}
@@ -1109,7 +1104,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def __index_legacy(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         legacy_params: LegacyHistoryContentsIndexParams,
     ) -> HistoryContentsResult:
         """Legacy implementation of the `index` action."""
@@ -1128,7 +1123,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
     def __index_v2(
         self,
         trans,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         params: HistoryContentsIndexParams,
         serialization_params: SerializationParams,
         filter_query_params: FilterQueryParams,
@@ -1195,7 +1190,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         content,
         dataset_details: Optional[DatasetDetailsType] = None,
     ):
-        encoded_content_id = self.encode_id(content.id)
+        encoded_content_id = content.id
         detailed = dataset_details and (dataset_details == "all" or (encoded_content_id in dataset_details))
         if isinstance(content, HistoryDatasetAssociation):
             view = "detailed" if detailed else "summary"
@@ -1222,7 +1217,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         serializer: Optional[ModelSerializer] = None
         if isinstance(content, HistoryDatasetAssociation):
             serializer = self.hda_serializer
-            if dataset_details and (dataset_details == "all" or self.encode_id(content.id) in dataset_details):
+            if dataset_details and (dataset_details == "all" or content.id in dataset_details):
                 view = "detailed"
         elif isinstance(content, HistoryDatasetCollectionAssociation):
             serializer = self.hdca_serializer
@@ -1257,27 +1252,25 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             **kwds,
         )
 
-    def _get_history(self, trans, history_id: EncodedDatabaseIdField) -> History:
+    def _get_history(self, trans, history_id: DecodedDatabaseIdField) -> History:
         """Retrieves the History with the given ID or raises an error if the current user cannot access it."""
-        history = self.history_manager.get_accessible(
-            self.decode_id(history_id), trans.user, current_history=trans.history
-        )
+        history = self.history_manager.get_accessible(history_id, trans.user, current_history=trans.history)
         return history
 
     def __show_dataset(
         self,
         trans,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         serialization_params: SerializationParams,
     ):
         serialization_params.default_view = "detailed"
-        hda = self.hda_manager.get_accessible(self.decode_id(id), trans.user)
+        hda = self.hda_manager.get_accessible(id, trans.user)
         return self.hda_serializer.serialize_to_view(hda, user=trans.user, trans=trans, **serialization_params.dict())
 
     def __show_dataset_collection(
         self,
         trans,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         serialization_params: SerializationParams,
         fuzzy_count: Optional[int] = None,
     ):
@@ -1285,7 +1278,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         view = serialization_params.view or "element"
         return self.__collection_dict(trans, dataset_collection_instance, view=view, fuzzy_count=fuzzy_count)
 
-    def __get_accessible_collection(self, trans, id: EncodedDatabaseIdField):
+    def __get_accessible_collection(self, trans, id: DecodedDatabaseIdField):
         return self.dataset_collection_manager.get_dataset_collection_instance(
             trans=trans,
             instance_type="history",
@@ -1306,7 +1299,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
             if content is None:
                 raise exceptions.RequestParameterMissingException("'content' id of lda or hda is missing")
 
-            folder_id = self.folder_manager.cut_and_decode(trans, content)
+            folder_id = content
             folder = self.folder_manager.get(trans, folder_id)
 
             current_user_roles = trans.get_current_user_roles()
@@ -1372,17 +1365,18 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         trans.sa_session.flush()
         return self.hda_serializer.serialize_to_view(hda, user=trans.user, trans=trans, **serialization_params.dict())
 
-    def __create_hda_from_ldda(self, trans, history: History, ldda_id: EncodedDatabaseIdField):
-        decoded_ldda_id = self.decode_id(ldda_id)
+    def __create_hda_from_ldda(self, trans, history: History, ldda_id: DecodedDatabaseIdField):
+        decoded_ldda_id = ldda_id
         ld = self.ldda_manager.get(trans, decoded_ldda_id)
         if type(ld) is not LibraryDataset:
-            raise exceptions.RequestParameterInvalidException(f"Library content id ( {ldda_id} ) is not a dataset")
+            raise exceptions.RequestParameterInvalidException(
+                f"Library content id ( {self.encode_id(ldda_id)} ) is not a dataset"
+            )
         hda = ld.library_dataset_dataset_association.to_history_dataset_association(history, add_to_history=True)
         return hda
 
-    def __create_hda_from_copy(self, trans, history: History, original_hda_id: EncodedDatabaseIdField):
-        unencoded_hda_id = self.decode_id(original_hda_id)
-        original = self.hda_manager.get_accessible(unencoded_hda_id, trans.user)
+    def __create_hda_from_copy(self, trans, history: History, original_hda_id: DecodedDatabaseIdField):
+        original = self.hda_manager.get_accessible(original_hda_id, trans.user)
         # check for access on history that contains the original hda as well
         self.history_manager.error_unless_accessible(original.history, trans.user, current_history=trans.history)
         hda = self.hda_manager.copy(original, history=history)
@@ -1524,7 +1518,7 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         contents: List[HistoryItemModel] = []
 
         dataset_items = filter(lambda item: item.history_content_type == HistoryContentType.dataset, items)
-        datasets_ids = map(lambda dataset: self.decode_id(dataset.id), dataset_items)
+        datasets_ids = map(lambda dataset: dataset.id, dataset_items)
         contents.extend(self.hda_manager.get_owned_ids(datasets_ids, history))
 
         collection_items = filter(


### PR DESCRIPTION
Addresses https://github.com/galaxyproject/galaxy/pull/14388#discussion_r935206820

Replace `EncodedDatabaseIdField` with `DecodedDatabaseIdField` to remove manual ID decodings from the service layer.

`DecodedDatabaseIdField` will now encode the ID when being serialized to JSON in response models. Those pydantic models must descend from the custom base [Model](https://github.com/galaxyproject/galaxy/pull/14392/commits/61cfa426fa50087abb332a55a12337568b8d7173#diff-a14c374c5acadf6b78f75edfc6626737be3f60422f447ffa6d40253e454bfa17R179).

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
