### PR TITLE
Improved handling of keep_outputs_dir for tool testing.

### DIFF
--- a/lib/galaxy/tool_util/unittest_utils/__init__.py
+++ b/lib/galaxy/tool_util/unittest_utils/__init__.py
@@ -1,3 +1,9 @@
+from typing import (
+    Callable,
+    Dict,
+    Optional,
+    Union,
+)
 from unittest.mock import Mock
 
 
@@ -9,3 +15,14 @@ def mock_trans(has_user=True, is_admin=False):
     else:
         trans.user = None
     return trans
+
+
+def t_data_downloader_for(content: Union[Dict[Optional[str], bytes], bytes]) -> Callable[[str], bytes]:
+    def get_content(filename: Optional[str]) -> bytes:
+        if isinstance(content, dict):
+            assert filename in content, f"failed to find {filename} in {content}"
+            return content[filename]
+        else:
+            return content
+
+    return get_content

--- a/lib/galaxy/tool_util/unittest_utils/interactor.py
+++ b/lib/galaxy/tool_util/unittest_utils/interactor.py
@@ -1,0 +1,62 @@
+NEW_HISTORY = object()
+NEW_HISTORY_ID = "new"
+EXISTING_HISTORY = {"id": "existing"}
+EXISTING_SUITE_NAME = "existing suite"
+EXISTING_HISTORY_NAME = f"History for {EXISTING_SUITE_NAME}"
+
+
+class MockGalaxyInteractor:
+    def __init__(self):
+        self.history_deleted = False
+        self.history_created = False
+        self.history_name = None
+        self.history_id = None
+
+    def get_history(self, history_name=""):
+        if history_name == EXISTING_HISTORY_NAME:
+            self.history_name = history_name
+            self.history_id = EXISTING_HISTORY["id"]
+            return EXISTING_HISTORY
+        else:
+            return None
+
+    def new_history(self, history_name="", publish_history=False):
+        self.history_created = True
+        self.history_name = history_name
+        self.history_id = NEW_HISTORY_ID
+        return NEW_HISTORY
+
+    def delete_history(self, history):
+        self.history_deleted = True
+
+    def get_tests_summary(self):
+        return {
+            "cat1": {
+                "0.2.0": {
+                    "count": 4,
+                },
+                "0.1.0": {
+                    "count": 2,
+                },
+            },
+        }
+
+    def get_tool_tests(self, tool_id, tool_version=None):
+        tool_dict = self.get_tests_summary().get(tool_id)
+        test_defs = []
+        for this_tool_version, version_defs in tool_dict.items():
+            if tool_version is not None and tool_version != "*" and this_tool_version != tool_version:
+                continue
+
+            count = version_defs["count"]
+            for _ in range(count):
+                test_def = {
+                    "tool_id": tool_id,
+                    "tool_version": this_tool_version or "0.1.1-default",
+                }
+                test_defs.append(test_def)
+
+            if tool_version is None or tool_version != "*":
+                break
+
+        return test_defs

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -100,6 +100,7 @@ def verify(
     if attributes is None:
         attributes = {}
 
+    compare = attributes.get("compare", "diff")
     # expected object might be None, so don't pull unless available
     has_expected_object = "object" in attributes
     if has_expected_object:
@@ -129,7 +130,7 @@ def verify(
         # may raise an exception if `filename` does not exist (e.g. when
         # generating a tool output file from scratch with
         # `planemo test --update_test_data`).
-        if keep_outputs_dir:
+        if keep_outputs_dir and compare in ["diff", "sim_size"]:
             ofn = os.path.join(keep_outputs_dir, filename)
             out_dir = os.path.dirname(ofn)
             if not os.path.exists(out_dir):
@@ -151,7 +152,6 @@ def verify(
             assert filename_, f"Failed to find output target for test {filename_}"
             local_name = filename_
 
-        compare = attributes.get("compare", "diff")
         try:
             if attributes.get("ftype", None) in [
                 "bam",

--- a/lib/galaxy/tool_util/verify/asserts/__init__.py
+++ b/lib/galaxy/tool_util/verify/asserts/__init__.py
@@ -30,14 +30,14 @@ for assertion_module_name in assertion_module_names:
             assertion_functions[member] = value
 
 
-def verify_assertions(data, assertion_description_list):
+def verify_assertions(data: bytes, assertion_description_list):
     """This function takes a list of assertions and a string to check
     these assertions against."""
     for assertion_description in assertion_description_list:
         verify_assertion(data, assertion_description)
 
 
-def verify_assertion(data, assertion_description):
+def verify_assertion(data: bytes, assertion_description):
     tag = assertion_description["tag"]
     assert_function_name = "assert_" + tag
     assert_function = assertion_functions.get(assert_function_name)

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -127,6 +127,7 @@ def stage_data_in_history(
 
 class GalaxyInteractorApi:
     api_key: Optional[str]
+    keep_outputs_dir: Optional[str]
 
     def __init__(self, **kwds):
         self.api_url = f"{kwds['galaxy_url'].rstrip('/')}/api"
@@ -950,7 +951,12 @@ class RunToolException(Exception):
 
 # Galaxy specific methods - rest of this can be used with arbitrary files and such.
 def verify_hid(
-    filename, hda_id, attributes, test_data_downloader, hid="", dataset_fetcher=None, keep_outputs_dir=False
+    filename: Optional[str],
+    hda_id: str,
+    attributes: Dict[str, Any],
+    test_data_downloader,
+    dataset_fetcher=None,
+    keep_outputs_dir: Optional[str] = None,
 ):
     assert dataset_fetcher is not None
 
@@ -1050,7 +1056,7 @@ def _verify_composite_datatype_file_content(
     attributes=None,
     dataset_fetcher=None,
     test_data_downloader=None,
-    keep_outputs_dir=False,
+    keep_outputs_dir: Optional[str] = None,
     mode="file",
 ):
     assert dataset_fetcher is not None
@@ -1073,7 +1079,9 @@ def _verify_composite_datatype_file_content(
         raise AssertionError(errmsg)
 
 
-def _verify_extra_files_content(extra_files, hda_id, dataset_fetcher, test_data_downloader, keep_outputs_dir):
+def _verify_extra_files_content(
+    extra_files: List[Dict[str, Any]], hda_id: str, dataset_fetcher, test_data_downloader, keep_outputs_dir
+):
     files_list = []
     cleanup_directories = []
     for extra_file_dict in extra_files:

--- a/lib/galaxy/tool_util/verify/script.py
+++ b/lib/galaxy/tool_util/verify/script.py
@@ -12,6 +12,7 @@ from concurrent.futures import (
     thread,
     ThreadPoolExecutor,
 )
+from typing import List
 
 import yaml
 
@@ -34,11 +35,13 @@ TestException = namedtuple("TestException", ["tool_id", "exception", "was_record
 
 
 class Results:
+    test_exceptions: List[Exception]
+
     def __init__(self, default_suitename, test_json, append=False, galaxy_url=None):
         self.test_json = test_json or "-"
         self.galaxy_url = galaxy_url
         test_results = []
-        test_exceptions = []
+        test_exceptions: List[Exception] = []
         suitename = default_suitename
         if append:
             assert test_json != "-"

--- a/lib/galaxy/tool_util/verify/test_data.py
+++ b/lib/galaxy/tool_util/verify/test_data.py
@@ -35,21 +35,26 @@ class TestDataResolver:
         else:
             self.resolvers = []
 
-    def get_filename(self, name):
+    def get_filename(self, name: str) -> str:
         for resolver in self.resolvers or []:
             if not resolver.exists(name):
                 continue
             filename = resolver.path(name)
             if filename:
                 return os.path.abspath(filename)
+        raise TestDataNotFoundError(f"Failed to find test file {name} against any test data resolvers")
 
-    def get_filecontent(self, name):
+    def get_filecontent(self, name: str) -> bytes:
         filename = self.get_filename(name=name)
         with open(filename, mode="rb") as f:
             return f.read()
 
-    def get_directory(self, name):
+    def get_directory(self, name: str) -> str:
         return self.get_filename(name=name)
+
+
+class TestDataNotFoundError(ValueError):
+    pass
 
 
 def build_resolver(uri, environ):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1228,7 +1228,10 @@ class Tool(Dictifiable):
             # Fallback to Galaxy test data directory for builtin tools, tools
             # under development, and some older ToolShed published tools that
             # used stock test data.
-            test_data = self.app.test_data_resolver.get_filename(filename)
+            try:
+                test_data = self.app.test_data_resolver.get_filename(filename)
+            except ValueError:
+                test_data = None
         return test_data
 
     def __walk_test_data(self, dir, filename):

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -1,6 +1,11 @@
 import os
 from contextlib import contextmanager
-from typing import Optional
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Tuple,
+)
 from urllib.parse import (
     urlencode,
     urljoin,
@@ -122,7 +127,7 @@ class UsesApiTestCaseMixin:
         user = [user for user in users if user["email"] == email][0]
         return user
 
-    def _setup_user_get_key(self, email, password=None, is_admin=True):
+    def _setup_user_get_key(self, email, password=None, is_admin=True) -> Tuple[Dict[str, Any], str]:
         user = self._setup_user(email, password, is_admin)
         return user, self._post(f"users/{user['id']}/api_key", admin=True).json()
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -294,8 +294,6 @@ check_untyped_defs = False
 check_untyped_defs = False
 [mypy-galaxy.tools.repositories]
 check_untyped_defs = False
-[mypy-galaxy.tool_util.verify.interactor]
-check_untyped_defs = False
 [mypy-galaxy.objectstore.s3]
 check_untyped_defs = False
 [mypy-galaxy.objectstore.pithos]

--- a/test/unit/tool_util/test_verify_function.py
+++ b/test/unit/tool_util/test_verify_function.py
@@ -6,7 +6,7 @@ def test_writes_output_to_target_directory(tmp_path):
     output_content = b"expected"
     filename = "my_output.txt"
 
-    def get_filecontent(str) -> bytes:
+    def get_filecontent(fname) -> bytes:
         return output_content
 
     assert not (tmp_path / filename).exists()
@@ -21,3 +21,81 @@ def test_writes_output_to_target_directory(tmp_path):
     assert (tmp_path / filename).exists()
     assert (tmp_path / filename).open("rb").read() == output_content
 
+
+def test_no_writes_output_to_target_directory_on_contains(tmp_path):
+    item_label = "my test case"
+    output_content = b"expected"
+    attributes = {
+        "compare": "contains",
+    }
+    filename = "my_output.txt"
+
+    def get_filecontent(fname) -> bytes:
+        return b"xpecte"
+
+    assert not (tmp_path / filename).exists()
+    verify(
+        item_label,
+        output_content,
+        attributes=attributes,
+        filename=filename,
+        keep_outputs_dir=str(tmp_path),
+        get_filecontent=get_filecontent,
+    )
+    assert not (tmp_path / filename).exists()
+
+
+def test_sim_size(tmp_path):
+    item_label = "my test case"
+    output_content = b"expected"
+    attributes = {
+        "compare": "sim_size",
+        "delta": 2,
+    }
+    filename = "my_output.txt"
+
+    def get_filecontent(fname) -> bytes:
+        return b"xpected"
+
+    assert not (tmp_path / filename).exists()
+    verify(
+        item_label,
+        output_content,
+        attributes=attributes,
+        filename=filename,
+        keep_outputs_dir=str(tmp_path),
+        get_filecontent=get_filecontent,
+    )
+    assert (tmp_path / filename).exists()
+    assert (tmp_path / filename).open("rb").read() == b"expected"
+
+
+def test_sim_size_failure_still_updates(tmp_path):
+    item_label = "my test case"
+    output_content = b"expected"
+    attributes = {
+        "compare": "sim_size",
+        "delta": 2,
+    }
+    filename = "my_output.txt"
+
+    def get_filecontent(fname) -> bytes:
+        return b"ected"
+
+    assert not (tmp_path / filename).exists()
+    assertion_error = None
+    try:
+        verify(
+            item_label,
+            output_content,
+            attributes=attributes,
+            filename=filename,
+            keep_outputs_dir=str(tmp_path),
+            get_filecontent=get_filecontent,
+        )
+    except AssertionError as ae:
+        assertion_error = ae
+
+    assert assertion_error
+    assert (tmp_path / filename).exists()
+    assert (tmp_path / filename).open("rb").read() == b"expected"

--- a/test/unit/tool_util/test_verify_function.py
+++ b/test/unit/tool_util/test_verify_function.py
@@ -1,0 +1,23 @@
+from galaxy.tool_util.verify import verify
+
+
+def test_writes_output_to_target_directory(tmp_path):
+    item_label = "my test case"
+    output_content = b"expected"
+    filename = "my_output.txt"
+
+    def get_filecontent(str) -> bytes:
+        return output_content
+
+    assert not (tmp_path / filename).exists()
+    verify(
+        item_label,
+        output_content,
+        attributes={},
+        filename=filename,
+        keep_outputs_dir=str(tmp_path),
+        get_filecontent=get_filecontent,
+    )
+    assert (tmp_path / filename).exists()
+    assert (tmp_path / filename).open("rb").read() == output_content
+

--- a/test/unit/tool_util/test_verify_function.py
+++ b/test/unit/tool_util/test_verify_function.py
@@ -1,3 +1,4 @@
+from galaxy.tool_util.unittest_utils import t_data_downloader_for
 from galaxy.tool_util.verify import verify
 
 
@@ -6,9 +7,6 @@ def test_writes_output_to_target_directory(tmp_path):
     output_content = b"expected"
     filename = "my_output.txt"
 
-    def get_filecontent(fname) -> bytes:
-        return output_content
-
     assert not (tmp_path / filename).exists()
     verify(
         item_label,
@@ -16,7 +14,7 @@ def test_writes_output_to_target_directory(tmp_path):
         attributes={},
         filename=filename,
         keep_outputs_dir=str(tmp_path),
-        get_filecontent=get_filecontent,
+        get_filecontent=t_data_downloader_for(output_content),
     )
     assert (tmp_path / filename).exists()
     assert (tmp_path / filename).open("rb").read() == output_content
@@ -30,9 +28,7 @@ def test_no_writes_output_to_target_directory_on_contains(tmp_path):
     }
     filename = "my_output.txt"
 
-    def get_filecontent(fname) -> bytes:
-        return b"xpecte"
-
+    get_filecontent = t_data_downloader_for(b"xpecte")
     assert not (tmp_path / filename).exists()
     verify(
         item_label,
@@ -54,9 +50,7 @@ def test_sim_size(tmp_path):
     }
     filename = "my_output.txt"
 
-    def get_filecontent(fname) -> bytes:
-        return b"xpected"
-
+    get_filecontent = t_data_downloader_for(b"xpected")
     assert not (tmp_path / filename).exists()
     verify(
         item_label,
@@ -79,9 +73,7 @@ def test_sim_size_failure_still_updates(tmp_path):
     }
     filename = "my_output.txt"
 
-    def get_filecontent(fname) -> bytes:
-        return b"ected"
-
+    get_filecontent = t_data_downloader_for(b"ected")
     assert not (tmp_path / filename).exists()
     assertion_error = None
     try:

--- a/test/unit/tool_util/test_verify_hid.py
+++ b/test/unit/tool_util/test_verify_hid.py
@@ -1,0 +1,110 @@
+from typing import (
+    Callable,
+    Dict,
+    Optional,
+)
+
+from galaxy.tool_util.unittest_utils import t_data_downloader_for
+from galaxy.tool_util.verify.interactor import verify_hid
+
+
+def dataset_fetcher_for(
+    expected_hda_id: str, content: Dict[Optional[str], bytes]
+) -> Callable[[str, Optional[str]], bytes]:
+    def get_content(hda_id, filename: Optional[str] = None) -> bytes:
+        assert expected_hda_id == hda_id
+        return content[filename]
+
+    return get_content
+
+
+TEST_ID = "mydatasetid"
+
+
+def test_verify_hid_simple_pass():
+    test_data_downloader = t_data_downloader_for(b"expected")
+    dataset_fetcher = dataset_fetcher_for(TEST_ID, {None: b"expected"})
+    verify_hid(
+        "",
+        TEST_ID,
+        {},
+        dataset_fetcher=dataset_fetcher,
+        test_data_downloader=test_data_downloader,
+    )
+
+
+def test_verify_hid_simple_fail():
+    test_data_downloader = t_data_downloader_for(b"expected")
+    dataset_fetcher = dataset_fetcher_for(TEST_ID, {None: b"unexpected"})
+    assertion_error = None
+    try:
+        verify_hid(
+            "",
+            TEST_ID,
+            {},
+            dataset_fetcher=dataset_fetcher,
+            test_data_downloader=test_data_downloader,
+        )
+    except AssertionError as ae:
+        assertion_error = ae
+    assert assertion_error
+
+
+def test_verify_extra_files_success(tmp_path):
+    test_data_downloader = t_data_downloader_for(
+        {
+            "": b"expected",
+            "test_extras/expected.txt": b"extra_expected",
+        }
+    )
+    found_data = {
+        None: b"expected",
+        "extra_1": b"extra_expected",
+    }
+    extra_files = [{"type": "file", "name": "extra_1", "attributes": {}, "value": "test_extras/expected.txt"}]
+    dataset_fetcher = dataset_fetcher_for(TEST_ID, found_data)
+    assert not (tmp_path / "expected.txt").exists()
+    verify_hid(
+        "",
+        TEST_ID,
+        {"extra_files": extra_files},
+        dataset_fetcher=dataset_fetcher,
+        test_data_downloader=test_data_downloader,
+        keep_outputs_dir=tmp_path,
+    )
+    extra_path = tmp_path / "test_extras" / "expected.txt"
+    assert extra_path.exists()
+    assert extra_path.open("rb").read() == b"extra_expected"
+
+
+def test_verify_extra_files_failed(tmp_path):
+    test_data_downloader = t_data_downloader_for(
+        {
+            "": b"expected",
+            "test_extras/expected.txt": b"extra_expected",
+        }
+    )
+    found_data = {
+        None: b"expected",
+        "extra_1": b"extra_unexpected",
+    }
+    extra_files = [{"type": "file", "name": "extra_1", "attributes": {}, "value": "test_extras/expected.txt"}]
+    dataset_fetcher = dataset_fetcher_for(TEST_ID, found_data)
+    assert not (tmp_path / "expected.txt").exists()
+    assert_error = None
+    try:
+        verify_hid(
+            "",
+            TEST_ID,
+            {"extra_files": extra_files},
+            dataset_fetcher=dataset_fetcher,
+            test_data_downloader=test_data_downloader,
+            keep_outputs_dir=tmp_path,
+        )
+    except AssertionError as ae:
+        assert_error = ae
+    assert assert_error
+    assert "Composite file (extra_1) of History item mydatasetid different than expected" in str(assert_error)
+    extra_path = tmp_path / "test_extras" / "expected.txt"
+    assert extra_path.exists()
+    assert extra_path.open("rb").read() == b"extra_unexpected"

--- a/test/unit/tool_util/test_verify_script.py
+++ b/test/unit/tool_util/test_verify_script.py
@@ -3,6 +3,13 @@ import os
 from tempfile import NamedTemporaryFile
 from unittest import mock
 
+from galaxy.tool_util.unittest_utils.interactor import (
+    EXISTING_HISTORY,
+    EXISTING_HISTORY_NAME,
+    EXISTING_SUITE_NAME,
+    MockGalaxyInteractor,
+    NEW_HISTORY_ID,
+)
 from galaxy.tool_util.verify.script import (
     arg_parser,
     build_case_references,
@@ -12,11 +19,6 @@ from galaxy.tool_util.verify.script import (
 )
 
 VT_PATH = "galaxy.tool_util.verify.script.verify_tool"
-NEW_HISTORY = object()
-NEW_HISTORY_ID = "new"
-EXISTING_HISTORY = {"id": "existing"}
-EXISTING_SUITE_NAME = "existing suite"
-EXISTING_HISTORY_NAME = f"History for {EXISTING_SUITE_NAME}"
 
 
 def test_arg_parse():
@@ -338,60 +340,3 @@ def assert_results_written(results):
     assert os.stat(results.test_json).st_size > 0
     with open(results.test_json) as f:
         json.load(f)
-
-
-class MockGalaxyInteractor:
-    def __init__(self):
-        self.history_deleted = False
-        self.history_created = False
-        self.history_name = None
-        self.history_id = None
-
-    def get_history(self, history_name=""):
-        if history_name == EXISTING_HISTORY_NAME:
-            self.history_name = history_name
-            self.history_id = EXISTING_HISTORY["id"]
-            return EXISTING_HISTORY
-        else:
-            return None
-
-    def new_history(self, history_name="", publish_history=False):
-        self.history_created = True
-        self.history_name = history_name
-        self.history_id = NEW_HISTORY_ID
-        return NEW_HISTORY
-
-    def delete_history(self, history):
-        self.history_deleted = True
-
-    def get_tests_summary(self):
-        return {
-            "cat1": {
-                "0.2.0": {
-                    "count": 4,
-                },
-                "0.1.0": {
-                    "count": 2,
-                },
-            },
-        }
-
-    def get_tool_tests(self, tool_id, tool_version=None):
-        tool_dict = self.get_tests_summary().get(tool_id)
-        test_defs = []
-        for this_tool_version, version_defs in tool_dict.items():
-            if tool_version is not None and tool_version != "*" and this_tool_version != tool_version:
-                continue
-
-            count = version_defs["count"]
-            for _ in range(count):
-                test_def = {
-                    "tool_id": tool_id,
-                    "tool_version": this_tool_version or "0.1.1-default",
-                }
-                test_defs.append(test_def)
-
-            if tool_version is None or tool_version != "*":
-                break
-
-        return test_defs


### PR DESCRIPTION
- Code quality things - typing and test cases.
- Fix so that it only copies for sim_size and diff - for file comparisons using regular expressions or contains do not replace the output.

The test cases and small fix in the last commit is the most relevant/interesting change. Ping @mvdbeek - is this problem with ``contains`` that you mentioned at the meeting?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
