### PR TITLE
Don't query the database when running migrations in offline mode

### DIFF
--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -1,6 +1,9 @@
 import logging
 
-from alembic import op
+from alembic import (
+    context,
+    op,
+)
 from sqlalchemy import inspect
 
 log = logging.getLogger(__name__)
@@ -12,7 +15,19 @@ def drop_column(table_name, column_name):
 
 
 def column_exists(table_name, column_name):
+    if is_offline_mode():
+        msg = (
+            "This script is being executed in offline mode and cannot connect to the database. "
+            f"Therefore, `column_exists({table_name}, {column_name})` returns `False` by default."
+        )
+        log.debug(msg)
+        return False
     bind = op.get_context().bind
     insp = inspect(bind)
     columns = insp.get_columns(table_name)
     return any(c["name"] == column_name for c in columns)
+
+
+def is_offline_mode():
+    cmd_opts = context.config.cmd_opts
+    return cmd_opts and cmd_opts.sql


### PR DESCRIPTION
When using the migration script, there is an option to run the migrations in offline mode (`--sql`), which will display the generated SQL without connecting to the database. In this mode, there is no connection to the database. As a result, any code relying on a connection will raise an error. This PR fixes one such case.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Downgrade to `e7b6dcb09efd`
  2. `./scripts/run_alembic.sh upgrade heads --sql` (this will trigger this helper)
  3. Observe no error. Prior to this fix, the error would happen.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
