### PR TITLE
[22.05] Ensure guid is hexadecimal value

### DIFF
--- a/lib/galaxy/security/idencoding.py
+++ b/lib/galaxy/security/idencoding.py
@@ -1,7 +1,10 @@
 import codecs
 import collections
 import logging
-from typing import Optional
+from typing import (
+    Optional,
+    Union,
+)
 
 from Crypto.Cipher import Blowfish
 from Crypto.Random import get_random_bytes
@@ -102,15 +105,18 @@ class IdEncodingHelper:
         # Encrypt
         return codecs.encode(self.id_cipher.encrypt(s), "hex")
 
-    def decode_guid(self, session_key):
+    def decode_guid(self, session_key: Union[bytes, str]) -> str:
         # Session keys are strings
         try:
             decoded_session_key = codecs.decode(session_key, "hex")
-            return unicodify(self.id_cipher.decrypt(decoded_session_key)).lstrip("!")
+            stripped_decoded_session_key = unicodify(self.id_cipher.decrypt(decoded_session_key)).lstrip("!")
+            # Ensure session key is hexadecimal value
+            int(stripped_decoded_session_key, 16)
+            return stripped_decoded_session_key
         except TypeError:
-            raise galaxy.exceptions.MalformedId(f"Malformed guid '{session_key}' specified, unable to decode.")
+            raise galaxy.exceptions.MalformedId(f"Malformed guid '{session_key!r}' specified, unable to decode.")
         except ValueError:
-            raise galaxy.exceptions.MalformedId(f"Wrong guid '{session_key}' specified, unable to decode.")
+            raise galaxy.exceptions.MalformedId(f"Wrong guid '{session_key!r}' specified, unable to decode.")
 
     def get_new_guid(self):
         # Generate a unique, high entropy 128 bit random number

--- a/lib/galaxy/tool_util/linters/help.py
+++ b/lib/galaxy/tool_util/linters/help.py
@@ -20,32 +20,20 @@ def lint_help(tool_xml, lint_ctx):
         lint_ctx.warn("No help section found, consider adding a help section to your tool.", node=root)
         return
 
-    help = helps[0].text or ""
-    if not help.strip():
+    help_text = helps[0].text or ""
+    if not help_text.strip():
         lint_ctx.warn("Help section appears to be empty.", node=helps[0])
         return
 
     lint_ctx.valid("Tool contains help section.", node=helps[0])
-    invalid_rst = rst_invalid(help)
 
-    if "TODO" in help:
+    if "TODO" in help_text:
         lint_ctx.warn("Help contains TODO text.", node=helps[0])
 
-    if invalid_rst:
-        lint_ctx.warn(f"Invalid reStructuredText found in help - [{invalid_rst}].", node=helps[0])
-    else:
-        lint_ctx.valid("Help contains valid reStructuredText.", node=helps[0])
-
-
-def rst_invalid(text):
-    """Predicate to determine if text is invalid reStructuredText.
-
-    Return False if the supplied text is valid reStructuredText or
-    a string indicating the problem.
-    """
-    invalid_rst = False
     try:
-        rst_to_html(text, error=True)
+        rst_to_html(help_text, error=True)
     except Exception as e:
-        invalid_rst = unicodify(e)
-    return invalid_rst
+        lint_ctx.warn(f"Invalid reStructuredText found in help - [{unicodify(e)}].", node=helps[0])
+        return
+
+    lint_ctx.valid("Help contains valid reStructuredText.", node=helps[0])

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -32,6 +32,12 @@ from email.mime.text import MIMEText
 from hashlib import md5
 from os.path import relpath
 from pathlib import Path
+from typing import (
+    Any,
+    Optional,
+    overload,
+    Union,
+)
 from urllib.parse import (
     urlencode,
     urlparse,
@@ -46,6 +52,7 @@ from boltons.iterutils import (
 )
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+from typing_extensions import Literal
 
 try:
     import grp
@@ -1083,7 +1090,35 @@ def roundify(amount, sfs=2):
         return amount[0:sfs] + "0" * (len(amount) - sfs)
 
 
-def unicodify(value, encoding=DEFAULT_ENCODING, error="replace", strip_null=False, log_exception=True):
+@overload
+def unicodify(
+    value: Literal[None],
+    encoding: str = DEFAULT_ENCODING,
+    error: str = "replace",
+    strip_null: bool = False,
+    log_exception: bool = True,
+) -> None:
+    ...
+
+
+@overload
+def unicodify(
+    value: Union[str, bytes, int, float, bool, Exception],  # Anything but None, but this seems fine for now
+    encoding: str = DEFAULT_ENCODING,
+    error: str = "replace",
+    strip_null: bool = False,
+    log_exception: bool = True,
+) -> str:
+    ...
+
+
+def unicodify(
+    value: Any,
+    encoding: str = DEFAULT_ENCODING,
+    error: str = "replace",
+    strip_null: bool = False,
+    log_exception: bool = True,
+) -> Optional[str]:
     """
     Returns a Unicode string or None.
 

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -36,7 +36,6 @@ from typing import (
     Any,
     Optional,
     overload,
-    Union,
 )
 from urllib.parse import (
     urlencode,
@@ -1091,7 +1090,7 @@ def roundify(amount, sfs=2):
 
 
 @overload
-def unicodify(
+def unicodify(  # type: ignore[misc]
     value: Literal[None],
     encoding: str = DEFAULT_ENCODING,
     error: str = "replace",
@@ -1103,7 +1102,7 @@ def unicodify(
 
 @overload
 def unicodify(
-    value: Union[str, bytes, int, float, bool, Exception],  # Anything but None, but this seems fine for now
+    value: Any,
     encoding: str = DEFAULT_ENCODING,
     error: str = "replace",
     strip_null: bool = False,

--- a/test/unit/data/security/test_id_encode_decode.py
+++ b/test/unit/data/security/test_id_encode_decode.py
@@ -62,6 +62,17 @@ def test_maximum_length_handling_nonascii():
     assert e11 != e12
 
 
+def test_unicode_null_decoding():
+    encoded_id = test_helper_1.encode_id(1)
+    threw_exception = False
+    try:
+        test_helper_1.decode_guid(f"{encoded_id[:-1]}\0")
+    except Exception:
+        threw_exception = True
+
+    assert threw_exception
+
+
 def test_encode_decode():
     # Different ids are encoded differently
     assert test_helper_1.encode_id(1) != test_helper_1.encode_id(2)


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/14560:

```
File '/gpfs1/data/galaxy_server/galaxy-dev/lib/galaxy/web/framework/middleware/error.py', line 165 in __call__
  app_iter = self.application(environ, sr_checker)
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/paste/recursive.py', line 85 in __call__
  return self.application(environ, start_response)
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/paste/httpexceptions.py', line 640 in __call__
  return self.application(environ, start_response)
File '/gpfs1/data/galaxy_server/galaxy-dev/lib/galaxy/web/framework/base.py', line 166 in __call__
  return self.handle_request(environ, start_response)
File '/gpfs1/data/galaxy_server/galaxy-dev/lib/galaxy/web/framework/base.py', line 222 in handle_request
  trans = self.transaction_factory(environ)
File '/gpfs1/data/galaxy_server/galaxy-dev/lib/galaxy/webapps/base/webapp.py', line 101 in <lambda>
  self.set_transaction_factory(lambda e: self.transaction_chooser(e, galaxy_app, session_cookie))
File '/gpfs1/data/galaxy_server/galaxy-dev/lib/galaxy/webapps/base/webapp.py', line 190 in transaction_chooser
  return GalaxyWebTransaction(environ, galaxy_app, self, session_cookie)
File '/gpfs1/data/galaxy_server/galaxy-dev/lib/galaxy/webapps/base/webapp.py', line 311 in __init__
  self._ensure_valid_session(session_cookie)
File '/gpfs1/data/galaxy_server/galaxy-dev/lib/galaxy/webapps/base/webapp.py', line 557 in _ensure_valid_session
  galaxy_session = self.session_manager.get_session_from_session_key(session_key=session_key)
File '/gpfs1/data/galaxy_server/galaxy-dev/lib/galaxy/managers/session.py', line 26 in get_session_from_session_key
  self.sa_session.query(self.model.GalaxySession)
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/orm/query.py', line 2819 in first
  return self.limit(1)._iter().first()
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/orm/query.py', line 2903 in _iter
  result = self.session.execute(
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/orm/session.py', line 1712 in execute
  result = conn._execute_20(statement, params or {}, execution_options)
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py', line 1631 in _execute_20
  return meth(self, args_10style, kwargs_10style, execution_options)
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/sql/elements.py', line 325 in _execute_on_connection
  return connection._execute_clauseelement(
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py', line 1498 in _execute_clauseelement
  ret = self._execute_context(
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py', line 1862 in _execute_context
  self._handle_dbapi_exception(
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py', line 2047 in _handle_dbapi_exception
  util.raise_(exc_info[1], with_traceback=exc_info[2])
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/util/compat.py', line 208 in raise_
  raise exception
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py', line 1819 in _execute_context
  self.dialect.do_execute(
File '/gpfs1/data/galaxy_server/galaxy-dev/.venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py', line 732 in do_execute
  cursor.execute(statement, parameters)
ValueError: A string literal cannot contain NUL (0x00) characters.
```

This got logged because https://github.com/galaxyproject/galaxy/commit/29bba7316a1ca22e0f7575f90d7b2b2b50e23d0c narrowed the exception catching, but we didn't anticipate the ValueError raised by sqlalchemy. Ensuring the decoded session key is a hexadecimal value seems like a clean fix.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
