### PR TITLE
[PROCEDURES] Recommend to use PR draft state instead of WIP title/label

### DIFF
--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -13,7 +13,7 @@ Issue Reporting
 ===============
 
 Issues (bugs, feature requests, etc.) should be reported at `GitHub issues`_, and
-handling of issues follows the procedures described in the `issues document`_.
+handling of issues follows the procedures described in this document.
 
 Milestones
 ==========
@@ -80,15 +80,12 @@ request/report to separate enhancements and new features from bugs, etc.
 Status Labels
 -------------
 
-The default ``status`` of an issue or PR is ``ready for review``. If that
-is not true the state should be communicated using the following
-labels:
+The default status of an issue or PR is "ready for review". If that is not the
+case, the state should be communicated as follows:
 
--  ``status/planning`` - the issue planning phase, this issue may
-   potentially need more information (or just more thinking) to proceed
-   to a work in progress
--  ``status/WIP`` - this issue or PR is currently being worked on and in
-   the case of a PR, it should not be merged until this tag is removed
+- for issues, by using the ``status/planning`` label;
+- for PRs, by using the `draft <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests>`__
+  state.
 
 Note that there are no ``status/complete``, ``status/wontfix``,
 ``status/duplicate``, or other terminal status indicators. This is
@@ -100,18 +97,11 @@ be indicated in the closing comment by the issue closer.
 The following statuses may be applied to issues that need to be revisited
 after some event.
 
-- ``status/waiting/response`` - this issue or pull request is waiting for
+- ``status/needs feedback`` - this issue or pull request is waiting for
   a response from the author. The issue or pull request may be assumed stale
   and closed after a month. The committers reserve the right to close issues
   and pull requests without this process, but this tag makes tracking explicit
   and easy.
-- ``status/waiting/deployment/org`` - this issue was exhibited on usegalaxy.org
-  and committers believe a fix has been committed but are not certain and so the
-  issue should be rechecked after deployment of the target branch. Typically the
-  committers will close out issues when a fix has been merged, but in cases they
-  are uncertain whether the fix will correct the underlying issue, this tag may be used.
-- ``status/waiting/deployment/eu`` - this is the same as above but for issues
-  affecting usegalaxy.eu.
 
 Area Labels
 -----------
@@ -177,7 +167,8 @@ special purpose.
 -  ``procedures`` is a special tag that indicates that the issue is
    related to project governance, and it overrides the need for the trio
    of kind/status/area tags, and these are never auto-flagged for
-   triage.  More details are available in the ORGANIZATION_ document.
+   triage. More details are available in the
+   :doc:`Galaxy Core Governance <organization>` document.
 
 -  ``planning`` is also a special tag that indicates the issue is
    related to larger-scale issue planning. These issues are typically
@@ -259,6 +250,4 @@ For now, we will rely on a few simple automation rules:
 -  All PRs that are not assigned to a milestone will be tagged
    ``triage`` to indicate that they require attention prior to merge.
 
-.. _ORGANIZATION: https://github.com/galaxyproject/galaxy/blob/dev/doc/source/project/organization.rst
-.. _issues document: https://github.com/galaxyproject/galaxy/blob/dev/doc/source/project/issues.rst
 .. _Github issues: https://github.com/galaxyproject/galaxy/issues/

--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -166,11 +166,11 @@ Pull requests modifying frozen and tagged release branches should be restricted
 to bug fixes. As an exception, pull requests which only add new datatypes can
 target a frozen branch or the latest tagged release branch.
 
-Pull requests marked *[WIP]* (i.e. work in progress) in the title by the
-author(s), or tagged WIP via GitHub tags, may *not* be merged without
-coordinating the removal of that tag with the pull request author(s), and
-completing the removal of that tag from wherever it is present in the open pull
-request.
+A pull request marked *[WIP]* (i.e. work in progress) in the title by its
+author(s) may *not* be merged without coordinating the removal of that mark with
+the pull request author(s). Nevertheless, pull request authors should normally
+use the `draft <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests>`__
+state to indicate a work-in-progress pull request.
 
 Timelines
 ---------
@@ -220,19 +220,17 @@ invokes a mandatory, minimum 72 hour, review period.
 Labeling and Milestones
 -----------------------
 
-Pull request handling, labeling, and milestone usage follows the procedures
-described in ISSUES_.
+Pull request labeling and milestone usage follows the procedures described in
+:doc:`Galaxy Issue Management <issues>`.
 
 
 Issue Reporting
 ===============
 
-Issues (bugs, feature requests, etc.) should be reported at ISSUE_REPORT_, and
-handling of issues follows the procedures described in ISSUES_.
+Issues (bugs, feature requests, etc.) should be reported and handled as
+described in :doc:`Galaxy Issue Management <issues>`.
 
 
 .. _CODE_OF_CONDUCT: https://github.com/galaxyproject/galaxy/blob/dev/CODE_OF_CONDUCT.md
 .. _SECURITY_POLICY: https://github.com/galaxyproject/galaxy/blob/dev/SECURITY.md
 .. _Apache Software Foundation voting rules: https://www.apache.org/foundation/voting.html
-.. _ISSUES: https://github.com/galaxyproject/galaxy/blob/dev/doc/source/project/issues.rst
-.. _ISSUE_REPORT: https://github.com/galaxyproject/galaxy/issues/


### PR DESCRIPTION
but keep the `status/planning` label for issues.

Also:
- Drop/rename ``status`` labels to sync with what we are using in the repository.
- Fix links.

This could later be followed by setting to draft state the PRs currently tagged WIP and the removal of the `status/WIP` label.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
