### PR TITLE
[22.05] Use subquery method in update_hdca_update_time_for_job

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1546,6 +1546,8 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         )
         if supports_skip_locked:
             subq = subq.with_for_update(skip_locked=True).subquery()
+        else:
+            subq = subq.subquery()
         implicit_statement = (
             HistoryDatasetCollectionAssociation.table.update()
             .where(HistoryDatasetCollectionAssociation.table.c.id.in_(select(subq)))


### PR DESCRIPTION
Might fix https://github.com/galaxyproject/galaxy/issues/14568 ?
Although I'm surprised Galaxy even boots with Postgres < 10 (https://docs.galaxyproject.org/en/master/releases/22.01_announce.html#deprecation-notices),
so possibly something else is wrong as well.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
