### PR TITLE
Change HTTP status code for ``DeprecatedMethod`` exception to 410

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -199,19 +199,18 @@ class ObjectNotFound(MessageException):
     err_code = error_codes_by_name["USER_OBJECT_NOT_FOUND"]
 
 
+class Conflict(MessageException):
+    status_code = 409
+    err_code = error_codes_by_name["CONFLICT"]
+
+
 class DeprecatedMethod(MessageException):
     """
     Method (or a particular form/arg signature) has been removed and won't be available later
     """
 
-    status_code = 404
-    # TODO:?? 410 Gone?
+    status_code = 410
     err_code = error_codes_by_name["DEPRECATED_API_CALL"]
-
-
-class Conflict(MessageException):
-    status_code = 409
-    err_code = error_codes_by_name["CONFLICT"]
 
 
 class ConfigurationError(Exception):

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -135,14 +135,14 @@
       "message": "No such object found."
    },
    {
-      "name": "DEPRECATED_API_CALL",
-      "code": 404002,
-      "message": "This API method or call signature has been deprecated and is no longer available"
-   },
-   {
       "name": "CONFLICT",
       "code": 409001,
       "message": "Database conflict prevented fulfilling the request."
+   },
+   {
+      "name": "DEPRECATED_API_CALL",
+      "code": 410001,
+      "message": "This API method or call signature has been deprecated and is no longer available"
    },
    {
       "name": "INTERNAL_SERVER_ERROR",


### PR DESCRIPTION
Replaced the 404 (Not Found) HTTP response status code with 410 (Gone), which is more correct, see details at:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
