### PR TITLE
Add and document make target for skipping the client build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,9 @@ update-cwl-conformance-tests: ## update CWL conformance tests
 	$(MAKE) clean-cwl-conformance-tests
 	$(MAKE) generate-cwl-conformance-tests
 
+skip-client: ## Build only the server, skipping the client build.
+	GALAXY_SKIP_CLIENT_BUILD=1 sh run.sh
+
 node-deps: ## Install NodeJS dependencies.
 ifndef YARN
 	@echo "Could not find yarn, which is required to build the Galaxy client.\nTo install yarn, please visit \033[0;34mhttps://yarnpkg.com/en/docs/install\033[0m for instructions, and package information for all platforms.\n"

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ update-cwl-conformance-tests: ## update CWL conformance tests
 	$(MAKE) clean-cwl-conformance-tests
 	$(MAKE) generate-cwl-conformance-tests
 
-skip-client: ## Build only the server, skipping the client build.
+skip-client: ## Run only the server, skipping the client build.
 	GALAXY_SKIP_CLIENT_BUILD=1 sh run.sh
 
 node-deps: ## Install NodeJS dependencies.

--- a/client/README.md
+++ b/client/README.md
@@ -86,11 +86,11 @@ Sometimes you want to run your local UI against a remote Galaxy server. This is 
 
     CHANGE_ORIGIN=true GALAXY_URL="https://usegalaxy.org/" make client-dev-server
 
-## Running a Seperate Server
+## Running a Separate Server
 
-When developing the client it can be helpful to run a local server for
-the client to connect to, and run the client seperatly with one of the
-above commands. This command will build galaxy without building the client:
+When developing the client it can be helpful to run a local server for the
+client to connect to, and run the client separately with one of the above
+commands. This command will run galaxy without building the client:
 
     make skip-client
 

--- a/client/README.md
+++ b/client/README.md
@@ -86,6 +86,14 @@ Sometimes you want to run your local UI against a remote Galaxy server. This is 
 
     CHANGE_ORIGIN=true GALAXY_URL="https://usegalaxy.org/" make client-dev-server
 
+## Running a Seperate Server
+
+When developing the client it can be helpful to run a local server for
+the client to connect to, and run the client seperatly with one of the
+above commands. This command will build galaxy without building the client:
+
+    make skip-client
+
 ## Changing Styles/CSS
 
 Galaxy uses Sass for its styling, which is a superset of CSS that compiles down


### PR DESCRIPTION
This PR adds the make target `skip-client` and an addition to the `client/README.md` explaining it's usage.
Galaxy can be compiled without the client by setting the `GALAXY_SKIP_CLIENT_BUILD` env variable.
This feature is very useful for client development, but was previously undocumented and hard to find.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. run `make skip-client` and check if galaxy is being built without building the client.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
