### PR TITLE
Better + additional fix for alembic offline mode

### DIFF
--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -32,5 +32,5 @@ def _handle_offline_mode(code, return_value):
         "This script is being executed in offline mode and cannot connect to the database. "
         f"Therefore, `{code}` returns `{return_value}` by default."
     )
-    log.debug(msg)
+    log.info(msg)
     return return_value


### PR DESCRIPTION
This is a follow-up fix for #14564:

1. This is a more correct way to handle it: by using the built-in method `is_offline_mode` we cover both script and programmatic usage (the prev. version covered only scripts).
2. This fix is added to yet another case that cannot be processed if offline mode. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
