### PR TITLE
Disable Dataset Display icon in queued state, and Improve Window Manager tour

### DIFF
--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -71,7 +71,7 @@ export default {
             return "Display";
         },
         displayDisabled() {
-            return ["discarded", "new", "upload"].includes(this.state);
+            return ["discarded", "new", "upload", "queued"].includes(this.state);
         },
         editButtonTitle() {
             if (this.editDisabled) {

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -8,6 +8,7 @@
             <b-button-group>
                 <b-button
                     v-b-tooltip.bottom.hover
+                    class="create-hist-btn"
                     data-description="create new history"
                     size="sm"
                     variant="link"

--- a/config/plugins/tours/core.windows.yaml
+++ b/config/plugins/tours/core.windows.yaml
@@ -6,14 +6,15 @@ tags:
   - "UI"
   - "visualization"
 
-requirements:
-  - new_history
-
 steps:
     - content: "This short tour will walk you through <b>Galaxy's Window Manager</b> feature"
 
+    - element: "#current-history-panel .create-hist-btn"
+      intro: "Before using the Window Manager, we will create a new history for this tour."
+      postclick: true
+
     - element: "#tool-panel-upload-button"
-      intro: "Before using the Window Manager, we will upload some tabular data."
+      intro: "Now, we will upload some tabular data into our new history."
       postclick: true
 
     - element: "#btn-new"

--- a/config/plugins/tours/core.windows.yaml
+++ b/config/plugins/tours/core.windows.yaml
@@ -6,6 +6,9 @@ tags:
   - "UI"
   - "visualization"
 
+requirements:
+  - new_history
+
 steps:
     - content: "This short tour will walk you through <b>Galaxy's Window Manager</b> feature"
 
@@ -17,7 +20,11 @@ steps:
       intro: "We will be using the paste feature to create a new dataset."
       postclick: true
 
-    - element: ".upload-text-content"
+    - element: "#upload-row-0 .upload-title"
+      intro: "Giving the dataset a name"
+      textinsert: First Dataset
+
+    - element: "#upload-row-0 .upload-text-content"
       intro: "...and paste content into the text area field."
       textinsert: |
         1 0.039 0.000
@@ -39,6 +46,23 @@ steps:
         - ".upload-space_to_tab"
         - ".popover-close"
 
+    - element: "#btn-new"
+      intro: "We will create another dataset, so that we can try the Window Manager on multiple datasets."
+      postclick: true
+
+    - element: "#upload-row-1 .upload-title"
+      intro: "Giving the second dataset a name"
+      textinsert: Second Dataset
+
+    - element: "#upload-row-1 .upload-text-content"
+      intro: "...and paste content into the text area field again."
+      textinsert: |
+        1 0.069 0.000
+        2 0.711 0.000
+        3 0.999 0.000
+        4 0.420 0.000
+        5 0.190 0.000
+
     - element: "#btn-start"
       intro: "Upload the data into your Galaxy history."
       postclick: true
@@ -52,9 +76,9 @@ steps:
       postclick: true
 
     - element: "#right"
-      intro: "This is your history. It contains all datasets you are currently working with including our uploaded table."
-
-    - element: "#current-history-panel div.content-item .display-btn"
+      intro: "This is your history. It contains our two tables being uploaded."
+    
+    - component: history_panel.item(hid=1,state=ok).display_button
       intro: "Clicking the eye-icon usually displays a dataset in the center panel."
       postclick: true
 
@@ -62,4 +86,8 @@ steps:
       intro: "However while using the Window Manager, the dataset will be shown as resizable window."
 
     - title: "Done."
-      intro: "You have created a Window. Click on the background and select more datasets."
+      intro: "You have created a Window. Click on eye-icon for the other dataset to view it in a window as well."
+
+    - component: history_panel.item(hid=2,state=ok).display_button
+      intro: "View the second dataset in a window as well."
+      postclick: true


### PR DESCRIPTION
**Disabling the eye icon** for the `queued` state. https://github.com/galaxyproject/galaxy/issues/14432
**Changed the Window Manager tour** so that it waits for a dataset to get an `ok` state, and only then try to view it. The following changes were made to the tour:
- Now creates a new history for the tour (to be able to click icon for a specific dataset that changes state from queued to ok)
- Uploads two datasets instead of one
- "Waits" for the dataset(s) to get an `ok` state, 
- and then views both in windows instead of just the one

Here's a `Before` and `After` for the tour (as you can see: **the tour was broken as it would try to view the dataset while it is uploading/queued** and this would trigger a download and empty window):

https://user-images.githubusercontent.com/78516064/186028146-246684b2-913a-4e0e-9cad-7b71be3264cd.mov

https://user-images.githubusercontent.com/78516064/186028178-fb881832-217f-4bad-941f-48f3d0fb76c6.mov

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
