### PR TITLE
Fix double nested application when visualizing dataset (without scratchbook)

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -139,21 +139,11 @@ export default {
             this.$router.push(`/root?job_id=${this.item.creating_job}`);
         },
         onVisualize() {
-            const name = this.item.name || "";
-            const title = `Visualization of ${name}`;
-            const path = this.itemUrls.visualize;
-            const redirectParams = {
-                path: path,
-                title: title,
-                tryIframe: false,
-            };
-            if (!iframeAdd(redirectParams)) {
-                // We still use iframeAdd here to allow usage from within window
-                // manager, but it shouldn't actually *use* an iframe in the
-                // standard case (deferring to $router in the legacy routing handler).
-                // This should be refactored.
-                this.$router.push(path);
-            }
+            iframeAdd({
+                path: this.itemUrls.visualize,
+                title: `Visualization of ${this.item.name || ""}`,
+                $router: this.$router,
+            });
         },
         onHighlight() {
             this.$emit("toggleHighlights");

--- a/client/src/components/plugins/legacyNavigation.js
+++ b/client/src/components/plugins/legacyNavigation.js
@@ -45,18 +45,12 @@ export function redirect(path) {
     redirectToUrl(prependPath(path));
 }
 
-// arbitrary Galaxy wrapper
-export function useGalaxy(fn) {
-    return fn(getGalaxyInstance());
-}
-
 // wrapper for navigation to be used as mixin
 export const legacyNavigationMixin = {
     methods: {
         redirect,
         iframeAdd,
         iframeRedirect,
-        useGalaxy,
         prependPath,
     },
 };


### PR DESCRIPTION


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Click viz icon on dataset, observe that it doesn't embed center iframe.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
