### PR TITLE
Remove broken tool shed API endpoint.

### DIFF
--- a/lib/tool_shed/webapp/api/tools.py
+++ b/lib/tool_shed/webapp/api/tools.py
@@ -7,19 +7,8 @@ from galaxy import (
     util,
     web,
 )
-from galaxy.tools.parameters import params_to_strings
-from galaxy.tools.repositories import ValidationContext
 from galaxy.web import expose_api_raw_anonymous_and_sessionless
 from galaxy.webapps.base.controller import BaseAPIController
-from tool_shed.dependencies.repository import relation_builder
-from tool_shed.tools import tool_validator
-from tool_shed.util import (
-    common_util,
-    metadata_util,
-    repository_util,
-    shed_util_common as suc,
-)
-from tool_shed.utility_containers import ToolShedUtilityContainerManager
 from tool_shed.webapp.search.tool_search import ToolSearch
 
 log = logging.getLogger(__name__)
@@ -114,79 +103,3 @@ class ToolsController(BaseAPIController):
         results = tool_search.search(trans, search_term, page, page_size, boosts)
         results["hostname"] = web.url_for("/", qualified=True)
         return results
-
-    @expose_api_raw_anonymous_and_sessionless
-    def json(self, trans, **kwd):
-        """
-        GET /api/tools/json
-
-        Get the tool form JSON for a tool in a repository.
-
-        :param guid:          the GUID of the tool
-        :param guid:          str
-
-        :param tsr_id:        the ID of the repository
-        :param tsr_id:        str
-
-        :param changeset:     the changeset at which to load the tool json
-        :param changeset:     str
-        """
-        guid = kwd.get("guid", None)
-        tsr_id = kwd.get("tsr_id", None)
-        changeset = kwd.get("changeset", None)
-        if None in [changeset, tsr_id, guid]:
-            message = "Changeset, repository ID, and tool GUID are all required parameters."
-            trans.response.status = 400
-            return {"status": "error", "message": message}
-        tsucm = ToolShedUtilityContainerManager(trans.app)
-        repository = repository_util.get_repository_in_tool_shed(self.app, tsr_id)
-        repository_clone_url = common_util.generate_clone_url_for_repository_in_tool_shed(repository.user, repository)
-        repository_metadata = metadata_util.get_repository_metadata_by_changeset_revision(trans.app, tsr_id, changeset)
-        toolshed_base_url = str(web.url_for("/", qualified=True)).rstrip("/")
-        rb = relation_builder.RelationBuilder(trans.app, repository, repository_metadata, toolshed_base_url)
-        repository_dependencies = rb.get_repository_dependencies_for_changeset_revision()
-        containers_dict = tsucm.build_repository_containers(
-            repository, changeset, repository_dependencies, repository_metadata
-        )
-        found_tool = None
-        for folder in containers_dict["valid_tools"].folders:
-            if hasattr(folder, "valid_tools"):
-                for tool in folder.valid_tools:
-                    tool.id = tool.tool_id
-                    tool_guid = suc.generate_tool_guid(repository_clone_url, tool)
-                    if tool_guid == guid:
-                        found_tool = tool
-                        break
-        if found_tool is None:
-            message = f"Unable to find tool with guid {guid} in repository {repository.name}."
-            trans.response.status = 404
-            return {"status": "error", "message": message}
-
-        with ValidationContext.from_app(trans.app) as validation_context:
-            tv = tool_validator.ToolValidator(validation_context)
-            repository, tool, valid, message = tv.load_tool_from_changeset_revision(
-                tsr_id, changeset, found_tool.tool_config
-            )
-        if message or not valid:
-            status = "error"
-            return dict(message=message, status=status)
-        tool_help = ""
-        if tool.help:
-            tool_help = tool.help.render(static_path=web.url_for("/static"), host_url=web.url_for("/", qualified=True))
-            tool_help = util.unicodify(tool_help, "utf-8")
-        tool_dict = tool.to_dict(trans)
-        tool_dict["inputs"] = {}
-        tool.populate_model(trans, tool.inputs, {}, tool_dict["inputs"])
-        tool_dict.update(
-            {
-                "help": tool_help,
-                "citations": bool(tool.citations),
-                "requirements": [{"name": r.name, "version": r.version} for r in tool.requirements],
-                "state_inputs": params_to_strings(tool.inputs, {}, trans.app),
-                "display": tool.display_interface,
-                "action": web.url_for(tool.action),
-                "method": tool.method,
-                "enctype": tool.enctype,
-            }
-        )
-        return json.dumps(tool_dict)


### PR DESCRIPTION
It has been broken since https://github.com/galaxyproject/galaxy/commit/5ecec9514a7c4f46fa2af1008ef39d9c1567daf9.

I like the idea of an API endpoint you can get a tool ID to and get this sort of information - but this is broken and we should just get rid of it.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Good luck 😅 - it is broken and it took a while for me to verify.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
