### PR TITLE
Fix path for history contents API request.

### DIFF
--- a/config/plugins/visualizations/mvpapp/package.json
+++ b/config/plugins/visualizations/mvpapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mvpapp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "keywords": [
     "galaxy",
     "visualization"

--- a/config/plugins/visualizations/mvpapp/src/index.js
+++ b/config/plugins/visualizations/mvpapp/src/index.js
@@ -663,7 +663,7 @@ var IGVTrackManager = (function (itm) {
     itm.galaxyTrackFiles = null;
 
     itm.queryGalaxyHistory = function () {
-        let url = itm.galaxyConfiguration.href + "/api/histories/" + itm.galaxyConfiguration.historyID + "/contents/";
+        let url = itm.galaxyConfiguration.href + "/api/histories/" + itm.galaxyConfiguration.historyID + "/contents";
 
         $.get(url, function (data) {
             let files = [];
@@ -3553,7 +3553,7 @@ var featureViewer = {
                 featureViewer.galaxyConfiguration.href +
                 "/api/histories/" +
                 featureViewer.galaxyConfiguration.historyID +
-                "/contents/";
+                "/contents";
 
             $.get(url, function (data) {
                 //Need to check if delete = True


### PR DESCRIPTION
In the recent Galaxy versions, the slash at the end of a request to `/api/histories/{history_id}/contents/` results in a 404, whereas removing the slash yields a successful response. This happens when loading the MVP Application visualization.

This PR removes the offending instances in MVP Application.

#10136 mentioned explicit tests aren't necessary for this plugin, but no 404 error should appear in the browser console when loading MVP Application.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
