### PR TITLE
linter: check for inputs with duplicated names

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -156,10 +156,10 @@ def lint_inputs(tool_xml, lint_ctx):
                 path.append(str(parent.attrib.get("value")))
             else:
                 path.append(str(parent.attrib.get("name")))
-        path = ".".join(reversed(path))
-        if path in input_names:
-            lint_ctx.error(f"Tool defines multiple parameters with the same name: '{path}'", node=param)
-        input_names.add(path)
+        path_str = ".".join(reversed(path))
+        if path_str in input_names:
+            lint_ctx.error(f"Tool defines multiple parameters with the same name: '{path_str}'", node=param)
+        input_names.add(path_str)
 
         if "type" not in param_attrib:
             lint_ctx.error(f"Param input [{param_name}] input with no type specified.", node=param)

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -117,6 +117,7 @@ PARAM_TYPE_CHILD_COMBINATIONS = [
 def lint_inputs(tool_xml, lint_ctx):
     """Lint parameters in a tool's inputs block."""
     datasource = is_datasource(tool_xml)
+    input_names = set()
     inputs = tool_xml.findall("./inputs//param")
     # determine node to report for general problems with outputs
     tool_node = tool_xml.find("./inputs")
@@ -141,7 +142,24 @@ def lint_inputs(tool_xml, lint_ctx):
         elif not is_valid_cheetah_placeholder(param_name):
             lint_ctx.warn(f"Param input [{param_name}] is not a valid Cheetah placeholder.", node=param)
 
-        # TODO lint for params with duplicated name (in inputs & outputs)
+        # check for parameters with duplicate names
+        path = [param_name]
+        parent = param
+        while True:
+            parent = parent.getparent()
+            if parent.tag == "inputs":
+                break
+            # parameters of the same name in different when branches are allowed
+            # just add the value of the when branch to the path (this also allows
+            # that the conditional select has the same name as params in the whens)
+            if parent.tag == "when":
+                path.append(str(parent.attrib.get("value")))
+            else:
+                path.append(str(parent.attrib.get("name")))
+        path = ".".join(reversed(path))
+        if path in input_names:
+            lint_ctx.error(f"Tool defines multiple parameters with the same name: '{path}'", node=param)
+        input_names.add(path)
 
         if "type" not in param_attrib:
             lint_ctx.error(f"Param input [{param_name}] input with no type specified.", node=param)
@@ -439,6 +457,16 @@ def lint_inputs(tool_xml, lint_ctx):
             lint_ctx.info("No input parameters, OK for data sources", node=tool_node)
         else:
             lint_ctx.warn("Found no input parameters.", node=tool_node)
+
+    # check if there is an output with the same name as an input
+    outputs = tool_xml.find("./outputs")
+    if outputs:
+        for output in outputs:
+            if output.get("name") in input_names:
+                lint_ctx.error(
+                    f'Tool defines an output with a name equal to the name of an input: \'{output.get("name")}\'',
+                    node=output,
+                )
 
 
 def lint_repeats(tool_xml, lint_ctx):

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -418,6 +418,34 @@ INPUTS_TYPE_CHILD_COMBINATIONS = """
 </tool>
 """
 
+INPUTS_DUPLICATE_NAMES = """
+<tool>
+    <inputs>
+        <param name="dup" type="text"/>
+        <param name="dup" type="text"/>
+        <param name="dup_in_section" type="text"/>
+        <section name="sec">
+            <param name="dup_in_section" type="text"/>
+        </section>
+        <conditional name="cond">
+            <param name="dup_in_cond" type="select">
+                <option value="a">a</option>
+                <option value="b">b</option>
+            </param>
+            <when value="a">
+                <param name="dup_in_cond" type="text"/>
+            </when>
+            <when value="b">
+                <param name="dup_in_cond" type="text"/>
+            </when>
+        </conditional>
+        <param name="dup_in_output" type="text"/>
+    </inputs>
+    <outputs>
+        <data name="dup_in_output"/>
+    </outputs>
+</tool>
+"""
 
 # test tool xml for outputs linter
 OUTPUTS_MISSING = """
@@ -1209,6 +1237,19 @@ def test_inputs_type_child_combinations(lint_ctx):
         in lint_ctx.error_messages
     )
     assert len(lint_ctx.error_messages) == 3
+
+
+def test_inputs_duplicate_names(lint_ctx):
+    tool_source = get_xml_tool_source(INPUTS_DUPLICATE_NAMES)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    assert len(lint_ctx.info_messages) == 1
+    assert not lint_ctx.valid_messages
+    assert not lint_ctx.warn_messages
+    assert "Tool defines multiple parameters with the same name: 'dup'" in lint_ctx.error_messages
+    assert (
+        "Tool defines an output with a name equal to the name of an input: 'dup_in_output'" in lint_ctx.error_messages
+    )
+    assert len(lint_ctx.error_messages) == 2
 
 
 def test_inputs_repeats(lint_ctx):


### PR DESCRIPTION
Just found a case here (macro is expanded twice) https://github.com/galaxyproject/tools-iuc/blob/7a486326f6d0ca87c1c41e857732319d31372799/tools/hyphy/hyphy_fade.xml#L28

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
