### PR TITLE
[22.05] Fix workflow parameter connectability

### DIFF
--- a/client/src/components/Workflow/Editor/modules/terminals.js
+++ b/client/src/components/Workflow/Editor/modules/terminals.js
@@ -333,6 +333,11 @@ class BaseInputTerminal extends Terminal {
     }
     _producesAcceptableDatatype(other) {
         // other is a non-collection output...
+
+        if (other instanceof OutputParameterTerminal) {
+            return new ConnectionAcceptable(false, "Cannot connect workflow parameter to data input.");
+        }
+
         for (const t in this.datatypes) {
             const thisDatatype = this.datatypes[t];
             if (thisDatatype == "input") {

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -241,6 +241,9 @@ steps:
     label: tool_exec
     in:
       inttest: input_int
+  cat1:
+    # regression test, ensures connecting works in the presence of data input terminals
+    tool_id: cat1
 """
         )
         self.screenshot("workflow_editor_parameter_connection_simple")


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/14473/commits/18e4c007efc6b0e6b539063ede801aea094ba851 simplified the can_accept_datatype logic a bit, but failed for workflow parameters where we don't actually have any `datatypes`. This fixes the bug, is more explicit and also also provides a better message to the user.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
