### PR TITLE
Allow changing type of regex rule in RBU

### DIFF
--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -1148,6 +1148,13 @@ export default {
                 this.addColumnRegexReplacement = null;
             }
         },
+        addColumnRegexGroupCount: function (oldVal, newVal) {
+            if (oldVal != newVal) {
+                if (newVal < 1) {
+                    this.addColumnRegexGroupCount = 1;
+                }
+            }
+        },
     },
     created() {
         if (this.elementsType !== "collection_contents") {

--- a/client/src/mvc/rules/rule-definitions.js
+++ b/client/src/mvc/rules/rule-definitions.js
@@ -272,10 +272,10 @@ const RULES = {
             } else if (component.addColumnRegexType == "groups" && component.addColumnRegexGroupCount) {
                 rule.group_count = parseInt(component.addColumnRegexGroupCount);
                 rule.replacement = null;
-            } else if (component.addColumnRegexType == "global"){
+            } else if (component.addColumnRegexType == "global") {
                 rule.replacement = null;
                 rule.group_count = null;
-            };
+            }
         },
         apply: (rule, data, sources, columns) => {
             const target = rule.target_column;

--- a/client/src/mvc/rules/rule-definitions.js
+++ b/client/src/mvc/rules/rule-definitions.js
@@ -266,12 +266,16 @@ const RULES = {
         save: (component, rule) => {
             rule.target_column = component.addColumnRegexTarget;
             rule.expression = component.addColumnRegexExpression;
-            if (component.addColumnRegexReplacement) {
+            if (component.addColumnRegexType == "replacement" && component.addColumnRegexReplacement) {
                 rule.replacement = component.addColumnRegexReplacement;
-            }
-            if (component.addColumnRegexGroupCount) {
+                rule.group_count = null;
+            } else if (component.addColumnRegexType == "groups" && component.addColumnRegexGroupCount) {
                 rule.group_count = parseInt(component.addColumnRegexGroupCount);
-            }
+                rule.replacement = null;
+            } else if (component.addColumnRegexType == "global"){
+                rule.replacement = null;
+                rule.group_count = null;
+            };
         },
         apply: (rule, data, sources, columns) => {
             const target = rule.target_column;


### PR DESCRIPTION
#13190 

Adding conditionals when changing type of regex rule, and nullifying unneccesary attributes. 

Also, while testing this issue to determine the cause, I noticed that you could *fix* the issue by selecting the groups option and typing in 0. That prompted me to test for negative numbers as well, and it allowed me to create -8 groups, so I figured I'd throw in a quick validation that prevents that from happening. This just takes any negative number or 0 and turns it into a 1. 


(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Open the Rule Builder
  2. Column > Using a Regular Expression
  3. Choose a regex type and fill in the form in a way that is acceptable to the Rule Builder (no errors when applying)
  4. Click Edit button
  5. Without changing the column or regex string, change the type of regex (radial button)
  6. See that the rule change takes effect in the table
  7. Click Edit button again
  8. Note that the Editor places you back in the regex type that you'd previously selected
  

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
