### PR TITLE
Skip redirect url if not available for oidc provider

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -146,6 +146,7 @@ class AuthnzManager:
             "client_secret": config_xml.find("client_secret").text,
             "redirect_uri": config_xml.find("redirect_uri").text,
             "enable_idp_logout": asbool(config_xml.findtext("enable_idp_logout", "false")),
+            "enable_idp_logout_redirect": asbool(config_xml.findtext("enable_idp_logout_redirect", "true")),
         }
         if config_xml.find("prompt") is not None:
             rtv["prompt"] = config_xml.find("prompt").text
@@ -169,6 +170,7 @@ class AuthnzManager:
             "client_secret": config_xml.find("client_secret").text,
             "redirect_uri": config_xml.find("redirect_uri").text,
             "enable_idp_logout": asbool(config_xml.findtext("enable_idp_logout", "false")),
+            "enable_idp_logout_redirect": asbool(config_xml.findtext("enable_idp_logout_redirect", "true")),
         }
         if config_xml.find("credential_url") is not None:
             rtv["credential_url"] = config_xml.find("credential_url").text
@@ -387,7 +389,9 @@ class AuthnzManager:
             unified_provider_name = self._unify_provider_name(provider)
             if self.oidc_backends_config[unified_provider_name]["enable_idp_logout"] is False:
                 return False, f"IDP logout is not enabled for {provider}", None
-
+            # check if idp supports logout redirects
+            if self.oidc_backends_config[unified_provider_name]["enable_idp_logout_redirect"] is False:
+                post_logout_redirect_url = None
             success, message, backend = self._get_authnz_backend(provider)
             if success is False:
                 return False, message, None

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -138,6 +138,8 @@ Please mind `http` and `https`.
         <!-- <idphint>cilogon</idphint> -->
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
         <!-- <enable_idp_logout>false</enable_idp_logout> -->
+        <!-- (Optional) Enable logout redirects back to Galaxy -->
+        <!-- <enable_idp_logout_redirect>true</enable_idp_logout_redirect> -->
         <!-- <icon>https://path/to/icon</icon>  -->
         <!-- (Optional) Enable PKCE for this IDP -->
         <!-- <pkce_support>false</pkce_support> -->


### PR DESCRIPTION
Some OIDC providers do not support logout urls. This PR adds an optional attribute to the `job_conf.xml` to reflect that. Still WIP.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
