### PR TITLE
[22.05] Fix cache image singularity resolver if path contains uppercase chars

### DIFF
--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -1,4 +1,5 @@
 import copy
+import os
 from typing import (
     Any,
     Callable,
@@ -186,8 +187,17 @@ class ContainerDescription:
         resolve_dependencies: bool = DEFAULT_CONTAINER_RESOLVE_DEPENDENCIES,
         shell: str = DEFAULT_CONTAINER_SHELL,
     ) -> None:
-        # Force to lowercase because container image names must be lowercase
-        self.identifier = identifier.lower() if identifier else None
+        # Force to lowercase because container image names must be lowercase.
+        # Cached singularity images include the path on disk, so only lowercase
+        # the image identifier portion.
+        self.identifier = None
+        if identifier:
+            parts = identifier.rsplit(os.sep, 1)
+            parts[-1] = parts[-1].lower()
+            if len(parts) == 2:
+                self.identifier = f"{parts[0]}{os.sep}{parts[1]}"
+            else:
+                self.identifier = parts[0]
         self.type = type
         self.resolve_dependencies = resolve_dependencies
         self.shell = shell

--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -194,10 +194,7 @@ class ContainerDescription:
         if identifier:
             parts = identifier.rsplit(os.sep, 1)
             parts[-1] = parts[-1].lower()
-            if len(parts) == 2:
-                self.identifier = f"{parts[0]}{os.sep}{parts[1]}"
-            else:
-                self.identifier = parts[0]
+            self.identifier = os.sep.join(parts)
         self.type = type
         self.resolve_dependencies = resolve_dependencies
         self.shell = shell

--- a/test/unit/tool_util/test_container_description.py
+++ b/test/unit/tool_util/test_container_description.py
@@ -1,0 +1,24 @@
+import pytest
+
+from galaxy.tool_util.deps.requirements import ContainerDescription
+
+
+@pytest.mark.parametrize(
+    "identifier,expected_identifier",
+    [
+        ("mulled-abc", "mulled-abc"),
+        ("docker://mulled-abc", "docker://mulled-abc"),
+        ("/Cache/mulled-abc", "/Cache/mulled-abc"),
+        ("/Cache/mUlled-abc", "/Cache/mulled-abc"),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_container_description(identifier, expected_identifier):
+    assert ContainerDescription(identifier=identifier).identifier == expected_identifier
+
+
+def test_to_from_dict():
+    container_description_dict = ContainerDescription("mulled-abc").to_dict()
+    container_description = ContainerDescription.from_dict(container_description_dict)
+    assert container_description_dict == container_description.to_dict()


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14425

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
