### PR TITLE
[22.05] Fix data_range_{min,max} parsing

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -39,7 +39,10 @@ from galaxy.schema.fields import (
     EncodedDatabaseIdField,
     ModelClassField,
 )
-from galaxy.schema.types import RelativeUrl
+from galaxy.schema.types import (
+    OffsetNaiveDatetime,
+    RelativeUrl,
+)
 
 USER_MODEL_CLASS_NAME = "User"
 GROUP_MODEL_CLASS_NAME = "Group"
@@ -1112,8 +1115,8 @@ class JobIndexQueryPayload(Model):
     user_id: Optional[DecodedDatabaseIdField] = None
     tool_ids: Optional[List[str]] = None
     tool_ids_like: Optional[List[str]] = None
-    date_range_min: Optional[Union[datetime, date]] = None
-    date_range_max: Optional[Union[datetime, date]] = None
+    date_range_min: Optional[Union[OffsetNaiveDatetime, date]] = None
+    date_range_max: Optional[Union[OffsetNaiveDatetime, date]] = None
     history_id: Optional[DecodedDatabaseIdField] = None
     workflow_id: Optional[DecodedDatabaseIdField] = None
     invocation_id: Optional[DecodedDatabaseIdField] = None

--- a/lib/galaxy/schema/types.py
+++ b/lib/galaxy/schema/types.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+
+from pydantic.datetime_parse import parse_datetime
 from typing_extensions import Literal
 
 # Relative URLs cannot be validated with AnyUrl, they need a scheme.
@@ -5,3 +8,15 @@ from typing_extensions import Literal
 RelativeUrl = str
 
 LatestLiteral = Literal["latest"]
+
+
+class OffsetNaiveDatetime(datetime):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        v = parse_datetime(v)
+        v = v.replace(tzinfo=None)
+        return v

--- a/lib/galaxy/schema/types.py
+++ b/lib/galaxy/schema/types.py
@@ -18,5 +18,4 @@ class OffsetNaiveDatetime(datetime):
     @classmethod
     def validate(cls, v):
         v = parse_datetime(v)
-        v = v.replace(tzinfo=None)
-        return v
+        return v.replace(tzinfo=None) - v.utcoffset() if v.tzinfo else v

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -38,6 +38,7 @@ from galaxy.managers.jobs import (
 )
 from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import JobIndexSortByEnum
+from galaxy.schema.types import OffsetNaiveDatetime
 from galaxy.util import listify
 from galaxy.web import (
     expose_api,
@@ -103,13 +104,13 @@ ToolIdLikeQueryParam: Optional[str] = Query(
     description="Limit listing of jobs to those that match one of the included tool ID sql-like patterns. If none, all are returned",
 )
 
-DateRangeMinQueryParam: Optional[Union[datetime, date]] = Query(
+DateRangeMinQueryParam: Optional[Union[OffsetNaiveDatetime, date]] = Query(
     default=None,
     title="Date Range Minimum",
     description="Limit listing of jobs to those that are updated after specified date (e.g. '2014-01-01')",
 )
 
-DateRangeMaxQueryParam: Optional[Union[datetime, date]] = Query(
+DateRangeMaxQueryParam: Optional[Union[OffsetNaiveDatetime, date]] = Query(
     default=None,
     title="Date Range Maximum",
     description="Limit listing of jobs to those that are updated before specified date (e.g. '2014-01-01')",

--- a/test/unit/webapps/api/test_datetime_parsing.py
+++ b/test/unit/webapps/api/test_datetime_parsing.py
@@ -8,7 +8,7 @@ class Time(BaseModel):
 
 
 def test_naive_datetime_parsing():
-    with_zulu = Time(time="2022-08-15T11:29:32.853974Z")
-    without_zulu = Time(time="2022-08-15T11:29:32.853974")
-    assert with_zulu.time == without_zulu.time
-    assert not with_zulu.time.tzinfo
+    with_tz = Time(time="2022-08-15T11:29:32.853974+02:00")
+    without_tz = Time(time="2022-08-15T09:29:32.853974")
+    assert with_tz.time == without_tz.time
+    assert with_tz.time.tzinfo is None

--- a/test/unit/webapps/api/test_datetime_parsing.py
+++ b/test/unit/webapps/api/test_datetime_parsing.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+from galaxy.schema.types import OffsetNaiveDatetime
+
+
+class Time(BaseModel):
+    time: OffsetNaiveDatetime
+
+
+def test_naive_datetime_parsing():
+    with_zulu = Time(time="2022-08-15T11:29:32.853974Z")
+    without_zulu = Time(time="2022-08-15T11:29:32.853974")
+    assert with_zulu.time == without_zulu.time
+    assert not with_zulu.time.tzinfo


### PR DESCRIPTION
All datetime values established via our sqlalchemy models don't include `tzinfo`.
Fixes https://github.com/galaxyproject/galaxy/issues/14094#issuecomment-1215166187

In general this is a bad thing, we should definitely be honoring timezone info, but the rest of the app just assumes UTC, so this will 
work.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
