### PR TITLE
[22.05]Fix absolute path generation util

### DIFF
--- a/client/src/utils/redirect.js
+++ b/client/src/utils/redirect.js
@@ -27,9 +27,11 @@ export function prependPath(path) {
  * @returns The absolute URL path.
  */
 export function absPath(path) {
-    const relativePath = hasRoot(path) ? path : prependPath(path);
+    // Root path here may be '/' or '/galaxy' for example.  we always append the
+    // base '/' and then clean up duplicates.
+    const relativePath = `/${hasRoot(path) ? path : prependPath(path)}`.replace(slashCleanup, "/");
     const server = window.location.origin;
-    return `${server}/${relativePath}`.replace(slashCleanup, "/");
+    return `${server}${relativePath}`;
 }
 
 /**


### PR DESCRIPTION
Just shifts slashcleanup to only the composed portion to avoid deduplicating '/' in protocol.

Issue reported by @nekrut on matrix; to test this use the dataset 'copy' function and note that before you'd get a url like:
```
https:/usegalaxy.org/api/datasets/f9cad7b01a4721358cfdfdaa2fac173c/display?to_ext=tabular
```

(note the single slash in `https:/`)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Try copying a dataset url with the link icon

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
