### PR TITLE
Refactor pydantic id handling

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -88,7 +88,7 @@ class LibraryActions:
     Mixin for controllers that provide library functionality.
     """
 
-    def _upload_dataset(self, trans, folder_id: str, replace_dataset: Optional[LibraryDataset] = None, **kwd):
+    def _upload_dataset(self, trans, folder_id: int, replace_dataset: Optional[LibraryDataset] = None, **kwd):
         # Set up the traditional tool state/params
         cntrller = "api"
         tool_id = "upload1"

--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -302,13 +302,11 @@ class LibraryActions:
             trans.sa_session.flush()
         return uploaded_dataset
 
-    def _create_folder(self, trans, parent_id, library_id, **kwd):
+    def _create_folder(self, trans, parent_id: int, **kwd):
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
         try:
-            parent_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(
-                trans.security.decode_id(parent_id)
-            )
+            parent_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(parent_id)
         except Exception:
             parent_folder = None
         # Check the library which actually contains the user-supplied parent folder, not the user-supplied

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -2,7 +2,10 @@ import json
 from concurrent.futures import TimeoutError
 from functools import lru_cache
 from pathlib import Path
-from typing import Callable
+from typing import (
+    Callable,
+    Optional,
+)
 
 from sqlalchemy import (
     exists,
@@ -57,7 +60,7 @@ def cached_create_tool_from_representation(app, raw_tool_source):
 
 
 @galaxy_task(ignore_result=True, action="recalculate a user's disk usage")
-def recalculate_user_disk_usage(session: galaxy_scoped_session, user_id=None):
+def recalculate_user_disk_usage(session: galaxy_scoped_session, user_id: Optional[int] = None):
     if user_id:
         user = session.query(model.User).get(user_id)
         if user:
@@ -70,7 +73,7 @@ def recalculate_user_disk_usage(session: galaxy_scoped_session, user_id=None):
 
 
 @galaxy_task(ignore_result=True, action="purge a history dataset")
-def purge_hda(hda_manager: HDAManager, hda_id):
+def purge_hda(hda_manager: HDAManager, hda_id: int):
     hda = hda_manager.by_id(hda_id)
     hda_manager._purge(hda)
 

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -298,9 +298,7 @@ class JobContext(BaseJobContext):
     def get_library_folder(self, destination):
         app = self.app
         library_folder_manager = app.library_folder_manager
-        library_folder = library_folder_manager.get(
-            self.work_context, app.security.decode_id(destination.get("library_folder_id"))
-        )
+        library_folder = library_folder_manager.get(self.work_context, destination.get("library_folder_id"))
         return library_folder
 
     def get_hdca(self, object_id):

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -298,7 +298,9 @@ class JobContext(BaseJobContext):
     def get_library_folder(self, destination):
         app = self.app
         library_folder_manager = app.library_folder_manager
-        library_folder = library_folder_manager.get(self.work_context, destination.get("library_folder_id"))
+        folder_id = destination.get("library_folder_id")
+        decoded_folder_id = app.security.decode_id(folder_id) if isinstance(folder_id, str) else folder_id
+        library_folder = library_folder_manager.get(self.work_context, decoded_folder_id)
         return library_folder
 
     def get_hdca(self, object_id):

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -165,7 +165,7 @@ def get_object(trans, id, class_name, check_ownership=False, check_accessible=Fa
     controller mixin code - however whenever possible the managers for a
     particular model should be used to load objects.
     """
-    decoded_id = decode_id(trans.app, id)
+    decoded_id = id if isinstance(id, int) else decode_id(trans.app, id)
     try:
         item_class = get_class(class_name)
         assert item_class is not None

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -10,7 +10,6 @@ import os
 import sys
 from typing import (
     Any,
-    cast,
     Dict,
     List,
 )
@@ -19,7 +18,6 @@ from galaxy.managers import base
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.markdown_util import weasyprint_available
 from galaxy.schema import SerializationParams
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.structured_app import StructuredApp
 from galaxy.web.framework.base import server_starttime
 
@@ -62,11 +60,11 @@ class ConfigurationManager:
 
     def decode_id(
         self,
-        encoded_id: EncodedDatabaseIdField,
+        encoded_id: str,
     ) -> Dict[str, int]:
         # Handle the special case for library folders
         if (len(encoded_id) % 16 == 1) and encoded_id.startswith("F"):
-            encoded_id = cast(EncodedDatabaseIdField, encoded_id[1:])
+            encoded_id = encoded_id[1:]
         decoded_id = self._app.security.decode_id(encoded_id)
         return {"decoded_id": decoded_id}
 

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -475,16 +475,8 @@ class DatasetAssociationManager(
                 raise exceptions.InternalServerError("An error occurred and the dataset is NOT private.")
         elif action == "set_permissions":
 
-            def to_role_id(encoded_role_id):
-                role_id = base.decode_id(self.app, encoded_role_id)
-                return role_id
-
             def parameters_roles_or_none(role_type):
-                encoded_role_ids = kwd.get(role_type, kwd.get(f"{role_type}_ids[]", None))
-                if encoded_role_ids is not None:
-                    return list(map(to_role_id, encoded_role_ids))
-                else:
-                    return None
+                return kwd.get(role_type, kwd.get(f"{role_type}_ids[]"))
 
             access_roles = parameters_roles_or_none("access")
             manage_roles = parameters_roles_or_none("manage")

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -77,16 +77,13 @@ class FolderManager:
     Interface/service object for interacting with folders.
     """
 
-    def get(self, trans, decoded_folder_id, check_manageable=False, check_accessible=True):
+    def get(self, trans, decoded_folder_id: int, check_manageable: bool = False, check_accessible: bool = True):
         """
         Get the folder from the DB.
 
         :param  decoded_folder_id:       decoded folder id
-        :type   decoded_folder_id:       int
         :param  check_manageable:        flag whether the check that user can manage item
-        :type   check_manageable:        bool
         :param  check_accessible:        flag whether to check that user can access item
-        :type   check_accessible:        bool
 
         :returns:   the requested folder
         :rtype:     LibraryFolder

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -1,14 +1,13 @@
 import logging
 from typing import (
-    Any,
+    List,
     Optional,
 )
 
 from galaxy import model
 from galaxy.exceptions import ObjectNotFound
-from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesAppContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
@@ -20,18 +19,17 @@ class GroupRolesManager:
     def __init__(self, app: MinimalManagerApp) -> None:
         self._app = app
 
-    def index(self, trans: ProvidesAppContext, group_id: EncodedDatabaseIdField):
+    def index(self, trans: ProvidesAppContext, group_id: int) -> List[model.GroupRoleAssociation]:
         """
         Returns a collection roles associated with the given group.
         """
         group = self._get_group(trans, group_id)
         return group.roles
 
-    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
+    def show(self, trans: ProvidesAppContext, role_id: int, group_id: int) -> model.Role:
         """
         Returns information about a group role.
         """
-        role_id = id
         group = self._get_group(trans, group_id)
         role = self._get_role(trans, role_id)
         group_role = self._get_group_role(trans, group, role)
@@ -39,11 +37,10 @@ class GroupRolesManager:
             raise ObjectNotFound(f"Role {role.name} not in group {group.name}")
         return role
 
-    def update(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
+    def update(self, trans: ProvidesAppContext, role_id: int, group_id: int) -> model.Role:
         """
         Adds a role to a group if it is not already associated.
         """
-        role_id = id
         group = self._get_group(trans, group_id)
         role = self._get_role(trans, role_id)
         group_role = self._get_group_role(trans, group, role)
@@ -51,11 +48,10 @@ class GroupRolesManager:
             self._add_role_to_group(trans, group, role)
         return role
 
-    def delete(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
+    def delete(self, trans: ProvidesAppContext, role_id: int, group_id: int) -> model.Role:
         """
         Removes a role from a group.
         """
-        role_id = id
         group = self._get_group(trans, group_id)
         role = self._get_role(trans, role_id)
         group_role = self._get_group_role(trans, group, role)
@@ -64,18 +60,16 @@ class GroupRolesManager:
         self._remove_role_from_group(trans, group_role)
         return role
 
-    def _get_group(self, trans: ProvidesAppContext, encoded_group_id: EncodedDatabaseIdField) -> Any:
-        decoded_group_id = decode_id(self._app, encoded_group_id)
-        group = trans.sa_session.query(model.Group).get(decoded_group_id)
+    def _get_group(self, trans: ProvidesAppContext, group_id: int) -> model.Group:
+        group = trans.sa_session.query(model.Group).get(group_id)
         if not group:
-            raise ObjectNotFound(f"Group with id {encoded_group_id} was not found.")
+            raise ObjectNotFound(f"Group with id {DecodedDatabaseIdField.encode(group_id)} was not found.")
         return group
 
-    def _get_role(self, trans: ProvidesAppContext, encoded_role_id: EncodedDatabaseIdField) -> model.Role:
-        decoded_role_id = decode_id(self._app, encoded_role_id)
-        role = trans.sa_session.query(model.Role).get(decoded_role_id)
+    def _get_role(self, trans: ProvidesAppContext, role_id: int) -> model.Role:
+        role = trans.sa_session.query(model.Role).get(role_id)
         if not role:
-            raise ObjectNotFound(f"Role with id {encoded_role_id} was not found.")
+            raise ObjectNotFound(f"Role with id {DecodedDatabaseIdField.encode(role_id)} was not found.")
         return role
 
     def _get_group_role(

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -12,6 +12,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Union,
 )
 
 from sqlalchemy import (
@@ -19,6 +20,7 @@ from sqlalchemy import (
     asc,
     desc,
 )
+from typing_extensions import Literal
 
 from galaxy import (
     exceptions as glx_exceptions,
@@ -34,6 +36,7 @@ from galaxy.managers.base import (
     Serializer,
     SortableManager,
 )
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     HDABasicInfo,
     ShareHistoryExtra,
@@ -185,7 +188,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         if default:
             return self.parse_order_by(default)
         raise glx_exceptions.RequestParameterInvalidException(
-            "Unkown order_by", order_by=order_by_string, available=["create_time", "update_time", "name", "size"]
+            "Unknown order_by", order_by=order_by_string, available=["create_time", "update_time", "name", "size"]
         )
 
     def non_ready_jobs(self, history):
@@ -319,7 +322,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         extra.can_share = not errors and (extra.accessible_count == total_dataset_count or option is not None)
         return extra
 
-    def is_history_shared_with(self, history, user) -> bool:
+    def is_history_shared_with(self, history: model.History, user: model.User) -> bool:
         return bool(
             self.session()
             .query(self.user_share_model)
@@ -352,18 +355,21 @@ class HistoryExportView:
     def __init__(self, app: MinimalManagerApp):
         self.app = app
 
-    def get_exports(self, trans, history_id):
+    def get_exports(self, trans, history_id: int):
         history = self._history(trans, history_id)
         matching_exports = history.exports
         return [self.serialize(trans, history_id, e) for e in matching_exports]
 
-    def serialize(self, trans, history_id, jeha):
+    def serialize(self, trans, history_id: int, jeha):
         rval = jeha.to_dict()
-        encoded_jeha_id = trans.security.encode_id(jeha.id)
-        api_url = trans.url_builder("history_archive_download", id=history_id, jeha_id=encoded_jeha_id)
-        external_url = trans.url_builder("history_archive_download", id=history_id, jeha_id="latest", qualified=True)
+        encoded_jeha_id = DecodedDatabaseIdField.encode(jeha.id)
+        encoded_history_id = DecodedDatabaseIdField.encode(history_id)
+        api_url = trans.url_builder("history_archive_download", id=encoded_history_id, jeha_id=encoded_jeha_id)
+        external_url = trans.url_builder(
+            "history_archive_download", id=encoded_history_id, jeha_id="latest", qualified=True
+        )
         external_permanent_url = trans.url_builder(
-            "history_archive_download", id=history_id, jeha_id=encoded_jeha_id, qualified=True
+            "history_archive_download", id=encoded_history_id, jeha_id=encoded_jeha_id, qualified=True
         )
         rval["download_url"] = api_url
         rval["external_download_latest_url"] = external_url
@@ -371,12 +377,11 @@ class HistoryExportView:
         rval = trans.security.encode_all_ids(rval)
         return rval
 
-    def get_ready_jeha(self, trans, history_id, jeha_id="latest"):
+    def get_ready_jeha(self, trans, history_id: int, jeha_id: Union[int, Literal["latest"]] = "latest"):
         history = self._history(trans, history_id)
         matching_exports = history.exports
         if jeha_id != "latest":
-            decoded_jeha_id = trans.security.decode_id(jeha_id)
-            matching_exports = [e for e in matching_exports if e.id == decoded_jeha_id]
+            matching_exports = [e for e in matching_exports if e.id == jeha_id]
         if len(matching_exports) == 0:
             raise glx_exceptions.ObjectNotFound("Failed to find target history export")
 
@@ -386,13 +391,8 @@ class HistoryExportView:
 
         return jeha
 
-    def _history(self, trans, history_id):
-        if history_id is not None:
-            history = self.app.history_manager.get_accessible(
-                trans.security.decode_id(history_id), trans.user, current_history=trans.history
-            )
-        else:
-            history = trans.history
+    def _history(self, trans, history_id: int) -> model.History:
+        history = self.app.history_manager.get_accessible(history_id, trans.user, current_history=trans.history)
         return history
 
 

--- a/lib/galaxy/managers/lddas.py
+++ b/lib/galaxy/managers/lddas.py
@@ -21,7 +21,7 @@ class LDDAManager(DatasetAssociationManager):
         """
         super().__init__(app)
 
-    def get(self, trans, id, check_accessible=True) -> model.LibraryDatasetDatasetAssociation:
+    def get(self, trans, id: int, check_accessible=True) -> model.LibraryDatasetDatasetAssociation:
         return manager_base.get_object(
             trans, id, "LibraryDatasetDatasetAssociation", check_ownership=False, check_accessible=check_accessible
         )

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -39,6 +39,7 @@ from galaxy.managers.markdown_util import (
 )
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.schema.schema import (
+    CreatePagePayload,
     PageContentFormat,
     PageIndexQueryPayload,
 )
@@ -134,39 +135,37 @@ class PageManager(sharable.SharableModelManager, UsesAnnotations):
             query = query.offset(payload.offset)
         return query, total_matches
 
-    def create(self, trans, payload):
+    def create_page(self, trans, payload: CreatePagePayload):
         user = trans.get_user()
 
-        if not payload.get("title"):
+        if not payload.title:
             raise exceptions.ObjectAttributeMissingException("Page name is required")
-        elif not payload.get("slug"):
+        elif not payload.slug:
             raise exceptions.ObjectAttributeMissingException("Page id is required")
-        elif not base.is_valid_slug(payload["slug"]):
+        elif not base.is_valid_slug(payload.slug):
             raise exceptions.ObjectAttributeInvalidException(
                 "Page identifier must consist of only lowercase letters, numbers, and the '-' character"
             )
         elif (
-            trans.sa_session.query(trans.app.model.Page)
-            .filter_by(user=user, slug=payload["slug"], deleted=False)
-            .first()
+            trans.sa_session.query(trans.app.model.Page).filter_by(user=user, slug=payload.slug, deleted=False).first()
         ):
             raise exceptions.DuplicatedSlugException("Page identifier must be unique")
 
-        if payload.get("invocation_id"):
-            invocation_id = payload.get("invocation_id")
+        if payload.invocation_id:
+            invocation_id = payload.invocation_id
             invocation_report = self.workflow_manager.get_invocation_report(trans, invocation_id)
             content = invocation_report.get("markdown")
             content_format = "markdown"
         else:
-            content = payload.get("content", "")
-            content_format = payload.get("content_format", "html")
+            content = payload.content
+            content_format = payload.content_format
         content = self.rewrite_content_for_import(trans, content, content_format)
 
         # Create the new stored page
         page = trans.app.model.Page()
-        page.title = payload["title"]
-        page.slug = payload["slug"]
-        page_annotation = payload.get("annotation", None)
+        page.title = payload.title
+        page.slug = payload.slug
+        page_annotation = payload.annotation
         if page_annotation is not None:
             page_annotation = sanitize_html(page_annotation)
             self.add_item_annotation(trans.sa_session, trans.get_user(), page, page_annotation)
@@ -174,7 +173,7 @@ class PageManager(sharable.SharableModelManager, UsesAnnotations):
         page.user = user
         # And the first (empty) page revision
         page_revision = trans.app.model.PageRevision()
-        page_revision.title = payload["title"]
+        page_revision.title = payload.title
         page_revision.page = page
         page.latest_revision = page_revision
         page_revision.content = content

--- a/lib/galaxy/managers/quotas.py
+++ b/lib/galaxy/managers/quotas.py
@@ -23,7 +23,6 @@ from galaxy.quota._schema import (
     DefaultQuotaValues,
     QuotaOperation,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.structured_app import StructuredApp
 
 log = logging.getLogger(__name__)
@@ -257,5 +256,5 @@ class QuotaManager:
         message += ", ".join(names)
         return message
 
-    def get_quota(self, trans, id: EncodedDatabaseIdField, deleted: Optional[bool] = None) -> model.Quota:
+    def get_quota(self, trans, id: int, deleted: Optional[bool] = None) -> model.Quota:
         return base.get_object(trans, id, "Quota", check_ownership=False, check_accessible=False, deleted=deleted)

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -122,7 +122,7 @@ class RemoteFilesManager:
         """Display plugin information for each of the gxfiles:// URI targets available."""
         user_file_source_context = ProvidesUserFileSourcesUserContext(user_context)
         plugins = self._file_sources.plugins_to_dict(user_context=user_file_source_context)
-        return FilesSourcePluginList.parse_obj(plugins)
+        return FilesSourcePluginList.construct(__root__=plugins)
 
     @property
     def _file_sources(self) -> ConfiguredFileSources:

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -2,6 +2,7 @@
 Manager and Serializer for Roles.
 """
 import logging
+from typing import List
 
 from sqlalchemy import false
 from sqlalchemy.orm import exc as sqlalchemy_exceptions
@@ -12,6 +13,7 @@ from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.managers import base
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import Role
+from galaxy.schema.schema import RoleDefinitionModel
 from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
@@ -28,12 +30,12 @@ class RoleManager(base.ModelManager[model.Role]):
     user_assoc = model.UserRoleAssociation
     group_assoc = model.GroupRoleAssociation
 
-    def get(self, trans: ProvidesUserContext, decoded_role_id) -> model.Role:
+    def get(self, trans: ProvidesUserContext, role_id: int) -> model.Role:
         """
         Method loads the role from the DB based on the given role id.
 
-        :param  decoded_role_id:      id of the role to load from the DB
-        :type   decoded_role_id:      int
+        :param  role_id:      id of the role to load from the DB
+        :type   role_id:      int
 
         :returns:   the loaded Role object
         :rtype:     galaxy.model.Role
@@ -41,7 +43,7 @@ class RoleManager(base.ModelManager[model.Role]):
         :raises: InconsistentDatabase, RequestParameterInvalidException, InternalServerError
         """
         try:
-            role = self.session().query(self.model_class).filter(self.model_class.id == decoded_role_id).one()
+            role = self.session().query(self.model_class).filter(self.model_class.id == role_id).one()
         except sqlalchemy_exceptions.MultipleResultsFound:
             raise galaxy.exceptions.InconsistentDatabase("Multiple roles found with the same id.")
         except sqlalchemy_exceptions.NoResultFound:
@@ -54,14 +56,14 @@ class RoleManager(base.ModelManager[model.Role]):
 
         return role
 
-    def list_displayable_roles(self, trans: ProvidesUserContext):
+    def list_displayable_roles(self, trans: ProvidesUserContext) -> List[Role]:
         roles = []
         for role in trans.sa_session.query(Role).filter(Role.deleted == false()):
             if trans.user_is_admin or trans.app.security_agent.ok_to_display(trans.user, role):
                 roles.append(role)
         return roles
 
-    def create_role(self, trans: ProvidesUserContext, role_definition_model) -> model.Role:
+    def create_role(self, trans: ProvidesUserContext, role_definition_model: RoleDefinitionModel) -> model.Role:
         name = role_definition_model.name
         description = role_definition_model.description
         user_ids = role_definition_model.user_ids or []
@@ -74,8 +76,8 @@ class RoleManager(base.ModelManager[model.Role]):
 
         role = Role(name=name, description=description, type=role_type)
         trans.sa_session.add(role)
-        users = [trans.sa_session.query(model.User).get(trans.security.decode_id(i)) for i in user_ids]
-        groups = [trans.sa_session.query(model.Group).get(trans.security.decode_id(i)) for i in group_ids]
+        users = [trans.sa_session.query(model.User).get(i) for i in user_ids]
+        groups = [trans.sa_session.query(model.Group).get(i) for i in group_ids]
 
         # Create the UserRoleAssociations
         for user in users:

--- a/lib/galaxy/managers/tool_data.py
+++ b/lib/galaxy/managers/tool_data.py
@@ -32,18 +32,18 @@ class ToolDataManager:
     def index(self) -> ToolDataEntryList:
         """Return all tool data tables."""
         data_tables = [table.to_dict() for table in self.data_tables.values()]
-        return ToolDataEntryList.parse_obj(data_tables)
+        return ToolDataEntryList.construct(__root__=data_tables)
 
     def show(self, table_name: str) -> ToolDataDetails:
         """Get details of a given data table"""
         data_table = self._data_table(table_name)
         element_view = data_table.to_dict(view="element")
-        return ToolDataDetails.parse_obj(element_view)
+        return ToolDataDetails.construct(**element_view)
 
     def show_field(self, table_name: str, field_name: str) -> ToolDataField:
         """Get information about a partiular field in a tool data table"""
         field = self._data_table_field(table_name, field_name)
-        return ToolDataField.parse_obj(field.to_dict())
+        return ToolDataField.construct(**field.to_dict())
 
     def reload(self, table_name: str) -> ToolDataDetails:
         """Reloads a tool data table."""

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -232,7 +232,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         # Purge the user
         super().purge(user, flush=flush)
 
-    def _error_on_duplicate_email(self, email):
+    def _error_on_duplicate_email(self, email: str) -> None:
         """
         Check for a duplicate email and raise if found.
 
@@ -242,11 +242,11 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         if self.by_email(email) is not None:
             raise exceptions.Conflict("Email must be unique", email=email)
 
-    def by_id(self, user_id):
+    def by_id(self, user_id: int) -> model.User:
         return self.app.model.session.query(self.model_class).get(user_id)
 
     # ---- filters
-    def by_email(self, email, filters=None, **kwargs):
+    def by_email(self, email: str, filters=None, **kwargs) -> Optional[model.User]:
         """
         Find a user by their email.
         """
@@ -257,7 +257,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         except exceptions.ObjectNotFound:
             return None
 
-    def by_api_key(self, api_key, sa_session=None):
+    def by_api_key(self, api_key: str, sa_session=None):
         """
         Find a user by API key.
         """
@@ -359,7 +359,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         return trans.user
 
     # ---- api keys
-    def create_api_key(self, user):
+    def create_api_key(self, user: model.User) -> str:
         """
         Create and return an API key for `user`.
         """

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -242,19 +242,19 @@ class WorkflowsManager(sharable.SharableModelManager):
                     trans.app.model.Workflow.uuid == workflow_uuid,
                 )
             )
-        elif by_stored_id:
-            workflow_id = decode_id(self.app, workflow_id)
-            workflow_query = trans.sa_session.query(trans.app.model.StoredWorkflow).filter(
-                trans.app.model.StoredWorkflow.id == workflow_id
-            )
         else:
-            workflow_id = decode_id(self.app, workflow_id)
-            workflow_query = trans.sa_session.query(trans.app.model.StoredWorkflow).filter(
-                and_(
-                    trans.app.model.StoredWorkflow.id == trans.app.model.Workflow.stored_workflow_id,
-                    trans.app.model.Workflow.id == workflow_id,
+            workflow_id = workflow_id if isinstance(workflow_id, int) else decode_id(self.app, workflow_id)
+            if by_stored_id:
+                workflow_query = trans.sa_session.query(trans.app.model.StoredWorkflow).filter(
+                    trans.app.model.StoredWorkflow.id == workflow_id
                 )
-            )
+            else:
+                workflow_query = trans.sa_session.query(trans.app.model.StoredWorkflow).filter(
+                    and_(
+                        trans.app.model.StoredWorkflow.id == trans.app.model.Workflow.stored_workflow_id,
+                        trans.app.model.Workflow.id == workflow_id,
+                    )
+                )
         stored_workflow = workflow_query.options(
             joinedload("annotations"),
             joinedload("tags"),

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -43,7 +43,9 @@ from galaxy import (
 )
 from galaxy.job_execution.actions.post import ActionBox
 from galaxy.managers import sharable
+from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.executables import artifact_class
 from galaxy.model import StoredWorkflow
 from galaxy.model.index_filter_util import (
     append_user_filter,
@@ -90,8 +92,6 @@ from galaxy.workflow.refactor.schema import (
 from galaxy.workflow.reports import generate_report
 from galaxy.workflow.resources import get_resource_mapper_function
 from galaxy.workflow.steps import attach_ordered_steps
-from .base import decode_id
-from .executables import artifact_class
 
 log = logging.getLogger(__name__)
 
@@ -368,7 +368,9 @@ class WorkflowsManager(sharable.SharableModelManager):
         return workflow_invocation
 
     def get_invocation_report(self, trans, invocation_id, **kwd):
-        decoded_workflow_invocation_id = trans.security.decode_id(invocation_id)
+        decoded_workflow_invocation_id = (
+            trans.security.decode_id(invocation_id) if isinstance(invocation_id, str) else invocation_id
+        )
         workflow_invocation = self.get_invocation(trans, decoded_workflow_invocation_id)
         generator_plugin_type = kwd.get("generator_plugin_type")
         runtime_report_config_json = kwd.get("runtime_report_config_json")

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -639,9 +639,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 and not self.sessionless
                 and self.import_options.allow_edit
             ):
-                library_folder = self.sa_session.query(model.LibraryFolder).get(
-                    self.app.security.decode_id(library_attrs["id"])
-                )
+                library_folder = self.sa_session.query(model.LibraryFolder).get(library_attrs["id"])
                 import_folder(library_attrs, root_folder=library_folder)
             else:
                 assert self.import_options.allow_library_creation

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -219,7 +219,7 @@ def recalculate_user_disk_usage(app, **kwargs):
     user_id = kwargs.get("user_id", None)
     sa_session = app.model.context
     if user_id:
-        user = sa_session.query(app.model.User).get(app.security.decode_id(user_id))
+        user = sa_session.query(app.model.User).get(user_id)
         if user:
             user.calculate_and_set_disk_usage()
         else:

--- a/lib/galaxy/quota/_schema.py
+++ b/lib/galaxy/quota/_schema.py
@@ -4,17 +4,15 @@ from typing import (
     Optional,
 )
 
-from pydantic import (
-    BaseModel,
-    Field,
-)
+from pydantic import Field
 
 from galaxy.schema.fields import (
-    EncodedDatabaseIdField,
+    DecodedDatabaseIdField,
     ModelClassField,
 )
 from galaxy.schema.schema import (
     GroupModel,
+    Model,
     UserModel,
 )
 
@@ -67,7 +65,7 @@ QuotaOperationField = Field(
 )
 
 
-class DefaultQuota(BaseModel):  # TODO: should this replace lib.galaxy.model.DefaultQuotaAssociation at some point?
+class DefaultQuota(Model):  # TODO: should this replace lib.galaxy.model.DefaultQuotaAssociation at some point?
     model_class: str = ModelClassField(DEFAULT_QUOTA_ASSOCIATION_MODEL_CLASS_NAME)
     type: DefaultQuotaTypes = Field(
         ...,
@@ -80,7 +78,7 @@ class DefaultQuota(BaseModel):  # TODO: should this replace lib.galaxy.model.Def
     )
 
 
-class UserQuota(BaseModel):
+class UserQuota(Model):
     model_class: str = ModelClassField(USER_QUOTA_ASSOCIATION_MODEL_CLASS_NAME)
     user: UserModel = Field(
         ...,
@@ -89,7 +87,7 @@ class UserQuota(BaseModel):
     )
 
 
-class GroupQuota(BaseModel):
+class GroupQuota(Model):
     model_class: str = ModelClassField(GROUP_QUOTA_ASSOCIATION_MODEL_CLASS_NAME)
     group: GroupModel = Field(
         ...,
@@ -98,11 +96,11 @@ class GroupQuota(BaseModel):
     )
 
 
-class QuotaBase(BaseModel):
+class QuotaBase(Model):
     """Base model containing common fields for Quotas."""
 
     model_class: str = ModelClassField(QUOTA_MODEL_CLASS_NAME)
-    id: EncodedDatabaseIdField = Field(
+    id: DecodedDatabaseIdField = Field(
         ...,
         title="ID",
         description="The `encoded identifier` of the quota.",
@@ -121,7 +119,7 @@ class QuotaSummary(QuotaBase):
     )
 
 
-class QuotaSummaryList(BaseModel):
+class QuotaSummaryList(Model):
     __root__: List[QuotaSummary] = Field(
         default=[],
         title="List with summary information of Quotas.",
@@ -166,7 +164,7 @@ class CreateQuotaResult(QuotaSummary):
     )
 
 
-class CreateQuotaParams(BaseModel):
+class CreateQuotaParams(Model):
     name: str = QuotaNameField
     description: str = QuotaDescriptionField
     amount: str = Field(
@@ -196,7 +194,7 @@ class CreateQuotaParams(BaseModel):
     )
 
 
-class UpdateQuotaParams(BaseModel):
+class UpdateQuotaParams(Model):
     name: Optional[str] = Field(
         default=None,
         title="Name",
@@ -243,7 +241,7 @@ class UpdateQuotaParams(BaseModel):
     )
 
 
-class DeleteQuotaPayload(BaseModel):
+class DeleteQuotaPayload(Model):
     purge: bool = Field(
         False,
         title="Purge",

--- a/lib/galaxy/schema/fetch_data.py
+++ b/lib/galaxy/schema/fetch_data.py
@@ -7,7 +7,6 @@ from typing import (
 )
 
 from pydantic import (
-    BaseModel,
     Extra,
     Field,
     Json,
@@ -18,11 +17,14 @@ from typing_extensions import (
     Literal,
 )
 
-from galaxy.schema.fields import EncodedDatabaseIdField
-from .schema import HistoryIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.schema import (
+    HistoryIdField,
+    Model,
+)
 
 
-class FetchBaseModel(BaseModel):
+class FetchBaseModel(Model):
     class Config:
         allow_population_by_field_name = True
 
@@ -76,7 +78,7 @@ class HdcaDestination(FetchBaseModel):
 
 class LibraryFolderDestination(FetchBaseModel):
     type: Literal["library_folder"]
-    library_folder_id: EncodedDatabaseIdField
+    library_folder_id: DecodedDatabaseIdField  # For some reason this folder ID must NOT have the 'F' prefix
 
 
 class BaseCollectionTarget(BaseFetchDataTarget):
@@ -151,7 +153,7 @@ class FtpImportElement(BaseDataElement):
     collection_type: Optional[str]
 
 
-class ItemsFromModel(BaseModel):
+class ItemsFromModel(Model):
     src: ItemsFromSrc
     path: Optional[str]
     ftp_path: Optional[str]
@@ -241,13 +243,13 @@ class HdcaDataItemsFromTarget(BaseCollectionTarget, ItemsFromModel):
     items_from: ElementsFromType = Field(..., alias="elements_from")
 
 
-class FilesPayload(BaseModel):
+class FilesPayload(Model):
     filename: str
     local_filename: str
 
 
 class BaseDataPayload(FetchBaseModel):
-    history_id: EncodedDatabaseIdField = HistoryIdField
+    history_id: DecodedDatabaseIdField = HistoryIdField
 
     class Config:
         # file payloads are just tacked on, so we need to allow everything

--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -79,7 +79,6 @@ class LibraryFolderDatabaseIdField(int, BaseDatabaseIdField):
         return f"F{cls.security.encode_id(v)}"
 
 
-# TODO: remove after replace
 class EncodedDatabaseIdField(str, BaseDatabaseIdField):
     @classmethod
     def validate(cls, v):
@@ -87,17 +86,12 @@ class EncodedDatabaseIdField(str, BaseDatabaseIdField):
             return cls(cls.security.encode_id(v))
         if not isinstance(v, str):
             raise TypeError("String required")
-        if v.startswith("F"):
-            # Library Folder ids start with an additional "F"
-            len_v = len(v) - 1
-        else:
-            len_v = len(v)
-        if len_v % ENCODED_ID_LENGTH_MULTIPLE:
-            raise ValueError("Invalid id length, must be multiple of 16")
-        m = ENCODED_DATABASE_ID_PATTERN.fullmatch(v.lower())
-        if not m:
-            raise ValueError("Invalid characters in encoded ID")
+        cls.ensure_valid(v)
         return cls(v)
+
+    @classmethod
+    def decode(cls, v) -> int:
+        return cls.security.decode_id(v)
 
 
 def ModelClassField(class_name: str) -> str:

--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -27,6 +27,15 @@ class BaseDatabaseIdField:
         return v
 
     @classmethod
+    def ensure_valid(cls, v: str):
+        len_v = len(v)
+        if len_v % ENCODED_ID_LENGTH_MULTIPLE:
+            raise ValueError("Invalid id length, must be multiple of 16")
+        m = ENCODED_DATABASE_ID_PATTERN.fullmatch(v.lower())
+        if not m:
+            raise ValueError("Invalid characters in encoded ID")
+
+    @classmethod
     def __modify_schema__(cls, field_schema):
         # __modify_schema__ should mutate the dict it receives in place,
         # the returned value will be ignored
@@ -46,22 +55,31 @@ class DecodedDatabaseIdField(int, BaseDatabaseIdField):
     def validate(cls, v):
         if not isinstance(v, str):
             raise TypeError("String required")
-        if v.startswith("F"):
-            # Library Folder ids start with an additional "F"
-            v = v[1:]
-        len_v = len(v)
-        if len_v % ENCODED_ID_LENGTH_MULTIPLE:
-            raise ValueError("Invalid id length, must be multiple of 16")
-        m = ENCODED_DATABASE_ID_PATTERN.fullmatch(v.lower())
-        if not m:
-            raise ValueError("Invalid characters in encoded ID")
+        cls.ensure_valid(v)
         return cls(cls.security.decode_id(v))
 
     @classmethod
-    def encode(cls, v):
+    def encode(cls, v) -> str:
         return cls.security.encode_id(v)
 
 
+class LibraryFolderDatabaseIdField(int, BaseDatabaseIdField):
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, str):
+            raise TypeError("String required")
+        if not v.startswith("F"):
+            raise TypeError("Invalid library folder ID. Folder IDs must start with an 'F'")
+        v = v[1:]
+        cls.ensure_valid(v)
+        return cls(cls.security.decode_id(v))
+
+    @classmethod
+    def encode(cls, v) -> str:
+        return f"F{cls.security.encode_id(v)}"
+
+
+# TODO: remove after replace
 class EncodedDatabaseIdField(str, BaseDatabaseIdField):
     @classmethod
     def validate(cls, v):

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -5,10 +5,11 @@ from typing import (
 )
 
 from pydantic import (
-    BaseModel,
     Extra,
     Field,
 )
+
+from galaxy.schema.schema import Model
 
 
 class RemoteFilesTarget(str, Enum):
@@ -28,7 +29,7 @@ class RemoteFilesDisableMode(str, Enum):
     files = "files"
 
 
-class FilesSourcePlugin(BaseModel):
+class FilesSourcePlugin(Model):
     id: str = Field(
         ...,  # This field is required
         title="ID",
@@ -83,7 +84,7 @@ class FilesSourcePlugin(BaseModel):
         extra = Extra.allow
 
 
-class FilesSourcePluginList(BaseModel):
+class FilesSourcePluginList(Model):
     __root__: List[FilesSourcePlugin] = Field(
         default=[],
         title="List of files source plugins",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -301,12 +301,12 @@ class MetadataFile(Model):
 class DatasetPermissions(Model):
     """Role-based permissions for accessing and managing a dataset."""
 
-    manage: List[EncodedDatabaseIdField] = Field(
+    manage: List[DecodedDatabaseIdField] = Field(
         [],
         title="Management",
         description="The set of roles (encoded IDs) that can manage this dataset.",
     )
-    access: List[EncodedDatabaseIdField] = Field(
+    access: List[DecodedDatabaseIdField] = Field(
         [],
         title="Access",
         description="The set of roles (encoded IDs) that can access this dataset.",
@@ -1384,7 +1384,7 @@ class JobExportHistoryArchiveCollection(Model):
     __root__: List[JobExportHistoryArchiveModel]
 
 
-class LabelValuePair(BaseModel):
+class LabelValuePair(Model):
     """Generic Label/Value pair model."""
 
     label: str = Field(
@@ -1399,7 +1399,7 @@ class LabelValuePair(BaseModel):
     )
 
 
-class CustomBuildsMetadataResponse(BaseModel):
+class CustomBuildsMetadataResponse(Model):
     installed_builds: List[LabelValuePair] = Field(
         ...,
         title="Installed Builds",
@@ -1416,10 +1416,10 @@ class CustomBuildsMetadataResponse(BaseModel):
     )
 
 
-class JobIdResponse(BaseModel):
+class JobIdResponse(Model):
     """Contains the ID of the job associated with a particular request."""
 
-    job_id: EncodedDatabaseIdField = Field(
+    job_id: DecodedDatabaseIdField = Field(
         ...,
         title="Job ID",
         description="The encoded database ID of the job that is currently processing a particular request.",
@@ -1427,14 +1427,14 @@ class JobIdResponse(BaseModel):
 
 
 class JobBaseModel(Model):
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(JOB_MODEL_CLASS_NAME)
     tool_id: str = Field(
         ...,
         title="Tool ID",
         description="Identifier of the tool that generated this job.",
     )
-    history_id: Optional[EncodedDatabaseIdField] = Field(
+    history_id: Optional[DecodedDatabaseIdField] = Field(
         None,
         title="History ID",
         description="The encoded ID of the history associated with this item.",
@@ -1468,7 +1468,7 @@ class JobImportHistoryResponse(JobBaseModel):
 
 
 class JobStateSummary(Model):
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     model: str = ModelClassField("Job")
     populated_state: DatasetCollection.populated_states = PopulatedStateField
     states: Dict[Job.states, int] = Field(
@@ -1513,7 +1513,7 @@ class JobSummary(JobBaseModel):
 
 
 class DatasetSourceId(Model):
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     src: DatasetSourceType = Field(
         ...,
         title="Source",
@@ -2711,7 +2711,7 @@ AnyJobStateSummary = Union[
 HistoryArchiveExportResult = Union[JobExportHistoryArchiveModel, JobIdResponse]
 
 
-class DeleteHistoryContentPayload(BaseModel):
+class DeleteHistoryContentPayload(Model):
     purge: bool = Field(
         default=False,
         title="Purge",
@@ -2734,7 +2734,7 @@ class DeleteHistoryContentResult(CustomHistoryItem):
 
     Can also contain any other properties of the item."""
 
-    id: EncodedDatabaseIdField = Field(
+    id: DecodedDatabaseIdField = Field(
         ...,
         title="ID",
         description="The encoded ID of the history item.",
@@ -2751,7 +2751,7 @@ class DeleteHistoryContentResult(CustomHistoryItem):
     )
 
 
-class HistoryContentsArchiveDryRunResult(BaseModel):
+class HistoryContentsArchiveDryRunResult(Model):
     """
     Contains a collection of filepath/filename entries that represent
     the contents that would have been included in the archive.
@@ -2765,7 +2765,7 @@ class HistoryContentsArchiveDryRunResult(BaseModel):
     __root__: List[List[str]]  # List[Tuple[str, str]]
 
 
-class HistoryContentStats(BaseModel):
+class HistoryContentStats(Model):
     total_matches: int = Field(
         ...,
         title="Total Matches",
@@ -2773,7 +2773,7 @@ class HistoryContentStats(BaseModel):
     )
 
 
-class ContentsNearStats(BaseModel):
+class ContentsNearStats(Model):
     """Stats used by the `contents_near` endpoint."""
 
     matches: int
@@ -2806,7 +2806,7 @@ class HistoryContentsResult(Model):
     __root__: List[AnyHistoryContentItem]
 
 
-class HistoryContentsWithStatsResult(BaseModel):
+class HistoryContentsWithStatsResult(Model):
     """Includes stats with items counting"""
 
     stats: HistoryContentStats = Field(
@@ -2826,7 +2826,7 @@ class HistoryContentsWithStatsResult(BaseModel):
     __accept_type__ = "application/vnd.galaxy.history.contents.stats+json"
 
 
-class ContentsNearResult(BaseModel):
+class ContentsNearResult(Model):
     contents: HistoryContentsResult
     stats: ContentsNearStats
 
@@ -3017,7 +3017,7 @@ class MaterializeDatasetInstanceAPIRequest(Model):
         title="Source",
         description="The source of the content. Can be other history element to be copied or library elements.",
     )
-    content: EncodedDatabaseIdField = Field(
+    content: DecodedDatabaseIdField = Field(
         None,
         title="Content",
         description=(
@@ -3029,7 +3029,7 @@ class MaterializeDatasetInstanceAPIRequest(Model):
 
 
 class MaterializeDatasetInstanceRequest(MaterializeDatasetInstanceAPIRequest):
-    history_id: EncodedDatabaseIdField
+    history_id: DecodedDatabaseIdField
 
 
 class CreatePagePayload(PageSummaryBase):
@@ -3051,7 +3051,7 @@ class CreatePagePayload(PageSummaryBase):
         extra = Extra.allow  # Allow any other extra fields
 
 
-class AsyncTaskResultSummary(BaseModel):
+class AsyncTaskResultSummary(Model):
     id: str = Field(
         ...,
         title="ID",
@@ -3072,7 +3072,7 @@ class AsyncTaskResultSummary(BaseModel):
     )
 
 
-class AsyncFile(BaseModel):
+class AsyncFile(Model):
     storage_request_id: str
     task: AsyncTaskResultSummary
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -354,12 +354,12 @@ class Visualization(Model):  # TODO annotate this model
 class HistoryItemBase(Model):
     """Basic information provided by items contained in a History."""
 
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     name: Optional[str] = Field(
         title="Name",
         description="The name of the item.",
     )
-    history_id: EncodedDatabaseIdField = HistoryIdField
+    history_id: DecodedDatabaseIdField = HistoryIdField
     hid: int = Field(
         ...,
         title="HID",
@@ -408,7 +408,7 @@ class HistoryItemCommon(HistoryItemBase):
 class HDASummary(HistoryItemCommon):
     """History Dataset Association summary information."""
 
-    dataset_id: EncodedDatabaseIdField = Field(
+    dataset_id: DecodedDatabaseIdField = Field(
         ...,
         title="Dataset ID",
         description="The encoded ID of the dataset associated with this item.",
@@ -583,7 +583,7 @@ class HDAExtended(HDADetailed):
         title="Tool Version",
         description="The version of the tool that produced this dataset.",
     )
-    parent_id: Optional[EncodedDatabaseIdField] = Field(
+    parent_id: Optional[DecodedDatabaseIdField] = Field(
         None,
         title="Parent ID",
         description="TODO",
@@ -611,11 +611,11 @@ class DCSummary(Model):
 class HDAObject(Model):
     """History Dataset Association Object"""
 
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(HDA_MODEL_CLASS_NAME)
     state: Dataset.states = DatasetStateField
     hda_ldda: DatasetSourceType = HdaLddaField
-    history_id: EncodedDatabaseIdField = HistoryIdField
+    history_id: DecodedDatabaseIdField = HistoryIdField
 
     class Config:
         extra = Extra.allow  # Can contain more fields like metadata_*
@@ -789,11 +789,10 @@ class HDCADetailed(HDCASummary):
     )
 
 
-class HistoryBase(BaseModel):
+class HistoryBase(Model):
     """Provides basic configuration for all the History models."""
 
     class Config:
-        use_enum_values = True  # When using .dict()
         extra = Extra.allow  # Allow any other extra fields
 
 
@@ -904,7 +903,7 @@ class HistorySummary(HistoryBase):
     """History summary information."""
 
     model_class: str = ModelClassField(HISTORY_MODEL_CLASS_NAME)
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     name: str = Field(
         ...,
         title="Name",
@@ -951,7 +950,7 @@ class HistoryActiveContentCounts(Model):
 
 
 HistoryStateCounts = Dict[Dataset.states, int]
-HistoryStateIds = Dict[Dataset.states, List[EncodedDatabaseIdField]]
+HistoryStateIds = Dict[Dataset.states, List[DecodedDatabaseIdField]]
 
 
 class HistoryDetailed(HistorySummary):  # Equivalent to 'dev-detailed' view, which seems the default
@@ -963,7 +962,7 @@ class HistoryDetailed(HistorySummary):  # Equivalent to 'dev-detailed' view, whi
         title="Size",
         description="The total size of the contents of this history in bytes.",
     )
-    user_id: EncodedDatabaseIdField = Field(
+    user_id: DecodedDatabaseIdField = Field(
         ...,
         title="User ID",
         description="The encoded ID of the user that owns this History.",
@@ -1186,7 +1185,7 @@ class CreateHistoryPayload(Model):
         title="Name",
         description="The new history name.",
     )
-    history_id: Optional[EncodedDatabaseIdField] = Field(
+    history_id: Optional[DecodedDatabaseIdField] = Field(
         default=None,
         title="History ID",
         description=(
@@ -1339,12 +1338,12 @@ class WriteStoreToPayload(StoreExportPayload):
 
 
 class JobExportHistoryArchiveModel(Model):
-    id: EncodedDatabaseIdField = Field(
+    id: DecodedDatabaseIdField = Field(
         ...,
         title="ID",
         description="The encoded database ID of the job that is currently processing a particular request.",
     )
-    job_id: EncodedDatabaseIdField = Field(
+    job_id: DecodedDatabaseIdField = Field(
         ...,
         title="Job ID",
         description="The encoded database ID of the job that generated this history export archive.",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -39,6 +39,7 @@ from galaxy.model import (
 )
 from galaxy.schema.fields import (
     DecodedDatabaseIdField,
+    EncodedDatabaseIdField,
     LibraryFolderDatabaseIdField,
     ModelClassField,
 )
@@ -1418,7 +1419,7 @@ class CustomBuildsMetadataResponse(Model):
 class JobIdResponse(Model):
     """Contains the ID of the job associated with a particular request."""
 
-    job_id: DecodedDatabaseIdField = Field(
+    job_id: EncodedDatabaseIdField = Field(
         ...,
         title="Job ID",
         description="The encoded database ID of the job that is currently processing a particular request.",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2160,13 +2160,13 @@ RoleNameIdTuple = List[str]  # Tuple[str, DecodedDatabaseIdField]
 # Group_Roles -----------------------------------------------------------------
 
 
-class GroupRoleModel(BaseModel):
-    id: EncodedDatabaseIdField = RoleIdField
+class GroupRoleModel(Model):
+    id: DecodedDatabaseIdField = RoleIdField
     name: str = RoleNameField
     url: RelativeUrl = RelativeUrlField
 
 
-class GroupRoleListModel(BaseModel):
+class GroupRoleListModel(Model):
     __root__: List[GroupRoleModel]
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -39,7 +39,6 @@ from galaxy.model import (
 )
 from galaxy.schema.fields import (
     DecodedDatabaseIdField,
-    EncodedDatabaseIdField,
     LibraryFolderDatabaseIdField,
     ModelClassField,
 )
@@ -2196,9 +2195,9 @@ class LibraryPermissionScope(str, Enum):
     available = "available"
 
 
-class LibraryLegacySummary(BaseModel):
+class LibraryLegacySummary(Model):
     model_class: str = ModelClassField("Library")
-    id: EncodedDatabaseIdField = Field(
+    id: DecodedDatabaseIdField = Field(
         ...,
         title="ID",
         description="Encoded ID of the Library.",
@@ -2218,7 +2217,7 @@ class LibraryLegacySummary(BaseModel):
         title="Description",
         description="A short text describing the contents of the Library.",
     )
-    root_folder_id: EncodedDatabaseIdField = Field(
+    root_folder_id: LibraryFolderDatabaseIdField = Field(
         ...,
         title="Root Folder ID",
         description="Encoded ID of the Library's base folder.",
@@ -2264,14 +2263,14 @@ class LibrarySummary(LibraryLegacySummary):
     )
 
 
-class LibrarySummaryList(BaseModel):
+class LibrarySummaryList(Model):
     __root__: List[LibrarySummary] = Field(
         default=[],
         title="List with summary information of Libraries.",
     )
 
 
-class CreateLibraryPayload(BaseModel):
+class CreateLibraryPayload(Model):
     name: str = Field(
         ...,
         title="Name",
@@ -2293,7 +2292,7 @@ class CreateLibrariesFromStore(StoreContentSource):
     pass
 
 
-class UpdateLibraryPayload(BaseModel):
+class UpdateLibraryPayload(Model):
     name: Optional[str] = Field(
         None,
         title="Name",
@@ -2311,7 +2310,7 @@ class UpdateLibraryPayload(BaseModel):
     )
 
 
-class DeleteLibraryPayload(BaseModel):
+class DeleteLibraryPayload(Model):
     undelete: bool = Field(
         ...,
         title="Undelete",
@@ -2319,7 +2318,7 @@ class DeleteLibraryPayload(BaseModel):
     )
 
 
-class LibraryCurrentPermissions(BaseModel):
+class LibraryCurrentPermissions(Model):
     access_library_role_list: List[RoleNameIdTuple] = Field(
         ...,
         title="Access Role List",
@@ -2343,11 +2342,11 @@ class LibraryCurrentPermissions(BaseModel):
 
 
 RoleIdList = Union[
-    List[EncodedDatabaseIdField], EncodedDatabaseIdField
-]  # Should we support just List[EncodedDatabaseIdField] in the future?
+    List[DecodedDatabaseIdField], DecodedDatabaseIdField
+]  # Should we support just List[DecodedDatabaseIdField] in the future?
 
 
-class LegacyLibraryPermissionsPayload(BaseModel):
+class LegacyLibraryPermissionsPayload(Model):
     LIBRARY_ACCESS_in: Optional[RoleIdList] = Field(
         [],
         title="Access IDs",
@@ -2443,9 +2442,9 @@ class LibraryFolderPermissionsPayload(LibraryPermissionsPayloadBase):
     )
 
 
-class LibraryFolderDetails(BaseModel):
+class LibraryFolderDetails(Model):
     model_class: str = ModelClassField("LibraryFolder")
-    id: EncodedDatabaseIdField = Field(
+    id: LibraryFolderDatabaseIdField = Field(
         ...,
         title="ID",
         description="Encoded ID of the library folder.",
@@ -2457,12 +2456,12 @@ class LibraryFolderDetails(BaseModel):
         title="Item Count",
         description="A detailed description of the library folder.",
     )
-    parent_library_id: EncodedDatabaseIdField = Field(
+    parent_library_id: DecodedDatabaseIdField = Field(
         ...,
         title="Parent Library ID",
         description="Encoded ID of the Library this folder belongs to.",
     )
-    parent_id: Optional[EncodedDatabaseIdField] = Field(
+    parent_id: Optional[LibraryFolderDatabaseIdField] = Field(
         None,
         title="Parent Folder ID",
         description="Encoded ID of the parent folder. Empty if it's the root folder.",
@@ -2481,12 +2480,12 @@ class LibraryFolderDetails(BaseModel):
     )
 
 
-class CreateLibraryFolderPayload(BaseModel):
+class CreateLibraryFolderPayload(Model):
     name: str = FolderNameField
     description: Optional[str] = FolderDescriptionField
 
 
-class UpdateLibraryFolderPayload(BaseModel):
+class UpdateLibraryFolderPayload(Model):
     name: Optional[str] = Field(
         default=None,
         title="Name",
@@ -2499,7 +2498,7 @@ class UpdateLibraryFolderPayload(BaseModel):
     )
 
 
-class LibraryAvailablePermissions(BaseModel):
+class LibraryAvailablePermissions(Model):
     roles: List[BasicRoleModel] = Field(
         ...,
         title="Roles",
@@ -2522,7 +2521,7 @@ class LibraryAvailablePermissions(BaseModel):
     )
 
 
-class LibraryFolderCurrentPermissions(BaseModel):
+class LibraryFolderCurrentPermissions(Model):
     modify_folder_role_list: List[RoleNameIdTuple] = Field(
         ...,
         title="Modify Role List",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1647,7 +1647,7 @@ class JobFullDetails(JobDetails):
 
 
 class StoredWorkflowSummary(Model):
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(STORED_WORKFLOW_MODEL_CLASS_NAME)
     create_time: datetime = CreateTimeField
     update_time: datetime = UpdateTimeField
@@ -1700,7 +1700,7 @@ class StoredWorkflowSummary(Model):
     )
 
 
-class WorkflowInput(BaseModel):
+class WorkflowInput(Model):
     label: str = Field(
         ...,
         title="Label",
@@ -1718,7 +1718,7 @@ class WorkflowInput(BaseModel):
     )
 
 
-class WorkflowOutput(BaseModel):
+class WorkflowOutput(Model):
     label: Optional[str] = Field(
         None,
         title="Label",
@@ -1736,7 +1736,7 @@ class WorkflowOutput(BaseModel):
     )
 
 
-class InputStep(BaseModel):
+class InputStep(Model):
     source_step: int = Field(
         ...,
         title="Source Step",
@@ -1760,7 +1760,7 @@ class WorkflowModuleType(str, Enum):
     pause = "pause"  # Experimental
 
 
-class WorkflowStepBase(BaseModel):
+class WorkflowStepBase(Model):
     id: int = Field(
         ...,
         title="ID",
@@ -1819,12 +1819,12 @@ class SubworkflowStep(WorkflowStepBase):
     type: WorkflowModuleType = Field(
         WorkflowModuleType.subworkflow, const=True, title="Type", description="The type of workflow module."
     )
-    workflow_id: EncodedDatabaseIdField = Field(
+    workflow_id: DecodedDatabaseIdField = Field(
         ..., title="Workflow ID", description="The encoded ID of the workflow that will be run on this step."
     )
 
 
-class Creator(BaseModel):
+class Creator(Model):
     class_: str = Field(..., alias="class", title="Class", description="The class representing this creator.")
     name: str = Field(..., title="Name", description="The name of the creator.")
     address: Optional[str] = Field(
@@ -1929,17 +1929,17 @@ class StoredWorkflowDetailed(StoredWorkflowSummary):
     ] = Field({}, title="Steps", description="A dictionary with information about all the steps of the workflow.")
 
 
-class Input(BaseModel):
+class Input(Model):
     name: str = Field(..., title="Name", description="The name of the input.")
     description: str = Field(..., title="Description", description="The annotation or description of the input.")
 
 
-class Output(BaseModel):
+class Output(Model):
     name: str = Field(..., title="Name", description="The name of the output.")
     type: str = Field(..., title="Type", description="The extension or type of output.")
 
 
-class InputConnection(BaseModel):
+class InputConnection(Model):
     id: int = Field(..., title="ID", description="The identifier of the input.")
     output_name: str = Field(
         ...,
@@ -1953,7 +1953,7 @@ class InputConnection(BaseModel):
     )
 
 
-class WorkflowStepLayoutPosition(BaseModel):
+class WorkflowStepLayoutPosition(Model):
     """Position and dimensions of the workflow step represented by a box on the graph."""
 
     bottom: int = Field(..., title="Bottom", description="Position in pixels of the bottom of the box.")
@@ -1966,7 +1966,7 @@ class WorkflowStepLayoutPosition(BaseModel):
     width: int = Field(..., title="Width", description="Width of the box in pixels.")
 
 
-class WorkflowStepToExportBase(BaseModel):
+class WorkflowStepToExportBase(Model):
     id: int = Field(
         ...,
         title="ID",
@@ -2031,7 +2031,7 @@ class WorkflowStepToExport(WorkflowStepToExportBase):
     )
 
 
-class ToolShedRepositorySummary(BaseModel):
+class ToolShedRepositorySummary(Model):
     name: str = Field(
         ...,
         title="Name",
@@ -2054,7 +2054,7 @@ class ToolShedRepositorySummary(BaseModel):
     )
 
 
-class PostJobAction(BaseModel):
+class PostJobAction(Model):
     action_type: str = Field(
         ...,
         title="Action Type",
@@ -2087,7 +2087,7 @@ class SubworkflowStepToExport(WorkflowStepToExportBase):
     )
 
 
-class WorkflowToExport(BaseModel):
+class WorkflowToExport(Model):
     a_galaxy_workflow: str = Field(  # Is this meant to be a bool instead?
         "true", title="Galaxy Workflow", description="Whether this workflow is a Galaxy Workflow."
     )

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2179,13 +2179,13 @@ UserDescriptionField = Field(title="Description", description="Description of th
 # Group_Users -----------------------------------------------------------------
 
 
-class GroupUserModel(BaseModel):
-    id: EncodedDatabaseIdField = UserIdField
+class GroupUserModel(Model):
+    id: DecodedDatabaseIdField = UserIdField
     email: str = UserEmailField
     url: RelativeUrl = RelativeUrlField
 
 
-class GroupUserListModel(BaseModel):
+class GroupUserListModel(Model):
     __root__: List[GroupUserModel]
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -40,6 +40,7 @@ from galaxy.model import (
 from galaxy.schema.fields import (
     DecodedDatabaseIdField,
     EncodedDatabaseIdField,
+    LibraryFolderDatabaseIdField,
     ModelClassField,
 )
 from galaxy.schema.types import (
@@ -188,6 +189,7 @@ class Model(BaseModel):
         json_encoders = {
             # This will ensure all IDs are encoded when serialized to JSON
             DecodedDatabaseIdField: lambda v: DecodedDatabaseIdField.encode(v),
+            LibraryFolderDatabaseIdField: lambda v: LibraryFolderDatabaseIdField.encode(v),
         }
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2997,7 +2997,7 @@ ContentField: Optional[str] = Field(
 )
 
 
-class PageSummaryBase(BaseModel):
+class PageSummaryBase(Model):
     title: str = Field(
         ...,  # Required
         title="Title",
@@ -3040,7 +3040,7 @@ class CreatePagePayload(PageSummaryBase):
         title="Annotation",
         description="Annotation that will be attached to the page.",
     )
-    invocation_id: Optional[EncodedDatabaseIdField] = Field(
+    invocation_id: Optional[DecodedDatabaseIdField] = Field(
         None,
         title="Workflow invocation ID",
         description="Encoded ID used by workflow generated reports.",
@@ -3078,7 +3078,7 @@ class AsyncFile(Model):
 
 
 class PageSummary(PageSummaryBase):
-    id: EncodedDatabaseIdField = Field(
+    id: DecodedDatabaseIdField = Field(
         ...,  # Required
         title="ID",
         description="Encoded ID of the Page.",
@@ -3109,12 +3109,12 @@ class PageSummary(PageSummaryBase):
         title="Deleted",
         description="Whether this Page has been deleted.",
     )
-    latest_revision_id: EncodedDatabaseIdField = Field(
+    latest_revision_id: DecodedDatabaseIdField = Field(
         ...,  # Required
         title="Latest revision ID",
         description="The encoded ID of the last revision of this Page.",
     )
-    revision_ids: List[EncodedDatabaseIdField] = Field(
+    revision_ids: List[DecodedDatabaseIdField] = Field(
         ...,  # Required
         title="List of revisions",
         description="The history with the encoded ID of each revision of the Page.",
@@ -3139,7 +3139,7 @@ class PageDetails(PageSummary):
         extra = Extra.allow  # Allow any other extra fields
 
 
-class PageSummaryList(BaseModel):
+class PageSummaryList(Model):
     __root__: List[PageSummary] = Field(
         default=[],
         title="List with summary information of Pages.",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2843,7 +2843,7 @@ class SharingOptions(str, Enum):
     no_changes = "no_changes"
 
 
-class ShareWithExtra(BaseModel):
+class ShareWithExtra(Model):
     can_share: bool = Field(
         False,
         title="Can Share",
@@ -2854,10 +2854,10 @@ class ShareWithExtra(BaseModel):
         extra = Extra.allow
 
 
-UserIdentifier = Union[EncodedDatabaseIdField, str]
+UserIdentifier = Union[DecodedDatabaseIdField, str]
 
 
-class ShareWithPayload(BaseModel):
+class ShareWithPayload(Model):
     user_ids: List[UserIdentifier] = Field(
         ...,
         title="User Identifiers",
@@ -2878,7 +2878,7 @@ class ShareWithPayload(BaseModel):
     )
 
 
-class SetSlugPayload(BaseModel):
+class SetSlugPayload(Model):
     new_slug: str = Field(
         ...,
         title="New Slug",
@@ -2886,8 +2886,8 @@ class SetSlugPayload(BaseModel):
     )
 
 
-class UserEmail(BaseModel):
-    id: EncodedDatabaseIdField = Field(
+class UserEmail(Model):
+    id: DecodedDatabaseIdField = Field(
         ...,
         title="User ID",
         description="The encoded ID of the user.",
@@ -2899,8 +2899,8 @@ class UserEmail(BaseModel):
     )
 
 
-class SharingStatus(BaseModel):
-    id: EncodedDatabaseIdField = Field(
+class SharingStatus(Model):
+    id: DecodedDatabaseIdField = Field(
         ...,
         title="ID",
         description="The encoded ID of the resource to be shared.",
@@ -2948,8 +2948,8 @@ class ShareWithStatus(SharingStatus):
     )
 
 
-class HDABasicInfo(BaseModel):
-    id: EncodedDatabaseIdField
+class HDABasicInfo(Model):
+    id: DecodedDatabaseIdField
     name: str
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2129,33 +2129,33 @@ RoleNameField = Field(title="Name", description="Name of the role")
 RoleDescriptionField = Field(title="Description", description="Description of the role")
 
 
-class BasicRoleModel(BaseModel):
-    id: EncodedDatabaseIdField = RoleIdField
+class BasicRoleModel(Model):
+    id: DecodedDatabaseIdField = RoleIdField
     name: str = RoleNameField
     type: str = Field(title="Type", description="Type or category of the role")
 
 
 class RoleModel(BasicRoleModel):
     description: Optional[str] = RoleDescriptionField
-    url: str = Field(title="URL", description="URL for the role")
+    url: RelativeUrl = RelativeUrlField
     model_class: str = ModelClassField("Role")
 
 
-class RoleDefinitionModel(BaseModel):
+class RoleDefinitionModel(Model):
     name: str = RoleNameField
     description: str = RoleDescriptionField
-    user_ids: Optional[List[EncodedDatabaseIdField]] = Field(title="User IDs", default=[])
-    group_ids: Optional[List[EncodedDatabaseIdField]] = Field(title="Group IDs", default=[])
+    user_ids: Optional[List[DecodedDatabaseIdField]] = Field(title="User IDs", default=[])
+    group_ids: Optional[List[DecodedDatabaseIdField]] = Field(title="Group IDs", default=[])
 
 
-class RoleListModel(BaseModel):
+class RoleListModel(Model):
     __root__: List[RoleModel]
 
 
 # The tuple should probably be another proper model instead?
 # Keeping it as a Tuple for now for backward compatibility
 # TODO: Use Tuple again when https://github.com/tiangolo/fastapi/issues/3665 is fixed upstream
-RoleNameIdTuple = List[str]  # Tuple[str, EncodedDatabaseIdField]
+RoleNameIdTuple = List[str]  # Tuple[str, DecodedDatabaseIdField]
 
 # Group_Roles -----------------------------------------------------------------
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -156,7 +156,7 @@ ElementsField = Field(
     description="The summary information of each of the elements inside the dataset collection.",
 )
 
-HistoryIdField: EncodedDatabaseIdField = Field(
+HistoryIdField: DecodedDatabaseIdField = Field(
     ...,
     title="History ID",
     description="The encoded ID of the history associated with this item.",
@@ -599,7 +599,7 @@ class DCSummary(Model):
     """Dataset Collection summary information."""
 
     model_class: str = ModelClassField(DC_MODEL_CLASS_NAME)
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     create_time: datetime = CreateTimeField
     update_time: datetime = UpdateTimeField
     collection_type: CollectionType = CollectionTypeField
@@ -624,7 +624,7 @@ class HDAObject(Model):
 class DCObject(Model):
     """Dataset Collection Object"""
 
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(DC_MODEL_CLASS_NAME)
     collection_type: CollectionType = CollectionTypeField
     populated: Optional[bool] = PopulatedField
@@ -636,7 +636,7 @@ class DCObject(Model):
 class DCESummary(Model):
     """Dataset Collection Element summary information."""
 
-    id: EncodedDatabaseIdField = EntityIdField
+    id: DecodedDatabaseIdField = EntityIdField
     model_class: str = ModelClassField(DCE_MODEL_CLASS_NAME)
     element_index: int = Field(
         ...,
@@ -756,7 +756,7 @@ class HDCASummary(HistoryItemCommon):
     populated_state: DatasetCollection.populated_states = PopulatedStateField
     populated_state_message: Optional[str] = PopulatedStateMessageField
     element_count: Optional[int] = ElementCountField
-    job_source_id: Optional[EncodedDatabaseIdField] = Field(
+    job_source_id: Optional[DecodedDatabaseIdField] = Field(
         None,
         title="Job Source ID",
         description="The encoded ID of the Job that produced this dataset collection. Used to track the state of the job.",
@@ -772,7 +772,7 @@ class HDCASummary(HistoryItemCommon):
         description="Overview of the job states working inside the dataset collection.",
     )
     contents_url: RelativeUrl = ContentsUrlField
-    collection_id: EncodedDatabaseIdField = Field(
+    collection_id: DecodedDatabaseIdField = Field(
         ...,
         title="Collection ID",
         description="The encoded ID of the dataset collection associated with this HDCA.",
@@ -1228,7 +1228,7 @@ class CollectionElementIdentifier(Model):
         title="Source",
         description="The source of the element.",
     )
-    id: Optional[EncodedDatabaseIdField] = Field(
+    id: Optional[DecodedDatabaseIdField] = Field(
         default=None,
         title="ID",
         description="The encoded ID of the element.",
@@ -1278,13 +1278,13 @@ class CreateNewCollectionPayload(Model):
         title="Instance Type",
         description="The type of the instance, either `history` (default) or `library`.",
     )
-    history_id: Optional[EncodedDatabaseIdField] = Field(
+    history_id: Optional[DecodedDatabaseIdField] = Field(
         default=None,
         description="The ID of the history that will contain the collection. Required if `instance_type=history`.",
     )
-    folder_id: Optional[EncodedDatabaseIdField] = Field(
+    folder_id: Optional[LibraryFolderDatabaseIdField] = Field(
         default=None,
-        description="The ID of the history that will contain the collection. Required if `instance_type=library`.",
+        description="The ID of the library folder that will contain the collection. Required if `instance_type=library`.",
     )
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -196,7 +196,7 @@ class Model(BaseModel):
 class UserModel(Model):
     """User in a transaction context."""
 
-    id: EncodedDatabaseIdField = Field(title="ID", description="User ID")
+    id: DecodedDatabaseIdField = Field(title="ID", description="User ID")
     username: str = Field(title="Username", description="User username")
     email: str = Field(title="Email", description="User email")
     active: bool = Field(title="Active", description="User is active")
@@ -205,11 +205,11 @@ class UserModel(Model):
     model_class: str = ModelClassField(USER_MODEL_CLASS_NAME)
 
 
-class GroupModel(BaseModel):
+class GroupModel(Model):
     """User group model"""
 
     model_class: str = ModelClassField(GROUP_MODEL_CLASS_NAME)
-    id: EncodedDatabaseIdField = Field(
+    id: DecodedDatabaseIdField = Field(
         ...,  # Required
         title="ID",
         description="Encoded group ID",

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -84,7 +84,7 @@ class LibraryParams:
 
 
 def handle_library_params(
-    trans, params, folder_id: str, replace_dataset: Optional[LibraryDataset] = None
+    trans, params, folder_id: int, replace_dataset: Optional[LibraryDataset] = None
 ) -> LibraryParams:
     # FIXME: the received params has already been parsed by util.Params() by the time it reaches here,
     # so no complex objects remain.  This is not good because it does not allow for those objects to be
@@ -93,7 +93,7 @@ def handle_library_params(
     # See if we have any template field contents
     template_field_contents = {}
     template_id = params.get("template_id", None)
-    folder = trans.sa_session.query(LibraryFolder).get(trans.security.decode_id(folder_id))
+    folder = trans.sa_session.query(LibraryFolder).get(folder_id)
     # We are inheriting the folder's info_association, so we may have received inherited contents or we may have redirected
     # here after the user entered template contents ( due to errors ).
     template: Optional[FormDefinition] = None

--- a/lib/galaxy/tools/data/_schema.py
+++ b/lib/galaxy/tools/data/_schema.py
@@ -3,13 +3,12 @@ from typing import (
     List,
 )
 
-from pydantic import (
-    BaseModel,
-    Field,
-)
+from pydantic import Field
+
+from galaxy.schema.schema import Model
 
 
-class ToolDataEntry(BaseModel):
+class ToolDataEntry(Model):
     name: str = Field(
         ...,  # Mark this field as required
         title="Name",
@@ -24,7 +23,7 @@ class ToolDataEntry(BaseModel):
     )
 
 
-class ToolDataEntryList(BaseModel):
+class ToolDataEntryList(Model):
     __root__: List[ToolDataEntry] = Field(
         title="A list with details on individual data tables.",
     )
@@ -38,7 +37,7 @@ class ToolDataDetails(ToolDataEntry):
         example=["value", "dbkey", "name", "path"],
     )
     # We must use an alias since the name 'fields'
-    # shadows a BaseModel attribute
+    # shadows a Model attribute
     fields_value: List[List[str]] = Field(
         alias="fields",
         default=[],
@@ -47,7 +46,7 @@ class ToolDataDetails(ToolDataEntry):
     )
 
 
-class ToolDataField(BaseModel):
+class ToolDataField(Model):
     name: str = Field(
         ...,  # Mark this field as required
         title="Name",
@@ -60,7 +59,7 @@ class ToolDataField(BaseModel):
         example="TabularToolDataField",
     )
     # We must use an alias since the name 'fields'
-    # shadows a BaseModel attribute
+    # shadows a Model attribute
     fields_value: Dict[str, str] = Field(
         ...,  # Mark this field as required
         alias="fields",
@@ -86,7 +85,7 @@ class ToolDataField(BaseModel):
     )
 
 
-class ToolDataItem(BaseModel):
+class ToolDataItem(Model):
     values: str = Field(
         ...,  # Mark this field as required
         title="Values",

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -4,6 +4,7 @@ Contains functionality needed in every web interface
 import logging
 from typing import (
     Any,
+    Callable,
     Optional,
 )
 
@@ -404,7 +405,10 @@ class SharableItemSecurityMixin:
 
 
 class UsesLibraryMixinItems(SharableItemSecurityMixin):
-    def get_library_folder(self, trans, id, check_ownership=False, check_accessible=True):
+
+    get_object: Callable
+
+    def get_library_folder(self, trans, id: int, check_ownership=False, check_accessible=True):
         return self.get_object(trans, id, "LibraryFolder", check_ownership=False, check_accessible=check_accessible)
 
     def get_library_dataset_dataset_association(self, trans, id, check_ownership=False, check_accessible=True):
@@ -452,7 +456,7 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
             # Slight misuse of ItemOwnershipException?
             raise exceptions.ItemOwnershipException("User cannot add to library item.")
 
-    def _copy_hdca_to_library_folder(self, trans, hda_manager, from_hdca_id, folder_id, ldda_message=""):
+    def _copy_hdca_to_library_folder(self, trans, hda_manager, from_hdca_id: int, folder_id: int, ldda_message=""):
         """
         Fetches the collection identified by `from_hcda_id` and dispatches individual collection elements to
         _copy_hda_to_library_folder
@@ -478,7 +482,7 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
         ]
 
     def _copy_hda_to_library_folder(
-        self, trans, hda_manager, from_hda_id, folder_id, ldda_message="", element_identifier=None
+        self, trans, hda_manager, from_hda_id: int, folder_id: int, ldda_message="", element_identifier=None
     ):
         """
         Copies hda ``from_hda_id`` to library folder ``folder_id``, optionally
@@ -488,7 +492,6 @@ class UsesLibraryMixinItems(SharableItemSecurityMixin):
         in its payload.
         """
         log.debug(f"_copy_hda_to_library_folder: {str((from_hda_id, folder_id, ldda_message))}")
-        # PRECONDITION: folder_id has already been altered to remove the folder prefix ('F')
         # TODO: allow name and other, editable ldda attrs?
         if ldda_message:
             ldda_message = sanitize_html(ldda_message)

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -60,7 +60,7 @@ from galaxy.exceptions import (
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.users import UserManager
 from galaxy.model import User
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import StructuredApp
 from galaxy.web.framework.decorators import require_admin_message
@@ -130,11 +130,10 @@ def get_session(
 
 
 def get_api_user(
-    security: IdEncodingHelper = depends(IdEncodingHelper),
     user_manager: UserManager = depends(UserManager),
     key: str = Security(api_key_query),
     x_api_key: str = Security(api_key_header),
-    run_as: Optional[EncodedDatabaseIdField] = Header(
+    run_as: Optional[DecodedDatabaseIdField] = Header(
         default=None,
         title="Run as User",
         description=(

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -56,7 +56,6 @@ from galaxy import (
 from galaxy.exceptions import (
     AdminRequiredException,
     UserCannotRunAsException,
-    UserInvalidRunAsException,
 )
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.users import UserManager
@@ -150,11 +149,7 @@ def get_api_user(
     user = user_manager.by_api_key(api_key=api_key)
     if run_as:
         if user_manager.user_can_do_run_as(user):
-            try:
-                decoded_run_as_id = security.decode_id(run_as)
-            except Exception:
-                raise UserInvalidRunAsException
-            return user_manager.by_id(decoded_run_as_id)
+            return user_manager.by_id(run_as)
         else:
             raise UserCannotRunAsException
     return user

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -14,10 +14,7 @@ from fastapi import Path
 
 from galaxy.managers.configuration import ConfigurationManager
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import (
-    DecodedDatabaseIdField,
-    EncodedDatabaseIdField,
-)
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import UserModel
 from galaxy.webapps.galaxy.api import (
     depends,
@@ -35,7 +32,7 @@ log = logging.getLogger(__name__)
 router = Router(tags=["configuration"])
 
 
-EncodedIdPathParam: EncodedDatabaseIdField = Path(
+EncodedIdPathParam = Path(
     ...,
     title="Encoded id",
     description="Encoded id to be decoded",
@@ -100,7 +97,7 @@ class FastAPIConfiguration:
         summary="Decode a given id",
         response_description="Decoded id",
     )
-    def decode_id(self, encoded_id: EncodedDatabaseIdField = EncodedIdPathParam) -> Dict[str, int]:
+    def decode_id(self, encoded_id: str = EncodedIdPathParam) -> Dict[str, int]:
         """Decode a given id."""
         return self.configuration_manager.decode_id(encoded_id)
 

--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -14,14 +14,17 @@ from fastapi import Path
 
 from galaxy.managers.configuration import ConfigurationManager
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import (
+    DecodedDatabaseIdField,
+    EncodedDatabaseIdField,
+)
 from galaxy.schema.schema import UserModel
-from . import (
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
 )
-from .common import (
+from galaxy.webapps.galaxy.api.common import (
     parse_serialization_params,
     SerializationKeysQueryParam,
     SerializationViewQueryParam,
@@ -50,7 +53,7 @@ class FastAPIConfiguration:
     )
     def whoami(self, trans: ProvidesUserContext = DependsOnTrans) -> Optional[UserModel]:
         """Return information about the current authenticated user."""
-        return _user_to_model(trans.user, trans.security)
+        return _user_to_model(trans.user)
 
     @router.get(
         "/api/configuration",
@@ -119,8 +122,10 @@ class FastAPIConfiguration:
         self.configuration_manager.reload_toolbox()
 
 
-def _user_to_model(user, security):
-    return UserModel(**user.to_dict(view="element", value_mapper={"id": security.encode_id})) if user else None
+def _user_to_model(user):
+    if user:
+        return UserModel.construct(**user.to_dict(view="element", value_mapper={"id": DecodedDatabaseIdField.encode}))
+    return None
 
 
 def _index(manager: ConfigurationManager, trans, view, keys):

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -8,7 +8,7 @@ from fastapi import (
 )
 
 from galaxy.managers.context import ProvidesHistoryContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     AnyHDCA,
     CreateNewCollectionPayload,
@@ -22,7 +22,7 @@ from galaxy.webapps.galaxy.services.dataset_collections import (
     SuitableConverters,
     UpdateCollectionAttributePayload,
 )
-from . import (
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
@@ -32,7 +32,7 @@ log = getLogger(__name__)
 
 router = Router(tags=["dataset collections"])
 
-DatasetCollectionIdPathParam: EncodedDatabaseIdField = Path(
+DatasetCollectionIdPathParam: DecodedDatabaseIdField = Path(
     ..., description="The encoded identifier of the dataset collection."
 )
 
@@ -64,7 +64,7 @@ class FastAPIDatasetCollections:
     def copy(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = Path(..., description="The ID of the dataset collection to copy."),
+        id: DecodedDatabaseIdField = Path(..., description="The ID of the dataset collection to copy."),
         payload: UpdateCollectionAttributePayload = Body(...),
     ):
         self.service.copy(trans, id, payload)
@@ -76,7 +76,7 @@ class FastAPIDatasetCollections:
     def attributes(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
+        id: DecodedDatabaseIdField = DatasetCollectionIdPathParam,
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
     ) -> DatasetCollectionAttributesResult:
         return self.service.attributes(trans, id, instance_type)
@@ -88,7 +88,7 @@ class FastAPIDatasetCollections:
     def suitable_converters(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
+        id: DecodedDatabaseIdField = DatasetCollectionIdPathParam,
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
     ) -> SuitableConverters:
         return self.service.suitable_converters(trans, id, instance_type)
@@ -100,7 +100,7 @@ class FastAPIDatasetCollections:
     def show(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
+        id: DecodedDatabaseIdField = DatasetCollectionIdPathParam,
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
     ) -> AnyHDCA:
         return self.service.show(trans, id, instance_type)
@@ -113,8 +113,8 @@ class FastAPIDatasetCollections:
     def contents(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        hdca_id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
-        parent_id: EncodedDatabaseIdField = Path(
+        hdca_id: DecodedDatabaseIdField = DatasetCollectionIdPathParam,
+        parent_id: DecodedDatabaseIdField = Path(
             ...,
             description="Parent collection ID describing what collection the contents belongs to.",
         ),

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -15,17 +15,17 @@ from galaxy.schema.schema import (
     DatasetCollectionInstanceType,
     HDCADetailed,
 )
+from galaxy.webapps.galaxy.api import (
+    depends,
+    DependsOnTrans,
+    Router,
+)
 from galaxy.webapps.galaxy.services.dataset_collections import (
     DatasetCollectionAttributesResult,
     DatasetCollectionContentElements,
     DatasetCollectionsService,
     SuitableConverters,
     UpdateCollectionAttributePayload,
-)
-from galaxy.webapps.galaxy.api import (
-    depends,
-    DependsOnTrans,
-    Router,
 )
 
 log = getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -30,7 +30,7 @@ from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     AnyHDA,
     AnyHistoryContentItem,
@@ -39,6 +39,11 @@ from galaxy.schema.schema import (
     UpdateDatasetPermissionsPayload,
 )
 from galaxy.util.zipstream import ZipstreamWrapper
+from galaxy.webapps.galaxy.api import (
+    depends,
+    DependsOnTrans,
+    Router,
+)
 from galaxy.webapps.galaxy.api.common import (
     get_filter_query_params,
     get_query_parameters_from_request_excluding,
@@ -55,19 +60,14 @@ from galaxy.webapps.galaxy.services.datasets import (
     DeleteDatasetBatchResult,
     RequestDataType,
 )
-from . import (
-    depends,
-    DependsOnTrans,
-    Router,
-)
 
 log = logging.getLogger(__name__)
 
 router = Router(tags=["datasets"])
 
-DatasetIDPathParam: EncodedDatabaseIdField = Path(..., description="The encoded database identifier of the dataset.")
+DatasetIDPathParam: DecodedDatabaseIdField = Path(..., description="The encoded database identifier of the dataset.")
 
-HistoryIDPathParam: EncodedDatabaseIdField = Path(..., description="The encoded database identifier of the History.")
+HistoryIDPathParam: DecodedDatabaseIdField = Path(..., description="The encoded database identifier of the History.")
 
 DatasetSourceQueryParam: DatasetSourceType = Query(
     default=DatasetSourceType.hda,
@@ -86,7 +86,7 @@ class FastAPIDatasets:
     def index(
         self,
         trans=DependsOnTrans,
-        history_id: Optional[EncodedDatabaseIdField] = Query(
+        history_id: Optional[DecodedDatabaseIdField] = Query(
             default=None,
             description="Optional identifier of a History. Use it to restrict the search whithin a particular History.",
         ),
@@ -102,7 +102,7 @@ class FastAPIDatasets:
     def show_storage(
         self,
         trans=DependsOnTrans,
-        dataset_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        dataset_id: DecodedDatabaseIdField = DatasetIDPathParam,
         hda_ldda: DatasetSourceType = DatasetSourceQueryParam,
     ) -> DatasetStorageDetails:
         return self.service.show_storage(trans, dataset_id, hda_ldda)
@@ -115,7 +115,7 @@ class FastAPIDatasets:
     def show_inheritance_chain(
         self,
         trans=DependsOnTrans,
-        dataset_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        dataset_id: DecodedDatabaseIdField = DatasetIDPathParam,
         hda_ldda: DatasetSourceType = DatasetSourceQueryParam,
     ) -> DatasetInheritanceChain:
         return self.service.show_inheritance_chain(trans, dataset_id, hda_ldda)
@@ -127,7 +127,7 @@ class FastAPIDatasets:
     def get_content_as_text(
         self,
         trans=DependsOnTrans,
-        dataset_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        dataset_id: DecodedDatabaseIdField = DatasetIDPathParam,
     ) -> DatasetTextContentDetails:
         return self.service.get_content_as_text(trans, dataset_id)
 
@@ -138,7 +138,7 @@ class FastAPIDatasets:
     def converted_ext(
         self,
         trans=DependsOnTrans,
-        dataset_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        dataset_id: DecodedDatabaseIdField = DatasetIDPathParam,
         ext: str = Path(
             ...,
             description="File extension of the new format to convert this dataset to.",
@@ -161,7 +161,7 @@ class FastAPIDatasets:
     def converted(
         self,
         trans=DependsOnTrans,
-        dataset_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        dataset_id: DecodedDatabaseIdField = DatasetIDPathParam,
     ) -> ConvertedDatasetsMap:
         """
         Return a map of `<converted extension> : <converted id>` containing all the *existing* converted datasets.
@@ -175,7 +175,7 @@ class FastAPIDatasets:
     def update_permissions(
         self,
         trans=DependsOnTrans,
-        dataset_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        dataset_id: DecodedDatabaseIdField = DatasetIDPathParam,
         # Using a generic Dict here as an attempt on supporting multiple aliases for the permissions params.
         payload: Dict[str, Any] = Body(
             default=...,
@@ -194,8 +194,8 @@ class FastAPIDatasets:
     def extra_files(
         self,
         trans=DependsOnTrans,
-        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
-        history_content_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        history_content_id: DecodedDatabaseIdField = DatasetIDPathParam,
     ):
         return self.service.extra_files(trans, history_content_id)
 
@@ -215,11 +215,11 @@ class FastAPIDatasets:
         self,
         request: Request,
         trans=DependsOnTrans,
-        history_id: Optional[EncodedDatabaseIdField] = Query(
+        history_id: Optional[DecodedDatabaseIdField] = Query(
             default=None,
             description="The encoded database identifier of the History.",
         ),
-        history_content_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        history_content_id: DecodedDatabaseIdField = DatasetIDPathParam,
         preview: bool = Query(
             default=False,
             description=(
@@ -276,11 +276,11 @@ class FastAPIDatasets:
     def get_metadata_file(
         self,
         trans=DependsOnTrans,
-        history_id: Optional[EncodedDatabaseIdField] = Query(
+        history_id: Optional[DecodedDatabaseIdField] = Query(
             default=None,
             description="The encoded database identifier of the History.",
         ),
-        history_content_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        history_content_id: DecodedDatabaseIdField = DatasetIDPathParam,
         metadata_file: str = Query(
             ...,
             description="The name of the metadata file to retrieve.",
@@ -297,7 +297,7 @@ class FastAPIDatasets:
         self,
         request: Request,
         trans=DependsOnTrans,
-        dataset_id: EncodedDatabaseIdField = DatasetIDPathParam,
+        dataset_id: DecodedDatabaseIdField = DatasetIDPathParam,
         hda_ldda: DatasetSourceType = Query(
             default=DatasetSourceType.hda,
             description=("The type of information about the dataset to be requested."),

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -11,25 +11,25 @@ from fastapi import (
 )
 
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.fields import LibraryFolderDatabaseIdField
 from galaxy.schema.schema import (
     CreateLibraryFilePayload,
     LibraryFolderContentsIndexQueryPayload,
     LibraryFolderContentsIndexResult,
     LibraryFolderContentsIndexSortByEnum,
 )
-from galaxy.webapps.galaxy.services.library_folder_contents import LibraryFolderContentsService
-from . import (
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
 )
+from galaxy.webapps.galaxy.services.library_folder_contents import LibraryFolderContentsService
 
 log = logging.getLogger(__name__)
 
 router = Router(tags=["data libraries folders"])
 
-FolderIdPathParam: DecodedDatabaseIdField = Path(
+FolderIdPathParam: LibraryFolderDatabaseIdField = Path(
     ..., title="Folder ID", description="The encoded identifier of the library folder."
 )
 
@@ -83,7 +83,7 @@ class FastAPILibraryFoldersContents:
     def index(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        folder_id: DecodedDatabaseIdField = FolderIdPathParam,
+        folder_id: LibraryFolderDatabaseIdField = FolderIdPathParam,
         limit: int = LimitQueryParam,
         offset: int = OffsetQueryParam,
         search_text: Optional[str] = SearchQueryParam,
@@ -121,7 +121,7 @@ class FastAPILibraryFoldersContents:
     def create(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        folder_id: DecodedDatabaseIdField = FolderIdPathParam,
+        folder_id: LibraryFolderDatabaseIdField = FolderIdPathParam,
         payload: CreateLibraryFilePayload = Body(...),
     ):
         return self.service.create(trans, folder_id, payload)

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -14,7 +14,7 @@ from fastapi import (
 )
 
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import LibraryFolderDatabaseIdField
 from galaxy.schema.schema import (
     CreateLibraryFolderPayload,
     LibraryAvailablePermissions,
@@ -25,18 +25,18 @@ from galaxy.schema.schema import (
     LibraryPermissionScope,
     UpdateLibraryFolderPayload,
 )
-from galaxy.webapps.galaxy.services.library_folders import LibraryFoldersService
-from . import (
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
 )
+from galaxy.webapps.galaxy.services.library_folders import LibraryFoldersService
 
 log = logging.getLogger(__name__)
 
 router = Router(tags=["data libraries folders"])
 
-FolderIdPathParam: EncodedDatabaseIdField = Path(
+FolderIdPathParam: LibraryFolderDatabaseIdField = Path(
     ..., title="Folder ID", description="The encoded identifier of the library folder."
 )
 
@@ -56,7 +56,7 @@ class FastAPILibraryFolders:
     def show(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: LibraryFolderDatabaseIdField = FolderIdPathParam,
     ) -> LibraryFolderDetails:
         """Returns detailed information about the library folder with the given ID."""
         return self.service.show(trans, id)
@@ -68,7 +68,7 @@ class FastAPILibraryFolders:
     def create(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: LibraryFolderDatabaseIdField = FolderIdPathParam,
         payload: CreateLibraryFolderPayload = Body(...),
     ) -> LibraryFolderDetails:
         """Returns detailed information about the newly created library folder."""
@@ -82,7 +82,7 @@ class FastAPILibraryFolders:
     def update(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: LibraryFolderDatabaseIdField = FolderIdPathParam,
         payload: UpdateLibraryFolderPayload = Body(...),
     ) -> LibraryFolderDetails:
         """Updates the information of an existing library folder."""
@@ -95,7 +95,7 @@ class FastAPILibraryFolders:
     def delete(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: LibraryFolderDatabaseIdField = FolderIdPathParam,
         undelete: Optional[bool] = UndeleteQueryParam,
     ) -> LibraryFolderDetails:
         """Marks the specified library folder as deleted (or undeleted)."""
@@ -108,7 +108,7 @@ class FastAPILibraryFolders:
     def get_permissions(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: LibraryFolderDatabaseIdField = FolderIdPathParam,
         scope: Optional[LibraryPermissionScope] = Query(
             None,
             title="Scope",
@@ -142,7 +142,7 @@ class FastAPILibraryFolders:
     def set_permissions(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = FolderIdPathParam,
+        id: LibraryFolderDatabaseIdField = FolderIdPathParam,
         action: Optional[LibraryFolderPermissionAction] = Query(
             default=None,
             title="Action",

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -8,12 +8,12 @@ from fastapi import Path
 
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.group_roles import GroupRolesManager
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     GroupRoleListModel,
     GroupRoleModel,
 )
-from . import (
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
@@ -23,15 +23,16 @@ log = logging.getLogger(__name__)
 
 router = Router(tags=["group_roles"])
 
-GroupIDParam: EncodedDatabaseIdField = Path(..., title="GroupID", description="The ID of the group")
+GroupIDParam: DecodedDatabaseIdField = Path(..., title="GroupID", description="The ID of the group")
 
-RoleIDParam: EncodedDatabaseIdField = Path(..., title="RoleID", description="The ID of the role")
+RoleIDParam: DecodedDatabaseIdField = Path(..., title="RoleID", description="The ID of the role")
 
 
-def group_role_to_model(trans, encoded_group_id, role):
-    encoded_role_id = trans.security.encode_id(role.id)
+def group_role_to_model(trans, group_id: int, role) -> GroupRoleModel:
+    encoded_group_id = DecodedDatabaseIdField.encode(group_id)
+    encoded_role_id = DecodedDatabaseIdField.encode(role.id)
     url = trans.url_builder("group_role", group_id=encoded_group_id, id=encoded_role_id)
-    return GroupRoleModel(id=encoded_role_id, name=role.name, url=url)
+    return GroupRoleModel.construct(id=encoded_role_id, name=role.name, url=url)
 
 
 @router.cbv
@@ -40,10 +41,12 @@ class FastAPIGroupRoles:
 
     @router.get("/api/groups/{group_id}/roles", require_admin=True, summary="Displays a collection (list) of groups.")
     def index(
-        self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam
+        self, trans: ProvidesAppContext = DependsOnTrans, group_id: DecodedDatabaseIdField = GroupIDParam
     ) -> GroupRoleListModel:
         group_roles = self.manager.index(trans, group_id)
-        return GroupRoleListModel(__root__=[group_role_to_model(trans, group_id, gr.role) for gr in group_roles])
+        return GroupRoleListModel.construct(
+            __root__=[group_role_to_model(trans, group_id, gr.role) for gr in group_roles]
+        )
 
     @router.get(
         "/api/groups/{group_id}/roles/{id}",
@@ -54,8 +57,8 @@ class FastAPIGroupRoles:
     def show(
         self,
         trans: ProvidesAppContext = DependsOnTrans,
-        group_id: EncodedDatabaseIdField = GroupIDParam,
-        id: EncodedDatabaseIdField = RoleIDParam,
+        group_id: DecodedDatabaseIdField = GroupIDParam,
+        id: DecodedDatabaseIdField = RoleIDParam,
     ) -> GroupRoleModel:
         role = self.manager.show(trans, id, group_id)
         return group_role_to_model(trans, group_id, role)
@@ -64,8 +67,8 @@ class FastAPIGroupRoles:
     def update(
         self,
         trans: ProvidesAppContext = DependsOnTrans,
-        group_id: EncodedDatabaseIdField = GroupIDParam,
-        role_id: EncodedDatabaseIdField = RoleIDParam,
+        group_id: DecodedDatabaseIdField = GroupIDParam,
+        role_id: DecodedDatabaseIdField = RoleIDParam,
     ) -> GroupRoleModel:
         role = self.manager.update(trans, role_id, group_id)
         return group_role_to_model(trans, group_id, role)
@@ -74,8 +77,8 @@ class FastAPIGroupRoles:
     def delete(
         self,
         trans: ProvidesAppContext = DependsOnTrans,
-        group_id: EncodedDatabaseIdField = GroupIDParam,
-        role_id: EncodedDatabaseIdField = RoleIDParam,
+        group_id: DecodedDatabaseIdField = GroupIDParam,
+        role_id: DecodedDatabaseIdField = RoleIDParam,
     ) -> GroupRoleModel:
         role = self.manager.delete(trans, role_id, group_id)
         return group_role_to_model(trans, group_id, role)

--- a/lib/galaxy/webapps/galaxy/api/group_users.py
+++ b/lib/galaxy/webapps/galaxy/api/group_users.py
@@ -7,12 +7,12 @@ from fastapi import Path
 
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.group_users import GroupUsersManager
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     GroupUserListModel,
     GroupUserModel,
 )
-from . import (
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
@@ -22,15 +22,16 @@ log = logging.getLogger(__name__)
 
 router = Router(tags=["group_users"])
 
-GroupIDParam: EncodedDatabaseIdField = Path(..., title="GroupID", description="The ID of the group")
+GroupIDParam: DecodedDatabaseIdField = Path(..., title="GroupID", description="The ID of the group")
 
-UserIDParam: EncodedDatabaseIdField = Path(..., title="UserID", description="The ID of the user")
+UserIDParam: DecodedDatabaseIdField = Path(..., title="UserID", description="The ID of the user")
 
 
-def group_user_to_model(trans, encoded_group_id, user):
-    encoded_user_id = trans.security.encode_id(user.id)
+def group_user_to_model(trans, group_id, user):
+    encoded_group_id = DecodedDatabaseIdField.encode(group_id)
+    encoded_user_id = DecodedDatabaseIdField.encode(user.id)
     url = trans.url_builder("group_user", group_id=encoded_group_id, id=encoded_user_id)
-    return GroupUserModel(id=encoded_user_id, email=user.email, url=url)
+    return GroupUserModel.construct(id=encoded_user_id, email=user.email, url=url)
 
 
 @router.cbv
@@ -39,7 +40,7 @@ class FastAPIGroupUsers:
 
     @router.get("/api/groups/{group_id}/users", require_admin=True, summary="Displays a collection (list) of groups.")
     def index(
-        self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam
+        self, trans: ProvidesAppContext = DependsOnTrans, group_id: DecodedDatabaseIdField = GroupIDParam
     ) -> GroupUserListModel:
         """
         GET /api/groups/{encoded_group_id}/users
@@ -58,8 +59,8 @@ class FastAPIGroupUsers:
     def show(
         self,
         trans: ProvidesAppContext = DependsOnTrans,
-        group_id: EncodedDatabaseIdField = GroupIDParam,
-        id: EncodedDatabaseIdField = UserIDParam,
+        group_id: DecodedDatabaseIdField = GroupIDParam,
+        id: DecodedDatabaseIdField = UserIDParam,
     ) -> GroupUserModel:
         """
         GET /api/groups/{encoded_group_id}/users/{encoded_user_id}
@@ -77,8 +78,8 @@ class FastAPIGroupUsers:
     def update(
         self,
         trans: ProvidesAppContext = DependsOnTrans,
-        group_id: EncodedDatabaseIdField = GroupIDParam,
-        user_id: EncodedDatabaseIdField = UserIDParam,
+        group_id: DecodedDatabaseIdField = GroupIDParam,
+        user_id: DecodedDatabaseIdField = UserIDParam,
     ) -> GroupUserModel:
         """
         PUT /api/groups/{encoded_group_id}/users/{encoded_user_id}
@@ -96,8 +97,8 @@ class FastAPIGroupUsers:
     def delete(
         self,
         trans: ProvidesAppContext = DependsOnTrans,
-        group_id: EncodedDatabaseIdField = GroupIDParam,
-        user_id: EncodedDatabaseIdField = UserIDParam,
+        group_id: DecodedDatabaseIdField = GroupIDParam,
+        user_id: DecodedDatabaseIdField = UserIDParam,
     ) -> GroupUserModel:
         """
         DELETE /api/groups/{encoded_group_id}/users/{encoded_user_id}

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -14,7 +14,7 @@ from galaxy.web import (
     expose_api,
     require_admin,
 )
-from . import (
+from galaxy.webapps.galaxy.api import (
     BaseGalaxyAPIController,
     depends,
 )
@@ -50,7 +50,7 @@ class GroupAPIController(BaseGalaxyAPIController):
         GET /api/groups/{encoded_group_id}
         Displays information about a group.
         """
-        return self.manager.show(trans, id)
+        return self.manager.show(trans, EncodedDatabaseIdField.decode(id))
 
     @expose_api
     @require_admin
@@ -59,4 +59,4 @@ class GroupAPIController(BaseGalaxyAPIController):
         PUT /api/groups/{encoded_group_id}
         Modifies a group.
         """
-        self.manager.update(trans, id, payload)
+        self.manager.update(trans, EncodedDatabaseIdField.decode(id), payload)

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -59,6 +59,11 @@ from galaxy.schema.schema import (
     WriteStoreToPayload,
 )
 from galaxy.web.framework.decorators import validation_error_to_message_exception
+from galaxy.webapps.galaxy.api import (
+    depends,
+    DependsOnTrans,
+    Router,
+)
 from galaxy.webapps.galaxy.api.common import (
     get_filter_query_params,
     get_update_permission_payload,
@@ -75,11 +80,6 @@ from galaxy.webapps.galaxy.services.history_contents import (
     HistoryContentsIndexJobsSummaryParams,
     HistoryContentsIndexParams,
     LegacyHistoryContentsIndexParams,
-)
-from galaxy.webapps.galaxy.api import (
-    depends,
-    DependsOnTrans,
-    Router,
 )
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -413,13 +413,11 @@ class FastAPIHistoryContents:
         "/api/histories/{history_id}/contents/{type}s/{id}",
         name="history_content_typed",
         summary="Return detailed information about a specific HDA or HDCA with the given `ID` within a history.",
-        response_model_exclude_unset=True,
     )
     @router.get(
         "/api/histories/{history_id}/contents/{id}",
         name="history_content",
         summary="Return detailed information about an HDA within a history.",
-        response_model_exclude_unset=True,
         deprecated=True,
     )
     def show(
@@ -575,12 +573,10 @@ class FastAPIHistoryContents:
     @router.post(
         "/api/histories/{history_id}/contents/{type}s",
         summary="Create a new `HDA` or `HDCA` in the given History.",
-        response_model_exclude_unset=True,
     )
     @router.post(
         "/api/histories/{history_id}/contents",
         summary="Create a new `HDA` or `HDCA` in the given History.",
-        response_model_exclude_unset=True,
         deprecated=True,
     )
     def create(
@@ -671,12 +667,10 @@ class FastAPIHistoryContents:
     @router.put(
         "/api/histories/{history_id}/contents/{type}s/{id}",
         summary="Updates the values for the history content item with the given ``ID``.",
-        response_model_exclude_unset=True,
     )
     @router.put(
         "/api/histories/{history_id}/contents/{id}",
         summary="Updates the values for the history content item with the given ``ID``.",
-        response_model_exclude_unset=True,
         deprecated=True,
     )
     def update(

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -900,12 +900,12 @@ class FastAPIHistoryContents:
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
     ) -> AsyncTaskResultSummary:
-        materializae_request = MaterializeDatasetInstanceRequest(
+        materialize_request = MaterializeDatasetInstanceRequest.construct(
             history_id=history_id,
             source=DatasetSourceType.hda,
             content=id,
         )
-        rval = self.service.materialize(trans, materializae_request)
+        rval = self.service.materialize(trans, materialize_request)
         return rval
 
     @router.post(
@@ -918,8 +918,8 @@ class FastAPIHistoryContents:
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         materialize_api_payload: MaterializeDatasetInstanceAPIRequest = Body(...),
     ) -> AsyncTaskResultSummary:
-        materializae_request: MaterializeDatasetInstanceRequest = MaterializeDatasetInstanceRequest(
+        materialize_request: MaterializeDatasetInstanceRequest = MaterializeDatasetInstanceRequest.construct(
             history_id=history_id, **materialize_api_payload.dict()
         )
-        rval = self.service.materialize(trans, materializae_request)
+        rval = self.service.materialize(trans, materialize_request)
         return rval

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -76,7 +76,7 @@ from galaxy.webapps.galaxy.services.history_contents import (
     HistoryContentsIndexParams,
     LegacyHistoryContentsIndexParams,
 )
-from . import (
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
@@ -636,7 +636,7 @@ class FastAPIHistoryContents:
         will be made to the items.
         """
         result = self.service.update_batch(trans, history_id, payload, serialization_params)
-        return HistoryContentsResult.parse_obj(result)
+        return HistoryContentsResult.construct(__root__=result)
 
     @router.put(
         "/api/histories/{history_id}/contents/bulk",

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -39,7 +39,7 @@ from galaxy.managers.jobs import (
     summarize_job_metrics,
     summarize_job_parameters,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import JobIndexSortByEnum
 from galaxy.schema.types import OffsetNaiveDatetime
 from galaxy.web import (
@@ -82,7 +82,7 @@ UserDetailsQueryParam: bool = Query(
     description="If true, and requestor is an admin, will return external job id and user email. This is only available to admins.",
 )
 
-UserIdQueryParam: Optional[EncodedDatabaseIdField] = Query(
+UserIdQueryParam: Optional[DecodedDatabaseIdField] = Query(
     default=None,
     title="User ID",
     description="an encoded user id to restrict query to, must be own id if not admin user",
@@ -122,19 +122,19 @@ DateRangeMaxQueryParam: Optional[Union[OffsetNaiveDatetime, date]] = Query(
     description="Limit listing of jobs to those that are updated before specified date (e.g. '2014-01-01')",
 )
 
-HistoryIdQueryParam: Optional[EncodedDatabaseIdField] = Query(
+HistoryIdQueryParam: Optional[DecodedDatabaseIdField] = Query(
     default=None,
     title="History ID",
     description="Limit listing of jobs to those that match the history_id. If none, jobs from any history may be returned.",
 )
 
-WorkflowIdQueryParam: Optional[EncodedDatabaseIdField] = Query(
+WorkflowIdQueryParam: Optional[DecodedDatabaseIdField] = Query(
     default=None,
     title="Workflow ID",
     description="Limit listing of jobs to those that match the specified workflow ID. If none, jobs from any workflow (or from no workflows) may be returned.",
 )
 
-InvocationIdQueryParam: Optional[EncodedDatabaseIdField] = Query(
+InvocationIdQueryParam: Optional[DecodedDatabaseIdField] = Query(
     default=None,
     title="Invocation ID",
     description="Limit listing of jobs to those that match the specified workflow invocation ID. If none, jobs from any workflow invocation (or from no workflows) may be returned.",
@@ -175,7 +175,7 @@ class FastAPIJobs:
     @router.get("/api/jobs/{id}")
     def show(
         self,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         trans: ProvidesUserContext = DependsOnTrans,
         full: Optional[bool] = False,
     ) -> Dict[str, Any]:
@@ -194,21 +194,21 @@ class FastAPIJobs:
         trans: ProvidesUserContext = DependsOnTrans,
         states: Optional[List[str]] = Depends(query_parameter_as_list(StateQueryParam)),
         user_details: bool = UserDetailsQueryParam,
-        user_id: Optional[EncodedDatabaseIdField] = UserIdQueryParam,
+        user_id: Optional[DecodedDatabaseIdField] = UserIdQueryParam,
         view: JobIndexViewEnum = ViewQueryParam,
         tool_ids: Optional[List[str]] = Depends(query_parameter_as_list(ToolIdQueryParam)),
         tool_ids_like: Optional[List[str]] = Depends(query_parameter_as_list(ToolIdLikeQueryParam)),
         date_range_min: Optional[Union[datetime, date]] = DateRangeMinQueryParam,
         date_range_max: Optional[Union[datetime, date]] = DateRangeMaxQueryParam,
-        history_id: Optional[EncodedDatabaseIdField] = HistoryIdQueryParam,
-        workflow_id: Optional[EncodedDatabaseIdField] = WorkflowIdQueryParam,
-        invocation_id: Optional[EncodedDatabaseIdField] = InvocationIdQueryParam,
+        history_id: Optional[DecodedDatabaseIdField] = HistoryIdQueryParam,
+        workflow_id: Optional[DecodedDatabaseIdField] = WorkflowIdQueryParam,
+        invocation_id: Optional[DecodedDatabaseIdField] = InvocationIdQueryParam,
         order_by: JobIndexSortByEnum = SortByQueryParam,
         search: Optional[str] = SearchQueryParam,
         limit: int = LimitQueryParam,
         offset: int = OffsetQueryParam,
     ) -> List[Dict[str, Any]]:
-        payload = JobIndexPayload(
+        payload = JobIndexPayload.construct(
             states=states,
             user_details=user_details,
             user_id=user_id,

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -15,7 +15,7 @@ from fastapi import (
 )
 
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     CreateLibrariesFromStore,
     CreateLibraryPayload,
@@ -31,12 +31,12 @@ from galaxy.schema.schema import (
     LibrarySummaryList,
     UpdateLibraryPayload,
 )
-from galaxy.webapps.galaxy.services.libraries import LibrariesService
-from . import (
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
 )
+from galaxy.webapps.galaxy.services.libraries import LibrariesService
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ DeletedQueryParam: Optional[bool] = Query(
     default=None, title="Display deleted", description="Whether to include deleted libraries in the result."
 )
 
-LibraryIdPathParam: EncodedDatabaseIdField = Path(
+LibraryIdPathParam: DecodedDatabaseIdField = Path(
     ..., title="Library ID", description="The encoded identifier of the Library."
 )
 
@@ -89,7 +89,7 @@ class FastAPILibraries:
     def show(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
     ) -> LibrarySummary:
         """Returns summary information about a particular library."""
         return self.service.show(trans, id)
@@ -126,7 +126,7 @@ class FastAPILibraries:
     def update(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
         payload: UpdateLibraryPayload = Body(...),
     ) -> LibrarySummary:
         """
@@ -142,7 +142,7 @@ class FastAPILibraries:
     def delete(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
         undelete: Optional[bool] = UndeleteQueryParam,
         payload: Optional[DeleteLibraryPayload] = Body(default=None),
     ) -> LibrarySummary:
@@ -159,7 +159,7 @@ class FastAPILibraries:
     def get_permissions(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
         scope: Optional[LibraryPermissionScope] = Query(
             None,
             title="Scope",
@@ -199,7 +199,7 @@ class FastAPILibraries:
     def set_permissions(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = LibraryIdPathParam,
+        id: DecodedDatabaseIdField = LibraryIdPathParam,
         action: Optional[LibraryPermissionAction] = Query(
             default=None,
             title="Action",

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -334,7 +334,7 @@ class LibraryContentsController(
                 )
             return rval
 
-    def _upload_library_dataset(self, trans, library_id, folder_id, **kwd):
+    def _upload_library_dataset(self, trans, library_id: int, folder_id: int, **kwd):
         replace_id = kwd.get("replace_id", None)
         replace_dataset: Optional[LibraryDataset] = None
         upload_option = kwd.get("upload_option", "upload_file")
@@ -347,7 +347,7 @@ class LibraryContentsController(
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
         if replace_id not in ["", None, "None"]:
-            replace_dataset = trans.sa_session.query(LibraryDataset).get(trans.security.decode_id(replace_id))
+            replace_dataset = trans.sa_session.query(LibraryDataset).get(replace_id)
             self._check_access(trans, is_admin, replace_dataset, current_user_roles)
             self._check_modify(trans, is_admin, replace_dataset, current_user_roles)
             library = replace_dataset.folder.parent_library
@@ -357,7 +357,7 @@ class LibraryContentsController(
             if not last_used_build:
                 last_used_build = replace_dataset.library_dataset_dataset_association.dbkey
         else:
-            folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(trans.security.decode_id(folder_id))
+            folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(folder_id)
             self._check_access(trans, is_admin, folder, current_user_roles)
             self._check_add(trans, is_admin, folder, current_user_roles)
             library = folder.parent_library
@@ -377,7 +377,7 @@ class LibraryContentsController(
             return 400, message
         else:
             created_outputs_dict = self._upload_dataset(
-                trans, folder_id=trans.security.encode_id(folder.id), replace_dataset=replace_dataset, **kwd
+                trans, folder_id=folder.id, replace_dataset=replace_dataset, **kwd
             )
             if created_outputs_dict:
                 if type(created_outputs_dict) == str:

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -258,10 +258,10 @@ class LibraryContentsController(
             raise exceptions.RequestParameterMissingException("Missing required 'folder_id' parameter.")
         folder_id = payload.pop("folder_id")
         _, folder_id = self._decode_library_content_id(folder_id)
+        folder_id = trans.security.decode_id(folder_id)
         # security is checked in the downstream controller
         parent = self.get_library_folder(trans, folder_id, check_ownership=False, check_accessible=False)
         # The rest of the security happens in the library_common controller.
-        real_folder_id = trans.security.encode_id(parent.id)
 
         payload["tag_using_filenames"] = util.string_as_bool(payload.get("tag_using_filenames", None))
         payload["tags"] = util.listify(payload.get("tags", None))
@@ -276,11 +276,11 @@ class LibraryContentsController(
         if create_type == "file":
             if from_hda_id:
                 return self._copy_hda_to_library_folder(
-                    trans, self.hda_manager, self.decode_id(from_hda_id), real_folder_id, ldda_message
+                    trans, self.hda_manager, self.decode_id(from_hda_id), folder_id, ldda_message
                 )
             if from_hdca_id:
                 return self._copy_hdca_to_library_folder(
-                    trans, self.hda_manager, self.decode_id(from_hdca_id), real_folder_id, ldda_message
+                    trans, self.hda_manager, self.decode_id(from_hdca_id), folder_id, ldda_message
                 )
 
         # check for extended metadata, store it and pop it out of the param
@@ -289,9 +289,9 @@ class LibraryContentsController(
 
         # Now create the desired content object, either file or folder.
         if create_type == "file":
-            status, output = self._upload_library_dataset(trans, library_id, real_folder_id, **payload)
+            status, output = self._upload_library_dataset(trans, library_id, folder_id, **payload)
         elif create_type == "folder":
-            status, output = self._create_folder(trans, real_folder_id, library_id, **payload)
+            status, output = self._create_folder(trans, folder_id, library_id, **payload)
         elif create_type == "collection":
             # Not delegating to library_common, so need to check access to parent
             # folder here.

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -335,7 +335,6 @@ class LibraryContentsController(
             return rval
 
     def _upload_library_dataset(self, trans, library_id: int, folder_id: int, **kwd):
-        replace_id = kwd.get("replace_id", None)
         replace_dataset: Optional[LibraryDataset] = None
         upload_option = kwd.get("upload_option", "upload_file")
         dbkey = kwd.get("dbkey", "?")
@@ -346,21 +345,10 @@ class LibraryContentsController(
         roles = kwd.get("roles", "")
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
-        if replace_id not in ["", None, "None"]:
-            replace_dataset = trans.sa_session.query(LibraryDataset).get(replace_id)
-            self._check_access(trans, is_admin, replace_dataset, current_user_roles)
-            self._check_modify(trans, is_admin, replace_dataset, current_user_roles)
-            library = replace_dataset.folder.parent_library
-            folder = replace_dataset.folder
-            # The name is stored - by the time the new ldda is created, replace_dataset.name
-            # will point to the new ldda, not the one it's replacing.
-            if not last_used_build:
-                last_used_build = replace_dataset.library_dataset_dataset_association.dbkey
-        else:
-            folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(folder_id)
-            self._check_access(trans, is_admin, folder, current_user_roles)
-            self._check_add(trans, is_admin, folder, current_user_roles)
-            library = folder.parent_library
+        folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(folder_id)
+        self._check_access(trans, is_admin, folder, current_user_roles)
+        self._check_add(trans, is_admin, folder, current_user_roles)
+        library = folder.parent_library
         if folder and last_used_build in ["None", None, "?"]:
             last_used_build = folder.genome_build
         error = False

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -36,7 +36,7 @@ from galaxy.webapps.base.controller import (
     UsesFormDefinitionsMixin,
     UsesLibraryMixinItems,
 )
-from . import BaseGalaxyAPIController
+from galaxy.webapps.galaxy.api import BaseGalaxyAPIController
 
 log = logging.getLogger(__name__)
 
@@ -289,9 +289,9 @@ class LibraryContentsController(
 
         # Now create the desired content object, either file or folder.
         if create_type == "file":
-            status, output = self._upload_library_dataset(trans, library_id, folder_id, **payload)
+            status, output = self._upload_library_dataset(trans, folder_id, **payload)
         elif create_type == "folder":
-            status, output = self._create_folder(trans, folder_id, library_id, **payload)
+            status, output = self._create_folder(trans, folder_id, **payload)
         elif create_type == "collection":
             # Not delegating to library_common, so need to check access to parent
             # folder here.
@@ -334,7 +334,7 @@ class LibraryContentsController(
                 )
             return rval
 
-    def _upload_library_dataset(self, trans, library_id: int, folder_id: int, **kwd):
+    def _upload_library_dataset(self, trans, folder_id: int, **kwd):
         replace_dataset: Optional[LibraryDataset] = None
         upload_option = kwd.get("upload_option", "upload_file")
         dbkey = kwd.get("dbkey", "?")

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -529,7 +529,7 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
         for input in tool.inputs.values():
             if input.type == "upload_dataset":
                 dataset_upload_inputs.append(input)
-        library_bunch = upload_common.handle_library_params(trans, {}, trans.security.encode_id(folder.id))
+        library_bunch = upload_common.handle_library_params(trans, {}, folder.id)
         abspath_datasets = []
         kwd["filesystem_paths"] = path
         if source in ["importdir_folder"]:

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -15,7 +15,7 @@ from fastapi import (
 from starlette.responses import StreamingResponse
 
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     AsyncFile,
     CreatePagePayload,
@@ -29,12 +29,12 @@ from galaxy.schema.schema import (
     ShareWithStatus,
     SharingStatus,
 )
-from galaxy.webapps.galaxy.services.pages import PagesService
-from . import (
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
 )
+from galaxy.webapps.galaxy.services.pages import PagesService
 
 log = logging.getLogger(__name__)
 
@@ -44,12 +44,12 @@ DeletedQueryParam: bool = Query(
     default=False, title="Display deleted", description="Whether to include deleted pages in the result."
 )
 
-UserIdQueryParam: Optional[EncodedDatabaseIdField] = Query(
+UserIdQueryParam: Optional[DecodedDatabaseIdField] = Query(
     default=None,
     title="Encoded user ID to restrict query to, must be own id if not an admin user",
 )
 
-PageIdPathParam: EncodedDatabaseIdField = Path(
+PageIdPathParam: DecodedDatabaseIdField = Path(
     ..., title="Page ID", description="The encoded database identifier of the Page."  # Required
 )
 
@@ -92,7 +92,7 @@ class FastAPIPages:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         deleted: bool = DeletedQueryParam,
-        user_id: Optional[EncodedDatabaseIdField] = UserIdQueryParam,
+        user_id: Optional[DecodedDatabaseIdField] = UserIdQueryParam,
         show_published: bool = ShowPublishedQueryParam,
         show_shared: bool = ShowSharedQueryParam,
         sort_by: PageSortByEnum = SortByQueryParam,
@@ -101,7 +101,7 @@ class FastAPIPages:
         offset: int = OffsetQueryParam,
     ) -> PageSummaryList:
         """Get a list with summary information of all Pages available to the user."""
-        payload = PageIndexQueryPayload(
+        payload = PageIndexQueryPayload.construct(
             deleted=deleted,
             user_id=user_id,
             show_published=show_published,
@@ -134,7 +134,7 @@ class FastAPIPages:
     async def delete(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ):
         """Marks the Page with the given ID as deleted."""
         self.service.delete(trans, id)
@@ -155,7 +155,7 @@ class FastAPIPages:
     async def show_pdf(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ):
         """Return a PDF document of the last revision of the Page.
 
@@ -177,7 +177,7 @@ class FastAPIPages:
     async def prepare_pdf(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ) -> AsyncFile:
         """Return a STS download link for this page to be downloaded as a PDF.
 
@@ -193,7 +193,7 @@ class FastAPIPages:
     async def show(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ) -> PageDetails:
         """Return summary information about a specific Page and the content of the last revision."""
         return self.service.show(trans, id)
@@ -205,7 +205,7 @@ class FastAPIPages:
     def sharing(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ) -> SharingStatus:
         """Return the sharing status of the item."""
         return self.service.shareable_service.sharing(trans, id)
@@ -217,7 +217,7 @@ class FastAPIPages:
     def enable_link_access(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ) -> SharingStatus:
         """Makes this item accessible by a URL link and return the current sharing status."""
         return self.service.shareable_service.enable_link_access(trans, id)
@@ -229,7 +229,7 @@ class FastAPIPages:
     def disable_link_access(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ) -> SharingStatus:
         """Makes this item inaccessible by a URL link and return the current sharing status."""
         return self.service.shareable_service.disable_link_access(trans, id)
@@ -241,7 +241,7 @@ class FastAPIPages:
     def publish(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ) -> SharingStatus:
         """Makes this item publicly available by a URL link and return the current sharing status."""
         return self.service.shareable_service.publish(trans, id)
@@ -253,7 +253,7 @@ class FastAPIPages:
     def unpublish(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
     ) -> SharingStatus:
         """Removes this item from the published list and return the current sharing status."""
         return self.service.shareable_service.unpublish(trans, id)
@@ -265,7 +265,7 @@ class FastAPIPages:
     def share_with_users(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
         payload: ShareWithPayload = Body(...),
     ) -> ShareWithStatus:
         """Shares this item with specific users and return the current sharing status."""
@@ -279,7 +279,7 @@ class FastAPIPages:
     def set_slug(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = PageIdPathParam,
+        id: DecodedDatabaseIdField = PageIdPathParam,
         payload: SetSlugPayload = Body(...),
     ):
         """Sets a new slug to access this item by URL. The new slug must be unique."""

--- a/lib/galaxy/webapps/galaxy/api/quotas.py
+++ b/lib/galaxy/webapps/galaxy/api/quotas.py
@@ -15,13 +15,13 @@ from galaxy.quota._schema import (
     QuotaSummaryList,
     UpdateQuotaParams,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
-from galaxy.webapps.galaxy.services.quotas import QuotasService
-from . import (
+from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.webapps.galaxy.api import (
     depends,
     DependsOnTrans,
     Router,
 )
+from galaxy.webapps.galaxy.services.quotas import QuotasService
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 router = Router(tags=["quotas"])
 
 
-QuotaIdPathParam: EncodedDatabaseIdField = Path(
+QuotaIdPathParam: DecodedDatabaseIdField = Path(
     ..., title="Quota ID", description="The encoded identifier of the Quota."  # Required
 )
 
@@ -64,24 +64,26 @@ class FastAPIQuota:
 
     @router.get(
         "/api/quotas/{id}",
+        name="quota",
         summary="Displays details on a particular active quota.",
         require_admin=True,
     )
     def show(
-        self, trans: ProvidesUserContext = DependsOnTrans, id: EncodedDatabaseIdField = QuotaIdPathParam
+        self, trans: ProvidesUserContext = DependsOnTrans, id: DecodedDatabaseIdField = QuotaIdPathParam
     ) -> QuotaDetails:
         """Displays details on a particular active quota."""
         return self.service.show(trans, id)
 
     @router.get(
         "/api/quotas/deleted/{id}",
+        name="deleted_quota",
         summary="Displays details on a particular quota that has been deleted.",
         require_admin=True,
     )
     def show_deleted(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = QuotaIdPathParam,
+        id: DecodedDatabaseIdField = QuotaIdPathParam,
     ) -> QuotaDetails:
         """Displays details on a particular quota that has been deleted."""
         return self.service.show(trans, id, deleted=True)
@@ -107,7 +109,7 @@ class FastAPIQuota:
     def update(
         self,
         payload: UpdateQuotaParams,
-        id: EncodedDatabaseIdField = QuotaIdPathParam,
+        id: DecodedDatabaseIdField = QuotaIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> str:
         """Updates an existing quota."""
@@ -120,7 +122,7 @@ class FastAPIQuota:
     )
     def delete(
         self,
-        id: EncodedDatabaseIdField = QuotaIdPathParam,
+        id: DecodedDatabaseIdField = QuotaIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
         payload: DeleteQuotaPayload = Body(None),  # Optional
     ) -> str:
@@ -134,7 +136,7 @@ class FastAPIQuota:
     )
     def undelete(
         self,
-        id: EncodedDatabaseIdField = QuotaIdPathParam,
+        id: DecodedDatabaseIdField = QuotaIdPathParam,
         trans: ProvidesUserContext = DependsOnTrans,
     ) -> str:
         """Restores a previously deleted quota."""

--- a/lib/galaxy/webapps/galaxy/api/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/visualizations.py
@@ -21,7 +21,7 @@ from galaxy import (
 )
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model.item_attrs import UsesAnnotations
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     SetSlugPayload,
     ShareWithPayload,
@@ -32,7 +32,7 @@ from galaxy.web import expose_api
 from galaxy.webapps.base.controller import UsesVisualizationMixin
 from galaxy.webapps.base.webapp import GalaxyWebTransaction
 from galaxy.webapps.galaxy.services.visualizations import VisualizationsService
-from . import (
+from galaxy.webapps.galaxy.api import (
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
@@ -43,7 +43,7 @@ log = logging.getLogger(__name__)
 
 router = Router(tags=["visualizations"])
 
-VisualizationIdPathParam: EncodedDatabaseIdField = Path(
+VisualizationIdPathParam: DecodedDatabaseIdField = Path(
     ..., title="Visualization ID", description="The encoded database identifier of the Visualization."
 )
 
@@ -59,7 +59,7 @@ class FastAPIVisualizations:
     def sharing(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = VisualizationIdPathParam,
+        id: DecodedDatabaseIdField = VisualizationIdPathParam,
     ) -> SharingStatus:
         """Return the sharing status of the item."""
         return self.service.shareable_service.sharing(trans, id)
@@ -71,7 +71,7 @@ class FastAPIVisualizations:
     def enable_link_access(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = VisualizationIdPathParam,
+        id: DecodedDatabaseIdField = VisualizationIdPathParam,
     ) -> SharingStatus:
         """Makes this item accessible by a URL link and return the current sharing status."""
         return self.service.shareable_service.enable_link_access(trans, id)
@@ -83,7 +83,7 @@ class FastAPIVisualizations:
     def disable_link_access(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = VisualizationIdPathParam,
+        id: DecodedDatabaseIdField = VisualizationIdPathParam,
     ) -> SharingStatus:
         """Makes this item inaccessible by a URL link and return the current sharing status."""
         return self.service.shareable_service.disable_link_access(trans, id)
@@ -95,7 +95,7 @@ class FastAPIVisualizations:
     def publish(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = VisualizationIdPathParam,
+        id: DecodedDatabaseIdField = VisualizationIdPathParam,
     ) -> SharingStatus:
         """Makes this item publicly available by a URL link and return the current sharing status."""
         return self.service.shareable_service.publish(trans, id)
@@ -107,7 +107,7 @@ class FastAPIVisualizations:
     def unpublish(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = VisualizationIdPathParam,
+        id: DecodedDatabaseIdField = VisualizationIdPathParam,
     ) -> SharingStatus:
         """Removes this item from the published list and return the current sharing status."""
         return self.service.shareable_service.unpublish(trans, id)
@@ -119,7 +119,7 @@ class FastAPIVisualizations:
     def share_with_users(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = VisualizationIdPathParam,
+        id: DecodedDatabaseIdField = VisualizationIdPathParam,
         payload: ShareWithPayload = Body(...),
     ) -> ShareWithStatus:
         """Shares this item with specific users and return the current sharing status."""
@@ -133,7 +133,7 @@ class FastAPIVisualizations:
     def set_slug(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        id: EncodedDatabaseIdField = VisualizationIdPathParam,
+        id: DecodedDatabaseIdField = VisualizationIdPathParam,
         payload: SetSlugPayload = Body(...),
     ):
         """Sets a new slug to access this item by URL. The new slug must be unique."""

--- a/lib/galaxy/webapps/galaxy/api/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/visualizations.py
@@ -31,13 +31,13 @@ from galaxy.schema.schema import (
 from galaxy.web import expose_api
 from galaxy.webapps.base.controller import UsesVisualizationMixin
 from galaxy.webapps.base.webapp import GalaxyWebTransaction
-from galaxy.webapps.galaxy.services.visualizations import VisualizationsService
 from galaxy.webapps.galaxy.api import (
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
     Router,
 )
+from galaxy.webapps.galaxy.services.visualizations import VisualizationsService
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm import (
 )
 
 from galaxy import (
-    exceptions,
     model,
     util,
     web,
@@ -28,6 +27,7 @@ from galaxy.managers.pages import (
 from galaxy.managers.sharable import SlugBuilder
 from galaxy.managers.workflows import WorkflowsManager
 from galaxy.model.item_attrs import UsesItemRatings
+from galaxy.schema.schema import CreatePagePayload
 from galaxy.structured_app import StructuredApp
 from galaxy.util import unicodify
 from galaxy.util.sanitize_html import sanitize_html
@@ -408,7 +408,7 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
             {"username": p.page.user.username, "slug": p.page.slug, "title": p.page.title} for p in shared_by_others
         ]
 
-    @web.legacy_expose_api
+    @web.expose_api
     @web.require_login("create pages")
     def create(self, trans, payload=None, **kwd):
         """
@@ -425,7 +425,9 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
                 invocation_id = kwd.get("invocation_id")
                 form_title = f"{form_title} from Invocation Report"
                 slug = f"invocation-report-{invocation_id}"
-                invocation_report = self.workflow_manager.get_invocation_report(trans, invocation_id)
+                invocation_report = self.workflow_manager.get_invocation_report(
+                    trans, trans.security.decode_id(invocation_id)
+                )
                 title = invocation_report.get("title")
                 content = invocation_report.get("markdown")
                 content_format_hide = True
@@ -467,10 +469,7 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
                 ],
             }
         else:
-            try:
-                page = self.page_manager.create(trans, payload)
-            except exceptions.MessageException as e:
-                return self.message_exception(trans, unicodify(e))
+            page = self.page_manager.create(trans, CreatePagePayload(**payload))
             return {"message": "Page '%s' successfully created." % page.title, "status": "success"}
 
     @web.legacy_expose_api

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -45,7 +45,7 @@ from galaxy.webapps.base.controller import (
     UsesStoredWorkflowMixin,
     UsesVisualizationMixin,
 )
-from ..api import depends
+from galaxy.webapps.galaxy.api import depends
 
 
 def format_bool(b):
@@ -469,7 +469,7 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
                 ],
             }
         else:
-            page = self.page_manager.create(trans, CreatePagePayload(**payload))
+            page = self.page_manager.create_page(trans, CreatePagePayload(**payload))
             return {"message": "Page '%s' successfully created." % page.title, "status": "success"}
 
     @web.legacy_expose_api

--- a/lib/galaxy/webapps/galaxy/services/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/services/_fetch_util.py
@@ -11,6 +11,7 @@ from galaxy.model.store.discover import (
     get_required_item,
     replace_request_syntax_sugar,
 )
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.tools.actions.upload_common import validate_datatype_extension
 from galaxy.util import relpath
 
@@ -47,7 +48,7 @@ def validate_and_normalize_targets(trans, payload):
             for key in ["name", "description", "synopsis"]:
                 if key in destination:
                     del destination[key]
-            destination["library_folder_id"] = trans.app.security.encode_id(library.root_folder.id)
+            destination["library_folder_id"] = DecodedDatabaseIdField.encode(library.root_folder.id)
 
     # Unlike upload.py we don't transmit or use run_as_real_user in the job - we just make sure
     # in_place and purge_source are set on the individual upload fetch sources as needed based

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -125,7 +125,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
             history = self.history_manager.get_owned(payload.history_id, trans.user, current_history=trans.history)
             create_params["parent"] = history
             create_params["history"] = history
-        elif payload.instance_type == "library":
+        elif payload.instance_type == "library" and payload.folder_id:
             library_folder = self.get_library_folder(trans, payload.folder_id, check_accessible=True)
             self.check_user_can_add_to_library_item(trans, library_folder, check_accessible=False)
             create_params["parent"] = library_folder

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -8,7 +8,6 @@ from typing import (
 )
 
 from pydantic import (
-    BaseModel,
     Extra,
     Field,
     ValidationError,
@@ -26,7 +25,7 @@ from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.managers.hdcas import HDCAManager
 from galaxy.managers.histories import HistoryManager
 from galaxy.schema.fields import (
-    EncodedDatabaseIdField,
+    DecodedDatabaseIdField,
     ModelClassField,
 )
 from galaxy.schema.schema import (
@@ -36,6 +35,7 @@ from galaxy.schema.schema import (
     DCESummary,
     DCEType,
     HDCADetailed,
+    Model,
     TagCollection,
 )
 from galaxy.security.idencoding import IdEncodingHelper
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 log = getLogger(__name__)
 
 
-class UpdateCollectionAttributePayload(BaseModel):
+class UpdateCollectionAttributePayload(Model):
     """Contains attributes that can be updated for all elements in a dataset collection."""
 
     dbkey: str = Field(..., description="TODO")
@@ -60,7 +60,7 @@ class UpdateCollectionAttributePayload(BaseModel):
         extra = Extra.forbid  # will cause validation to fail if extra attributes are included,
 
 
-class DatasetCollectionAttributesResult(BaseModel):
+class DatasetCollectionAttributesResult(Model):
     dbkey: str = Field(..., description="TODO")
     # Are the following fields really used/needed?
     extension: str = Field(..., description="The dataset file extension.", example="txt")
@@ -70,20 +70,20 @@ class DatasetCollectionAttributesResult(BaseModel):
     tags: TagCollection
 
 
-class SuitableConverter(BaseModel):
+class SuitableConverter(Model):
     tool_id: str = Field(..., description="The ID of the tool that can perform the type conversion.")
     name: str = Field(..., description="The name of the converter.")
     target_type: str = Field(..., description="The type to convert to.")
     original_type: str = Field(..., description="The type to convert from.")
 
 
-class SuitableConverters(BaseModel):
+class SuitableConverters(Model):
     """Collection of converters that can be used on a particular dataset collection."""
 
     __root__: List[SuitableConverter]
 
 
-class DatasetCollectionContentElements(BaseModel):
+class DatasetCollectionContentElements(Model):
     """Represents a collection of elements contained in the dataset collection."""
 
     __root__: List[DCESummary]
@@ -122,8 +122,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         if payload.instance_type == "history":
             if payload.history_id is None:
                 raise exceptions.RequestParameterInvalidException("Parameter history_id is required.")
-            history_id = self.decode_id(payload.history_id)
-            history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
+            history = self.history_manager.get_owned(payload.history_id, trans.user, current_history=trans.history)
             create_params["parent"] = history
             create_params["history"] = history
         elif payload.instance_type == "library":
@@ -143,7 +142,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         return rval
 
     def copy(
-        self, trans: ProvidesHistoryContext, id: EncodedDatabaseIdField, payload: UpdateCollectionAttributePayload
+        self, trans: ProvidesHistoryContext, id: DecodedDatabaseIdField, payload: UpdateCollectionAttributePayload
     ):
         """
         Iterate over all datasets of a collection and copy datasets with new attributes to a new collection.
@@ -156,7 +155,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
     def attributes(
         self,
         trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         instance_type: DatasetCollectionInstanceType = "history",
     ) -> DatasetCollectionAttributesResult:
         """
@@ -171,7 +170,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
     def suitable_converters(
         self,
         trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         instance_type: DatasetCollectionInstanceType = "history",
     ) -> SuitableConverters:
         """
@@ -183,7 +182,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
     def show(
         self,
         trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         instance_type: DatasetCollectionInstanceType = "history",
     ) -> AnyHDCA:
         """
@@ -211,8 +210,8 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
     def contents(
         self,
         trans: ProvidesHistoryContext,
-        hdca_id: EncodedDatabaseIdField,
-        parent_id: EncodedDatabaseIdField,
+        hdca_id: DecodedDatabaseIdField,
+        parent_id: DecodedDatabaseIdField,
         instance_type: DatasetCollectionInstanceType = "history",
         limit: Optional[int] = None,
         offset: Optional[int] = None,
@@ -242,14 +241,13 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         )
 
         # check to make sure the dsc is part of the validated hdca
-        decoded_parent_id = self.decode_id(parent_id)
-        if not hdca.contains_collection(decoded_parent_id):
+        if not hdca.contains_collection(parent_id):
             raise exceptions.ObjectNotFound(
                 "Requested dataset collection is not contained within indicated history content"
             )
 
         # retrieve contents
-        contents = self.collection_manager.get_collection_contents(trans, decoded_parent_id, limit=limit, offset=offset)
+        contents = self.collection_manager.get_collection_contents(trans, parent_id, limit=limit, offset=offset)
 
         # dictify and tack on a collection_url for drilling down into nested collections
         def serialize_element(dsc_element) -> DCESummary:
@@ -266,7 +264,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
 
         rval = [serialize_element(el) for el in contents]
         try:
-            return DatasetCollectionContentElements.parse_obj(rval)
+            return DatasetCollectionContentElements.construct(__root__=rval)
         except ValidationError:
             log.exception(
                 f"Serializing DatasetCollectionContentsElements failed. Collection is populated: {hdca.collection.populated}"

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -547,8 +547,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             # we don't have a jeha, there will never be a download_url. Just let
             # the client poll on the created job_id to determine when the file has been
             # written.
-            job_id = trans.security.encode_id(job.id)
-            return (JobIdResponse(job_id=job_id), ready)
+            return (JobIdResponse.construct(job_id=job.id), ready)
 
         if up_to_date and jeha.ready:
             serialized_jeha = self.history_export_view.serialize(trans, id, jeha)
@@ -560,8 +559,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                 return (JobExportHistoryArchiveModel.construct(**serialized_jeha), ready)
             else:
                 assert job is not None, "logic error, don't have a jeha or a job"
-                job_id = trans.security.encode_id(job.id)
-                return (JobIdResponse.construct(job_id=job_id), ready)
+                return (JobIdResponse.construct(job_id=job.id), ready)
 
     def get_ready_history_export(
         self,

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -44,7 +44,7 @@ from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     AnyHistoryView,
     AsyncFile,
@@ -230,13 +230,14 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                 "message"
             ] = f"Importing history from source '{archive_source}'. This history will be visible when the import is complete."
             job_dict = trans.security.encode_all_ids(job_dict)
-            return JobImportHistoryResponse.parse_obj(job_dict)
+            return JobImportHistoryResponse.construct(**job_dict)
 
         new_history = None
         # if a history id was passed, copy that history
         if copy_this_history_id:
-            decoded_id = self.decode_id(copy_this_history_id)
-            original_history = self.manager.get_accessible(decoded_id, trans.user, current_history=trans.history)
+            original_history = self.manager.get_accessible(
+                copy_this_history_id, trans.user, current_history=trans.history
+            )
             hist_name = hist_name or (f"Copy of '{original_history.name}'")
             new_history = original_history.copy(
                 name=hist_name, target_user=trans.user, all_datasets=payload.all_datasets
@@ -304,7 +305,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         self,
         trans: ProvidesHistoryContext,
         serialization_params: SerializationParams,
-        history_id: Optional[EncodedDatabaseIdField] = None,
+        history_id: Optional[DecodedDatabaseIdField] = None,
     ):
         """
         Returns detailed information about the history with the given encoded `id`. If no `id` is
@@ -324,13 +325,13 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
                 trans.user, filters=(model.History.deleted == false()), current_history=trans.history
             )
         else:
-            history = self.manager.get_accessible(self.decode_id(history_id), trans.user, current_history=trans.history)
+            history = self.manager.get_accessible(history_id, trans.user, current_history=trans.history)
         return self._serialize_history(trans, history, serialization_params)
 
     def prepare_download(
-        self, trans: ProvidesHistoryContext, history_id: EncodedDatabaseIdField, payload: StoreExportPayload
+        self, trans: ProvidesHistoryContext, history_id: DecodedDatabaseIdField, payload: StoreExportPayload
     ) -> AsyncFile:
-        history = self.manager.get_accessible(self.decode_id(history_id), trans.user, current_history=trans.history)
+        history = self.manager.get_accessible(history_id, trans.user, current_history=trans.history)
         short_term_storage_target = model_store_storage_target(
             self.short_term_storage_allocator,
             history.name,
@@ -346,9 +347,9 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         return AsyncFile(storage_request_id=short_term_storage_target.request_id, task=async_task_summary(result))
 
     def write_store(
-        self, trans: ProvidesHistoryContext, history_id: EncodedDatabaseIdField, payload: WriteStoreToPayload
+        self, trans: ProvidesHistoryContext, history_id: DecodedDatabaseIdField, payload: WriteStoreToPayload
     ) -> AsyncTaskResultSummary:
-        history = self.manager.get_accessible(self.decode_id(history_id), trans.user, current_history=trans.history)
+        history = self.manager.get_accessible(history_id, trans.user, current_history=trans.history)
         request = WriteHistoryTo(user=trans.async_request_user, history_id=history.id, **payload.dict())
         result = write_history_to.delay(request=request)
         return async_task_summary(result)
@@ -356,7 +357,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
     def update(
         self,
         trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         payload,
         serialization_params: SerializationParams,
     ):
@@ -378,14 +379,14 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             any values that were different from the original and, therefore, updated
         """
         # TODO: PUT /api/histories/{encoded_history_id} payload = { rating: rating } (w/ no security checks)
-        history = self.manager.get_owned(self.decode_id(id), trans.user, current_history=trans.history)
+        history = self.manager.get_owned(id, trans.user, current_history=trans.history)
         self.deserializer.deserialize(history, payload, user=trans.user, trans=trans)
         return self._serialize_history(trans, history, serialization_params)
 
     def delete(
         self,
         trans: ProvidesHistoryContext,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         serialization_params: SerializationParams,
         purge: bool = False,
     ):
@@ -402,7 +403,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         :rtype:     dict
         :returns:   the deleted or purged history
         """
-        history = self.manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
+        history = self.manager.get_owned(history_id, trans.user, current_history=trans.history)
         if purge:
             self.manager.purge(history)
         else:
@@ -412,7 +413,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
     def undelete(
         self,
         trans: ProvidesHistoryContext,
-        history_id: EncodedDatabaseIdField,
+        history_id: DecodedDatabaseIdField,
         serialization_params: SerializationParams,
     ):
         """Undelete history (that hasn't been purged) with the given ``id``
@@ -426,7 +427,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         :rtype:     dict
         :returns:   the undeleted history
         """
-        history = self.manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
+        history = self.manager.get_owned(history_id, trans.user, current_history=trans.history)
         self.manager.undelete(history)
         return self._serialize_history(trans, history, serialization_params)
 
@@ -478,12 +479,12 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         ]
         return rval
 
-    def citations(self, trans: ProvidesHistoryContext, history_id: EncodedDatabaseIdField):
+    def citations(self, trans: ProvidesHistoryContext, history_id: DecodedDatabaseIdField):
         """
         Return all the citations for the tools used to produce the datasets in
         the history.
         """
-        history = self.manager.get_accessible(self.decode_id(history_id), trans.user, current_history=trans.history)
+        history = self.manager.get_accessible(history_id, trans.user, current_history=trans.history)
         tool_ids = set()
         for dataset in history.datasets:
             job = dataset.creating_job
@@ -495,7 +496,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             tool_ids.add(tool_id)
         return [citation.to_dict("bibtex") for citation in self.citations_manager.citations_for_tool_ids(tool_ids)]
 
-    def index_exports(self, trans: ProvidesHistoryContext, id: EncodedDatabaseIdField):
+    def index_exports(self, trans: ProvidesHistoryContext, id: DecodedDatabaseIdField):
         """
         Get previous history exports (to links). Effectively returns serialized
         JEHA objects.
@@ -505,7 +506,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
     def archive_export(
         self,
         trans,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         payload: Optional[ExportHistoryArchivePayload] = None,
     ) -> Tuple[HistoryArchiveExportResult, bool]:
         """
@@ -520,7 +521,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         """
         if payload is None:
             payload = ExportHistoryArchivePayload()
-        history = self.manager.get_accessible(self.decode_id(id), trans.user, current_history=trans.history)
+        history = self.manager.get_accessible(id, trans.user, current_history=trans.history)
         jeha = history.latest_export
         exporting_to_uri = payload.directory_uri
         # always just issue a new export when exporting to a URI.
@@ -551,22 +552,22 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
 
         if up_to_date and jeha.ready:
             serialized_jeha = self.history_export_view.serialize(trans, id, jeha)
-            return (JobExportHistoryArchiveModel.parse_obj(serialized_jeha), ready)
+            return (JobExportHistoryArchiveModel.construct(**serialized_jeha), ready)
         else:
             # Valid request, just resource is not ready yet.
             if jeha:
                 serialized_jeha = self.history_export_view.serialize(trans, id, jeha)
-                return (JobExportHistoryArchiveModel.parse_obj(serialized_jeha), ready)
+                return (JobExportHistoryArchiveModel.construct(**serialized_jeha), ready)
             else:
                 assert job is not None, "logic error, don't have a jeha or a job"
                 job_id = trans.security.encode_id(job.id)
-                return (JobIdResponse(job_id=job_id), ready)
+                return (JobIdResponse.construct(job_id=job_id), ready)
 
     def get_ready_history_export(
         self,
         trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
-        jeha_id: Union[EncodedDatabaseIdField, LatestLiteral],
+        id: DecodedDatabaseIdField,
+        jeha_id: Union[DecodedDatabaseIdField, LatestLiteral],
     ) -> model.JobExportHistoryArchive:
         """Returns the exported history archive information if it's ready
         or raises an exception if not."""
@@ -594,8 +595,8 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
     def legacy_archive_download(
         self,
         trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
-        jeha_id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
+        jeha_id: DecodedDatabaseIdField,
     ):
         """
         If ready and available, return raw contents of exported history.
@@ -606,12 +607,12 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
     def get_custom_builds_metadata(
         self,
         trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
     ) -> CustomBuildsMetadataResponse:
         """
         Returns metadata for custom builds.
         """
-        history = self.manager.get_accessible(self.decode_id(id), trans.user, current_history=trans.history)
+        history = self.manager.get_accessible(id, trans.user, current_history=trans.history)
         installed_builds = []
         for build in glob.glob(os.path.join(trans.app.config.len_file_path, "*.len")):
             installed_builds.append(os.path.basename(build).split(".len")[0])

--- a/lib/galaxy/webapps/galaxy/services/invocations.py
+++ b/lib/galaxy/webapps/galaxy/services/invocations.py
@@ -23,7 +23,7 @@ from galaxy.exceptions import (
 )
 from galaxy.managers.histories import HistoryManager
 from galaxy.managers.workflows import WorkflowsManager
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     AsyncFile,
     AsyncTaskResultSummary,
@@ -135,12 +135,11 @@ class InvocationsService(ServiceBase):
         return invocation_dict, total_matches
 
     def prepare_store_download(
-        self, trans, invocation_id: EncodedDatabaseIdField, payload: PrepareStoreDownloadPayload
+        self, trans, invocation_id: DecodedDatabaseIdField, payload: PrepareStoreDownloadPayload
     ) -> AsyncFile:
         ensure_celery_tasks_enabled(trans.app.config)
         model_store_format = payload.model_store_format
-        decoded_workflow_invocation_id = self.decode_id(invocation_id)
-        workflow_invocation = self._workflows_manager.get_invocation(trans, decoded_workflow_invocation_id, eager=True)
+        workflow_invocation = self._workflows_manager.get_invocation(trans, invocation_id, eager=True)
         if not workflow_invocation:
             raise ObjectNotFound()
         try:
@@ -162,11 +161,10 @@ class InvocationsService(ServiceBase):
         return AsyncFile(storage_request_id=short_term_storage_target.request_id, task=async_task_summary(result))
 
     def write_store(
-        self, trans, invocation_id: EncodedDatabaseIdField, payload: WriteStoreToPayload
+        self, trans, invocation_id: DecodedDatabaseIdField, payload: WriteStoreToPayload
     ) -> AsyncTaskResultSummary:
         ensure_celery_tasks_enabled(trans.app.config)
-        decoded_workflow_invocation_id = self.decode_id(invocation_id)
-        workflow_invocation = self._workflows_manager.get_invocation(trans, decoded_workflow_invocation_id, eager=True)
+        workflow_invocation = self._workflows_manager.get_invocation(trans, invocation_id, eager=True)
         if not workflow_invocation:
             raise ObjectNotFound()
         request = WriteInvocationTo(

--- a/lib/galaxy/webapps/galaxy/services/jobs.py
+++ b/lib/galaxy/webapps/galaxy/services/jobs.py
@@ -15,7 +15,7 @@ from galaxy.managers.jobs import (
     JobSearch,
     view_show_job,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import JobIndexQueryPayload
 
 
@@ -46,10 +46,9 @@ class JobsService:
     def show(
         self,
         trans: ProvidesUserContext,
-        id: EncodedDatabaseIdField,
+        id: DecodedDatabaseIdField,
         full: bool = False,
     ) -> Dict[str, Any]:
-        id = trans.app.security.decode_id(id)
         job = self.job_manager.get_accessible_job(trans, id)
         return view_show_job(trans, job, bool(full))
 

--- a/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
@@ -17,7 +17,7 @@ from galaxy.managers.folders import FolderManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.model import tags
 from galaxy.model.security import GalaxyRBACAgent
-from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.fields import LibraryFolderDatabaseIdField
 from galaxy.schema.schema import (
     CreateLibraryFilePayload,
     LibraryFolderContentsIndexQueryPayload,
@@ -62,7 +62,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
     def index(
         self,
         trans: ProvidesUserContext,
-        folder_id: DecodedDatabaseIdField,
+        folder_id: LibraryFolderDatabaseIdField,
         payload: LibraryFolderContentsIndexQueryPayload,
     ) -> LibraryFolderContentsIndexResult:
         """
@@ -87,7 +87,9 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
         metadata = self._serialize_library_folder_metadata(trans, folder, user_permissions, total_rows)
         return LibraryFolderContentsIndexResult.construct(metadata=metadata, folder_contents=folder_contents)
 
-    def create(self, trans: ProvidesUserContext, folder_id: DecodedDatabaseIdField, payload: CreateLibraryFilePayload):
+    def create(
+        self, trans: ProvidesUserContext, folder_id: LibraryFolderDatabaseIdField, payload: CreateLibraryFilePayload
+    ):
         """
         Create a new library file from an HDA/HDCA.
         """

--- a/lib/galaxy/webapps/galaxy/services/pages.py
+++ b/lib/galaxy/webapps/galaxy/services/pages.py
@@ -12,7 +12,7 @@ from galaxy.managers.pages import (
     PageSerializer,
 )
 from galaxy.schema import PdfDocumentType
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     AsyncFile,
     CreatePagePayload,
@@ -69,7 +69,9 @@ class PagesService(ServiceBase):
                 raise exceptions.AdminRequiredException("Only admins can index the pages of others")
 
         pages, _ = self.manager.index_query(trans, payload)
-        return PageSummaryList.parse_obj([trans.security.encode_all_ids(p.to_dict(), recursive=True) for p in pages])
+        return PageSummaryList.construct(
+            __root__=[trans.security.encode_all_ids(p.to_dict(), recursive=True) for p in pages]
+        )
 
     def create(self, trans, payload: CreatePagePayload) -> PageSummary:
         """
@@ -79,9 +81,9 @@ class PagesService(ServiceBase):
         rval = trans.security.encode_all_ids(page.to_dict(), recursive=True)
         rval["content"] = page.latest_revision.content
         self.manager.rewrite_content_for_export(trans, rval)
-        return PageSummary.parse_obj(rval)
+        return PageSummary.construct(**rval)
 
-    def delete(self, trans, id: EncodedDatabaseIdField):
+    def delete(self, trans, id: DecodedDatabaseIdField):
         """
         Deletes a page (or marks it as deleted)
         """
@@ -91,7 +93,7 @@ class PagesService(ServiceBase):
         page.deleted = True
         trans.sa_session.flush()
 
-    def show(self, trans, id: EncodedDatabaseIdField) -> PageDetails:
+    def show(self, trans, id: DecodedDatabaseIdField) -> PageDetails:
         """View a page summary and the content of the latest revision
 
         :param  id:    ID of page to be displayed
@@ -104,9 +106,9 @@ class PagesService(ServiceBase):
         rval["content"] = page.latest_revision.content
         rval["content_format"] = page.latest_revision.content_format
         self.manager.rewrite_content_for_export(trans, rval)
-        return PageDetails.parse_obj(rval)
+        return PageDetails.construct(**rval)
 
-    def show_pdf(self, trans, id: EncodedDatabaseIdField):
+    def show_pdf(self, trans, id: DecodedDatabaseIdField):
         """
         View a page summary and the content of the latest revision as PDF.
 
@@ -121,7 +123,7 @@ class PagesService(ServiceBase):
         internal_galaxy_markdown = page.latest_revision.content
         return internal_galaxy_markdown_to_pdf(trans, internal_galaxy_markdown, PdfDocumentType.page)
 
-    def prepare_pdf(self, trans, id: EncodedDatabaseIdField) -> AsyncFile:
+    def prepare_pdf(self, trans, id: DecodedDatabaseIdField) -> AsyncFile:
         ensure_celery_tasks_enabled(trans.app.config)
         page = base.get_object(trans, id, "Page", check_ownership=False, check_accessible=True)
         short_term_storage_target = self.short_term_storage_allocator.new_target(

--- a/lib/galaxy/webapps/galaxy/services/pages.py
+++ b/lib/galaxy/webapps/galaxy/services/pages.py
@@ -77,7 +77,7 @@ class PagesService(ServiceBase):
         """
         Create a page and return Page summary
         """
-        page = self.manager.create(trans, payload.dict())
+        page = self.manager.create_page(trans, payload)
         rval = trans.security.encode_all_ids(page.to_dict(), recursive=True)
         rval["content"] = page.latest_revision.content
         self.manager.rewrite_content_for_export(trans, rval)

--- a/lib/galaxy/webapps/galaxy/services/sharable.py
+++ b/lib/galaxy/webapps/galaxy/services/sharable.py
@@ -8,20 +8,20 @@ from typing import (
 
 from sqlalchemy import false
 
-from galaxy import exceptions
 from galaxy.managers import base
 from galaxy.managers.sharable import (
     SharableModelManager,
     SharableModelSerializer,
 )
 from galaxy.model import User
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     SetSlugPayload,
     ShareWithPayload,
     ShareWithStatus,
     SharingOptions,
     SharingStatus,
+    UserIdentifier,
 )
 
 log = logging.getLogger(__name__)
@@ -40,16 +40,16 @@ class ShareableService:
         self.manager = manager
         self.serializer = serializer
 
-    def set_slug(self, trans, id: EncodedDatabaseIdField, payload: SetSlugPayload):
+    def set_slug(self, trans, id: DecodedDatabaseIdField, payload: SetSlugPayload):
         item = self._get_item_by_id(trans, id)
         self.manager.set_slug(item, payload.new_slug, trans.user)
 
-    def sharing(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def sharing(self, trans, id: DecodedDatabaseIdField) -> SharingStatus:
         """Gets the current sharing status of the item with the given id."""
         item = self._get_item_by_id(trans, id)
         return self._get_sharing_status(trans, item)
 
-    def enable_link_access(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def enable_link_access(self, trans, id: DecodedDatabaseIdField) -> SharingStatus:
         """Makes this item accessible by link.
         If this item contains other elements they will be publicly accessible too.
         """
@@ -58,12 +58,12 @@ class ShareableService:
         self.manager.make_importable(item)
         return self._get_sharing_status(trans, item)
 
-    def disable_link_access(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def disable_link_access(self, trans, id: DecodedDatabaseIdField) -> SharingStatus:
         item = self._get_item_by_id(trans, id)
         self.manager.make_non_importable(item)
         return self._get_sharing_status(trans, item)
 
-    def publish(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def publish(self, trans, id: DecodedDatabaseIdField) -> SharingStatus:
         """Makes this item publicly accessible.
         If this item contains other elements they will be publicly accessible too.
         """
@@ -72,17 +72,17 @@ class ShareableService:
         self.manager.publish(item)
         return self._get_sharing_status(trans, item)
 
-    def unpublish(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+    def unpublish(self, trans, id: DecodedDatabaseIdField) -> SharingStatus:
         item = self._get_item_by_id(trans, id)
         self.manager.unpublish(item)
         return self._get_sharing_status(trans, item)
 
-    def share_with_users(self, trans, id: EncodedDatabaseIdField, payload: ShareWithPayload) -> ShareWithStatus:
+    def share_with_users(self, trans, id: DecodedDatabaseIdField, payload: ShareWithPayload) -> ShareWithStatus:
         item = self._get_item_by_id(trans, id)
         users, errors = self._get_users(trans, payload.user_ids)
         extra = self._share_with_options(trans, item, users, errors, payload.share_option)
         base_status = self._get_sharing_status(trans, item)
-        status = ShareWithStatus.parse_obj(base_status)
+        status = ShareWithStatus.construct(**base_status.dict())
         status.extra = extra
         status.errors.extend(errors)
         return status
@@ -101,7 +101,7 @@ class ShareableService:
             extra = None
         return extra
 
-    def _get_item_by_id(self, trans, id: EncodedDatabaseIdField):
+    def _get_item_by_id(self, trans, id: DecodedDatabaseIdField):
         class_name = self.manager.model_class.__name__
         item = base.get_object(trans, id, class_name, check_ownership=True, check_accessible=True, deleted=False)
         return item
@@ -112,31 +112,26 @@ class ShareableService:
             {"id": self.manager.app.security.encode_id(a.user.id), "email": a.user.email}
             for a in item.users_shared_with
         ]
-        return SharingStatus.parse_obj(status)
+        return SharingStatus.construct(**status)
 
-    def _get_users(self, trans, emails_or_ids: Optional[List] = None) -> Tuple[Set[User], Set[str]]:
-        if emails_or_ids is None:
-            raise exceptions.MessageException("Missing required user IDs or emails")
+    def _get_users(self, trans, emails_or_ids: List[UserIdentifier]) -> Tuple[Set[User], Set[str]]:
         send_to_users: Set[User] = set()
         send_to_err: Set[str] = set()
         for email_or_id in set(emails_or_ids):
-            email_or_id = email_or_id.strip()
-            if not email_or_id:
-                continue
+            if isinstance(email_or_id, str):
+                email_or_id = email_or_id.strip()
+                if not email_or_id:
+                    continue
 
-            send_to_user = None
-            if "@" in email_or_id:
-                email_address = email_or_id
-                send_to_user = self.manager.user_manager.by_email(
-                    email_address, filters=[User.table.c.deleted == false()]
-                )
+                send_to_user = None
+                if "@" in email_or_id:
+                    email_address = email_or_id
+                    send_to_user = self.manager.user_manager.by_email(
+                        email_address, filters=[User.table.c.deleted == false()]
+                    )
             else:
-                try:
-                    decoded_user_id = trans.security.decode_id(email_or_id)
-                    send_to_user = self.manager.user_manager.by_id(decoded_user_id)
-                    if send_to_user.deleted:
-                        send_to_user = None
-                except exceptions.MalformedId:
+                send_to_user = self.manager.user_manager.by_id(email_or_id)
+                if send_to_user.deleted:
                     send_to_user = None
 
             if not send_to_user:

--- a/lib/galaxy/webapps/galaxy/services/sharable.py
+++ b/lib/galaxy/webapps/galaxy/services/sharable.py
@@ -118,21 +118,18 @@ class ShareableService:
         send_to_users: Set[User] = set()
         send_to_err: Set[str] = set()
         for email_or_id in set(emails_or_ids):
-            if isinstance(email_or_id, str):
-                email_or_id = email_or_id.strip()
-                if not email_or_id:
-                    continue
-
-                send_to_user = None
-                if "@" in email_or_id:
-                    email_address = email_or_id
-                    send_to_user = self.manager.user_manager.by_email(
-                        email_address, filters=[User.table.c.deleted == false()]
-                    )
-            else:
+            send_to_user = None
+            if isinstance(email_or_id, int):
                 send_to_user = self.manager.user_manager.by_id(email_or_id)
                 if send_to_user.deleted:
                     send_to_user = None
+            else:
+                email_address = email_or_id.strip()
+                if not email_address:
+                    continue
+                send_to_user = self.manager.user_manager.by_email(
+                    email_address, filters=[User.table.c.deleted == false()]
+                )
 
             if not send_to_user:
                 send_to_err.add(f"{email_or_id} is not a valid Galaxy user.")

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -32,8 +32,8 @@ from galaxy.schema.fetch_data import (
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.tools import Tool
 from galaxy.tools.search import ToolBoxSearch
+from galaxy.webapps.galaxy.services._fetch_util import validate_and_normalize_targets
 from galaxy.webapps.galaxy.services.base import ServiceBase
-from ._fetch_util import validate_and_normalize_targets
 
 log = logging.getLogger(__name__)
 
@@ -132,8 +132,8 @@ class ToolsService(ServiceBase):
         # dataset upload.
         history_id = payload.get("history_id")
         if history_id:
-            decoded_id = self.decode_id(history_id)
-            target_history = self.history_manager.get_owned(decoded_id, trans.user, current_history=trans.history)
+            history_id = trans.security.decode_id(history_id) if isinstance(history_id, str) else history_id
+            target_history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
         else:
             target_history = None
 

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -35,5 +35,5 @@ class UsersService(ServiceBase):
             send_local_control_task(
                 trans.app,
                 "recalculate_user_disk_usage",
-                kwargs={"user_id": self.encode_id(trans.user.id)},
+                kwargs={"user_id": trans.user.id},
             )

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -4,7 +4,7 @@ from typing import (
 )
 
 from galaxy_test.base.populators import DatasetPopulator
-from ._framework import ApiTestCase
+from galaxy_test.api._framework import ApiTestCase
 
 
 class GroupRolesApiTestCase(ApiTestCase):
@@ -41,7 +41,7 @@ class GroupRolesApiTestCase(ApiTestCase):
         response = self._get(f"groups/{encoded_group_id}/roles/{encoded_role_id}", admin=True)
         self._assert_status_code_is(response, 200)
         group_role = response.json()
-        self._assert_valid_group_role(group_role)
+        self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
 
     def test_show_only_admin(self):
         encoded_group_id = "any-group-id"

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -3,8 +3,8 @@ from typing import (
     Optional,
 )
 
-from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.api._framework import ApiTestCase
+from galaxy_test.base.populators import DatasetPopulator
 
 
 class GroupRolesApiTestCase(ApiTestCase):

--- a/lib/galaxy_test/api/test_group_users.py
+++ b/lib/galaxy_test/api/test_group_users.py
@@ -3,8 +3,8 @@ from typing import (
     Optional,
 )
 
-from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.api._framework import ApiTestCase
+from galaxy_test.base.populators import DatasetPopulator
 
 
 class GroupUsersApiTestCase(ApiTestCase):

--- a/lib/galaxy_test/api/test_group_users.py
+++ b/lib/galaxy_test/api/test_group_users.py
@@ -4,7 +4,7 @@ from typing import (
 )
 
 from galaxy_test.base.populators import DatasetPopulator
-from ._framework import ApiTestCase
+from galaxy_test.api._framework import ApiTestCase
 
 
 class GroupUsersApiTestCase(ApiTestCase):
@@ -41,7 +41,7 @@ class GroupUsersApiTestCase(ApiTestCase):
         response = self._get(f"groups/{encoded_group_id}/users/{encoded_user_id}", admin=True)
         self._assert_status_code_is(response, 200)
         group_user = response.json()
-        self._assert_valid_group_user(group_user)
+        self._assert_valid_group_user(group_user, assert_id=encoded_user_id)
 
     def test_show_only_admin(self):
         encoded_group_id = "any-group-id"

--- a/lib/galaxy_test/api/test_pages.py
+++ b/lib/galaxy_test/api/test_pages.py
@@ -18,7 +18,7 @@ from galaxy_test.base.populators import (
     skip_without_tool,
     WorkflowPopulator,
 )
-from ._framework import ApiTestCase
+from galaxy_test.api._framework import ApiTestCase
 
 
 class BasePageApiTestCase(ApiTestCase):
@@ -169,9 +169,9 @@ steps:
     def test_index_show_shared_with_me_deleted(self):
         user_id = self.dataset_populator.user_id()
         with self._different_user():
-            response_published = self._create_valid_page_with_slug("indexshowsharedpublished")
+            response_published = self._create_valid_page_with_slug("indexshowsharedpublisheddeleted")
             self._make_public(response_published["id"])
-            response_shared = self._create_valid_page_with_slug("indexshowsharedshared")
+            response_shared = self._create_valid_page_with_slug("indexshowsharedshareddeleted")
             self._share_with_user(response_shared["id"], user_id)
             self._delete(f"pages/{response_published['id']}").raise_for_status()
             self._delete(f"pages/{response_shared['id']}").raise_for_status()

--- a/lib/galaxy_test/api/test_pages.py
+++ b/lib/galaxy_test/api/test_pages.py
@@ -11,6 +11,7 @@ from requests import delete
 from requests.models import Response
 
 from galaxy.exceptions import error_codes
+from galaxy_test.api._framework import ApiTestCase
 from galaxy_test.api.sharable import SharingApiTests
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import (
@@ -18,7 +19,6 @@ from galaxy_test.base.populators import (
     skip_without_tool,
     WorkflowPopulator,
 )
-from galaxy_test.api._framework import ApiTestCase
 
 
 class BasePageApiTestCase(ApiTestCase):

--- a/test/unit/app/managers/base.py
+++ b/test/unit/app/managers/base.py
@@ -126,8 +126,7 @@ class CreatesCollectionsMixin:
             #    src = 'collection'#?
             # elif isinstance( element, model.LibraryDatasetDatasetAssociation ):
             #    src = 'ldda'#?
-            encoded_id = self.trans.security.encode_id(element.id)
-            identifier_list.append(dict(src=src, name=element.name, id=encoded_id))
+            identifier_list.append(dict(src=src, name=element.name, id=element.id))
         return identifier_list
 
 

--- a/test/unit/webapps/api/conftest.py
+++ b/test/unit/webapps/api/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from galaxy.schema.fields import BaseDatabaseIdField
+from galaxy.security.idencoding import IdEncodingHelper
+
+
+@pytest.fixture(scope="session", autouse=True)
+def security() -> IdEncodingHelper:
+    BaseDatabaseIdField.security = IdEncodingHelper(id_secret="testing")
+    return BaseDatabaseIdField.security

--- a/test/unit/webapps/api/test_fetch_schema.py
+++ b/test/unit/webapps/api/test_fetch_schema.py
@@ -10,7 +10,7 @@ from galaxy.schema.fetch_data import (
     UrlDataElement,
 )
 
-HISTORY_ID = "abcdef0123456789"
+HISTORY_ID = "378807ae895b74ff"
 example_payload = {
     "targets": [
         {
@@ -69,7 +69,7 @@ ftp_hdca_target = {
 }
 
 recursive_archive_payload = {
-    "history_id": "f3f73e481f432006",
+    "history_id": "70583a56914a26f9",
     "targets": [
         {
             "destination": {"type": "library", "name": "My Cool Library"},
@@ -82,7 +82,7 @@ recursive_archive_payload = {
 
 
 nested_element_regression_payload = {
-    "history_id": "80a1fcbe9fcb3c61",
+    "history_id": "c369577e3c21d7b7",
     "targets": [
         {
             "destination": {"type": "hdca"},

--- a/test/unit/webapps/api/test_id_fields.py
+++ b/test/unit/webapps/api/test_id_fields.py
@@ -1,10 +1,14 @@
 import pytest
-from pydantic import BaseModel
+from pydantic import (
+    BaseModel,
+    ValidationError,
+)
 
 from galaxy.schema.fields import (
     BaseDatabaseIdField,
     DecodedDatabaseIdField,
     EncodedDatabaseIdField,
+    LibraryFolderDatabaseIdField,
 )
 from galaxy.security.idencoding import IdEncodingHelper
 
@@ -15,6 +19,10 @@ class DecodedIdModel(BaseModel):
 
 class EncodedIdModel(BaseModel):
     id: EncodedDatabaseIdField
+
+
+class LibraryFolderIdModel(BaseModel):
+    id: LibraryFolderDatabaseIdField
 
 
 @pytest.fixture
@@ -35,5 +43,23 @@ def test_encoded_id_schema_override():
 
 def test_decoded_database_id_field(security: IdEncodingHelper):
     decoded_id = 1
-    id_model = EncodedIdModel(id=decoded_id)
-    assert id_model.id == security.encode_id(decoded_id)
+    encoded_id = security.encode_id(decoded_id)
+    model = DecodedIdModel(id=encoded_id)
+    assert model.id == decoded_id
+    assert DecodedDatabaseIdField.encode(model.id) == encoded_id
+
+
+def test_library_folder_database_id_field(security: IdEncodingHelper):
+    decoded_id = 1
+    encoded_id = f"F{security.encode_id(decoded_id)}"
+    model = LibraryFolderIdModel(id=encoded_id)
+    assert model.id == decoded_id
+    assert LibraryFolderDatabaseIdField.encode(model.id) == encoded_id
+
+
+def test_library_folder_database_id_field_raises_validation_error(security: IdEncodingHelper):
+    decoded_id = 1
+    # The encoded ID must start with 'F'
+    invalid_encoded_id = security.encode_id(decoded_id)
+    with pytest.raises(ValidationError):
+        LibraryFolderIdModel(id=invalid_encoded_id)


### PR DESCRIPTION
This is an intermediate approach to #13598

In this first pass, I will try to see if we can cover most of the encoding/decoding directly with the existing models while adding more type hints and reducing the use of `trans`, and general cleanup.

Then we can explore separating the request models from response models to be more explicit about what will be encoded and decoded as in #13598 which will be the ideal solution.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
