### PR TITLE
[22.05] Grep1 tool: fix keep_header option

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -262,7 +262,7 @@ WORKFLOW_SAFE_TOOL_VERSION_UPDATES = {
     "__BUILD_LIST__": safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.1.0")),
     "__APPLY_RULES__": safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.1.0")),
     "__EXTRACT_DATASET__": safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
-    "Grep1": safe_update(packaging.version.parse("1.0.1"), packaging.version.parse("1.0.3")),
+    "Grep1": safe_update(packaging.version.parse("1.0.1"), packaging.version.parse("1.0.4")),
     "Show beginning1": safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
     "Show tail1": safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
     "sort1": safe_update(packaging.version.parse("1.1.0"), packaging.version.parse("1.2.0")),

--- a/tools/filters/grep.xml
+++ b/tools/filters/grep.xml
@@ -53,7 +53,19 @@
       <param name="keep_header" value="true"/>
       <output name="out_file1">
         <assert_contents>
+          <has_text text="CCDS989.1_cds_0_0_chr1_147962193_r"/>
+          <not_has_text text="CCDS993.1_cds_0_0_chr1_148078401_r"/>
+        </assert_contents>
+      </output>
+    </test>
+    <test>
+      <param name="input" value="1.bed"/>
+      <param name="invert" value=""/>
+      <param name="pattern" value="+"/>
+      <output name="out_file1">
+        <assert_contents>
           <not_has_text text="CCDS989.1_cds_0_0_chr1_147962193_r"/>
+          <not_has_text text="CCDS993.1_cds_0_0_chr1_148078401_r"/>
         </assert_contents>
       </output>
     </test>

--- a/tools/filters/grep.xml
+++ b/tools/filters/grep.xml
@@ -17,7 +17,7 @@
     #else
       cat '$input'
     #end if
-    | grep -P -f '$pattern_file' $invert > '$out_file1'
+    | grep -P -f '$pattern_file' $invert >> '$out_file1'
   ]]></command>
   <configfiles>
     <configfile name="pattern_file">$pattern</configfile>

--- a/tools/filters/grep.xml
+++ b/tools/filters/grep.xml
@@ -1,4 +1,4 @@
-<tool id="Grep1" name="Select" version="1.0.3" profile="20.05">
+<tool id="Grep1" name="Select" version="1.0.4" profile="20.05">
   <description>lines that match an expression</description>
   <requirements>
     <requirement type="package" version="3.4">grep</requirement>


### PR DESCRIPTION
In version 1.0.3 the tool follows two different paths depending on how the keep_header argument is set:

true:
```bash
head -n 1 INPUT_FILE > OUTPUT_FILE && tail -n +2 INPUT_FILE | grep PATTERN > OUTPUT_FILE
```

false:
```bash
cat INPUT_FILE | grep PATTERN > OUTPUT_FILE
```

In both cases the output of grep is piped to OUTPUT_FILE with a single `>`. In the case of `keep_header = true`, the header, which was written to OUTPUT_FILE first is thereby overwritten with the output from grep and lost if it isn't part of that output.

The change is simply to use `>>` to make sure that the grep output is appended instead.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
