### PR TITLE
[22.01] fix lint context fail function

### DIFF
--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -251,10 +251,9 @@ class LintContext:
     def failed(self, fail_level: Union[LintLevel, str]) -> bool:
         if isinstance(fail_level, str):
             fail_level = LintLevel[fail_level.upper()]
-
         found_warns = self.found_warns
         found_errors = self.found_errors
-        if fail_level >= LintLevel.WARN:
+        if fail_level == LintLevel.WARN:
             lint_fail = (found_warns or found_errors)
         elif fail_level >= LintLevel.ERROR:
             lint_fail = found_errors


### PR DESCRIPTION
error introduced here https://github.com/galaxyproject/galaxy/pull/13186

found this while working on https://github.com/galaxyproject/planemo/pull/1264

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
 
The test that currently fails in the linked PR runs with this change:

```
planemo workflow_lint --fail_level error PLANEMODIR/tests/data/wf_repos/from_format2/0_basic_format2
```

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
