### PR TITLE
Adding Bulk Datatype Change to Collection Edit

### DIFF
--- a/client/src/components/Collections/common/ChangeDatatypeTab.vue
+++ b/client/src/components/Collections/common/ChangeDatatypeTab.vue
@@ -1,0 +1,57 @@
+<template>
+    <div>
+        <div class="alert alert-secondary" role="alert">
+            <div class="float-left">Change Datatype/Extension of all elements in collection</div>
+            <div class="text-right">
+                <button
+                    class="save-collection-edit btn btn-primary"
+                    :disabled="selectedDatatype.id == datatypeFromElements"
+                    @click="clickedSave">
+                    {{ l("Save") }}
+                </button>
+            </div>
+        </div>
+        <b>{{ l("New Type:") }}: </b>
+        <multiselect
+            v-model="selectedDatatype"
+            deselect-label="Can't remove this value"
+            track-by="id"
+            label="text"
+            :options="datatypes"
+            :searchable="true"
+            :allow-empty="false">
+            {{ selectedDatatype.text }}
+        </multiselect>
+    </div>
+</template>
+<script>
+import Multiselect from "vue-multiselect";
+
+export default {
+    components: { Multiselect },
+    props: {
+        datatypes: {
+            type: Array,
+            required: true,
+        },
+        datatypeFromElements: {
+            type: String,
+            required: true,
+        },
+    },
+    data: function () {
+        return {
+            selectedDatatype: {},
+        };
+    },
+    created() {
+        this.selectedDatatype = this.datatypes.find((element) => element.id == this.datatypeFromElements);
+    },
+    methods: {
+        clickedSave: function () {
+            this.$emit("clicked-save", "dbkey", this.selectedDatatype);
+            this.selectedDatatype = this.datatypes.find((element) => element.id == this.datatypeFromElements);
+        },
+    },
+};
+</script>

--- a/client/src/components/Collections/common/ChangeDatatypeTab.vue
+++ b/client/src/components/Collections/common/ChangeDatatypeTab.vue
@@ -49,7 +49,7 @@ export default {
     },
     methods: {
         clickedSave: function () {
-            this.$emit("clicked-save", "dbkey", this.selectedDatatype);
+            this.$emit("clicked-save", this.selectedDatatype);
             this.selectedDatatype = this.datatypes.find((element) => element.id == this.datatypeFromElements);
         },
     },

--- a/client/src/components/Collections/common/ChangeDatatypeTab.vue
+++ b/client/src/components/Collections/common/ChangeDatatypeTab.vue
@@ -5,7 +5,7 @@
             <div class="text-right">
                 <button
                     class="save-datatype-edit btn btn-primary"
-                    :disabled="selectedDatatype.id == datatypeFromElements"
+                    :disabled="selectedDatatype.id == currentDatatype"
                     @click="clickedSave">
                     {{ l("Save") }}
                 </button>
@@ -43,15 +43,17 @@ export default {
     data: function () {
         return {
             selectedDatatype: {},
+            currentDatatype: "",
         };
     },
     created() {
         this.selectedDatatype = this.datatypes.find((element) => element.id == this.datatypeFromElements);
+        this.currentDatatype = this.datatypeFromElements;
     },
     methods: {
         clickedSave: function () {
             this.$emit("clicked-save", this.selectedDatatype);
-            this.datatypeFromElements = this.selectedDatatype.id;
+            this.currentDatatype = this.selectedDatatype.id;
         },
     },
 };

--- a/client/src/components/Collections/common/ChangeDatatypeTab.vue
+++ b/client/src/components/Collections/common/ChangeDatatypeTab.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
-        <div class="alert alert-secondary" role="alert">
-            <div class="float-left">Change Datatype/Extension of all elements in collection</div>
+        <div>
+            <h4 class="float-left">Change Datatype/Extension of all elements in collection</h4>
             <div class="text-right">
                 <button
                     class="save-datatype-edit btn btn-primary"

--- a/client/src/components/Collections/common/ChangeDatatypeTab.vue
+++ b/client/src/components/Collections/common/ChangeDatatypeTab.vue
@@ -4,15 +4,16 @@
             <div class="float-left">Change Datatype/Extension of all elements in collection</div>
             <div class="text-right">
                 <button
-                    class="save-collection-edit btn btn-primary"
+                    class="save-datatype-edit btn btn-primary"
                     :disabled="selectedDatatype.id == datatypeFromElements"
                     @click="clickedSave">
                     {{ l("Save") }}
                 </button>
             </div>
         </div>
-        <b>{{ l("New Type:") }}: </b>
+        <b>{{ l("New Type") }}: </b>
         <multiselect
+            class="datatype-dropdown"
             v-model="selectedDatatype"
             deselect-label="Can't remove this value"
             track-by="id"
@@ -50,7 +51,7 @@ export default {
     methods: {
         clickedSave: function () {
             this.$emit("clicked-save", this.selectedDatatype);
-            this.selectedDatatype = this.datatypes.find((element) => element.id == this.datatypeFromElements);
+            this.datatypeFromElements = this.selectedDatatype.id;
         },
     },
 };

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -35,7 +35,7 @@
                         <font-awesome-icon icon="database" /> &nbsp; {{ l("Datatypes") }}
                     </template>
                     <datatypes-provider v-slot="{ item, loading }">
-                        <div v-if="loading"><loading-span :message="loadingString"/></div>
+                        <div v-if="loading"><loading-span :message="loadingString" /></div>
                         <div v-else>
                             <change-datatype-tab
                                 v-if="item && datatypeFromElements"
@@ -64,7 +64,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faDatabase, faTable, faBars, faUser, faCog } from "@fortawesome/free-solid-svg-icons";
 import ConfigProvider from "components/providers/ConfigProvider";
 import ChangeDatatypeTab from "./ChangeDatatypeTab";
-import LoadingSpan from "../../LoadingSpan.vue"
+import LoadingSpan from "../../LoadingSpan.vue";
 
 library.add(faDatabase, faTable, faBars, faUser, faCog);
 
@@ -93,7 +93,7 @@ export default {
             errorMessage: null,
             jobError: null,
             noQuotaIncrease: true,
-            loadingString: "Loading Datatypes"
+            loadingString: "Loading Datatypes",
         };
     },
     computed: {

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -143,8 +143,24 @@ export default {
             axios.post(url, data).catch(this.handleError);
         },
         clickedDatatypeChange: function (selectedDatatype) {
+            const historyId = this.$store?.getters["history/currentHistoryId"];
+
             console.log("New Type:", selectedDatatype);
-            const url = prependPath(`/api/histories/${this.history_id}/contents/bulk`)
+            const url = prependPath(`/api/histories/${historyId}/contents/bulk`);
+            const data = {
+                operation: "change_datatype",
+                items: [
+                    {
+                        history_content_type: "dataset_collection",
+                        id: this.collection_id,
+                    },
+                ],
+                params: {
+                    type: "change_datatype",
+                    datatype: selectedDatatype.id,
+                },
+            };
+            axios.put(url, data).catch(this.handleError);
         },
         handleError: function (err) {
             this.errorMessage = errorMessageAsString(err, "History import failed.");

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -87,7 +87,7 @@ export default {
     },
     data: function () {
         return {
-            attributes_data: {},
+            attributesData: {},
             errorMessage: null,
             jobError: null,
             noQuotaIncrease: true,
@@ -95,10 +95,10 @@ export default {
     },
     computed: {
         databaseKeyFromElements: function () {
-            return this.attributes_data.dbkey;
+            return this.attributesData.dbkey;
         },
         datatypeFromElements: function () {
-            return this.attributes_data.extension;
+            return this.attributesData.extension;
         },
         newCollectionInfoMessage: function () {
             let newCollectionMessage = "This will create a new collection in your History.";
@@ -107,6 +107,9 @@ export default {
             }
             return newCollectionMessage;
         },
+        historyId: function() {
+            return this.$store.getters["history/currentHistoryId"];
+        }
     },
     created() {
         this.getCollectionDataAndAttributes();
@@ -118,7 +121,7 @@ export default {
                 await this.$store.dispatch("fetchCollectionAttributes", this.collection_id);
                 attributesGet = this.$store.getters.getCollectionAttributes(this.collection_id);
             }
-            this.attributes_data = attributesGet;
+            this.attributesData = attributesGet;
         },
         clickedSave: function (attribute, newValue) {
             const url = prependPath(`/api/dataset_collections/${this.collection_id}/copy`);
@@ -143,10 +146,7 @@ export default {
             axios.post(url, data).catch(this.handleError);
         },
         clickedDatatypeChange: function (selectedDatatype) {
-            const historyId = this.$store?.getters["history/currentHistoryId"];
-
-            console.log("New Type:", selectedDatatype);
-            const url = prependPath(`/api/histories/${historyId}/contents/bulk`);
+            const url = prependPath(`/api/histories/${this.historyId}/contents/bulk`);
             const data = {
                 operation: "change_datatype",
                 items: [

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -35,7 +35,7 @@
                         <font-awesome-icon icon="database" /> &nbsp; {{ l("Datatypes") }}
                     </template>
                     <datatypes-provider v-slot="{ item, loading }">
-                        <div v-if="loading"><b-spinner label="Loading Datatypes..."></b-spinner></div>
+                        <div v-if="loading"><loading-span :message="loadingString"/></div>
                         <div v-else>
                             <change-datatype-tab
                                 v-if="item && datatypeFromElements"
@@ -64,6 +64,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faDatabase, faTable, faBars, faUser, faCog } from "@fortawesome/free-solid-svg-icons";
 import ConfigProvider from "components/providers/ConfigProvider";
 import ChangeDatatypeTab from "./ChangeDatatypeTab";
+import LoadingSpan from "../../LoadingSpan.vue"
 
 library.add(faDatabase, faTable, faBars, faUser, faCog);
 
@@ -78,6 +79,7 @@ export default {
         ConfigProvider,
         ChangeDatatypeTab,
         DatatypesProvider,
+        LoadingSpan,
     },
     props: {
         collection_id: {
@@ -91,6 +93,7 @@ export default {
             errorMessage: null,
             jobError: null,
             noQuotaIncrease: true,
+            loadingString: "Loading Datatypes"
         };
     },
     computed: {

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -107,9 +107,9 @@ export default {
             }
             return newCollectionMessage;
         },
-        historyId: function() {
+        historyId: function () {
             return this.$store.getters["history/currentHistoryId"];
-        }
+        },
     },
     created() {
         this.getCollectionDataAndAttributes();

--- a/client/src/components/Collections/common/DatabaseEditTab.vue
+++ b/client/src/components/Collections/common/DatabaseEditTab.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
-        <div class="alert alert-secondary" role="alert">
-            <div class="float-left">Change Database/Build of all elements in collection</div>
+        <div>
+            <h4 class="float-left">Change Database/Build of all elements in collection</h4>
             <div class="text-right">
                 <button
                     class="save-dbkey-edit btn btn-primary"

--- a/client/src/components/Collections/common/DatabaseEditTab.vue
+++ b/client/src/components/Collections/common/DatabaseEditTab.vue
@@ -4,7 +4,7 @@
             <div class="float-left">Change Database/Build of all elements in collection</div>
             <div class="text-right">
                 <button
-                    class="save-collection-edit btn btn-primary"
+                    class="save-dbkey-edit btn btn-primary"
                     :disabled="selectedGenome.id == databaseKeyFromElements"
                     @click="clickedSave">
                     {{ l("Save") }}
@@ -13,6 +13,7 @@
         </div>
         <b>{{ l("Database/Build") }}: </b>
         <multiselect
+            class="database-dropdown"
             v-model="selectedGenome"
             deselect-label="Can't remove this value"
             track-by="id"

--- a/client/src/components/Collections/common/SuitableConvertersTab.vue
+++ b/client/src/components/Collections/common/SuitableConvertersTab.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
-        <div class="alert alert-secondary" role="alert">
-            <div class="float-left">Convert all datasets to new format</div>
+        <div>
+            <h4 class="float-left">Convert all datasets to new format</h4>
             <div class="text-right">
                 <button
                     class="run-tool-collection-edit btn btn-primary"

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -308,9 +308,15 @@ edit_collection_attributes:
     database_genome_tab:
       type: xpath
       selector: '//a[contains(text(), "Database/Build")]'
+    datatypes_tab:
+      type: xpath
+      selector: '//a[contains(text(), "Datatypes")]'
     database_value:
       type: xpath
       selector: '//span[contains(text(), "${dbkey}")]'
+    datatype_value:
+      type: xpath
+      selector: '//span[contains(text(), "${datatype}")]'
     save_btn: '.save-collection-edit'
 
 tool_panel:

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -173,6 +173,7 @@ history_panel:
       name: '${_} .name'
       blurb: '${_} .not-loading .blurb .value'
       dbkey: '${_} .not-loading .dbkey .value'
+      datatype: '${_} .not-loading .datatype .value'
       info: '${_} .not-loading .info .value'
       peek: '${_} .not-loading .dataset-peek'
       toolhelp_title: '${_} .toolhelp strong'

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -311,13 +311,11 @@ edit_collection_attributes:
     datatypes_tab:
       type: xpath
       selector: '//a[contains(text(), "Datatypes")]'
-    database_value:
+    data_value:
       type: xpath
-      selector: '//span[contains(text(), "${dbkey}")]'
-    datatype_value:
-      type: xpath
-      selector: '//span[contains(text(), "${datatype}")]'
-    save_btn: '.save-collection-edit'
+      selector: '//span[contains(text(), "${data_change}")]'
+    save_dbkey_btn: '.save-dbkey-edit'
+    save_datatype_btn: '.save-datatype-edit'
 
 tool_panel:
   selectors:

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3468,7 +3468,7 @@ mapping:
 
       enable_celery_tasks:
         type: bool
-        default: true
+        default: false
         required: false
         desc: |
           Offload long-running tasks to a Celery task queue.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3468,7 +3468,7 @@ mapping:
 
       enable_celery_tasks:
         type: bool
-        default: false
+        default: true
         required: false
         desc: |
           Offload long-running tasks to a Celery task queue.

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -1,8 +1,9 @@
+import time
+
 from .framework import (
     selenium_test,
     SeleniumTestCase,
 )
-import time
 
 
 class CollectionEditTestCase(SeleniumTestCase):

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -77,14 +77,22 @@ class CollectionEditTestCase(SeleniumTestCase):
 
     def change_dbkey_value_and_click_submit(self, dataValue, dataNew):
         self.components.edit_collection_attributes.data_value(data_change=dataValue).wait_for_and_click()
-        self.find_element_by_selector("div.database-dropdown > div.multiselect__tags > input.multiselect__input").send_keys(dataNew)
-        self.find_element_by_selector("div.database-dropdown > div.multiselect__tags > input.multiselect__input").send_keys(self.keys.ENTER)
+        self.find_element_by_selector(
+            "div.database-dropdown > div.multiselect__tags > input.multiselect__input"
+        ).send_keys(dataNew)
+        self.find_element_by_selector(
+            "div.database-dropdown > div.multiselect__tags > input.multiselect__input"
+        ).send_keys(self.keys.ENTER)
         self.components.edit_collection_attributes.save_dbkey_btn.wait_for_and_click()
 
     def change_datatype_value_and_click_submit(self, dataValue, dataNew):
         self.components.edit_collection_attributes.data_value(data_change=dataValue).wait_for_and_click()
-        self.find_element_by_selector("div.datatype-dropdown > div.multiselect__tags > input.multiselect__input").send_keys(dataNew)
-        self.find_element_by_selector("div.datatype-dropdown > div.multiselect__tags > input.multiselect__input").send_keys(self.keys.ENTER)
+        self.find_element_by_selector(
+            "div.datatype-dropdown > div.multiselect__tags > input.multiselect__input"
+        ).send_keys(dataNew)
+        self.find_element_by_selector(
+            "div.datatype-dropdown > div.multiselect__tags > input.multiselect__input"
+        ).send_keys(self.keys.ENTER)
         self.components.edit_collection_attributes.save_datatype_btn.wait_for_and_click()
 
     def _wait_for_and_select(self, hids):

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -35,7 +35,6 @@ class CollectionEditTestCase(SeleniumTestCase):
         self.wait_for_history()
         self.find_element_by_selector("span.content-title").click()
         self.wait_for_selector_clickable("div.d-flex.justify-content-between")
-        # into dataset
         self.find_element_by_selector("div.d-flex.justify-content-between").click()
         self.wait_for_selector_visible("span.datatype")
         assert self.find_element_by_selector("span.datatype > span").text == dataNew

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -2,7 +2,7 @@ from .framework import (
     selenium_test,
     SeleniumTestCase,
 )
-
+import time
 
 class CollectionEditTestCase(SeleniumTestCase):
 
@@ -13,14 +13,14 @@ class CollectionEditTestCase(SeleniumTestCase):
         self.create_simple_list_collection()
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
-        dbkeyValue = "unspecified"
-        self.check_current_dbkey_value(dbkeyValue)
-        dbkeyNew = "hg17"
-        self.change_dbkey_value_and_click_submit(dbkeyValue, dbkeyNew)
+        dataValue = "unspecified"
+        self.check_current_data_value(dataValue)
+        dataNew = "hg17"
+        self.change_dbkey_value_and_click_submit(dataValue, dataNew)
         self.history_panel_wait_for_hid_ok(4)
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
-        self.check_current_dbkey_value(dbkeyNew)
+        self.check_current_data_value(dataNew)
 
     @selenium_test
     def test_change_datatype_simple_list(self):
@@ -28,10 +28,21 @@ class CollectionEditTestCase(SeleniumTestCase):
         self.create_simple_list_collection_txt()
         self.open_collection_edit_view()
         self.navigate_to_datatype_tab()
-        datatypeValue = "txt"
-        self.check_current_datatype_value(datatypeValue)
-        datatypeNew = "tabular"
-        self.change_datatype_value_and_click_submit(datatypeValue, datatypeNew)
+        dataValue = "txt"
+        self.check_current_data_value(dataValue)
+        dataNew = "tabular"
+        self.change_datatype_value_and_click_submit(dataValue, dataNew)
+        self.check_current_data_value(dataNew)
+        time.sleep(10)
+        # into collection
+        self.find_element_by_selector("span.content-title").click()
+        time.sleep(3)
+        # into dataset
+        self.find_element_by_selector("div.d-flex.justify-content-between").click()
+        time.sleep(3)
+        assert self.find_element_by_selector("span.datatype > span").text == dataNew
+
+
 
     def create_simple_list_collection(self):
         self.perform_upload(self.get_filename("1.fasta"))
@@ -62,23 +73,20 @@ class CollectionEditTestCase(SeleniumTestCase):
     def navigate_to_datatype_tab(self):
         self.components.edit_collection_attributes.datatypes_tab.wait_for_and_click()
 
-    def check_current_dbkey_value(self, dbkeyValue):
-        self.components.edit_collection_attributes.database_value(dbkey=dbkeyValue).wait_for_visible()
+    def check_current_data_value(self, dataValue):
+        self.components.edit_collection_attributes.data_value(data_change=dataValue).wait_for_visible()
 
-    def check_current_datatype_value(self, datatypeValue):
-        self.components.edit_collection_attributes.datatype_value(datatype=datatypeValue).wait_for_visible()
+    def change_dbkey_value_and_click_submit(self, dataValue, dataNew):
+        self.components.edit_collection_attributes.data_value(data_change=dataValue).wait_for_and_click()
+        self.find_element_by_selector("div.database-dropdown > div.multiselect__tags > input.multiselect__input").send_keys(dataNew)
+        self.find_element_by_selector("div.database-dropdown > div.multiselect__tags > input.multiselect__input").send_keys(self.keys.ENTER)
+        self.components.edit_collection_attributes.save_dbkey_btn.wait_for_and_click()
 
-    def change_dbkey_value_and_click_submit(self, dbkeyValue, dbkeyNew):
-        self.components.edit_collection_attributes.database_value(dbkey=dbkeyValue).wait_for_and_click()
-        self.find_element_by_selector("input.multiselect__input").send_keys(dbkeyNew)
-        self.find_element_by_selector("input.multiselect__input").send_keys(self.keys.ENTER)
-        self.components.edit_collection_attributes.save_btn.wait_for_and_click()
-
-    def change_datatype_value_and_click_submit(self, datatypeValue, datatypeNew):
-        self.components.edit_collection_attributes.datatype_value(datatype=datatypeValue).wait_for_and_click()
-        self.find_element_by_selector("input.multiselect__input").send_keys(datatypeNew)
-        # self.find_element_by_selector("input.multiselect__input").send_keys(self.keys.ENTER)
-        # self.components.edit_collection_attributes.save_btn.wait_for_and_click()
+    def change_datatype_value_and_click_submit(self, dataValue, dataNew):
+        self.components.edit_collection_attributes.data_value(data_change=dataValue).wait_for_and_click()
+        self.find_element_by_selector("div.datatype-dropdown > div.multiselect__tags > input.multiselect__input").send_keys(dataNew)
+        self.find_element_by_selector("div.datatype-dropdown > div.multiselect__tags > input.multiselect__input").send_keys(self.keys.ENTER)
+        self.components.edit_collection_attributes.save_datatype_btn.wait_for_and_click()
 
     def _wait_for_and_select(self, hids):
         """

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -24,7 +24,6 @@ class CollectionEditTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_change_datatype_simple_list(self):
-        self.use_beta_history()
         self.create_simple_list_collection_txt()
         self.open_collection_edit_view()
         self.navigate_to_datatype_tab()

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -1,5 +1,3 @@
-import time
-
 from .framework import (
     selenium_test,
     SeleniumTestCase,

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -34,9 +34,10 @@ class CollectionEditTestCase(SeleniumTestCase):
         self.check_current_data_value(dataNew)
         self.wait_for_history()
         self.find_element_by_selector("span.content-title").click()
-        self.wait_for_selector_clickable("div.d-flex.justify-content-between")
-        self.find_element_by_selector("div.d-flex.justify-content-between").click()
-        self.wait_for_selector_visible("span.datatype")
+        self.wait_for_selector_clickable("div.content-item")
+        self.find_element_by_selector("div.content-item").click()
+        item = self.history_panel_item_component(hid=1)
+        item.datatype.wait_for_visible()
         assert self.find_element_by_selector("span.datatype > span").text == dataNew
 
     def create_simple_list_collection(self):

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -35,13 +35,12 @@ class CollectionEditTestCase(SeleniumTestCase):
         dataNew = "tabular"
         self.change_datatype_value_and_click_submit(dataValue, dataNew)
         self.check_current_data_value(dataNew)
-        time.sleep(10)
-        # into collection
+        self.wait_for_history()
         self.find_element_by_selector("span.content-title").click()
-        time.sleep(3)
+        self.wait_for_selector_clickable("div.d-flex.justify-content-between")
         # into dataset
         self.find_element_by_selector("div.d-flex.justify-content-between").click()
-        time.sleep(3)
+        self.wait_for_selector_visible("span.datatype")
         assert self.find_element_by_selector("span.datatype > span").text == dataNew
 
     def create_simple_list_collection(self):

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -3,6 +3,8 @@ from .framework import (
     SeleniumTestCase,
 )
 import time
+
+
 class CollectionEditTestCase(SeleniumTestCase):
 
     ensure_registered = True

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -22,10 +22,32 @@ class CollectionEditTestCase(SeleniumTestCase):
         self.navigate_to_database_tab()
         self.check_current_dbkey_value(dbkeyNew)
 
+    @selenium_test
+    def test_change_datatype_simple_list(self):
+        self.use_beta_history()
+        self.create_simple_list_collection_txt()
+        self.open_collection_edit_view()
+        self.navigate_to_datatype_tab()
+        datatypeValue = "txt"
+        self.check_current_datatype_value(datatypeValue)
+        datatypeNew = "tabular"
+        self.change_datatype_value_and_click_submit(datatypeValue, datatypeNew)
+
     def create_simple_list_collection(self):
         self.perform_upload(self.get_filename("1.fasta"))
         self._wait_for_and_select([1])
         self._collection_dropdown("build list")
+        self.collection_builder_set_name("my cool list")
+        self.screenshot("collection_builder_list")
+        self.collection_builder_create()
+        self._wait_for_hid_visible(2)
+
+    def create_simple_list_collection_txt(self):
+        self.perform_upload(self.get_filename("1.txt"))
+        self._wait_for_and_select([1])
+
+        self._collection_dropdown("build list")
+
         self.collection_builder_set_name("my cool list")
         self.screenshot("collection_builder_list")
         self.collection_builder_create()
@@ -37,14 +59,26 @@ class CollectionEditTestCase(SeleniumTestCase):
     def navigate_to_database_tab(self):
         self.components.edit_collection_attributes.database_genome_tab.wait_for_and_click()
 
+    def navigate_to_datatype_tab(self):
+        self.components.edit_collection_attributes.datatypes_tab.wait_for_and_click()
+
     def check_current_dbkey_value(self, dbkeyValue):
         self.components.edit_collection_attributes.database_value(dbkey=dbkeyValue).wait_for_visible()
+
+    def check_current_datatype_value(self, datatypeValue):
+        self.components.edit_collection_attributes.datatype_value(datatype=datatypeValue).wait_for_visible()
 
     def change_dbkey_value_and_click_submit(self, dbkeyValue, dbkeyNew):
         self.components.edit_collection_attributes.database_value(dbkey=dbkeyValue).wait_for_and_click()
         self.find_element_by_selector("input.multiselect__input").send_keys(dbkeyNew)
         self.find_element_by_selector("input.multiselect__input").send_keys(self.keys.ENTER)
         self.components.edit_collection_attributes.save_btn.wait_for_and_click()
+
+    def change_datatype_value_and_click_submit(self, datatypeValue, datatypeNew):
+        self.components.edit_collection_attributes.datatype_value(datatype=datatypeValue).wait_for_and_click()
+        self.find_element_by_selector("input.multiselect__input").send_keys(datatypeNew)
+        # self.find_element_by_selector("input.multiselect__input").send_keys(self.keys.ENTER)
+        # self.components.edit_collection_attributes.save_btn.wait_for_and_click()
 
     def _wait_for_and_select(self, hids):
         """

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -3,7 +3,6 @@ from .framework import (
     SeleniumTestCase,
 )
 import time
-
 class CollectionEditTestCase(SeleniumTestCase):
 
     ensure_registered = True
@@ -41,8 +40,6 @@ class CollectionEditTestCase(SeleniumTestCase):
         self.find_element_by_selector("div.d-flex.justify-content-between").click()
         time.sleep(3)
         assert self.find_element_by_selector("span.datatype > span").text == dataNew
-
-
 
     def create_simple_list_collection(self):
         self.perform_upload(self.get_filename("1.fasta"))


### PR DESCRIPTION
I created a tab to edit the datatype of all elements in a collection, celery tasks must be enabled to see the tab, becuase changing the metadata for large collections is resource heavy. 
#12725 


https://user-images.githubusercontent.com/26912553/190717800-56538a60-d788-4884-afe5-48bf6b958abd.mp4



## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Enable Celery on your local machine
  2. Create a collection of one datatype
  3.  Navigate to Collection Editor > Datatypes Tab
  4. Select a new datatype and click Save

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
