### PR TITLE
indicate history name in collection navigation

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionNavigation.vue
+++ b/client/src/components/History/CurrentCollection/CollectionNavigation.vue
@@ -1,14 +1,14 @@
 <template>
     <div class="mx-1 mt-1">
         <b-button
-            v-b-tooltip:hover="history.name"
+            v-b-tooltip:hover="historyName"
             size="sm"
             class="text-left text-decoration-none overflow-hidden text-nowrap w-100"
             style="text-overflow: ellipsis"
             variant="link"
             @click="close">
             <icon icon="angle-double-left" class="mr-1" data-description="back to history" /><span
-                >History: {{ history.name }}</span
+                >History: {{ historyName }}</span
             >
         </b-button>
         <b-button v-if="previousName" size="sm" class="text-decoration-none" variant="link" @click="back">
@@ -20,7 +20,7 @@
 <script>
 export default {
     props: {
-        history: { type: Object, required: true },
+        historyName: { type: String, required: true },
         selectedCollections: { type: Array, required: true, validate: (val) => val.length > 0 },
     },
     computed: {

--- a/client/src/components/History/CurrentCollection/CollectionNavigation.vue
+++ b/client/src/components/History/CurrentCollection/CollectionNavigation.vue
@@ -1,7 +1,15 @@
 <template>
-    <div class="ml-1 mt-1">
-        <b-button size="sm" class="text-decoration-none" variant="link" @click="close">
-            <icon icon="angle-double-left" class="mr-1" data-description="back to history" /><span>History</span>
+    <div class="mx-1 mt-1">
+        <b-button
+            v-b-tooltip:hover="history.name"
+            size="sm"
+            class="text-left text-decoration-none overflow-hidden text-nowrap w-100"
+            style="text-overflow: ellipsis"
+            variant="link"
+            @click="close">
+            <icon icon="angle-double-left" class="mr-1" data-description="back to history" /><span
+                >History: {{ history.name }}</span
+            >
         </b-button>
         <b-button v-if="previousName" size="sm" class="text-decoration-none" variant="link" @click="back">
             <span class="fa fa-angle-left mr-1" /><span>{{ previousName }}</span>
@@ -12,6 +20,7 @@
 <script>
 export default {
     props: {
+        history: { type: Object, required: true },
         selectedCollections: { type: Array, required: true, validate: (val) => val.length > 0 },
     },
     computed: {

--- a/client/src/components/History/CurrentCollection/CollectionPanel.vue
+++ b/client/src/components/History/CurrentCollection/CollectionPanel.vue
@@ -12,7 +12,7 @@
             <section class="dataset-collection-panel w-100 d-flex flex-column">
                 <section>
                     <CollectionNavigation
-                        :history="history"
+                        :history-name="history.name"
                         :selected-collections="selectedCollections"
                         v-on="$listeners" />
                     <CollectionDetails :dsc="dsc" :writeable="isRoot" @update:dsc="updateDsc(dsc, $event)" />

--- a/client/src/components/History/Multiple/MultipleViewItem.vue
+++ b/client/src/components/History/Multiple/MultipleViewItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="list-item" class="d-flex flex-column align-items-center">
+    <div id="list-item" class="d-flex flex-column align-items-center w-100">
         <CollectionPanel
             v-if="selectedCollections.length && selectedCollections[0].history_id === source.id"
             :history="getHistory"


### PR DESCRIPTION
Related #14600

![history name](https://user-images.githubusercontent.com/8046843/191036919-c8466a92-1df6-4848-8462-7fffdcec3621.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. click on a collection in the current history panel or history multiview
  2. in the top, the name of history is shown 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
