### PR TITLE
Use dataset uuid to authorize history export archive downloads

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -364,8 +364,7 @@ class HistoryExportView:
             if jeha_id == "latest":
                 jeha = matching_exports[0]
         if jeha_id != "latest":
-            decoded_jeha_id = trans.security.decode_id(jeha_id)
-            jeha = self.app.model.session.query(model.JobExportHistoryArchive).get(decoded_jeha_id)
+            jeha = self.app.model.session.query(model.JobExportHistoryArchive).get(jeha_id)
             if uuid and jeha.dataset.uuid != uuid:
                 raise glx_exceptions.ObjectNotFound("Failed to find target history export")
         if not jeha:

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -201,18 +201,6 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         trans.app.job_manager.enqueue(job, tool=history_imp_tool)
         return job
 
-    # TODO: remove this function when the legacy endpoint using it is removed
-    def legacy_serve_ready_history_export(self, trans, jeha):
-        assert jeha.ready
-        if jeha.compressed:
-            trans.response.set_content_type("application/x-gzip")
-        else:
-            trans.response.set_content_type("application/x-tar")
-        disposition = f'attachment; filename="{jeha.export_name}"'
-        trans.response.headers["Content-Disposition"] = disposition
-        archive = trans.app.object_store.get_filename(jeha.dataset)
-        return open(archive, mode="rb")
-
     def get_ready_history_export_file_path(self, trans, jeha) -> str:
         """
         Serves the history export archive for use as a streaming response so the file

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -38,6 +38,7 @@ from galaxy.workflow.trs_proxy import TrsProxy
 
 if TYPE_CHECKING:
     from galaxy.jobs import JobConfiguration
+    from galaxy.managers.histories import HistoryManager
     from galaxy.managers.workflows import WorkflowsManager
     from galaxy.tools.data import ToolDataTableManager
 
@@ -88,7 +89,7 @@ class MinimalManagerApp(MinimalApp):
     file_sources: ConfiguredFileSources
     genome_builds: GenomeBuilds
     dataset_collection_manager: Any  # 'galaxy.managers.collections.DatasetCollectionManager'
-    history_manager: Any  # 'galaxy.managers.histories.HistoryManager'
+    history_manager: "HistoryManager"
     hda_manager: Any  # 'galaxy.managers.hdas.HDAManager'
     workflow_manager: Any  # 'galaxy.managers.workflows.WorkflowsManager'
     workflow_contents_manager: Any  # 'galaxy.managers.workflows.WorkflowContentsManager'

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Union,
 )
+from uuid import UUID
 
 from fastapi import (
     Body,
@@ -385,13 +386,14 @@ class FastAPIHistories:
         trans: ProvidesHistoryContext = DependsOnTrans,
         id: EncodedDatabaseIdField = HistoryIDPathParam,
         jeha_id: Union[EncodedDatabaseIdField, LatestLiteral] = JehaIDPathParam,
+        uuid: Optional[UUID] = None,
     ):
         """
         See ``PUT /api/histories/{id}/exports`` to initiate the creation
         of the history export - when ready, that route will return 200 status
         code (instead of 202) and this route can be used to download the archive.
         """
-        jeha = self.service.get_ready_history_export(trans, id, jeha_id)
+        jeha = self.service.get_ready_history_export(trans, id, jeha_id, uuid)
         media_type = self.service.get_archive_media_type(jeha)
         file_path = self.service.get_archive_download_path(trans, jeha)
         return FileResponse(

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -32,7 +32,10 @@ from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import (
+    DecodedDatabaseIdField,
+    EncodedDatabaseIdField,
+)
 from galaxy.schema.schema import (
     AnyHistoryView,
     AsyncFile,
@@ -73,7 +76,7 @@ HistoryIDPathParam: EncodedDatabaseIdField = Path(
     ..., title="History ID", description="The encoded database identifier of the History."
 )
 
-JehaIDPathParam: Union[EncodedDatabaseIdField, LatestLiteral] = Path(
+JehaIDPathParam: Union[DecodedDatabaseIdField, LatestLiteral] = Path(
     default="latest",
     title="Job Export History ID",
     description=(
@@ -385,7 +388,7 @@ class FastAPIHistories:
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         id: EncodedDatabaseIdField = HistoryIDPathParam,
-        jeha_id: Union[EncodedDatabaseIdField, LatestLiteral] = JehaIDPathParam,
+        jeha_id: Union[DecodedDatabaseIdField, LatestLiteral] = JehaIDPathParam,
         uuid: Optional[UUID] = None,
     ):
         """

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -589,20 +589,6 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             media_type = "application/x-gzip"
         return media_type
 
-    # TODO: remove this function and HistoryManager.legacy_serve_ready_history_export when
-    # removing the legacy HistoriesController
-    def legacy_archive_download(
-        self,
-        trans: ProvidesHistoryContext,
-        id: EncodedDatabaseIdField,
-        jeha_id: EncodedDatabaseIdField,
-    ):
-        """
-        If ready and available, return raw contents of exported history.
-        """
-        jeha = self.history_export_view.get_ready_jeha(trans, id, jeha_id)
-        return self.manager.legacy_serve_ready_history_export(trans, jeha)
-
     def get_custom_builds_metadata(
         self,
         trans: ProvidesHistoryContext,

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -43,7 +43,10 @@ from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.fields import (
+    DecodedDatabaseIdField,
+    EncodedDatabaseIdField,
+)
 from galaxy.schema.schema import (
     AnyHistoryView,
     AsyncFile,
@@ -565,7 +568,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         self,
         trans: ProvidesHistoryContext,
         id: EncodedDatabaseIdField,
-        jeha_id: Union[EncodedDatabaseIdField, LatestLiteral],
+        jeha_id: Union[DecodedDatabaseIdField, LatestLiteral],
         uuid: Optional[UUID],
     ) -> model.JobExportHistoryArchive:
         """Returns the exported history archive information if it's ready

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -13,6 +13,7 @@ from typing import (
     Tuple,
     Union,
 )
+from uuid import UUID
 
 from sqlalchemy import (
     false,
@@ -565,10 +566,11 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         trans: ProvidesHistoryContext,
         id: EncodedDatabaseIdField,
         jeha_id: Union[EncodedDatabaseIdField, LatestLiteral],
+        uuid: Optional[UUID],
     ) -> model.JobExportHistoryArchive:
         """Returns the exported history archive information if it's ready
         or raises an exception if not."""
-        return self.history_export_view.get_ready_jeha(trans, id, jeha_id)
+        return self.history_export_view.get_ready_jeha(trans, id, jeha_id, uuid)
 
     def get_archive_download_path(
         self,


### PR DESCRIPTION
It's a pretty common thing that users try to import history archives to another server via the URL we provide, or try to download the archive via cURL or friends. You just need to know and remember to publish the history for that to work. This instead uses the URL itself to authorize access.

The history id and jeha id are kind-of predictable
(already part of the url) since they're just hashed integers, but we can include the uuid, which isn't easily predictable. That means anyone with access to the URL can download that particular history archive, which I think is the expectation.

Fixes https://github.com/galaxyproject/galaxy/issues/14447 and part of https://github.com/galaxyproject/galaxy/issues/12761


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
