### PR TITLE
Better tabular/csv file splitting

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "bootstrap-vue": "^2.21.2",
     "citation-js": "^0.5.5",
     "core-js": "^3.21.0",
+    "csv-parse": "^5.3.0",
     "d3": "3",
     "date-fns": "^2.28.0",
     "date-fns-tz": "^1.3.3",

--- a/client/src/mvc/dataset/data.js
+++ b/client/src/mvc/dataset/data.js
@@ -1,6 +1,8 @@
 import _ from "underscore";
 import $ from "jquery";
 import Backbone from "backbone";
+import { parse } from "csv-parse/sync";
+
 import { getAppRoot } from "onload/loadConfig";
 import _l from "utils/localization";
 import mod_icon_btn from "mvc/ui/icon-button";
@@ -137,8 +139,10 @@ var TabularDatasetChunkedView = Backbone.View.extend({
     initialize: function (options) {
         // Row count for rendering.
         this.row_count = 0;
+        // Flag for active loading
         this.loading_chunk = false;
-
+        // Configure delimiter for parsing data
+        this.delimiter = this.model?.attributes?.file_ext === "csv" ? "," : "\t";
         // load trackster button
         new TabularButtonTracksterView({
             model: options.model,
@@ -237,10 +241,7 @@ var TabularDatasetChunkedView = Backbone.View.extend({
         return $cell;
     },
 
-    _renderRow: function (line) {
-        // Check length of cells to ensure this is a complete row.
-        var cells = line.split("\t");
-
+    _renderRow: function (rowData) {
         var row = $("<tr>");
         var num_columns = this.model.get_metadata("columns");
 
@@ -248,39 +249,40 @@ var TabularDatasetChunkedView = Backbone.View.extend({
             row.addClass("dark_row");
         }
 
-        if (cells.length === num_columns) {
+        if (rowData.length === num_columns) {
             _.each(
-                cells,
+                rowData,
                 function (cell_contents, index) {
                     row.append(this._renderCell(cell_contents, index));
                 },
                 this
             );
-        } else if (cells.length > num_columns) {
+        } else if (rowData.length > num_columns) {
             // SAM file or like format with optional metadata included.
             _.each(
-                cells.slice(0, num_columns - 1),
+                rowData.slice(0, num_columns - 1),
                 function (cell_contents, index) {
                     row.append(this._renderCell(cell_contents, index));
                 },
                 this
             );
-            row.append(this._renderCell(cells.slice(num_columns - 1).join("\t"), num_columns - 1));
-        } else if (cells.length === 1) {
-            cells = line.split(",");
-            if (cells.length === num_columns) {
+            row.append(this._renderCell(rowData.slice(num_columns - 1).join("\t"), num_columns - 1));
+        } else if (rowData.length === 1) {
+            // Try to split by comma first
+            rowData = rowData[0].split(",");
+            if (rowData.length === num_columns) {
                 _.each(
-                    cells,
+                    rowData,
                     function (cell_contents, index) {
                         row.append(this._renderCell(cell_contents, index));
                     },
                     this
                 );
             } else {
-                cells = line.split(" ");
-                if (cells.length === num_columns) {
+                rowData = rowData[0].split(" ");
+                if (rowData.length === num_columns) {
                     _.each(
-                        cells,
+                        rowData,
                         function (cell_contents, index) {
                             row.append(this._renderCell(cell_contents, index));
                         },
@@ -288,21 +290,21 @@ var TabularDatasetChunkedView = Backbone.View.extend({
                     );
                 } else {
                     // Comment line, just return the one cell.
-                    row.append(this._renderCell(line, 0, num_columns));
+                    row.append(this._renderCell(rowData[0], 0, num_columns));
                 }
             }
         } else {
-            // cells.length is greater than one, but less than num_columns.  Render cells and pad tds.
+            // rowData.length is greater than one, but less than num_columns.  Render cells and pad tds.
             // Possibly a SAM file or like format with optional metadata missing.
             // Could also be a tabular file with a line with missing columns.
             _.each(
-                cells,
+                rowData,
                 function (cell_contents, index) {
                     row.append(this._renderCell(cell_contents, index));
                 },
                 this
             );
-            _.each(_.range(num_columns - cells.length), () => {
+            _.each(_.range(num_columns - rowData.length), () => {
                 row.append($("<td>"));
             });
         }
@@ -314,7 +316,9 @@ var TabularDatasetChunkedView = Backbone.View.extend({
     _renderChunk: function (chunk) {
         var data_table = this.$el.find("table");
         _.each(
-            chunk.ck_data.split("\n"),
+            parse(chunk.ck_data, {
+                delimiter: this.delimiter,
+            }),
             function (line, index) {
                 if (line !== "" && index >= (chunk.data_line_offset || 0)) {
                     data_table.append(this._renderRow(line));

--- a/client/src/mvc/dataset/data.js
+++ b/client/src/mvc/dataset/data.js
@@ -190,7 +190,7 @@ var TabularDatasetChunkedView = Backbone.View.extend({
             header_row.append(`<th>${column_names.join("</th><th>")}</th>`);
         } else {
             for (var j = 1; j <= this.model.get_metadata("columns"); j++) {
-                header_row.append(`<th>${j}</th>`);
+                header_row.append(`<th>Column ${j}</th>`);
             }
         }
 

--- a/client/src/mvc/dataset/data.js
+++ b/client/src/mvc/dataset/data.js
@@ -269,20 +269,20 @@ var TabularDatasetChunkedView = Backbone.View.extend({
             row.append(this._renderCell(rowData.slice(num_columns - 1).join("\t"), num_columns - 1));
         } else if (rowData.length === 1) {
             // Try to split by comma first
-            rowData = rowData[0].split(",");
-            if (rowData.length === num_columns) {
+            let rowDataSplit = rowData[0].split(",");
+            if (rowDataSplit.length === num_columns) {
                 _.each(
-                    rowData,
+                    rowDataSplit,
                     function (cell_contents, index) {
                         row.append(this._renderCell(cell_contents, index));
                     },
                     this
                 );
             } else {
-                rowData = rowData[0].split(" ");
-                if (rowData.length === num_columns) {
+                rowDataSplit = rowData[0].split(" ");
+                if (rowDataSplit.length === num_columns) {
                     _.each(
-                        rowData,
+                        rowDataSplit,
                         function (cell_contents, index) {
                             row.append(this._renderCell(cell_contents, index));
                         },
@@ -315,13 +315,14 @@ var TabularDatasetChunkedView = Backbone.View.extend({
 
     _renderChunk: function (chunk) {
         var data_table = this.$el.find("table");
+        const parsedChunk = parse(chunk.ck_data, {
+            delimiter: this.delimiter,
+        });
         _.each(
-            parse(chunk.ck_data, {
-                delimiter: this.delimiter,
-            }),
-            function (line, index) {
-                if (line !== "" && index >= (chunk.data_line_offset || 0)) {
-                    data_table.append(this._renderRow(line));
+            parsedChunk,
+            (rowData, index) => {
+                if (index >= (chunk.data_line_offset || 0)) {
+                    data_table.append(this._renderRow(rowData));
                 }
             },
             this

--- a/client/src/mvc/dataset/data.js
+++ b/client/src/mvc/dataset/data.js
@@ -186,7 +186,7 @@ var TabularDatasetChunkedView = Backbone.View.extend({
         var column_names = this.model.get_metadata("column_names");
         var header_container = $("<thead/>").appendTo(data_table);
         var header_row = $("<tr/>").appendTo(header_container);
-        if (column_names) {
+        if (column_names?.length > 0) {
             header_row.append(`<th>${column_names.join("</th><th>")}</th>`);
         } else {
             for (var j = 1; j <= this.model.get_metadata("columns"); j++) {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3557,6 +3557,11 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
+csv-parse@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.3.0.tgz#85cc02fc9d1c89bd1b02e69069c960f8b8064322"
+  integrity sha512-UXJCGwvJ2fep39purtAn27OUYmxB1JQto+zhZ4QlJpzsirtSFbzLvip1aIgziqNdZp/TptvsKEV5BZSxe10/DQ==
+
 custom-error-instance@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/custom-error-instance/-/custom-error-instance-2.1.1.tgz#3cf6391487a6629a6247eb0ca0ce00081b7e361a"


### PR DESCRIPTION
Fixes #14213.  I'm going to follow up separately with a more comprehensive overhaul of this tabular display.

![image](https://user-images.githubusercontent.com/155398/182707011-9991e255-61a0-4c7b-99e8-bc5a0ea86c61.png)
to
![image](https://user-images.githubusercontent.com/155398/182706980-59725935-7793-4375-b37c-b923fc3d488a.png)

and 


![image](https://user-images.githubusercontent.com/155398/182709269-f172cd6e-5a4b-4604-9a1b-4a9131cf1cb7.png)
to 
![image](https://user-images.githubusercontent.com/155398/182709154-b1bff3ea-b63d-4b43-a1df-d482590e3e95.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
