### PR TITLE
Fix dataset list operation to switch between histories

### DIFF
--- a/client/src/components/Dataset/DatasetList.vue
+++ b/client/src/components/Dataset/DatasetList.vue
@@ -28,6 +28,7 @@
     </div>
 </template>
 <script>
+import store from "store";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import { Services } from "./services";
@@ -147,16 +148,13 @@ export default {
                     this.onError(error);
                 });
         },
-        onShowDataset(item) {
-            const Galaxy = getGalaxyInstance();
-            this.services
-                .setHistory(item.history_id)
-                .then(() => {
-                    Galaxy.currHistoryPanel.loadCurrentHistory();
-                })
-                .catch((error) => {
-                    this.onError(error);
-                });
+        async onShowDataset(item) {
+            const historyId = item.history_id;
+            try {
+                await store.dispatch("history/setCurrentHistory", historyId);
+            } catch (error) {
+                this.onError(error);
+            }
         },
         onTags(tags, index) {
             const item = this.rows[index];

--- a/client/src/components/Dataset/services.js
+++ b/client/src/components/Dataset/services.js
@@ -45,16 +45,6 @@ export class Services {
         }
     }
 
-    async setHistory(id) {
-        const url = `${this.root}history/set_as_current?id=${id}`;
-        try {
-            const response = await axios.get(url);
-            return response.data;
-        } catch (e) {
-            this._errorMessage(e);
-        }
-    }
-
     async updateTags(item_id, item_class, item_tags) {
         const url = `${this.root}api/tags`;
         try {

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -147,7 +147,7 @@ const actions = {
     async setCurrentHistory({ dispatch, getters }, id) {
         if (id !== getters.currentHistoryId) {
             const changedHistory = await setCurrentHistoryOnServer(id);
-            dispatch("selectHistory", changedHistory);
+            return dispatch("selectHistory", changedHistory);
         }
     },
     setHistory({ commit }, history) {


### PR DESCRIPTION
Fixes #14286.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
   - Go to the Dataset List grid
   - Select a dataset and click on `Show Dataset` in the Dropdown.
   - Notice how the history switches to the history which contains that dataset. 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
