### PR TITLE
[22.05] Backport #14283

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Disallow: /display?
 Disallow: /display_as?
+Disallow: /training-material/


### PR DESCRIPTION
Disallow indexing of the /training-materials/ proxy used for "Tutorial Mode"

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
