### PR TITLE
Place Toolshed JS modules into separate bundle

### DIFF
--- a/client/src/bundleToolshed.js
+++ b/client/src/bundleToolshed.js
@@ -1,0 +1,83 @@
+/**
+ * The big list of horrible globals we expose on window.bundleEntries.
+ *
+ * Everything that is exposed on this global variable is something that the python templates
+ * require for their hardcoded initializations. These objects are going to have to continue
+ * to exist until such time as we replace the overall application with a Vue component which
+ * will handle initializations for components individually.
+ */
+
+/* jquery and _ are exposed via expose-loader while several external plugins rely on these */
+import $ from "jquery";
+import _ from "underscore"; // eslint-disable-line no-unused-vars
+
+export { getGalaxyInstance, setGalaxyInstance } from "app";
+import { TracksterUIView } from "viz/trackster";
+export { TracksterUI } from "viz/trackster";
+import Circster from "viz/circster";
+export { PhylovizView as phyloviz } from "viz/phyloviz";
+export { SweepsterVisualization, SweepsterVisualizationView } from "viz/sweepster";
+export { createTabularDatasetChunkedView } from "mvc/dataset/data";
+import { HistoryCollection } from "mvc/history/history-model";
+export { History } from "mvc/history/history-model";
+export { HistoryContents } from "mvc/history/history-contents";
+import MultiPanel from "mvc/history/multi-panel";
+export { historyEntry as history } from "mvc/history/history-view";
+export { default as HistoryViewAnnotated } from "mvc/history/history-view-annotated";
+export { default as HistoryCopyDialog } from "mvc/history/copy-dialog";
+export { default as HDAListItemEdit } from "mvc/history/hda-li-edit";
+export { default as HDAModel } from "mvc/history/hda-model";
+export { default as LegacyGridView } from "legacy/grid/grid-view";
+export { create_chart, create_histogram } from "reports/run_stats";
+export { default as ToolshedGroups } from "toolshed/toolshed.groups";
+export { openGlobalUploadModal } from "components/Upload";
+export { runTour } from "components/Tour/runTour";
+export { Toast } from "ui/toast"; // TODO: remove when external consumers are updated/gone (IES right now)
+
+export function trackster(options) {
+    new TracksterUIView(options);
+}
+
+export function circster(options) {
+    new Circster.GalaxyApp(options);
+}
+
+export function multiHistory(options) {
+    const histories = new HistoryCollection([], {
+        includeDeleted: options.includingDeleted,
+        order: options.order,
+        limitOnFirstFetch: options.limit,
+        limitPerFetch: options.limit,
+        currentHistoryId: options.current_history_id,
+    });
+    const multipanel = new MultiPanel.MultiPanelColumns({
+        el: $("#center").get(0),
+        histories: histories,
+    });
+
+    histories.fetchFirst({ silent: true }).done(function () {
+        multipanel.createColumns();
+        multipanel.render(0);
+    });
+}
+
+// Previously wandering around as window.thing = thing in the onload script
+export { show_in_overlay, hide_modal, show_message, show_modal, Modal } from "layout/modal";
+export { make_popupmenu, make_popup_menus } from "ui/popupmenu";
+export { render_embedded_items } from "mvc/embedded-objects";
+export { default as async_save_text } from "utils/async-save-text";
+
+// Previously "chart"
+import Client from "mvc/visualization/chart/chart-client";
+export function chart(options) {
+    return new Client(options);
+}
+
+export { initMasthead } from "components/Masthead/initMasthead";
+export { mountMakoTags } from "components/Tags";
+export { mountWorkflowEditor } from "components/Workflow/Editor/mount";
+export { mountPageEditor } from "components/PageEditor/mount";
+export { mountPageDisplay } from "components/PageDisplay";
+
+// Used in common.mako
+export { default as store } from "storemodern";

--- a/client/src/bundleToolshed.js
+++ b/client/src/bundleToolshed.js
@@ -1,5 +1,5 @@
 /**
- * The big list of horrible globals we expose on window.bundleEntries.
+ * The the toolshed list of globals we expose on window.bundleToolshed.
  *
  * Everything that is exposed on this global variable is something that the python templates
  * require for their hardcoded initializations. These objects are going to have to continue
@@ -11,73 +11,6 @@
 import $ from "jquery";
 import _ from "underscore"; // eslint-disable-line no-unused-vars
 
-export { getGalaxyInstance, setGalaxyInstance } from "app";
-import { TracksterUIView } from "viz/trackster";
-export { TracksterUI } from "viz/trackster";
-import Circster from "viz/circster";
-export { PhylovizView as phyloviz } from "viz/phyloviz";
-export { SweepsterVisualization, SweepsterVisualizationView } from "viz/sweepster";
-export { createTabularDatasetChunkedView } from "mvc/dataset/data";
-import { HistoryCollection } from "mvc/history/history-model";
-export { History } from "mvc/history/history-model";
-export { HistoryContents } from "mvc/history/history-contents";
-import MultiPanel from "mvc/history/multi-panel";
-export { historyEntry as history } from "mvc/history/history-view";
-export { default as HistoryViewAnnotated } from "mvc/history/history-view-annotated";
-export { default as HistoryCopyDialog } from "mvc/history/copy-dialog";
-export { default as HDAListItemEdit } from "mvc/history/hda-li-edit";
-export { default as HDAModel } from "mvc/history/hda-model";
 export { default as LegacyGridView } from "legacy/grid/grid-view";
-export { create_chart, create_histogram } from "reports/run_stats";
 export { default as ToolshedGroups } from "toolshed/toolshed.groups";
-export { openGlobalUploadModal } from "components/Upload";
-export { runTour } from "components/Tour/runTour";
-export { Toast } from "ui/toast"; // TODO: remove when external consumers are updated/gone (IES right now)
-
-export function trackster(options) {
-    new TracksterUIView(options);
-}
-
-export function circster(options) {
-    new Circster.GalaxyApp(options);
-}
-
-export function multiHistory(options) {
-    const histories = new HistoryCollection([], {
-        includeDeleted: options.includingDeleted,
-        order: options.order,
-        limitOnFirstFetch: options.limit,
-        limitPerFetch: options.limit,
-        currentHistoryId: options.current_history_id,
-    });
-    const multipanel = new MultiPanel.MultiPanelColumns({
-        el: $("#center").get(0),
-        histories: histories,
-    });
-
-    histories.fetchFirst({ silent: true }).done(function () {
-        multipanel.createColumns();
-        multipanel.render(0);
-    });
-}
-
-// Previously wandering around as window.thing = thing in the onload script
-export { show_in_overlay, hide_modal, show_message, show_modal, Modal } from "layout/modal";
-export { make_popupmenu, make_popup_menus } from "ui/popupmenu";
-export { render_embedded_items } from "mvc/embedded-objects";
-export { default as async_save_text } from "utils/async-save-text";
-
-// Previously "chart"
-import Client from "mvc/visualization/chart/chart-client";
-export function chart(options) {
-    return new Client(options);
-}
-
-export { initMasthead } from "components/Masthead/initMasthead";
-export { mountMakoTags } from "components/Tags";
-export { mountWorkflowEditor } from "components/Workflow/Editor/mount";
-export { mountPageEditor } from "components/PageEditor/mount";
-export { mountPageDisplay } from "components/PageDisplay";
-
-// Used in common.mako
 export { default as store } from "storemodern";

--- a/client/src/bundleToolshed.js
+++ b/client/src/bundleToolshed.js
@@ -1,10 +1,5 @@
 /**
- * The the toolshed list of globals we expose on window.bundleToolshed.
- *
- * Everything that is exposed on this global variable is something that the python templates
- * require for their hardcoded initializations. These objects are going to have to continue
- * to exist until such time as we replace the overall application with a Vue component which
- * will handle initializations for components individually.
+ * The toolshed list of globals we expose in window.bundleToolshed used by Toolshed makos.
  */
 
 /* jquery and _ are exposed via expose-loader while several external plugins rely on these */

--- a/client/src/bundleToolshed.js
+++ b/client/src/bundleToolshed.js
@@ -3,7 +3,7 @@
  */
 
 /* jquery and _ are exposed via expose-loader while several external plugins rely on these */
-import $ from "jquery";
+import $ from "jquery"; // eslint-disable-line no-unused-vars
 import _ from "underscore"; // eslint-disable-line no-unused-vars
 
 export { default as LegacyGridView } from "legacy/grid/grid-view";

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = (env = {}, argv = {}) => {
         entry: {
             analysis: ["polyfills", "bundleEntries", "entry/analysis"],
             generic: ["polyfills", "bundleEntries", "entry/generic"],
+            toolshed: ["polyfills", "bundleToolshed", "entry/generic"],
         },
         output: {
             path: path.join(__dirname, "../", "/static/dist"),
@@ -125,6 +126,18 @@ module.exports = (env = {}, argv = {}) => {
                             loader: "expose-loader",
                             options: {
                                 exposes: "bundleEntries",
+                            },
+                        },
+                    ],
+                },
+                // Attaches the bundleToolshed to the window object.
+                {
+                    test: `${scriptsBase}/bundleToolshed`,
+                    use: [
+                        {
+                            loader: "expose-loader",
+                            options: {
+                                exposes: "bundleToolshed",
                             },
                         },
                     ],

--- a/lib/tool_shed/webapp/templates/base.mako
+++ b/lib/tool_shed/webapp/templates/base.mako
@@ -53,7 +53,7 @@
 </%def>
 
 <%def name="javascript_entry()">
-    ${h.dist_js('generic.bundled')}
+    ${h.dist_js('toolshed.bundled')}
 </%def>
 
 <%def name="javascript_app()">

--- a/lib/tool_shed/webapp/templates/base/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/base/base_panels.mako
@@ -39,7 +39,7 @@
 
 <%def name="javascript_entry()">
     <!-- base/base_panels.mako javascript_entry -->
-    ${ h.dist_js('generic.bundled')}
+    ${ h.dist_js('toolshed.bundled')}
 </%def>
 
 <%def name="javascript_app()">

--- a/lib/tool_shed/webapp/templates/legacy/grid_base.mako
+++ b/lib/tool_shed/webapp/templates/legacy/grid_base.mako
@@ -58,7 +58,7 @@
         config.addInitialization(function() {
             var legacyGridViewConfig = ${ h.dumps( self.get_grid_config( embedded=embedded, insert=insert ) ) };
             console.log("grid_base.mako, javascript_app", legacyGridViewConfig);
-            new window.bundleEntries.LegacyGridView(legacyGridViewConfig);
+            new window.bundleToolshed.LegacyGridView(legacyGridViewConfig);
         });
     </script>
 </%def>

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/group/index.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/group/index.mako
@@ -29,7 +29,7 @@
     <script type="text/javascript">
         window.globalTS = new Object();
         $( function(){
-            new window.bundleEntries.ToolshedGroups.ToolshedGroups();
+            new window.bundleToolshed.ToolshedGroups.ToolshedGroups();
         });
     </script>
     <div id="groups_element" style="width: 95%; margin:auto; margin-top:2em; "></div>

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/repository/common.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/repository/common.mako
@@ -77,7 +77,7 @@
         config.addInitialization(function() {
             console.log("common.mako, container_javascripts");
 
-            var store = window.bundleEntries.store;
+            var store = window.bundleToolshed.store;
             var init_dependencies = function() {
                 var storage_id = "library-expand-state-${trans.security.encode_id(10000)}";
                 var restore_folder_state = function() {

--- a/templates/webapps/tool_shed/repository/common.mako
+++ b/templates/webapps/tool_shed/repository/common.mako
@@ -77,7 +77,7 @@
         config.addInitialization(function() {
             console.log("common.mako, container_javascripts");
 
-            var store = window.bundleEntries.store;
+            var store = window.bundleToolshed.store;
             var init_dependencies = function() {
                 var storage_id = "library-expand-state-${trans.security.encode_id(10000)}";
                 var restore_folder_state = function() {


### PR DESCRIPTION
In this PR separate js-modules needed for the toolshed into a separate bundle, as a starting point to reduce the risk of conflicts with future changes to the modernized client app.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
