### PR TITLE
Remove no longer useful API endpoint in the toolshed.

### DIFF
--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -5,10 +5,9 @@ from ..base.api import ShedApiTestCase
 COLUMN_MAKER_PATH = resource_path(__package__, "../test_data/column_maker/column_maker.tar")
 
 
-# Things seemingly not used by Galaxy, Planemo, or Ephemeris...
+# Things seemingly *NOT* used by Galaxy, Planemo, or Ephemeris...
 #   (perhaps we can delete instead of test?)...
 # - reset_metadata_on_repository
-# - repository_ids_for_setting_metadata
 # - reset_metadata_on_repositories
 # - remove_repository_registry_entry
 # - get_repository_revision_install_info

--- a/lib/tool_shed/webapp/api/repositories.py
+++ b/lib/tool_shed/webapp/api/repositories.py
@@ -528,37 +528,6 @@ class RepositoriesController(BaseAPIController):
         return response_dict
 
     @web.legacy_expose_api
-    def repository_ids_for_setting_metadata(self, trans, my_writable=False, **kwd):
-        """
-        GET /api/repository_ids_for_setting_metadata
-
-        Displays a collection (list) of repository ids ordered for setting metadata.
-
-        :param key: the API key of the Tool Shed user.
-        :param my_writable (optional): if the API key is associated with an admin user in the Tool Shed, setting this param value
-                                       to True will restrict resetting metadata to only repositories that are writable by the user
-                                       in addition to those repositories of type tool_dependency_definition.  This param is ignored
-                                       if the current user is not an admin user, in which case this same restriction is automatic.
-        """
-        if trans.user_is_admin:
-            my_writable = util.asbool(my_writable)
-        else:
-            my_writable = True
-        handled_repository_ids = []
-        repository_ids = []
-        rmm = repository_metadata_manager.RepositoryMetadataManager(self.app, trans.user)
-        query = rmm.get_query_for_setting_metadata_on_repositories(my_writable=my_writable, order=False)
-        # Make sure repositories of type tool_dependency_definition are first in the list.
-        for repository in query:
-            if repository.type == rt_util.TOOL_DEPENDENCY_DEFINITION and repository.id not in handled_repository_ids:
-                repository_ids.append(trans.security.encode_id(repository.id))
-        # Now add all remaining repositories to the list.
-        for repository in query:
-            if repository.type != rt_util.TOOL_DEPENDENCY_DEFINITION and repository.id not in handled_repository_ids:
-                repository_ids.append(trans.security.encode_id(repository.id))
-        return repository_ids
-
-    @web.legacy_expose_api
     def reset_metadata_on_repositories(self, trans, payload, **kwd):
         """
         PUT /api/repositories/reset_metadata_on_repositories

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -142,7 +142,6 @@ def app_pair(global_conf, load_app_kwds=None, **kwargs):
             "get_ordered_installable_revisions": "GET",
             "get_installable_revisions": "GET",
             "remove_repository_registry_entry": "POST",
-            "repository_ids_for_setting_metadata": "GET",
             "reset_metadata_on_repositories": "POST",
             "reset_metadata_on_repository": "POST",
         },


### PR DESCRIPTION
Was added in https://github.com/galaxyproject/galaxy/commit/c90c0e503b362f838ca4b39cb8c52228befca436 to control the order reset happens in when doing that in batch, but that underlying API does that now the corresponding script has been simplified.

## How to test the changes?

- [x] Instructions for manual testing are as follows:
  1. I think it is sufficient that existing tests pass since I don't think we want this functionality, but there is no way to test the PR per se.
 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
