### PR TITLE
Request extended details when modifying history attributes

### DIFF
--- a/client/src/store/historyStore/model/queries.js
+++ b/client/src/store/historyStore/model/queries.js
@@ -128,7 +128,7 @@ export async function deleteHistoryById(id, purge = false) {
  */
 export async function updateHistoryFields(id, payload) {
     const url = `api/histories/${id}`;
-    const response = await axios.put(prependPath(url), payload, { params: stdHistoryParams });
+    const response = await axios.put(prependPath(url), payload, { params: extendedHistoryParams });
     const props = doResponse(response);
     return new History(props);
 }


### PR DESCRIPTION
Fixes #14465. This PR requests extended parameters when the history name, annotation or tags (i.e. history attributes) change to quickly update the UI. This is better then waiting for an update which can lead to delays. An alternative would be to modify `setHistory` operations such that it combines existing details with newly received details but this might lead to other unforeseen issues and complexity. For now the cleanest solution seems to be to just request the correct attributes. This has no performance consequences since this extended request is only done once and only when the user manually edits history attributes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
