### PR TITLE
Git rid of JQuery from ToolHelp.vue

### DIFF
--- a/client/src/components/Tool/ToolHelp.vue
+++ b/client/src/components/Tool/ToolHelp.vue
@@ -17,13 +17,18 @@ export default {
             const temp = document.createElement("div");
             temp.id = "formattedContent";
             temp.insertAdjacentHTML("beforeend", this.content);
-            temp.getElementsByTagName("a").forEach((elem) => elem.setAttribute("target", "_blank"));
-            temp.getElementsByTagName("img").forEach((elem) => {
-                const imgSrc = elem.getAttribute("src");
-                if (elem.src.indexOf("admin_toolshed") !== -1) {
-                    elem.setAttribute("src", getAppRoot() + imgSrc);
-                }
-            });
+            const anchorElements = temp.getElementsByTagName("a");
+            anchorElements.length > 0 ? anchorElements.forEach((elem) => elem.setAttribute("target", "_blank")) : null;
+            const imageElements = temp.getElementsByTagName("img");
+            imageElements.length > 0
+                ? imageElements.forEach((elem) => {
+                      const imgSrc = elem.getAttribute("src");
+                      if (elem.src.indexOf("admin_toolshed") !== -1) {
+                          elem.setAttribute("src", getAppRoot() + imgSrc);
+                      }
+                  })
+                : null;
+
             return temp.innerHTML;
         },
     },

--- a/client/src/components/Tool/ToolHelp.vue
+++ b/client/src/components/Tool/ToolHelp.vue
@@ -1,29 +1,13 @@
 <template>
-    <div class="form-help form-text mt-4" v-html="formattedContent" />
+    <div id="formattedContent" class="form-help form-text mt-4" v-html="content" />
 </template>
 
 <script>
-import $ from "jquery";
-import { getAppRoot } from "onload/loadConfig";
-
 export default {
     props: {
         content: {
             type: String,
             required: true,
-        },
-    },
-    computed: {
-        formattedContent() {
-            const $tmpl = $("<div/>").append(this.content);
-            $tmpl.find("a").attr("target", "_blank");
-            $tmpl.find("img").each(function () {
-                const img_src = $(this).attr("src");
-                if (img_src.indexOf("admin_toolshed") !== -1) {
-                    $(this).attr("src", getAppRoot() + img_src);
-                }
-            });
-            return $tmpl.html();
         },
     },
 };

--- a/client/src/components/Tool/ToolHelp.vue
+++ b/client/src/components/Tool/ToolHelp.vue
@@ -1,8 +1,10 @@
 <template>
-    <div class="form-help form-text mt-4" v-html="content" />
+    <div v-html="formatContent" class="form-help form-text mt-4"></div>
 </template>
 
 <script>
+import { getAppRoot } from "onload/loadConfig";
+
 export default {
     props: {
         content: {
@@ -10,5 +12,20 @@ export default {
             required: true,
         },
     },
+    computed: {
+        formatContent() {
+            let temp = document.createElement("div")
+            temp.id = 'formattedContent'
+            temp.insertAdjacentHTML( 'beforeend', this.content );
+            temp.getElementsByTagName('a').forEach(elem => elem.setAttribute('target', '_blank'))
+            temp.getElementsByTagName('img').forEach((elem) => {
+                const imgSrc = elem.getAttribute("src")
+                if(elem.src.indexOf('admin_toolshed') !== -1) {
+                    elem.setAttribute('src', getAppRoot() + imgSrc)
+                }
+            })
+            return temp.innerHTML
+        }
+    }
 };
 </script>

--- a/client/src/components/Tool/ToolHelp.vue
+++ b/client/src/components/Tool/ToolHelp.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="formattedContent" class="form-help form-text mt-4" v-html="content" />
+    <div class="form-help form-text mt-4" v-html="content" />
 </template>
 
 <script>

--- a/client/src/components/Tool/ToolHelp.vue
+++ b/client/src/components/Tool/ToolHelp.vue
@@ -14,18 +14,18 @@ export default {
     },
     computed: {
         formatContent() {
-            let temp = document.createElement("div")
-            temp.id = 'formattedContent'
-            temp.insertAdjacentHTML( 'beforeend', this.content );
-            temp.getElementsByTagName('a').forEach(elem => elem.setAttribute('target', '_blank'))
-            temp.getElementsByTagName('img').forEach((elem) => {
-                const imgSrc = elem.getAttribute("src")
-                if(elem.src.indexOf('admin_toolshed') !== -1) {
-                    elem.setAttribute('src', getAppRoot() + imgSrc)
+            const temp = document.createElement("div");
+            temp.id = "formattedContent";
+            temp.insertAdjacentHTML("beforeend", this.content);
+            temp.getElementsByTagName("a").forEach((elem) => elem.setAttribute("target", "_blank"));
+            temp.getElementsByTagName("img").forEach((elem) => {
+                const imgSrc = elem.getAttribute("src");
+                if (elem.src.indexOf("admin_toolshed") !== -1) {
+                    elem.setAttribute("src", getAppRoot() + imgSrc);
                 }
-            })
-            return temp.innerHTML
-        }
-    }
+            });
+            return temp.innerHTML;
+        },
+    },
 };
 </script>


### PR DESCRIPTION
Instead of using the function formattedComponent which in turn used Jquery selector to directly using the content that comes from props which is already having the HTML that we need to render in String format. Related to task #11939

(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
