### PR TITLE
[22.01] Pin CacheControl to prevent missing dependency

### DIFF
--- a/packages/tool_util/setup.py
+++ b/packages/tool_util/setup.py
@@ -102,6 +102,7 @@ setup(
     install_requires=requirements,
     extras_require={
         'cwl': [
+            'CacheControl<0.12.12',  # https://github.com/common-workflow-language/schema_salad/issues/95#issuecomment-1244271884
             'cwltool==3.1.20211107152837',
         ],
         'mulled': [


### PR DESCRIPTION
schema-salad currently requires:
- "CacheControl >= 0.11.7, < 0.13"
- "lockfile >= 0.9", which is needed for CacheControl's FileCache until 0.12.11

but CacheControl 0.12.12 replaced lockfile with filelock.

Prevent the following traceback:

```
self = <cachecontrol.caches.file_cache.FileCache object at 0x7fe36ac5d190>
directory = PosixPath('/tmp/.cache/salad'), forever = False, filemode = 384
dirmode = 448, lock_class = None

    def __init__(
        self,
        directory,
        forever=False,
        filemode=0o0600,
        dirmode=0o0700,
        lock_class=None,
    ):

        try:
            if lock_class is None:
>               from filelock import FileLock
E               ModuleNotFoundError: No module named 'filelock'

/tmp/gxpkgtestenvcy0lxY/lib/python3.7/site-packages/cachecontrol/caches/file_cache.py:74: ModuleNotFoundError
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
