### PR TITLE
Include HID count in quick history menu switcher

### DIFF
--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -6,6 +6,7 @@
 
         <b-table
             striped
+            no-sort-reset
             hover
             sticky-header="50vh"
             primary-key="id"
@@ -24,6 +25,10 @@
             @filtered="onFiltered">
             <template v-slot:cell(tags)="row">
                 <stateless-tags :value="row.item.tags" :disabled="true" />
+            </template>
+            <template v-slot:cell(published)="data">
+                <span v-if="data.value" class="fa fa-check text-success" />
+                <span v-else class="fa fa-times text-danger" />
             </template>
             <template v-slot:cell(update_time)="data">
                 <UtcDate :date="data.value" mode="elapsed" />
@@ -84,6 +89,8 @@ export default {
         this.fields = [
             { key: "name", sortable: true },
             { key: "tags", sortable: true },
+            { key: "count", label: "Length", sortable: true },
+            { key: "published", sortable: false },
             { key: "update_time", label: "Updated", sortable: true },
         ];
     },

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -6,7 +6,6 @@
 
         <b-table
             striped
-            no-sort-reset
             hover
             sticky-header="50vh"
             primary-key="id"
@@ -25,10 +24,6 @@
             @filtered="onFiltered">
             <template v-slot:cell(tags)="row">
                 <stateless-tags :value="row.item.tags" :disabled="true" />
-            </template>
-            <template v-slot:cell(published)="data">
-                <span v-if="data.value" class="fa fa-check text-success" />
-                <span v-else class="fa fa-times text-danger" />
             </template>
             <template v-slot:cell(update_time)="data">
                 <UtcDate :date="data.value" mode="elapsed" />
@@ -89,8 +84,7 @@ export default {
         this.fields = [
             { key: "name", sortable: true },
             { key: "tags", sortable: true },
-            { key: "count", label: "Length", sortable: true },
-            { key: "published", sortable: false },
+            { key: "count", label: "Items", sortable: true },
             { key: "update_time", label: "Updated", sortable: true },
         ];
     },

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -427,7 +427,7 @@ class HistorySerializer(sharable.SharableModelSerializer, deletable.PurgableSeri
                 "name",
                 "deleted",
                 "purged",
-                # 'count'
+                "count",
                 "url",
                 # TODO: why these?
                 "published",

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2595,6 +2595,10 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     @property
     def empty(self):
         return self.hid_counter is None or self.hid_counter == 1
+    
+    @property
+    def count(self):
+        return self.hid_counter-1
 
     def add_pending_items(self, set_output_hid=True):
         # These are assumed to be either copies of existing datasets or new, empty datasets,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2595,10 +2595,10 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
     @property
     def empty(self):
         return self.hid_counter is None or self.hid_counter == 1
-    
+
     @property
     def count(self):
-        return self.hid_counter-1
+        return self.hid_counter - 1
 
     def add_pending_items(self, set_output_hid=True):
         # These are assumed to be either copies of existing datasets or new, empty datasets,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -925,6 +925,11 @@ class HistorySummary(HistoryBase):
         title="Published",
         description="Whether this resource is currently publicly available to all users.",
     )
+    count: int = Field(
+        ...,
+        title="Count",
+        description="The number of items in the history.",
+    )
     annotation: Optional[str] = AnnotationField
     tags: TagCollection
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14545. 
![image](https://user-images.githubusercontent.com/78516064/187940231-a35726b5-a606-4ccd-b7f9-431b5804cecb.png)

## Preventing overload of information for the user (possible additions/changes):
> OTOH I think it's also important we don't overload the user with information.

> I would second that. The purpose is that its a __fast history__ selector and adding information and cluttering the user interface is imho counter-productive for the intended use.
If a user can not choose a correct history we should nudge them to tag/name their histories better and also provide a way - from that widget - to get to the more complicated, more enriched history list view.

_Originally posted by @bgruening in https://github.com/galaxyproject/galaxy/issues/14545#issuecomment-1233234051_

Taking these recommendations into consideration: another option we could explore is to:
- add a link to the comprehensive history list on the bottom left of the modal (_also provide a way - from that widget - to get to the more complicated, more enriched history list view_)

**as shown below:**
![image](https://user-images.githubusercontent.com/78516064/187751841-13c92ae4-8c79-492b-bc36-c8b23d3c98db.png)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
