### PR TITLE
Data Libraries - Change "Export to History" to "Send to History"

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -61,7 +61,7 @@
                             class="primary-button dropdown-toggle add-to-history"
                             data-toggle="dropdown">
                             <font-awesome-icon icon="book" />
-                            Export to History <span class="caret"></span>
+                            Add to History <span class="caret"></span>
                         </button>
                         <div class="dropdown-menu" role="menu">
                             <a


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14323
![Screen Recording 2022-08-02 at 2 19 24 PM](https://user-images.githubusercontent.com/78516064/182446371-9605cafc-8a50-4fc1-87db-61c23258bf97.gif)
Didn't change the `Import into History` header from the modal in `import-dataset.js`: https://github.com/galaxyproject/galaxy/blob/86df2aecf54badb9249d0b507d980f403794ad08/client/src/components/Libraries/LibraryFolder/TopToolbar/import-to-history/import-dataset.js#L38 
to `Send to History` because that modal might be used elsewhere. Could still change it though if necessary.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
