### PR TITLE
[22.05] Update error message when building ucsc_build_sites.txt fails

### DIFF
--- a/cron/updateucsc.sh.sample
+++ b/cron/updateucsc.sh.sample
@@ -60,7 +60,7 @@ then
         cp -f "${GALAXY}/tool-data/shared/ucsc/new/ucsc_build_sites.txt" "${GALAXY}/tool-data/shared/ucsc/ucsc_build_sites.txt"
     fi
 else
-    echo "Failed to update builds.txt" >&2
+    echo "Failed to update ucsc_build_sites.txt" >&2
 fi
 
 # Try to build chromInfo tables


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14478

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
