### PR TITLE
Deprecate `cluster_files_directory` and store DRMAA job template and PBS shell, error and out files in job working directory

### DIFF
--- a/doc/source/admin/cluster.md
+++ b/doc/source/admin/cluster.md
@@ -59,13 +59,6 @@ If your cluster nodes have Internet access (NAT is okay) and you want to run the
 new_file_path: /clusterfs/galaxy/tmp
 ```
 
-
-Additionally some of the runners including DRMAA may use the ``cluster_files_directory`` for sharing files with the cluster, which defaults to ``database/pbs``. You may need to create this folder.
-
-```yaml
-cluster_files_directory: database/pbs
-```
-
 You may also find that attribute caching in your filesystem causes problems with job completion since it interferes with Galaxy detecting the presence and correct sizes of output files. In NFS caching can be disabled with the `-noac` mount option on Linux (on the Galaxy server), but this may have a significant impact on performance since all attributes will have to be read from the file server upon every file access. You should try the `retry_job_output_collection` option in `galaxy.yml` first to see if this solves the problem.
 
 ## Runner Configuration

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1071,19 +1071,6 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``cluster_files_directory``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    If using a cluster, Galaxy will write job scripts and
-    stdout/stderr to this directory.
-    The value of this option will be resolved with respect to
-    <data_dir>.
-:Default: ``pbs``
-:Type: str
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~
 ``template_cache_path``
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -677,7 +677,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     hours_between_check: int
     galaxy_data_manager_data_path: str
     use_remote_user: bool
-    cluster_files_directory: str
     preserve_python_environment: str
     email_from: str
     workflow_resource_params_mapper: str
@@ -843,7 +842,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             if len(ip.strip()) > 0
         ]
         self.job_queue_cleanup_interval = int(kwargs.get("job_queue_cleanup_interval", "5"))
-        self.cluster_files_directory = self._in_root_dir(self.cluster_files_directory)
 
         # Fall back to legacy job_working_directory config variable if set.
         self.jobs_directory = self._in_data_dir(kwargs.get("jobs_directory", self.job_working_directory))

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -687,12 +687,6 @@ galaxy:
   # <data_dir>.
   #job_working_directory: jobs_directory
 
-  # If using a cluster, Galaxy will write job scripts and stdout/stderr
-  # to this directory.
-  # The value of this option will be resolved with respect to
-  # <data_dir>.
-  #cluster_files_directory: pbs
-
   # Mako templates are compiled as needed and cached for reuse, this
   # directory is used for the cache
   # The value of this option will be resolved with respect to

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -779,15 +779,6 @@ mapping:
 
           The value of this option will be resolved with respect to <data_dir>.
 
-      cluster_files_directory:
-        type: str
-        default: pbs
-        path_resolves_to: data_dir
-        required: false
-        desc: |
-          If using a cluster, Galaxy will write job scripts and stdout/stderr to this
-          directory.
-
       template_cache_path:
         type: str
         default: compiled_templates

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -426,7 +426,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         Path is hard-coded, but it's no worse than other path in this module.
         Uses Galaxy's JobID, so file is expected to be unique."""
         filename = f"{self.app.config.cluster_files_directory}/{job_wrapper.get_id_tag()}.jt_json"
-        with open(filename, "w+") as fp:
+        with open(filename, "w") as fp:
             json.dump(jt, fp)
         log.debug(f"({job_wrapper.job_id}) Job script for external submission is: {filename}")
         return filename

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -420,9 +420,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
             self.monitor_queue.put(ajs)
 
     def store_jobtemplate(self, job_wrapper, jt):
-        """Stores the content of a DRMAA JobTemplate object in a file as a JSON string.
-        Path is hard-coded, but it's no worse than other path in this module.
-        Uses Galaxy's JobID, so file is expected to be unique."""
+        """Stores the content of a DRMAA JobTemplate object in a file as a JSON string."""
         filename = os.path.join(job_wrapper.working_directory, f"{job_wrapper.get_id_tag()}.jt_json")
         with open(filename, "w") as fp:
             json.dump(jt, fp)

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -224,6 +224,8 @@ class DRMAAJobRunner(AsynchronousJobRunner):
             if external_job_id is None:
                 job_wrapper.fail(f"({galaxy_id_tag}) could not queue job")
                 return
+            else:
+                os.unlink(filename)
         log.info(f"({galaxy_id_tag}) queued as {external_job_id}")
 
         # store runner information for tracking if Galaxy restarts

--- a/lib/galaxy/jobs/runners/pbs.py
+++ b/lib/galaxy/jobs/runners/pbs.py
@@ -238,9 +238,9 @@ class PBSJobRunner(AsynchronousJobRunner):
             return
 
         # define job attributes
-        ofile = f"{self.app.config.cluster_files_directory}/{job_wrapper.job_id}.o"
-        efile = f"{self.app.config.cluster_files_directory}/{job_wrapper.job_id}.e"
-        ecfile = f"{self.app.config.cluster_files_directory}/{job_wrapper.job_id}.ec"
+        ofile = f"{job_wrapper.working_directory}/{job_wrapper.job_id}.o"
+        efile = f"{job_wrapper.working_directory}/{job_wrapper.job_id}.e"
+        ecfile = f"{job_wrapper.working_directory}/{job_wrapper.job_id}.ec"
 
         output_fnames = job_wrapper.job_io.get_output_fnames()
 
@@ -293,7 +293,7 @@ class PBSJobRunner(AsynchronousJobRunner):
         script = self.get_job_file(
             job_wrapper, exit_code_path=ecfile, env_setup_commands=env_setup_commands, shell=job_wrapper.shell
         )
-        job_file = f"{self.app.config.cluster_files_directory}/{job_wrapper.job_id}.sh"
+        job_file = f"{job_wrapper.working_directory}/{job_wrapper.job_id}.sh"
         self.write_executable_script(job_file, script, job_io=job_wrapper.job_io)
         # job was deleted while we were preparing it
         if job_wrapper.get_state() in (model.Job.states.DELETED, model.Job.states.STOPPED):
@@ -537,10 +537,10 @@ class PBSJobRunner(AsynchronousJobRunner):
         pbs_job_state = AsynchronousJobState(
             job_wrapper=job_wrapper,
             job_id=job_id,
-            job_file=f"{self.app.config.cluster_files_directory}/{job.id}.sh",
-            output_file=f"{self.app.config.cluster_files_directory}/{job.id}.o",
-            error_file=f"{self.app.config.cluster_files_directory}/{job.id}.e",
-            exit_code_file=f"{self.app.config.cluster_files_directory}/{job.id}.ec",
+            job_file=f"{job_wrapper.working_directory}/{job.id}.sh",
+            output_file=f"{job_wrapper.working_directory}/{job.id}.o",
+            error_file=f"{job_wrapper.working_directory}/{job.id}.e",
+            exit_code_file=f"{job_wrapper.working_directory}/{job.id}.ec",
             job_destination=job_wrapper.job_destination,
         )
         pbs_job_state.runner_url = job_wrapper.get_job_runner_url()

--- a/scripts/drmaa_external_runner.py
+++ b/scripts/drmaa_external_runner.py
@@ -129,9 +129,7 @@ def set_user(uid, assign_all_groups):
 
 def main():
     userid, json_filename, assign_all_groups = validate_paramters()
-    # load JSON job template data before changing the user
-    # then the pbs cluster_files_directory does not need to
-    # be readable by all users
+    # load JSON job template data
     json_file_exists(json_filename)
     with open(json_filename) as f:
         data = json.load(f)

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -53,7 +53,6 @@ PATH_CONFIG_PROPERTIES = [
     "builds_file_path",
     "citation_cache_data_dir",
     "citation_cache_lock_dir",
-    "cluster_files_directory",
     "container_resolvers_config_file",
     "data_manager_config_file",
     "datatypes_config_file",

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -107,7 +107,6 @@ class ExpectedValues:
             "cache_dir": self._in_data_dir("cache"),
             "citation_cache_data_dir": self._in_cache_dir("citations/data"),
             "citation_cache_lock_dir": self._in_cache_dir("citations/locks"),
-            "cluster_files_directory": self._in_data_dir("pbs"),
             "config_dir": self._in_config_dir(),
             "data_dir": self._in_data_dir(),
             "data_manager_config_file": self._in_config_dir("data_manager_conf.xml"),


### PR DESCRIPTION
On my system 10 thousands of job template files accumulated (was not aware) in `cluster_files_directory`. Then the files are cleaned up automatically.

- [x] get rid of  `cluster_files_directory` in the `pbs` runner. Then the config variable can be removed. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
