### PR TITLE
One or two fixes to timeouts

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -210,7 +210,6 @@ class GalaxyInteractorApi:
         attributes = output_testdef.attributes
         name = output_testdef.name
         expected_count = attributes.get("count")
-        self.wait_for_jobs(history_id, jobs, maxseconds)
         hid = self.__output_id(output_data)
         # TODO: Twill version verifies dataset is 'ok' in here.
         try:

--- a/lib/galaxy/tool_util/verify/wait.py
+++ b/lib/galaxy/tool_util/verify/wait.py
@@ -8,6 +8,7 @@ from typing import (
     Optional,
     Union,
 )
+
 DEFAULT_POLLING_BACKOFF = 0
 DEFAULT_POLLING_DELTA = 0.25
 
@@ -35,9 +36,7 @@ def wait_on(
     start = time()
     while True:
         total_wait = time() - start
-        print(f"{total_wait=} > {timeout=} {total_wait > timeout}")
         if total_wait > timeout:
-            print(f"TIMEOUT")
             raise TimeoutAssertionError(TIMEOUT_MESSAGE_TEMPLATE.format(int(total_wait), desc))
         value = function()
         if value is not None:

--- a/lib/galaxy/tool_util/verify/wait.py
+++ b/lib/galaxy/tool_util/verify/wait.py
@@ -22,7 +22,7 @@ def wait_on(
     timeout: timeout_type,
     delta: timeout_type = DEFAULT_POLLING_DELTA,
     polling_backoff: timeout_type = DEFAULT_POLLING_BACKOFF,
-    _sleep: Optional[Callable] = None,  # only used in tests
+    sleep_: Optional[Callable] = None,  # only used in tests
 ):
     """Wait for function to return non-None value.
 
@@ -31,8 +31,10 @@ def wait_on(
 
     Throw a TimeoutAssertionError if the supplied timeout is reached without
     supplied function ever returning a non-None value.
+
+    The sleep_ parameter is used by the unit tests to "mock" out sleeping
     """
-    sleep_foo = _sleep or sleep
+    sleep_foo = sleep_ or sleep
     start = time()
     while True:
         total_wait = time() - start

--- a/lib/galaxy/tool_util/verify/wait.py
+++ b/lib/galaxy/tool_util/verify/wait.py
@@ -5,6 +5,7 @@ from time import (
 )
 from typing import (
     Callable,
+    Optional,
     Union,
 )
 DEFAULT_POLLING_BACKOFF = 0
@@ -20,6 +21,7 @@ def wait_on(
     timeout: timeout_type,
     delta: timeout_type = DEFAULT_POLLING_DELTA,
     polling_backoff: timeout_type = DEFAULT_POLLING_BACKOFF,
+    _sleep: Optional[Callable] = None,  # only used in tests
 ):
     """Wait for function to return non-None value.
 
@@ -29,15 +31,18 @@ def wait_on(
     Throw a TimeoutAssertionError if the supplied timeout is reached without
     supplied function ever returning a non-None value.
     """
+    sleep_foo = _sleep or sleep
     start = time()
     while True:
         total_wait = time() - start
+        print(f"{total_wait=} > {timeout=} {total_wait > timeout}")
         if total_wait > timeout:
+            print(f"TIMEOUT")
             raise TimeoutAssertionError(TIMEOUT_MESSAGE_TEMPLATE.format(int(total_wait), desc))
         value = function()
         if value is not None:
             return value
-        sleep(delta)
+        sleep_foo(delta)
         delta += polling_backoff
 
 

--- a/lib/galaxy/tool_util/verify/wait.py
+++ b/lib/galaxy/tool_util/verify/wait.py
@@ -1,12 +1,12 @@
 """Abstraction for waiting on API conditions to become true."""
-
-import time
+from time import (
+    sleep,
+    time,
+)
 from typing import (
     Callable,
-    Optional,
     Union,
 )
-
 DEFAULT_POLLING_BACKOFF = 0
 DEFAULT_POLLING_DELTA = 0.25
 
@@ -20,7 +20,6 @@ def wait_on(
     timeout: timeout_type,
     delta: timeout_type = DEFAULT_POLLING_DELTA,
     polling_backoff: timeout_type = DEFAULT_POLLING_BACKOFF,
-    sleep_: Optional[Callable] = None,
 ):
     """Wait for function to return non-None value.
 
@@ -30,15 +29,14 @@ def wait_on(
     Throw a TimeoutAssertionError if the supplied timeout is reached without
     supplied function ever returning a non-None value.
     """
-    sleep = sleep_ or time.sleep
-    total_wait = 0.0
+    start = time()
     while True:
+        total_wait = time() - start
         if total_wait > timeout:
-            raise TimeoutAssertionError(TIMEOUT_MESSAGE_TEMPLATE.format(total_wait, desc))
+            raise TimeoutAssertionError(TIMEOUT_MESSAGE_TEMPLATE.format(int(total_wait), desc))
         value = function()
         if value is not None:
             return value
-        total_wait += delta
         sleep(delta)
         delta += polling_backoff
 

--- a/test/unit/tool_util/test_wait.py
+++ b/test/unit/tool_util/test_wait.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from galaxy.tool_util.verify.wait import (
     TimeoutAssertionError,
     wait_on,
@@ -9,6 +11,7 @@ class Sleeper:
         self.sleeps = []
 
     def sleep(self, delta):
+        sleep(delta)
         self.sleeps.append(delta)
 
 
@@ -30,7 +33,7 @@ def test_immediate_return():
     condition = WaitCondition(return_value="first")
     sleeper = Sleeper()
 
-    assert "first" == wait_on(condition, "condition", 100, sleep_=sleeper.sleep)
+    assert "first" == wait_on(condition, "condition", 100, _sleep=sleeper.sleep)
     assert len(sleeper.sleeps) == 0
 
 
@@ -40,10 +43,10 @@ def test_timeout_first_call():
 
     exception_called = False
     try:
-        wait_on(condition, "never met condition", 1, delta=2, sleep_=sleeper.sleep)
+        wait_on(condition, "never met condition", 1, delta=2, _sleep=sleeper.sleep)
     except TimeoutAssertionError as e:
         assert "never met condition" in str(e)
-        assert "after 2.0 seconds" in str(e)
+        assert "after 2 seconds" in str(e)
         exception_called = True
     assert len(sleeper.sleeps) == 1
     assert sleeper.sleeps[0] == 2  # delta of 2
@@ -56,7 +59,7 @@ def test_timeout_third_call():
 
     exception_called = False
     try:
-        wait_on(condition, "condition", 5, delta=2, sleep_=sleeper.sleep)
+        wait_on(condition, "condition", 5, delta=2, _sleep=sleeper.sleep)
     except TimeoutAssertionError:
         exception_called = True
     assert len(sleeper.sleeps) == 3
@@ -70,7 +73,7 @@ def test_return_on_third_call():
     condition = WaitCondition(after_call_count=2, return_value="second")
     sleeper = Sleeper()
 
-    assert "second" == wait_on(condition, "condition", 5, delta=2, sleep_=sleeper.sleep)
+    assert "second" == wait_on(condition, "condition", 5, delta=2, _sleep=sleeper.sleep)
     assert len(sleeper.sleeps) == 2
     assert sleeper.sleeps[0] == 2  # delta of 2
     assert sleeper.sleeps[1] == 2  # delta of 2
@@ -82,7 +85,7 @@ def test_timeout_backoff():
 
     exception_called = False
     try:
-        wait_on(condition, "condition", 8, delta=2, polling_backoff=1, sleep_=sleeper.sleep)
+        wait_on(condition, "condition", 8, delta=2, polling_backoff=1, _sleep=sleeper.sleep)
     except TimeoutAssertionError:
         exception_called = True
     assert len(sleeper.sleeps) == 3

--- a/test/unit/tool_util/test_wait.py
+++ b/test/unit/tool_util/test_wait.py
@@ -33,7 +33,7 @@ def test_immediate_return():
     condition = WaitCondition(return_value="first")
     sleeper = Sleeper()
 
-    assert "first" == wait_on(condition, "condition", 100, _sleep=sleeper.sleep)
+    assert "first" == wait_on(condition, "condition", 100, sleep_=sleeper.sleep)
     assert len(sleeper.sleeps) == 0
 
 
@@ -43,7 +43,7 @@ def test_timeout_first_call():
 
     exception_called = False
     try:
-        wait_on(condition, "never met condition", 1, delta=2, _sleep=sleeper.sleep)
+        wait_on(condition, "never met condition", 1, delta=2, sleep_=sleeper.sleep)
     except TimeoutAssertionError as e:
         assert "never met condition" in str(e)
         assert "after 2 seconds" in str(e)
@@ -59,7 +59,7 @@ def test_timeout_third_call():
 
     exception_called = False
     try:
-        wait_on(condition, "condition", 5, delta=2, _sleep=sleeper.sleep)
+        wait_on(condition, "condition", 5, delta=2, sleep_=sleeper.sleep)
     except TimeoutAssertionError:
         exception_called = True
     assert len(sleeper.sleeps) == 3
@@ -73,7 +73,7 @@ def test_return_on_third_call():
     condition = WaitCondition(after_call_count=2, return_value="second")
     sleeper = Sleeper()
 
-    assert "second" == wait_on(condition, "condition", 5, delta=2, _sleep=sleeper.sleep)
+    assert "second" == wait_on(condition, "condition", 5, delta=2, sleep_=sleeper.sleep)
     assert len(sleeper.sleeps) == 2
     assert sleeper.sleeps[0] == 2  # delta of 2
     assert sleeper.sleeps[1] == 2  # delta of 2
@@ -85,7 +85,7 @@ def test_timeout_backoff():
 
     exception_called = False
     try:
-        wait_on(condition, "condition", 8, delta=2, polling_backoff=1, _sleep=sleeper.sleep)
+        wait_on(condition, "condition", 8, delta=2, polling_backoff=1, sleep_=sleeper.sleep)
     except TimeoutAssertionError:
         exception_called = True
     assert len(sleeper.sleeps) == 3


### PR DESCRIPTION
1. do not wait 2x in tool tests
2. do not use accumulated sleep times but time difference 

Not sure if the 2nd is good or possible. If not we should change the planemo CLI docs for the `--test_timeout` parameter.

Edit: 

OK I see `sleep_` is used in testing and also accumulated test times maybe easier to test. So I'm happy to revert https://github.com/galaxyproject/galaxy/pull/14667/commits/cdf7187f583880159aec14da2de59be3c95ade20 .. but I will wait for feedback.

Maybe increasing `delta` a bit will make `--test_timeout` be closer to what the `planemo` user observes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage 
       **I hope / assume**
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
