### PR TITLE
[21.01] fix metadata setting for bed and interval

### DIFF
--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -567,7 +567,7 @@ class BedStrict(Bed):
     MetadataElement(name="chromCol", default=1, desc="Chrom column", readonly=True, param=metadata.MetadataParameter)
     MetadataElement(name="startCol", default=2, desc="Start column", readonly=True, param=metadata.MetadataParameter)  # TODO: start and end should be able to be set to these or the proper thick[start/end]?
     MetadataElement(name="endCol", default=3, desc="End column", readonly=True, param=metadata.MetadataParameter)
-    MetadataElement(name="strandCol", desc="Strand column (click box & select)", readonly=True, param=metadata.MetadataParameter, no_value=0, optional=True)
+    MetadataElement(name="strandCol", default=0, desc="Strand column (click box & select)", readonly=True, param=metadata.MetadataParameter, no_value=0, optional=True)
     MetadataElement(name="nameCol", desc="Name/Identifier column (click box & select)", readonly=True, param=metadata.MetadataParameter, no_value=0, optional=True)
     MetadataElement(name="columns", default=3, desc="Number of columns", readonly=True, visible=False)
 
@@ -1423,7 +1423,7 @@ class ENCODEPeak(Interval):
     MetadataElement(name="chromCol", default=1, desc="Chrom column", param=metadata.ColumnParameter)
     MetadataElement(name="startCol", default=2, desc="Start column", param=metadata.ColumnParameter)
     MetadataElement(name="endCol", default=3, desc="End column", param=metadata.ColumnParameter)
-    MetadataElement(name="strandCol", desc="Strand column (click box & select)", param=metadata.ColumnParameter, optional=True, no_value=0)
+    MetadataElement(name="strandCol", default=0, desc="Strand column (click box & select)", param=metadata.ColumnParameter, optional=True, no_value=0)
     MetadataElement(name="columns", default=3, desc="Number of columns", readonly=True, visible=False)
 
     def sniff(self, filename):

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -66,7 +66,7 @@ class Interval(Tabular):
     MetadataElement(name="chromCol", default=1, desc="Chrom column", param=metadata.ColumnParameter)
     MetadataElement(name="startCol", default=2, desc="Start column", param=metadata.ColumnParameter)
     MetadataElement(name="endCol", default=3, desc="End column", param=metadata.ColumnParameter)
-    MetadataElement(name="strandCol", desc="Strand column (click box & select)", param=metadata.ColumnParameter, optional=True, no_value=0)
+    MetadataElement(name="strandCol", default=0, desc="Strand column (click box & select)", param=metadata.ColumnParameter, optional=True, no_value=0)
     MetadataElement(name="nameCol", desc="Name/Identifier column (click box & select)", param=metadata.ColumnParameter, optional=True, no_value=0)
     MetadataElement(name="columns", default=3, desc="Number of columns", readonly=True, visible=False)
 
@@ -386,7 +386,7 @@ class Bed(Interval):
     MetadataElement(name="chromCol", default=1, desc="Chrom column", param=metadata.ColumnParameter)
     MetadataElement(name="startCol", default=2, desc="Start column", param=metadata.ColumnParameter)
     MetadataElement(name="endCol", default=3, desc="End column", param=metadata.ColumnParameter)
-    MetadataElement(name="strandCol", desc="Strand column (click box & select)", param=metadata.ColumnParameter, optional=True, no_value=0)
+    MetadataElement(name="strandCol", default=0, desc="Strand column (click box & select)", param=metadata.ColumnParameter, optional=True, no_value=0)
     MetadataElement(name="columns", default=3, desc="Number of columns", readonly=True, visible=False)
     MetadataElement(name="viz_filter_cols", desc="Score column for visualization", default=[4], param=metadata.ColumnParameter, optional=True, multiple=True)
     # do we need to repeat these? they are the same as should be inherited from interval type

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -347,7 +347,10 @@ class MetadataElementSpec:
                  visible=True, set_in_upload=False, **kwargs):
         self.name = name
         self.desc = desc or name
-        self.default = default
+        if default is None and no_value is not None:
+            self.default = no_value
+        else:
+            self.default = default
         self.no_value = no_value
         self.visible = visible
         self.set_in_upload = set_in_upload

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -347,10 +347,7 @@ class MetadataElementSpec:
                  visible=True, set_in_upload=False, **kwargs):
         self.name = name
         self.desc = desc or name
-        if default is None and no_value is not None:
-            self.default = no_value
-        else:
-            self.default = default
+        self.default = default
         self.no_value = no_value
         self.visible = visible
         self.set_in_upload = set_in_upload

--- a/test/functional/tools/metadata_bed.xml
+++ b/test/functional/tools/metadata_bed.xml
@@ -1,0 +1,28 @@
+<tool id="metadata_bed" name="BED metadata test" version="1.0.0">
+    <command>
+    <![CDATA[
+    echo "chromCol $input1.metadata.chromCol" > $out_file1 &&
+    echo "startCol $input1.metadata.startCol" >> $out_file1 &&
+    echo "endCol $input1.metadata.endCol" >> $out_file1 &&
+    echo "strandCol $input1.metadata.strandCol" >> $out_file1
+    ]]>
+    </command>
+    <inputs>
+        <param format="interval" name="input1" type="data" label="Choose intervals"/>
+    </inputs>
+    <outputs>
+        <data format="txt" name="out_file1"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="1.bed" ftype="bed"/>
+            <output name="out_file1">
+                <assert_contents>
+                    <has_text text="strandCol 6"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -57,6 +57,7 @@
   <tool file="metadata.xml" />
   <tool file="metadata_bam.xml" />
   <tool file="metadata_bcf.xml" />
+  <tool file="metadata_bed.xml" />
   <tool file="metadata_biom1.xml" />
   <tool file="metadata_column_names.xml" />
   <tool file="strict_shell.xml" />


### PR DESCRIPTION
broke in https://github.com/galaxyproject/galaxy/commit/7d0ec29fa06ae6f04c0ae6fc193a390bc11cddcd

this is also the reason that IUC's interval2maf is failing CI (the strand column is not set but the default)

... tried to add a unit test for this (which might be faster) but failed. 

seems that we are doing not the best job in testing all those `set_meta` functions :( 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
