### PR TITLE
[22.05] Fix workflow direct step insertion in workflow editor

### DIFF
--- a/client/src/components/Workflow/Editor/Index.test.js
+++ b/client/src/components/Workflow/Editor/Index.test.js
@@ -16,7 +16,7 @@ jest.mock("app");
 import { getDatatypesMapper } from "components/Datatypes/factory";
 import { testDatatypesMapper } from "components/Datatypes/test_fixtures";
 import { getVersions, loadWorkflow } from "./modules/services";
-import { getStateUpgradeMessages, saveAs } from "./modules/utilities";
+import { getStateUpgradeMessages } from "./modules/utilities";
 import { getAppRoot } from "onload/loadConfig";
 import WorkflowCanvas from "./modules/canvas";
 
@@ -114,13 +114,6 @@ describe("Index", () => {
 
         await wrapper.setData({ name: "new name" });
         expect(wrapper.vm.hasChanges).toBeTruthy();
-    });
-
-    it("delegates to a module onSaveAs", async () => {
-        mountAndWaitForCreated();
-        saveAs.mockReturnThis();
-        wrapper.vm.onSaveAs();
-        expect(saveAs).toBeCalled();
     });
 
     it("prevents navigation only if hasChanges", async () => {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -14,11 +14,11 @@
             @onShow="hideModal" />
         <MessagesModal :title="messageTitle" :message="messageBody" :error="messageIsError" @onHidden="resetMessage" />
         <b-modal
+            v-model="showSaveAsModal"
             title="Save As a New Workflow"
             ok-title="Save"
             cancel-title="Cancel"
-            @ok="doSaveAs"
-            v-model="showSaveAsModal">
+            @ok="doSaveAs">
             <b-form-group label="Name">
                 <b-form-input v-model="saveAsName" />
             </b-form-group>

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -465,19 +465,19 @@ export default {
                 this.onInsertedStateMessages(insertedStateMessages);
             });
         },
-        async onInsertWorkflowSteps(workflow_id, step_count) {
+        async onInsertWorkflowSteps(workflowId, stepCount) {
             if (!this.isCanvas) {
                 this.isCanvas = true;
                 return;
             }
-            if (step_count < 4) {
-                this.copyIntoWorkflow(workflow_id);
+            if (stepCount < 10) {
+                this.copyIntoWorkflow(workflowId);
             } else {
                 const confirmed = await this.$bvModal.msgBoxConfirm(
-                    `Warning this will add ${step_count} new steps into your current workflow.  You may want to consider using a subworkflow instead.`
+                    `Warning this will add ${stepCount} new steps into your current workflow.  You may want to consider using a subworkflow instead.`
                 );
                 if (confirmed) {
-                    this.copyIntoWorkflow(workflow_id);
+                    this.copyIntoWorkflow(workflowId);
                 }
             }
         },

--- a/client/src/components/Workflow/Editor/modules/utilities.js
+++ b/client/src/components/Workflow/Editor/modules/utilities.js
@@ -1,8 +1,4 @@
 import _ from "underscore";
-import $ from "jquery";
-import { getAppRoot } from "onload/loadConfig";
-import { toSimple } from "./model";
-import { show_modal } from "layout/modal";
 import WorkflowIcons from "components/Workflow/icons";
 
 export function getStateUpgradeMessages(data) {
@@ -29,45 +25,6 @@ export function getStateUpgradeMessages(data) {
         }
     });
     return messages;
-}
-
-export function saveAs(workflow) {
-    var body = $(
-        '<form><label style="display:inline-block; width: 100%;">Save as name: </label><input type="text" id="workflow_rename" style="width: 80%;" autofocus/>' +
-            '<br><label style="display:inline-block; width: 100%;">Annotation: </label><input type="text" id="wf_annotation" style="width: 80%;" /></form>'
-    );
-    show_modal("Save As a New Workflow", body, {
-        OK: function () {
-            var rename_name =
-                $("#workflow_rename").val().length > 0 ? $("#workflow_rename").val() : `SavedAs_${workflow.name}`;
-            var rename_annotation = $("#wf_annotation").val().length > 0 ? $("#wf_annotation").val() : "";
-            $.ajax({
-                url: `${getAppRoot()}workflow/save_workflow_as`,
-                type: "POST",
-                data: {
-                    workflow_name: rename_name,
-                    workflow_annotation: rename_annotation,
-                    from_tool_form: true,
-                    workflow_data: () => {
-                        return JSON.stringify(toSimple(workflow));
-                    },
-                },
-            })
-                .done((id) => {
-                    workflow.onNavigate(`${getAppRoot()}workflow/editor?id=${id}`, true);
-                })
-                .fail((err) => {
-                    console.debug(err);
-                    workflow.onWorkflowError(
-                        "Saving this workflow failed. Please contact this site's administrator.",
-                        err
-                    );
-                });
-        },
-        Cancel: () => {
-            workflow.hideModal();
-        },
-    });
 }
 
 export function getCompatibleRecommendations(predChild, outputDatatypes, datatypesMapper) {

--- a/client/src/components/Workflow/Editor/modules/utilities.js
+++ b/client/src/components/Workflow/Editor/modules/utilities.js
@@ -1,7 +1,6 @@
 import _ from "underscore";
 import $ from "jquery";
 import { getAppRoot } from "onload/loadConfig";
-import _l from "utils/localization";
 import { loadWorkflow } from "./services";
 import { toSimple } from "./model";
 import { show_modal } from "layout/modal";
@@ -20,13 +19,14 @@ export function copyIntoWorkflow(workflow, id = null, stepCount = null) {
     if (stepCount < 2) {
         _copy_into_workflow_ajax();
     } else {
-        // don't ruin the workflow by adding 50 steps unprompted.
-        show_modal(_l("Warning"), `This will copy ${stepCount} new steps into your workflow.`, {
-            Cancel: () => {
-                workflow.hideModal();
-            },
-            Copy: _copy_into_workflow_ajax,
-        });
+        // but don't ruin the workflow if it's a ton of steps.
+        if (
+            window.confirm(
+                `Warning this will add ${stepCount} new steps into your current workflow.  You may want to consider using a subworkflow instead.`
+            )
+        ) {
+            _copy_into_workflow_ajax();
+        }
     }
 }
 

--- a/client/src/components/Workflow/Editor/modules/utilities.js
+++ b/client/src/components/Workflow/Editor/modules/utilities.js
@@ -1,35 +1,9 @@
 import _ from "underscore";
 import $ from "jquery";
 import { getAppRoot } from "onload/loadConfig";
-import { loadWorkflow } from "./services";
 import { toSimple } from "./model";
 import { show_modal } from "layout/modal";
 import WorkflowIcons from "components/Workflow/icons";
-
-export function copyIntoWorkflow(workflow, id = null, stepCount = null) {
-    const _copy_into_workflow_ajax = () => {
-        // Load workflow definition
-        workflow.onWorkflowMessage("Importing workflow", "progress");
-        loadWorkflow(workflow, id, null, true).then((data) => {
-            // Determine if any parameters were 'upgraded' and provide message
-            const insertedStateMessages = getStateUpgradeMessages(data);
-            workflow.onInsertedStateMessages(insertedStateMessages);
-        });
-    };
-    if (stepCount < 10) {
-        // If it's less than 10 steps, just do it.
-        _copy_into_workflow_ajax();
-    } else {
-        // but don't ruin the workflow if it's a ton of steps.
-        if (
-            window.confirm(
-                `Warning this will add ${stepCount} new steps into your current workflow.  You may want to consider using a subworkflow instead.`
-            )
-        ) {
-            _copy_into_workflow_ajax();
-        }
-    }
-}
 
 export function getStateUpgradeMessages(data) {
     // Determine if any parameters were 'upgraded' and provide message

--- a/client/src/components/Workflow/Editor/modules/utilities.js
+++ b/client/src/components/Workflow/Editor/modules/utilities.js
@@ -16,7 +16,8 @@ export function copyIntoWorkflow(workflow, id = null, stepCount = null) {
             workflow.onInsertedStateMessages(insertedStateMessages);
         });
     };
-    if (stepCount < 2) {
+    if (stepCount < 10) {
+        // If it's less than 10 steps, just do it.
         _copy_into_workflow_ajax();
     } else {
         // but don't ruin the workflow if it's a ton of steps.


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14421 by converting both modals to modern b-modals.  Could use refactoring but I kept it minimal-ish for 22.05, and because the save_as stuff targeting the old web controller needs a rewrite to use the API anyway.

Additionally raises threshold for insertion confirmation to 10 steps, from 2.


## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. See source issue.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
