### PR TITLE
Warn users if History is not being watched

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -45,8 +45,8 @@
             </b-button>
             <b-button
                 v-b-tooltip.hover
-                :title="'Last refreshed ' + diffToNow"
-                variant="link"
+                :title="reloadButtonTitle"
+                :variant="reloadButtonVariant"
                 size="sm"
                 class="rounded-0 text-decoration-none"
                 @click="reloadContents()">
@@ -70,12 +70,14 @@ export default {
     mixins: [usesDetailedHistoryMixin],
     props: {
         history: { type: Object, required: true },
+        isWatching: { type: Boolean, default: false },
         lastChecked: { type: Date, default: null },
     },
     data() {
         return {
-            diffToNow: 0,
             reloadButtonCls: "fa fa-sync",
+            reloadButtonTitle: "",
+            reloadButtonVariant: "link",
         };
     },
     mounted() {
@@ -91,7 +93,16 @@ export default {
             this.$emit("update:filter-text", newFilterText);
         },
         updateTime() {
-            this.diffToNow = formatDistanceToNowStrict(this.lastChecked, { addSuffix: true, includeSeconds: true });
+            const diffToNow = formatDistanceToNowStrict(this.lastChecked, { addSuffix: true, includeSeconds: true });
+            const diffToNowSec = Date.now() - this.lastChecked;
+            // if history isn't being watched or hasn't been watched/polled for over 2 minutes
+            if (!this.isWatching || diffToNowSec > 120000) {
+                this.reloadButtonTitle = "Last refreshed " + diffToNow + ". Consider reloading the page.";
+                this.reloadButtonVariant = "danger";
+            } else {
+                this.reloadButtonTitle = "Last refreshed " + diffToNow;
+                this.reloadButtonVariant = "link";
+            }
         },
         async reloadContents() {
             this.$emit("reloadContents");

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -38,6 +38,7 @@
                         <HistoryMessages :history="history" />
                         <HistoryCounter
                             :history="history"
+                            :is-watching="isWatching"
                             :last-checked="lastChecked"
                             :filter-text.sync="filterText"
                             @reloadContents="reloadContents" />
@@ -210,6 +211,9 @@ export default {
         /** @returns {Date} */
         lastChecked() {
             return this.$store.getters.getLastCheckedTime();
+        },
+        isWatching() {
+            return this.$store.getters.getWatchingVisibility();
         },
     },
     watch: {

--- a/client/src/store/historyStore/historyItemsStore.js
+++ b/client/src/store/historyStore/historyItemsStore.js
@@ -18,6 +18,7 @@ const state = {
     latestCreateTime: new Date(),
     totalMatchesCount: undefined,
     lastCheckedTime: new Date(),
+    isWatching: false,
 };
 
 const getters = {
@@ -40,6 +41,7 @@ const getters = {
     getLatestCreateTime: (state) => () => state.latestCreateTime,
     getTotalMatchesCount: (state) => () => state.totalMatchesCount,
     getLastCheckedTime: (state) => () => state.lastCheckedTime,
+    getWatchingVisibility: (state) => () => state.isWatching,
 };
 
 const getQueryString = (filterText) => {
@@ -81,6 +83,9 @@ const mutations = {
     },
     setLastCheckedTime: (state, { checkForUpdate }) => {
         state.lastCheckedTime = checkForUpdate;
+    },
+    setWatchingVisibility: (state, { watchingVisibility }) => {
+        state.isWatching = watchingVisibility;
     },
     saveQueryStats: (state, { stats }) => {
         state.totalMatchesCount = stats.total_matches;

--- a/client/src/store/historyStore/model/watchHistory.js
+++ b/client/src/store/historyStore/model/watchHistory.js
@@ -87,13 +87,16 @@ export async function watchHistory(store = defaultStore) {
     // Only set up visibility listeners once, whenever a watch is first started
     if (watchingVisibility === false) {
         watchingVisibility = true;
+        store.commit("setWatchingVisibility", { watchingVisibility });
         document.addEventListener("visibilitychange", setVisibilityThrottle);
     }
     try {
         await watchHistoryOnce(store);
     } catch (error) {
-        // would be fantastic if we could show some error alerting the user to this
+        // error alerting the user that watch history failed
         console.warn(error);
+        watchingVisibility = false;
+        store.commit("setWatchingVisibility", { watchingVisibility });
     } finally {
         watchTimeout = setTimeout(() => {
             watchHistory(store);


### PR DESCRIPTION
![Screen Shot 2022-08-03 at 11 50 35 AM](https://user-images.githubusercontent.com/78516064/182692295-5ebb6170-1004-4998-acda-b93e015ce80e.png)

Fixes https://github.com/galaxyproject/galaxy/issues/14238. Stored the history `watchingVisibility` state in the vuex `historyItemsStore`. This is used to warn the users if the history is not being watched. The user can try to refresh the history itself, or if that fails, refresh the page:

https://user-images.githubusercontent.com/78516064/182692223-c76eeb6c-3cd6-4e92-8bbe-e862ef02b329.mov

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
