### PR TITLE
[22.05] Fix additional errors when requesting dataset details in history contents

### DIFF
--- a/client/src/store/historyStore/model/watchHistory.js
+++ b/client/src/store/historyStore/model/watchHistory.js
@@ -122,7 +122,7 @@ function getCurrentlyExpandedHistoryContentIds() {
     expandedItems.forEach((key) => {
         // Items have the format: <type>-<id>
         const itemId = key.split("-")[1];
-        if (itemId) {
+        if (itemId?.trim()) {
             expandedItemIds.push(itemId);
         }
     });

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -9,13 +9,13 @@ from typing import (
 )
 
 from galaxy.webapps.galaxy.services.history_contents import DirectionOptions
+from galaxy_test.api._framework import ApiTestCase
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
     LibraryPopulator,
     skip_without_tool,
 )
-from ._framework import ApiTestCase
 
 TEST_SOURCE_URI = "http://google.com/dataset.txt"
 TEST_HASH_FUNCTION = "MD5"
@@ -166,10 +166,15 @@ class HistoryContentsApiTestCase(ApiTestCase):
 
     def test_index_detail_parameter_error(self):
         hda1 = self.dataset_populator.new_dataset(self.history_id)
-        wrong_details_query_with_empty_ids = f"details=,,{hda1['id']}"
-        contents_response = self._get(
-            f"histories/{self.history_id}/contents?v=dev&{wrong_details_query_with_empty_ids}"
-        )
+        # Invalid details should return 400
+        contents_response = self._get(f"histories/{self.history_id}/contents?v=dev&details= ")
+        self._assert_status_code_is(contents_response, 400)
+        # Empty IDs should return 400
+        contents_response = self._get(f"histories/{self.history_id}/contents?v=dev&details=,,{hda1['id']}")
+        self._assert_status_code_is(contents_response, 400)
+
+        # Invalid IDs should return 400
+        contents_response = self._get(f"histories/{self.history_id}/contents?v=dev&details={hda1['id']}, ,{hda1['id']}")
         self._assert_status_code_is(contents_response, 400)
 
     def test_show_hda(self):


### PR DESCRIPTION
Follow up on #14395

Well, unfortunately, this issue is still present, but now in a slightly different form. Instead of getting requests for details with empty dataset IDs like in `&details=,,f2db41e1fa331b3e` we get requests that have just white spaces instead of the ID `&details=f2db41e1fa331b3e, ,f597429621d6eb2b`. To finally deal with that in the backend, now the unhandled ValidationError is wrapped in our custom exceptions to get a proper Bad Request in those situations.

The client also tries to avoid sending requests with whitespaces in the IDs.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
