### PR TITLE
[22.05] Always allow 'copy datasets' action in history, even when empty.

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/Operations.vue
@@ -13,7 +13,7 @@
             <b-dropdown-text id="history-op-all-content">
                 <span v-localize>With entire history...</span>
             </b-dropdown-text>
-            <b-dropdown-item v-if="numItemsActive" data-description="copy datasets" @click="onCopy">
+            <b-dropdown-item data-description="copy datasets" @click="onCopy">
                 <span v-localize>Copy Datasets</span>
             </b-dropdown-item>
             <b-dropdown-item v-if="numItemsHidden" v-b-modal:show-all-hidden-content>


### PR DESCRIPTION
fixes #14401 

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. See issue.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
