### PR TITLE
Packaging and configurability for the container monitor script

### DIFF
--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -1076,9 +1076,10 @@
                  internally by the runner. -->
             <param id="docker_enabled">true</param>
             <param id="container_monitor">true</param>
-            <!-- Flag for appending the container monitor command to jobs. This should be set to false
-                 when running Interactive Tools with the kubernetes runner, but is needed for running with the
-                 local docker runner.
+            <!-- Flag for appending the container monitor command to jobs. The monitor is responsible for determining
+                 the IP and port of the container and reporting it to Galaxy. This should be set to false when running
+                 Interactive Tools with the kubernetes runner, but is needed for running with local, DRM, and
+                 non-Kubernetes Pulsar docker runners.
             -->
         </destination>
         <destination id="kubernetes" runner="k8s">

--- a/lib/galaxy/job_execution/container_monitor.py
+++ b/lib/galaxy/job_execution/container_monitor.py
@@ -1,0 +1,74 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import traceback
+
+import requests
+
+from galaxy.tool_util.deps import docker_util
+from galaxy.util import DEFAULT_SOCKET_TIMEOUT
+from galaxy.util.sockets import get_ip
+
+
+def parse_ports(container_name, connection_configuration):
+    while True:
+        ports_command = docker_util.build_docker_simple_command(
+            "port", container_name=container_name, **connection_configuration
+        )
+        with tempfile.TemporaryFile(prefix="docker_port_") as stdout_file:
+            exit_code = subprocess.call(ports_command, shell=True, stdout=stdout_file, preexec_fn=os.setpgrp)
+            if exit_code == 0:
+                stdout_file.seek(0)
+                ports_raw = stdout_file.read().decode("utf-8")
+                return ports_raw
+
+
+def main():
+    if not os.path.exists("configs"):
+        # on Pulsar and in tool working directory instead of job directory
+        os.chdir("..")
+
+    with open("configs/container_config.json") as f:
+        container_config = json.load(f)
+
+    container_type = container_config["container_type"]
+    container_name = container_config["container_name"]
+    callback_url = container_config.get("callback_url")
+    connection_configuration = container_config["connection_configuration"]
+    if container_type != "docker":
+        raise Exception(f"Monitoring container type [{container_type}], not yet implemented.")
+
+    ports_raw = None
+    exc_traceback = ""
+    for i in range(10):
+        try:
+            ports_raw = parse_ports(container_name, connection_configuration)
+            if ports_raw is not None:
+                host_ip = get_ip()
+                ports = docker_util.parse_port_text(ports_raw)
+                if host_ip is not None:
+                    for key in ports:
+                        if ports[key]["host"] == "0.0.0.0":
+                            ports[key]["host"] = host_ip
+                if callback_url:
+                    requests.post(callback_url, json={"container_runtime": ports}, timeout=DEFAULT_SOCKET_TIMEOUT)
+                else:
+                    with open("container_runtime.json", "w") as f:
+                        json.dump(ports, f)
+                break
+            else:
+                raise Exception("Failed to recover ports...")
+        except Exception:
+            exc_info = sys.exc_info()
+            exc_traceback = "".join(traceback.format_exception(*exc_info))
+        time.sleep(i * 2)
+    else:
+        with open("container_monitor_exception.txt", "w") as f:
+            f.write(exc_traceback)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -6,6 +6,5 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pa
 
 from galaxy.job_execution.container_monitor import main
 
-
 if __name__ == "__main__":
     main()

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -1,76 +1,10 @@
-import json
 import os
-import subprocess
 import sys
-import tempfile
-import time
-import traceback
 
 # insert *this* galaxy before all others on sys.path
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)))
 
-import requests
-
-from galaxy.tool_util.deps import docker_util
-from galaxy.util import DEFAULT_SOCKET_TIMEOUT
-from galaxy.util.sockets import get_ip
-
-
-def parse_ports(container_name, connection_configuration):
-    while True:
-        ports_command = docker_util.build_docker_simple_command(
-            "port", container_name=container_name, **connection_configuration
-        )
-        with tempfile.TemporaryFile(prefix="docker_port_") as stdout_file:
-            exit_code = subprocess.call(ports_command, shell=True, stdout=stdout_file, preexec_fn=os.setpgrp)
-            if exit_code == 0:
-                stdout_file.seek(0)
-                ports_raw = stdout_file.read().decode("utf-8")
-                return ports_raw
-
-
-def main():
-    if not os.path.exists("configs"):
-        # on Pulsar and in tool working directory instead of job directory
-        os.chdir("..")
-
-    with open("configs/container_config.json") as f:
-        container_config = json.load(f)
-
-    container_type = container_config["container_type"]
-    container_name = container_config["container_name"]
-    callback_url = container_config.get("callback_url")
-    connection_configuration = container_config["connection_configuration"]
-    if container_type != "docker":
-        raise Exception(f"Monitoring container type [{container_type}], not yet implemented.")
-
-    ports_raw = None
-    exc_traceback = ""
-    for i in range(10):
-        try:
-            ports_raw = parse_ports(container_name, connection_configuration)
-            if ports_raw is not None:
-                host_ip = get_ip()
-                ports = docker_util.parse_port_text(ports_raw)
-                if host_ip is not None:
-                    for key in ports:
-                        if ports[key]["host"] == "0.0.0.0":
-                            ports[key]["host"] = host_ip
-                if callback_url:
-                    requests.post(callback_url, json={"container_runtime": ports}, timeout=DEFAULT_SOCKET_TIMEOUT)
-                else:
-                    with open("container_runtime.json", "w") as f:
-                        json.dump(ports, f)
-                break
-            else:
-                raise Exception("Failed to recover ports...")
-        except Exception:
-            exc_info = sys.exc_info()
-            exc_traceback = "".join(traceback.format_exception(*exc_info))
-        time.sleep(i * 2)
-    else:
-        with open("container_monitor_exception.txt", "w") as f:
-            f.write(exc_traceback)
+from galaxy.job_execution.container_monitor import main
 
 
 if __name__ == "__main__":

--- a/packages/job_execution/setup.cfg
+++ b/packages/job_execution/setup.cfg
@@ -44,6 +44,7 @@ python_requires = >=3.7
 [options.entry_points]
 console_scripts =
         galaxy-set-metadata = galaxy.metadata.set_metadata:set_metadata
+        galaxy-container-monitor = galaxy.job_execution.container_monitor:main
 
 [options.packages.find]
 exclude =

--- a/test/unit/app/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/app/jobs/job_conf.sample_advanced.yml
@@ -520,6 +520,24 @@ execution:
       # the deployer.
       #require_container: true
 
+      # Flag for appending the container monitor command to jobs. The monitor is
+      # responsible for determining the IP and port of the container and
+      # reporting it to Galaxy. This should be set to false when running
+      # Interactive Tools with the kubernetes runner, but is needed for running
+      # with local, DRM, and non-Kubernetes Pulsar docker runners.
+      #container_monitor: true
+
+      # Store container connection information to a file in the job working
+      # directory ('file') or the Galaxy job ports API ('callback'). You should
+      # generally use 'file' unless you are using a non-Kubernetes Pulsar
+      # runner.
+      #container_monitor_result: file
+
+      # Override the command that runs the container monitor. It can be run via
+      # the `galaxy-container-monitor` command from the galaxy-job-execution
+      # package if you wish to install it somewhere (e.g. on a Pulsar server)
+      #container_monitor_command: python /path/to/galaxy/lib/galaxy_ext/container_monitor/monitor.py
+
     singularity_local:
       runner: local
       # Enable Singularity execution of tools with the follow property.


### PR DESCRIPTION
Add the container monitor script to the galaxy-job-execution package so that it can be installed standalone. This is useful if you are running GxITs via Pulsar. First implemented in #9349 but not really usable in production when Galaxy is not accessible at the same path on the Pulsar server.

You can configure the command to run with the `container_monitor_command` param on destinations.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
