### PR TITLE
[22.05] Calculate CRC32 for files in size between 1444 and 1459 bytes

### DIFF
--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -442,7 +442,7 @@ galaxy:
 Galaxy creates zip archives when downloading multiple datasets from a history or a dataset library.
 While this works fine for small datasets and few users, nginx can handle the creation of zip archives
 more efficiently using [mod-zip](https://www.nginx.com/resources/wiki/modules/zip/).
-To use this feature, install nginx with mod-zip enabled, provide the file locations from which
+To use this feature, install nginx with mod-zip enabled (requires <https://github.com/evanmiller/mod_zip/commit/51cf45d3e9f51e02224af017b235d1d30fbf28fb> or a newer), provide the file locations from which
 nginx should serve files and edit `galaxy.yml` and make the following changes before restarting Galaxy:
 
 ```yaml

--- a/lib/galaxy/util/zipstream.py
+++ b/lib/galaxy/util/zipstream.py
@@ -1,9 +1,13 @@
 import os
+import zlib
 from urllib.parse import quote
 
 import zipstream
 
 from .path import safe_walk
+
+CRC32_MIN = 1444
+CRC32_MAX = 1459
 
 
 class ZipstreamWrapper:
@@ -38,6 +42,12 @@ class ZipstreamWrapper:
         if self.upstream_mod_zip:
             # calculating crc32 would defeat the point of using mod-zip, but if we ever calculate hashsums we should consider this
             crc32 = "-"
+            # We do have to calculate the crc32 for files that are between 1444 and 1459 bytes in size, xref: https://github.com/evanmiller/mod_zip/issues/44#issuecomment-656660686
+            # Oddly that seems to be only true for usegalaxy.org (nginx version 1.12.2), and works fine locally (nginx 1.19.10).
+            # May have been fixed in nginx 1.17.0
+            if CRC32_MIN <= os.path.getsize(path) <= CRC32_MAX:
+                with open(path, "rb") as contents:
+                    crc32 = hex(zlib.crc32(contents.read()))[2:]
             line = f"{crc32} {size} {quote(path)} {archive_name}"
             self.files.append(line)
         else:


### PR DESCRIPTION
Fixes downloads via mod-zip for uncompressed files in the size range of 1444 and 14559 bytes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
See https://github.com/galaxyproject/galaxy/issues/14365

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
