### PR TITLE
[22.05] Fix validation issue for dataset_details

### DIFF
--- a/client/src/store/historyStore/model/watchHistory.js
+++ b/client/src/store/historyStore/model/watchHistory.js
@@ -121,7 +121,10 @@ function getCurrentlyExpandedHistoryContentIds() {
     const expandedItems = loadSet(cacheKey);
     expandedItems.forEach((key) => {
         // Items have the format: <type>-<id>
-        expandedItemIds.push(key.split("-")[1]);
+        const itemId = key.split("-")[1];
+        if (itemId) {
+            expandedItemIds.push(itemId);
+        }
     });
     return expandedItemIds;
 }

--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -40,9 +40,6 @@ class BaseDatabaseIdField:
     def __repr__(self):
         return f"DatabaseID ({super().__repr__()})"
 
-    def __hash__(self) -> int:
-        return hash(self)
-
 
 class DecodedDatabaseIdField(int, BaseDatabaseIdField):
     @classmethod

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -27,6 +27,7 @@ from starlette.responses import (
 )
 
 from galaxy import util
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.schema import (
     FilterQueryParams,
@@ -252,6 +253,8 @@ def parse_dataset_details(details: Optional[str]):
     dataset_details: Optional[DatasetDetailsType] = None
     if details and details != "all":
         dataset_details = set(util.listify(details))
+        if "" in dataset_details:
+            raise RequestParameterInvalidException("Invalid empty IDs found in dataset details parameter")
     else:  # either None or 'all'
         dataset_details = details  # type: ignore
     return dataset_details

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -164,6 +164,14 @@ class HistoryContentsApiTestCase(ApiTestCase):
         hda_details = self.__check_for_hda(contents_response, hda1)
         self.__assert_hda_has_full_details(hda_details)
 
+    def test_index_detail_parameter_error(self):
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
+        wrong_details_query_with_empty_ids = f"details=,,{hda1['id']}"
+        contents_response = self._get(
+            f"histories/{self.history_id}/contents?v=dev&{wrong_details_query_with_empty_ids}"
+        )
+        self._assert_status_code_is(contents_response, 400)
+
     def test_show_hda(self):
         hda1 = self.dataset_populator.new_dataset(self.history_id)
         show_response = self.__show(hda1)

--- a/test/unit/webapps/api/test_id_fields.py
+++ b/test/unit/webapps/api/test_id_fields.py
@@ -37,21 +37,3 @@ def test_decoded_database_id_field(security: IdEncodingHelper):
     decoded_id = 1
     id_model = EncodedIdModel(id=decoded_id)
     assert id_model.id == security.encode_id(decoded_id)
-
-
-def test_decoded_id_hash(security: IdEncodingHelper):
-    id_a = 1
-    id_b = 2
-    model_a = DecodedIdModel(id=security.encode_id(id_a))
-    model_b = DecodedIdModel(id=security.encode_id(id_b))
-    model_same_1 = DecodedIdModel(id=security.encode_id(id_a))
-    assert hash(model_a.id) != hash(model_b.id)
-    assert hash(model_a.id) == hash(model_same_1.id)
-
-
-def test_encoded_id_hash(security: IdEncodingHelper):
-    model_a = EncodedIdModel(id=1)
-    model_b = EncodedIdModel(id=2)
-    model_same_a = EncodedIdModel(id=1)
-    assert hash(model_a.id) != hash(model_b.id)
-    assert hash(model_a.id) == hash(model_same_a.id)


### PR DESCRIPTION
Follow up on #14388 trying to fix https://github.com/galaxyproject/galaxy/issues/14387 which still persists

<del>Try to use a simple list for the query parameter and then convert it to a `set` directly when needed.</del>

<del>The strange thing is that we have API tests that should fail for this, but I can't reproduce it either locally. I wonder if is somehow related to the python version... I'm using Python 3.10.4 and the request with details doesn't seem to fail while on https://usegalaxy.eu/ (Python 3.8) seems to fail consistently :thinking: </del>


The third time's a charm... I think I finally got this.. see https://github.com/galaxyproject/galaxy/pull/14395#issuecomment-1205179421

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
