### PR TITLE
[22.05] Fix post job action getting lost when node is made active

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
@@ -23,16 +23,15 @@ describe("FormDefault", () => {
                         nodes: [],
                     };
                 },
-                getNode: () => {
-                    return {
-                        name: "node-title",
-                        type: "subworkflow",
-                        outputs: outputs,
-                        activeOutputs: activeOutputs,
-                        config_form: {
-                            inputs: [],
-                        },
-                    };
+                nodeId: "id",
+                nodeContentId: "id",
+                nodeLabel: "label",
+                nodeName: "node-title",
+                nodeType: "subworkflow",
+                nodeOutputs: outputs,
+                nodeActiveOutputs: activeOutputs,
+                configForm: {
+                    inputs: [],
                 },
             },
             localVue,

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -1,5 +1,5 @@
 <template>
-    <FormCard :title="node.name" :icon="nodeIcon">
+    <FormCard :title="nodeName" :icon="nodeIcon">
         <template v-slot:operations>
             <b-button
                 v-if="isSubworkflow"
@@ -27,14 +27,14 @@
         <template v-slot:body>
             <FormElement
                 id="__label"
-                :value="node.label"
+                :value="nodeLabel"
                 title="Label"
                 help="Add a step label."
                 :error="errorLabel"
                 @input="onLabel" />
             <FormElement
                 id="__annotation"
-                :value="node.annotation"
+                :value="nodeAnnotation"
                 title="Step Annotation"
                 :area="true"
                 help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
@@ -42,10 +42,10 @@
             <FormDisplay :id="id" :inputs="inputs" @onChange="onChange" />
             <div v-if="isSubworkflow">
                 <FormOutputLabel
-                    v-for="(output, index) in node.outputs"
+                    v-for="(output, index) in nodeOutputs"
                     :key="index"
                     :name="output.name"
-                    :active-outputs="node.activeOutputs"
+                    :active-outputs="nodeActiveOutputs"
                     :show-details="true" />
             </div>
         </template>
@@ -68,6 +68,42 @@ export default {
         FormOutputLabel,
     },
     props: {
+        nodeName: {
+            type: String,
+            required: true,
+        },
+        nodeId: {
+            type: String,
+            required: true,
+        },
+        nodeContentId: {
+            type: String,
+            required: true,
+        },
+        nodeAnnotation: {
+            type: String,
+            required: false,
+        },
+        nodeLabel: {
+            type: String,
+            required: true,
+        },
+        nodeType: {
+            type: String,
+            required: true,
+        },
+        nodeActiveOutputs: {
+            type: Object,
+            required: true,
+        },
+        nodeOutputs: {
+            type: Array,
+            required: true,
+        },
+        configForm: {
+            type: Object,
+            required: true,
+        },
         datatypes: {
             type: Array,
             required: true,
@@ -76,43 +112,36 @@ export default {
             type: Function,
             required: true,
         },
-        getNode: {
-            type: Function,
-            required: true,
-        },
     },
     computed: {
-        node() {
-            return this.getNode();
-        },
         nodeIcon() {
-            return WorkflowIcons[this.node.type];
+            return WorkflowIcons[this.nodeType];
         },
         workflow() {
             return this.getManager();
         },
         id() {
-            return this.node.id;
+            return this.nodeId;
         },
         inputs() {
-            return this.node.config_form.inputs;
+            return this.configForm.inputs;
         },
         isSubworkflow() {
-            return this.node.type == "subworkflow";
+            return this.nodeType == "subworkflow";
         },
         errorLabel() {
-            return checkLabels(this.node.id, this.node.label, this.workflow.nodes);
+            return checkLabels(this.nodeId, this.nodeLabel, this.workflow.nodes);
         },
     },
     methods: {
         onAnnotation(newAnnotation) {
-            this.$emit("onAnnotation", this.node.id, newAnnotation);
+            this.$emit("onAnnotation", this.nodeId, newAnnotation);
         },
         onLabel(newLabel) {
-            this.$emit("onLabel", this.node.id, newLabel);
+            this.$emit("onLabel", this.nodeId, newLabel);
         },
         onEditSubworkflow() {
-            this.$emit("onEditSubworkflow", this.node.content_id);
+            this.$emit("onEditSubworkflow", this.nodeContentId);
         },
         onUpgradeSubworkflow() {
             this.$emit("onAttemptRefactor", [
@@ -120,10 +149,10 @@ export default {
             ]);
         },
         onChange(values) {
-            this.$emit("onSetData", this.node.id, {
-                id: this.node.id,
-                type: this.node.type,
-                content_id: this.node.content_id,
+            this.$emit("onSetData", this.nodeId, {
+                id: this.nodeId,
+                type: this.nodeType,
+                content_id: this.nodeContentId,
                 inputs: values,
             });
         },

--- a/client/src/components/Workflow/Editor/Forms/FormSection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormSection.vue
@@ -18,8 +18,8 @@
             v-for="(output, index) in outputs"
             :key="index"
             :output-name="output.name"
-            :active-outputs="node.activeOutputs"
-            :inputs="node.inputs"
+            :active-outputs="nodeActiveOutputs"
+            :inputs="nodeInputs"
             :datatypes="datatypes"
             :form-data="formData"
             @onInput="onInput"
@@ -41,12 +41,24 @@ export default {
             type: String,
             required: true,
         },
-        getNode: {
-            type: Function,
+        nodeInputs: {
+            type: Array,
+            required: true,
+        },
+        nodeOutputs: {
+            type: Array,
+            required: true,
+        },
+        nodeActiveOutputs: {
+            type: Object,
             required: true,
         },
         datatypes: {
             type: Array,
+            required: true,
+        },
+        postJobActions: {
+            type: Object,
             required: true,
         },
     },
@@ -56,14 +68,8 @@ export default {
         };
     },
     computed: {
-        node() {
-            return this.getNode();
-        },
-        postJobActions() {
-            return this.node.postJobActions;
-        },
         outputs() {
-            return this.node.outputs;
+            return this.nodeOutputs;
         },
         firstOutput() {
             return this.outputs.length > 0 && this.outputs[0];
@@ -87,6 +93,34 @@ export default {
     created() {
         this.setFormData();
     },
+    watch: {
+        formData() {
+            // The formData shape is kind of unfortunate, but it is what we have now.
+            // This should be a properly nested object whose values should be retrieved and set via a store
+            const postJobActions = {};
+            Object.entries(this.formData).forEach(([key, value]) => {
+                const [pja, outputName, actionType, name] = key.split("__", 4);
+                if (pja == "pja") {
+                    const pjaKey = `${actionType}${outputName}`;
+                    if (!postJobActions[pjaKey]) {
+                        postJobActions[pjaKey] = {
+                            action_type: actionType,
+                            output_name: outputName,
+                            action_arguments: {},
+                        };
+                    }
+                    if (name) {
+                        if (name == "output_name") {
+                            postJobActions[pjaKey]["output_name"] = value;
+                        } else {
+                            postJobActions[pjaKey]["action_arguments"][name] = value;
+                        }
+                    }
+                }
+            });
+            this.$emit("onChange", postJobActions);
+        },
+    },
     methods: {
         setFormData() {
             const pjas = {};
@@ -104,9 +138,8 @@ export default {
             if (pjas[this.emailPayloadKey]) {
                 pjas[this.emailActionKey] = true;
             }
-            this.formData = pjas;
             console.debug("FormSection - Setting new data.", this.postJobActions, pjas);
-            this.$emit("onChange", this.formData);
+            this.formData = pjas;
         },
         setEmailAction(pjas) {
             if (pjas[this.emailActionKey]) {
@@ -131,7 +164,6 @@ export default {
             this.setEmailAction(this.formData);
             if (changed) {
                 this.formData = Object.assign({}, this.formData);
-                this.$emit("onChange", this.formData);
             }
         },
         onDatatype(pjaKey, outputName, newDatatype) {

--- a/client/src/components/Workflow/Editor/Forms/FormTool.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.test.js
@@ -14,22 +14,22 @@ describe("FormTool", () => {
             propsData: {
                 id: "input",
                 datatypes: [],
-                getNode: () => {
-                    return {
-                        id: "id",
-                        config_form: {
-                            id: "tool_id+1.0",
-                            name: "tool_name",
-                            version: "1.0",
-                            description: "description",
-                            inputs: [],
-                            help: "help_text",
-                            versions: ["1.0", "2.0", "3.0"],
-                        },
-                        outputs: [],
-                        postJobActions: [],
-                    };
+                configForm: {
+                    id: "tool_id+1.0",
+                    name: "tool_name",
+                    version: "1.0",
+                    description: "description",
+                    inputs: [],
+                    help: "help_text",
+                    versions: ["1.0", "2.0", "3.0"],
                 },
+                nodeId: "id",
+                nodeAnnotation: "",
+                nodeLabel: "",
+                nodeInputs: [],
+                nodeOutputs: [],
+                nodeActiveOutputs: {},
+                postJobActions: {},
                 getManager: () => {
                     return {};
                 },
@@ -46,19 +46,16 @@ describe("FormTool", () => {
 
     it("check version change", async () => {
         const dropdowns = wrapper.findAll(".dropdown-item");
-        let state = wrapper.emitted().onSetData[0][1];
-        expect(state.tool_version).toEqual("1.0");
-        expect(state.tool_id).toEqual("tool_id+1.0");
         let version = dropdowns.at(3);
         expect(version.text()).toBe("Switch to 2.0");
         await version.trigger("click");
-        state = wrapper.emitted().onSetData[1][1];
+        let state = wrapper.emitted().onSetData[0][1];
         expect(state.tool_version).toEqual("2.0");
         expect(state.tool_id).toEqual("tool_id+2.0");
         version = dropdowns.at(2);
         expect(version.text()).toBe("Switch to 3.0");
         await version.trigger("click");
-        state = wrapper.emitted().onSetData[2][1];
+        state = wrapper.emitted().onSetData[1][1];
         expect(state.tool_version).toEqual("3.0");
         expect(state.tool_id).toEqual("tool_id+3.0");
     });

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -135,15 +135,31 @@
                                     v-if="hasActiveNodeTool"
                                     :key="activeNodeId"
                                     :get-manager="getManager"
-                                    :get-node="getNode"
+                                    :node-id="activeNodeId"
+                                    :node-annotation="activeNodeAnnotation"
+                                    :node-label="activeNodeLabel"
+                                    :node-inputs="activeNodeInputs"
+                                    :node-outputs="activeNodeOutputs"
+                                    :node-active-outputs="activeNodeActiveOutputs"
+                                    :config-form="activeNodeConfigForm"
                                     :datatypes="datatypes"
+                                    :post-job-actions="postJobActions"
+                                    @onChangePostJobActions="onChangePostJobActions"
                                     @onAnnotation="onAnnotation"
                                     @onLabel="onLabel"
                                     @onSetData="onSetData" />
                                 <FormDefault
                                     v-else-if="hasActiveNodeDefault"
+                                    :node-name="activeNodeName"
+                                    :node-id="activeNodeId"
+                                    :node-content-id="activeNodeContentId"
+                                    :node-annotation="activeNodeAnnotation"
+                                    :node-label="activeNodeLabel"
+                                    :node-type="activeNodeType"
+                                    :node-outputs="activeNodeOutputs"
+                                    :node-active-outputs="activeNodeActiveOutputs"
+                                    :config-form="activeNodeConfigForm"
                                     :get-manager="getManager"
-                                    :get-node="getNode"
                                     :datatypes="datatypes"
                                     @onAnnotation="onAnnotation"
                                     @onLabel="onLabel"
@@ -299,8 +315,38 @@ export default {
         showLint() {
             return this.showInPanel == "lint";
         },
+        postJobActions() {
+            return this.activeNode.postJobActions;
+        },
         activeNodeId() {
             return this.activeNode && this.activeNode.id;
+        },
+        activeNodeName() {
+            return this.activeNode?.name;
+        },
+        activeNodeContentId() {
+            return this.activeNode && this.activeNode.contentId;
+        },
+        activeNodeLabel() {
+            return this.activeNode?.label;
+        },
+        activeNodeAnnotation() {
+            return this.activeNode?.annotation;
+        },
+        activeNodeConfigForm() {
+            return this.activeNode?.config_form;
+        },
+        activeNodeInputs() {
+            return this.activeNode?.inputs;
+        },
+        activeNodeOutputs() {
+            return this.activeNode?.outputs;
+        },
+        activeNodeActiveOutputs() {
+            return this.activeNode?.activeOutputs;
+        },
+        activeNodeType() {
+            return this.activeNode?.type;
         },
         hasActiveNodeDefault() {
             return this.activeNode && this.activeNode.type != "tool";
@@ -435,6 +481,10 @@ export default {
         },
         onChange() {
             this.hasChanges = true;
+        },
+        onChangePostJobActions(nodeId, postJobActions) {
+            Vue.set(this.nodes[nodeId], "postJobActions", postJobActions);
+            this.onChange();
         },
         onRemove(node) {
             delete this.nodes[node.id];

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -140,11 +140,12 @@ export default {
     data() {
         return {
             popoverShow: false,
-            node: null,
             inputs: [],
             outputs: [],
             inputTerminals: {},
             outputTerminals: {},
+            postJobActions: {},
+            activeOutputs: null,
             errors: null,
             label: null,
             annotation: null,
@@ -321,7 +322,9 @@ export default {
             const outputNames = this.outputs.map((output) => output.name);
             this.activeOutputs.initialize(this.outputs, data.workflow_outputs);
             this.activeOutputs.filterOutputs(outputNames);
-            this.postJobActions = data.post_job_actions || {};
+            // data coming from the workflow editor API has post job actions,
+            // data coming from the build_module call does not (and should not)
+            this.postJobActions = data.post_job_actions || this.postJobActions;
             this.config_form = data.config_form;
         },
         initData(data) {

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -80,6 +80,9 @@ export default {
             }
             return extensions;
         },
+        effectiveOutput() {
+            return { ...this.output, extensions: this.extensions };
+        },
     },
     watch: {
         label() {
@@ -88,10 +91,10 @@ export default {
                 this.$emit("onChange");
             });
         },
-        output(newOutput) {
+        effectiveOutput(newOutput) {
             const oldTerminal = this.terminal;
             if (oldTerminal instanceof this.terminalClassForOutput(newOutput)) {
-                oldTerminal.update({ ...newOutput, extensions: this.extensions });
+                oldTerminal.update(newOutput);
                 oldTerminal.destroyInvalidConnections();
             } else {
                 // create new terminal, connect like old terminal, destroy old terminal

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -670,7 +670,6 @@ class WorkflowsAPIController(
             "inputs": module.get_all_inputs(connectable_only=True),
             "outputs": module.get_all_outputs(),
             "config_form": module.get_config_form(),
-            "post_job_actions": module.get_post_job_actions(inputs),
         }
 
     @expose_api

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -558,6 +558,31 @@ steps:
         editor.node.output_data_row(output_name="out_file1", extension="bam").wait_for_visible()
         self.assert_not_connected("create_2#out_file1", "checksum#input")
 
+    @selenium_test
+    def test_change_datatype_post_job_action_lost_regression(self):
+        self.open_in_workflow_editor(
+            """
+class: GalaxyWorkflow
+inputs: []
+steps:
+  - tool_id: create_2
+    label: create_2
+    outputs:
+      out_file1:
+        change_datatype: bam
+  - tool_id: metadata_bam
+    label: metadata_bam
+    in:
+      input_bam: create_2/out_file1
+"""
+        )
+        self.assert_connected("create_2#out_file1", "metadata_bam#input_bam")
+        editor = self.components.workflow_editor
+        node = editor.node._(label="create_2")
+        node.wait_for_and_click()
+        self.assert_connected("create_2#out_file1", "metadata_bam#input_bam")
+
+    @selenium_test
     def test_change_datatype_in_subworkflow(self):
         self.open_in_workflow_editor(
             """


### PR DESCRIPTION
And many more reactivity fixes.

The core of the issue was that the FormElement would emit a `onUpdate`
event, which triggers a request to `api/workflows/build_module`.
The FormSection that controls the post job action data is not ready at
this point, so when the data comes back in we have to break the
connection because the post job action that sets the datatype is
missing.

We really don't need to call `build_module` though when changing post job
actions, they don't require the backend at all, we just need to bubble
them up to the Index component, which can set the postJobAction on the
active node (let's ignore that we should manipulate the data, not the vue instance
...).

In order for that to be properly reactive I had to remove the majority
of the getNode hacks.

We do still rely on this in the Terminals and Connectors, so those can
get out of sync still, but it fixes an annoying issue where connections
are dropped without notice.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
