### PR TITLE
[22.05] Make history contents filter with `contains` case insensitive

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -28,6 +28,7 @@ attribute change to a model object.
 import datetime
 import logging
 import re
+from functools import partial
 from typing import (
     Any,
     Callable,
@@ -68,6 +69,7 @@ log = logging.getLogger(__name__)
 class ParsedFilter(NamedTuple):
     filter_type: str  # orm_function, function, or orm
     filter: Any
+    case_insensitive: bool = False
 
 
 parsed_filter = ParsedFilter
@@ -1169,10 +1171,6 @@ class ModelFilterParser(HasAModelManager):
         if op not in allowed_ops:
             return None
 
-        if op == "contains":  # Ignore case (in a hacky way...)
-            op = "ilike"
-            val = f"%{val}%"
-
         converted_op = self._convert_op_string_to_fn(column, op)
         if not converted_op:
             return None
@@ -1185,9 +1183,12 @@ class ModelFilterParser(HasAModelManager):
             val_parser = val_parser.get(op)
         if val_parser:
             val = val_parser(val)
+        if op == "contains":
+            # Do we want to make this configurable ?
+            val = val.lower()
 
         orm_filter = converted_op(val)
-        return self.parsed_filter(filter_type="orm", filter=orm_filter)
+        return self.parsed_filter(filter_type="orm", filter=orm_filter, case_insensitive=op == "contains")
 
     #: these are the easier/shorter string equivalents to the python operator fn names that need '__' around them
     UNDERSCORED_OPS = ("lt", "le", "eq", "ne", "ge", "gt")
@@ -1209,6 +1210,8 @@ class ModelFilterParser(HasAModelManager):
         op_fn = getattr(column, fn_name, None)
         if not op_fn or not callable(op_fn):
             return None
+        if op_string == "contains":
+            op_fn = partial(op_fn, autoescape=True)
         return op_fn
 
     # ---- preset fn_filters: dictionaries of standard filter ops for standard datatypes
@@ -1216,7 +1219,7 @@ class ModelFilterParser(HasAModelManager):
         return {
             "op": {
                 "eq": lambda i, v: v == getattr(i, key),
-                "contains": lambda i, v: v in getattr(i, key),
+                "contains": lambda i, v: v in partial(getattr(i, key), autoescape=True),
             }
         }
 

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -1168,6 +1168,11 @@ class ModelFilterParser(HasAModelManager):
         allowed_ops = column_map["op"]
         if op not in allowed_ops:
             return None
+
+        if op == "contains":  # Ignore case (in a hacky way...)
+            op = "ilike"
+            val = f"%{val}%"
+
         converted_op = self._convert_op_string_to_fn(column, op)
         if not converted_op:
             return None

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -329,8 +329,8 @@ class HistoryContentsManager(base.SortableManager):
                 contained_query = contained_query.filter(orm_filter.filter(self.contained_class))
                 subcontainer_query = subcontainer_query.filter(orm_filter.filter(self.subcontainer_class))
             elif orm_filter.filter_type == "orm":
-                contained_query = self._apply_orm_filter(contained_query, orm_filter.filter)
-                subcontainer_query = self._apply_orm_filter(subcontainer_query, orm_filter.filter)
+                contained_query = self._apply_orm_filter(contained_query, orm_filter)
+                subcontainer_query = self._apply_orm_filter(subcontainer_query, orm_filter)
 
         contents_query = contained_query.union_all(subcontainer_query)
         contents_query = contents_query.order_by(*order_by)
@@ -342,10 +342,12 @@ class HistoryContentsManager(base.SortableManager):
         return contents_query
 
     def _apply_orm_filter(self, qry, orm_filter):
-        if isinstance(orm_filter, sql.elements.BinaryExpression):
-            for match in filter(lambda col: col["name"] == orm_filter.left.name, qry.column_descriptions):
+        if isinstance(orm_filter.filter, sql.elements.BinaryExpression):
+            for match in filter(lambda col: col["name"] == orm_filter.filter.left.name, qry.column_descriptions):
                 column = match["expr"]
-                new_filter = orm_filter._clone()
+                new_filter = orm_filter.filter._clone()
+                if orm_filter.case_insensitive:
+                    column = func.lower(column)
                 new_filter.left = column
                 qry = qry.filter(new_filter)
         return qry

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -859,6 +859,11 @@ class HistoryContentsApiTestCase(ApiTestCase):
             f"histories/{history_id}/contents?v=dev&q=name-contains&qv={contains_text}"
         ).json()
         assert len(contents_response) == 3
+        contains_text = "%"
+        contents_response = self._get(
+            f"histories/{history_id}/contents?v=dev&q=name-contains&qv={contains_text}"
+        ).json()
+        assert len(contents_response) == 0
 
     def test_elements_datatypes_field(self):
         history_id = self.dataset_populator.new_history()

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -838,6 +838,28 @@ class HistoryContentsApiTestCase(ApiTestCase):
         contents_response = self._get(f"histories/{history_id}/contents?types=dataset&types=dataset_collection").json()
         assert len(contents_response) == expected_num_datasets + expected_num_collections
 
+    def test_index_filter_by_name_ignores_case(self):
+        history_id = self.dataset_populator.new_history()
+        self.dataset_populator.new_dataset(history_id, name="AC")
+        self.dataset_populator.new_dataset(history_id, name="ac")
+        self.dataset_populator.new_dataset(history_id, name="Bc")
+
+        contains_text = "a"
+        contents_response = self._get(
+            f"histories/{history_id}/contents?v=dev&q=name-contains&qv={contains_text}"
+        ).json()
+        assert len(contents_response) == 2
+        contains_text = "b"
+        contents_response = self._get(
+            f"histories/{history_id}/contents?v=dev&q=name-contains&qv={contains_text}"
+        ).json()
+        assert len(contents_response) == 1
+        contains_text = "c"
+        contents_response = self._get(
+            f"histories/{history_id}/contents?v=dev&q=name-contains&qv={contains_text}"
+        ).json()
+        assert len(contents_response) == 3
+
     def test_elements_datatypes_field(self):
         history_id = self.dataset_populator.new_history()
         collection_name = "homogeneous"


### PR DESCRIPTION
Fixes #14416

I really don't like this hacky solution :disappointed:
I'm just opening the PR to see if someone has a better understanding of the filtering system for history contents and can suggest a proper way of fixing it.

I tried also to apply `func.lower` to the column and the value as we do in other filters but it doesn't work... 
```python
if op == "contains":
    column = sqlalchemy.func.lower(column)
    val = val.lower()
```

I had to replace the `contains` with an `ilike` operation which just feels wrong...


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  Follow instructions in #14416

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
