### PR TITLE
More API tests for the tool shed.

### DIFF
--- a/lib/tool_shed/test/functional/test_galaxy_install.py
+++ b/lib/tool_shed/test/functional/test_galaxy_install.py
@@ -15,3 +15,19 @@ class ShedGalaxyInstallApiTestCase(ShedApiTestCase):
         expected_tool = f"{self.host}:{self.port}/repos/{owner}/{name}/Add_a_column1/1.1.0"
         tool_ids = [t["id"] for t in response.json()]
         assert expected_tool in tool_ids, f"Didn't find {expected_tool} in {tool_ids}"
+
+    def test_install_simple_after_repository_metadata_reset(self):
+        populator = self.populator
+        repository = populator.setup_column_maker_repo(prefix="repoformetadata")
+        owner = repository.owner
+        name = repository.name
+        installable_revisions = populator.get_ordered_installable_revisions(owner, name)
+        latest_install_revision = installable_revisions.__root__[-1]
+        metadata_response = populator.reset_metadata(repository)
+        assert metadata_response.status == "ok"
+        self.install_repository(owner, name, latest_install_revision, tool_shed_url=self.url)
+        response = self.galaxy_interactor._get("tools?in_panel=False")
+        response.raise_for_status()
+        expected_tool = f"{self.host}:{self.port}/repos/{owner}/{name}/Add_a_column1/1.1.0"
+        tool_ids = [t["id"] for t in response.json()]
+        assert expected_tool in tool_ids, f"Didn't find {expected_tool} in {tool_ids}"

--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -76,3 +76,18 @@ class ShedRepositoriesApiTestCase(ShedApiTestCase):
         assert repository.name
         revisions = populator.get_ordered_installable_revisions(repository.owner, repository.name)
         assert len(revisions.__root__) == 1
+
+    def test_reset_on_repository(self):
+        populator = self.populator
+        repository = populator.setup_column_maker_repo(prefix="repoforreseta")
+        assert repository.owner
+        assert repository.name
+        revisions = populator.get_ordered_installable_revisions(repository.owner, repository.name)
+        assert len(revisions.__root__) == 1
+        metadata_response = populator.reset_metadata(repository)
+        assert metadata_response.start_time
+        assert metadata_response.stop_time
+        assert metadata_response.status == "ok"
+        assert len(metadata_response.repository_status) == 1
+        revisions = populator.get_ordered_installable_revisions(repository.owner, repository.name)
+        assert len(revisions.__root__) == 1

--- a/lib/tool_shed/webapp/api/repositories.py
+++ b/lib/tool_shed/webapp/api/repositories.py
@@ -659,7 +659,7 @@ class RepositoriesController(BaseAPIController):
     @web.legacy_expose_api
     def reset_metadata_on_repository(self, trans, payload, **kwd):
         """
-        PUT /api/repositories/reset_metadata_on_repository
+        POST /api/repositories/reset_metadata_on_repository
 
         Resets all metadata on a specified repository in the Tool Shed.
 

--- a/lib/tool_shed_client/schema/__init__.py
+++ b/lib/tool_shed_client/schema/__init__.py
@@ -25,6 +25,11 @@ class FailedRepositoryUpdateMessage(BaseModel):
     err_msg: str
 
 
+class GetOrderedInstallableRevisionsRequest(BaseModel):
+    name: str
+    owner: str
+
+
 class OrderedInstallableRevisions(BaseModel):
     __root__: List[str]
 
@@ -35,3 +40,14 @@ class RepositoryUpdate(BaseModel):
     @property
     def is_ok(self):
         return isinstance(self.__root__, ValidRepostiroyUpdateMessage)
+
+
+class ResetMetadataOnRepositoryRequest(BaseModel):
+    repository_id: str
+
+
+class ResetMetadataOnRepositoryResponse(BaseModel):
+    status: str  # TODO: enum...
+    repository_status: List[str]
+    start_time: str
+    stop_time: str


### PR DESCRIPTION
Continue working toward a set of pydantic models to rapidly move toward FastAPI/OpenAPI also.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
