### PR TITLE
VCF/Tabular display fix

### DIFF
--- a/client/src/mvc/dataset/data.js
+++ b/client/src/mvc/dataset/data.js
@@ -317,6 +317,7 @@ var TabularDatasetChunkedView = Backbone.View.extend({
         var data_table = this.$el.find("table");
         const parsedChunk = parse(chunk.ck_data, {
             delimiter: this.delimiter,
+            comment: "#",
         });
         _.each(
             parsedChunk,

--- a/client/src/mvc/dataset/data.js
+++ b/client/src/mvc/dataset/data.js
@@ -143,6 +143,9 @@ var TabularDatasetChunkedView = Backbone.View.extend({
         this.loading_chunk = false;
         // Configure delimiter for parsing data
         this.delimiter = this.model?.attributes?.file_ext === "csv" ? "," : "\t";
+        this.parseArgs = {
+            delimiter: this.delimiter,
+        };
         // load trackster button
         new TabularButtonTracksterView({
             model: options.model,
@@ -316,9 +319,7 @@ var TabularDatasetChunkedView = Backbone.View.extend({
         var data_table = this.$el.find("table");
         let parsedChunk = [];
         try {
-            parsedChunk = parse(chunk.ck_data, {
-                delimiter: this.delimiter,
-            });
+            parsedChunk = parse(chunk.ck_data, this.parseArgs);
         } catch (error) {
             // If this blows up it's likely data in a comment or header line
             // (e.g. VCF files) so just split it by newline first then parse
@@ -326,9 +327,7 @@ var TabularDatasetChunkedView = Backbone.View.extend({
             parsedChunk = chunk.ck_data.trim().split("\n");
             parsedChunk = parsedChunk.map((line) => {
                 try {
-                    return parse(line, {
-                        delimiter: this.delimiter,
-                    })[0];
+                    return parse(line, this.parseArgs)[0];
                 } catch (error) {
                     // Failing lines get passed through intact for row-level
                     // rendering/parsing.


### PR DESCRIPTION
The new CSV parser added in #14396 gets grumpy about some VCF files that have comment lines it tries to split.

This tries to parse, catches any exception that might be happening due to these lines, and then parses each line in a chunk indivdiually.  This allows us to catch, individually, invalid lines out of a chunk and pass them through while parsing the remainder of the chunk with the same parse configuration.

Separately as mentioned in the linked issue I've started rebuilding this as a vue-based visualization component as the first step towards our 'all display is a visualization' overhaul, instead of the backbone mess it is now.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Upload and display a visualization with a comment line like `##INFO=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
