### PR TITLE
[22.05] Support quoted strings in bool expressions

### DIFF
--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -19,6 +19,7 @@ from pyparsing import (
     opAssoc,
     ParseException,
     ParserElement,
+    QuotedString,
     Word,
 )
 
@@ -35,6 +36,7 @@ FALSE = Keyword("False")
 NOT_OP = CaselessKeyword("not")
 AND_OP = CaselessKeyword("and")
 OR_OP = CaselessKeyword("or")
+QUOTED_STRING = QuotedString("'")
 
 
 class TokenEvaluator:
@@ -133,7 +135,7 @@ class BooleanExpressionEvaluator:
         """
         action = BoolOperand
         action.evaluator = evaluator
-        boolOperand = TRUE | FALSE | Word(token_format or DEFAULT_TOKEN_FORMAT)
+        boolOperand = TRUE | FALSE | QUOTED_STRING | Word(token_format or DEFAULT_TOKEN_FORMAT)
         boolOperand.setParseAction(action)
         self.boolExpr: ParserElement = infixNotation(
             boolOperand,

--- a/lib/galaxy_test/driver/integration_setup.py
+++ b/lib/galaxy_test/driver/integration_setup.py
@@ -6,10 +6,12 @@ import shutil
 from tempfile import mkdtemp
 from typing import ClassVar
 
-from .driver_util import GalaxyTestDriver
+from galaxy_test.driver.driver_util import GalaxyTestDriver
 
-REQUIRED_ROLE = "user@bx.psu.edu"
-REQUIRED_GROUP = "fs_test_group"
+REQUIRED_ROLE_EXPRESSION = "user@bx.psu.edu"
+GROUP_A = "fs_test_group"
+GROUP_B = "group name with spaces"
+REQUIRED_GROUP_EXPRESSION = f"{GROUP_A} or '{GROUP_B}'"
 
 
 def get_posix_file_source_config(root_dir: str, roles: str, groups: str, include_test_data_dir: bool) -> str:
@@ -36,7 +38,9 @@ def get_posix_file_source_config(root_dir: str, roles: str, groups: str, include
 
 
 def create_file_source_config_file_on(temp_dir, root_dir, include_test_data_dir):
-    file_contents = get_posix_file_source_config(root_dir, REQUIRED_ROLE, REQUIRED_GROUP, include_test_data_dir)
+    file_contents = get_posix_file_source_config(
+        root_dir, REQUIRED_ROLE_EXPRESSION, REQUIRED_GROUP_EXPRESSION, include_test_data_dir
+    )
     file_path = os.path.join(temp_dir, "file_sources_conf_posix.yml")
     with open(file_path, "w") as f:
         f.write(file_contents)

--- a/test/unit/util/test_bool_expressions.py
+++ b/test/unit/util/test_bool_expressions.py
@@ -12,7 +12,7 @@ TOKEN_FORMAT = DEFAULT_TOKEN_FORMAT
 
 # The set of tokens that will be evaluated to True using the TokenContainedEvaluator the rest
 # of the *valid tokens* (those that match the TOKEN_FORMAT) will be evaluated to False.
-TOKENS_THAT_ARE_TRUE = {"T1", "token_2"}
+TOKENS_THAT_ARE_TRUE = {"T1", "token_2", "valid quoted str"}
 
 VALID_EXPRESSIONS_TESTS = [
     ("T1", True),
@@ -26,12 +26,13 @@ VALID_EXPRESSIONS_TESTS = [
     ("not T3 or (T3 AND token_2)", True),
     ("T1 and (T3 OR token_2)", True),
     ("(T3 OR T1) and not (T3 OR valid_token)", True),
+    ("'some quoted str' and T1", False),
+    ("'valid quoted str' and T1", True),
 ]
 
 INVALID_EXPRESSIONS_TESTS = [
     "",
     "23 45",
-    "'some quoted str' and not T1",
     "invalid expression",
     "T1 and and T2",
     "T1 not and T3",


### PR DESCRIPTION
Fixes #14405

The expression parser was not configured to support tokens with spaces surrounded by quotes and group and role names can contain spaces so definitely a bug.

I have updated the unit and integrations tests to take this case into account.

We can backport this fix up to 21.05 if really needed.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
