### PR TITLE
[22.05] Fix Jobs API index to accept query parameters as lists

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -18,6 +18,7 @@ from galaxy.schema import (
     ValueFilterQueryParams,
 )
 from galaxy.schema.schema import UpdateDatasetPermissionsPayload
+from galaxy.util import listify
 
 SerializationViewQueryParam: Optional[str] = Query(
     None,
@@ -142,3 +143,44 @@ def get_query_parameters_from_request_excluding(request: Request, exclude: Set[s
     for param_name in exclude:
         extra_params.pop(param_name, None)
     return extra_params
+
+
+def query_parameter_as_list(query):
+    """Used as FastAPI dependable for query parameters that need to behave as a list of values separated by comma
+    or as multiple instances of the same parameter.
+
+    **Important**: the `query` annotation provided must define the `alias` exactly as the name of the actual parameter name.
+
+    Usage example:
+    ```python
+        ValueQueryParam: Optional[str] = Query(
+            default=None,
+            alias="value", # Important! this is the parameter name that will be displayed in the API docs
+            title="My Value",
+            description="A single value, a comma-separated list of values or a list of values.",
+        )
+
+        @router.get("/api/my_route")
+        def index(
+            self,
+            values: Optional[List[str]] = Depends(query_parameter_as_list(ValueQueryParam)),
+        ):
+            ...
+    ```
+
+    This will render in the API docs as a single string query parameter but will make the following requests equivalent:
+    - `api/my_route?value=val1,val2,val3`
+    - `api/my_route?value=val1&value=val2&value=val3`
+    """
+
+    def parse_elements(
+        element: str = query,
+        elements: Optional[List[str]] = Query(default=None, alias=query.alias, include_in_schema=False),
+    ) -> Optional[List[Any]]:
+        if query.default != Ellipsis and element is None and not elements:
+            return query.default
+        if elements and len(elements) > 1:
+            return elements
+        return listify(element)
+
+    return parse_elements

--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -153,7 +153,7 @@ def query_parameter_as_list(query):
 
     Usage example:
     ```python
-        ValueQueryParam: Optional[str] = Query(
+        ValueQueryParam = Query(
             default=None,
             alias="value", # Important! this is the parameter name that will be displayed in the API docs
             title="My Value",
@@ -174,13 +174,12 @@ def query_parameter_as_list(query):
     """
 
     def parse_elements(
-        element: str = query,
-        elements: Optional[List[str]] = Query(default=None, alias=query.alias, include_in_schema=False),
+        elements: Optional[List[str]] = query,
     ) -> Optional[List[Any]]:
-        if query.default != Ellipsis and element is None and not elements:
+        if query.default != Ellipsis and not elements:
             return query.default
-        if elements and len(elements) > 1:
-            return elements
-        return listify(element)
+        if elements and len(elements) == 1:
+            return listify(elements[0])
+        return elements
 
     return parse_elements

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -69,11 +69,11 @@ log = logging.getLogger(__name__)
 router = Router(tags=["jobs"])
 
 
-StateQueryParam: Optional[str] = Query(
+StateQueryParam = Query(
     default=None,
     alias="state",
     title="States",
-    description="Comma-separated list of states to filter job query on. If unspecified, jobs of any state may be returned.",
+    description="A list or comma-separated list of states to filter job query on. If unspecified, jobs of any state may be returned.",
 )
 
 UserDetailsQueryParam: bool = Query(
@@ -95,7 +95,7 @@ ViewQueryParam: JobIndexViewEnum = Query(
 )
 
 
-ToolIdQueryParam: Optional[str] = Query(
+ToolIdQueryParam = Query(
     default=None,
     alias="tool_id",
     title="Tool ID(s)",
@@ -103,7 +103,7 @@ ToolIdQueryParam: Optional[str] = Query(
 )
 
 
-ToolIdLikeQueryParam: Optional[str] = Query(
+ToolIdLikeQueryParam = Query(
     default=None,
     alias="tool_id_like",
     title="Tool ID Pattern(s)",

--- a/test/unit/webapps/test_query_params_lists.py
+++ b/test/unit/webapps/test_query_params_lists.py
@@ -1,0 +1,56 @@
+from typing import List
+
+from fastapi.applications import FastAPI
+from fastapi.param_functions import (
+    Depends,
+    Query,
+)
+from fastapi.testclient import TestClient
+
+from galaxy.webapps.galaxy.api.common import query_parameter_as_list
+
+app = FastAPI()
+
+client = TestClient(app)
+
+
+@app.get("/test/get_value_as_list")
+async def get_value_as_list(
+    values: List[str] = Depends(query_parameter_as_list(Query(alias="value"))),
+):
+    return values
+
+
+def test_single_value():
+    query_params = "value=val"
+    result = _get_result_for_params(query_params)
+    assert len(result) == 1
+    assert result[0] == "val"
+
+
+def test_list_as_comma_separated_values():
+    query_params = "value=val1,val2,val3"
+    result = _get_result_for_params(query_params)
+
+    assert len(result) == 3
+    assert result[0] == "val1"
+    assert result[1] == "val2"
+    assert result[2] == "val3"
+
+
+def test_list_as_multiple_query_entries():
+    query_params = "value=val1&value=val2&value=val3"
+    result = _get_result_for_params(query_params)
+
+    assert len(result) == 3
+    assert result[0] == "val1"
+    assert result[1] == "val2"
+    assert result[2] == "val3"
+
+
+def _get_result_for_params(query_params: str):
+    response = client.get(f"/test/get_value_as_list?{query_params}")
+
+    assert response.status_code == 200
+    result = response.json()
+    return result


### PR DESCRIPTION
Fixes #14451

This adds a new FastAPI dependency function as an attempt to support lists of values in a single query parameter that can be either comma-separated values or lists of values (as repeated parameters).

The idea is to render these parameters as repeated inputs in the interactive API documentation while maintaining backward compatibility with the old API framework behavior and allowing comma-separated values in the first input.

## Usage example

```python
    ValueQueryParam: Optional[str] = Query(
        default=None,
        alias="value", # Important! this is the parameter name that will be displayed in the API docs
        title="My Value",
        description="A single value, a comma-separated list of values, or a list of values.",
    )

    @router.get("/api/my_route")
    def index(
        self,
        values: Optional[List[str]] = Depends(query_parameter_as_list(ValueQueryParam)),
    ):
        ...
```

This will render in the API docs as a single string query parameter but will make the following requests equivalent:
- `api/my_route?value=val1,val2,val3`
- `api/my_route?value=val1&value=val2&value=val3`

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
