### PR TITLE
[22.05] linter: allow options elements in data params

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3968,14 +3968,18 @@ dataset for the contained input of the type specified using the ``type`` tag.
   <xs:complexType name="ParamOptions">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[
-
 See [/tools/extract/liftOver_wrapper.xml](https://github.com/galaxyproject/galaxy/blob/master/tools/extract/liftOver_wrapper.xml)
 for an example of how to use this tag set. This tag set is optionally contained
 within the ``<param>`` tag when the ``type`` attribute value is ``select`` or
-``data`` and used to dynamically generated lists of options. This tag set
-dynamically creates a list of options whose values can be
-obtained from a predefined file stored locally or a dataset selected from the
-current history.
+``data`` and used to dynamically generated lists of options.
+
+For data parameters it can only be used to restrict inputs to datasets having
+the same ``dbkey`` like another input by using a ``data_meta`` filter. See for
+instance here: [/tools/maf/interval2maf.xml](https://github.com/galaxyproject/galaxy/blob/master/tools/maf/interval2maf.xml)
+
+For select parameters this tag set dynamically creates a list of options whose
+values can be obtained from a predefined file stored locally or a dataset
+selected from the current history.
 
 There are at least five basic ways to use this tag - four of these correspond to
 a ``from_XXX`` attribute on the ``options`` directive and the other is to

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3973,8 +3973,7 @@ for an example of how to use this tag set. This tag set is optionally contained
 within the ``<param>`` tag when the ``type`` attribute value is ``select`` or
 ``data`` and used to dynamically generated lists of options.
 
-For data parameters it can only be used to restrict inputs to datasets having
-the same ``dbkey`` like another input by using a ``data_meta`` filter. See for
+For data parameters this tag can be used to restrict possible input datasets to datasets that match the ``dbkey`` of another data input by including a ``data_meta`` filter. See for
 instance here: [/tools/maf/interval2maf.xml](https://github.com/galaxyproject/galaxy/blob/master/tools/maf/interval2maf.xml)
 
 For select parameters this tag set dynamically creates a list of options whose

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -190,6 +190,31 @@ INPUTS_DATA_PARAM = """
 </tool>
 """
 
+INPUTS_DATA_PARAM_OPTIONS = """
+<tool>
+    <inputs>
+        <param name="valid_name" type="data" format="txt">
+            <options>
+                <filter type="data_meta" key="dbkey"/>
+            </options>
+        </param>
+    </inputs>
+</tool>
+"""
+
+INPUTS_DATA_PARAM_INVALIDOPTIONS = """
+<tool>
+    <inputs>
+        <param name="valid_name" type="data" format="txt">
+            <options/>
+            <options from_file="blah">
+                <filter type="expression"/>
+            </options>
+        </param>
+    </inputs>
+</tool>
+"""
+
 INPUTS_CONDITIONAL = """
 <tool>
     <inputs>
@@ -1012,6 +1037,31 @@ def test_inputs_data_param(lint_ctx):
     assert not lint_ctx.error_messages
 
 
+def test_inputs_data_param_options(lint_ctx):
+    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_OPTIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    assert not lint_ctx.valid_messages
+    assert "Found 1 input parameters." in lint_ctx.info_messages
+    assert len(lint_ctx.info_messages) == 1
+    assert not lint_ctx.warn_messages
+    assert not lint_ctx.error_messages
+
+
+def test_inputs_data_param_invalidoptions(lint_ctx):
+    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_INVALIDOPTIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    assert not lint_ctx.valid_messages
+    assert "Found 1 input parameters." in lint_ctx.info_messages
+    assert len(lint_ctx.info_messages) == 1
+    assert not lint_ctx.warn_messages
+    assert "Data parameter [valid_name] contains multiple options elements." in lint_ctx.error_messages
+    assert (
+        'Data parameter [valid_name] for filters only type="data_meta" and key="dbkey" are allowed, found type="expression" and key="None"'
+        in lint_ctx.error_messages
+    )
+    assert len(lint_ctx.error_messages) == 2
+
+
 def test_inputs_conditional(lint_ctx):
     tool_source = get_xml_tool_source(INPUTS_CONDITIONAL)
     run_lint(lint_ctx, inputs.lint_inputs, tool_source)
@@ -1197,7 +1247,7 @@ def test_inputs_type_child_combinations(lint_ctx):
     assert not lint_ctx.valid_messages
     assert not lint_ctx.warn_messages
     assert (
-        "Parameter [text_param] './options' tags are only allowed for parameters of type ['select', 'drill_down']"
+        "Parameter [text_param] './options' tags are only allowed for parameters of type ['data', 'select', 'drill_down']"
         in lint_ctx.error_messages
     )
     assert (

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -195,7 +195,19 @@ INPUTS_DATA_PARAM_OPTIONS = """
     <inputs>
         <param name="valid_name" type="data" format="txt">
             <options>
-                <filter type="data_meta" key="dbkey"/>
+                <filter type="data_meta" key="dbkey" ref="input"/>
+            </options>
+        </param>
+    </inputs>
+</tool>
+"""
+
+INPUTS_DATA_PARAM_OPTIONS_FILTER_ATTRIBUTE = """
+<tool>
+    <inputs>
+        <param name="valid_name" type="data" format="txt">
+            <options options_filter_attribute="metadata.foo">
+                <filter type="data_meta" key="foo" ref="input"/>
             </options>
         </param>
     </inputs>
@@ -1047,6 +1059,16 @@ def test_inputs_data_param_options(lint_ctx):
     assert not lint_ctx.error_messages
 
 
+def test_inputs_data_param_options_filter_attribute(lint_ctx):
+    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_OPTIONS_FILTER_ATTRIBUTE)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    assert not lint_ctx.valid_messages
+    assert "Found 1 input parameters." in lint_ctx.info_messages
+    assert len(lint_ctx.info_messages) == 1
+    assert not lint_ctx.warn_messages
+    assert not lint_ctx.error_messages
+
+
 def test_inputs_data_param_invalidoptions(lint_ctx):
     tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_INVALIDOPTIONS)
     run_lint(lint_ctx, inputs.lint_inputs, tool_source)
@@ -1055,11 +1077,12 @@ def test_inputs_data_param_invalidoptions(lint_ctx):
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.warn_messages
     assert "Data parameter [valid_name] contains multiple options elements." in lint_ctx.error_messages
+    assert "Data parameter [valid_name] filter needs to define a ref attribute" in lint_ctx.error_messages
     assert (
         'Data parameter [valid_name] for filters only type="data_meta" and key="dbkey" are allowed, found type="expression" and key="None"'
         in lint_ctx.error_messages
     )
-    assert len(lint_ctx.error_messages) == 2
+    assert len(lint_ctx.error_messages) == 3
 
 
 def test_inputs_conditional(lint_ctx):

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1069,7 +1069,7 @@ def test_inputs_data_param_options_filter_attribute(lint_ctx):
     assert not lint_ctx.error_messages
 
 
-def test_inputs_data_param_invalidoptions(lint_ctx):
+def test_inputs_data_param_invalid_options(lint_ctx):
     tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_INVALIDOPTIONS)
     run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert not lint_ctx.valid_messages


### PR DESCRIPTION
Linting of valid childs for params has been added here: https://github.com/galaxyproject/galaxy/pull/12232, but options for data params has been forgotten.

In addition also checks for valid attribs and filter types has been added to linting.

Questions: 

- [ ] why are tools like `tools/maf/interval2maf.xml` not linted by the CI?

TODO

- `options_filter_attribute` seems allowed
- [x] check if this is still true https://github.com/galaxyproject/galaxy/blob/a5c2eb839bc87b9a67537efce9f1434af94520f9/lib/galaxy/tools/parameters/basic.py#L1843 .. example (interval2maf suggests that also other metadata works) 
- [x] maybe doc better alternative https://github.com/galaxyproject/galaxy/blob/a5c2eb839bc87b9a67537efce9f1434af94520f9/test/functional/tools/validation_metadata_in_range.xml#L7
  - seems that filtering for a fixed set of metadata values is possible as well with a validator
  - but filtering for a metadata value of another input parameter is not at the moment .. maybe we should extend the validator in this respect?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
