### PR TITLE
Fix dataset operations inconsistent hover styles

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -224,7 +224,7 @@ export default {
     },
 };
 </script>
-<style>
+<style lang="scss">
 .content-item:hover {
     filter: brightness(105%);
 }

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -1003,10 +1003,17 @@ a.action-button {
     .btn:active,
     .btn:focus,
     .btn:focus-visible {
-        @extend .text-info;
         background-color: transparent !important;
         border-color: transparent !important;
         box-shadow: none !important;
+    }
+
+    .btn:hover {
+        color: $brand-info;
+    }
+
+    .btn:active {
+        color: $brand-dark;
     }
 }
 


### PR DESCRIPTION
 fixes #14487
 Also aligns the "active" styles, and fixes a minor <style> tag error.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. hover over the delete operation for history datasets
  2. hover over the edit attributes operation
  3. they should have the same hover style

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
