### PR TITLE
Use active attribute for some dropdown menus

### DIFF
--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -40,7 +40,8 @@
                 :href="formatUrl(item.url)"
                 :target="item.target || '_parent'"
                 role="menuitem"
-                :disabled="item.disabled === true"
+                :active="item.disabled"
+                :disabled="item.disabled"
                 @click="open(item, $event)">
                 {{ item.title }}
             </b-dropdown-item>

--- a/client/src/components/Panels/Buttons/PanelViewMenuItem.vue
+++ b/client/src/components/Panels/Buttons/PanelViewMenuItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <b-dropdown-item :data-panel-id="panelView.id" :disabled="isSelected" @click="onClick">
+    <b-dropdown-item :data-panel-id="panelView.id" :active="isSelected" @click="onClick">
         <span :class="['fa', `fa-${icon}`]" fixed-width />
         <span v-localize class="ml-1" :title="title">{{ name }}</span>
     </b-dropdown-item>

--- a/client/src/style/scss/overrides.scss
+++ b/client/src/style/scss/overrides.scss
@@ -199,7 +199,7 @@ table.info_data_table th:nth-child(1) {
         cursor: default;
 
         // differentiate disabled items more
-        color: #bfc7cf;
+        color: lighten($text-color, 50%);
     }
 
     .dropdown-item.active {

--- a/client/src/style/scss/overrides.scss
+++ b/client/src/style/scss/overrides.scss
@@ -201,4 +201,10 @@ table.info_data_table th:nth-child(1) {
         // differentiate disabled items more
         color: #bfc7cf !important;
     }
+
+    .dropdown-item.active {
+        background-color: unset;
+        color: $brand-primary !important;
+        font-weight: 600;
+    }
 }

--- a/client/src/style/scss/overrides.scss
+++ b/client/src/style/scss/overrides.scss
@@ -199,12 +199,12 @@ table.info_data_table th:nth-child(1) {
         cursor: default;
 
         // differentiate disabled items more
-        color: #bfc7cf !important;
+        color: #bfc7cf;
     }
 
     .dropdown-item.active {
         background-color: unset;
-        color: $brand-primary !important;
+        color: $brand-primary;
         font-weight: 600;
     }
 }

--- a/client/src/style/scss/unsorted.scss
+++ b/client/src/style/scss/unsorted.scss
@@ -569,11 +569,6 @@ div.popmenu-wrapper {
         float: none;
     }
 }
-.dropdown-menu {
-    .dropdown-item.disabled {
-        color: $text-light;
-    }
-}
 
 .popup-arrow {
     cursor: pointer;


### PR DESCRIPTION
Some dropdown menus make use of the `disabled` attribute for items which are not disabled menu items, but selected items, or simply text sections. This PR changes these items to use the `active`attribute, to better tell them apart from actually disabled menu items.

| With `disabled` | With `active` or `active disabled` |
|--|--|
| ![image](https://user-images.githubusercontent.com/44241786/187910571-16827132-8deb-4d02-872b-4b5a29d36f44.png) | ![image](https://user-images.githubusercontent.com/44241786/187910066-280989f9-1018-4bdd-ac9f-abb0660df16c.png) |
| ![image](https://user-images.githubusercontent.com/44241786/187910648-cecf4fd8-0eec-468d-8be8-0fc3e50cb117.png) | ![image](https://user-images.githubusercontent.com/44241786/187910225-136c402a-e720-414e-a50a-15116023cf92.png) |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
