### PR TITLE
Enable logging for manage_db.sh

### DIFF
--- a/lib/galaxy/model/migrations/scripts.py
+++ b/lib/galaxy/model/migrations/scripts.py
@@ -124,8 +124,8 @@ def _pop_config_file(argv: List[str]) -> Optional[str]:
 
 
 def add_db_urls_to_command_arguments(argv: List[str], gxy_url: str, tsi_url: str) -> None:
-    _insert_x_argument(argv, "tsi_url", tsi_url)
-    _insert_x_argument(argv, "gxy_url", gxy_url)
+    _insert_x_argument(argv, f"{TSI}_url", tsi_url)
+    _insert_x_argument(argv, f"{GXY}_url", gxy_url)
 
 
 def _insert_x_argument(argv, key: str, value: str) -> None:
@@ -249,9 +249,9 @@ class LegacyScripts:
                 self.argv.append("heads")
             else:  # for separate databases, choose one
                 if self.database in ["galaxy", self.DEFAULT_DB_ARG]:
-                    self.argv.append("gxy@head")
+                    self.argv.append(f"{GXY}@head")
                 elif self.database == "install":
-                    self.argv.append("tsi@head")
+                    self.argv.append(f"{TSI}@head")
 
     def get_db_url(self):
         if self.database in ["galaxy", self.DEFAULT_DB_ARG]:

--- a/scripts/manage_db_adapter.py
+++ b/scripts/manage_db_adapter.py
@@ -17,6 +17,7 @@ The converted sys.argv will include `-c path-to-alembic.ini`.
 The optional `-c` argument name is renamed to `--galaxy-config`.
 """
 
+import logging
 import os
 import sys
 
@@ -27,6 +28,9 @@ from galaxy.model.migrations.scripts import (
     LegacyScripts,
     verify_database_is_initialized,
 )
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 def run():


### PR DESCRIPTION
Fixes #14353 + minor cleanup

## How to test the changes?
1. Run `./manage_db.sh upgrade` 
2. Run `./run_alembic.sh upgrade heads` 
3. Logging output should be the same (unless the first command performed an upgrade)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
