### PR TITLE
Add config option for post logout redirect url

### DIFF
--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -5,7 +5,7 @@
         v-b-tooltip.hover.bottom
         v-b-popover.manual.bottom="{ id: tab.id, content: popoverNote, html: true }"
         :class="classes"
-        :href="tab.url"
+        :href="getPath(tab.url)"
         :target="tab.target || '_parent'"
         :link-classes="linkClasses"
         :title="tab.tooltip"
@@ -36,7 +36,7 @@
             <b-dropdown-item
                 v-else-if="item.hidden !== true"
                 :key="`item-${idx}`"
-                :href="item.url"
+                :href="getPath(item.url)"
                 :target="item.target || '_parent'"
                 role="menuitem"
                 :active="item.disabled"
@@ -52,7 +52,7 @@
 import Vue from "vue";
 import { VBPopoverPlugin, VBTooltipPlugin } from "bootstrap-vue";
 import { BNavItem, BNavItemDropdown, BDropdownItem } from "bootstrap-vue";
-import { getAppRoot } from "onload/loadConfig";
+import { safePath } from "utils/redirect";
 
 Vue.use(VBPopoverPlugin);
 Vue.use(VBTooltipPlugin);
@@ -83,7 +83,7 @@ export default {
             return this.tab.menu;
         },
         popoverNote() {
-            return `Please <a href="${getAppRoot()}login">log in or register</a> to use this feature.`;
+            return `Please <a href="${safePath("/login")}">log in or register</a> to use this feature.`;
         },
         classes() {
             const isActiveTab = this.tab.id == this.activeTab;
@@ -116,6 +116,9 @@ export default {
             if (this.$refs.dropdown) {
                 this.$refs.dropdown.hide();
             }
+        },
+        getPath(url) {
+            return safePath(url);
         },
         open(tab, event) {
             if (tab.onclick) {

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3337,6 +3337,17 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``post_user_logout_href``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    This is the default url to which users are redirected after they
+    log out.
+:Default: ``/root/login?is_logout_redirect=true``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``normalize_remote_user_email``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/authnz/__init__.py
+++ b/lib/galaxy/authnz/__init__.py
@@ -72,7 +72,7 @@ class IdentityProvider:
     def disconnect(self, provider, trans, disconnect_redirect_url=None):
         raise NotImplementedError()
 
-    def logout(self, trans, post_logout_redirect_url=None):
+    def logout(self, trans, post_user_logout_href=None):
         """
         Return a URL that will log the user out of the IDP. In OIDC this is
         called the 'end_session_endpoint'.
@@ -80,7 +80,7 @@ class IdentityProvider:
         :type trans: GalaxyWebTransaction
         :param trans: Galaxy web transaction.
 
-        :type post_logout_redirect_url: string
-        :param post_logout_redirect_url: Optional URL to redirect to after logging out of IDP.
+        :type post_user_logout_href: string
+        :param post_user_logout_href: Optional URL to redirect to after logging out of IDP.
         """
         raise NotImplementedError()

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -243,11 +243,11 @@ class CustosAuthnz(IdentityProvider):
         except Exception as e:
             return False, f"Failed to disconnect provider {provider}: {util.unicodify(e)}", None
 
-    def logout(self, trans, post_logout_redirect_url=None):
+    def logout(self, trans, post_user_logout_href=None):
         try:
             redirect_url = self.config["end_session_endpoint"]
-            if post_logout_redirect_url is not None:
-                redirect_url += f"?redirect_uri={quote(post_logout_redirect_url)}"
+            if post_user_logout_href is not None:
+                redirect_url += f"?redirect_uri={quote(post_user_logout_href)}"
             return redirect_url
         except Exception as e:
             log.error("Failed to generate logout redirect_url", exc_info=e)

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -369,7 +369,7 @@ class AuthnzManager:
             log.exception(msg)
             return False, msg, (None, None)
 
-    def logout(self, provider, trans, post_logout_redirect_url=None):
+    def logout(self, provider, trans, post_user_logout_href=None):
         """
         Log the user out of the identity provider.
 
@@ -377,8 +377,8 @@ class AuthnzManager:
         :param provider: set the name of the identity provider.
         :type trans: GalaxyWebTransaction
         :param trans: Galaxy web transaction.
-        :type post_logout_redirect_url: string
-        :param post_logout_redirect_url: (Optional) URL for identity provider
+        :type post_user_logout_href: string
+        :param post_user_logout_href: (Optional) URL for identity provider
             to redirect to after logging user out.
         :return: a tuple (success boolean, message, redirect URI)
         """
@@ -391,7 +391,7 @@ class AuthnzManager:
             success, message, backend = self._get_authnz_backend(provider)
             if success is False:
                 return False, message, None
-            return True, message, backend.logout(trans, post_logout_redirect_url)
+            return True, message, backend.logout(trans, post_user_logout_href)
         except Exception:
             msg = f"An error occurred when logging out from `{provider}` identity provider.  Please contact an administrator for assistance."
             log.exception(msg)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -160,6 +160,18 @@ gravity:
     # Must match ``tus_upload_store`` setting in ``galaxy:`` section.
     # upload_dir:
 
+    # Comma-separated string of enabled tusd hooks.
+    # 
+    # Leave at the default value to require authorization at upload creation time.
+    # This means Galaxy's web process does not need to be running after creating the initial
+    # upload request.
+    # 
+    # Set to empty string to disable all authorization. This means data can be uploaded (but not processed)
+    # without the Galaxy web process being available.
+    # 
+    # You can find a list of available hooks at https://github.com/tus/tusd/blob/master/docs/hooks.md#list-of-available-hooks.
+    # hooks_enabled_events: pre-create
+
     # Extra arguments to pass to tusd command line.
     # extra_args:
 
@@ -1693,6 +1705,10 @@ galaxy:
   # If use_remote_user is enabled, you can set this to a URL that will
   # log your users out.
   #remote_user_logout_href: null
+
+  # This is the default url to which users are redirected after they log
+  # out.
+  #post_user_logout_href: /root/login?is_logout_redirect=true
 
   # If your proxy and/or authentication source does not normalize e-mail
   # addresses or user names being passed to Galaxy - set this option to

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2427,6 +2427,13 @@ mapping:
           If use_remote_user is enabled, you can set this to a URL that will log your
           users out.
 
+      post_user_logout_href:
+        type: str
+        default: /root/login?is_logout_redirect=true
+        required: false
+        desc: |
+          This is the default url to which users are redirected after they log out.
+
       normalize_remote_user_email:
         type: bool
         default: false

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -145,6 +145,7 @@ class ConfigSerializer(base.ModelSerializer):
             "prefer_custos_login": _use_config,
             "enable_quotas": _use_config,
             "remote_user_logout_href": _use_config,
+            "post_user_logout_href": _use_config,
             "datatypes_disable_auto": _use_config,
             "allow_user_dataset_purge": _defaults_to(False),  # schema default is True
             "ga_code": _use_config,

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -180,9 +180,11 @@ class OIDC(JSAppLauncher):
     @web.json
     @web.expose
     def logout(self, trans, provider, **kwargs):
-        post_logout_redirect_url = f"{trans.request.base + url_for('/')}root/login?is_logout_redirect=true"
+        post_user_logout_href = trans.app.config.post_user_logout_href
+        if post_user_logout_href is not None:
+            post_user_logout_href = trans.request.base + url_for(post_user_logout_href)
         success, message, redirect_uri = trans.app.authnz_manager.logout(
-            provider, trans, post_logout_redirect_url=post_logout_redirect_url
+            provider, trans, post_user_logout_href=post_user_logout_href
         )
         if success:
             return {"redirect_uri": redirect_uri}


### PR DESCRIPTION
Currently our post log out url is fixed to `/root/login?is_login_redirect=true`, and this constant is used in the client and the backend. This PR suggests to add the post logout url to the Galaxy configuration and handle it consistently in both cases. It also optionally enables admins to customize the logout urls.

Additionally this PR contains a fix to properly route the context-menu new tab handling.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
