### PR TITLE
More cleanup of tool shed tests.

### DIFF
--- a/lib/galaxy/tool_shed/util/hg_util.py
+++ b/lib/galaxy/tool_shed/util/hg_util.py
@@ -1,7 +1,10 @@
 import logging
 import os
 import subprocess
-from typing import Optional
+from typing import (
+    Optional,
+    Tuple,
+)
 
 from galaxy.tool_shed.util import basic_util
 from galaxy.util import unicodify
@@ -11,7 +14,7 @@ log = logging.getLogger(__name__)
 INITIAL_CHANGELOG_HASH = "000000000000"
 
 
-def clone_repository(repository_clone_url, repository_file_dir, ctx_rev=None):
+def clone_repository(repository_clone_url: str, repository_file_dir: str, ctx_rev=None) -> Tuple[bool, Optional[str]]:
     """
     Clone the repository up to the specified changeset_revision.  No subsequent revisions will be
     present in the cloned repository.

--- a/lib/tool_shed/test/base/populators.py
+++ b/lib/tool_shed/test/base/populators.py
@@ -18,14 +18,14 @@ from tool_shed_client.schema import (
     GetOrderedInstallableRevisionsRequest,
     OrderedInstallableRevisions,
     Repository,
+    RepositoryIndexRequest,
+    RepositoryIndexResponse,
     RepositoryMetadata,
     RepositorySearchRequest,
     RepositorySearchResults,
     RepositoryUpdate,
     ResetMetadataOnRepositoryRequest,
     ResetMetadataOnRepositoryResponse,
-    RepositoryIndexRequest,
-    RepositoryIndexResponse,
     ToolSearchRequest,
     ToolSearchResults,
 )
@@ -148,24 +148,25 @@ class ToolShedPopulator:
         api_asserts.assert_status_code_is_ok(revisions_response)
         return OrderedInstallableRevisions(__root__=revisions_response.json())
 
-    def get_repository_for(self, owner: str, name: str) -> Optional[Repository]:
+    def get_repository_for(self, owner: str, name: str, deleted: str = "false") -> Optional[Repository]:
         request = RepositoryIndexRequest(
             owner=owner,
             name=name,
+            deleted=deleted,
         )
         index = self.repository_index(request)
         return index.__root__[0] if index.__root__ else None
 
     def repository_index(self, request: Optional[RepositoryIndexRequest]) -> RepositoryIndexResponse:
-        repository_response = self._api_interactor.get(
-            "repositories", params=(request.dict() if request else {})
-        )
+        repository_response = self._api_interactor.get("repositories", params=(request.dict() if request else {}))
         api_asserts.assert_status_code_is_ok(repository_response)
         return RepositoryIndexResponse(__root__=repository_response.json())
 
-    def get_metadata(self, repository: HasRepositoryId) -> RepositoryMetadata:
+    def get_metadata(self, repository: HasRepositoryId, downloadable_only=True) -> RepositoryMetadata:
         repository_id = self._repository_id(repository)
-        metadata_response = self._api_interactor.get(f"repositories/{repository_id}/metadata")
+        metadata_response = self._api_interactor.get(
+            f"repositories/{repository_id}/metadata?downloadable_only={downloadable_only}"
+        )
         api_asserts.assert_status_code_is_ok(metadata_response)
         return RepositoryMetadata(__root__=metadata_response.json())
 

--- a/lib/tool_shed/test/base/populators.py
+++ b/lib/tool_shed/test/base/populators.py
@@ -24,6 +24,8 @@ from tool_shed_client.schema import (
     RepositoryUpdate,
     ResetMetadataOnRepositoryRequest,
     ResetMetadataOnRepositoryResponse,
+    RepositoryIndexRequest,
+    RepositoryIndexResponse,
     ToolSearchRequest,
     ToolSearchResults,
 )
@@ -145,6 +147,21 @@ class ToolShedPopulator:
         )
         api_asserts.assert_status_code_is_ok(revisions_response)
         return OrderedInstallableRevisions(__root__=revisions_response.json())
+
+    def get_repository_for(self, owner: str, name: str) -> Optional[Repository]:
+        request = RepositoryIndexRequest(
+            owner=owner,
+            name=name,
+        )
+        index = self.repository_index(request)
+        return index.__root__[0] if index.__root__ else None
+
+    def repository_index(self, request: Optional[RepositoryIndexRequest]) -> RepositoryIndexResponse:
+        repository_response = self._api_interactor.get(
+            "repositories", params=(request.dict() if request else {})
+        )
+        api_asserts.assert_status_code_is_ok(repository_response)
+        return RepositoryIndexResponse(__root__=repository_response.json())
 
     def get_metadata(self, repository: HasRepositoryId) -> RepositoryMetadata:
         repository_id = self._repository_id(repository)

--- a/lib/tool_shed/test/base/test_db_util.py
+++ b/lib/tool_shed/test/base/test_db_util.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from sqlalchemy import (
     and_,
@@ -128,7 +129,10 @@ def get_repository_downloadable_revisions(repository_id):
     return revisions
 
 
-def get_repository_metadata_for_changeset_revision(repository_id, changeset_revision):
+def get_repository_metadata_for_changeset_revision(
+    repository_id: int, changeset_revision: Optional[str]
+) -> model.RepositoryMetadata:
+    assert sa_session
     repository_metadata = (
         sa_session.query(model.RepositoryMetadata)
         .filter(

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -5,7 +5,10 @@ import string
 import tempfile
 import time
 from json import loads
-from typing import List
+from typing import (
+    List,
+    Optional,
+)
 from urllib.parse import (
     quote_plus,
     urlencode,
@@ -35,7 +38,12 @@ from tool_shed.util import (
     hgweb_config,
     xml_util,
 )
-from tool_shed_client.schema import Category
+from tool_shed.webapp.model import Repository as DbRepository
+from tool_shed_client.schema import (
+    Category,
+    Repository,
+    RepositoryMetadata,
+)
 from . import (
     common,
     test_db_util,
@@ -239,11 +247,11 @@ class ShedTwillTestCase(ShedBaseTestCase):
             fh.write(smart_str(content))
         return fh.name
 
-    def assign_admin_role(self, repository, user):
+    def assign_admin_role(self, repository: Repository, user):
         # As elsewhere, twill limits the possibility of submitting the form, this time due to not executing the javascript
         # attached to the role selection form. Visit the action url directly with the necessary parameters.
         params = {
-            "id": self.security.encode_id(repository.id),
+            "id": repository.id,
             "in_users": user.id,
             "manage_role_associations_button": "Save",
         }
@@ -259,8 +267,8 @@ class ShedTwillTestCase(ShedBaseTestCase):
         self.visit_url("/repository/browse_valid_categories", params=params)
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
-    def browse_repository(self, repository, strings_displayed=None, strings_not_displayed=None):
-        params = {"id": self.security.encode_id(repository.id)}
+    def browse_repository(self, repository: Repository, strings_displayed=None, strings_not_displayed=None):
+        params = {"id": repository.id}
         self.visit_url("/repository/browse_repository", params=params)
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
@@ -284,7 +292,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
         self.visit_url(url)
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
-    def check_count_of_metadata_revisions_associated_with_repository(self, repository, metadata_count):
+    def check_count_of_metadata_revisions_associated_with_repository(self, repository: Repository, metadata_count):
         self.check_repository_changelog(repository)
         self.check_string_count_in_page("Repository metadata is associated with this change set.", metadata_count)
 
@@ -332,22 +340,22 @@ class ShedTwillTestCase(ShedBaseTestCase):
             tool_panel_section == expected_tool_panel_section
         ), f"Expected to find tool panel section *{expected_tool_panel_section}*, but instead found *{tool_panel_section}*\nMetadata: {metadata}\n"
 
-    def check_repository_changelog(self, repository, strings_displayed=None, strings_not_displayed=None):
-        params = {"id": self.security.encode_id(repository.id)}
+    def check_repository_changelog(self, repository: Repository, strings_displayed=None, strings_not_displayed=None):
+        params = {"id": repository.id}
         self.visit_url("/repository/view_changelog", params=params)
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def check_repository_dependency(
-        self, repository, depends_on_repository, depends_on_changeset_revision=None, changeset_revision=None
+        self, repository: Repository, depends_on_repository, depends_on_changeset_revision=None, changeset_revision=None
     ):
-        strings_displayed = [depends_on_repository.name, depends_on_repository.user.username]
+        strings_displayed = [depends_on_repository.name, depends_on_repository.owner]
         if depends_on_changeset_revision:
             strings_displayed.append(depends_on_changeset_revision)
         self.display_manage_repository_page(
             repository, changeset_revision=changeset_revision, strings_displayed=strings_displayed
         )
 
-    def check_repository_metadata(self, repository, tip_only=True):
+    def check_repository_metadata(self, repository: Repository, tip_only=True):
         if tip_only:
             assert (
                 self.tip_has_metadata(repository) and len(self.get_repository_metadata_revisions(repository)) == 1
@@ -361,14 +369,19 @@ class ShedTwillTestCase(ShedBaseTestCase):
             )
 
     def check_repository_tools_for_changeset_revision(
-        self, repository, changeset_revision, tool_metadata_strings_displayed=None, tool_page_strings_displayed=None
+        self,
+        repository: Repository,
+        changeset_revision,
+        tool_metadata_strings_displayed=None,
+        tool_page_strings_displayed=None,
     ):
         """
         Loop through each tool dictionary in the repository metadata associated with the received changeset_revision.
         For each of these, check for a tools attribute, and load the tool metadata page if it exists, then display that tool's page.
         """
-        test_db_util.refresh(repository)
-        repository_metadata = self.get_repository_metadata_by_changeset_revision(repository, changeset_revision)
+        db_repository = self._db_repository(repository)
+        test_db_util.refresh(db_repository)
+        repository_metadata = self.get_repository_metadata_by_changeset_revision(db_repository.id, changeset_revision)
         metadata = repository_metadata.metadata
         if "tools" not in metadata:
             raise AssertionError(f"No tools in {repository.name} revision {changeset_revision}.")
@@ -376,7 +389,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
             tool_id = tool_dict["id"]
             tool_xml = tool_dict["tool_config"]
             params = {
-                "repository_id": self.security.encode_id(repository.id),
+                "repository_id": repository.id,
                 "changeset_revision": changeset_revision,
                 "tool_id": tool_id,
             }
@@ -391,10 +404,11 @@ class ShedTwillTestCase(ShedBaseTestCase):
             )
 
     def check_repository_invalid_tools_for_changeset_revision(
-        self, repository, changeset_revision, strings_displayed=None, strings_not_displayed=None
+        self, repository: Repository, changeset_revision, strings_displayed=None, strings_not_displayed=None
     ):
         """Load the invalid tool page for each invalid tool associated with this changeset revision and verify the received error messages."""
-        repository_metadata = self.get_repository_metadata_by_changeset_revision(repository, changeset_revision)
+        db_repository = self._db_repository(repository)
+        repository_metadata = self.get_repository_metadata_by_changeset_revision(db_repository.id, changeset_revision)
         metadata = repository_metadata.metadata
         assert (
             "invalid_tools" in metadata
@@ -428,8 +442,8 @@ class ShedTwillTestCase(ShedBaseTestCase):
             )
             raise AssertionError(errmsg)
 
-    def clone_repository(self, repository, destination_path):
-        url = f"{self.url}/repos/{repository.user.username}/{repository.name}"
+    def clone_repository(self, repository: Repository, destination_path: str) -> None:
+        url = f"{self.url}/repos/{repository.owner}/{repository.name}"
         success, message = hg_util.clone_repository(url, destination_path, self.get_repository_tip(repository))
         assert success is True, message
 
@@ -460,7 +474,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
 
     def create_repository_dependency(
         self,
-        repository=None,
+        repository: Optional[Repository] = None,
         repository_tuples=None,
         filepath=None,
         prior_installation_required=False,
@@ -470,6 +484,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
         strings_displayed=None,
         strings_not_displayed=None,
     ):
+        assert repository
         repository_tuples = repository_tuples or []
         repository_names = []
         if complex:
@@ -528,7 +543,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
         assert response.status_code != 403, response.content
 
     def delete_files_from_repository(
-        self, repository, filenames=None, strings_displayed=None, strings_not_displayed=None
+        self, repository: Repository, filenames=None, strings_displayed=None, strings_not_displayed=None
     ):
         filenames = filenames or []
         files_to_delete = []
@@ -545,13 +560,13 @@ class ShedTwillTestCase(ShedBaseTestCase):
         tc.submit("select_files_to_delete_button")
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
-    def delete_repository(self, repository):
-        repository_id = self.security.encode_id(repository.id)
+    def delete_repository(self, repository: Repository) -> None:
+        repository_id = repository.id
         self.visit_url("/admin/browse_repositories")
         params = {"operation": "Delete", "id": repository_id}
         self.visit_url("/admin/browse_repositories", params=params)
         strings_displayed = ["Deleted 1 repository", repository.name]
-        strings_not_displayed = []
+        strings_not_displayed: List[str] = []
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def display_galaxy_browse_repositories_page(self, strings_displayed=None, strings_not_displayed=None):
@@ -592,9 +607,9 @@ class ShedTwillTestCase(ShedBaseTestCase):
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def display_manage_repository_page(
-        self, repository, changeset_revision=None, strings_displayed=None, strings_not_displayed=None
+        self, repository: Repository, changeset_revision=None, strings_displayed=None, strings_not_displayed=None
     ):
-        params = {"id": self.security.encode_id(repository.id)}
+        params = {"id": repository.id}
         if changeset_revision:
             params["changeset_revision"] = changeset_revision
         self.visit_url("/repository/manage_repository", params=params)
@@ -608,7 +623,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def display_repository_file_contents(
-        self, repository, filename, filepath=None, strings_displayed=None, strings_not_displayed=None
+        self, repository: Repository, filename, filepath=None, strings_displayed=None, strings_not_displayed=None
     ):
         """Find a file in the repository and display the contents."""
         basepath = self.get_repo_path(repository)
@@ -621,19 +636,17 @@ class ShedTwillTestCase(ShedBaseTestCase):
             repository=repository, base_path=relative_path, current_path=None
         )
         assert filename in repository_file_list, f"File {filename} not found in the repository under {relative_path}."
-        params = dict(
-            file_path=os.path.join(relative_path, filename), repository_id=self.security.encode_id(repository.id)
-        )
+        params = dict(file_path=os.path.join(relative_path, filename), repository_id=repository.id)
         url = "/repository/get_file_contents"
         self.visit_url(url, params=params)
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def edit_repository_categories(
-        self, repository, categories_to_add=None, categories_to_remove=None, restore_original=True
-    ):
+        self, repository: Repository, categories_to_add=None, categories_to_remove=None, restore_original=True
+    ) -> None:
         categories_to_add = categories_to_add or []
         categories_to_remove = categories_to_remove or []
-        params = {"id": self.security.encode_id(repository.id)}
+        params = {"id": repository.id}
         self.visit_url("/repository/manage_repository", params=params)
         strings_displayed = []
         strings_not_displayed = []
@@ -657,11 +670,14 @@ class ShedTwillTestCase(ShedBaseTestCase):
             tc.submit("manage_categories_button")
             self.check_for_strings(strings_displayed, strings_not_displayed)
 
-    def edit_repository_information(self, repository, revert=True, **kwd):
-        params = {"id": self.security.encode_id(repository.id)}
+    def edit_repository_information(self, repository: Repository, revert=True, **kwd):
+        params = {"id": repository.id}
         self.visit_url("/repository/manage_repository", params=params)
+        db_repository = self._db_repository(repository)
         original_information = dict(
-            repo_name=repository.name, description=repository.description, long_description=repository.long_description
+            repo_name=db_repository.name,
+            description=db_repository.description,
+            long_description=db_repository.long_description,
         )
         strings_displayed = []
         for input_elem_name in ["repo_name", "description", "long_description", "repository_type"]:
@@ -678,8 +694,8 @@ class ShedTwillTestCase(ShedBaseTestCase):
             tc.submit("edit_repository_button")
             self.check_for_strings(strings_displayed)
 
-    def enable_email_alerts(self, repository, strings_displayed=None, strings_not_displayed=None):
-        repository_id = self.security.encode_id(repository.id)
+    def enable_email_alerts(self, repository: Repository, strings_displayed=None, strings_not_displayed=None) -> None:
+        repository_id = repository.id
         params = dict(operation="Receive email alerts", id=repository_id)
         self.visit_url("/repository/browse_repositories", params)
         self.check_for_strings(strings_displayed)
@@ -699,8 +715,8 @@ class ShedTwillTestCase(ShedBaseTestCase):
             f"Repository <b>{name}</b> has been created",
         ]
 
-    def fetch_repository_metadata(self, repository, strings_displayed=None, strings_not_displayed=None):
-        url = f"/api/repositories/{self.security.encode_id(repository.id)}/metadata"
+    def fetch_repository_metadata(self, repository: Repository, strings_displayed=None, strings_not_displayed=None):
+        url = f"/api/repositories/{repository.id}/metadata"
         self.visit_url(url)
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
@@ -823,26 +839,27 @@ class ShedTwillTestCase(ShedBaseTestCase):
 
     def get_or_create_repository(
         self, category: Category, owner=None, strings_displayed=None, strings_not_displayed=None, **kwd
-    ):
+    ) -> Optional[Repository]:
         # If not checking for a specific string, it should be safe to assume that
         # we expect repository creation to be successful.
         if strings_displayed is None:
             strings_displayed = ["Repository", kwd["name"], "has been created"]
         if strings_not_displayed is None:
             strings_not_displayed = []
-        repository = test_db_util.get_repository_by_name_and_owner(kwd["name"], owner)
+        name = kwd["name"]
+        repository = self.populator.get_repository_for(owner, name)
         category_id = category.id
         assert category_id
         if repository is None:
             self.visit_url("/repository/create_repository")
             self.submit_form(button="create_repository_button", category_id=category_id, **kwd)
             self.check_for_strings(strings_displayed, strings_not_displayed)
-            repository = test_db_util.get_repository_by_name_and_owner(kwd["name"], owner)
+            repository = self.populator.get_repository_for(owner, name)
         return repository
 
-    def get_repo_path(self, repository):
+    def get_repo_path(self, repository: Repository) -> str:
         # An entry in the hgweb.config file looks something like: repos/test/mira_assembler = database/community_files/000/repo_123
-        lhs = f"repos/{repository.user.username}/{repository.name}"
+        lhs = f"repos/{repository.owner}/{repository.name}"
         try:
             return self.hgweb_config_manager.get_entry(lhs)
         except Exception:
@@ -858,14 +875,14 @@ class ShedTwillTestCase(ShedBaseTestCase):
             changelog_tuples.append((ctx.rev(), ctx))
         return changelog_tuples
 
-    def get_repository_file_list(self, repository, base_path, current_path=None):
+    def get_repository_file_list(self, repository: Repository, base_path: str, current_path=None) -> List[str]:
         """Recursively load repository folder contents and append them to a list. Similar to os.walk but via /repository/open_folder."""
         if current_path is None:
             request_param_path = base_path
         else:
             request_param_path = os.path.join(base_path, current_path)
         # Get the current folder's contents.
-        params = dict(folder_path=request_param_path, repository_id=self.security.encode_id(repository.id))
+        params = dict(folder_path=request_param_path, repository_id=repository.id)
         url = "/repository/open_folder"
         self.visit_url(url, params=params)
         file_list = loads(self.last_page())
@@ -896,18 +913,39 @@ class ShedTwillTestCase(ShedBaseTestCase):
                     returned_file_list.append(file_dict["title"])
         return returned_file_list
 
-    def get_repository_metadata(self, repository):
+    def _db_repository(self, repository: Repository) -> DbRepository:
+        return self.test_db_util.get_repository_by_name_and_owner(repository.name, repository.owner)
+
+    def get_repository_metadata(self, repository: Repository):
+        return self.get_repository_metadata_for_db_object(self._db_repository(repository))
+
+    def get_repository_metadata_for_db_object(self, repository: DbRepository):
         return [metadata_revision for metadata_revision in repository.metadata_revisions]
 
-    def get_repository_metadata_by_changeset_revision(self, repository, changeset_revision):
-        return test_db_util.get_repository_metadata_for_changeset_revision(repository.id, changeset_revision)
+    def get_repository_metadata_by_changeset_revision(self, repository_id: int, changeset_revision):
+        return test_db_util.get_repository_metadata_for_changeset_revision(
+            repository_id, changeset_revision
+        ) or test_db_util.get_repository_metadata_for_changeset_revision(repository_id, None)
 
-    def get_repository_metadata_revisions(self, repository):
-        return [str(repository_metadata.changeset_revision) for repository_metadata in repository.metadata_revisions]
+    def get_repository_metadata_revisions(self, repository: Repository) -> List[str]:
+        return [
+            str(repository_metadata.changeset_revision)
+            for repository_metadata in self._db_repository(repository).metadata_revisions
+        ]
 
-    def get_repository_tip(self, repository):
+    def _get_repository_by_name_and_owner(self, name: str, owner: str) -> Optional[Repository]:
+        repo = self.populator.get_repository_for(owner, name)
+        if repo is None:
+            repo = self.populator.get_repository_for(owner, name, deleted="true")
+        return repo
+
+    def get_repository_tip(self, repository: Repository) -> str:
         repo = self.get_hg_repo(self.get_repo_path(repository))
         return str(repo[repo.changelog.tip()])
+
+    def _get_metadata_revision_count(self, repository: Repository) -> int:
+        repostiory_metadata: RepositoryMetadata = self.populator.get_metadata(repository, downloadable_only=False)
+        return len(repostiory_metadata.__root__)
 
     def get_tools_from_repository_metadata(self, repository, include_invalid=False):
         """Get a list of valid and (optionally) invalid tool dicts from the repository metadata."""
@@ -977,7 +1015,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
 
     def grant_write_access(
         self,
-        repository,
+        repository: Repository,
         usernames=None,
         strings_displayed=None,
         strings_not_displayed=None,
@@ -1043,8 +1081,8 @@ class ShedTwillTestCase(ShedBaseTestCase):
         self.browse_tool_shed(url=self.url)
         self.browse_category(self.populator.get_category_with_name(category_name))
         self.preview_repository_in_tool_shed(name, owner, strings_displayed=preview_strings_displayed)
-        repository = test_db_util.get_repository_by_name_and_owner(name, owner)
-        repository_id = self.security.encode_id(repository.id)
+        repository = self._get_repository_by_name_and_owner(name, owner)
+        repository_id = repository.id
         if changeset_revision is None:
             changeset_revision = self.get_repository_tip(repository)
         params = {
@@ -1130,6 +1168,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
     def load_changeset_in_tool_shed(
         self, repository_id, changeset_revision, strings_displayed=None, strings_not_displayed=None
     ):
+        # Only used in 0000
         params = {"ctx_str": changeset_revision, "id": repository_id}
         self.visit_url("/repository/view_changeset", params=params)
         self.check_for_strings(strings_displayed, strings_not_displayed)
@@ -1147,10 +1186,15 @@ class ShedTwillTestCase(ShedBaseTestCase):
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def load_display_tool_page(
-        self, repository, tool_xml_path, changeset_revision, strings_displayed=None, strings_not_displayed=None
+        self,
+        repository: Repository,
+        tool_xml_path,
+        changeset_revision,
+        strings_displayed=None,
+        strings_not_displayed=None,
     ):
         params = {
-            "repository_id": self.security.encode_id(repository.id),
+            "repository_id": repository.id,
             "tool_config": tool_xml_path,
             "changeset_revision": changeset_revision,
         }
@@ -1158,10 +1202,10 @@ class ShedTwillTestCase(ShedBaseTestCase):
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def load_invalid_tool_page(
-        self, repository, tool_xml, changeset_revision, strings_displayed=None, strings_not_displayed=None
+        self, repository: Repository, tool_xml, changeset_revision, strings_displayed=None, strings_not_displayed=None
     ):
         params = {
-            "repository_id": self.security.encode_id(repository.id),
+            "repository_id": repository.id,
             "tool_config": tool_xml,
             "changeset_revision": changeset_revision,
         }
@@ -1169,12 +1213,18 @@ class ShedTwillTestCase(ShedBaseTestCase):
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def preview_repository_in_tool_shed(
-        self, name, owner, changeset_revision=None, strings_displayed=None, strings_not_displayed=None
+        self,
+        name: str,
+        owner: str,
+        changeset_revision: Optional[str] = None,
+        strings_displayed=None,
+        strings_not_displayed=None,
     ):
-        repository = test_db_util.get_repository_by_name_and_owner(name, owner)
+        repository = self._get_repository_by_name_and_owner(name, owner)
+        assert repository
         if not changeset_revision:
             changeset_revision = self.get_repository_tip(repository)
-        params = {"repository_id": self.security.encode_id(repository.id), "changeset_revision": changeset_revision}
+        params = {"repository_id": repository.id, "changeset_revision": changeset_revision}
         self.visit_url("/repository/preview_tools_in_changeset", params=params)
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
@@ -1223,7 +1273,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
         # Finally, wait until all repositories are in a final state (either Error or Installed) before returning.
         self.wait_for_repository_installation(repository_ids)
 
-    def repository_is_new(self, repository):
+    def repository_is_new(self, repository: Repository) -> bool:
         repo = self.get_hg_repo(self.get_repo_path(repository))
         tip_ctx = repo[repo.changelog.tip()]
         return tip_ctx.rev() < 0
@@ -1253,12 +1303,12 @@ class ShedTwillTestCase(ShedBaseTestCase):
         assert response.status_code != 403, response.content
 
     def reset_repository_metadata(self, repository):
-        params = {"id": self.security.encode_id(repository.id)}
+        params = {"id": repository.id}
         self.visit_url("/repository/reset_all_metadata", params=params)
         self.check_for_strings(["All repository metadata has been reset."])
 
     def revoke_write_access(self, repository, username):
-        params = {"user_access_button": "Remove", "id": self.security.encode_id(repository.id), "remove_auth": username}
+        params = {"user_access_button": "Remove", "id": repository.id, "remove_auth": username}
         self.visit_url("/repository/manage_repository", params=params)
 
     def search_for_valid_tools(
@@ -1282,14 +1332,14 @@ class ShedTwillTestCase(ShedBaseTestCase):
 
     def send_message_to_repository_owner(
         self,
-        repository,
-        message,
+        repository: Repository,
+        message: str,
         strings_displayed=None,
         strings_not_displayed=None,
         post_submit_strings_displayed=None,
         post_submit_strings_not_displayed=None,
-    ):
-        params = {"id": self.security.encode_id(repository.id)}
+    ) -> None:
+        params = {"id": repository.id}
         self.visit_url("/repository/contact_owner", params=params)
         self.check_for_strings(strings_displayed, strings_not_displayed)
         tc.fv(1, "message", message)
@@ -1314,29 +1364,30 @@ class ShedTwillTestCase(ShedBaseTestCase):
         return kwd
 
     def set_repository_deprecated(
-        self, repository, set_deprecated=True, strings_displayed=None, strings_not_displayed=None
+        self, repository: Repository, set_deprecated=True, strings_displayed=None, strings_not_displayed=None
     ):
-        params = {"id": self.security.encode_id(repository.id), "mark_deprecated": set_deprecated}
+        params = {"id": repository.id, "mark_deprecated": set_deprecated}
         self.visit_url("/repository/deprecate", params=params)
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def set_repository_malicious(
-        self, repository, set_malicious=True, strings_displayed=None, strings_not_displayed=None
-    ):
+        self, repository: Repository, set_malicious=True, strings_displayed=None, strings_not_displayed=None
+    ) -> None:
         self.display_manage_repository_page(repository)
         tc.fv("malicious", "malicious", set_malicious)
         tc.submit("malicious_button")
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
-    def tip_has_metadata(self, repository):
+    def tip_has_metadata(self, repository: Repository) -> bool:
         tip = self.get_repository_tip(repository)
-        return test_db_util.get_repository_metadata_by_repository_id_changeset_revision(repository.id, tip)
+        db_repository = self._db_repository(repository)
+        return test_db_util.get_repository_metadata_by_repository_id_changeset_revision(db_repository.id, tip)
 
-    def undelete_repository(self, repository):
-        params = {"operation": "Undelete", "id": self.security.encode_id(repository.id)}
+    def undelete_repository(self, repository: Repository) -> None:
+        params = {"operation": "Undelete", "id": repository.id}
         self.visit_url("/admin/browse_repositories", params=params)
         strings_displayed = ["Undeleted 1 repository", repository.name]
-        strings_not_displayed = []
+        strings_not_displayed: List[str] = []
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def uninstall_repository(self, installed_repository, strings_displayed=None, strings_not_displayed=None):
@@ -1369,7 +1420,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
 
     def upload_file(
         self,
-        repository,
+        repository: Repository,
         filename,
         filepath,
         valid_tools_only,
@@ -1391,7 +1442,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
         else:
             if removed_message not in strings_not_displayed:
                 strings_not_displayed.append(removed_message)
-        params = {"repository_id": self.security.encode_id(repository.id)}
+        params = {"repository_id": repository.id}
         self.visit_url("/upload/upload", params=params)
         if valid_tools_only:
             strings_displayed.extend(["has been successfully", "uploaded to the repository."])
@@ -1440,7 +1491,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
         else:
             if removed_message not in strings_not_displayed:
                 strings_not_displayed.append(removed_message)
-        params = {"repository_id": self.security.encode_id(repository.id)}
+        params = {"repository_id": repository.id}
         self.visit_url("/upload/upload", params=params)
         if valid_tools_only:
             strings_displayed.extend(["has been successfully", "uploaded to the repository."])
@@ -1556,7 +1607,7 @@ class ShedTwillTestCase(ShedBaseTestCase):
             self.visit_galaxy_url(url, params)
             self.check_for_strings(strings, strings_not_displayed)
 
-    def verify_unchanged_repository_metadata(self, repository):
+    def verify_unchanged_repository_metadata(self, repository: Repository):
         old_metadata = dict()
         new_metadata = dict()
         for metadata in self.get_repository_metadata(repository):

--- a/lib/tool_shed/test/functional/api_notes.md
+++ b/lib/tool_shed/test/functional/api_notes.md
@@ -37,6 +37,7 @@ for deletion instead of writing new tests and modernizing the API.
 | reset_metadata_on_repository | NO | NO | NO | YES | NO | Bjoern said it was a thing that is done via the UI still |
 | GET repositories/{repository_id}/metadata| Yes (getRepository in client?) | NO? | NO? | YES | NO | |
 | tool search | NO | NO | NO | YES | NO | Community contributed - used by tool dog or something? |
-| repo search | YES | NO | NO | YES | NO | Used by the Vue tool shed install interface. |
+| repo search (Get repositories + q param) | YES | NO | NO | YES | NO | Used by the Vue tool shed install interface. |
 | repositories/{repository_id}/changeset_revision | NO | YES | NO | YES | NO | |
 | POST repositories | NO | YES | NO | YES | NO | |
+| GET repositories (without search query) | ? | ? |? | True | True | |

--- a/lib/tool_shed/test/functional/api_notes.md
+++ b/lib/tool_shed/test/functional/api_notes.md
@@ -36,8 +36,9 @@ for deletion instead of writing new tests and modernizing the API.
 | get_ordered_installable_revisions | NO | NO | YES | YES | NO | used by complete_repo_information in ephemeris for shed_tools |
 | reset_metadata_on_repository | NO | NO | NO | YES | NO | Bjoern said it was a thing that is done via the UI still |
 | GET repositories/{repository_id}/metadata| Yes (getRepository in client?) | NO? | NO? | YES | NO | |
-| tool search | NO | NO | NO | YES | NO | Community contributed - used by tool dog or something? |
+/github.com/galaxyproject/galaxy/pull/14672#pullrequestreview-1116016874) |
 | repo search (Get repositories + q param) | YES | NO | NO | YES | NO | Used by the Vue tool shed install interface. |
 | repositories/{repository_id}/changeset_revision | NO | YES | NO | YES | NO | |
 | POST repositories | NO | YES | NO | YES | NO | |
 | GET repositories (without search query) | ? | ? |? | True | True | |
+

--- a/lib/tool_shed/test/functional/test_0000_basic_repository_features.py
+++ b/lib/tool_shed/test/functional/test_0000_basic_repository_features.py
@@ -52,7 +52,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0020_edit_repository(self):
         """Edit the repository name, description, and long description"""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         new_name = "renamed_filtering"
         new_description = "Edited filtering tool"
         new_long_description = "Edited long description"
@@ -62,7 +62,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0025_change_repository_category(self):
         """Change the categories associated with the filtering repository"""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.edit_repository_categories(
             repository,
             categories_to_add=["Test 0000 Basic Repository Features 2"],
@@ -71,13 +71,13 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0030_grant_write_access(self):
         """Grant write access to another user"""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.grant_write_access(repository, usernames=[common.test_user_2_name])
         self.revoke_write_access(repository, common.test_user_2_name)
 
     def test_0035_upload_filtering_1_1_0(self):
         """Upload filtering_1.1.0.tar to the repository"""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="filtering/filtering_1.1.0.tar",
@@ -92,7 +92,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0040_verify_repository(self):
         """Display basic repository pages"""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         latest_changeset_revision = self.get_repository_tip(repository)
         self.check_for_valid_tools(repository, strings_displayed=["Filter1"])
         self.check_count_of_metadata_revisions_associated_with_repository(repository, metadata_count=1)
@@ -124,7 +124,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0045_alter_repository_states(self):
         """Test toggling the malicious and deprecated repository flags."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
         self.set_repository_malicious(
             repository, set_malicious=True, strings_displayed=["The repository tip has been defined as malicious."]
@@ -151,7 +151,8 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0050_display_repository_tip_file(self):
         """Display the contents of filtering.xml in the repository tip revision"""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        assert repository
         self.display_repository_file_contents(
             repository=repository,
             filename="filtering.xml",
@@ -162,7 +163,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0055_upload_filtering_txt_file(self):
         """Upload filtering.txt file associated with tool version 1.1.0."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="filtering/filtering_0000.txt",
@@ -180,7 +181,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0060_upload_filtering_test_data(self):
         """Upload filtering test data."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="filtering/filtering_test_data.tar",
@@ -203,7 +204,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0065_upload_filtering_2_2_0(self):
         """Upload filtering version 2.2.0"""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="filtering/filtering_2.2.0.tar",
@@ -218,7 +219,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0070_verify_filtering_repository(self):
         """Verify the new tool versions and repository metadata."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         tip = self.get_repository_tip(repository)
         self.check_for_valid_tools(repository)
         strings_displayed = ["Select a revision"]
@@ -243,7 +244,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0075_upload_readme_txt_file(self):
         """Upload readme.txt file associated with tool version 2.2.0."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="readme.txt",
@@ -269,7 +270,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0080_delete_readme_txt_file(self):
         """Delete the readme.txt file."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.delete_files_from_repository(repository, filenames=["readme.txt"])
         self.check_count_of_metadata_revisions_associated_with_repository(repository, metadata_count=2)
         self.display_manage_repository_page(
@@ -278,7 +279,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0085_search_for_valid_filter_tool(self):
         """Search for the filtering tool by tool ID, name, and version."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         tip_changeset = self.get_repository_tip(repository)
         search_fields = dict(tool_id="Filter1", tool_name="filter", tool_version="2.2.0")
         self.search_for_valid_tools(
@@ -287,7 +288,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0090_verify_repository_metadata(self):
         """Verify that resetting the metadata does not change it."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.verify_unchanged_repository_metadata(repository)
 
     def test_0095_verify_reserved_repository_name_handling(self):
@@ -324,7 +325,7 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
         the email is the last step in the process, this will verify functional correctness of all preceding steps.
         """
         self.login(email=common.test_user_2_email, username=common.test_user_2_name)
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         message = "This is a test message."
         strings_displayed = [
             "Contact the owner of the repository named",
@@ -341,41 +342,41 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0110_delete_filtering_repository(self):
         """Delete the filtering_0000 repository and verify that it no longer has any downloadable revisions."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
         self.delete_repository(repository)
         # Explicitly reload all metadata revisions from the database, to ensure that we have the current status of the downloadable flag.
-        for metadata_revision in repository.metadata_revisions:
-            self.test_db_util.refresh(metadata_revision)
+        # for metadata_revision in repository.metadata_revisions:
+        #    self.test_db_util.refresh(metadata_revision)
         # Marking a repository as deleted should result in no metadata revisions being downloadable.
-        assert True not in [metadata.downloadable for metadata in repository.metadata_revisions]
+        assert True not in [metadata.downloadable for metadata in self._db_repository(repository).metadata_revisions]
 
     def test_0115_undelete_filtering_repository(self):
         """Undelete the filtering_0000 repository and verify that it now has two downloadable revisions."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
         self.undelete_repository(repository)
         # Explicitly reload all metadata revisions from the database, to ensure that we have the current status of the downloadable flag.
-        for metadata_revision in repository.metadata_revisions:
-            self.test_db_util.refresh(metadata_revision)
+        # for metadata_revision in repository.metadata_revisions:
+        #    self.test_db_util.refresh(metadata_revision)
         # Marking a repository as undeleted should result in all previously downloadable metadata revisions being downloadable again.
         # In this case, there should be two downloadable revisions, one for filtering 1.1.0 and one for filtering 2.2.0.
-        assert True in [metadata.downloadable for metadata in repository.metadata_revisions]
-        assert len(repository.downloadable_revisions) == 2
+        assert True in [metadata.downloadable for metadata in self._db_repository(repository).metadata_revisions]
+        assert len(self._db_repository(repository).downloadable_revisions) == 2
 
     def test_0120_enable_email_notifications(self):
         """Enable email notifications for test user 2 on filtering_0000."""
         # Log in as test_user_2
         self.login(email=common.test_user_2_email, username=common.test_user_2_name)
         # Get the repository, so we can pass the encoded repository id and browse_repositories method to the set_email_alerts method.
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         strings_displayed = ["Total alerts added: 1, total alerts removed: 0"]
         self.enable_email_alerts(repository, strings_displayed=strings_displayed)
 
     def test_0125_upload_new_readme_file(self):
         """Upload a new readme file to the filtering_0000 repository and verify that there is no error."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         # Upload readme.txt to the filtering_0000 repository and verify that it is now displayed.
         self.upload_file(
             repository,
@@ -394,9 +395,9 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0130_verify_handling_of_invalid_characters(self):
         """Load the above changeset in the change log and confirm that there is no server error displayed."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         changeset_revision = self.get_repository_tip(repository)
-        repository_id = self.security.encode_id(repository.id)
+        repository_id = repository.id
         changelog_tuples = self.get_repository_changelog_tuples(repository)
         revision_number = -1
         revision_hash = "000000000000"
@@ -426,8 +427,8 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
 
     def test_0140_view_invalid_changeset(self):
         """View repository using an invalid changeset"""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
-        encoded_repository_id = self.security.encode_id(repository.id)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        encoded_repository_id = repository.id
         strings_displayed = ["Invalid+changeset+revision"]
         self.visit_url(
             f"/repository/view_repository?id={encoded_repository_id}&changeset_revision=nonsensical_changeset"

--- a/lib/tool_shed/test/functional/test_0010_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0010_repository_with_tool_dependencies.py
@@ -52,6 +52,7 @@ class TestFreebayesRepository(ShedTwillTestCase):
             category=category,
             strings_displayed=[],
         )
+        assert repository
         self.upload_file(
             repository,
             filename="freebayes/freebayes.xml",
@@ -76,7 +77,7 @@ class TestFreebayesRepository(ShedTwillTestCase):
         We are at step 2 - Upload the tool_data_table_conf.xml.sample file.
         Uploading the tool_data_table_conf.xml.sample alone should not make the tool valid, but the error message should change.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="freebayes/tool_data_table_conf.xml.sample",
@@ -101,7 +102,7 @@ class TestFreebayesRepository(ShedTwillTestCase):
         We are at step 3 - Upload the tool_data_table_conf.xml.sample file.
         Uploading the tool_data_table_conf.xml.sample alone should not make the tool valid, but the error message should change.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="freebayes/sam_fa_indices.loc.sample",
@@ -120,7 +121,7 @@ class TestFreebayesRepository(ShedTwillTestCase):
         We are at step 4 - Upload a tool_dependencies.xml file that should not parse correctly.
         Upload a tool_dependencies.xml file that contains <> in the text of the readme tag. This should show an error message about malformed xml.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename=os.path.join("freebayes", "malformed_tool_dependencies", "tool_dependencies.xml"),
@@ -139,7 +140,7 @@ class TestFreebayesRepository(ShedTwillTestCase):
         We are at step 5 - Upload a tool_dependencies.xml file that specifies a version that does not match the tool's requirements.
         This should result in a message about the tool dependency configuration not matching the tool's requirements.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename=os.path.join("freebayes", "invalid_tool_dependencies", "tool_dependencies.xml"),
@@ -160,7 +161,7 @@ class TestFreebayesRepository(ShedTwillTestCase):
         We are at step 6 - Upload a valid tool_dependencies.xml file.
         At this stage, there should be no errors on the upload page, as every missing or invalid file has been corrected.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename=os.path.join("freebayes", "tool_dependencies.xml"),
@@ -179,7 +180,7 @@ class TestFreebayesRepository(ShedTwillTestCase):
         We are at step 7 - Check for the appropriate strings on the manage repository page.
         Verify that the manage repository page now displays the valid tool dependencies, and that there are no invalid tools shown on the manage page.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         strings_displayed = ["freebayes", "0.9.4_9696d0ce8a9", "samtools", "0.1.18", "Valid tools", "package"]
         strings_not_displayed = ["Invalid tools"]
         self.display_manage_repository_page(

--- a/lib/tool_shed/test/functional/test_0020_basic_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0020_basic_repository_dependencies.py
@@ -75,15 +75,15 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
 
     def test_0025_generate_and_upload_repository_dependencies_xml(self):
         """Generate and upload the repository_dependencies.xml file"""
-        repository = self.test_db_util.get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
-        column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        column_maker_repository = self._get_repository_by_name_and_owner(
             column_maker_repository_name, common.test_user_1_name
         )
         repository_dependencies_path = self.generate_temp_path("test_0020", additional_paths=["emboss", "5"])
         repository_tuple = (
             self.url,
             column_maker_repository.name,
-            column_maker_repository.user.username,
+            column_maker_repository.owner,
             self.get_repository_tip(column_maker_repository),
         )
         self.create_repository_dependency(
@@ -92,8 +92,8 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
 
     def test_0030_verify_emboss_5_dependencies(self):
         """Verify that the emboss_5 repository now depends on the emboss_datatypes repository with correct name, owner, and changeset revision."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
-        column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        column_maker_repository = self._get_repository_by_name_and_owner(
             column_maker_repository_name, common.test_user_1_name
         )
         changeset_revision = self.get_repository_tip(column_maker_repository)
@@ -110,10 +110,8 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
 
     def test_0040_verify_repository_metadata(self):
         """Verify that resetting the metadata does not change it."""
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        column_maker_repository = self._get_repository_by_name_and_owner(
             column_maker_repository_name, common.test_user_1_name
         )
         self.verify_unchanged_repository_metadata(emboss_repository)

--- a/lib/tool_shed/test/functional/test_0030_repository_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_0030_repository_dependency_revisions.py
@@ -123,17 +123,15 @@ class TestRepositoryDependencyRevisions(ShedTwillTestCase):
 
     def test_0030_generate_repository_dependencies_for_emboss_5(self):
         """Generate a repository_dependencies.xml file specifying emboss_datatypes and upload it to the emboss_5 repository."""
-        column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+        column_maker_repository = self._get_repository_by_name_and_owner(
             column_maker_repository_name, common.test_user_1_name
         )
-        emboss_5_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_5_repository_name, common.test_user_1_name
-        )
+        emboss_5_repository = self._get_repository_by_name_and_owner(emboss_5_repository_name, common.test_user_1_name)
         repository_dependencies_path = self.generate_temp_path("test_0030", additional_paths=["emboss5"])
         column_maker_tuple = (
             self.url,
             column_maker_repository.name,
-            column_maker_repository.user.username,
+            column_maker_repository.owner,
             self.get_repository_tip(column_maker_repository),
         )
         self.create_repository_dependency(
@@ -144,17 +142,15 @@ class TestRepositoryDependencyRevisions(ShedTwillTestCase):
 
     def test_0035_generate_repository_dependencies_for_emboss_6(self):
         """Generate a repository_dependencies.xml file specifying emboss_datatypes and upload it to the emboss_6 repository."""
-        emboss_6_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_6_repository_name, common.test_user_1_name
-        )
-        column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+        emboss_6_repository = self._get_repository_by_name_and_owner(emboss_6_repository_name, common.test_user_1_name)
+        column_maker_repository = self._get_repository_by_name_and_owner(
             column_maker_repository_name, common.test_user_1_name
         )
         repository_dependencies_path = self.generate_temp_path("test_0030", additional_paths=["emboss6"])
         column_maker_tuple = (
             self.url,
             column_maker_repository.name,
-            column_maker_repository.user.username,
+            column_maker_repository.owner,
             self.get_repository_tip(column_maker_repository),
         )
         self.create_repository_dependency(
@@ -165,17 +161,13 @@ class TestRepositoryDependencyRevisions(ShedTwillTestCase):
 
     def test_0040_generate_repository_dependency_on_emboss_5(self):
         """Create and upload repository_dependencies.xml for the emboss_5_0030 repository."""
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        emboss_5_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_5_repository_name, common.test_user_1_name
-        )
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        emboss_5_repository = self._get_repository_by_name_and_owner(emboss_5_repository_name, common.test_user_1_name)
         repository_dependencies_path = self.generate_temp_path("test_0030", additional_paths=["emboss", "5"])
         emboss_tuple = (
             self.url,
             emboss_5_repository.name,
-            emboss_5_repository.user.username,
+            emboss_5_repository.owner,
             self.get_repository_tip(emboss_5_repository),
         )
         self.create_repository_dependency(
@@ -184,17 +176,13 @@ class TestRepositoryDependencyRevisions(ShedTwillTestCase):
 
     def test_0045_generate_repository_dependency_on_emboss_6(self):
         """Create and upload repository_dependencies.xml for the emboss_6_0030 repository."""
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        emboss_6_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_6_repository_name, common.test_user_1_name
-        )
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        emboss_6_repository = self._get_repository_by_name_and_owner(emboss_6_repository_name, common.test_user_1_name)
         repository_dependencies_path = self.generate_temp_path("test_0030", additional_paths=["emboss", "5"])
         emboss_tuple = (
             self.url,
             emboss_6_repository.name,
-            emboss_6_repository.user.username,
+            emboss_6_repository.owner,
             self.get_repository_tip(emboss_6_repository),
         )
         self.create_repository_dependency(
@@ -203,11 +191,11 @@ class TestRepositoryDependencyRevisions(ShedTwillTestCase):
 
     def test_0050_verify_repository_dependency_revisions(self):
         """Verify that different metadata revisions of the emboss repository have different repository dependencies."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         repository_metadata = [
             (metadata.metadata, metadata.changeset_revision) for metadata in self.get_repository_metadata(repository)
         ]
-        column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+        column_maker_repository = self._get_repository_by_name_and_owner(
             column_maker_repository_name, common.test_user_1_name
         )
         column_maker_tip = self.get_repository_tip(column_maker_repository)
@@ -223,16 +211,10 @@ class TestRepositoryDependencyRevisions(ShedTwillTestCase):
 
     def test_0055_verify_repository_metadata(self):
         """Verify that resetting the metadata does not change it."""
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        emboss_5_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_5_repository_name, common.test_user_1_name
-        )
-        emboss_6_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_6_repository_name, common.test_user_1_name
-        )
-        column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        emboss_5_repository = self._get_repository_by_name_and_owner(emboss_5_repository_name, common.test_user_1_name)
+        emboss_6_repository = self._get_repository_by_name_and_owner(emboss_6_repository_name, common.test_user_1_name)
+        column_maker_repository = self._get_repository_by_name_and_owner(
             column_maker_repository_name, common.test_user_1_name
         )
         for repository in [emboss_repository, emboss_5_repository, emboss_6_repository, column_maker_repository]:

--- a/lib/tool_shed/test/functional/test_0040_repository_circular_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0040_repository_circular_dependencies.py
@@ -84,14 +84,12 @@ class TestRepositoryCircularDependencies(ShedTwillTestCase):
         # Filtering revision 0 -> freebayes revision 0.
         # Freebayes revision 0 -> filtering revision 1.
         # Filtering will have two revisions, one with just the filtering tool, and one with the filtering tool and a dependency on freebayes.
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            freebayes_repository_name, common.test_user_1_name
-        )
-        filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(freebayes_repository_name, common.test_user_1_name)
+        filtering_repository = self._get_repository_by_name_and_owner(
             filtering_repository_name, common.test_user_1_name
         )
         repository_dependencies_path = self.generate_temp_path("test_0040", additional_paths=["filtering"])
-        repository_tuple = (self.url, repository.name, repository.user.username, self.get_repository_tip(repository))
+        repository_tuple = (self.url, repository.name, repository.owner, self.get_repository_tip(repository))
         self.create_repository_dependency(
             repository=filtering_repository, repository_tuples=[repository_tuple], filepath=repository_dependencies_path
         )
@@ -102,24 +100,22 @@ class TestRepositoryCircularDependencies(ShedTwillTestCase):
         # Filtering revision 0 -> freebayes revision 0.
         # Freebayes revision 0 -> filtering revision 1.
         # Filtering will have two revisions, one with just the filtering tool, and one with the filtering tool and a dependency on freebayes.
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            filtering_repository_name, common.test_user_1_name
-        )
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(filtering_repository_name, common.test_user_1_name)
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
         repository_dependencies_path = self.generate_temp_path("test_0040", additional_paths=["freebayes"])
-        repository_tuple = (self.url, repository.name, repository.user.username, self.get_repository_tip(repository))
+        repository_tuple = (self.url, repository.name, repository.owner, self.get_repository_tip(repository))
         self.create_repository_dependency(
             repository=freebayes_repository, repository_tuples=[repository_tuple], filepath=repository_dependencies_path
         )
 
     def test_0030_verify_repository_dependencies(self):
         """Verify that each repository can depend on the other without causing an infinite loop."""
-        filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+        filtering_repository = self._get_repository_by_name_and_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
         # The dependency structure should look like:
@@ -136,10 +132,10 @@ class TestRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0035_verify_repository_metadata(self):
         """Verify that resetting the metadata does not change it."""
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
-        filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+        filtering_repository = self._get_repository_by_name_and_owner(
             filtering_repository_name, common.test_user_1_name
         )
         for repository in [freebayes_repository, filtering_repository]:
@@ -147,9 +143,7 @@ class TestRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0040_verify_tool_dependencies(self):
         """Verify that freebayes displays tool dependencies."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            freebayes_repository_name, common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(freebayes_repository_name, common.test_user_1_name)
         self.display_manage_repository_page(
             repository,
             strings_displayed=["freebayes", "0.9.4_9696d0ce8a9", "samtools", "0.1.18", "Valid tools", "package"],

--- a/lib/tool_shed/test/functional/test_0050_circular_dependencies_4_levels.py
+++ b/lib/tool_shed/test/functional/test_0050_circular_dependencies_4_levels.py
@@ -183,24 +183,16 @@ class TestRepositoryCircularDependenciesToNLevels(ShedTwillTestCase):
         )
 
     def test_0040_create_and_upload_dependency_definitions(self):
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        filtering_repository = self._get_repository_by_name_and_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
-        bismark_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bismark_repository_name, common.test_user_1_name
-        )
+        bismark_repository = self._get_repository_by_name_and_owner(bismark_repository_name, common.test_user_1_name)
         dependency_xml_path = self.generate_temp_path("test_0050", additional_paths=["freebayes"])
         # convert_chars depends on column_maker
         # column_maker depends on convert_chars
@@ -211,31 +203,31 @@ class TestRepositoryCircularDependenciesToNLevels(ShedTwillTestCase):
         column_tuple = (
             self.url,
             column_repository.name,
-            column_repository.user.username,
+            column_repository.owner,
             self.get_repository_tip(column_repository),
         )
         convert_tuple = (
             self.url,
             convert_repository.name,
-            convert_repository.user.username,
+            convert_repository.owner,
             self.get_repository_tip(convert_repository),
         )
         freebayes_tuple = (
             self.url,
             freebayes_repository.name,
-            freebayes_repository.user.username,
+            freebayes_repository.owner,
             self.get_repository_tip(freebayes_repository),
         )
         emboss_tuple = (
             self.url,
             emboss_repository.name,
-            emboss_repository.user.username,
+            emboss_repository.owner,
             self.get_repository_tip(emboss_repository),
         )
         bismark_tuple = (
             self.url,
             bismark_repository.name,
-            bismark_repository.user.username,
+            bismark_repository.owner,
             self.get_repository_tip(bismark_repository),
         )
         self.create_repository_dependency(
@@ -275,24 +267,16 @@ class TestRepositoryCircularDependenciesToNLevels(ShedTwillTestCase):
              id: 7 key: http://toolshed.local:10001__ESEP__emboss_5__ESEP__test__ESEP__8de5fe0d7b04
                  ['http://toolshed.local:10001', 'emboss_datatypes', 'test', 'dbd4f68bf507']
         """
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        filtering_repository = self._get_repository_by_name_and_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        bismark_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bismark_repository_name, common.test_user_1_name
-        )
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        bismark_repository = self._get_repository_by_name_and_owner(bismark_repository_name, common.test_user_1_name)
         self.check_repository_dependency(convert_repository, column_repository)
         self.check_repository_dependency(column_repository, convert_repository)
         self.check_repository_dependency(emboss_repository, bismark_repository)
@@ -304,12 +288,10 @@ class TestRepositoryCircularDependenciesToNLevels(ShedTwillTestCase):
 
     def test_0050_verify_tool_dependencies(self):
         """Check that freebayes and emboss display tool dependencies."""
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         self.display_manage_repository_page(
             freebayes_repository,
             strings_displayed=["freebayes", "0.9.4_9696d0ce8a9", "samtools", "0.1.18", "Tool dependencies", "package"],
@@ -320,13 +302,11 @@ class TestRepositoryCircularDependenciesToNLevels(ShedTwillTestCase):
 
     def test_0055_verify_repository_metadata(self):
         """Verify that resetting the metadata does not change it."""
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        filtering_repository = self._get_repository_by_name_and_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
         for repository in [emboss_repository, freebayes_repository, filtering_repository]:

--- a/lib/tool_shed/test/functional/test_0070_invalid_tool.py
+++ b/lib/tool_shed/test/functional/test_0070_invalid_tool.py
@@ -55,7 +55,6 @@ class TestBismarkRepository(ShedTwillTestCase):
             strings_not_displayed=[],
         )
         valid_revision = self.get_repository_tip(repository)
-        self.test_db_util.refresh(repository)
         tool_guid = f"{self.url.replace('http://', '').rstrip('/')}/repos/user1/bismark_0070/bismark_methylation_extractor/0.7.7.3"
         tool_metadata_strings_displayed = [
             tool_guid,

--- a/lib/tool_shed/test/functional/test_0080_advanced_circular_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0080_advanced_circular_dependencies.py
@@ -74,17 +74,13 @@ class TestRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0020_create_repository_dependencies(self):
         """Upload a repository_dependencies.xml file that specifies the current revision of convert_chars_0080 to the column_maker_0080 repository."""
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
         repository_dependencies_path = self.generate_temp_path("test_0080", additional_paths=["convert"])
         repository_tuple = (
             self.url,
             convert_repository.name,
-            convert_repository.user.username,
+            convert_repository.owner,
             self.get_repository_tip(convert_repository),
         )
         self.create_repository_dependency(
@@ -93,17 +89,13 @@ class TestRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0025_create_dependency_on_filtering(self):
         """Upload a repository_dependencies.xml file that specifies the current revision of filtering to the freebayes_0040 repository."""
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
         repository_dependencies_path = self.generate_temp_path("test_0080", additional_paths=["convert"])
         repository_tuple = (
             self.url,
             column_repository.name,
-            column_repository.user.username,
+            column_repository.owner,
             self.get_repository_tip(column_repository),
         )
         self.create_repository_dependency(
@@ -112,12 +104,8 @@ class TestRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0030_verify_repository_dependencies(self):
         """Verify that each repository can depend on the other without causing an infinite loop."""
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
         self.check_repository_dependency(
             convert_repository, column_repository, self.get_repository_tip(column_repository)
         )
@@ -127,11 +115,7 @@ class TestRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0035_verify_repository_metadata(self):
         """Verify that resetting the metadata does not change it."""
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         for repository in [column_repository, convert_repository]:
             self.verify_unchanged_repository_metadata(repository)

--- a/lib/tool_shed/test/functional/test_0090_tool_search.py
+++ b/lib/tool_shed/test/functional/test_0090_tool_search.py
@@ -154,38 +154,34 @@ class TestRepositoryCircularDependenciesAgain(ShedTwillTestCase):
 
     def test_0035_create_and_upload_dependency_definitions(self):
         """Create and upload repository dependency definitions."""
-        bwa_color_repository = self.test_db_util.get_repository_by_name_and_owner(
+        bwa_color_repository = self._get_repository_by_name_and_owner(
             bwa_color_repository_name, common.test_user_1_name
         )
-        bwa_base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+        bwa_base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        filtering_repository = self._get_repository_by_name_and_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
         dependency_xml_path = self.generate_temp_path("test_0090", additional_paths=["freebayes"])
         freebayes_tuple = (
             self.url,
             freebayes_repository.name,
-            freebayes_repository.user.username,
+            freebayes_repository.owner,
             self.get_repository_tip(freebayes_repository),
         )
         emboss_tuple = (
             self.url,
             emboss_repository.name,
-            emboss_repository.user.username,
+            emboss_repository.owner,
             self.get_repository_tip(emboss_repository),
         )
         filtering_tuple = (
             self.url,
             filtering_repository.name,
-            filtering_repository.user.username,
+            filtering_repository.owner,
             self.get_repository_tip(filtering_repository),
         )
         self.create_repository_dependency(
@@ -200,19 +196,15 @@ class TestRepositoryCircularDependenciesAgain(ShedTwillTestCase):
 
     def test_0040_verify_repository_dependencies(self):
         """Verify the generated dependency structure."""
-        bwa_color_repository = self.test_db_util.get_repository_by_name_and_owner(
+        bwa_color_repository = self._get_repository_by_name_and_owner(
             bwa_color_repository_name, common.test_user_1_name
         )
-        bwa_base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+        bwa_base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        filtering_repository = self._get_repository_by_name_and_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
         self.check_repository_dependency(filtering_repository, freebayes_repository)

--- a/lib/tool_shed/test/functional/test_0100_complex_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0100_complex_repository_dependencies.py
@@ -89,13 +89,9 @@ class TestComplexRepositoryDependencies(ShedTwillTestCase):
         """Generate and upload a complex repository definition that specifies an invalid tool shed URL."""
         dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex", "invalid"])
         # The repository named bwa_base_repository_0100 is the dependent repository.
-        base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
+        base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
         # The repository named package_bwa_0_5_9_0100 is the required repository.
-        tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_package_repository_name, common.test_user_1_name
-        )
+        tool_repository = self._get_repository_by_name_and_owner(bwa_package_repository_name, common.test_user_1_name)
         url = "http://http://this is not an url!"
         name = "package_bwa_0_5_9_0100"
         owner = "user1"
@@ -117,13 +113,9 @@ class TestComplexRepositoryDependencies(ShedTwillTestCase):
         """Generate and upload a complex repository definition that specifies an invalid repository name."""
         dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex", "invalid"])
         # The base_repository named bwa_base_repository_0100 is the dependent repository.
-        base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
+        base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
         # The repository named package_bwa_0_5_9_0100 is the required repository.
-        tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_package_repository_name, common.test_user_1_name
-        )
+        tool_repository = self._get_repository_by_name_and_owner(bwa_package_repository_name, common.test_user_1_name)
         url = self.url
         name = "invalid_repository!?"
         owner = "user1"
@@ -145,13 +137,9 @@ class TestComplexRepositoryDependencies(ShedTwillTestCase):
         """Generate and upload a complex repository definition that specifies an invalid owner."""
         dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex", "invalid"])
         # The base_repository named bwa_base_repository_0100 is the dependent repository.
-        base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
+        base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
         # The repository named package_bwa_0_5_9_0100 is the required repository.
-        tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_package_repository_name, common.test_user_1_name
-        )
+        tool_repository = self._get_repository_by_name_and_owner(bwa_package_repository_name, common.test_user_1_name)
         url = self.url
         name = "package_bwa_0_5_9_0100"
         owner = "invalid_owner!?"
@@ -172,9 +160,7 @@ class TestComplexRepositoryDependencies(ShedTwillTestCase):
         """Generate and upload a complex repository definition that specifies an invalid changeset revision."""
         dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex", "invalid"])
         # The base_repository named bwa_base_repository_0100 is the dependent repository.
-        base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
+        base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
         # The repository named package_bwa_0_5_9_0100 is the required repository.
         url = self.url
         name = "package_bwa_0_5_9_0100"
@@ -195,13 +181,9 @@ class TestComplexRepositoryDependencies(ShedTwillTestCase):
     def test_0035_generate_complex_repository_dependency(self):
         """Generate and upload a valid tool_dependencies.xml file that specifies package_bwa_0_5_9_0100."""
         # The base_repository named bwa_base_repository_0100 is the dependent repository.
-        base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
+        base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
         # The repository named package_bwa_0_5_9_0100 is the required repository.
-        tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_package_repository_name, common.test_user_1_name
-        )
+        tool_repository = self._get_repository_by_name_and_owner(bwa_package_repository_name, common.test_user_1_name)
         dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex"])
         url = self.url
         name = "package_bwa_0_5_9_0100"
@@ -224,13 +206,9 @@ class TestComplexRepositoryDependencies(ShedTwillTestCase):
     def test_0040_generate_tool_dependency(self):
         """Generate and upload a new tool_dependencies.xml file that specifies an arbitrary file on the filesystem, and verify that bwa_base depends on the new changeset revision."""
         # The base_repository named bwa_base_repository_0100 is the dependent repository.
-        base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
+        base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
         # The repository named package_bwa_0_5_9_0100 is the required repository.
-        tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_package_repository_name, common.test_user_1_name
-        )
+        tool_repository = self._get_repository_by_name_and_owner(bwa_package_repository_name, common.test_user_1_name)
         previous_changeset = self.get_repository_tip(tool_repository)
         old_tool_dependency = self.get_filename(os.path.join("bwa", "complex", "readme", "tool_dependencies.xml"))
         new_tool_dependency_path = self.generate_temp_path("test_1100", additional_paths=["tool_dependency"])

--- a/lib/tool_shed/test/functional/test_0110_invalid_simple_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0110_invalid_simple_repository_dependencies.py
@@ -77,15 +77,13 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
     def test_0025_generate_repository_dependency_with_invalid_url(self):
         """Generate a repository dependency for emboss 5 with an invalid URL."""
         dependency_path = self.generate_temp_path("test_0110", additional_paths=["simple"])
-        column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+        column_maker_repository = self._get_repository_by_name_and_owner(
             column_maker_repository_name, common.test_user_1_name
         )
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         url = "http://http://this is not an url!"
         name = column_maker_repository.name
-        owner = column_maker_repository.user.username
+        owner = column_maker_repository.owner
         changeset_revision = self.get_repository_tip(column_maker_repository)
         strings_displayed = ["Repository dependencies are currently supported only within the same tool shed"]
         repository_tuple = (url, name, owner, changeset_revision)
@@ -100,15 +98,11 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
     def test_0030_generate_repository_dependency_with_invalid_name(self):
         """Generate a repository dependency for emboss 5 with an invalid name."""
         dependency_path = self.generate_temp_path("test_0110", additional_paths=["simple"])
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_maker_repository_name, common.test_user_1_name
-        )
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(column_maker_repository_name, common.test_user_1_name)
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         url = self.url
         name = "!?invalid?!"
-        owner = repository.user.username
+        owner = repository.owner
         changeset_revision = self.get_repository_tip(repository)
         strings_displayed = ["because the name is invalid."]
         repository_tuple = (url, name, owner, changeset_revision)
@@ -123,12 +117,8 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
     def test_0035_generate_repository_dependency_with_invalid_owner(self):
         """Generate a repository dependency for emboss 5 with an invalid owner."""
         dependency_path = self.generate_temp_path("test_0110", additional_paths=["simple"])
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_maker_repository_name, common.test_user_1_name
-        )
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(column_maker_repository_name, common.test_user_1_name)
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         url = self.url
         name = repository.name
         owner = "!?invalid?!"
@@ -146,15 +136,11 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
     def test_0040_generate_repository_dependency_with_invalid_changeset_revision(self):
         """Generate a repository dependency for emboss 5 with an invalid changeset revision."""
         dependency_path = self.generate_temp_path("test_0110", additional_paths=["simple", "invalid"])
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_maker_repository_name, common.test_user_1_name
-        )
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(column_maker_repository_name, common.test_user_1_name)
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         url = self.url
         name = repository.name
-        owner = repository.user.username
+        owner = repository.owner
         changeset_revision = "!?invalid?!"
         strings_displayed = ["because the changeset revision is invalid."]
         repository_tuple = (url, name, owner, changeset_revision)

--- a/lib/tool_shed/test/functional/test_0120_simple_repository_dependency_multiple_owners.py
+++ b/lib/tool_shed/test/functional/test_0120_simple_repository_dependency_multiple_owners.py
@@ -70,9 +70,7 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
         Check for appropriate strings, most importantly BlastXml, BlastNucDb, and BlastProtDb,
         the datatypes that are defined in datatypes_conf.xml.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            datatypes_repository_name, common.test_user_2_name
-        )
+        repository = self._get_repository_by_name_and_owner(datatypes_repository_name, common.test_user_2_name)
         strings_displayed = [
             "BlastXml",
             "BlastNucDb",
@@ -120,7 +118,7 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
         We are at step 2a.
         Check for appropriate strings, such as tool name, description, and version.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(tool_repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(tool_repository_name, common.test_user_1_name)
         strings_displayed = ["blastxml_to_top_descr_0120", "BLAST top hit descriptions", "Make a table from BLAST XML"]
         strings_displayed.extend(["0.0.1", "Valid tools"])
         self.display_manage_repository_page(repository, strings_displayed=strings_displayed)
@@ -131,17 +129,15 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
         We are at step 3.
         Create a simple repository dependency for blastxml_to_top_descr_0120 that defines a dependency on blast_datatypes_0120.
         """
-        datatypes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        datatypes_repository = self._get_repository_by_name_and_owner(
             datatypes_repository_name, common.test_user_2_name
         )
-        tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-            tool_repository_name, common.test_user_1_name
-        )
+        tool_repository = self._get_repository_by_name_and_owner(tool_repository_name, common.test_user_1_name)
         dependency_xml_path = self.generate_temp_path("test_0120", additional_paths=["dependencies"])
         datatypes_tuple = (
             self.url,
             datatypes_repository.name,
-            datatypes_repository.user.username,
+            datatypes_repository.owner,
             self.get_repository_tip(datatypes_repository),
         )
         self.create_repository_dependency(
@@ -154,10 +150,8 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
         We are at step 3a.
         Check the newly created repository dependency to ensure that it was defined and displays correctly.
         """
-        datatypes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        datatypes_repository = self._get_repository_by_name_and_owner(
             datatypes_repository_name, common.test_user_2_name
         )
-        tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-            tool_repository_name, common.test_user_1_name
-        )
+        tool_repository = self._get_repository_by_name_and_owner(tool_repository_name, common.test_user_1_name)
         self.check_repository_dependency(tool_repository, datatypes_repository)

--- a/lib/tool_shed/test/functional/test_0140_tool_help_images.py
+++ b/lib/tool_shed/test/functional/test_0140_tool_help_images.py
@@ -71,15 +71,15 @@ class TestToolHelpImages(ShedTwillTestCase):
 
         src="/repository/static/images/<id>/count_modes.png"
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         # Get the repository tip.
         changeset_revision = self.get_repository_tip(repository)
         self.display_manage_repository_page(repository)
         # Generate the image path.
-        image_path = f'src="/repository/static/images/{self.security.encode_id(repository.id)}/count_modes.png"'
+        image_path = f'src="/repository/static/images/{repository.id}/count_modes.png"'
         # The repository uploaded in this test should only have one metadata revision, with one tool defined, which
         # should be the tool that contains a link to the image.
-        repository_metadata = repository.metadata_revisions[0].metadata
+        repository_metadata = self._db_repository(repository).metadata_revisions[0].metadata
         tool_path = repository_metadata["tools"][0]["tool_config"]
         self.load_display_tool_page(
             repository, tool_path, changeset_revision, strings_displayed=[image_path], strings_not_displayed=[]

--- a/lib/tool_shed/test/functional/test_0150_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_0150_prior_installation_required.py
@@ -90,17 +90,13 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
         Column maker repository dependency:
             <repository toolshed="self.url" name="convert_chars" owner="test" changeset_revision="<tip>" prior_installation_required="True" />
         """
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         dependency_xml_path = self.generate_temp_path("test_0150", additional_paths=["column"])
         convert_tuple = (
             self.url,
             convert_repository.name,
-            convert_repository.user.username,
+            convert_repository.owner,
             self.get_repository_tip(convert_repository),
         )
         self.create_repository_dependency(
@@ -112,12 +108,8 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0020_verify_repository_dependency(self):
         """Verify that the previously generated repositiory dependency displays correctly."""
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         self.check_repository_dependency(
             repository=column_repository,
             depends_on_repository=convert_repository,

--- a/lib/tool_shed/test/functional/test_0160_circular_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_0160_circular_prior_installation_required.py
@@ -111,22 +111,16 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
         Each of the three repositories should depend on the other two, to make this as circular as possible.
         """
-        filter_repository = self.test_db_util.get_repository_by_name_and_owner(
-            filter_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        filter_repository = self._get_repository_by_name_and_owner(filter_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         dependency_xml_path = self.generate_temp_path("test_0160", additional_paths=["column"])
         filter_revision = self.get_repository_tip(filter_repository)
         column_revision = self.get_repository_tip(column_repository)
         convert_revision = self.get_repository_tip(convert_repository)
-        column_tuple = (self.url, column_repository.name, column_repository.user.username, column_revision)
-        convert_tuple = (self.url, convert_repository.name, convert_repository.user.username, convert_revision)
-        filter_tuple = (self.url, filter_repository.name, filter_repository.user.username, filter_revision)
+        column_tuple = (self.url, column_repository.name, column_repository.owner, column_revision)
+        convert_tuple = (self.url, convert_repository.name, convert_repository.owner, convert_revision)
+        filter_tuple = (self.url, filter_repository.name, filter_repository.owner, filter_revision)
         self.create_repository_dependency(
             repository=column_repository,
             repository_tuples=[convert_tuple, filter_tuple],
@@ -148,15 +142,9 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0025_verify_repository_dependency(self):
         """Verify that the previously generated repositiory dependency displays correctly."""
-        filter_repository = self.test_db_util.get_repository_by_name_and_owner(
-            filter_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        filter_repository = self._get_repository_by_name_and_owner(filter_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         self.check_repository_dependency(
             repository=column_repository,
             depends_on_repository=convert_repository,

--- a/lib/tool_shed/test/functional/test_0170_complex_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_0170_complex_prior_installation_required.py
@@ -99,10 +99,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         set to True. When matplotlib is selected for installation, the result should be that numpy is compiled
         and installed first.
         """
-        numpy_repository = self.test_db_util.get_repository_by_name_and_owner(
-            numpy_repository_name, common.test_user_1_name
-        )
-        matplotlib_repository = self.test_db_util.get_repository_by_name_and_owner(
+        numpy_repository = self._get_repository_by_name_and_owner(numpy_repository_name, common.test_user_1_name)
+        matplotlib_repository = self._get_repository_by_name_and_owner(
             matplotlib_repository_name, common.test_user_1_name
         )
         # Generate the new dependency XML. Normally, the create_repository_dependency method would be used for this, but
@@ -114,7 +112,7 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         new_xml += "    </package>\n"
         url = self.url
         name = numpy_repository.name
-        owner = numpy_repository.user.username
+        owner = numpy_repository.owner
         changeset_revision = self.get_repository_tip(numpy_repository)
         processed_xml = new_xml % (url, name, owner, changeset_revision)
         original_xml = open(self.get_filename("package_matplotlib/tool_dependencies.xml")).read()
@@ -142,10 +140,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         'Inherited' in this case means that matplotlib should show a package tool dependency on numpy version 1.7, and a repository
         dependency on the latest revision of package_numpy_1_7_0170.
         """
-        numpy_repository = self.test_db_util.get_repository_by_name_and_owner(
-            numpy_repository_name, common.test_user_1_name
-        )
-        matplotlib_repository = self.test_db_util.get_repository_by_name_and_owner(
+        numpy_repository = self._get_repository_by_name_and_owner(numpy_repository_name, common.test_user_1_name)
+        matplotlib_repository = self._get_repository_by_name_and_owner(
             matplotlib_repository_name, common.test_user_1_name
         )
         changeset_revision = self.get_repository_tip(numpy_repository)

--- a/lib/tool_shed/test/functional/test_0300_reset_all_metadata.py
+++ b/lib/tool_shed/test/functional/test_0300_reset_all_metadata.py
@@ -335,35 +335,29 @@ class TestResetAllRepositoryMetadata(ShedTwillTestCase):
         """Create the dependency structure for test 0030."""
         global running_standalone
         if running_standalone:
-            column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+            column_maker_repository = self._get_repository_by_name_and_owner(
                 "column_maker_0030", common.test_user_1_name
             )
-            emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-                "emboss_0030", common.test_user_1_name
-            )
-            emboss_5_repository = self.test_db_util.get_repository_by_name_and_owner(
-                "emboss_5_0030", common.test_user_1_name
-            )
-            emboss_6_repository = self.test_db_util.get_repository_by_name_and_owner(
-                "emboss_6_0030", common.test_user_1_name
-            )
+            emboss_repository = self._get_repository_by_name_and_owner("emboss_0030", common.test_user_1_name)
+            emboss_5_repository = self._get_repository_by_name_and_owner("emboss_5_0030", common.test_user_1_name)
+            emboss_6_repository = self._get_repository_by_name_and_owner("emboss_6_0030", common.test_user_1_name)
             repository_dependencies_path = self.generate_temp_path("test_0330", additional_paths=["emboss"])
             column_maker_tuple = (
                 self.url,
                 column_maker_repository.name,
-                column_maker_repository.user.username,
+                column_maker_repository.owner,
                 self.get_repository_tip(column_maker_repository),
             )
             emboss_5_tuple = (
                 self.url,
                 emboss_5_repository.name,
-                emboss_5_repository.user.username,
+                emboss_5_repository.owner,
                 self.get_repository_tip(emboss_5_repository),
             )
             emboss_6_tuple = (
                 self.url,
                 emboss_6_repository.name,
-                emboss_6_repository.user.username,
+                emboss_6_repository.owner,
                 self.get_repository_tip(emboss_6_repository),
             )
             self.create_repository_dependency(
@@ -447,23 +441,19 @@ class TestResetAllRepositoryMetadata(ShedTwillTestCase):
         """Create the dependency structure for test 0040."""
         global running_standalone
         if running_standalone:
-            freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
-                "freebayes_0040", common.test_user_1_name
-            )
-            filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
-                "filtering_0040", common.test_user_1_name
-            )
+            freebayes_repository = self._get_repository_by_name_and_owner("freebayes_0040", common.test_user_1_name)
+            filtering_repository = self._get_repository_by_name_and_owner("filtering_0040", common.test_user_1_name)
             repository_dependencies_path = self.generate_temp_path("test_0340", additional_paths=["dependencies"])
             freebayes_tuple = (
                 self.url,
                 freebayes_repository.name,
-                freebayes_repository.user.username,
+                freebayes_repository.owner,
                 self.get_repository_tip(freebayes_repository),
             )
             filtering_tuple = (
                 self.url,
                 filtering_repository.name,
-                filtering_repository.user.username,
+                filtering_repository.owner,
                 self.get_repository_tip(filtering_repository),
             )
             self.create_repository_dependency(
@@ -647,22 +637,18 @@ class TestResetAllRepositoryMetadata(ShedTwillTestCase):
         global running_standalone
         if running_standalone:
             self.login(email=common.test_user_1_email, username=common.test_user_1_name)
-            column_repository = self.test_db_util.get_repository_by_name_and_owner(
-                column_repository_name, common.test_user_1_name
-            )
-            convert_repository = self.test_db_util.get_repository_by_name_and_owner(
+            column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+            convert_repository = self._get_repository_by_name_and_owner(
                 convert_repository_name, common.test_user_1_name
             )
-            emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-                emboss_repository_name, common.test_user_1_name
-            )
-            filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+            emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+            filtering_repository = self._get_repository_by_name_and_owner(
                 filtering_repository_name, common.test_user_1_name
             )
-            freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+            freebayes_repository = self._get_repository_by_name_and_owner(
                 freebayes_repository_name, common.test_user_1_name
             )
-            bismark_repository = self.test_db_util.get_repository_by_name_and_owner(
+            bismark_repository = self._get_repository_by_name_and_owner(
                 bismark_repository_name, common.test_user_1_name
             )
             dependency_xml_path = self.generate_temp_path("test_0050", additional_paths=["freebayes"])
@@ -675,31 +661,31 @@ class TestResetAllRepositoryMetadata(ShedTwillTestCase):
             column_tuple = (
                 self.url,
                 column_repository.name,
-                column_repository.user.username,
+                column_repository.owner,
                 self.get_repository_tip(column_repository),
             )
             convert_tuple = (
                 self.url,
                 convert_repository.name,
-                convert_repository.user.username,
+                convert_repository.owner,
                 self.get_repository_tip(convert_repository),
             )
             freebayes_tuple = (
                 self.url,
                 freebayes_repository.name,
-                freebayes_repository.user.username,
+                freebayes_repository.owner,
                 self.get_repository_tip(freebayes_repository),
             )
             emboss_tuple = (
                 self.url,
                 emboss_repository.name,
-                emboss_repository.user.username,
+                emboss_repository.owner,
                 self.get_repository_tip(emboss_repository),
             )
             bismark_tuple = (
                 self.url,
                 bismark_repository.name,
-                bismark_repository.user.username,
+                bismark_repository.owner,
                 self.get_repository_tip(bismark_repository),
             )
             self.create_repository_dependency(
@@ -728,12 +714,12 @@ class TestResetAllRepositoryMetadata(ShedTwillTestCase):
         repositories = self.test_db_util.get_all_repositories()
         for repository in repositories:
             old_metadata[self.security.encode_id(repository.id)] = dict()
-            for metadata in self.get_repository_metadata(repository):
+            for metadata in self.get_repository_metadata_for_db_object(repository):
                 old_metadata[self.security.encode_id(repository.id)][metadata.changeset_revision] = metadata.metadata
         self.reset_metadata_on_selected_repositories(list(old_metadata.keys()))
         for repository in repositories:
             new_metadata[self.security.encode_id(repository.id)] = dict()
-            for metadata in self.get_repository_metadata(repository):
+            for metadata in self.get_repository_metadata_for_db_object(repository):
                 new_metadata[self.security.encode_id(repository.id)][metadata.changeset_revision] = metadata.metadata
             if (
                 old_metadata[self.security.encode_id(repository.id)]

--- a/lib/tool_shed/test/functional/test_0310_hg_api_features.py
+++ b/lib/tool_shed/test/functional/test_0310_hg_api_features.py
@@ -87,7 +87,7 @@ class TestHgWebFeatures(ShedTwillTestCase):
         test-data/filter1_test3.sam
         test-data/filter1_test4.bed
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         clone_path = self.generate_temp_path("test_0310", additional_paths=["filtering_0310", "user2"])
         self.clone_repository(repository, clone_path)
         files_in_repository = os.listdir(clone_path)

--- a/lib/tool_shed/test/functional/test_0420_citable_urls_for_repositories.py
+++ b/lib/tool_shed/test/functional/test_0420_citable_urls_for_repositories.py
@@ -80,7 +80,7 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
         Add valid change set revision 1.
         The repository should now contain two changeset revisions, 0:<revision hash> and 1:<revision hash>.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="readme.txt",
@@ -124,10 +124,10 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
         Visit the following url and check for strings: ``<tool shed base url>/view/user1/filtering_0420`` .
         The resulting page should contain change set revision 1
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         test_user_1 = self.test_db_util.get_user(common.test_user_1_email)
         encoded_user_id = self.security.encode_id(test_user_1.id)
-        encoded_repository_id = self.security.encode_id(repository.id)
+        encoded_repository_id = repository.id
         # Since twill does not load the contents of an iframe, we need to check that the iframe has been generated correctly,
         # then directly load the url that the iframe should be loading and check for the expected strings.
         # The iframe should point to /repository/bview_repository?id=<encoded repository ID>
@@ -154,10 +154,10 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
         The resulting page should not contain change set revision 1, but should contain change set revision 0.
         """
         global first_changeset_hash
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         test_user_1 = self.test_db_util.get_user(common.test_user_1_email)
         encoded_user_id = self.security.encode_id(test_user_1.id)
-        encoded_repository_id = self.security.encode_id(repository.id)
+        encoded_repository_id = repository.id
         # Since twill does not load the contents of an iframe, we need to check that the iframe has been generated correctly,
         # then directly load the url that the iframe should be loading and check for the expected strings.
         # The iframe should point to /repository/view_repository?id=<encoded repository ID>
@@ -184,10 +184,10 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
 
     def test_0030_load_sharable_url_with_invalid_changeset_revision(self):
         """Load a citable url with an invalid changeset revision specified."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         test_user_1 = self.test_db_util.get_user(common.test_user_1_email)
         encoded_user_id = self.security.encode_id(test_user_1.id)
-        encoded_repository_id = self.security.encode_id(repository.id)
+        encoded_repository_id = repository.id
         invalid_changeset_hash = "invalid"
         # Since twill does not load the contents of an iframe, we need to check that the iframe has been generated correctly,
         # then directly load the url that the iframe should be loading and check for the expected strings.

--- a/lib/tool_shed/test/functional/test_0430_browse_utilities.py
+++ b/lib/tool_shed/test/functional/test_0430_browse_utilities.py
@@ -103,7 +103,7 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
         We are at step 3.
         Verify the existence of emboss tools in the browse tools page.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         changeset_revision = self.get_repository_tip(repository)
         strings_displayed = ["EMBOSS", "antigenic1", "5.0.0", changeset_revision, "user1", "emboss_0430"]
         self.browse_tools(strings_displayed=strings_displayed)
@@ -114,7 +114,7 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
         We are at step 4.
         Verify that the browse tool dependencies page shows the correct dependencies defined for freebayes_0430.
         """
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
         freebayes_changeset_revision = self.get_repository_tip(freebayes_repository)

--- a/lib/tool_shed/test/functional/test_0440_deleting_dependency_definitions.py
+++ b/lib/tool_shed/test/functional/test_0440_deleting_dependency_definitions.py
@@ -1,3 +1,4 @@
+from tool_shed_client.schema import Repository
 from ..base.twilltestcase import (
     common,
     ShedTwillTestCase,
@@ -128,17 +129,13 @@ class TestDeletedDependencies(ShedTwillTestCase):
         We are at simple repository dependencies, step 3 - Add a valid simple repository_dependencies.xml to
         convert_chars_0440 that points to the installable revision of column_maker_0440.
         """
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
         dependency_xml_path = self.generate_temp_path("test_0440", additional_paths=["dependencies"])
         column_tuple = (
             self.url,
             column_repository.name,
-            column_repository.user.username,
+            column_repository.owner,
             self.get_repository_tip(column_repository),
         )
         # After this, convert_chars_0440 should depend on column_maker_0440.
@@ -156,18 +153,16 @@ class TestDeletedDependencies(ShedTwillTestCase):
         We are at simple repository dependencies, step 4 - Make sure the installable revision of convert_chars_0440 is now
         revision 1 (the tip) instead of revision 0.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         tip = self.get_repository_tip(repository)
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, tip)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, tip)
         # Make sure that the new tip is now downloadable, and that there are no other downloadable revisions.
         assert metadata_record.downloadable, "Tip is not downloadable."
         assert (
-            len(repository.downloadable_revisions) == 1
+            len(self._db_repository(repository).downloadable_revisions) == 1
         ), "Repository %s has %d downloadable revisions, expected 1." % (
             repository.name,
-            len(repository.downloadable_revisions),
+            len(self._db_repository(repository).downloadable_revisions),
         )
 
     def test_0025_delete_repository_dependency(self):
@@ -176,33 +171,29 @@ class TestDeletedDependencies(ShedTwillTestCase):
         We are at simple repository dependencies, steps 5 and 6 - Delete repository_dependencies.xml from convert_chars_0440.
         Make sure convert_chars_0440 now has two installable revisions: 1 and 2
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         # Record the current tip, so we can verify that it's still a downloadable revision after repository_dependencies.xml
         # is deleted and a new downloadable revision is created.
         old_changeset_revision = self.get_repository_tip(repository)
         self.delete_files_from_repository(repository, filenames=["repository_dependencies.xml"])
         new_changeset_revision = self.get_repository_tip(repository)
         # Check that the old changeset revision is still downloadable.
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, old_changeset_revision)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, old_changeset_revision)
         assert metadata_record.downloadable, (
             "The revision of %s that contains repository_dependencies.xml is no longer downloadable." % repository.name
         )
         # Check that the new tip is also downloadable.
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, new_changeset_revision)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, new_changeset_revision)
         assert metadata_record.downloadable, (
             "The revision of %s that does not contain repository_dependencies.xml is not downloadable."
             % repository.name
         )
-        # Explicitly reload the repository instance from the database, to avoid potential caching issues.
-        self.test_db_util.refresh(repository)
         # Verify that there are only two downloadable revisions.
         assert (
-            len(repository.downloadable_revisions) == 2
+            len(self._db_repository(repository).downloadable_revisions) == 2
         ), "Repository %s has %d downloadable revisions, expected 2." % (
             repository.name,
-            len(repository.downloadable_revisions),
+            len(self._db_repository(repository).downloadable_revisions),
         )
 
     def test_0030_create_bwa_package_repository(self):
@@ -269,15 +260,13 @@ class TestDeletedDependencies(ShedTwillTestCase):
         We are at complex repository dependencies, step 3 - Add a valid complex repository dependency tool_dependencies.xml to
         bwa_base_0440 that points to the installable revision 0 of bwa_package_0440.
         """
-        bwa_package_repository = self.test_db_util.get_repository_by_name_and_owner(
+        bwa_package_repository = self._get_repository_by_name_and_owner(
             bwa_package_repository_name, common.test_user_1_name
         )
-        bwa_base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
+        bwa_base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
         dependency_path = self.generate_temp_path("test_0440", additional_paths=["complex"])
         changeset_revision = self.get_repository_tip(bwa_package_repository)
-        bwa_tuple = (self.url, bwa_package_repository.name, bwa_package_repository.user.username, changeset_revision)
+        bwa_tuple = (self.url, bwa_package_repository.name, bwa_package_repository.owner, changeset_revision)
         self.create_repository_dependency(
             repository=bwa_base_repository,
             repository_tuples=[bwa_tuple],
@@ -294,18 +283,16 @@ class TestDeletedDependencies(ShedTwillTestCase):
         We are at complex repository dependencies, step 4 - Make sure that bwa_base_0440 installable revision is now revision 1
         instead of revision 0.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
         tip = self.get_repository_tip(repository)
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, tip)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, tip)
         # Make sure that the new tip is now downloadable, and that there are no other downloadable revisions.
         assert metadata_record.downloadable, "Tip is not downloadable."
         assert (
-            len(repository.downloadable_revisions) == 1
+            len(self._db_repository(repository).downloadable_revisions) == 1
         ), "Repository %s has %d downloadable revisions, expected 1." % (
             repository.name,
-            len(repository.downloadable_revisions),
+            len(self._db_repository(repository).downloadable_revisions),
         )
 
     def test_0050_delete_complex_repository_dependency(self):
@@ -314,30 +301,28 @@ class TestDeletedDependencies(ShedTwillTestCase):
         We are at complex repository dependencies, step 5 - Delete tool_dependencies.xml from bwa_base_0440,
         and make sure bwa_base_0440 now has two installable revisions: 1 and 2
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
         # Record the current tip, so we can verify that it's still a downloadable revision after tool_dependencies.xml
         # is deleted and a new downloadable revision is created.
         old_changeset_revision = self.get_repository_tip(repository)
         self.delete_files_from_repository(repository, filenames=["tool_dependencies.xml"])
         new_changeset_revision = self.get_repository_tip(repository)
         # Check that the old changeset revision is still downloadable.
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, old_changeset_revision)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, old_changeset_revision)
         assert metadata_record.downloadable, (
             "The revision of %s that contains tool_dependencies.xml is no longer downloadable." % repository.name
         )
         # Check that the new tip is also downloadable.
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, new_changeset_revision)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, new_changeset_revision)
         assert metadata_record.downloadable, (
             "The revision of %s that does not contain tool_dependencies.xml is not downloadable." % repository.name
         )
         # Verify that there are only two downloadable revisions.
         assert (
-            len(repository.downloadable_revisions) == 2
+            len(self._db_repository(repository).downloadable_revisions) == 2
         ), "Repository %s has %d downloadable revisions, expected 2." % (
             repository.name,
-            len(repository.downloadable_revisions),
+            len(self._db_repository(repository).downloadable_revisions),
         )
 
     def test_0055_create_bwa_tool_dependency_repository(self):
@@ -375,7 +360,7 @@ class TestDeletedDependencies(ShedTwillTestCase):
         We are at tool dependencies, step 2 - Delete tool_dependencies.xml from bwa_tool_dependency_0440.
         Make sure bwa_tool_dependency_0440 still has a downloadable changeset revision at the old tip.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(
             bwa_tool_dependency_repository_name, common.test_user_1_name
         )
         # Record the current tip, so we can verify that it's still a downloadable revision after repository_dependencies.xml
@@ -383,23 +368,24 @@ class TestDeletedDependencies(ShedTwillTestCase):
         old_changeset_revision = self.get_repository_tip(repository)
         self.delete_files_from_repository(repository, filenames=["tool_dependencies.xml"])
         new_changeset_revision = self.get_repository_tip(repository)
+        assert old_changeset_revision != new_changeset_revision
         # Check that the old changeset revision is still downloadable.
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, old_changeset_revision)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, old_changeset_revision)
         assert metadata_record.downloadable, (
             "The revision of %s that contains tool_dependencies.xml is no longer downloadable." % repository.name
         )
         # Check that the new tip does not have a metadata revision.
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, new_changeset_revision)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, new_changeset_revision)
         # If a changeset revision does not have metadata, the above method will return None.
         assert (
             metadata_record is None
         ), f"The tip revision of {repository.name} should not have metadata, but metadata was found."
         # Verify that the new changeset revision is not downloadable.
         assert (
-            len(repository.downloadable_revisions) == 1
+            len(self._db_repository(repository).downloadable_revisions) == 1
         ), "Repository %s has %d downloadable revisions, expected 1." % (
             repository.name,
-            len(repository.downloadable_revisions),
+            len(self._db_repository(repository).downloadable_revisions),
         )
 
     def test_0065_reupload_bwa_tool_dependency_definition(self):
@@ -408,7 +394,7 @@ class TestDeletedDependencies(ShedTwillTestCase):
         We are at tool dependencies, step 3 - Add the same tool_dependencies.xml file to bwa_tool_dependency_0440, and make sure
         that bwa_tool_dependency_0440 still has a single installable revision 0.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(
             bwa_tool_dependency_repository_name, common.test_user_1_name
         )
         # Record the current tip, so we can verify that it's still not a downloadable revision after tool_dependencies.xml
@@ -427,20 +413,23 @@ class TestDeletedDependencies(ShedTwillTestCase):
         )
         new_changeset_revision = self.get_repository_tip(repository)
         # Check that the old changeset revision is still downloadable.
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, old_changeset_revision)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, old_changeset_revision)
         assert metadata_record is None, (
             "The revision of %s that does not contain tool_dependencies.xml should not be downloadable, but is."
             % repository.name
         )
         # Check that the new tip is also downloadable.
-        metadata_record = self.get_repository_metadata_by_changeset_revision(repository, new_changeset_revision)
+        metadata_record = self._get_repository_metadata_by_changeset_revision(repository, new_changeset_revision)
         assert metadata_record.downloadable, (
             "The revision of %s that contains tool_dependencies.xml is not downloadable." % repository.name
         )
         # Verify that there are only two downloadable revisions.
         assert (
-            len(repository.downloadable_revisions) == 1
+            len(self._db_repository(repository).downloadable_revisions) == 1
         ), "Repository %s has %d downloadable revisions, expected 1." % (
             repository.name,
-            len(repository.downloadable_revisions),
+            len(self._db_repository(repository).downloadable_revisions),
         )
+
+    def _get_repository_metadata_by_changeset_revision(self, repository: Repository, changeset: str):
+        return self.get_repository_metadata_by_changeset_revision(self._db_repository(repository).id, changeset)

--- a/lib/tool_shed/test/functional/test_0460_upload_to_repository.py
+++ b/lib/tool_shed/test/functional/test_0460_upload_to_repository.py
@@ -132,12 +132,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         This is step 4 - Upload an uncompressed tool_dependencies.xml to complex_dependency_test_1_0460 that specifies
         a complex repository dependency on package_bwa_0_5_9_0460 without a specified changeset revision or tool shed url.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            "complex_dependency_test_1_0460", common.test_user_1_name
-        )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            "package_bwa_0_5_9_0460", common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner("complex_dependency_test_1_0460", common.test_user_1_name)
+        package_repository = self._get_repository_by_name_and_owner("package_bwa_0_5_9_0460", common.test_user_1_name)
         self.upload_file(
             repository,
             filename="0460_files/tool_dependencies.xml",
@@ -162,12 +158,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         This is step 5 - Upload an tarball with tool_dependencies.xml to complex_dependency_test_2_0460 that specifies
         a complex repository dependency on package_bwa_0_5_9_0460 without a specified changeset revision or tool shed url.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            "complex_dependency_test_2_0460", common.test_user_1_name
-        )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            "package_bwa_0_5_9_0460", common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner("complex_dependency_test_2_0460", common.test_user_1_name)
+        package_repository = self._get_repository_by_name_and_owner("package_bwa_0_5_9_0460", common.test_user_1_name)
         self.upload_file(
             repository,
             filename="0460_files/tool_dependencies_in_root.tar",
@@ -192,12 +184,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         This is step 6 - Upload an tarball with tool_dependencies.xml in a subfolder to complex_dependency_test_3_0460 that
         specifies a complex repository dependency on package_bwa_0_5_9_0460 without a specified changeset revision or tool shed url.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            "complex_dependency_test_3_0460", common.test_user_1_name
-        )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            "package_bwa_0_5_9_0460", common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner("complex_dependency_test_3_0460", common.test_user_1_name)
+        package_repository = self._get_repository_by_name_and_owner("package_bwa_0_5_9_0460", common.test_user_1_name)
         self.upload_file(
             repository,
             filename="0460_files/tool_dependencies_in_subfolder.tar",
@@ -267,12 +255,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         This is step 8 - Upload to complex_dependency_test_4_0460 using the url hg://<tool shed url>/repos/user1/hg_tool_dependency_0460.
         """
         url = f"hg://{self.host}:{self.port}/repos/user1/hg_tool_dependency_0460"
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            "complex_dependency_test_4_0460", common.test_user_1_name
-        )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            "package_bwa_0_5_9_0460", common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner("complex_dependency_test_4_0460", common.test_user_1_name)
+        package_repository = self._get_repository_by_name_and_owner("package_bwa_0_5_9_0460", common.test_user_1_name)
         self.upload_url(
             repository,
             url=url,
@@ -297,12 +281,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         This is step 9 - Upload to complex_dependency_test_5_0460 using the url hg://<tool shed url>/repos/user1/hg_subfolder_tool_dependency_0460.
         """
         url = f"hg://{self.host}:{self.port}/repos/user1/hg_subfolder_tool_dependency_0460"
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            "complex_dependency_test_5_0460", common.test_user_1_name
-        )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            "package_bwa_0_5_9_0460", common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner("complex_dependency_test_5_0460", common.test_user_1_name)
+        package_repository = self._get_repository_by_name_and_owner("package_bwa_0_5_9_0460", common.test_user_1_name)
         self.upload_url(
             repository,
             url=url,
@@ -354,12 +334,10 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         This is step 11 - Upload an uncompressed repository_dependencies.xml to repository_dependency_test_1_0460 that specifies a
         repository dependency on emboss_datatypes_0460 without a specified changeset revision or tool shed url.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(
             "repository_dependency_test_1_0460", common.test_user_1_name
         )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_repository_name, common.test_user_1_name
-        )
+        package_repository = self._get_repository_by_name_and_owner(bwa_repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="0460_files/repository_dependencies.xml",
@@ -383,12 +361,10 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
 
         This is step 12 - Upload a tarball to repository_dependency_test_2_0460 with a repository_dependencies.xml in the root of the tarball.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(
             "repository_dependency_test_2_0460", common.test_user_1_name
         )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_repository_name, common.test_user_1_name
-        )
+        package_repository = self._get_repository_by_name_and_owner(bwa_repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="0460_files/in_root/repository_dependencies_in_root.tar",
@@ -413,12 +389,10 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         This is step 13 - Upload a tarball to repository_dependency_test_3_0460 with a repository_dependencies.xml in a
         subfolder within the tarball.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(
             "repository_dependency_test_3_0460", common.test_user_1_name
         )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_repository_name, common.test_user_1_name
-        )
+        package_repository = self._get_repository_by_name_and_owner(bwa_repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="0460_files/in_subfolder/repository_dependencies_in_subfolder.tar",
@@ -493,12 +467,10 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         hg://<tool shed url>/repos/user1/hg_repository_dependency_0460.
         """
         url = f"hg://{self.host}:{self.port}/repos/user1/hg_repository_dependency_0460"
-        repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(
             "repository_dependency_test_4_0460", common.test_user_1_name
         )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_repository_name, common.test_user_1_name
-        )
+        package_repository = self._get_repository_by_name_and_owner(bwa_repository_name, common.test_user_1_name)
         self.upload_url(
             repository,
             url=url,
@@ -524,12 +496,10 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         hg://<tool shed url>/repos/user1/hg_subfolder_repository_dependency_0460.
         """
         url = f"hg://{self.host}:{self.port}/repos/user1/hg_subfolder_repository_dependency_0460"
-        repository = self.test_db_util.get_repository_by_name_and_owner(
+        repository = self._get_repository_by_name_and_owner(
             "repository_dependency_test_5_0460", common.test_user_1_name
         )
-        package_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_repository_name, common.test_user_1_name
-        )
+        package_repository = self._get_repository_by_name_and_owner(bwa_repository_name, common.test_user_1_name)
         self.upload_url(
             repository,
             url=url,

--- a/lib/tool_shed/test/functional/test_0470_tool_dependency_repository_type.py
+++ b/lib/tool_shed/test/functional/test_0470_tool_dependency_repository_type.py
@@ -170,7 +170,7 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
         This is step 4 - Add a comment to the tool_dependencies.xml file to be uploaded to the package_x11_client_1_5_prot_7_0 repository, creating
         a new installable changeset revision at the repository tip.
         """
-        package_x11_repository = self.test_db_util.get_repository_by_name_and_owner(
+        package_x11_repository = self._get_repository_by_name_and_owner(
             package_libx11_repository_name, common.test_user_1_name
         )
         # Upload the tool dependency definition to the package_x11_client_1_5_proto_7_0_0470 repository.
@@ -185,9 +185,10 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
             strings_displayed=[],
             strings_not_displayed=[],
         )
-        assert len(package_x11_repository.metadata_revisions) == 1, (
+        count = self._get_metadata_revision_count(package_x11_repository)
+        assert count == 1, (
             "package_x11_client_1_5_proto_7_0_0470 has incorrect number of metadata revisions, expected 1 but found %d"
-            % len(package_x11_repository.metadata_revisions)
+            % count
         )
 
     def test_0025_upload_updated_tool_dependency_to_package_emboss(self):
@@ -197,7 +198,7 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
         the change set_revision attribute so that it gets automatically populated when uploaded. After uploading the file,
         the package_emboss_5_0_0 repository should have 2 installable changeset revisions.
         """
-        package_emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
+        package_emboss_repository = self._get_repository_by_name_and_owner(
             package_emboss_repository_name, common.test_user_1_name
         )
         # Populate package_emboss_5_0_0_0470 with updated tool dependency definition.
@@ -212,10 +213,9 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
             strings_displayed=[],
             strings_not_displayed=[],
         )
-        assert (
-            len(package_emboss_repository.metadata_revisions) == 2
-        ), "package_emboss_5_0_0_0470 has incorrect number of metadata revisions, expected 2 but found %d" % len(
-            package_emboss_repository.metadata_revisions
+        count = self._get_metadata_revision_count(package_emboss_repository)
+        assert count == 2, (
+            "package_emboss_5_0_0_0470 has incorrect number of metadata revisions, expected 2 but found %d" % count
         )
 
     def test_0030_upload_updated_tool_dependency_to_emboss_5_repository(self):
@@ -225,9 +225,7 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
         changeset_revision attribute so that it gets automatically populated when uploaded. After uploading the file,
         the emboss5 repository should have 2 installable metadata revisions.
         """
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         # Populate package_emboss_5_0_0_0470 with updated tool dependency definition.
         self.upload_file(
             emboss_repository,
@@ -240,16 +238,15 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
             strings_displayed=[],
             strings_not_displayed=[],
         )
-        assert (
-            len(emboss_repository.metadata_revisions) == 2
-        ), "package_emboss_5_0_0_0470 has incorrect number of metadata revisions"
+        count = self._get_metadata_revision_count(emboss_repository)
+        assert count == 2, "package_emboss_5_0_0_0470 has incorrect number of metadata revisions"
 
     def test_0035_modify_package_x11_repository_type(self):
         """Set package_x11_client_1_5_proto_7_0 type tool_dependency_definition.
 
         This is step 7 - Change the repository type of the package_x11_client_1_5_proto_7_0 repository to be tool_dependency_definition.
         """
-        package_x11_repository = self.test_db_util.get_repository_by_name_and_owner(
+        package_x11_repository = self._get_repository_by_name_and_owner(
             package_libx11_repository_name, common.test_user_1_name
         )
         self.edit_repository_information(package_x11_repository, repository_type="tool_dependency_definition")
@@ -259,7 +256,7 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
 
         This is step 8 - Change the repository type of the package_emboss_5_0_0 repository to be tool_dependency_definition.
         """
-        package_emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
+        package_emboss_repository = self._get_repository_by_name_and_owner(
             package_emboss_repository_name, common.test_user_1_name
         )
         self.edit_repository_information(package_emboss_repository, repository_type="tool_dependency_definition")
@@ -270,23 +267,19 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
         This is step 9 - Reset metadata on the package_emboss_5_0_0 and package_x11_client_1_5_proto_7_0 repositories. They should
         now have only their tip as the installable revision.
         """
-        package_emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
+        package_emboss_repository = self._get_repository_by_name_and_owner(
             package_emboss_repository_name, common.test_user_1_name
         )
-        package_x11_repository = self.test_db_util.get_repository_by_name_and_owner(
+        package_x11_repository = self._get_repository_by_name_and_owner(
             package_libx11_repository_name, common.test_user_1_name
         )
         self.reset_repository_metadata(package_emboss_repository)
         self.reset_repository_metadata(package_x11_repository)
-        assert (
-            len(package_emboss_repository.metadata_revisions) == 1
-        ), "Repository package_emboss_5_0_0 has %d installable revisions, expected 1." % len(
-            package_emboss_repository.metadata_revisions
-        )
-        assert (
-            len(package_x11_repository.metadata_revisions) == 1
-        ), "Repository package_x11_client_1_5_proto_7_0 has %d installable revisions, expected 1." % len(
-            package_x11_repository.metadata_revisions
+        count = self._get_metadata_revision_count(package_emboss_repository)
+        assert count == 1, "Repository package_emboss_5_0_0 has %d installable revisions, expected 1." % count
+        count = self._get_metadata_revision_count(package_x11_repository)
+        assert count == 1, (
+            "Repository package_x11_client_1_5_proto_7_0 has %d installable revisions, expected 1." % count
         )
 
     def test_0050_reset_emboss_5_metadata(self):
@@ -294,10 +287,7 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
 
         This is step 10 - Reset metadata on the emboss_5 repository. It should now have only its tip as the installable revision.
         """
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         self.reset_repository_metadata(emboss_repository)
-        assert (
-            len(emboss_repository.metadata_revisions) == 1
-        ), "Repository emboss_5 has %d installable revisions, expected 1." % len(emboss_repository.metadata_revisions)
+        count = self._get_metadata_revision_count(emboss_repository)
+        assert count == 1, "Repository emboss_5 has %d installable revisions, expected 1." % count

--- a/lib/tool_shed/test/functional/test_0480_tool_dependency_xml_verification.py
+++ b/lib/tool_shed/test/functional/test_0480_tool_dependency_xml_verification.py
@@ -65,7 +65,7 @@ class TestDependencyDefinitionValidation(ShedTwillTestCase):
 
         This is step 3 - Verify repository. The uploaded tool dependency XML should not have resulted in a new changeset.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         assert self.repository_is_new(
             repository
         ), "Uploading an incorrectly defined tool_dependencies.xml resulted in a changeset being generated."

--- a/lib/tool_shed/test/functional/test_0530_repository_admin_feature.py
+++ b/lib/tool_shed/test/functional/test_0530_repository_admin_feature.py
@@ -83,11 +83,11 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
 
         This is step 3 - Check to make sure a new repository_role_association record was created with appropriate repository id and role id.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         test_user_1 = self.test_db_util.get_user(common.test_user_1_email)
         repository_admin_role = self.test_db_util.get_role(test_user_1, "filtering_0530_user1_admin")
         repository_role_association = self.test_db_util.get_repository_role_association(
-            repository.id, repository_admin_role.id
+            self._db_repository(repository).id, repository_admin_role.id
         )
         assert (
             repository_role_association is not None
@@ -99,9 +99,9 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         This is step 4 - Change the name of the repository created in step 1 - this can be done as long as the repository has not
         been installed or cloned.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.edit_repository_information(repository, revert=False, repo_name="renamed_filtering_0530")
-        self.test_db_util.refresh(repository)
+        repository = self._get_repository_by_name_and_owner("renamed_filtering_0530", common.test_user_1_name)
         assert repository.name == "renamed_filtering_0530", "Repository was not renamed to renamed_filtering_0530."
 
     def test_0030_verify_access_denied(self):
@@ -111,9 +111,7 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         name and description cannot be changed.
         """
         self.login(email=common.test_user_2_email, username=common.test_user_2_name)
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            "renamed_filtering_0530", common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner("renamed_filtering_0530", common.test_user_1_name)
         strings_not_displayed = ["Manage repository"]
         strings_displayed = ["View repository"]
         self.display_manage_repository_page(repository, strings_not_displayed=strings_not_displayed)
@@ -129,9 +127,7 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         """
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         test_user_2 = self.test_db_util.get_user(common.test_user_2_email)
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            "renamed_filtering_0530", common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner("renamed_filtering_0530", common.test_user_1_name)
         self.assign_admin_role(repository, test_user_2)
 
     def test_0040_rename_repository_as_repository_admin(self):
@@ -140,11 +136,9 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         This is step 8 - Log into the Tool Shed as user user2 and make sure the repository name and description can now be changed.
         """
         self.login(email=common.test_user_2_email, username=common.test_user_2_name)
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            "renamed_filtering_0530", common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner("renamed_filtering_0530", common.test_user_1_name)
         self.edit_repository_information(repository, revert=False, repo_name="filtering_0530")
-        self.test_db_util.refresh(repository)
+        repository = self._get_repository_by_name_and_owner("filtering_0530", common.test_user_1_name)
         assert repository.name == "filtering_0530", "User with admin role failed to rename repository."
         test_user_1 = self.test_db_util.get_user(common.test_user_1_email)
         old_repository_admin_role = self.test_db_util.get_role(test_user_1, "renamed_filtering_0530_user1_admin")

--- a/lib/tool_shed/test/functional/test_0540_get_all_metadata_from_api.py
+++ b/lib/tool_shed/test/functional/test_0540_get_all_metadata_from_api.py
@@ -143,9 +143,7 @@ class TestGetAllMetadata(ShedTwillTestCase):
 
     def test_0020_create_repository_dependency(self):
         """Make column_maker depend on convert_chars."""
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            repositories["column"]["name"], common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(repositories["column"]["name"], common.test_user_1_name)
         self.upload_file(
             repository,
             filename="0540_files/column_maker/repository_dependencies.xml",
@@ -163,9 +161,7 @@ class TestGetAllMetadata(ShedTwillTestCase):
         Load the API endpoint to retrieve all repository metadata and verify
         that all three repository names are displayed.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            repositories["column"]["name"], common.test_user_1_name
-        )
+        repository = self._get_repository_by_name_and_owner(repositories["column"]["name"], common.test_user_1_name)
         strings_displayed = [
             repositories["column"]["name"],
             repositories["convert"]["name"],

--- a/lib/tool_shed/test/functional/test_0550_metadata_updated_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0550_metadata_updated_dependencies.py
@@ -133,31 +133,19 @@ class TestGetUpdatedMetadata(ShedTwillTestCase):
 
     def test_0020_check_repository_dependency(self):
         """Make filtering depend on samtools and freebayes."""
-        freebayes = self.test_db_util.get_repository_by_name_and_owner(
-            repositories["freebayes"]["name"], common.test_user_1_name
-        )
-        samtools = self.test_db_util.get_repository_by_name_and_owner(
-            repositories["samtools"]["name"], common.test_user_1_name
-        )
-        filtering = self.test_db_util.get_repository_by_name_and_owner(
-            repositories["filtering"]["name"], common.test_user_1_name
-        )
-        strings_displayed = [self.security.encode_id(freebayes.id), self.security.encode_id(samtools.id)]
+        freebayes = self._get_repository_by_name_and_owner(repositories["freebayes"]["name"], common.test_user_1_name)
+        samtools = self._get_repository_by_name_and_owner(repositories["samtools"]["name"], common.test_user_1_name)
+        filtering = self._get_repository_by_name_and_owner(repositories["filtering"]["name"], common.test_user_1_name)
+        strings_displayed = [freebayes.id, samtools.id]
         self.display_manage_repository_page(filtering, strings_displayed=strings_displayed)
 
     def test_0025_update_dependent_repositories(self):
         """
         Update freebayes and samtools, load the API endpoint again.
         """
-        freebayes = self.test_db_util.get_repository_by_name_and_owner(
-            repositories["freebayes"]["name"], common.test_user_1_name
-        )
-        samtools = self.test_db_util.get_repository_by_name_and_owner(
-            repositories["samtools"]["name"], common.test_user_1_name
-        )
-        filtering = self.test_db_util.get_repository_by_name_and_owner(
-            repositories["filtering"]["name"], common.test_user_1_name
-        )
+        freebayes = self._get_repository_by_name_and_owner(repositories["freebayes"]["name"], common.test_user_1_name)
+        samtools = self._get_repository_by_name_and_owner(repositories["samtools"]["name"], common.test_user_1_name)
+        filtering = self._get_repository_by_name_and_owner(repositories["filtering"]["name"], common.test_user_1_name)
         self.upload_file(
             freebayes,
             filename="0550_files/package_freebayes_2_0550.tgz",

--- a/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
@@ -81,7 +81,7 @@ class ToolWithToolDependencies(ShedTwillTestCase):
                 uncompress_file=False,
                 remove_repo_files_not_in_tar=False,
                 commit_message="Uploaded malformed tool dependency XML.",
-                strings_displayed=["Exception attempting to parse", "not well-formed"],
+                strings_displayed=["Exception attempting to parse", "invalid element name"],
                 strings_not_displayed=[],
             )
             self.upload_file(

--- a/lib/tool_shed/test/functional/test_1020_install_repository_with_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1020_install_repository_with_repository_dependencies.py
@@ -70,7 +70,7 @@ class ToolWithRepositoryDependencies(ShedTwillTestCase):
             repository_tuple = (
                 self.url,
                 column_maker_repository.name,
-                column_maker_repository.user.username,
+                column_maker_repository.owner,
                 self.get_repository_tip(column_maker_repository),
             )
             self.create_repository_dependency(

--- a/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
@@ -76,7 +76,7 @@ class RepositoryWithDependencyRevisions(ShedTwillTestCase):
             column_maker_tuple = (
                 self.url,
                 column_maker_repository.name,
-                column_maker_repository.user.username,
+                column_maker_repository.owner,
                 self.get_repository_tip(column_maker_repository),
             )
             self.create_repository_dependency(
@@ -107,7 +107,7 @@ class RepositoryWithDependencyRevisions(ShedTwillTestCase):
             column_maker_tuple = (
                 self.url,
                 column_maker_repository.name,
-                column_maker_repository.user.username,
+                column_maker_repository.owner,
                 self.get_repository_tip(column_maker_repository),
             )
             self.create_repository_dependency(
@@ -138,7 +138,7 @@ class RepositoryWithDependencyRevisions(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 emboss_5_repository.name,
-                emboss_5_repository.user.username,
+                emboss_5_repository.owner,
                 self.get_repository_tip(emboss_5_repository),
             )
             self.create_repository_dependency(
@@ -149,7 +149,7 @@ class RepositoryWithDependencyRevisions(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 emboss_6_repository.name,
-                emboss_6_repository.user.username,
+                emboss_6_repository.owner,
                 self.get_repository_tip(emboss_6_repository),
             )
             self.create_repository_dependency(

--- a/lib/tool_shed/test/functional/test_1040_install_repository_basic_circular_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1040_install_repository_basic_circular_dependencies.py
@@ -90,17 +90,17 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
         # Filtering will have two revisions, one with just the filtering tool, and one with the filtering tool and a dependency on freebayes.
         global running_standalone
         if running_standalone:
-            freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+            freebayes_repository = self._get_repository_by_name_and_owner(
                 freebayes_repository_name, common.test_user_1_name
             )
-            filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+            filtering_repository = self._get_repository_by_name_and_owner(
                 filtering_repository_name, common.test_user_1_name
             )
             repository_dependencies_path = self.generate_temp_path("test_1040", additional_paths=["circular"])
             repository_tuple = (
                 self.url,
                 freebayes_repository.name,
-                freebayes_repository.user.username,
+                freebayes_repository.owner,
                 self.get_repository_tip(freebayes_repository),
             )
             self.create_repository_dependency(
@@ -111,7 +111,7 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
             repository_tuple = (
                 self.url,
                 filtering_repository.name,
-                filtering_repository.user.username,
+                filtering_repository.owner,
                 self.get_repository_tip(filtering_repository),
             )
             self.create_repository_dependency(

--- a/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
+++ b/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
@@ -196,22 +196,18 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
         """Set up the dependency structure."""
         global running_standalone
         if running_standalone:
-            column_repository = self.test_db_util.get_repository_by_name_and_owner(
-                column_repository_name, common.test_user_1_name
-            )
-            convert_repository = self.test_db_util.get_repository_by_name_and_owner(
+            column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+            convert_repository = self._get_repository_by_name_and_owner(
                 convert_repository_name, common.test_user_1_name
             )
-            emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-                emboss_repository_name, common.test_user_1_name
-            )
-            filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+            emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+            filtering_repository = self._get_repository_by_name_and_owner(
                 filtering_repository_name, common.test_user_1_name
             )
-            freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+            freebayes_repository = self._get_repository_by_name_and_owner(
                 freebayes_repository_name, common.test_user_1_name
             )
-            bismark_repository = self.test_db_util.get_repository_by_name_and_owner(
+            bismark_repository = self._get_repository_by_name_and_owner(
                 bismark_repository_name, common.test_user_1_name
             )
             dependency_xml_path = self.generate_temp_path("test_1050", additional_paths=["dependencies"])
@@ -223,31 +219,31 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
             column_tuple = (
                 self.url,
                 column_repository.name,
-                column_repository.user.username,
+                column_repository.owner,
                 self.get_repository_tip(column_repository),
             )
             convert_tuple = (
                 self.url,
                 convert_repository.name,
-                convert_repository.user.username,
+                convert_repository.owner,
                 self.get_repository_tip(convert_repository),
             )
             freebayes_tuple = (
                 self.url,
                 freebayes_repository.name,
-                freebayes_repository.user.username,
+                freebayes_repository.owner,
                 self.get_repository_tip(freebayes_repository),
             )
             emboss_tuple = (
                 self.url,
                 emboss_repository.name,
-                emboss_repository.user.username,
+                emboss_repository.owner,
                 self.get_repository_tip(emboss_repository),
             )
             bismark_tuple = (
                 self.url,
                 bismark_repository.name,
-                bismark_repository.user.username,
+                bismark_repository.owner,
                 self.get_repository_tip(bismark_repository),
             )
             self.create_repository_dependency(
@@ -287,24 +283,16 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
              id: 7 key: http://toolshed.local:10001__ESEP__emboss_5__ESEP__test__ESEP__8de5fe0d7b04
                  ['http://toolshed.local:10001', 'emboss_datatypes', 'test', 'dbd4f68bf507']
         """
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
-        filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        filtering_repository = self._get_repository_by_name_and_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        bismark_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bismark_repository_name, common.test_user_1_name
-        )
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        bismark_repository = self._get_repository_by_name_and_owner(bismark_repository_name, common.test_user_1_name)
         self.check_repository_dependency(convert_repository, column_repository)
         self.check_repository_dependency(column_repository, convert_repository)
         self.check_repository_dependency(emboss_repository, bismark_repository)
@@ -323,12 +311,10 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0050_verify_tool_dependencies(self):
         """Check that freebayes and emboss display tool dependencies."""
-        freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        freebayes_repository = self._get_repository_by_name_and_owner(
             freebayes_repository_name, common.test_user_1_name
         )
-        emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
+        emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         self.display_manage_repository_page(
             freebayes_repository,
             strings_displayed=["freebayes", "0.9.4_9696d0ce8a9", "samtools", "0.1.18", "Tool dependencies"],

--- a/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
+++ b/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
@@ -261,7 +261,7 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
             )
             self.create_repository_dependency(
                 repository=freebayes_repository,
-                repository_tuples=[freebayes_tuple, bismark_tuple, emboss_tuple, column_tuple],
+                repository_tuples=[freebayes_tuple, emboss_tuple, column_tuple],
                 filepath=dependency_xml_path,
             )
             self.create_repository_dependency(

--- a/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
+++ b/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
@@ -89,17 +89,15 @@ class TestRepositoryDependencies(ShedTwillTestCase):
         """If this test is being run by itself, it will not have repository dependencies configured yet."""
         global running_standalone
         if running_standalone:
-            convert_repository = self.test_db_util.get_repository_by_name_and_owner(
+            convert_repository = self._get_repository_by_name_and_owner(
                 convert_repository_name, common.test_user_1_name
             )
-            column_repository = self.test_db_util.get_repository_by_name_and_owner(
-                column_repository_name, common.test_user_1_name
-            )
+            column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
             repository_dependencies_path = self.generate_temp_path("test_1080", additional_paths=["convert"])
             repository_tuple = (
                 self.url,
                 convert_repository.name,
-                convert_repository.user.username,
+                convert_repository.owner,
                 self.get_repository_tip(convert_repository),
             )
             self.create_repository_dependency(
@@ -110,7 +108,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
             repository_tuple = (
                 self.url,
                 column_repository.name,
-                column_repository.user.username,
+                column_repository.owner,
                 self.get_repository_tip(column_repository),
             )
             self.create_repository_dependency(

--- a/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
+++ b/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
@@ -79,17 +79,13 @@ class TestRepositoryDependencies(ShedTwillTestCase):
             )
 
     def test_0015_create_and_upload_dependency_files(self):
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
         repository_dependencies_path = self.generate_temp_path("test_1085", additional_paths=["column"])
         repository_tuple = (
             self.url,
             convert_repository.name,
-            convert_repository.user.username,
+            convert_repository.owner,
             self.get_repository_tip(convert_repository),
         )
         self.create_repository_dependency(
@@ -98,7 +94,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
         repository_tuple = (
             self.url,
             column_repository.name,
-            column_repository.user.username,
+            column_repository.owner,
             self.get_repository_tip(column_repository),
         )
         self.create_repository_dependency(

--- a/lib/tool_shed/test/functional/test_1100_install_updated_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1100_install_updated_repository_dependencies.py
@@ -95,17 +95,13 @@ class TestRepositoryDependencies(ShedTwillTestCase):
     def test_0020_upload_dependency_xml(self):
         """Upload a repository_dependencies.xml file to column_maker that specifies convert_chars."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
         repository_dependencies_path = self.generate_temp_path("test_1085", additional_paths=["column"])
         convert_tuple = (
             self.url,
             convert_repository.name,
-            convert_repository.user.username,
+            convert_repository.owner,
             self.get_repository_tip(convert_repository),
         )
         self.create_repository_dependency(
@@ -114,12 +110,8 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0025_verify_repository_dependency(self):
         """Verify that the new revision of column_maker now depends on convert_chars."""
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
         self.check_repository_dependency(column_repository, convert_repository)
 
     def test_0030_reinstall_column_repository(self):
@@ -128,9 +120,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
         installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         strings_displayed = [
             "Handle repository dependencies",
             "convert_chars_1087",

--- a/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
@@ -82,7 +82,7 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
                 category=category,
                 strings_displayed=[],
             )
-            self.test_db_util.get_repository_by_name_and_owner(bwa_package_repository_name, common.test_user_1_name)
+            self._get_repository_by_name_and_owner(bwa_package_repository_name, common.test_user_1_name)
             self.upload_file(
                 repository,
                 filename="bwa/complex/bwa_base.tar",
@@ -100,15 +100,13 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
         global running_standalone
         if running_standalone:
             dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex", "shed"])
-            base_repository = self.test_db_util.get_repository_by_name_and_owner(
-                bwa_base_repository_name, common.test_user_1_name
-            )
-            tool_repository = self.test_db_util.get_repository_by_name_and_owner(
+            base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
+            tool_repository = self._get_repository_by_name_and_owner(
                 bwa_package_repository_name, common.test_user_1_name
             )
             url = "http://http://this is not an url!"
             name = tool_repository.name
-            owner = tool_repository.user.username
+            owner = tool_repository.owner
             changeset_revision = self.get_repository_tip(tool_repository)
             strings_displayed = ["Repository dependencies are currently supported only within the same tool shed"]
             repository_tuple = (url, name, owner, changeset_revision)
@@ -127,15 +125,13 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
         global running_standalone
         if running_standalone:
             dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex", "shed"])
-            base_repository = self.test_db_util.get_repository_by_name_and_owner(
-                bwa_base_repository_name, common.test_user_1_name
-            )
-            tool_repository = self.test_db_util.get_repository_by_name_and_owner(
+            base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
+            tool_repository = self._get_repository_by_name_and_owner(
                 bwa_package_repository_name, common.test_user_1_name
             )
             url = self.url
             name = "invalid_repository!?"
-            owner = tool_repository.user.username
+            owner = tool_repository.owner
             changeset_revision = self.get_repository_tip(tool_repository)
             strings_displayed = ["because the name is invalid."]
             repository_tuple = (url, name, owner, changeset_revision)
@@ -154,10 +150,8 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
         global running_standalone
         if running_standalone:
             dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex", "shed"])
-            base_repository = self.test_db_util.get_repository_by_name_and_owner(
-                bwa_base_repository_name, common.test_user_1_name
-            )
-            tool_repository = self.test_db_util.get_repository_by_name_and_owner(
+            base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
+            tool_repository = self._get_repository_by_name_and_owner(
                 bwa_package_repository_name, common.test_user_1_name
             )
             url = self.url
@@ -181,15 +175,13 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
         global running_standalone
         if running_standalone:
             dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex", "shed"])
-            base_repository = self.test_db_util.get_repository_by_name_and_owner(
-                bwa_base_repository_name, common.test_user_1_name
-            )
-            tool_repository = self.test_db_util.get_repository_by_name_and_owner(
+            base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
+            tool_repository = self._get_repository_by_name_and_owner(
                 bwa_package_repository_name, common.test_user_1_name
             )
             url = self.url
             name = tool_repository.name
-            owner = tool_repository.user.username
+            owner = tool_repository.owner
             changeset_revision = "1234abcd"
             strings_displayed = ["because the changeset revision is invalid."]
             repository_tuple = (url, name, owner, changeset_revision)
@@ -207,16 +199,14 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
         """Generate and upload a valid tool_dependencies.xml file that specifies package_bwa_0_5_9_0100."""
         global running_standalone
         if running_standalone:
-            base_repository = self.test_db_util.get_repository_by_name_and_owner(
-                bwa_base_repository_name, common.test_user_1_name
-            )
-            tool_repository = self.test_db_util.get_repository_by_name_and_owner(
+            base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
+            tool_repository = self._get_repository_by_name_and_owner(
                 bwa_package_repository_name, common.test_user_1_name
             )
             dependency_path = self.generate_temp_path("test_0100", additional_paths=["complex"])
             url = self.url
             name = tool_repository.name
-            owner = tool_repository.user.username
+            owner = tool_repository.owner
             changeset_revision = self.get_repository_tip(tool_repository)
             repository_tuple = (url, name, owner, changeset_revision)
             self.create_repository_dependency(
@@ -234,10 +224,8 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
         """Upload a new tool_dependencies.xml to the tool repository, and verify that the base repository displays the new changeset."""
         global running_standalone
         if running_standalone:
-            base_repository = self.test_db_util.get_repository_by_name_and_owner(
-                bwa_base_repository_name, common.test_user_1_name
-            )
-            tool_repository = self.test_db_util.get_repository_by_name_and_owner(
+            base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
+            tool_repository = self._get_repository_by_name_and_owner(
                 bwa_package_repository_name, common.test_user_1_name
             )
             previous_changeset = self.get_repository_tip(tool_repository)
@@ -268,12 +256,8 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
     def test_0045_install_base_repository(self):
         """Verify installation of the repository with complex repository dependencies."""
         self.galaxy_login(email=common.admin_email, username=common.admin_username)
-        base_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_base_repository_name, common.test_user_1_name
-        )
-        tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-            bwa_package_repository_name, common.test_user_1_name
-        )
+        base_repository = self._get_repository_by_name_and_owner(bwa_base_repository_name, common.test_user_1_name)
+        tool_repository = self._get_repository_by_name_and_owner(bwa_package_repository_name, common.test_user_1_name)
         preview_strings_displayed = [tool_repository.name, self.get_repository_tip(tool_repository)]
         self.install_repository(
             bwa_base_repository_name,

--- a/lib/tool_shed/test/functional/test_1130_install_repository_with_invalid_repository_dependency.py
+++ b/lib/tool_shed/test/functional/test_1130_install_repository_with_invalid_repository_dependency.py
@@ -85,15 +85,13 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
         global running_standalone
         if running_standalone:
             dependency_path = self.generate_temp_path("test_1110", additional_paths=["simple"])
-            column_maker_repository = self.test_db_util.get_repository_by_name_and_owner(
+            column_maker_repository = self._get_repository_by_name_and_owner(
                 column_maker_repository_name, common.test_user_1_name
             )
-            emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-                emboss_repository_name, common.test_user_1_name
-            )
+            emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
             url = "http://http://this is not an url!"
             name = column_maker_repository.name
-            owner = column_maker_repository.user.username
+            owner = column_maker_repository.owner
             changeset_revision = self.get_repository_tip(column_maker_repository)
             strings_displayed = ["Repository dependencies are currently supported only within the same tool shed"]
             repository_tuple = (url, name, owner, changeset_revision)
@@ -110,15 +108,11 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
         global running_standalone
         if running_standalone:
             dependency_path = self.generate_temp_path("test_1110", additional_paths=["simple"])
-            repository = self.test_db_util.get_repository_by_name_and_owner(
-                column_maker_repository_name, common.test_user_1_name
-            )
-            emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-                emboss_repository_name, common.test_user_1_name
-            )
+            repository = self._get_repository_by_name_and_owner(column_maker_repository_name, common.test_user_1_name)
+            emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
             url = self.url
             name = "!?invalid?!"
-            owner = repository.user.username
+            owner = repository.owner
             changeset_revision = self.get_repository_tip(repository)
             strings_displayed = ["because the name is invalid."]
             repository_tuple = (url, name, owner, changeset_revision)
@@ -135,12 +129,8 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
         global running_standalone
         if running_standalone:
             dependency_path = self.generate_temp_path("test_1110", additional_paths=["simple"])
-            repository = self.test_db_util.get_repository_by_name_and_owner(
-                column_maker_repository_name, common.test_user_1_name
-            )
-            emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-                emboss_repository_name, common.test_user_1_name
-            )
+            repository = self._get_repository_by_name_and_owner(column_maker_repository_name, common.test_user_1_name)
+            emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
             url = self.url
             name = repository.name
             owner = "!?invalid?!"
@@ -160,15 +150,11 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
         global running_standalone
         if running_standalone:
             dependency_path = self.generate_temp_path("test_1110", additional_paths=["simple", "invalid"])
-            repository = self.test_db_util.get_repository_by_name_and_owner(
-                column_maker_repository_name, common.test_user_1_name
-            )
-            emboss_repository = self.test_db_util.get_repository_by_name_and_owner(
-                emboss_repository_name, common.test_user_1_name
-            )
+            repository = self._get_repository_by_name_and_owner(column_maker_repository_name, common.test_user_1_name)
+            emboss_repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
             url = self.url
             name = repository.name
-            owner = repository.user.username
+            owner = repository.owner
             changeset_revision = "!?invalid?!"
             strings_displayed = ["because the changeset revision is invalid."]
             repository_tuple = (url, name, owner, changeset_revision)
@@ -183,7 +169,7 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
     def test_0045_install_repository_with_invalid_repository_dependency(self):
         """Install the repository and verify that galaxy detects invalid repository dependencies."""
         self.galaxy_login(email=common.admin_email, username=common.admin_username)
-        repository = self.test_db_util.get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         preview_strings_displayed = [
             "emboss_0110",
             self.get_repository_tip(repository),

--- a/lib/tool_shed/test/functional/test_1140_simple_repository_dependency_multiple_owners.py
+++ b/lib/tool_shed/test/functional/test_1140_simple_repository_dependency_multiple_owners.py
@@ -77,9 +77,7 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         Check for appropriate strings, most importantly BlastXml, BlastNucDb, and BlastProtDb,
         the datatypes that are defined in datatypes_conf.xml.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(
-            datatypes_repository_name, common.test_user_2_name
-        )
+        repository = self._get_repository_by_name_and_owner(datatypes_repository_name, common.test_user_2_name)
         strings_displayed = [
             "BlastXml",
             "BlastNucDb",
@@ -130,7 +128,7 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         We are at step 2a.
         Check for appropriate strings, such as tool name, description, and version.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(tool_repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(tool_repository_name, common.test_user_1_name)
         strings_displayed = ["blastxml_to_top_descr_0120", "BLAST top hit descriptions", "Make a table from BLAST XML"]
         strings_displayed.extend(["0.0.1", "Valid tools"])
         self.display_manage_repository_page(repository, strings_displayed=strings_displayed)
@@ -143,17 +141,15 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         """
         global running_standalone
         if running_standalone:
-            datatypes_repository = self.test_db_util.get_repository_by_name_and_owner(
+            datatypes_repository = self._get_repository_by_name_and_owner(
                 datatypes_repository_name, common.test_user_2_name
             )
-            tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-                tool_repository_name, common.test_user_1_name
-            )
+            tool_repository = self._get_repository_by_name_and_owner(tool_repository_name, common.test_user_1_name)
             dependency_xml_path = self.generate_temp_path("test_1120", additional_paths=["dependencies"])
             datatypes_tuple = (
                 self.url,
                 datatypes_repository.name,
-                datatypes_repository.user.username,
+                datatypes_repository.owner,
                 self.get_repository_tip(datatypes_repository),
             )
             self.create_repository_dependency(
@@ -166,12 +162,10 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         We are at step 3a.
         Check the newly created repository dependency to ensure that it was defined and displays correctly.
         """
-        datatypes_repository = self.test_db_util.get_repository_by_name_and_owner(
+        datatypes_repository = self._get_repository_by_name_and_owner(
             datatypes_repository_name, common.test_user_2_name
         )
-        tool_repository = self.test_db_util.get_repository_by_name_and_owner(
-            tool_repository_name, common.test_user_1_name
-        )
+        tool_repository = self._get_repository_by_name_and_owner(tool_repository_name, common.test_user_1_name)
         self.check_repository_dependency(tool_repository, datatypes_repository)
 
     def test_0045_install_blastxml_to_top_descr(self):

--- a/lib/tool_shed/test/functional/test_1160_tool_help_images.py
+++ b/lib/tool_shed/test/functional/test_1160_tool_help_images.py
@@ -64,15 +64,15 @@ class TestToolHelpImages(ShedTwillTestCase):
 
         This is a duplicate of test method _0010 in test_0140_tool_help_images.
         """
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         # Get the repository tip.
         changeset_revision = self.get_repository_tip(repository)
         self.display_manage_repository_page(repository)
         # Generate the image path.
-        image_path = f'src="/repository/static/images/{self.security.encode_id(repository.id)}/count_modes.png"'
+        image_path = f'src="/repository/static/images/{repository.id}/count_modes.png"'
         # The repository uploaded in this test should only have one metadata revision, with one tool defined, which
         # should be the tool that contains a link to the image.
-        repository_metadata = repository.metadata_revisions[0].metadata
+        repository_metadata = self._db_repository(repository).metadata_revisions[0].metadata
         tool_path = repository_metadata["tools"][0]["tool_config"]
         self.load_display_tool_page(
             repository, tool_path, changeset_revision, strings_displayed=[image_path], strings_not_displayed=[]

--- a/lib/tool_shed/test/functional/test_1170_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1170_prior_installation_required.py
@@ -103,18 +103,14 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
             <repository toolshed="self.url" name="convert_chars" owner="test" changeset_revision="<tip>" prior_installation_required="True" />
         """
         global running_standalone
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         if running_standalone:
             dependency_xml_path = self.generate_temp_path("test_1150", additional_paths=["column"])
             convert_tuple = (
                 self.url,
                 convert_repository.name,
-                convert_repository.user.username,
+                convert_repository.owner,
                 self.get_repository_tip(convert_repository),
             )
             self.create_repository_dependency(
@@ -126,12 +122,8 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0020_verify_repository_dependency(self):
         """Verify that the previously generated repositiory dependency displays correctly."""
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         self.check_repository_dependency(
             repository=column_repository,
             depends_on_repository=convert_repository,
@@ -142,9 +134,7 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
     def test_0025_install_column_repository(self):
         """Install column_maker_0150."""
         self.galaxy_login(email=common.admin_email, username=common.admin_username)
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
         preview_strings_displayed = ["column_maker_0150", self.get_repository_tip(column_repository)]
         strings_displayed = ["Choose the tool panel section"]
         self.install_repository(

--- a/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
@@ -140,23 +140,17 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
         Each of the three repositories should depend on the other two, to make this as circular as possible.
         """
         global running_standalone
-        filter_repository = self.test_db_util.get_repository_by_name_and_owner(
-            filter_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        filter_repository = self._get_repository_by_name_and_owner(filter_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         filter_revision = self.get_repository_tip(filter_repository)
         column_revision = self.get_repository_tip(column_repository)
         convert_revision = self.get_repository_tip(convert_repository)
         if running_standalone:
             dependency_xml_path = self.generate_temp_path("test_1160", additional_paths=["column"])
-            column_tuple = (self.url, column_repository.name, column_repository.user.username, column_revision)
-            convert_tuple = (self.url, convert_repository.name, convert_repository.user.username, convert_revision)
-            filter_tuple = (self.url, filter_repository.name, filter_repository.user.username, filter_revision)
+            column_tuple = (self.url, column_repository.name, column_repository.owner, column_revision)
+            convert_tuple = (self.url, convert_repository.name, convert_repository.owner, convert_revision)
+            filter_tuple = (self.url, filter_repository.name, filter_repository.owner, filter_revision)
             self.create_repository_dependency(
                 repository=column_repository,
                 repository_tuples=[convert_tuple, filter_tuple],
@@ -178,15 +172,9 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0025_verify_repository_dependency(self):
         """Verify that the previously generated repositiory dependency displays correctly."""
-        filter_repository = self.test_db_util.get_repository_by_name_and_owner(
-            filter_repository_name, common.test_user_1_name
-        )
-        column_repository = self.test_db_util.get_repository_by_name_and_owner(
-            column_repository_name, common.test_user_1_name
-        )
-        convert_repository = self.test_db_util.get_repository_by_name_and_owner(
-            convert_repository_name, common.test_user_1_name
-        )
+        filter_repository = self._get_repository_by_name_and_owner(filter_repository_name, common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
+        convert_repository = self._get_repository_by_name_and_owner(convert_repository_name, common.test_user_1_name)
         self.check_repository_dependency(
             repository=column_repository,
             depends_on_repository=convert_repository,
@@ -227,9 +215,7 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
     def test_0030_install_filtering_repository(self):
         """Install the filtering_0160 repository."""
         self.galaxy_login(email=common.admin_email, username=common.admin_username)
-        filter_repository = self.test_db_util.get_repository_by_name_and_owner(
-            filter_repository_name, common.test_user_1_name
-        )
+        filter_repository = self._get_repository_by_name_and_owner(filter_repository_name, common.test_user_1_name)
         preview_strings_displayed = ["filtering_0160", self.get_repository_tip(filter_repository)]
         strings_displayed = ["Choose the tool panel section"]
         self.install_repository(

--- a/lib/tool_shed/test/functional/test_1190_complex_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1190_complex_prior_installation_required.py
@@ -113,10 +113,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         and installed first.
         """
         global running_standalone
-        numpy_repository = self.test_db_util.get_repository_by_name_and_owner(
-            numpy_repository_name, common.test_user_1_name
-        )
-        matplotlib_repository = self.test_db_util.get_repository_by_name_and_owner(
+        numpy_repository = self._get_repository_by_name_and_owner(numpy_repository_name, common.test_user_1_name)
+        matplotlib_repository = self._get_repository_by_name_and_owner(
             matplotlib_repository_name, common.test_user_1_name
         )
         # Generate the new dependency XML. Normally, the create_repository_dependency method would be used for this, but
@@ -128,7 +126,7 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         new_xml += "    </package>\n"
         url = self.url
         name = numpy_repository.name
-        owner = numpy_repository.user.username
+        owner = numpy_repository.owner
         if running_standalone:
             changeset_revision = self.get_repository_tip(numpy_repository)
             processed_xml = new_xml % (url, name, owner, changeset_revision)
@@ -157,10 +155,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         'Inherited' in this case means that matplotlib should show a package tool dependency on numpy version 1.7, and a repository
         dependency on the latest revision of package_numpy_1_7_0170.
         """
-        numpy_repository = self.test_db_util.get_repository_by_name_and_owner(
-            numpy_repository_name, common.test_user_1_name
-        )
-        matplotlib_repository = self.test_db_util.get_repository_by_name_and_owner(
+        numpy_repository = self._get_repository_by_name_and_owner(numpy_repository_name, common.test_user_1_name)
+        matplotlib_repository = self._get_repository_by_name_and_owner(
             matplotlib_repository_name, common.test_user_1_name
         )
         changeset_revision = self.get_repository_tip(numpy_repository)
@@ -175,7 +171,7 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         This is step 4 - Install package_matplotlib_1_2_0170 with repository dependencies.
         """
         self.galaxy_login(email=common.admin_email, username=common.admin_username)
-        matplotlib_repository = self.test_db_util.get_repository_by_name_and_owner(
+        matplotlib_repository = self._get_repository_by_name_and_owner(
             matplotlib_repository_name, common.test_user_1_name
         )
         preview_strings_displayed = ["package_matplotlib_1_2_0170", self.get_repository_tip(matplotlib_repository)]

--- a/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
@@ -66,7 +66,7 @@ class UninstallingAndReinstallingRepositories(ShedTwillTestCase):
             column_maker_tuple = (
                 self.url,
                 column_maker_repository.name,
-                column_maker_repository.user.username,
+                column_maker_repository.owner,
                 self.get_repository_tip(column_maker_repository),
             )
             self.create_repository_dependency(
@@ -97,7 +97,7 @@ class UninstallingAndReinstallingRepositories(ShedTwillTestCase):
             column_maker_tuple = (
                 self.url,
                 column_maker_repository.name,
-                column_maker_repository.user.username,
+                column_maker_repository.owner,
                 self.get_repository_tip(column_maker_repository),
             )
             self.create_repository_dependency(
@@ -128,7 +128,7 @@ class UninstallingAndReinstallingRepositories(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 emboss_5_repository.name,
-                emboss_5_repository.user.username,
+                emboss_5_repository.owner,
                 self.get_repository_tip(emboss_5_repository),
             )
             self.create_repository_dependency(
@@ -139,7 +139,7 @@ class UninstallingAndReinstallingRepositories(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 emboss_6_repository.name,
-                emboss_6_repository.user.username,
+                emboss_6_repository.owner,
                 self.get_repository_tip(emboss_6_repository),
             )
             self.create_repository_dependency(

--- a/lib/tool_shed/test/functional/test_1300_reset_all_metadata.py
+++ b/lib/tool_shed/test/functional/test_1300_reset_all_metadata.py
@@ -249,7 +249,7 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 column_maker_repository.name,
-                column_maker_repository.user.username,
+                column_maker_repository.owner,
                 self.get_repository_tip(column_maker_repository),
             )
             self.create_repository_dependency(
@@ -280,7 +280,7 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 column_maker_repository.name,
-                column_maker_repository.user.username,
+                column_maker_repository.owner,
                 self.get_repository_tip(column_maker_repository),
             )
             self.create_repository_dependency(
@@ -311,7 +311,7 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 emboss_5_repository.name,
-                emboss_5_repository.user.username,
+                emboss_5_repository.owner,
                 self.get_repository_tip(emboss_5_repository),
             )
             self.create_repository_dependency(
@@ -322,7 +322,7 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 emboss_6_repository.name,
-                emboss_6_repository.user.username,
+                emboss_6_repository.owner,
                 self.get_repository_tip(emboss_6_repository),
             )
             self.create_repository_dependency(
@@ -373,15 +373,13 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
                 strings_displayed=[],
                 strings_not_displayed=[],
             )
-            repository = self.test_db_util.get_repository_by_name_and_owner("freebayes_0040", common.test_user_1_name)
-            filtering_repository = self.test_db_util.get_repository_by_name_and_owner(
-                "filtering_0040", common.test_user_1_name
-            )
+            repository = self._get_repository_by_name_and_owner("freebayes_0040", common.test_user_1_name)
+            filtering_repository = self._get_repository_by_name_and_owner("filtering_0040", common.test_user_1_name)
             repository_dependencies_path = self.generate_temp_path("test_1340", additional_paths=["filtering"])
             repository_tuple = (
                 self.url,
                 repository.name,
-                repository.user.username,
+                repository.owner,
                 self.get_repository_tip(repository),
             )
             self.create_repository_dependency(
@@ -389,15 +387,13 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
                 repository_tuples=[repository_tuple],
                 filepath=repository_dependencies_path,
             )
-            repository = self.test_db_util.get_repository_by_name_and_owner("filtering_0040", common.test_user_1_name)
-            freebayes_repository = self.test_db_util.get_repository_by_name_and_owner(
-                "freebayes_0040", common.test_user_1_name
-            )
+            repository = self._get_repository_by_name_and_owner("filtering_0040", common.test_user_1_name)
+            freebayes_repository = self._get_repository_by_name_and_owner("freebayes_0040", common.test_user_1_name)
             repository_dependencies_path = self.generate_temp_path("test_1340", additional_paths=["freebayes"])
             repository_tuple = (
                 self.url,
                 repository.name,
-                repository.user.username,
+                repository.owner,
                 self.get_repository_tip(repository),
             )
             self.create_repository_dependency(
@@ -472,7 +468,7 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 emboss_repository.name,
-                emboss_repository.user.username,
+                emboss_repository.owner,
                 self.get_repository_tip(emboss_repository),
             )
             self.create_repository_dependency(
@@ -484,7 +480,7 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
             dependency_tuple = (
                 self.url,
                 filtering_repository.name,
-                filtering_repository.user.username,
+                filtering_repository.owner,
                 self.get_repository_tip(filtering_repository),
             )
             self.create_repository_dependency(
@@ -496,19 +492,19 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
                 (
                     self.url,
                     emboss_repository.name,
-                    emboss_repository.user.username,
+                    emboss_repository.owner,
                     self.get_repository_tip(emboss_repository),
                 ),
                 (
                     self.url,
                     filtering_repository.name,
-                    filtering_repository.user.username,
+                    filtering_repository.owner,
                     self.get_repository_tip(filtering_repository),
                 ),
                 (
                     self.url,
                     freebayes_repository.name,
-                    freebayes_repository.user.username,
+                    freebayes_repository.owner,
                     self.get_repository_tip(freebayes_repository),
                 ),
             ]

--- a/lib/tool_shed/test/functional/test_1410_update_manager.py
+++ b/lib/tool_shed/test/functional/test_1410_update_manager.py
@@ -98,7 +98,7 @@ class TestUpdateManager(ShedTwillTestCase):
         revision.
         """
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="readme.txt",

--- a/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
+++ b/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
@@ -106,11 +106,11 @@ class TestRepairRepository(ShedTwillTestCase):
         This is step 3 - Upload a repository_dependencies.xml file to the column_1430 repository that creates a repository
         dependency on the filter_1430 repository.
         """
-        column_repository = self.test_db_util.get_repository_by_name_and_owner("column_1430", common.test_user_1_name)
-        filter_repository = self.test_db_util.get_repository_by_name_and_owner("filter_1430", common.test_user_1_name)
+        column_repository = self._get_repository_by_name_and_owner("column_1430", common.test_user_1_name)
+        filter_repository = self._get_repository_by_name_and_owner("filter_1430", common.test_user_1_name)
         tool_shed_url = self.url
         name = filter_repository.name
-        owner = filter_repository.user.username
+        owner = filter_repository.owner
         changeset_revision = self.get_repository_tip(filter_repository)
         repository_dependency_tuple = (tool_shed_url, name, owner, changeset_revision)
         filepath = self.generate_temp_path("1430_repository_dependency")

--- a/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
+++ b/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
@@ -93,7 +93,7 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
         eliminate the process we're testing in this script. So, we upload a readme file.
         """
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
-        repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
+        repository = self._get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
         self.upload_file(
             repository,
             filename="filtering/readme.txt",

--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -49,13 +49,18 @@ class ShedRepositoriesApiTestCase(ShedApiTestCase):
 
     def test_index_simple(self):
         populator = self.populator
-        repository_id = populator.setup_column_maker_repo(prefix="repoforindex").id
+        repo = populator.setup_column_maker_repo(prefix="repoforindex")
+        repository_id = repo.id
         show_response = self.api_interactor.get(f"repositories/{repository_id}")
         index_response = self.api_interactor.get("repositories")
         api_asserts.assert_status_code_is_ok(show_response)
         api_asserts.assert_status_code_is_ok(index_response)
         repository_ids = [r["id"] for r in index_response.json()]
         assert repository_id in repository_ids
+
+        repository = self.populator.get_repository_for(repo.owner, repo.name)
+        assert repository.owner == repo.owner
+        assert repository.name == repo.name
 
     def test_get_ordered_installable_revisions(self):
         # Used in ephemeris...

--- a/lib/tool_shed/webapp/api/repositories.py
+++ b/lib/tool_shed/webapp/api/repositories.py
@@ -815,17 +815,23 @@ class RepositoriesController(BaseAPIController):
 
         :param id: the encoded id of the Repository object
 
+        :param downloadable_only: Return only downloadable revisions (defaults to True).
+                                  Added for test cases - shouldn't be considered part of the stable API.
+
         :returns:   A dictionary containing the specified repository's metadata, by changeset,
                     recursively including dependencies and their metadata.
 
         :not found:  Empty dictionary.
         """
         recursive = util.asbool(kwd.get("recursive", "True"))
+        downloadable_only = util.asbool(kwd.get("downloadable_only", "True"))
         all_metadata = {}
         repository = repository_util.get_repository_in_tool_shed(
             self.app, id, eagerload_columns=["downloadable_revisions"]
         )
-        for changeset, changehash in repository.installable_revisions(self.app):
+        for changeset, changehash in metadata_util.get_metadata_revisions(
+            self.app, repository, sort_revisions=True, downloadable=downloadable_only
+        ):
             metadata = metadata_util.get_current_repository_metadata_for_changeset_revision(
                 self.app, repository, changehash
             )

--- a/lib/tool_shed_client/schema/__init__.py
+++ b/lib/tool_shed_client/schema/__init__.py
@@ -149,6 +149,15 @@ class ToolSearchResults(BaseModel):
         return matching_hit
 
 
+class RepositoryIndexRequest(BaseModel):
+    owner: Optional[str]
+    name: Optional[str]
+
+
+class RepositoryIndexResponse(BaseModel):
+    __root__: List[Repository]
+
+
 class RepositorySearchRequest(BaseModel):
     q: str
     page: Optional[int]

--- a/lib/tool_shed_client/schema/__init__.py
+++ b/lib/tool_shed_client/schema/__init__.py
@@ -73,7 +73,7 @@ class RepositoryRevisionMetadata(BaseModel):
     id: str
     repository: Repository
     repository_dependencies: List[RepositoryDependency]
-    tools: List[RepositoryTool]
+    tools: Optional[List[RepositoryTool]]
     repository_id: str
     numeric_revision: int
     changeset_revision: str
@@ -95,6 +95,17 @@ class RepositoryMetadata(BaseModel):
     @property
     def latest_revision(self) -> RepositoryRevisionMetadata:
         return list(self.__root__.values())[-1]
+
+    @property
+    def tip(self) -> str:
+        if self.is_new:
+            return "000000000000"
+        else:
+            return self.latest_revision.changeset_revision
+
+    @property
+    def is_new(self) -> bool:
+        return len(self.__root__) == 0
 
 
 class ResetMetadataOnRepositoryRequest(BaseModel):
@@ -152,6 +163,7 @@ class ToolSearchResults(BaseModel):
 class RepositoryIndexRequest(BaseModel):
     owner: Optional[str]
     name: Optional[str]
+    deleted: str = "false"
 
 
 class RepositoryIndexResponse(BaseModel):


### PR DESCRIPTION
More cleanup along the lines of https://github.com/galaxyproject/galaxy/pull/14662 - this time replacing repository abstraction used by test from the database model to the pydantic model fetched from the API.

The result is a better tested API, a more cohesive test that doesn't depend as much on tool shed internals, and more typing.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
