### PR TITLE
[22.05] Fix first startup when only python3 is on PATH

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -124,14 +124,9 @@ if [ $SET_VENV -eq 1 ] && [ $CREATE_VENV -eq 1 ]; then
             python3 -m venv "$GALAXY_VIRTUAL_ENV"
         else
             # If $GALAXY_VIRTUAL_ENV does not exist, and there is no conda available, attempt to create it.
-            if [ -z "$GALAXY_PYTHON" ]; then
-                if command -v python3 >/dev/null; then
-                    GALAXY_PYTHON=python3
-                else
-                    GALAXY_PYTHON=python
-                fi
-            fi
+
             # Ensure Python is a supported version before creating $GALAXY_VIRTUAL_ENV
+            find_python_command
             "$GALAXY_PYTHON" ./scripts/check_python.py || exit 1
             echo "Creating Python virtual environment for Galaxy: $GALAXY_VIRTUAL_ENV"
             echo "using Python: $GALAXY_PYTHON"

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -90,6 +90,16 @@ conda_activate() {
     fi
 }
 
+find_python_command() {
+    if [ -z "$GALAXY_PYTHON" ]; then
+        if command -v python3 >/dev/null; then
+            GALAXY_PYTHON=python3
+        else
+            GALAXY_PYTHON=python
+        fi
+    fi
+}
+
 setup_python() {
     # If there is a .venv/ directory, assume it contains a virtualenv that we
     # should run this instance in.
@@ -120,7 +130,8 @@ setup_python() {
     # in case you don't.
     [ -n "$PYTHONPATH" ] && echo 'WARNING: $PYTHONPATH is set, this can cause problems importing Galaxy dependencies'
 
-    python ./scripts/check_python.py || exit 1
+    find_python_command
+    "$GALAXY_PYTHON" ./scripts/check_python.py || exit 1
 }
 
 setup_gravity_state_dir() {


### PR DESCRIPTION
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

```
docker run -it ubuntu bash
apt update
apt install -y python3 git python3.10-venv
git clone --depth=1 --branch=work_around_python_not_on_path https://github.com/mvdbeek/galaxy
cd galaxy/
./run.sh
```

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
