### PR TITLE
[22.05] Release script fixes

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -444,7 +444,7 @@ function packages_make_all() {
     (
         cd packages/
         for dir in *; do
-            [ ! -d "$dir" -o ! -f "${dir}/setup.py" ] && continue
+            [ ! -d "$dir" -o ! -f "${dir}/setup.cfg" ] && continue
             # can't use log_exec here because we want to capture output
             echo + make -C "$dir" "$@" 1>&2
             make -C "$dir" "$@" >"${dir}/make-${1}.log" 2>&1
@@ -460,9 +460,9 @@ function update_package_versions() {
     (
         cd packages/
         for dir in *; do
-            project_file="${dir}/galaxy/project_galaxy_${dir}.py"
+            project_file="${dir}/galaxy/setup.cfg"
             if [ -f "${project_file}" ]; then
-                sed_inplace -e "s/^__version__ =.*/__version__ = \"${package_version}\"/" "$project_file"
+                sed_inplace -e "s/^version =.*/version = \"${package_version}\"/" "$project_file"
             fi
         done
     )


### PR DESCRIPTION
I'm not sure about https://github.com/galaxyproject/galaxy/commit/d38217635465471a5c96ce399b9fe6179b07d1b9, it's unclear if this was an oversight or we really want the minor version to be `None` ?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
