### PR TITLE
[22.01] Revert startswith of tool parameter options

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4121,7 +4121,7 @@ used to generate dynamic options.
     </xs:attribute>
     <xs:attribute name="startswith" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Ignore lines starting with the given string.</xs:documentation>
+        <xs:documentation xml:lang="en">Keep only lines starting with the given string.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="meta_file_key" type="xs:string">

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -645,7 +645,7 @@ class DynamicOptions:
         rval = []
         field_count = None
         for line in reader:
-            if line.startswith("#") or (self.line_startswith and line.startswith(self.line_startswith)):
+            if line.startswith("#") or (self.line_startswith and not line.startswith(self.line_startswith)):
                 continue
             line = line.rstrip("\n\r")
             if line:

--- a/test/functional/tools/select_from_csvdataset.xml
+++ b/test/functional/tools/select_from_csvdataset.xml
@@ -6,7 +6,7 @@ echo select_single '$select_single' > '$output'
     <inputs>
         <param name="single" type="data" format="csv" label="single"/>
         <param name="select_single" type="select" label="select_single">
-            <options from_dataset="single" separator="," startswith="Transaction_date">
+            <options from_dataset="single" separator="," startswith="1/3/09">
                 <column name="name" index="1"/>
                 <column name="value" index="2"/>
                 <validator type="no_options" message="No data is available in single" />
@@ -29,10 +29,14 @@ echo select_single '$select_single' > '$output'
                 </assert_contents>
             </output>
         </test>
-        <!-- test that data from "comment" lines can not be selected, i.e. if the startswith attribute of <options> works-->
+        <!-- test that only data from lines starting with "1/2/09" can be selected, i.e. if the startswith attribute of <options> works-->
         <test expect_failure="true">
             <param name="single" value="1.csv" />
             <param name="select_single" value="Product" />
+        </test>
+        <test expect_failure="true">
+            <param name="single" value="1.csv" />
+            <param name="select_single" value="Product2" />
         </test>
     </tests>
     <help>


### PR DESCRIPTION
I think the previous change broke the `startswith`.
ping @bernt-matthias 

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
