### PR TITLE
Fix toolshed installation progress overview shows no status

### DIFF
--- a/client/src/components/Toolshed/InstalledList/Monitor.test.js
+++ b/client/src/components/Toolshed/InstalledList/Monitor.test.js
@@ -1,4 +1,5 @@
-import { createLocalVue, mount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import Monitor from "./Monitor";
 
 jest.mock("app");
@@ -33,16 +34,19 @@ Services.mockImplementation(() => {
 
 describe("Monitor", () => {
     it("test monitor", async () => {
-        const localVue = createLocalVue();
-        const wrapper = mount(Monitor, localVue);
+        const localVue = getLocalVue();
+        const wrapper = mount(Monitor, { localVue });
         await localVue.nextTick();
         const headers = wrapper.findAll("th");
-        expect(headers.length).toBe(2);
+        expect(headers.length).toBe(3);
         expect(headers.at(0).text()).toBe("Name");
         expect(headers.at(1).text()).toBe("Status");
+
         const cells = wrapper.findAll("td");
-        expect(cells.length).toBe(4);
+        expect(cells.length).toBe(6);
         expect(cells.at(0).text()).toBe("name_0 (owner_0)");
-        expect(cells.at(2).text()).toBe("name_1 (owner_1)");
+        expect(cells.at(1).text()).toContain("status_0_0");
+        expect(cells.at(3).text()).toBe("name_1 (owner_1)");
+        expect(cells.at(4).text()).toContain("status_1");
     });
 });

--- a/client/src/components/Toolshed/InstalledList/Monitor.vue
+++ b/client/src/components/Toolshed/InstalledList/Monitor.vue
@@ -15,6 +15,9 @@
                     <b-link @click="onQuery(row.item.name)"> {{ row.item.name }} ({{ row.item.owner }}) </b-link>
                 </template>
                 <template v-slot:cell(status)="row">
+                    <b>Status: </b><span>{{ row.item.status }}</span>
+                </template>
+                <template v-slot:cell(actions)="row">
                     <InstallationActions
                         class="float-right"
                         :status="row.item.status"
@@ -43,7 +46,7 @@ export default {
             loading: true,
             error: null,
             items: [],
-            fields: ["name", "status"],
+            fields: ["name", "status", "actions"],
         };
     },
     computed: {


### PR DESCRIPTION
fixes #14512

Toolshed Monitor now also displays Installation Status.

![image](https://user-images.githubusercontent.com/44241786/186882462-ee655ad2-f53b-4d48-af99-fd69142c091a.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
   1. Install a tool via the toolshed
   2. Click "Installed Only"
   3. Click "Show Installation Progress"
   4. Check for Installation Status

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
