### PR TITLE
More tool shed API tests (+fixes)

### DIFF
--- a/lib/galaxy/model/orm/engine_factory.py
+++ b/lib/galaxy/model/orm/engine_factory.py
@@ -48,7 +48,7 @@ def pretty_stack():
 
 
 def build_engine(
-    url,
+    url: str,
     engine_options=None,
     database_query_profiling_proxy=False,
     trace_logger=None,

--- a/lib/tool_shed/test/base/api_util.py
+++ b/lib/tool_shed/test/base/api_util.py
@@ -65,3 +65,4 @@ class ShedApiInteractor:
 
     get = decorate_method(requests.get)
     post = decorate_method(requests.post)
+    put = decorate_method(requests.put)

--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -91,3 +91,13 @@ class ShedRepositoriesApiTestCase(ShedApiTestCase):
         assert len(metadata_response.repository_status) == 1
         revisions = populator.get_ordered_installable_revisions(repository.owner, repository.name)
         assert len(revisions.__root__) == 1
+
+    def test_repository_search(self):
+        populator = self.populator
+        repository = populator.setup_column_maker_repo(prefix="repoforreposearch")
+        populator.reindex()
+        results = populator.repo_search_query("repoforreposearch")
+        assert len(results.hits) == 1
+        first_hit = results.hits[0]
+        assert first_hit.repository.name == repository.name
+        assert first_hit.repository.times_downloaded == 0

--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -47,15 +47,16 @@ class ShedRepositoriesApiTestCase(ShedApiTestCase):
     # used by getRepository in TS client.
     def test_metadata_simple(self):
         populator = self.populator
-        repository_id = populator.setup_column_maker_repo(prefix="repoformetadata").id
-        metadata_response = self.api_interactor.get(f"repositories/{repository_id}/metadata")
-        api_asserts.assert_status_code_is_ok(metadata_response)
-        metadata_for_revisions = metadata_response.json()
+        repository = populator.setup_column_maker_repo(prefix="repoformetadata")
+        repository_metadata = populator.get_metadata(repository)
+        metadata_for_revisions = repository_metadata.__root__
         assert len(metadata_for_revisions) == 1
         only_key = list(metadata_for_revisions.keys())[0]
         assert only_key.startswith("0:")
         only_revision = list(metadata_for_revisions.values())[0]
-        api_asserts.assert_has_keys(only_revision, "repository", "repository_dependencies", "numeric_revision")
+        assert only_revision
+        assert only_revision.downloadable
+        assert not only_revision.malicious
 
     def test_index_simple(self):
         populator = self.populator

--- a/lib/tool_shed/test/functional/test_shed_tools.py
+++ b/lib/tool_shed/test/functional/test_shed_tools.py
@@ -1,0 +1,34 @@
+from ..base.api import ShedApiTestCase
+
+
+class ShedToolsApiTestCase(ShedApiTestCase):
+    def test_tool_search(self):
+        populator = self.populator
+        repository = populator.setup_column_maker_repo(prefix="toolsearch")
+        populator.reindex()
+        response = populator.tool_search_query("Compute")
+        hit_count = len(response.hits)
+        assert hit_count >= 1
+
+        if hit_count == 1:
+            # if running the test standalone, we know this repository was in the results
+            # but if this tool has been installed a bunch by other tests - it might not be.
+            tool_search_hit = response.find_search_hit(repository)
+            assert tool_search_hit
+            assert tool_search_hit.tool.id == "Add_a_column1"
+            assert tool_search_hit.tool.name == "Compute"
+
+        # ensure re-index doesn't modify number of hits (regression of an issue pre-Fall 2022)
+        response = populator.reindex()
+        response = populator.reindex()
+
+        response = populator.tool_search_query("Compute")
+        new_hit_count = len(response.hits)
+
+        assert hit_count == new_hit_count
+
+        if hit_count == 1:
+            # if running the test standalone, we know this repository was in the results
+            # but if this tool has been installed a bunch by other tests - it might not be.
+            tool_search_hit = response.find_search_hit(repository)
+            assert tool_search_hit

--- a/lib/tool_shed/util/shed_index.py
+++ b/lib/tool_shed/util/shed_index.py
@@ -40,7 +40,7 @@ def build_index(whoosh_index_dir, file_path, hgweb_config_dir, dburi, **kwargs):
 
     Returns a tuple with number of repos and tools that were indexed.
     """
-    model = ts_mapping.init(file_path, dburi, engine_options={}, create_tables=False)
+    model = ts_mapping.init(dburi, engine_options={}, create_tables=False)
     sa_session = model.session
     repo_index, tool_index = _get_or_create_index(whoosh_index_dir)
 
@@ -66,8 +66,15 @@ def build_index(whoosh_index_dir, file_path, hgweb_config_dir, dburi, **kwargs):
             repo_index_writer.add_document(**repo)
 
             #  Tools get their own index
+            tool_index_writer.delete_by_term("repo_id", repo_id)
             for tool in tools_list:
-                tool_index_writer.add_document(**tool)
+                tool_contents = tool.copy()
+                # tool_id = tool_contents["id"]
+                # tool_contents["path"] = f"{repo_id}/{tool_id}"
+                tool_contents["repo_owner_username"] = repo.get("repo_owner_username")
+                tool_contents["repo_name"] = repo.get("name")
+                tool_contents["repo_id"] = repo_id
+                tool_index_writer.add_document(**tool_contents)
                 tools_indexed += 1
 
             repos_indexed += 1

--- a/lib/tool_shed/webapp/api/tools.py
+++ b/lib/tool_shed/webapp/api/tools.py
@@ -7,8 +7,13 @@ from galaxy import (
     util,
     web,
 )
-from galaxy.web import expose_api_raw_anonymous_and_sessionless
+from galaxy.web import (
+    expose_api,
+    expose_api_raw_anonymous_and_sessionless,
+    require_admin,
+)
 from galaxy.webapps.base.controller import BaseAPIController
+from tool_shed.util.shed_index import build_index
 from tool_shed.webapp.search.tool_search import ToolSearch
 
 log = logging.getLogger(__name__)
@@ -16,6 +21,26 @@ log = logging.getLogger(__name__)
 
 class ToolsController(BaseAPIController):
     """RESTful controller for interactions with tools in the Tool Shed."""
+
+    @expose_api
+    @require_admin
+    def build_search_index(self, trans, **kwd):
+        """
+        PUT /api/tools/build_search_index
+
+        Not part of the stable API, just something to simplify bootstrapping tool sheds,
+        scripting, testing, etc...
+        """
+        repos_indexed, tools_indexed = build_index(
+            trans.app.config.whoosh_index_dir,
+            trans.app.config.file_path,
+            trans.app.config.hgweb_config_dir,
+            trans.app.config.database_connection,
+        )
+        return {
+            "repositories_indexed": repos_indexed,
+            "tools_indexed": tools_indexed,
+        }
 
     @expose_api_raw_anonymous_and_sessionless
     def index(self, trans, **kwd):

--- a/lib/tool_shed/webapp/app.py
+++ b/lib/tool_shed/webapp/app.py
@@ -70,9 +70,7 @@ class UniverseApplication(BasicSharedApp, SentryClientMixin, HaltableContainer):
         # Set up the Tool Shed database engine and ORM.
         from tool_shed.webapp.model import mapping
 
-        model: mapping.ToolShedModelMapping = mapping.init(
-            self.config.file_path, db_url, self.config.database_engine_options
-        )
+        model: mapping.ToolShedModelMapping = mapping.init(db_url, self.config.database_engine_options)
         self.model = model
         self.security = idencoding.IdEncodingHelper(id_secret=self.config.id_secret)
         self._register_singleton(idencoding.IdEncodingHelper, self.security)

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -201,8 +201,14 @@ def app_pair(global_conf, load_app_kwds=None, **kwargs):
         action="create",
         conditions=dict(method=["POST"]),
     )
+    webapp.mapper.connect(
+        "tools",
+        "/api/tools/build_search_index",
+        controller="tools",
+        action="build_search_index",
+        conditions=dict(method=["PUT"]),
+    )
     webapp.mapper.connect("tools", "/api/tools", controller="tools", action="index", conditions=dict(method=["GET"]))
-    webapp.mapper.connect("json", "/api/tools/json", controller="tools", action="json", conditions=dict(method=["GET"]))
     webapp.mapper.connect(
         "version", "/api/version", controller="configuration", action="version", conditions=dict(method=["GET"])
     )

--- a/lib/tool_shed/webapp/model/mapping.py
+++ b/lib/tool_shed/webapp/model/mapping.py
@@ -3,6 +3,11 @@ Details of how the data model objects are mapped onto the relational database
 are encapsulated here.
 """
 import logging
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
 
 import tool_shed.webapp.model
 import tool_shed.webapp.util.shed_statistics as shed_statistics
@@ -22,7 +27,9 @@ class ToolShedModelMapping(SharedModelMapping):
     create_tables: bool
 
 
-def init(file_path, url, engine_options=None, create_tables=False) -> ToolShedModelMapping:
+def init(
+    url: str, engine_options: Optional[Dict[str, Any]] = None, create_tables: bool = False
+) -> ToolShedModelMapping:
     """Connect mappings to the database"""
     engine_options = engine_options or {}
     # Create the database engine

--- a/lib/tool_shed/webapp/search/tool_search.py
+++ b/lib/tool_shed/webapp/search/tool_search.py
@@ -5,8 +5,8 @@ import os
 import whoosh.index
 from whoosh import scoring
 from whoosh.fields import (
+    ID,
     Schema,
-    STORED,
     TEXT,
 )
 from whoosh.qparser import MultifieldParser
@@ -26,7 +26,7 @@ schema = Schema(
     version=TEXT(stored=True),
     repo_name=TEXT(stored=True),
     repo_owner_username=TEXT(stored=True),
-    repo_id=STORED,
+    repo_id=ID(stored=True),
 )
 
 

--- a/lib/tool_shed_client/schema/__init__.py
+++ b/lib/tool_shed_client/schema/__init__.py
@@ -1,5 +1,7 @@
 from typing import (
+    Dict,
     List,
+    Optional,
     Union,
 )
 
@@ -7,9 +9,20 @@ from pydantic import BaseModel
 
 
 class Repository(BaseModel):
+    # element/collection view on the backend have same keys/impl
     id: str
     name: str
     owner: str
+    type: str  # TODO: enum
+    remote_repository_url: Optional[str]
+    homepage_url: Optional[str]
+    description: str
+    user_id: str
+    private: bool
+    deleted: bool
+    times_downloaded: int
+    deprecated: bool
+    create_time: str
 
 
 class Category(BaseModel):
@@ -40,6 +53,42 @@ class RepositoryUpdate(BaseModel):
     @property
     def is_ok(self):
         return isinstance(self.__root__, ValidRepostiroyUpdateMessage)
+
+
+class RepositoryDependency(BaseModel):
+    pass
+
+
+class RepositoryTool(BaseModel):
+    pass
+
+
+class RepositoryRevisionMetadata(BaseModel):
+    id: str
+    repository: Repository
+    repository_dependencies: List[RepositoryDependency]
+    tools: List[RepositoryTool]
+    repository_id: str
+    numeric_revision: int
+    changeset_revision: str
+    malicious: bool
+    downloadable: bool
+    missing_test_components: bool
+    has_repository_dependencies: bool
+    includes_tools: bool
+    includes_tools_for_display_in_tool_panel: bool
+    # Deprecate these...
+    includes_tool_dependencies: Optional[bool]
+    includes_datatypes: Optional[bool]
+    includes_workflows: Optional[bool]
+
+
+class RepositoryMetadata(BaseModel):
+    __root__: Dict[str, RepositoryRevisionMetadata]
+
+    @property
+    def latest_revision(self) -> RepositoryRevisionMetadata:
+        return list(self.__root__.values())[-1]
 
 
 class ResetMetadataOnRepositoryRequest(BaseModel):

--- a/lib/tool_shed_client/schema/__init__.py
+++ b/lib/tool_shed_client/schema/__init__.py
@@ -1,4 +1,5 @@
 from typing import (
+    Any,
     Dict,
     List,
     Optional,
@@ -100,3 +101,79 @@ class ResetMetadataOnRepositoryResponse(BaseModel):
     repository_status: List[str]
     start_time: str
     stop_time: str
+
+
+class ToolSearchRequest(BaseModel):
+    q: str
+    page: Optional[int]
+    page_size: Optional[int]
+
+
+class ToolSearchHitTool(BaseModel):
+    id: str
+    repo_owner_username: str
+    repo_name: str
+    name: str
+    description: str
+
+
+class ToolSearchHit(BaseModel):
+    tool: ToolSearchHitTool
+    matched_terms: Dict[str, Any]
+    score: float
+
+
+class ToolSearchResults(BaseModel):
+    # These next three really should be ints :<
+    total_results: str
+    page: str
+    page_size: str
+    hostname: str
+    hits: List[ToolSearchHit]
+
+    def find_search_hit(self, repository: Repository) -> Optional[ToolSearchHit]:
+        matching_hit: Optional[ToolSearchHit] = None
+
+        for hit in self.hits:
+            owner_matches = hit.tool.repo_owner_username == repository.owner
+            name_matches = hit.tool.repo_name == repository.name
+            if owner_matches and name_matches:
+                matching_hit = hit
+                break
+
+        return matching_hit
+
+
+class RepositorySearchRequest(BaseModel):
+    q: str
+    page: Optional[int]
+    page_size: Optional[int]
+
+
+class RepositorySearchResult(BaseModel):
+    id: str
+    name: str
+    repo_owner_username: str
+    description: str
+    long_description: Optional[str]
+    remote_repository_url: Optional[str]
+    homepage_url: Optional[str]
+    last_update: Optional[str]
+    full_last_updated: str
+    repo_lineage: str
+    approved: bool
+    times_downloaded: int
+    categories: str
+
+
+class RepositorySearchHit(BaseModel):
+    score: float
+    repository: RepositorySearchResult
+
+
+class RepositorySearchResults(BaseModel):
+    total_results: str
+    page: str
+    page_size: str
+    hostname: str
+    hits: List[RepositorySearchHit]

--- a/test/unit/shed_unit/model/test_mapping.py
+++ b/test/unit/shed_unit/model/test_mapping.py
@@ -926,7 +926,7 @@ def ensure_database_is_empty(session, model):
 @pytest.fixture(scope="module")
 def model():
     db_uri = "sqlite:///:memory:"
-    return mapping.init("/tmp", db_uri, create_tables=True)
+    return mapping.init(db_uri, create_tables=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
More tool shed API tests - flush out metadata models for better validation and add search tests. Some small fixes for search also and adding an admin only API endpoint for indexing the tool shed that cleans up writing API tests for these things nicely.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
