### PR TITLE
Fix export RO-crate to file source

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2240,8 +2240,8 @@ class ROCrateArchiveModelExportStore(DirectoryModelExportStore, WriteCrates):
         else:
             file_source_path = self.file_sources.get_file_source_path(self.file_source_uri)
             file_source = file_source_path.file_source
-            assert os.path.exists(self.out_file)
-            file_source.write_from(file_source_path.path, self.out_file)
+            assert os.path.exists(rval), rval
+            file_source.write_from(file_source_path.path, rval)
         shutil.rmtree(self.temp_output_dir)
 
 

--- a/test/integration/test_workflow_tasks.py
+++ b/test/integration/test_workflow_tasks.py
@@ -58,6 +58,10 @@ class WorkflowTasksIntegrationTestCase(
         ro_crate_path = self._export_ro_crate(False)
         assert CompressedFile(ro_crate_path).file_type == "zip"
 
+    def test_export_ro_crate_to_uri(self):
+        ro_crate_path = self._export_ro_crate(True)
+        assert CompressedFile(ro_crate_path).file_type == "zip"
+
     def _export_ro_crate(self, to_uri):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow_with_runtime_data_column_parameter(history_id)


### PR DESCRIPTION
Follow up on #14595 and required for #14606 

I think this writes the correct packaged file to the file source.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
