### PR TITLE
add scroll shadow on the right and left sides

### DIFF
--- a/client/src/components/History/Multiple/MultipleViewList.vue
+++ b/client/src/components/History/Multiple/MultipleViewList.vue
@@ -93,5 +93,14 @@ export default {
     .history-picker {
         border: dotted lightgray;
     }
+
+    background-image: linear-gradient(to right, white, white), linear-gradient(to right, white, white),
+        linear-gradient(to right, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0)),
+        linear-gradient(to left, rgba(0, 0, 0, 0.25), rgba(255, 255, 255, 0));
+    background-position: left center, right center, left center, right center;
+    background-repeat: no-repeat;
+    background-color: white;
+    background-size: 20px 100%, 20px 100%, 10px 100%, 10px 100%;
+    background-attachment: local, local, scroll, scroll;
 }
 </style>


### PR DESCRIPTION
Related #14600: the backdrop shadow in scroll list

https://user-images.githubusercontent.com/8046843/191488998-7f720a9d-f2c9-47aa-9b41-a3e0f5619d26.mp4

### Known issue
Any background colour of elements is shown on top of these shadows

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
