### PR TITLE
[22.01] Register routes with trailing slash

### DIFF
--- a/lib/galaxy_test/api/test_configuration.py
+++ b/lib/galaxy_test/api/test_configuration.py
@@ -25,7 +25,7 @@ TEST_KEYS_FOR_ADMIN_ONLY = [
 class ConfigurationApiTestCase(ApiTestCase):
 
     def test_whoami(self):
-        response = self._get("whoami")
+        response = self._get("whoami/")
         self._assert_status_code_is(response, 200)
         assert response.json()['email'] == TEST_USER
 

--- a/lib/galaxy_test/api/test_group_users.py
+++ b/lib/galaxy_test/api/test_group_users.py
@@ -67,7 +67,7 @@ class GroupUsersApiTestCase(ApiTestCase):
         self._assert_status_code_is_ok(update_response)
         group_user = update_response.json()
         self._assert_valid_group_user(group_user, assert_id=encoded_user_id)
-        assert group_user["url"] == f"/api/groups/{encoded_group_id}/users/{encoded_user_id}"
+        assert group_user["url"] == f"/api/groups/{encoded_group_id}/user/{encoded_user_id}"
 
     def test_update_only_admin(self):
         encoded_group_id = "any-group-id"


### PR DESCRIPTION
And partially backport the `wrap_with_alias` changes to reduce conflicts when merging forward and also I'm feeling lazy ...
Noticed this bug in #14437 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
