### PR TITLE
Use hsluv to generate colors instead of hsl

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -53,6 +53,7 @@
     "flush-promises": "^1.0.2",
     "glob": "^7.2.0",
     "handsontable": "^2.0.0",
+    "hsluv": "^0.1.0",
     "imask": "^6.4.0",
     "jquery": "2",
     "jquery-migrate": "~1.4",

--- a/client/src/components/Nametags/Nametag.vue
+++ b/client/src/components/Nametags/Nametag.vue
@@ -14,10 +14,10 @@ export default {
             return this.tag.startsWith("name:") ? this.tag.replace("name:", "") : this.tag;
         },
         tagStyles() {
-            const { primary, contrasting, darker } = keyedColorScheme(this.tag);
+            const { primary, darker } = keyedColorScheme(this.tag);
             return {
                 "background-color": primary,
-                color: contrasting,
+                color: "black",
                 "border-color": darker,
             };
         },

--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -24,11 +24,11 @@ function TagModel(props = {}) {
     Object.defineProperty(this, "style", {
         enumerable: true,
         get: function () {
-            const { primary, contrasting, darker } = keyedColorScheme(this.text);
+            const { primary, darker } = keyedColorScheme(this.text);
 
             const styles = {
                 "background-color": primary,
-                color: contrasting,
+                color: "black",
                 "border-color": darker,
             };
             if (this.text.startsWith("name:")) {

--- a/client/src/mvc/ui/ui-select-default.js
+++ b/client/src/mvc/ui/ui-select-default.js
@@ -209,7 +209,7 @@ var View = Backbone.View.extend({
                             const isNametag = tag.indexOf("name:") === 0;
                             const tagDisplayText = isNametag ? `#${tag.slice(5)}` : tag;
                             const styleBlock = isNametag
-                                ? `style="background-color: ${tagColors.primary}; color: ${tagColors.contrasting}; border: 1px solid ${tagColors.darker}"`
+                                ? `style="background-color: ${tagColors.primary}; color: black; border: 1px solid ${tagColors.darker}"`
                                 : "";
                             return `${memo}&nbsp;<div ${styleBlock} class="badge badge-primary badge-tags">${_.escape(
                                 tagDisplayText

--- a/client/src/utils/color.js
+++ b/client/src/utils/color.js
@@ -2,22 +2,6 @@ import { hashFnv32a } from "utils/utils";
 import { hsluvToRgb, hsluvToHex } from "hsluv";
 
 /**
- * Implement W3C contrasting color algorithm
- * http://www.w3.org/TR/AERT#color-contrast
- *
- * @param   {number}  r       Red
- * @param   {number}  g       Green
- * @param   {number}  b       Blue
- * @return  {string}          Either 'white' or 'black'
- *
- * Assumes r, g, b are in the set [0, 1]
- */
-export function contrastingColor(r, g, b) {
-    var o = (r * 255 * 299 + g * 255 * 587 + b * 255 * 114) / 1000;
-    return o > 125 ? "black" : "white";
-}
-
-/**
  * Simple 3-color keyed color scheme generated
  * from a string key
  */
@@ -25,12 +9,16 @@ export function keyedColorScheme(strKey) {
     const hash = hashFnv32a(strKey);
     const hue = Math.abs((hash >> 4) % 360);
     const lightnessOffset = 75;
-    const lightness = lightnessOffset + (hash & 0xf);
+    let lightness = lightnessOffset + (hash & 0xf);
+
+    // randomly make yellow tags bright
+    if (hue >= 70 && hue <= 95 && (hash & 0x100) === 0x100) {
+        lightness += (100 - lightness) * 0.75;
+    }
 
     const [r, g, b] = hsluvToRgb([hue, 100, lightness]);
     const primary = `rgb(${r * 255},${g * 255},${b * 255})`;
     const darker = hsluvToHex([hue, 100, lightness - 20]);
-    const contrasting = contrastingColor(r, g, b);
 
-    return { primary, darker, contrasting };
+    return { primary, darker };
 }

--- a/client/src/utils/color.js
+++ b/client/src/utils/color.js
@@ -1,4 +1,5 @@
 import { hashFnv32a } from "utils/utils";
+import { hsluvToRgb, hsluvToHex } from "hsluv";
 
 /**
  * Implement W3C contrasting color algorithm
@@ -17,54 +18,6 @@ export function contrastingColor(r, g, b) {
 }
 
 /**
- * Converts an HSL color value to RGB. Conversion formula
- * adapted from http://en.wikipedia.org/wiki/HSL_color_space.
- * Assumes h, s, and l are contained in the set [0, 1] and
- * returns r, g, and b in the set [0, 1].
- *
- * @param   {number}  h       The hue
- * @param   {number}  s       The saturation
- * @param   {number}  l       The lightness
- * @return  {Array}           The RGB representation
- */
-export function hslToRgb(h, s, l) {
-    var r;
-    var g;
-    var b;
-
-    if (s == 0) {
-        r = g = b = l; // achromatic
-    } else {
-        var hue2rgb = function hue2rgb(p, q, t) {
-            if (t < 0) {
-                t += 1;
-            }
-            if (t > 1) {
-                t -= 1;
-            }
-            if (t < 1 / 6) {
-                return p + (q - p) * 6 * t;
-            }
-            if (t < 1 / 2) {
-                return q;
-            }
-            if (t < 2 / 3) {
-                return p + (q - p) * (2 / 3 - t) * 6;
-            }
-            return p;
-        };
-
-        var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-        var p = 2 * l - q;
-        r = hue2rgb(p, q, h + 1 / 3);
-        g = hue2rgb(p, q, h);
-        b = hue2rgb(p, q, h - 1 / 3);
-    }
-
-    return [r, g, b];
-}
-
-/**
  * Simple 3-color keyed color scheme generated
  * from a string key
  */
@@ -74,9 +27,9 @@ export function keyedColorScheme(strKey) {
     const lightnessOffset = 75;
     const lightness = lightnessOffset + (hash & 0xf);
 
-    const primary = `hsl(${hue}, 100%, ${lightness}%)`;
-    const darker = `hsl(${hue}, 100%, ${lightness - 40}%)`;
-    const [r, g, b] = hslToRgb(hue, 1.0, lightness / 100);
+    const [r, g, b] = hsluvToRgb([hue, 100, lightness]);
+    const primary = `rgb(${r * 255},${g * 255},${b * 255})`;
+    const darker = hsluvToHex([hue, 100, lightness - 20]);
     const contrasting = contrastingColor(r, g, b);
 
     return { primary, darker, contrasting };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5166,6 +5166,11 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+hsluv@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/hsluv/-/hsluv-0.1.0.tgz#29f40d49642bd56dd0c192122abcc723bb5c2d6c"
+  integrity sha512-ERcanKLAszD2XN3Vh5r5Szkrv9q0oSTudmP0rkiKAGM/3NMc9FLmMZBB7TSqTaXJfSDBOreYTfjezCOYbRKqlw==
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"


### PR DESCRIPTION
This PR makes tags more readable and easier to distinguish from the background, by using the [HSLuv](https://www.hsluv.org/) color space instead of HSL.

HSL has the downside of not having consistent lightness over different hues, which can make it's readability and contrast unpredictable.

![image](https://user-images.githubusercontent.com/44241786/189082172-7b1e8a92-de38-4028-9344-986e9ad0cf51.png)
taken from https://www.hsluv.org/comparison/

HSLuv is an alternative color space to HSL, with a consistent lightness factor. This makes it a good choice to generate color at runtime, since a set contrast to other elements can be guranteed.

Here are the Tags in HSL and HSLuv with otherwise no settings changed:

| ![image](https://user-images.githubusercontent.com/44241786/189084855-9accaabd-c1eb-40db-b580-31af3e35bc4f.png) | ![image](https://user-images.githubusercontent.com/44241786/189084630-1e34c984-1131-47fe-855d-b7253402031a.png) |
|---|---|
| HSL | HSLuv |

Notice how the `a` and `7` tags are hard to tell apart from the background in HSL, and how the `a_very_long_tag` tag is hard to read.

The lightness still varies for HSLuv in this example, as the color generation randomly varies the lightness value. With this change, this random lightness range is much easier to tune, as the resulting colors lightness is predictable.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
