### PR TITLE
[22.05] Fix xml deprecation warning in ``parse_requirements_from_xml``

### DIFF
--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -345,7 +345,7 @@ def parse_requirements_from_xml(xml_root, parse_resources=False):
 
     containers = [container_from_element(c) for c in container_elems]
     if parse_resources:
-        resource_elems = requirements_elem.findall("resource") if requirements_elem else []
+        resource_elems = requirements_elem.findall("resource") if requirements_elem is not None else []
         resources = [resource_from_element(r) for r in resource_elems]
         return requirements, containers, resources
 


### PR DESCRIPTION
which pops up at every `planemo lint`:

```
galaxy/tool_util/deps/requirements.py:348: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
