### PR TITLE
Fix ``output_action_change_format`` framework tests

### DIFF
--- a/lib/galaxy/tool_util/parser/output_actions.py
+++ b/lib/galaxy/tool_util/parser/output_actions.py
@@ -31,7 +31,7 @@ class ToolOutputActionGroup:
                 else:
                     log.debug(f"Unknown ToolOutputAction tag specified: {elem.tag}")
 
-    def apply_action(self, output_dataset, other_values):
+    def apply_action(self, output_dataset, other_values) -> None:
         for action in self.actions:
             action.apply_action(output_dataset, other_values)
 
@@ -62,26 +62,26 @@ class ToolOutputActionConditionalWhen(ToolOutputActionGroup):
         super().__init__(parent, config_elem)
         self.value = value
 
-    def is_case(self, output_dataset, other_values):
+    def is_case(self, other_values):
         raise TypeError("Not implemented")
 
-    def get_ref(self, output_dataset, other_values):
+    def get_ref(self, other_values):
         ref = other_values
         for ref_name in self.parent.name:
             assert ref_name in ref, f"Required dependency '{ref_name}' not found in incoming values"
             ref = ref.get(ref_name)
         return ref
 
-    def apply_action(self, output_dataset, other_values):
-        if self.is_case(output_dataset, other_values):
-            return super().apply_action(output_dataset, other_values)
+    def apply_action(self, output_dataset, other_values) -> None:
+        if self.is_case(other_values):
+            super().apply_action(output_dataset, other_values)
 
 
 class ValueToolOutputActionConditionalWhen(ToolOutputActionConditionalWhen):
     tag = "when value"
 
-    def is_case(self, output_dataset, other_values):
-        ref = self.get_ref(output_dataset, other_values)
+    def is_case(self, other_values) -> bool:
+        ref = self.get_ref(other_values)
         return ref == self.value
 
 
@@ -92,8 +92,8 @@ class DatatypeIsInstanceToolOutputActionConditionalWhen(ToolOutputActionConditio
         super().__init__(parent, config_elem, value)
         self.value = type(self.tool.app.datatypes_registry.get_datatype_by_extension(value))
 
-    def is_case(self, output_dataset, other_values):
-        ref = self.get_ref(output_dataset, other_values)
+    def is_case(self, other_values) -> bool:
+        ref = self.get_ref(other_values)
         return isinstance(ref.datatype, self.value)
 
 
@@ -109,7 +109,7 @@ class ToolOutputActionConditional:
         for when_elem in config_elem.findall("when"):
             self.cases.append(ToolOutputActionConditionalWhen.from_elem(self, when_elem))
 
-    def apply_action(self, output_dataset, other_values):
+    def apply_action(self, output_dataset, other_values) -> None:
         for case in self.cases:
             case.apply_action(output_dataset, other_values)
 
@@ -303,7 +303,7 @@ class MetadataToolOutputAction(ToolOutputAction):
         self.name = elem.get("name", None)
         assert self.name is not None, "Required 'name' attribute missing from MetadataToolOutputAction"
 
-    def apply_action(self, output_dataset, other_values):
+    def apply_action(self, output_dataset, other_values) -> None:
         value = self.option.get_value(other_values)
         # TODO: figure out correct type based on MetadataElementSpec,
         # but MetadataElementSpec doesn't actually define a type (but it should).
@@ -327,7 +327,7 @@ class FormatToolOutputAction(ToolOutputAction):
         super().__init__(parent, elem)
         self.default = elem.get("default", None)
 
-    def apply_action(self, output_dataset, other_values):
+    def apply_action(self, output_dataset, other_values) -> None:
         value = self.option.get_value(other_values)
         if value is None and self.default is not None:
             value = self.default

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -14,10 +14,6 @@ from galaxy.model import (
     MetadataFile,
     User,
 )
-from galaxy.tools.wrappers import (
-    DatasetFilenameWrapper,
-    DatasetListWrapper,
-)
 from galaxy.util import string_as_bool
 from . import validation
 
@@ -467,6 +463,8 @@ class RemoveValueFilter(Filter):
         self.separator = elem.get("separator", ",")
 
     def filter_options(self, options, trans, other_values):
+        from galaxy.tools.wrappers import DatasetFilenameWrapper
+
         if trans is not None and trans.workflow_building_mode:
             return options
 
@@ -803,6 +801,11 @@ def _get_ref_data(other_values, ref_name):
     - a KeyError is raised if no such element exists
     - a ValueError is raised if the element is not of the type DatasetFilenameWrapper, HistoryDatasetAssociation, DatasetListWrapper, HistoryDatasetCollectionAssociation, list
     """
+    from galaxy.tools.wrappers import (
+        DatasetFilenameWrapper,
+        DatasetListWrapper,
+    )
+
     ref = other_values[ref_name]
     if not isinstance(
         ref,

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -491,9 +491,7 @@ class RemoveValueFilter(Filter):
                 data_ref = other_values.get(self.meta_ref)
                 if isinstance(data_ref, HistoryDatasetCollectionAssociation):
                     data_ref = data_ref.to_hda_representative()
-                if not isinstance(data_ref, HistoryDatasetAssociation) and not isinstance(
-                    data_ref, DatasetFilenameWrapper
-                ):
+                if not isinstance(data_ref, (HistoryDatasetAssociation, DatasetFilenameWrapper)):
                     return options  # cannot modify options
                 value = data_ref.metadata.get(self.metadata_key, None)
         # Default to the second column (i.e. 1) since this used to work only on options produced by the data_meta filter

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -27,13 +27,18 @@ from galaxy.model import (
     HasTags,
     HistoryDatasetCollectionAssociation,
 )
+from galaxy.model.metadata import FileParameter
 from galaxy.model.none_like import NoneDataset
 from galaxy.security.object_wrapper import wrap_with_safe_string
+from galaxy.tools.parameters.basic import BooleanToolParameter
 from galaxy.tools.parameters.wrapped_json import (
     data_collection_input_to_staging_path_and_source_path,
     data_input_to_staging_path_and_source_path,
 )
-from galaxy.util import filesystem_safe_string
+from galaxy.util import (
+    filesystem_safe_string,
+    string_as_bool,
+)
 
 if TYPE_CHECKING:
     from galaxy.datatypes.registry import Registry
@@ -121,25 +126,29 @@ class InputValueWrapper(ToolParameterValueWrapper):
         self.value = value
         self._other_values: Dict[str, str] = other_values or {}
 
-    def _get_cast_value(self, other: Any) -> Union[str, int, float, bool, None]:
-        if self.input.type == "boolean" and isinstance(other, str):
-            return str(self)
+    def _get_cast_values(self, other: Any) -> Tuple[Union[str, int, float, bool, None], Any]:
+        if isinstance(self.input, BooleanToolParameter) and isinstance(other, str):
+            if other in (self.input.truevalue, self.input.falsevalue):
+                return str(self), other
+            else:
+                return bool(self), string_as_bool(other)
         # For backward compatibility, allow `$wrapper != ""` for optional non-text param
         if self.input.optional and self.value is None:
             if isinstance(other, str):
-                return str(self)
+                return str(self), other
             else:
-                return None
+                return None, other
         cast_table = {
             "text": str,
             "integer": int,
             "float": float,
             "boolean": bool,
         }
-        return cast(Union[str, int, float, bool], cast_table.get(self.input.type, str)(self))
+        return cast(Union[str, int, float, bool], cast_table.get(self.input.type, str)(self)), other
 
     def __eq__(self, other: Any) -> bool:
-        return bool(self._get_cast_value(other) == other)
+        casted_self, casted_other = self._get_cast_values(other)
+        return casted_self == casted_other
 
     def __ne__(self, other: Any) -> bool:
         return not self == other
@@ -162,7 +171,8 @@ class InputValueWrapper(ToolParameterValueWrapper):
         return getattr(self.value, key)
 
     def __gt__(self, other: Any) -> bool:
-        return bool(self._get_cast_value(other) > other)
+        casted_self, casted_other = self._get_cast_values(other)
+        return casted_self > casted_other
 
     def __int__(self) -> int:
         return int(float(self))
@@ -290,7 +300,6 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
                 if rval is None:
                     rval = self.metadata.spec[name].no_value
                 metadata_param = self.metadata.spec[name].param
-                from galaxy.model.metadata import FileParameter
 
                 rval = metadata_param.to_safe_string(rval)
                 if isinstance(metadata_param, FileParameter) and self.compute_environment:

--- a/test/unit/app/tools/test_wrappers.py
+++ b/test/unit/app/tools/test_wrappers.py
@@ -185,7 +185,7 @@ def test_input_value_wrapper_comparison_optional(tool):
     assert wrapper != 1
     assert str(wrapper) == ""
     assert wrapper == None  # noqa: E711
-    wrapper = valuewrapper(tool, None, "boolean")
+    wrapper = valuewrapper(tool, None, "boolean", optional=True)
     assert bool(wrapper) is False, wrapper
     assert str(wrapper) == "falsevalue"
 

--- a/test/unit/app/tools/test_wrappers.py
+++ b/test/unit/app/tools/test_wrappers.py
@@ -160,10 +160,12 @@ def test_input_value_wrapper_comparison(tool):
     assert bool(wrapper) is True, wrapper
     assert str(wrapper) == "truevalue"
     assert wrapper == "truevalue"
+    assert wrapper == "true"
     wrapper = valuewrapper(tool, False, "boolean")
     assert bool(wrapper) is False, wrapper
     assert str(wrapper) == "falsevalue"
     assert wrapper == "falsevalue"
+    assert wrapper == "false"
 
 
 @with_mock_tool


### PR DESCRIPTION
Fix comparing a boolean `InputValueWrapper` to "True"/"False" strings to fix the following framework test failures:

test/functional/test_toolbox_pytest.py::test_tool[output_action_change_format_test_1]

```
E           galaxy.tool_util.verify.interactor.JobOutputsError: Dataset metadata verification for [metadata_dbkey] failed, expected [hg19] but found [?]. Dataset API value was [{'id': '8ac6d96e308f61e5', 'name': 'output_action_change_format on data 1', 'history_id': '2cf235fc3a3387c3', 'hid': 2, 'history_content_type': 'dataset', 'deleted': False, 'visible': True, 'type_id': 'dataset-8ac6d96e308f61e5', 'type': 'file', 'create_time': '2022-09-01T18:07:56.177858', 'update_time': '2022-09-01T18:08:01.856249', 'url': '/api/histories/2cf235fc3a3387c3/contents/8ac6d96e308f61e5', 'tags': [], 'dataset_id': '8ac6d96e308f61e5', 'state': 'ok', 'extension': 'data', 'purged': False, 'misc_info': '', 'data_type': 'galaxy.datatypes.data.Data', 'creating_job': '7fbe67cfae825002', 'hda_ldda': 'hda', 'peek': None, 'created_from_basename': 'out1', 'display_types': [], 'download_url': '/api/histories/2cf235fc3a3387c3/contents/8ac6d96e308f61e5/display', 'display_apps': [], 'meta_files': [], 'file_ext': 'data', 'sources': [], 'copied_from_ldda_id': None, 'uuid': '6decb7d7-1e5a-4036-9895-6cea83a85737', 'file_name': '/tmp/tmpdsxagstf/tmp84ke9cq4/tmpv3mcqttw/database/objects/6/d/e/dataset_6decb7d7-1e5a-4036-9895-6cea83a85737.dat', 'api_type': 'file', 'misc_blurb': 'data', 'hashes': [], 'accessible': True, 'file_size': 4, 'model_class': 'HistoryDatasetAssociation', 'metadata_dbkey': '?', 'validated_state_message': None, 'resubmitted': False, 'permissions': {'manage': ['adb5f5c93f827949'], 'access': []}, 'annotation': None, 'validated_state': 'unknown', 'rerunnable': True, 'genome_build': '?'}].
```

test/functional/test_toolbox_pytest.py::test_tool[output_action_change_format_test_2]

```
E           galaxy.tool_util.verify.interactor.JobOutputsError: Dataset metadata verification for [metadata_dbkey] failed, expected [hg38] but found [?]. Dataset API value was [{'id': 'b316627aece188a7', 'name': 'output_action_change_format on data 1', 'history_id': 'a53aa9d4dc32b5ed', 'hid': 2, 'history_content_type': 'dataset', 'deleted': False, 'visible': True, 'type_id': 'dataset-b316627aece188a7', 'type': 'file', 'create_time': '2022-09-01T18:08:12.870025', 'update_time': '2022-09-01T18:08:18.490136', 'url': '/api/histories/a53aa9d4dc32b5ed/contents/b316627aece188a7', 'tags': [], 'dataset_id': 'b316627aece188a7', 'state': 'ok', 'extension': 'txt', 'purged': False, 'misc_info': '', 'data_type': 'galaxy.datatypes.data.Text', 'creating_job': '3607dcbef30930ec', 'hda_ldda': 'hda', 'peek': '<table cellspacing="0" cellpadding="3"><tr><td>1\t2</td></tr></table>', 'created_from_basename': 'out1', 'display_types': [], 'download_url': '/api/histories/a53aa9d4dc32b5ed/contents/b316627aece188a7/display', 'display_apps': [], 'meta_files': [], 'file_ext': 'txt', 'sources': [], 'copied_from_ldda_id': None, 'uuid': '4a58c935-6fea-4b55-b659-871e652021de', 'file_name': '/tmp/tmpdsxagstf/tmp84ke9cq4/tmpv3mcqttw/database/objects/4/a/5/dataset_4a58c935-6fea-4b55-b659-871e652021de.dat', 'api_type': 'file', 'misc_blurb': '1 line', 'hashes': [], 'accessible': True, 'file_size': 4, 'model_class': 'HistoryDatasetAssociation', 'metadata_dbkey': '?', 'validated_state_message': None, 'resubmitted': False, 'permissions': {'manage': ['adb5f5c93f827949'], 'access': []}, 'annotation': None, 'validated_state': 'unknown', 'metadata_data_lines': 1, 'rerunnable': True, 'genome_build': '?'}].
```

that started to appear after commit https://github.com/galaxyproject/galaxy/commit/94c75a083c25612b5f9e4aac6fc53d0ac2c77253 was merged forward.
In particular, for the above tests the `ref` variable at https://github.com/galaxyproject/galaxy/commit/94c75a083c25612b5f9e4aac6fc53d0ac2c77253#diff-0251b89ba313ad7ec78f79bfc21e416597cefd52447314029a728af5d775dbc6R85
is now a boolean `InputValueWrapper` instance, which could not be meaningfully compared to `value` if it was a "True" or "False" string because `ref` would be converted to the `truevalue` or `falsevalue` of the parameter when casted to `str`.

Includes also some related changes/fixes.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
