### PR TITLE
watching historyID for change, if it changes, close the CollectionPanel

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -14,7 +14,8 @@
                     <CollectionNavigation
                         :history="history"
                         :selected-collections="selectedCollections"
-                        v-on="$listeners" />
+                        v-on="$listeners"
+                        ref="collectionNav" />
                     <CollectionDetails :dsc="dsc" :writeable="isRoot" @update:dsc="updateDsc(dsc, $event)" />
                     <CollectionOperations v-if="isRoot" :dsc="dsc" />
                 </section>
@@ -58,6 +59,11 @@ export default {
         ContentItem,
         ExpandedItems,
         ListingLayout,
+    },
+    watch: {
+        history() {
+            this.$refs.collectionNav.close();
+        },
     },
     props: {
         history: { type: Object, required: true },

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -84,9 +84,11 @@ export default {
         },
     },
     watch: {
-        history() {
-            // Send up event closing out selected collection on history change.
-            this.$emit("update:selected-collections", []);
+        history(newHistory, oldHistory) {
+            if (newHistory.id != oldHistory.id) {
+                // Send up event closing out selected collection on history change.
+                this.$emit("update:selected-collections", []);
+            }
         },
     },
     methods: {

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -85,7 +85,8 @@ export default {
     },
     watch: {
         history() {
-            this.$refs.collectionNav.close();
+            // Send up event closing out selected collection on history change.
+            this.$emit("update:selected-collections", []);
         },
     },
     methods: {

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -12,7 +12,6 @@
             <section class="dataset-collection-panel d-flex flex-column">
                 <section>
                     <CollectionNavigation
-                        ref="collectionNav"
                         :history="history"
                         :selected-collections="selectedCollections"
                         v-on="$listeners" />

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -12,10 +12,10 @@
             <section class="dataset-collection-panel d-flex flex-column">
                 <section>
                     <CollectionNavigation
+                        ref="collectionNav"
                         :history="history"
                         :selected-collections="selectedCollections"
-                        v-on="$listeners"
-                        ref="collectionNav" />
+                        v-on="$listeners" />
                     <CollectionDetails :dsc="dsc" :writeable="isRoot" @update:dsc="updateDsc(dsc, $event)" />
                     <CollectionOperations v-if="isRoot" :dsc="dsc" />
                 </section>
@@ -60,11 +60,6 @@ export default {
         ExpandedItems,
         ListingLayout,
     },
-    watch: {
-        history() {
-            this.$refs.collectionNav.close();
-        },
-    },
     props: {
         history: { type: Object, required: true },
         selectedCollections: { type: Array, required: true },
@@ -87,6 +82,11 @@ export default {
         },
         contentsUrl() {
             return this.dsc.contents_url.substring(1);
+        },
+    },
+    watch: {
+        history() {
+            this.$refs.collectionNav.close();
         },
     },
     methods: {


### PR DESCRIPTION
Fix for #14200; Added a watch to the history, when it changes, close the Collection Panel

https://user-images.githubusercontent.com/26912553/186000661-cc7aaf8e-ca91-43fa-ab37-3bd1fb14f0c6.mp4

with much thanks to @dannon for getting me on the right path! 


## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Open a Collection in one History
  2. Navigate to User > Histories
  3. Switch to a different History, see that the History Panel reflects the change

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
