### PR TITLE
Implement keyedColorScheme for all tags, not only nametags

### DIFF
--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -24,20 +24,20 @@ function TagModel(props = {}) {
     Object.defineProperty(this, "style", {
         enumerable: true,
         get: function () {
+            const { primary, contrasting, darker } = keyedColorScheme(this.text);
+
+            const styles = {
+                "background-color": primary,
+                color: contrasting,
+                "border-color": darker,
+            };
             if (this.text.startsWith("name:")) {
-                const { primary, contrasting, darker } = keyedColorScheme(this.text);
-
-                const styles = {
-                    "background-color": primary,
-                    color: contrasting,
-                    "border-color": darker,
-                };
-
-                return Object.keys(styles)
-                    .map((prop) => `${prop}: ${styles[prop]}`)
-                    .join(";");
+                styles["font-weight"] = "bold";
             }
-            return "";
+
+            return Object.keys(styles)
+                .map((prop) => `${prop}: ${styles[prop]}`)
+                .join(";");
         },
     });
 


### PR DESCRIPTION
As discussed in [UI/UX meeting](https://docs.google.com/document/d/12JyHIrv256tveJoXJaUvbpaWr_S4SqYcZuzM5Rfi_5Y) (08/30/2022): 
Currently, nametags have unique colored styles through a `keyedColorScheme`, whereas, non-nametags are the same color. Changed it so all tags have a `keyedColorScheme`, except **nametags are bold for differentiation**:
| **Before** | **After** |
| ----------- | ----------- |
| ![Screen Shot 2022-08-30 at 8 57 50 PM](https://user-images.githubusercontent.com/78516064/187570392-ae8d7e43-0b3b-483e-8daf-7b29993a894c.png) | ![Screen Shot 2022-08-30 at 8 58 26 PM](https://user-images.githubusercontent.com/78516064/187570412-630eeb58-ebfd-447b-814a-e04a16e4a70e.png) |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
