### PR TITLE
Replace ``self.assert*()`` method calls with plain asserts

### DIFF
--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -963,11 +963,3 @@ validator_types = dict(
 
 deprecated_validator_types = dict(dataset_metadata_in_file=MetadataInFileColumnValidator)
 validator_types.update(deprecated_validator_types)
-
-
-def get_suite():
-    """Get unittest suite for this module"""
-    import doctest
-    import sys
-
-    return doctest.DocTestSuite(sys.modules[__name__])

--- a/lib/galaxy/util/form_builder.py
+++ b/lib/galaxy/util/form_builder.py
@@ -199,11 +199,3 @@ class HistoryField(BaseField):
                 if not a.deleted:
                     d["data"].append({"label": a.name, "value": self.security.encode_id(a.id)})
         return d
-
-
-def get_suite():
-    """Get unittest suite for this module"""
-    import doctest
-    import sys
-
-    return doctest.DocTestSuite(sys.modules[__name__])

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -88,8 +88,8 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         assert pair_1_element["element_index"] == 0, pair_1_element
         pair_1_object = pair_1_element["object"]
         self._assert_has_keys(pair_1_object, "collection_type", "elements", "element_count")
-        self.assertEqual(pair_1_object["collection_type"], "paired")
-        self.assertEqual(pair_1_object["populated"], True)
+        assert pair_1_object["collection_type"] == "paired"
+        assert pair_1_object["populated"] is True
         pair_elements = pair_1_object["elements"]
         assert len(pair_elements) == 2
         pair_1_element_1 = pair_elements[0]
@@ -233,7 +233,7 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         }
         self.dataset_populator.fetch(payload)
         hdca = self._assert_one_collection_created_in_history()
-        self.assertEqual(hdca["name"], "Test upload")
+        assert hdca["name"] == "Test upload"
         hdca_tags = hdca["tags"]
         assert len(hdca_tags) == 1
         assert "name:collection1" in hdca_tags
@@ -262,7 +262,7 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         }
         self.dataset_populator.fetch(payload)
         hdca = self._assert_one_collection_created_in_history()
-        self.assertEqual(hdca["name"], "Test upload")
+        assert hdca["name"] == "Test upload"
         assert len(hdca["elements"]) == 1, hdca
         element0 = hdca["elements"][0]
         assert element0["element_identifier"] == "samp1"

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -32,7 +32,7 @@ class BaseHistories:
         post_data = dict(name=name)
         create_response = self._post("histories", data=post_data).json()
         self._assert_has_keys(create_response, "name", "id")
-        self.assertEqual(create_response["name"], name)
+        assert create_response["name"] == name
         return create_response
 
     def _assert_history_length(self, history_id, n):
@@ -56,14 +56,14 @@ class HistoriesApiTestCase(ApiTestCase, BaseHistories):
         # Make sure new history appears in index of user's histories.
         index_response = self._get("histories").json()
         indexed_history = [h for h in index_response if h["id"] == created_id][0]
-        self.assertEqual(indexed_history["name"], "TestHistory1")
+        assert indexed_history["name"] == "TestHistory1"
 
     def test_create_history_json(self):
         name = "TestHistoryJson"
         post_data = dict(name=name)
         create_response = self._post("histories", data=post_data, json=True).json()
         self._assert_has_keys(create_response, "name", "id")
-        self.assertEqual(create_response["name"], name)
+        assert create_response["name"] == name
         return create_response
 
     def test_show_history(self):

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -897,7 +897,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
         )
         self._assert_status_code_is(contents_response, 200)
         collection = contents_response.json()[0]
-        self.assertCountEqual(collection["elements_datatypes"], expected_datatypes)
+        assert sorted(collection["elements_datatypes"]) == sorted(expected_datatypes)
 
 
 class HistoryContentsApiNearTestCase(ApiTestCase):

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -943,7 +943,7 @@ steps:
         search_payload = self._search_payload(history_id=history_id, tool_id=tool_id, inputs=inputs)
         empty_search_response = self._post("jobs/search", data=search_payload)
         self._assert_status_code_is(empty_search_response, 200)
-        self.assertEqual(len(empty_search_response.json()), 0)
+        assert len(empty_search_response.json()) == 0
         tool_response = self._post("tools", data=search_payload)
         self.dataset_populator.wait_for_tool_run(history_id, run_response=tool_response)
         self._search(search_payload, expected_search_count=1)

--- a/lib/galaxy_test/api/test_pages.py
+++ b/lib/galaxy_test/api/test_pages.py
@@ -98,9 +98,9 @@ steps:
             self._assert_status_code_is(show_response, 200)
             show_json = show_response.json()
             self._assert_has_keys(show_json, "slug", "title", "id")
-            self.assertEqual(show_json["slug"], "invocation-report")
-            self.assertEqual(show_json["title"], "Invocation Report")
-            self.assertEqual(show_json["content_format"], "markdown")
+            assert show_json["slug"] == "invocation-report"
+            assert show_json["title"] == "Invocation Report"
+            assert show_json["content_format"] == "markdown"
             markdown_content = show_json["content"]
             assert "## Workflow Outputs" in markdown_content
             assert "## Workflow Inputs" in markdown_content
@@ -307,10 +307,10 @@ steps:
         self._assert_status_code_is(show_response, 200)
         show_json = show_response.json()
         self._assert_has_keys(show_json, "slug", "title", "id")
-        self.assertEqual(show_json["slug"], "pagetoshow")
-        self.assertEqual(show_json["title"], "MY PAGE")
-        self.assertEqual(show_json["content"], "<p>Page!</p>")
-        self.assertEqual(show_json["content_format"], "html")
+        assert show_json["slug"] == "pagetoshow"
+        assert show_json["title"] == "MY PAGE"
+        assert show_json["content"] == "<p>Page!</p>"
+        assert show_json["content_format"] == "html"
 
     def test_403_on_unowner_show(self):
         response_json = self._create_valid_page_as("others_page_show@bx.psu.edu", "otherspageshow")

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -347,8 +347,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         put_response.raise_for_status()
 
         response = get(user_info_url).json()
-        self.assertEqual(len(response["addresses"]), 1)
-        self.assertEqual(response["addresses"][0]["desc"], cool_name_with_quote)
+        assert len(response["addresses"]) == 1
+        assert response["addresses"][0]["desc"] == cool_name_with_quote
 
         hda1 = self.dataset_populator.new_dataset(history_id, content="1\t2\t3", name=cool_name_with_quote)
         assert hda1["name"] == cool_name_with_quote
@@ -549,7 +549,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             response = self._run("__UNZIP_COLLECTION__", history_id, inputs, assert_ok=True)
             outputs = response["outputs"]
-            self.assertEqual(len(outputs), 2)
+            assert len(outputs) == 2
             output_forward = outputs[0]
             output_reverse = outputs[1]
             output_forward_content = self.dataset_populator.get_history_dataset_content(
@@ -605,7 +605,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             }
             response = self._run("__UNZIP_COLLECTION__", history_id, inputs, assert_ok=True)
             implicit_collections = response["implicit_collections"]
-            self.assertEqual(len(implicit_collections), 2)
+            assert len(implicit_collections) == 2
             unzipped_hdca = self.dataset_populator.get_history_collection_details(
                 history_id, hid=implicit_collections[0]["hid"]
             )
@@ -622,7 +622,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             response = self._run("__ZIP_COLLECTION__", history_id, inputs, assert_ok=True)
             output_collections = response["output_collections"]
-            self.assertEqual(len(output_collections), 1)
+            assert len(output_collections) == 1
             self.dataset_populator.wait_for_job(response["jobs"][0]["id"], assert_ok=True)
             zipped_hdca = self.dataset_populator.get_history_collection_details(
                 history_id, hid=output_collections[0]["hid"]
@@ -678,7 +678,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             response = self._run("__ZIP_COLLECTION__", history_id, inputs, assert_ok=True)
             implicit_collections = response["implicit_collections"]
-            self.assertEqual(len(implicit_collections), 1)
+            assert len(implicit_collections) == 1
             self.dataset_populator.wait_for_job(response["jobs"][0]["id"], assert_ok=True)
             zipped_hdca = self.dataset_populator.get_history_collection_details(
                 history_id, hid=implicit_collections[0]["hid"]
@@ -694,7 +694,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             response = self.dataset_populator.run_exit_code_from_file(history_id, ok_hdca_id)
 
             mixed_implicit_collections = response["implicit_collections"]
-            self.assertEqual(len(mixed_implicit_collections), 1)
+            assert len(mixed_implicit_collections) == 1
             mixed_hdca_hid = mixed_implicit_collections[0]["hid"]
             mixed_hdca = self.dataset_populator.get_history_collection_details(
                 history_id, hid=mixed_hdca_hid, wait=False
@@ -725,7 +725,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             response = self.dataset_populator.run_exit_code_from_file(history_id, ok_hdca_id)
 
             mixed_implicit_collections = response["implicit_collections"]
-            self.assertEqual(len(mixed_implicit_collections), 1)
+            assert len(mixed_implicit_collections) == 1
             mixed_hdca_hid = mixed_implicit_collections[0]["hid"]
             mixed_hdca = self.dataset_populator.get_history_collection_details(
                 history_id, hid=mixed_hdca_hid, wait=False
@@ -774,7 +774,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         filter_output_collections = response["output_collections"]
         if batch:
             return response["implicit_collections"][0]
-        self.assertEqual(len(filter_output_collections), 1)
+        assert len(filter_output_collections) == 1
         filtered_hid = filter_output_collections[0]["hid"]
         filtered_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=filtered_hid, wait=False)
         return filtered_hdca
@@ -787,7 +787,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             self.dataset_populator.wait_for_history(history_id)
             response = self._run("__APPLY_RULES__", history_id, inputs, assert_ok=True)
             output_collections = response["output_collections"]
-            self.assertEqual(len(output_collections), 1)
+            assert len(output_collections) == 1
             output_hid = output_collections[0]["hid"]
             output_hdca = self.dataset_populator.get_history_collection_details(history_id, hid=output_hid, wait=False)
             example["check"](output_hdca, self.dataset_populator)
@@ -874,10 +874,10 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             input1=dataset_to_param(new_dataset),
         )
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEqual(len(outputs), 1)
+        assert len(outputs) == 1
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "Cat1Test")
+        assert output1_content.strip() == "Cat1Test"
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=True)
@@ -909,10 +909,10 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             input1=[dataset_to_param(new_dataset)],
         )
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEqual(len(outputs), 1)
+        assert len(outputs) == 1
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "Cat1Testlistified")
+        assert output1_content.strip() == "Cat1Testlistified"
 
     @skip_without_tool("multiple_versions")
     @uses_test_history(require_new=False)
@@ -922,10 +922,10 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             outputs = self._run_and_get_outputs(
                 tool_id="multiple_versions", history_id=history_id, tool_version=version
             )
-            self.assertEqual(len(outputs), 1)
+            assert len(outputs) == 1
             output1 = outputs[0]
             output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-            self.assertEqual(output1_content.strip(), f"Version {version}")
+            assert output1_content.strip() == f"Version {version}"
 
     @skip_without_tool("multiple_versions")
     @uses_test_history(require_new=False)
@@ -958,10 +958,10 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             input1={"batch": False, "values": [dataset_to_param(new_dataset)]},
         )
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEqual(len(outputs), 1)
+        assert len(outputs) == 1
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "123")
+        assert output1_content.strip() == "123"
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=False)
@@ -986,7 +986,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         assert_inputs(inputs, can_be_used=False)
 
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEqual(len(outputs), 1)
+        assert len(outputs) == 1
         output1 = outputs[0]
 
         inputs_2 = dict(
@@ -1175,7 +1175,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self._assert_has_keys(output_collection, "id", "name", "elements", "populated")
         assert not output_collection["populated"]
         assert len(output_collection["elements"]) == 0
-        self.assertEqual(output_collection["name"], "Table split on first column")
+        assert output_collection["name"] == "Table split on first column"
         self.dataset_populator.wait_for_job(create["jobs"][0]["id"], assert_ok=True)
 
         get_collection_response = self._get(
@@ -1186,7 +1186,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         output_collection = get_collection_response.json()
         self._assert_has_keys(output_collection, "id", "name", "elements", "populated")
         assert output_collection["populated"]
-        self.assertEqual(output_collection["name"], "Table split on first column")
+        assert output_collection["name"] == "Table split on first column"
 
         assert len(output_collection["elements"]) == 2
         output_element_0 = output_collection["elements"][0]
@@ -1228,7 +1228,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
 
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         output_content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(output_content, "Hello World\n")
+        assert output_content == "Hello World\n"
 
     def test_dynamic_tool_from_path(self):
         # Create tool.
@@ -1244,7 +1244,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
 
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         output_content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(output_content, "Hello World 2\n")
+        assert output_content == "Hello World 2\n"
 
     def test_dynamic_tool_no_id(self):
         # Create tool.
@@ -1257,7 +1257,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
 
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         output_content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(output_content, "Hello World 2\n")
+        assert output_content == "Hello World 2\n"
 
     def test_show_dynamic_tools(self):
         # Create tool.
@@ -1316,10 +1316,10 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         new_dataset2 = self.dataset_populator.new_dataset(history_id, content="Cat2Test")
         inputs = {"input1": dataset_to_param(new_dataset1), "queries_0|input2": dataset_to_param(new_dataset2)}
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEqual(len(outputs), 1)
+        assert len(outputs) == 1
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "Cat1Test\nCat2Test")
+        assert output1_content.strip() == "Cat1Test\nCat2Test"
 
     @skip_without_tool("mapper_two")
     @uses_test_history(require_new=False)
@@ -1375,13 +1375,13 @@ class ToolsTestCase(ApiTestCase, TestsTools):
 
     def _check_cat1_multirun(self, history_id, inputs):
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEqual(len(outputs), 2)
+        assert len(outputs) == 2
         output1 = outputs[0]
         output2 = outputs[1]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEqual(output1_content.strip(), "123")
-        self.assertEqual(output2_content.strip(), "456")
+        assert output1_content.strip() == "123"
+        assert output2_content.strip() == "456"
 
     @skip_without_tool("random_lines1")
     @uses_test_history(require_new=False)
@@ -1422,7 +1422,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             "queries_0|input2": {"batch": True, "values": second_two},
         }
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEqual(len(outputs), 2)
+        assert len(outputs) == 2
         outputs_contents = [
             self.dataset_populator.get_history_dataset_content(history_id, dataset=o).strip() for o in outputs
         ]
@@ -1440,7 +1440,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs_contents = [
             self.dataset_populator.get_history_dataset_content(history_id, dataset=o).strip() for o in outputs
         ]
-        self.assertEqual(len(outputs), 4)
+        assert len(outputs) == 4
         assert "123\n789" in outputs_contents
         assert "456\n0ab" in outputs_contents
         assert "123\n0ab" in outputs_contents
@@ -1533,19 +1533,19 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         implicit_collections = create["implicit_collections"]
         collections = create["output_collections"]
 
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(implicit_collections), 0)
-        self.assertEqual(len(collections), 1)
+        assert len(jobs) == 1
+        assert len(implicit_collections) == 0
+        assert len(collections) == 1
 
         output_collection = collections[0]
         return output_collection
 
     def _assert_elements_are(self, collection, *args):
         elements = collection["elements"]
-        self.assertEqual(len(elements), len(args))
+        assert len(elements) == len(args)
         for index, element in enumerate(elements):
             arg = args[index]
-            self.assertEqual(arg, element["element_identifier"])
+            assert arg == element["element_identifier"]
         return elements
 
     def _verify_element(self, history_id, element, **props):
@@ -1555,14 +1555,14 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             expected_contents = props["contents"]
 
             contents = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=object_id)
-            self.assertEqual(contents, expected_contents)
+            assert contents == expected_contents
 
             del props["contents"]
 
         if props:
             details = self.dataset_populator.get_history_dataset_details(history_id, dataset_id=object_id)
             for key, value in props.items():
-                self.assertEqual(details[key], value)
+                assert details[key] == value
 
     def _setup_repeat_multirun(self):
         history_id = self.dataset_populator.new_history()
@@ -1577,13 +1577,13 @@ class ToolsTestCase(ApiTestCase, TestsTools):
 
     def _check_repeat_multirun(self, history_id, inputs):
         outputs = self._cat1_outputs(history_id, inputs=inputs)
-        self.assertEqual(len(outputs), 2)
+        assert len(outputs) == 2
         output1 = outputs[0]
         output2 = outputs[1]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEqual(output1_content.strip(), "Common\n123")
-        self.assertEqual(output2_content.strip(), "Common\n456")
+        assert output1_content.strip() == "Common\n123"
+        assert output2_content.strip() == "Common\n456"
 
     def _setup_two_multiruns(self):
         history_id = self.dataset_populator.new_history()
@@ -1619,9 +1619,9 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 0)
-        self.assertEqual(len(outputs), 0)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(jobs) == 0
+        assert len(outputs) == 0
+        assert len(implicit_collections) == 1
 
         empty_output = implicit_collections[0]
         assert empty_output["name"] == "Concatenate datasets on collection 1", empty_output
@@ -1639,9 +1639,9 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             outputs = create["outputs"]
             jobs = create["jobs"]
             implicit_collections = create["implicit_collections"]
-            self.assertEqual(len(jobs), 2)
-            self.assertEqual(len(outputs), 2)
-            self.assertEqual(len(implicit_collections), 1)
+            assert len(jobs) == 2
+            assert len(outputs) == 2
+            assert len(implicit_collections) == 1
             output1 = outputs[0]
             output2 = outputs[1]
             output1_details = self.dataset_populator.get_history_dataset_details(history_id, dataset=output1)
@@ -1658,9 +1658,9 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 2)
-        self.assertEqual(len(outputs), 2)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(jobs) == 2
+        assert len(outputs) == 2
+        assert len(implicit_collections) == 1
         for output in outputs:
             assert output["file_ext"] == "txt", output
 
@@ -1678,8 +1678,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         create = self._run("output_filter_with_input", history_id, inputs).json()
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 3)
-        self.assertEqual(len(implicit_collections), 3)
+        assert len(jobs) == 3
+        assert len(implicit_collections) == 3
         self._check_implicit_collection_populated(create)
 
     @skip_without_tool("output_filter_with_input_optional")
@@ -1694,9 +1694,9 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         create = self._run("output_filter_with_input_optional", history_id, inputs).json()
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
+        assert len(jobs) == 1
         self.dataset_populator.wait_for_job(jobs[0]["id"], assert_ok=True)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(implicit_collections) == 1
         self._check_implicit_collection_populated(create)
 
     @skip_without_tool("output_filter_with_input")
@@ -1713,8 +1713,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         create = self._run("output_filter_with_input", history_id, inputs).json()
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 3)
-        self.assertEqual(len(implicit_collections), 2)
+        assert len(jobs) == 3
+        assert len(implicit_collections) == 2
         self._check_implicit_collection_populated(create)
 
     @skip_without_tool("Cut1")
@@ -1730,9 +1730,9 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 2)
-        self.assertEqual(len(outputs), 2)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(jobs) == 2
+        assert len(outputs) == 2
+        assert len(implicit_collections) == 1
         output1 = outputs[0]
         output2 = outputs[1]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
@@ -1749,14 +1749,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         inputs = {"input": {"batch": True, "values": [{"src": "hdca", "id": hdca_id}]}}
         create = self._run("collection_creates_dynamic_list_of_pairs", history_id, inputs).json()
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(implicit_collections), 1)
-        self.assertEqual(implicit_collections[0]["collection_type"], "list:list:paired")
-        self.assertEqual(implicit_collections[0]["elements"][0]["object"]["element_count"], None)
+        assert len(implicit_collections) == 1
+        assert implicit_collections[0]["collection_type"] == "list:list:paired"
+        assert implicit_collections[0]["elements"][0]["object"]["element_count"] is None
         self.dataset_populator.wait_for_job(create["jobs"][0]["id"], assert_ok=True)
         hdca = self._get(f"histories/{history_id}/contents/dataset_collections/{implicit_collections[0]['id']}").json()
-        self.assertEqual(
-            hdca["elements"][0]["object"]["elements"][0]["object"]["elements"][0]["element_identifier"], "forward"
-        )
+        assert hdca["elements"][0]["object"]["elements"][0]["object"]["elements"][0]["element_identifier"] == "forward"
 
     def _bed_list(self, history_id):
         bed1_contents = open(self.get_filename("1.bed")).read()
@@ -1778,15 +1776,15 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 2)
-        self.assertEqual(len(outputs), 2)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(jobs) == 2
+        assert len(outputs) == 2
+        assert len(implicit_collections) == 1
         output1 = outputs[0]
         output2 = outputs[1]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEqual(output1_content.strip(), "forward")
-        self.assertEqual(output2_content.strip(), "reverse")
+        assert output1_content.strip() == "forward"
+        assert output2_content.strip() == "reverse"
 
     @skip_without_tool("identifier_single")
     @uses_test_history(require_new=False)
@@ -1801,12 +1799,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(len(implicit_collections), 0)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
+        assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "Plain HDA")
+        assert output1_content.strip() == "Plain HDA"
 
     @skip_without_tool("identifier_multiple")
     @uses_test_history(require_new=False)
@@ -1828,12 +1826,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(len(implicit_collections), 0)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
+        assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "forward\nreverse")
+        assert output1_content.strip() == "forward\nreverse"
 
     @skip_without_tool("identifier_in_conditional")
     @uses_test_history(require_new=False)
@@ -1848,12 +1846,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(len(implicit_collections), 0)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
+        assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "forward\nreverse")
+        assert output1_content.strip() == "forward\nreverse"
 
     @skip_without_tool("identifier_in_conditional")
     @uses_test_history(require_new=False)
@@ -1871,12 +1869,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(len(implicit_collections), 0)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
+        assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "forward\nreverse")
+        assert output1_content.strip() == "forward\nreverse"
 
     @skip_without_tool("identifier_multiple_in_repeat")
     @uses_test_history(require_new=False)
@@ -1891,12 +1889,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(len(implicit_collections), 0)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
+        assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "forward\nreverse")
+        assert output1_content.strip() == "forward\nreverse"
 
     @skip_without_tool("identifier_in_conditional")
     @uses_test_history(require_new=False)
@@ -1913,15 +1911,15 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 2)
-        self.assertEqual(len(outputs), 2)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(jobs) == 2
+        assert len(outputs) == 2
+        assert len(implicit_collections) == 1
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "forward")
+        assert output1_content.strip() == "forward"
         output2 = outputs[1]
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEqual(output2_content.strip(), "reverse")
+        assert output2_content.strip() == "reverse"
 
     @skip_without_tool("identifier_multiple_in_conditional")
     @uses_test_history(require_new=False)
@@ -1936,12 +1934,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(len(implicit_collections), 0)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
+        assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "forward\nreverse")
+        assert output1_content.strip() == "forward\nreverse"
 
     @skip_without_tool("identifier_multiple_in_repeat")
     @uses_test_history(require_new=False)
@@ -1956,12 +1954,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(len(implicit_collections), 0)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
+        assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "forward\nreverse")
+        assert output1_content.strip() == "forward\nreverse"
 
     @skip_without_tool("identifier_single_in_repeat")
     @uses_test_history(require_new=False)
@@ -1973,8 +1971,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         create = create_response.json()
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 2)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(jobs) == 2
+        assert len(implicit_collections) == 1
         output_collection = implicit_collections[0]
         elements = output_collection["elements"]
         assert len(elements) == 2
@@ -1995,12 +1993,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(len(implicit_collections), 0)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
+        assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "Normal HDA1")
+        assert output1_content.strip() == "Normal HDA1"
 
     @skip_without_tool("identifier_multiple")
     @uses_test_history(require_new=False)
@@ -2014,12 +2012,12 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(len(implicit_collections), 0)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
+        assert len(implicit_collections) == 0
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "Normal HDA1\nNormal HDA2")
+        assert output1_content.strip() == "Normal HDA1\nNormal HDA2"
 
     @skip_without_tool("identifier_collection")
     @uses_test_history(require_new=False)
@@ -2046,11 +2044,11 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         create = create_response.json()
         outputs = create["outputs"]
         jobs = create["jobs"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 1)
+        assert len(jobs) == 1
+        assert len(outputs) == 1
         output1 = outputs[0]
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        self.assertEqual(output1_content.strip(), "\n".join(d["name"] for d in element_identifiers))
+        assert output1_content.strip() == "\n".join(d["name"] for d in element_identifiers)
 
     @skip_without_tool("identifier_in_actions")
     @uses_test_history(require_new=False)
@@ -2101,8 +2099,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         create = self._run("collection_paired_structured_like", history_id, inputs, assert_ok=True)
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 2)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(jobs) == 2
+        assert len(implicit_collections) == 1
         implicit_collection = implicit_collections[0]
         assert implicit_collection["collection_type"] == "list:paired", implicit_collection["collection_type"]
         outer_elements = implicit_collection["elements"]
@@ -2120,8 +2118,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         create = self._run("collection_paired_conditional_structured_like", history_id, inputs, assert_ok=True)
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 2)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(jobs) == 2
+        assert len(implicit_collections) == 1
         implicit_collection = implicit_collections[0]
         assert implicit_collection["collection_type"] == "list:paired", implicit_collection["collection_type"]
         outer_elements = implicit_collection["elements"]
@@ -2132,9 +2130,9 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         outputs = create["outputs"]
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 4)
-        self.assertEqual(len(outputs), 4)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(jobs) == 4
+        assert len(outputs) == 4
+        assert len(implicit_collections) == 1
         implicit_collection = implicit_collections[0]
         self._assert_has_keys(implicit_collection, "collection_type", "elements")
         assert implicit_collection["collection_type"] == "list:paired"
@@ -2147,7 +2145,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         assert first_object["collection_type"] == "paired"
         assert len(first_object["elements"]) == 2
         first_object_forward_element = first_object["elements"][0]
-        self.assertEqual(outputs[0]["id"], first_object_forward_element["object"]["id"])
+        assert outputs[0]["id"] == first_object_forward_element["object"]["id"]
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=False)
@@ -2165,17 +2163,17 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self._assert_status_code_is(response, 200)
         response_object = response.json()
         outputs = response_object["outputs"]
-        self.assertEqual(len(outputs), 2)
+        assert len(outputs) == 2
         output1 = outputs[0]
         output2 = outputs[1]
         self.dataset_populator.wait_for_history(history_id)
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-        self.assertEqual(output1_content.strip(), "123\n789")
-        self.assertEqual(output2_content.strip(), "456\n0ab")
+        assert output1_content.strip() == "123\n789"
+        assert output2_content.strip() == "456\n0ab"
 
-        self.assertEqual(len(response_object["jobs"]), 2)
-        self.assertEqual(len(response_object["implicit_collections"]), 1)
+        assert len(response_object["jobs"]) == 2
+        assert len(response_object["implicit_collections"]) == 1
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=False)
@@ -2190,13 +2188,13 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self._assert_status_code_is(response, 200)
         response_object = response.json()
         outputs = response_object["outputs"]
-        self.assertEqual(len(outputs), 4)
+        assert len(outputs) == 4
 
-        self.assertEqual(len(response_object["jobs"]), 4)
+        assert len(response_object["jobs"]) == 4
         implicit_collections = response_object["implicit_collections"]
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(implicit_collections) == 1
         implicit_collection = implicit_collections[0]
-        self.assertEqual(implicit_collection["collection_type"], "paired:paired")
+        assert implicit_collection["collection_type"] == "paired:paired"
 
         outer_elements = implicit_collection["elements"]
         assert len(outer_elements) == 2
@@ -2227,7 +2225,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         for (element, expected_contents) in expected_contents_list:
             dataset_id = element["object"]["id"]
             contents = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=dataset_id)
-            self.assertEqual(expected_contents, contents)
+            assert expected_contents == contents
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=False)
@@ -2247,10 +2245,10 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self._assert_status_code_is(response, 200)
         response_object = response.json()
         outputs = response_object["outputs"]
-        self.assertEqual(len(outputs), 2)
+        assert len(outputs) == 2
 
-        self.assertEqual(len(response_object["jobs"]), 2)
-        self.assertEqual(len(response_object["implicit_collections"]), 1)
+        assert len(response_object["jobs"]) == 2
+        assert len(response_object["implicit_collections"]) == 1
 
     @skip_without_tool("identifier_source")
     def test_default_identifier_source_map_over(self):
@@ -2287,8 +2285,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             create = self._run("collection_creates_pair", history_id, inputs, assert_ok=True)
             jobs = create["jobs"]
             implicit_collections = create["implicit_collections"]
-            self.assertEqual(len(jobs), 2)
-            self.assertEqual(len(implicit_collections), 1)
+            assert len(jobs) == 2
+            assert len(implicit_collections) == 1
             implicit_collection = implicit_collections[0]
             assert implicit_collection["collection_type"] == "list:paired", implicit_collection
             outer_elements = implicit_collection["elements"]
@@ -2319,7 +2317,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             ]
             for i in range(4):
                 contents = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=pair_ids[i])
-                self.assertEqual(expected_contents[i], contents)
+                assert expected_contents[i] == contents
 
     @skip_without_tool("cat1")
     def test_cannot_map_over_incompatible_collections(self):
@@ -2436,8 +2434,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
             jobs = create["jobs"]
             implicit_collections = create["implicit_collections"]
-            self.assertEqual(len(jobs), 1)
-            self.assertEqual(len(implicit_collections), 2)
+            assert len(jobs) == 1
+            assert len(implicit_collections) == 2
             output_hdca = self.dataset_populator.get_history_collection_details(
                 history_id, hid=implicit_collections[0]["hid"]
             )
@@ -2482,7 +2480,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             }
             create = self._run("column_multi_param", history_id, inputs, assert_ok=True)
             jobs = create["jobs"]
-            self.assertEqual(len(jobs), 1)
+            assert len(jobs) == 1
             content = self.dataset_populator.get_history_dataset_content(history_id, hid=3)
             assert content.strip() == "hg17", content
 
@@ -2496,8 +2494,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             create = self._run("multi_data_repeat", history_id, inputs, assert_ok=True)
             outputs = create["outputs"]
             jobs = create["jobs"]
-            self.assertEqual(len(jobs), 1)
-            self.assertEqual(len(outputs), 1)
+            assert len(jobs) == 1
+            assert len(outputs) == 1
             output1 = outputs[0]
             output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
             assert output1_content.strip() == "123\n456", output1_content
@@ -2512,8 +2510,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             create = self._run("multi_data_repeat", history_id, inputs, assert_ok=True)
             outputs = create["outputs"]
             jobs = create["jobs"]
-            self.assertEqual(len(jobs), 1)
-            self.assertEqual(len(outputs), 1)
+            assert len(jobs) == 1
+            assert len(outputs) == 1
             output1 = outputs[0]
             output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
             assert output1_content.strip() == "123\n456", output1_content
@@ -2532,20 +2530,20 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
             outputs = create["outputs"]
             jobs = create["jobs"]
-            self.assertEqual(len(jobs), 1)
-            self.assertEqual(len(outputs), 2)
+            assert len(jobs) == 1
+            assert len(outputs) == 2
             output1, output2 = outputs
             output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
             output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
-            self.assertEqual(output1_content.strip(), "123\n456\nTestData123\nTestData123\nTestData123")
-            self.assertEqual(output2_content.strip(), "123\n456")
+            assert output1_content.strip() == "123\n456\nTestData123\nTestData123\nTestData123"
+            assert output2_content.strip() == "123\n456"
 
     def _check_simple_reduce_job(self, history_id, inputs):
         create = self._run("multi_data_param", history_id, inputs, assert_ok=True)
         outputs = create["outputs"]
         jobs = create["jobs"]
-        self.assertEqual(len(jobs), 1)
-        self.assertEqual(len(outputs), 2)
+        assert len(jobs) == 1
+        assert len(outputs) == 2
         output1, output2 = outputs
         output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
         output2_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output2)
@@ -2654,10 +2652,10 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         response = self._run("collection_cat_group_tag", history_id, inputs, assert_ok=True)
         outputs = response["outputs"]
-        self.assertEqual(len(outputs), 1)
+        assert len(outputs) == 1
         output = outputs[0]
         output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output)
-        self.assertEqual(output_content.strip(), "123\n456")
+        assert output_content.strip() == "123\n456"
 
     @skip_without_tool("collection_cat_group_tag_multiple")
     @uses_test_history(require_new=False)
@@ -2670,10 +2668,10 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         response = self._run("collection_cat_group_tag_multiple", history_id, inputs, assert_ok=True)
         outputs = response["outputs"]
-        self.assertEqual(len(outputs), 1)
+        assert len(outputs) == 1
         output = outputs[0]
         output_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output)
-        self.assertEqual(output_content.strip(), "123\n456\n456\n0ab")
+        assert output_content.strip() == "123\n456\n456\n0ab"
 
     @skip_without_tool("expression_forty_two")
     def test_galaxy_expression_tool_simplest(self):
@@ -2682,7 +2680,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self._assert_status_code_is(run_response, 200)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         output_content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(output_content, "42")
+        assert output_content == "42"
 
     @skip_without_tool("expression_parse_int")
     def test_galaxy_expression_tool_simple(self):
@@ -2694,7 +2692,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self._assert_status_code_is(run_response, 200)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         output_content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(output_content, "7")
+        assert output_content == "7"
 
     @skip_without_tool("expression_log_line_count")
     def test_galaxy_expression_metadata(self):
@@ -2709,7 +2707,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self._assert_status_code_is(run_response, 200)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         output_content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(output_content, "3")
+        assert output_content == "3"
 
     @skip_without_tool("cat1")
     @uses_test_history(require_new=False)
@@ -2981,9 +2979,9 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         create = self._run("collection_paired_structured_like", history_id, inputs, assert_ok=True)
         jobs = create["jobs"]
         implicit_collections = create["implicit_collections"]
-        self.assertEqual(len(jobs), 2)
+        assert len(jobs) == 2
         self.dataset_populator.wait_for_jobs(jobs, assert_ok=True)
-        self.assertEqual(len(implicit_collections), 1)
+        assert len(implicit_collections) == 1
         implicit_collection = implicit_collections[0]
         assert implicit_collection["collection_type"] == "list:paired", implicit_collection["collection_type"]
         outer_elements = implicit_collection["elements"]

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -51,22 +51,22 @@ class ToolsUploadTestCase(ApiTestCase):
     def test_upload_posix_newline_fixes_by_default(self):
         windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content)
-        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
+        assert result_content == ONE_TO_SIX_WITH_TABS
 
     def test_fetch_posix_unaltered(self):
         windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content, api="fetch")
-        self.assertEqual(result_content, ONE_TO_SIX_ON_WINDOWS)
+        assert result_content == ONE_TO_SIX_ON_WINDOWS
 
     def test_upload_disable_posix_fix(self):
         windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content, to_posix_lines=None)
-        self.assertEqual(result_content, windows_content)
+        assert result_content == windows_content
 
     def test_fetch_post_lines_option(self):
         windows_content = ONE_TO_SIX_ON_WINDOWS
         result_content = self._upload_and_get_content(windows_content, api="fetch", to_posix_lines=True)
-        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
+        assert result_content == ONE_TO_SIX_WITH_TABS
 
     # Test how trailing new lines are added
     # - upload1 adds by default because to_posix_lines is on by default
@@ -75,47 +75,47 @@ class ToolsUploadTestCase(ApiTestCase):
     def test_post_lines_trailing(self):
         input_content = ONE_TO_SIX_WITH_TABS_NO_TRAILING_NEWLINE
         result_content = self._upload_and_get_content(input_content)
-        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
+        assert result_content == ONE_TO_SIX_WITH_TABS
 
     def test_post_lines_trailing_off(self):
         input_content = ONE_TO_SIX_WITH_TABS_NO_TRAILING_NEWLINE
         result_content = self._upload_and_get_content(input_content, to_posix_lines=False)
-        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS_NO_TRAILING_NEWLINE)
+        assert result_content == ONE_TO_SIX_WITH_TABS_NO_TRAILING_NEWLINE
 
     def test_fetch_post_lines_trailing_off_by_default(self):
         input_content = ONE_TO_SIX_WITH_TABS_NO_TRAILING_NEWLINE
         result_content = self._upload_and_get_content(input_content, api="fetch")
-        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS_NO_TRAILING_NEWLINE)
+        assert result_content == ONE_TO_SIX_WITH_TABS_NO_TRAILING_NEWLINE
 
     def test_fetch_post_lines_trailing_if_to_posix(self):
         input_content = ONE_TO_SIX_WITH_TABS_NO_TRAILING_NEWLINE
         result_content = self._upload_and_get_content(input_content, api="fetch", to_posix_lines=True)
-        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
+        assert result_content == ONE_TO_SIX_WITH_TABS
 
     def test_upload_tab_to_space_off_by_default(self):
         table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table)
-        self.assertEqual(result_content, table)
+        assert result_content == table
 
     def test_fetch_tab_to_space_off_by_default(self):
         table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table, api="fetch")
-        self.assertEqual(result_content, table)
+        assert result_content == table
 
     def test_upload_tab_to_space(self):
         table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table, space_to_tab="Yes")
-        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
+        assert result_content == ONE_TO_SIX_WITH_TABS
 
     def test_fetch_tab_to_space(self):
         table = ONE_TO_SIX_WITH_SPACES
         result_content = self._upload_and_get_content(table, api="fetch", space_to_tab=True)
-        self.assertEqual(result_content, ONE_TO_SIX_WITH_TABS)
+        assert result_content == ONE_TO_SIX_WITH_TABS
 
     def test_fetch_tab_to_space_doesnt_swap_newlines(self):
         table = ONE_TO_SIX_WITH_SPACES_ON_WINDOWS
         result_content = self._upload_and_get_content(table, api="fetch", space_to_tab=True)
-        self.assertEqual(result_content, ONE_TO_SIX_ON_WINDOWS)
+        assert result_content == ONE_TO_SIX_ON_WINDOWS
 
     def test_fetch_compressed_with_explicit_type(self):
         fastqgz_path = TestDataResolver().get_filename("1.fastqsanger.gz")
@@ -191,42 +191,42 @@ class ToolsUploadTestCase(ApiTestCase):
         rdata_path = TestDataResolver().get_filename("1.RData")
         with open(rdata_path, "rb") as fh:
             rdata_metadata = self._upload_and_get_details(fh, file_type="auto")
-        self.assertEqual(rdata_metadata["file_ext"], "rdata")
+        assert rdata_metadata["file_ext"] == "rdata"
 
     @skip_without_datatype("csv")
     def test_csv_upload(self):
         csv_path = TestDataResolver().get_filename("1.csv")
         with open(csv_path, "rb") as fh:
             csv_metadata = self._upload_and_get_details(fh, file_type="csv")
-        self.assertEqual(csv_metadata["file_ext"], "csv")
+        assert csv_metadata["file_ext"] == "csv"
 
     @skip_without_datatype("csv")
     def test_csv_upload_auto(self):
         csv_path = TestDataResolver().get_filename("1.csv")
         with open(csv_path, "rb") as fh:
             csv_metadata = self._upload_and_get_details(fh, file_type="auto")
-        self.assertEqual(csv_metadata["file_ext"], "csv")
+        assert csv_metadata["file_ext"] == "csv"
 
     @skip_without_datatype("csv")
     def test_csv_fetch(self):
         csv_path = TestDataResolver().get_filename("1.csv")
         with open(csv_path, "rb") as fh:
             csv_metadata = self._upload_and_get_details(fh, api="fetch", ext="csv", to_posix_lines=True)
-        self.assertEqual(csv_metadata["file_ext"], "csv")
+        assert csv_metadata["file_ext"] == "csv"
 
     @skip_without_datatype("csv")
     def test_csv_sniff_fetch(self):
         csv_path = TestDataResolver().get_filename("1.csv")
         with open(csv_path, "rb") as fh:
             csv_metadata = self._upload_and_get_details(fh, api="fetch", ext="auto", to_posix_lines=True)
-        self.assertEqual(csv_metadata["file_ext"], "csv")
+        assert csv_metadata["file_ext"] == "csv"
 
     @skip_without_datatype("tiff")
     def test_image_upload_auto(self):
         tiff_path = TestDataResolver().get_filename("1.tiff")
         with open(tiff_path, "rb") as fh:
             tiff_metadata = self._upload_and_get_details(fh, file_type="auto")
-        self.assertEqual(tiff_metadata["file_ext"], "tiff")
+        assert tiff_metadata["file_ext"] == "tiff"
 
     @uses_test_history(require_new=False)
     def test_newlines_stage_fetch(self, history_id):
@@ -241,7 +241,7 @@ class ToolsUploadTestCase(ApiTestCase):
         dataset = datasets[0][0]
         content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=dataset)
         # By default this appends the newline.
-        self.assertEqual(content, "This is a line of text.\n")
+        assert content == "This is a line of text.\n"
 
     @uses_test_history(require_new=False)
     def test_stage_object(self, history_id):
@@ -251,7 +251,7 @@ class ToolsUploadTestCase(ApiTestCase):
         )
         dataset = datasets[0][0]
         content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=dataset)
-        self.assertEqual(content.strip(), '"randomstr"')
+        assert content.strip() == '"randomstr"'
 
     @uses_test_history(require_new=False)
     def test_stage_object_fetch(self, history_id):
@@ -259,7 +259,7 @@ class ToolsUploadTestCase(ApiTestCase):
         inputs, datasets = stage_inputs(self.galaxy_interactor, history_id, job, use_path_paste=False)
         dataset = datasets[0][0]
         content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=dataset)
-        self.assertEqual(content, '"randomstr"')
+        assert content == '"randomstr"'
 
     @uses_test_history(require_new=False)
     def test_newlines_stage_fetch_configured(self, history_id):
@@ -277,7 +277,7 @@ class ToolsUploadTestCase(ApiTestCase):
         dataset = datasets[0][0]
         content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=dataset)
         # By default this appends the newline, but we disabled with 'to_posix_lines=False' above.
-        self.assertEqual(content, "This is a line of text.")
+        assert content == "This is a line of text."
         details = self.dataset_populator.get_history_dataset_details(history_id=history_id, dataset=dataset)
         assert details["genome_build"] == "hg19"
 

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -52,7 +52,7 @@ class UsersApiTestCase(ApiTestCase):
             update_response = self.__update(user, username=new_name)
             self._assert_status_code_is(update_response, 200)
             update_json = update_response.json()
-            self.assertEqual(update_json["username"], new_name)
+            assert update_json["username"] == new_name
 
             # too short
             update_response = self.__update(user, username="")
@@ -75,7 +75,7 @@ class UsersApiTestCase(ApiTestCase):
         update_response = put(update_url, data=json.dumps(dict(username=new_name)))
         self._assert_status_code_is(update_response, 200)
         update_json = update_response.json()
-        self.assertEqual(update_json["username"], new_name)
+        assert update_json["username"] == new_name
 
     def test_delete_user(self):
         user = self._setup_user(TEST_USER_EMAIL_DELETE)
@@ -111,27 +111,27 @@ class UsersApiTestCase(ApiTestCase):
         user = self._setup_user(TEST_USER_EMAIL)
         url = self.__url("information/inputs", user)
         response = get(url).json()
-        self.assertEqual(response["username"], user["username"])
-        self.assertEqual(response["email"], TEST_USER_EMAIL)
+        assert response["username"] == user["username"]
+        assert response["email"] == TEST_USER_EMAIL
         put(url, data=json.dumps(dict(username="newname", email="new@email.email")))
         response = get(url).json()
-        self.assertEqual(response["username"], "newname")
-        self.assertEqual(response["email"], "new@email.email")
+        assert response["username"] == "newname"
+        assert response["email"] == "new@email.email"
         put(url, data=json.dumps(dict(username=user["username"], email=TEST_USER_EMAIL)))
         response = get(url).json()
-        self.assertEqual(response["username"], user["username"])
-        self.assertEqual(response["email"], TEST_USER_EMAIL)
+        assert response["username"] == user["username"]
+        assert response["email"] == TEST_USER_EMAIL
         put(url, data=json.dumps({"address_0|desc": "_desc"}))
         response = get(url).json()
-        self.assertEqual(len(response["addresses"]), 1)
-        self.assertEqual(response["addresses"][0]["desc"], "_desc")
+        assert len(response["addresses"]) == 1
+        assert response["addresses"][0]["desc"] == "_desc"
 
     def test_create_api_key(self):
         user = self._setup_user(TEST_USER_EMAIL)
         user_id = user["id"]
         response = self._put(f"users/{user_id}/api_key/inputs", admin=True)
         self._assert_status_code_is_ok(response)
-        self.assertEqual(response.json()["inputs"][0]["name"], "api-key")
+        assert response.json()["inputs"][0]["name"] == "api-key"
 
     @skip_without_tool("cat1")
     def test_favorites(self):
@@ -140,7 +140,7 @@ class UsersApiTestCase(ApiTestCase):
         url = self._api_url(f"users/{user['id']}/favorites/tools", params=dict(key=self.master_api_key))
         put_response = put(url, data=json.dumps({"object_id": "cat1"}))
         self._assert_status_code_is_ok(put_response)
-        self.assertEqual(put_response.json()["tools"][0], "cat1")
+        assert put_response.json()["tools"][0] == "cat1"
         # not implemented for workflows yet
         url = self._api_url(f"users/{user['id']}/favorites/workflows", params=dict(key=self.master_api_key))
         put_response = put(url, data=json.dumps({"object_id": "14ds68f4sda68gf46dsag4"}))
@@ -149,7 +149,7 @@ class UsersApiTestCase(ApiTestCase):
         url = self._api_url(f"users/{user['id']}/favorites/tools/cat1", params=dict(key=self.master_api_key))
         delete_response = delete(url)
         self._assert_status_code_is_ok(delete_response)
-        self.assertEqual(delete_response.json()["tools"], [])
+        assert delete_response.json()["tools"] == []
         # delete non-existing tool favorite
         url = self._api_url(
             f"users/{user['id']}/favorites/tools/madeuptoolthatdoes/not/exist/in/favs",

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -32,7 +32,7 @@ class WorkflowExtractionApiTestCase(BaseWorkflowsApiTestCase):
             dataset_ids=input_hids,
             job_ids=[cat1_job_id],
         )
-        self.assertEqual(downloaded_workflow["name"], "test import from history")
+        assert downloaded_workflow["name"] == "test import from history"
         self.__assert_looks_like_cat1_example_workflow(downloaded_workflow)
 
     @summarize_instance_history_on_error
@@ -222,7 +222,7 @@ test_data:
 
         collection_step = self._get_steps_of_type(downloaded_workflow, "data_collection_input", expected_len=1)[0]
         collection_step_state = loads(collection_step["tool_state"])
-        self.assertEqual(collection_step_state["collection_type"], "paired")
+        assert collection_step_state["collection_type"] == "paired"
 
     @skip_without_tool("cat_collection")
     def test_subcollection_mapping(self):
@@ -264,7 +264,7 @@ test_data:
 
         collection_step = self._get_steps_of_type(downloaded_workflow, "data_collection_input", expected_len=1)[0]
         collection_step_state = loads(collection_step["tool_state"])
-        self.assertEqual(collection_step_state["collection_type"], "list:paired")
+        assert collection_step_state["collection_type"] == "list:paired"
 
     @skip_without_tool("cat_list")
     @skip_without_tool("collection_creates_dynamic_nested")
@@ -450,8 +450,8 @@ test_data:
         input1 = tool_step["input_connections"]["input1"]
         input2 = tool_step["input_connections"]["queries_0|input2"]
 
-        self.assertEqual(input_steps[0]["id"], input1["id"])
-        self.assertEqual(input_steps[1]["id"], input2["id"])
+        assert input_steps[0]["id"] == input1["id"]
+        assert input_steps[1]["id"] == input2["id"]
 
     def _history_contents(self, history_id=None):
         if history_id is None:
@@ -484,7 +484,7 @@ test_data:
         collection_steps = self._get_steps_of_type(downloaded_workflow, "data_collection_input", expected_len=1)
         collection_step = collection_steps[0]
         collection_step_state = loads(collection_step["tool_state"])
-        self.assertEqual(collection_step_state["collection_type"], "paired")
+        assert collection_step_state["collection_type"] == "paired"
         collect_step_idx = collection_step["id"]
         return collect_step_idx
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -223,7 +223,7 @@ class BaseWorkflowsApiTestCase(ApiTestCase, RunsWorkflowFixtures):
 
     def _assert_history_job_count(self, history_id, n):
         jobs = self._history_jobs(history_id)
-        self.assertEqual(len(jobs), n)
+        assert len(jobs) == n
 
     def _download_workflow(self, workflow_id, style=None, history_id=None):
         return self.workflow_populator.download_workflow(workflow_id, style=style, history_id=history_id)
@@ -314,7 +314,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         workflow = show_response.json()
         self._assert_looks_like_instance_workflow_representation(workflow)
         assert len(workflow["steps"]) == 3
-        self.assertEqual(sorted(step["id"] for step in workflow["steps"].values()), [0, 1, 2])
+        assert sorted(step["id"] for step in workflow["steps"].values()) == [0, 1, 2]
 
         show_response = self._get(f"workflows/{workflow_id}", {"legacy": True})
         workflow = show_response.json()
@@ -322,7 +322,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert len(workflow["steps"]) == 3
         # Can't reay say what the legacy IDs are but must be greater than 3 because dummy
         # workflow was created first in this instance.
-        self.assertNotEqual(sorted(step["id"] for step in workflow["steps"].values()), [0, 1, 2])
+        assert sorted(step["id"] for step in workflow["steps"].values()) != [0, 1, 2]
 
     def test_show_invalid_key_is_400(self):
         show_response = self._get(f"workflows/{self._random_key()}")
@@ -768,8 +768,8 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
             assert order_index in uuids
             assert order_index in labels
 
-            self.assertEqual(uuids[order_index], step_dict["uuid"])
-            self.assertEqual(labels[order_index], step_dict["label"])
+            assert uuids[order_index] == step_dict["uuid"]
+            assert labels[order_index] == step_dict["label"]
 
         upload_response = self.__test_upload(workflow=original_workflow)
         workflow_id = upload_response.json()["id"]
@@ -1347,7 +1347,7 @@ steps:
     def test_workflow_run_output_collections(self) -> None:
         with self.dataset_populator.test_history() as history_id:
             self._run_workflow(WORKFLOW_WITH_OUTPUT_COLLECTION, history_id=history_id)
-            self.assertEqual("a\nc\nb\nd\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0))
+            assert "a\nc\nb\nd\n" == self.dataset_populator.get_history_dataset_content(history_id, hid=0)
 
     @skip_without_tool("job_properties")
     @skip_without_tool("identifier_multiple_in_conditional")
@@ -1642,9 +1642,7 @@ steps:
             }
             invocation_id = self.__invoke_workflow(workflow_id, inputs=inputs, history_id=history_id)
             self.workflow_populator.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
-            self.assertEqual(
-                "a\nc\nb\nd\ne\ng\nf\nh\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0)
-            )
+            assert "a\nc\nb\nd\ne\ng\nf\nh\n" == self.dataset_populator.get_history_dataset_content(history_id, hid=0)
 
     @skip_without_tool("cat_list")
     @skip_without_tool("collection_split_on_column")
@@ -1655,7 +1653,7 @@ steps:
             last_item_hid = details["hid"]
             assert last_item_hid == 7, f"Expected 7 history items, got {last_item_hid}"
             content = self.dataset_populator.get_history_dataset_content(history_id, hid=0)
-            self.assertEqual("10.0\n30.0\n20.0\n40.0\n", content)
+            assert "10.0\n30.0\n20.0\n40.0\n" == content
 
     @skip_without_tool("collection_split_on_column")
     @skip_without_tool("min_repeat")
@@ -1696,7 +1694,7 @@ steps:
             collection_details = self.dataset_populator.get_history_collection_details(history_id, hid=7)
             assert collection_details["populated_state"] == "ok"
             content = self.dataset_populator.get_history_dataset_content(history_id, hid=11)
-            self.assertEqual(content.strip(), "samp1\t10.0\nsamp2\t20.0")
+            assert content.strip() == "samp1\t10.0\nsamp2\t20.0"
 
     @skip_without_tool("cat")
     @skip_without_tool("collection_split_on_column")
@@ -1885,9 +1883,9 @@ outer_input:
             invocation_id = summary.invocation_id
 
             content = self.dataset_populator.get_history_dataset_content(history_id)
-            self.assertEqual(
-                "chrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n",
-                content,
+            assert (
+                content
+                == "chrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n"
             )
             steps = self.workflow_populator.get_invocation(invocation_id)["steps"]
             assert sum(1 for step in steps if step["subworkflow_invocation_id"] is None) == 3
@@ -2034,12 +2032,12 @@ test_data:
         """
                 summary = self._run_workflow(workflow_text, test_data=test_data, history_id=history_id)
                 jobs = summary.jobs
-                assert len(jobs) == 4, "4 jobs expected, got %d jobs" % len(jobs)
+                assert len(jobs) == 4, f"4 jobs expected, got {len(jobs)} jobs"
 
                 content = self.dataset_populator.get_history_dataset_content(history_id)
-                self.assertEqual(
-                    "chrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n",
-                    content,
+                assert (
+                    content
+                    == "chrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n"
                 )
 
         run_test(NESTED_WORKFLOW_AUTO_LABELS_MODERN_SYNTAX)
@@ -2080,7 +2078,7 @@ steps:
             invocation_id = self.__invoke_workflow(workflow_id, inputs=inputs, history_id=history_id)
             self.workflow_populator.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
             content = self.dataset_populator.get_history_dataset_content(history_id)
-            self.assertEqual(content.strip(), "samp1\t10.0\nsamp2\t20.0\nsamp1\t20.0\nsamp2\t40.0")
+            assert content.strip() == "samp1\t10.0\nsamp2\t20.0\nsamp1\t20.0\nsamp2\t40.0"
 
     @skip_without_tool("collection_paired_test")
     def test_workflow_flatten(self):
@@ -2214,7 +2212,7 @@ steps:
             invocation_id = summary.invocation_id
             bco = self.workflow_populator.get_biocompute_object(invocation_id)
             self.workflow_populator.validate_biocompute_object(bco)
-            self.assertEqual(bco["provenance_domain"]["name"], "Simple Workflow")
+            assert bco["provenance_domain"]["name"] == "Simple Workflow"
 
     @skip_without_tool("__APPLY_RULES__")
     def test_workflow_run_apply_rules(self):
@@ -2615,11 +2613,11 @@ test_data:
                 wait=True,
                 round_trip_format_conversion=True,
             )
-            self.assertEqual(
-                "chr6\t108722976\t108723115\tCCDS5067.1_cds_0_0_chr6_108722977_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n",
-                self.dataset_populator.get_history_dataset_content(history_id),
+            assert (
+                self.dataset_populator.get_history_dataset_content(history_id)
+                == "chr6\t108722976\t108723115\tCCDS5067.1_cds_0_0_chr6_108722977_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n"
             )
-            # self.assertEqual("chr16\t142908\t143003\tCCDS10397.1_cds_0_0_chr16_142909_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n", self.dataset_populator.get_history_dataset_content(history_id))
+            # assert self.dataset_populator.get_history_dataset_content(history_id) == "chr16\t142908\t143003\tCCDS10397.1_cds_0_0_chr16_142909_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n"
 
     @skip_without_tool("cat_list")
     @skip_without_tool("random_lines1")
@@ -2686,9 +2684,9 @@ outer_input:
                 wait=True,
                 round_trip_format_conversion=True,
             )
-            self.assertEqual(
-                "chr6\t108722976\t108723115\tCCDS5067.1_cds_0_0_chr6_108722977_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n",
-                self.dataset_populator.get_history_dataset_content(history_id),
+            assert (
+                self.dataset_populator.get_history_dataset_content(history_id)
+                == "chr6\t108722976\t108723115\tCCDS5067.1_cds_0_0_chr6_108722977_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n"
             )
 
     @skip_without_tool("cat_list")
@@ -2747,9 +2745,9 @@ outer_input:
                 wait=True,
                 round_trip_format_conversion=True,
             )
-            self.assertEqual(
-                "chr6\t108722976\t108723115\tCCDS5067.1_cds_0_0_chr6_108722977_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n",
-                self.dataset_populator.get_history_dataset_content(history_id),
+            assert (
+                self.dataset_populator.get_history_dataset_content(history_id)
+                == "chr6\t108722976\t108723115\tCCDS5067.1_cds_0_0_chr6_108722977_f\t0\t+\nchrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n"
             )
 
     @skip_without_tool("empty_list")
@@ -2792,7 +2790,7 @@ input1:
                 history_id=history_id,
                 wait=True,
             )
-            self.assertEqual("0\n", self.dataset_populator.get_history_dataset_content(history_id))
+            assert "0\n" == self.dataset_populator.get_history_dataset_content(history_id)
 
     @skip_without_tool("random_lines1")
     def test_change_datatype_collection_map_over(self):
@@ -2889,7 +2887,7 @@ input1:
                 wait=True,
                 round_trip_format_conversion=True,
             )
-            self.assertEqual("0\n", self.dataset_populator.get_history_dataset_content(history_id))
+            assert "0\n" == self.dataset_populator.get_history_dataset_content(history_id)
 
     @skip_without_tool("cat")
     def test_cancel_new_workflow_when_history_deleted(self):
@@ -3008,9 +3006,7 @@ input1:
             self.workflow_populator.wait_for_invocation_and_jobs(history_id, uploaded_workflow_id, invocation_id)
             invocation = self._invocation_details(uploaded_workflow_id, invocation_id)
             assert invocation["state"] == "scheduled"
-            self.assertEqual(
-                "reviewed\n1\nreviewed\n4\n", self.dataset_populator.get_history_dataset_content(history_id)
-            )
+            assert "reviewed\n1\nreviewed\n4\n" == self.dataset_populator.get_history_dataset_content(history_id)
 
     @skip_without_tool("cat")
     def test_cancel_workflow_invocation(self):
@@ -3406,7 +3402,7 @@ text_input:
 
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             content = self.dataset_populator.get_history_dataset_content(history_id)
-            self.assertEqual("chrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n", content)
+            assert "chrX\t152691446\t152691471\tCCDS14735.1_cds_0_0_chrX_152691447_f\t0\t+\n" == content
 
     def test_run_with_numeric_input_connection(self):
         history_id = self.dataset_populator.new_history()
@@ -3612,10 +3608,8 @@ outer_input:
             for i, (item_one, item_two) in enumerate(zip(history_one_contents, history_two_contents)):
                 assert (
                     item_one["dataset_id"] == item_two["dataset_id"]
-                ), 'Dataset ids should match, but "%s" and "%s" are not the same for History item %i.' % (
-                    item_one["dataset_id"],
-                    item_two["dataset_id"],
-                    i + 1,
+                ), 'Dataset ids should match, but "{}" and "{}" are not the same for History item {}.'.format(
+                    item_one["dataset_id"], item_two["dataset_id"], i + 1
                 )
 
     def test_cannot_run_inaccessible_workflow(self):
@@ -3668,9 +3662,7 @@ outer_input:
             self.workflow_populator.invoke_workflow_and_wait(
                 workflow_id, history_id=history_id, request=workflow_request
             )
-            self.assertEqual(
-                "1 2 3\n4 5 6\n7 8 9\n0 a b\n", self.dataset_populator.get_history_dataset_content(history_id)
-            )
+            assert "1 2 3\n4 5 6\n7 8 9\n0 a b\n" == self.dataset_populator.get_history_dataset_content(history_id)
 
     def test_workflow_stability(self):
         # Run this index stability test with following command:
@@ -4858,10 +4850,10 @@ steps:
             t2 = self.dataset_populator.get_history_dataset_content(history_id, hid=10)
             t3 = self.dataset_populator.get_history_dataset_content(history_id, hid=13)
             t4 = self.dataset_populator.get_history_dataset_content(history_id, hid=16)
-            self.assertEqual(r1, t1)
-            self.assertEqual(r2, t2)
-            self.assertEqual(r3, t3)
-            self.assertEqual(r4, t4)
+            assert r1 == t1
+            assert r2 == t2
+            assert r3 == t3
+            assert r4 == t4
 
     @skip_without_tool("cat1")
     @skip_without_tool("addValue")
@@ -4910,10 +4902,10 @@ steps:
             t2 = self.dataset_populator.get_history_dataset_content(history_id, hid=10)
             t3 = self.dataset_populator.get_history_dataset_content(history_id, hid=13)
             t4 = self.dataset_populator.get_history_dataset_content(history_id, hid=16)
-            self.assertEqual(r1, t1)
-            self.assertEqual(r2, t2)
-            self.assertEqual(r3, t3)
-            self.assertEqual(r4, t4)
+            assert r1 == t1
+            assert r2 == t2
+            assert r3 == t3
+            assert r4 == t4
 
     @skip_without_tool("validation_default")
     def test_parameter_substitution_sanitization(self):
@@ -4921,9 +4913,7 @@ steps:
         run_workflow_response, history_id = self._run_validation_workflow_with_substitions(substitions)
 
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        self.assertEqual(
-            "__dq__ X echo __dq__moo\n", self.dataset_populator.get_history_dataset_content(history_id, hid=1)
-        )
+        assert "__dq__ X echo __dq__moo\n" == self.dataset_populator.get_history_dataset_content(history_id, hid=1)
 
     @skip_without_tool("validation_repeat")
     def test_parameter_substitution_validation_value_errors_0(self):
@@ -5014,7 +5004,7 @@ steps:
         )
         workflow_request["parameters"] = params
         self.workflow_populator.invoke_workflow_and_wait(workflow_id, request=workflow_request)
-        self.assertEqual("2\n", self.dataset_populator.get_history_dataset_content(history_id))
+        assert "2\n" == self.dataset_populator.get_history_dataset_content(history_id)
 
     @skip_without_tool("random_lines1")
     def test_run_replace_params_nested_normalized(self):
@@ -5030,7 +5020,7 @@ steps:
         workflow_request["parameters"] = params
         workflow_request["parameters_normalized"] = False
         self.workflow_populator.invoke_workflow_and_wait(workflow_id, request=workflow_request)
-        self.assertEqual("2\n", self.dataset_populator.get_history_dataset_content(history_id))
+        assert "2\n" == self.dataset_populator.get_history_dataset_content(history_id)
 
     @skip_without_tool("random_lines1")
     def test_run_replace_params_over_default(self):
@@ -5512,7 +5502,7 @@ input_c:
         hda_summary = next(hc for hc in history_contents if hc["hid"] == hid)
         hda_info_response = self._get(f"{contents_url}/{hda_summary['id']}")
         self._assert_status_code_is(hda_info_response, 200)
-        self.assertEqual(hda_info_response.json()["metadata_data_lines"], lines)
+        assert hda_info_response.json()["metadata_data_lines"] == lines
 
     def __history_contents(self, history_id):
         contents_url = f"histories/{history_id}/contents"
@@ -5606,7 +5596,4 @@ test_data:
             inputs=json.dumps({"input1": self._ds_entry(hda1)}),
         )
         self.workflow_populator.invoke_workflow_and_wait(workflow_id, history_id=history_id, request=workflow_request)
-        self.assertEqual(
-            "Hello World Second!\nhello world 2\n",
-            self.dataset_populator.get_history_dataset_content(history_id),
-        )
+        assert self.dataset_populator.get_history_dataset_content(history_id) == "Hello World Second!\nhello world 2\n"

--- a/lib/galaxy_test/api/test_workflows_from_yaml.py
+++ b/lib/galaxy_test/api/test_workflows_from_yaml.py
@@ -78,13 +78,13 @@ input1: "hello world"
             round_trip_format_conversion=True,
         )
         contents1 = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(contents1.strip(), "hello world\nhello world")
+        assert contents1.strip() == "hello world\nhello world"
 
     def test_outputs(self):
         workflow_id = self._upload_yaml_workflow(WORKFLOW_WITH_OUTPUTS, round_trip_format_conversion=True)
         workflow = self._get(f"workflows/{workflow_id}/download").json()
-        self.assertEqual(workflow["steps"]["1"]["workflow_outputs"][0]["output_name"], "out_file1")
-        self.assertEqual(workflow["steps"]["1"]["workflow_outputs"][0]["label"], "wf_output_1")
+        assert workflow["steps"]["1"]["workflow_outputs"][0]["output_name"] == "out_file1"
+        assert workflow["steps"]["1"]["workflow_outputs"][0]["label"] == "wf_output_1"
         workflow = self.workflow_populator.download_workflow(workflow_id, style="format2")
 
     def test_runtime_inputs(self):
@@ -160,7 +160,7 @@ steps:
         assert subworkflow_connection["input_subworkflow_step_id"] == 0
 
         # content = self.dataset_populator.get_history_dataset_content( history_id )
-        # self.assertEqual("chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n", content)
+        # assert content == "chr5\t131424298\t131424460\tCCDS4149.1_cds_0_0_chr5_131424299_f\t0\t+\n"
 
     def test_subworkflow_duplicate(self):
         duplicate_subworkflow_invocate_wf = """
@@ -339,7 +339,7 @@ test_data:
         )
 
         content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(content, "hello world\nhello world 2\n")
+        assert content == "hello world\nhello world 2\n"
 
     def test_workflow_import_tool(self):
         history_id = self.dataset_populator.new_history()
@@ -347,7 +347,7 @@ test_data:
         jobs_descriptions = {"test_data": {"input1": "hello world"}}
         self._run_jobs(workflow_path, source_type="path", jobs_descriptions=jobs_descriptions, history_id=history_id)
         content = self.dataset_populator.get_history_dataset_content(history_id)
-        self.assertEqual(content, "hello world\nhello world 2\n")
+        assert content == "hello world\nhello world 2\n"
 
     def test_parameter_default_rep(self):
         workflow = self._upload_and_download(WORKFLOW_PARAMETER_INPUT_INTEGER_DEFAULT)

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -138,13 +138,13 @@ class AdminAppTestCase(SeleniumTestCase):
         self.sleep_for(self.wait_types.UX_TRANSITION)
         # Make sure the job lock has been toggled.
         new_label = lock_label.wait_for_text()
-        self.assertNotEqual(new_label, original_label)
+        assert new_label != original_label
         self.screenshot("admin_jobs_locked")
         lock_label.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_TRANSITION)
         self.screenshot("admin_jobs_unlocked")
         # And confirm that it has toggled back to what it was.
-        self.assertEqual(lock_label.wait_for_text(), original_label)
+        assert lock_label.wait_for_text() == original_label
 
     @selenium_test
     def test_admin_server_display(self):

--- a/lib/galaxy_test/selenium/test_custom_builds.py
+++ b/lib/galaxy_test/selenium/test_custom_builds.py
@@ -27,9 +27,9 @@ class CustomBuildsTestcase(SharedStateSeleniumTestCase):
         actual_builds = self.get_custom_builds()
         intersection = set(actual_builds).intersection(expected_builds)
         if present:
-            self.assertEqual(intersection, set(expected_builds))
+            assert intersection == set(expected_builds)
         else:
-            self.assertEqual(intersection, set())
+            assert intersection == set()
 
     def _login(self):
         self.home()  # ensure Galaxy is loaded

--- a/lib/galaxy_test/selenium/test_histories_list.py
+++ b/lib/galaxy_test/selenium/test_histories_list.py
@@ -22,7 +22,7 @@ class SavedHistoriesTestCase(SharedStateSeleniumTestCase):
 
         @retry_assertion_during_transitions
         def assert_history_name_switched():
-            self.assertEqual(self.history_panel_name(), self.history2_name)
+            assert self.history_panel_name() == self.history2_name
 
         assert_history_name_switched()
 
@@ -32,7 +32,7 @@ class SavedHistoriesTestCase(SharedStateSeleniumTestCase):
         self.navigate_to_histories_page()
         self.click_grid_popup_option(self.history2_name, "View")
         history_name = self.wait_for_selector("[data-description='name display']")
-        self.assertEqual(history_name.text, self.history2_name)
+        assert history_name.text == self.history2_name
 
     @selenium_test
     def test_history_publish(self):
@@ -155,7 +155,7 @@ class SavedHistoriesTestCase(SharedStateSeleniumTestCase):
         # Filter out histories created by other tests
         actual_histories = [x for x in actual_histories if x in self.all_histories]
 
-        self.assertEqual(actual_histories, expected_histories)
+        assert actual_histories == expected_histories
 
     @selenium_test
     def test_standard_search(self):
@@ -238,16 +238,16 @@ class SavedHistoriesTestCase(SharedStateSeleniumTestCase):
         if not sort_matters:
             actual_histories = set(actual_histories)
             expected_histories = set(expected_histories)
-        self.assertEqual(actual_histories, expected_histories)
+        assert actual_histories == expected_histories
 
     @retry_assertion_during_transitions
     def assert_histories_in_grid(self, expected_histories, present=True):
         actual_histories = self.get_histories()
         intersection = set(actual_histories).intersection(expected_histories)
         if present:
-            self.assertEqual(intersection, set(expected_histories))
+            assert intersection == set(expected_histories)
         else:
-            self.assertEqual(intersection, set())
+            assert intersection == set()
 
     def get_histories(self):
         return self.histories_get_history_names()

--- a/lib/galaxy_test/selenium/test_history_panel.py
+++ b/lib/galaxy_test/selenium/test_history_panel.py
@@ -244,7 +244,7 @@ class HistoryPanelTestCase(SeleniumTestCase):
     @retry_assertion_during_transitions
     def assert_name_changed(self):
         name = self.history_panel_name()
-        self.assertEqual(name, NEW_HISTORY_NAME)
+        assert name == NEW_HISTORY_NAME
 
     def _refresh(self):
         if self.is_beta_history():

--- a/lib/galaxy_test/selenium/test_invocation_grid.py
+++ b/lib/galaxy_test/selenium/test_invocation_grid.py
@@ -47,4 +47,4 @@ class InvocationGridSeleniumTestCase(SeleniumTestCase, TestsGalaxyPagers):
 
     @retry_assertion_during_transitions
     def _assert_showing_n_invocations(self, n):
-        self.assertEqual(len(self.invocation_index_table_elements()), n)
+        assert len(self.invocation_index_table_elements()) == n

--- a/lib/galaxy_test/selenium/test_library_landing.py
+++ b/lib/galaxy_test/selenium/test_library_landing.py
@@ -87,7 +87,7 @@ class LibraryLandingTestCase(SeleniumTestCase):
     @retry_assertion_during_transitions
     def _assert_names_are(self, expected_names):
         names = [e.find_element(self.by.CSS_SELECTOR, "td a").text for e in self.libraries_index_table_elements()]
-        self.assertEqual(names, expected_names)
+        assert names == expected_names
 
     @retry_assertion_during_transitions
     def _assert_at_least_one_library_displayed(self):
@@ -95,7 +95,7 @@ class LibraryLandingTestCase(SeleniumTestCase):
 
     @retry_assertion_during_transitions
     def _assert_num_displayed_libraries_is(self, n):
-        self.assertEqual(n, self._num_displayed_libraries())
+        assert n == self._num_displayed_libraries()
 
     def _num_displayed_libraries(self):
         return len(self.libraries_index_table_elements())

--- a/lib/galaxy_test/selenium/test_personal_information.py
+++ b/lib/galaxy_test/selenium/test_personal_information.py
@@ -13,25 +13,25 @@ class ManageInformationTestCase(SeleniumTestCase):
         'Not available.'
         """
         self.login()
-        self.assertEqual(self.get_api_key(), "Not available.")
+        assert self.get_api_key() == "Not available."
         api_key = self.get_api_key()
         self.navigate_to_user_preferences()
         self.components.preferences.manage_api_key.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_TRANSITION)
         api_key_input = self.components.preferences.api_key_input.wait_for_visible()
         # Assert that what's rendered on screen is what the API is returning
-        self.assertEqual(api_key_input.get_property("value"), api_key)
+        assert api_key_input.get_property("value") == api_key
         self.components.preferences.get_new_key.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_TRANSITION)
         new_api_key = self.get_api_key()
         api_key_input = self.components.preferences.api_key_input.wait_for_visible()
         # And assert that this has now changed, and still renders correctly
-        self.assertEqual(new_api_key, api_key_input.get_property("value"))
+        assert new_api_key == api_key_input.get_property("value")
 
     @selenium_test
     def test_change_email(self):
         def assert_email(email_to_check):
-            self.assertTrue(email_to_check == self.components.preferences.current_email.wait_for_text())
+            assert email_to_check == self.components.preferences.current_email.wait_for_text()
 
         email = self._get_random_email()
         self.register(email)
@@ -46,7 +46,7 @@ class ManageInformationTestCase(SeleniumTestCase):
 
         new_email = self._get_random_email()
         # new email should be different from initially registered
-        self.assertTrue(email != new_email)
+        assert email != new_email
         email_input_field = self.components.preferences.email_input.wait_for_visible()
 
         self.clear_input_field_and_write(email_input_field, new_email)
@@ -64,7 +64,7 @@ class ManageInformationTestCase(SeleniumTestCase):
             return self.components.preferences.username_input.wait_for_visible()
 
         def assert_public_name(expected_name):
-            self.assertTrue(expected_name == get_name_input_field().get_attribute("value"))
+            assert expected_name == get_name_input_field().get_attribute("value")
 
         public_name = "user-public-name"
         self.register(username=public_name)
@@ -123,7 +123,7 @@ class ManageInformationTestCase(SeleniumTestCase):
         # check if address was saved correctly
         for input_field_label in address_fields.keys():
             input_field = self.get_address_input_field(get_address_form(), input_field_label)
-            self.assertTrue(input_field.get_attribute("value") == address_fields[input_field_label])
+            assert input_field.get_attribute("value") == address_fields[input_field_label]
 
     def navigate_to_manage_information(self):
         self.navigate_to_user_preferences()

--- a/lib/galaxy_test/selenium/test_published_histories_grid.py
+++ b/lib/galaxy_test/selenium/test_published_histories_grid.py
@@ -105,7 +105,7 @@ class HistoryGridTestCase(SharedStateSeleniumTestCase):
             if tag_button_text == target_tag_button_text:
                 break
 
-        self.assertEqual(tag_button_text, target_tag_button_text)
+        assert tag_button_text == target_tag_button_text
         tag_button.click()
 
         self.assert_grid_histories_are([self.history1_name, self.history3_name], False)
@@ -139,16 +139,16 @@ class HistoryGridTestCase(SharedStateSeleniumTestCase):
         if not sort_matters:
             actual_histories = set(actual_histories)
             expected_histories = set(expected_histories)
-        self.assertEqual(actual_histories, expected_histories)
+        assert actual_histories == expected_histories
 
     @retry_assertion_during_transitions
     def assert_histories_in_grid(self, expected_histories, present=True):
         actual_histories = self.get_histories()
         intersection = set(actual_histories).intersection(expected_histories)
         if present:
-            self.assertEqual(intersection, set(expected_histories))
+            assert intersection == set(expected_histories)
         else:
-            self.assertEqual(intersection, set())
+            assert intersection == set()
 
     def set_filter(self, selector, value):
         filter_input = self.wait_for_selector_clickable(selector)

--- a/lib/galaxy_test/selenium/test_sign_out.py
+++ b/lib/galaxy_test/selenium/test_sign_out.py
@@ -17,7 +17,7 @@ class SignOutTestCase(SeleniumTestCase):
         self.components.sign_out.cancel_button.wait_for_and_click()
         assert self.is_logged_in()
         new_email = self.driver.find_element(By.ID, "user-preferences-current-email").text
-        self.assertTrue(email == new_email)
+        assert email == new_email
         self.components.preferences.sign_out.wait_for_and_click()
         self.components.sign_out.sign_out_button.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_TRANSITION)

--- a/lib/galaxy_test/selenium/test_tool_describing_tours.py
+++ b/lib/galaxy_test/selenium/test_tool_describing_tours.py
@@ -70,7 +70,7 @@ class ToolDescribingToursTestCase(SeleniumTestCase):
     def _ensure_tdt_available(self):
         """Skip a test if the webhook TDT doesn't appear."""
         response = self.api_get("webhooks", raw=True)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
         data = response.json()
         webhooks = [x["id"] for x in data]
         if "tour_generator" not in webhooks:

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -724,7 +724,7 @@ steps:
         def assert_workflow_bookmarked_status(target_status):
             name_matches = [c.text == new_workflow_name for c in self.components.tool_panel.workflow_names.all()]
             status = any(name_matches)
-            self.assertTrue(status == target_status)
+            assert status == target_status
 
         new_workflow_name = self.workflow_create_new(clear_placeholder=True)
 

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -75,7 +75,7 @@ class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers, UsesWorkfl
 
         @retry_assertion_during_transitions
         def check_tags():
-            self.assertEqual(self.workflow_index_tags(), ["cooltag"])
+            assert self.workflow_index_tags() == ["cooltag"]
 
         check_tags()
         self.screenshot("workflow_manage_tags")

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -189,7 +189,7 @@ steps:
         )
         self.workflow_run_wait_for_ok(hid=7)
         content = self.dataset_populator.get_history_dataset_content(history_id, hid=7)
-        self.assertEqual("10.0\n30.0\n20.0\n40.0\n", content)
+        assert "10.0\n30.0\n20.0\n40.0\n" == content
 
     @selenium_test
     @managed_history

--- a/test/integration/test_tool_data_delete.py
+++ b/test/integration/test_tool_data_delete.py
@@ -54,7 +54,7 @@ class AdminToolDataIntegrationTestCase(integration_util.IntegrationTestCase):
         time.sleep(2)
         show_response = self._get("tool_data/testbeta")
         updated_fields = show_response.json()["fields"]
-        self.assertEqual(len(updated_fields), original_count + 1)
+        assert len(updated_fields) == original_count + 1
         new_field = updated_fields[-1]
         url = self._api_url(f"tool_data/testbeta?key={self.galaxy_interactor.api_key}")
 

--- a/test/integration/test_vault_extra_prefs.py
+++ b/test/integration/test_vault_extra_prefs.py
@@ -52,32 +52,32 @@ class ExtraUserPreferencesTestCase(integration_util.IntegrationTestCase):
 
         # value should be what we saved
         input_client_id = get_input_by_name(inputs, "client_id")
-        self.assertEqual(input_client_id["value"], "hello_client_id")
+        assert input_client_id["value"] == "hello_client_id"
 
         # however, this value should not be in the vault
-        self.assertIsNone(app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/client_id"))
+        assert app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/client_id") is None
         # it should be in the user preferences model
-        self.assertEqual(db_user.extra_preferences["vaulttestsection|client_id"], "hello_client_id")
+        assert db_user.extra_preferences["vaulttestsection|client_id"] == "hello_client_id"
 
         # the secret however, was configured to be stored in the vault
         input_client_secret = get_input_by_name(inputs, "client_secret")
-        self.assertEqual(input_client_secret["value"], "hello_client_secret")
-        self.assertEqual(
-            app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/client_secret"),
-            "hello_client_secret",
+        assert input_client_secret["value"] == "hello_client_secret"
+        assert (
+            app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/client_secret")
+            == "hello_client_secret"
         )
         # it should not be stored in the user preferences model
-        self.assertIsNone(db_user.extra_preferences["vaulttestsection|client_secret"])
+        assert db_user.extra_preferences["vaulttestsection|client_secret"] is None
 
         # secret type values should not be retrievable by the client
         input_refresh_token = get_input_by_name(inputs, "refresh_token")
-        self.assertNotEqual(input_refresh_token["value"], "a_super_secret_value")
-        self.assertEqual(input_refresh_token["value"], "__SECRET_PLACEHOLDER__")
+        assert input_refresh_token["value"] != "a_super_secret_value"
+        assert input_refresh_token["value"] == "__SECRET_PLACEHOLDER__"
 
         # however, that secret value should be correctly stored on the server
-        self.assertEqual(
-            app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/refresh_token"),
-            "a_super_secret_value",
+        assert (
+            app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/refresh_token")
+            == "a_super_secret_value"
         )
 
     def test_extra_prefs_vault_storage_update_secret(self):
@@ -107,8 +107,9 @@ class ExtraUserPreferencesTestCase(integration_util.IntegrationTestCase):
         )
 
         # value should not have been overwritten
-        self.assertEqual(
-            app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/refresh_token"), "a_new_secret_value"
+        assert (
+            app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/refresh_token")
+            == "a_new_secret_value"
         )
 
         # write a new value
@@ -122,9 +123,9 @@ class ExtraUserPreferencesTestCase(integration_util.IntegrationTestCase):
         )
 
         # value should now be overwritten
-        self.assertEqual(
-            app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/refresh_token"),
-            "an_updated_secret_value",
+        assert (
+            app.vault.read_secret(f"user/{db_user.id}/preferences/vaulttestsection/refresh_token")
+            == "an_updated_secret_value"
         )
 
     def __url(self, action, user):

--- a/test/integration/test_workflow_invocation.py
+++ b/test/integration/test_workflow_invocation.py
@@ -40,16 +40,16 @@ steps:
                 workflow_id, history_id=history_id, request={"require_exact_tool_versions": True}
             )
             self._assert_status_code_is(invocation_response, 400)
-            self.assertEqual(
-                invocation_response.json().get("err_msg"),
-                "Workflow was not invoked; the following required tools are not installed: nonexistent_tool (version 0.1), compose_text_param (version 0.0.1)",
+            assert (
+                invocation_response.json().get("err_msg")
+                == "Workflow was not invoked; the following required tools are not installed: nonexistent_tool (version 0.1), compose_text_param (version 0.0.1)"
             )
             # should fail but return only the tool_id of non_existent tool as another version of compose_text_param is installed
             invocation_response = self.workflow_populator.invoke_workflow(
                 workflow_id, history_id=history_id, request={"require_exact_tool_versions": False}
             )
             self._assert_status_code_is(invocation_response, 400)
-            self.assertEqual(
-                invocation_response.json().get("err_msg"),
-                "Workflow was not invoked; the following required tools are not installed: nonexistent_tool",
+            assert (
+                invocation_response.json().get("err_msg")
+                == "Workflow was not invoked; the following required tools are not installed: nonexistent_tool"
             )

--- a/test/integration/test_workflow_scheduling_options.py
+++ b/test/integration/test_workflow_scheduling_options.py
@@ -92,9 +92,7 @@ steps:
             }
             self.workflow_populator.invoke_workflow_and_wait(history_id, workflow_id, inputs)
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-            self.assertEqual(
-                "a\nc\nb\nd\ne\ng\nf\nh\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0)
-            )
+            assert "a\nc\nb\nd\ne\ng\nf\nh\n" == self.dataset_populator.get_history_dataset_content(history_id, hid=0)
 
     def test_scheduling_rounds(self):
         with self.dataset_populator.test_history() as history_id:

--- a/test/integration_selenium/test_toolbox_filters.py
+++ b/test/integration_selenium/test_toolbox_filters.py
@@ -42,4 +42,5 @@ class ToolboxFiltersSeleniumIntegrationTestCase(SeleniumIntegrationTestCase):
         self.sleep_for(self.wait_types.UX_RENDER)
         self.home()
         # But now it should raise NoSuchElementException
-        self.assertRaises(NoSuchElementException, lambda: self.driver.find_element(By.LINK_TEXT, "Test Section"))
+        with self.assertRaises(NoSuchElementException):
+            self.driver.find_element(By.LINK_TEXT, "Test Section")

--- a/test/unit/app/authnz/test_custos_authnz.py
+++ b/test/unit/app/authnz/test_custos_authnz.py
@@ -239,20 +239,20 @@ class CustosAuthnzTestCase(unittest.TestCase):
         requests.get = self.orig_requests_get
 
     def test_parse_config(self):
-        self.assertTrue(self.custos_authnz.config["verify_ssl"])
-        self.assertEqual(self.custos_authnz.config["client_id"], "test-client-id")
-        self.assertEqual(self.custos_authnz.config["client_secret"], "test-client-secret")
-        self.assertEqual(self.custos_authnz.config["redirect_uri"], "https://test-redirect-uri")
-        self.assertEqual(self.custos_authnz.config["authorization_endpoint"], "https://test-auth-endpoint")
-        self.assertEqual(self.custos_authnz.config["token_endpoint"], "https://test-token-endpoint")
-        self.assertEqual(self.custos_authnz.config["userinfo_endpoint"], "https://test-userinfo-endpoint")
+        assert self.custos_authnz.config["verify_ssl"]
+        assert self.custos_authnz.config["client_id"] == "test-client-id"
+        assert self.custos_authnz.config["client_secret"] == "test-client-secret"
+        assert self.custos_authnz.config["redirect_uri"] == "https://test-redirect-uri"
+        assert self.custos_authnz.config["authorization_endpoint"] == "https://test-auth-endpoint"
+        assert self.custos_authnz.config["token_endpoint"] == "https://test-token-endpoint"
+        assert self.custos_authnz.config["userinfo_endpoint"] == "https://test-userinfo-endpoint"
 
     def test_authenticate_set_state_cookie(self):
         """Verify that authenticate() sets a state cookie."""
         authorization_url = self.custos_authnz.authenticate(self.trans)
         parsed = urlparse(authorization_url)
         state = parse_qs(parsed.query)["state"][0]
-        self.assertEqual(state, self.trans.cookies[custos_authnz.STATE_COOKIE_NAME])
+        assert state == self.trans.cookies[custos_authnz.STATE_COOKIE_NAME]
 
     def test_authenticate_set_nonce_cookie(self):
         """Verify that authenticate() sets a nonce cookie."""
@@ -261,7 +261,7 @@ class CustosAuthnzTestCase(unittest.TestCase):
         hashed_nonce_in_url = parse_qs(parsed.query)["nonce"][0]
         nonce_in_cookie = self.trans.cookies[custos_authnz.NONCE_COOKIE_NAME]
         hashed_nonce = self.custos_authnz._hash_nonce(nonce_in_cookie)
-        self.assertEqual(hashed_nonce, hashed_nonce_in_url)
+        assert hashed_nonce == hashed_nonce_in_url
 
     def test_authenticate_set_pkce_verifier_cookie(self):
         try:
@@ -275,14 +275,14 @@ class CustosAuthnzTestCase(unittest.TestCase):
         code_challenge_in_url = parse_qs(parsed.query)["code_challenge"][0]
         verifier_in_cookie = self.trans.cookies[custos_authnz.VERIFIER_COOKIE_NAME]
         code_challenge_from_verifier = pkce.get_code_challenge(verifier_in_cookie)
-        self.assertEqual(code_challenge_in_url, code_challenge_from_verifier)
+        assert code_challenge_in_url == code_challenge_from_verifier
 
     def test_authenticate_adds_extra_params(self):
         """Verify that authenticate() adds configured extra params."""
         authorization_url = self.custos_authnz.authenticate(self.trans)
         parsed = urlparse(authorization_url)
         param1_value = parse_qs(parsed.query)["kc_idp_hint"][0]
-        self.assertEqual(param1_value, "oidc")
+        assert param1_value == "oidc"
 
     def test_authenticate_sets_env_var_when_localhost_redirect(self):
         """Verify that OAUTHLIB_INSECURE_TRANSPORT var is set with localhost redirect."""
@@ -298,15 +298,15 @@ class CustosAuthnzTestCase(unittest.TestCase):
             },
         )
         self.setupMocks()
-        self.assertIsNone(os.environ.get("OAUTHLIB_INSECURE_TRANSPORT", None))
+        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT", None) is None
         self.custos_authnz.authenticate(self.trans)
-        self.assertEqual("1", os.environ["OAUTHLIB_INSECURE_TRANSPORT"])
+        assert "1" == os.environ["OAUTHLIB_INSECURE_TRANSPORT"]
 
     def test_authenticate_does_not_set_env_var_when_https_redirect(self):
-        self.assertTrue(self.custos_authnz.config["redirect_uri"].startswith("https:"))
-        self.assertIsNone(os.environ.get("OAUTHLIB_INSECURE_TRANSPORT", None))
+        assert self.custos_authnz.config["redirect_uri"].startswith("https:")
+        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT", None) is None
         self.custos_authnz.authenticate(self.trans)
-        self.assertIsNone(os.environ.get("OAUTHLIB_INSECURE_TRANSPORT", None))
+        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT", None) is None
 
     def test_callback_verify_with_state_cookie(self):
         """Verify that state from cookie is passed to OAuth2Session constructor."""
@@ -329,10 +329,11 @@ class CustosAuthnzTestCase(unittest.TestCase):
         )
 
         self.trans.sa_session._query.custos_authnz_token = existing_custos_authnz_token
-        self.assertIsNotNone(
+        assert (
             self.trans.sa_session.query(CustosAuthnzToken)
             .filter_by(external_user_id=self.test_user_id, provider=self.custos_authnz.config["provider"])
             .one_or_none()
+            is not None
         )
         self.trans.sa_session._query.user = User(email=self.test_email, username=self.test_username)
 
@@ -344,11 +345,11 @@ class CustosAuthnzTestCase(unittest.TestCase):
         login_redirect_url, user = self.custos_authnz.callback(
             state_token="xxx", authz_code=self.test_code, trans=self.trans, login_redirect_url="http://localhost:8000/"
         )
-        self.assertTrue(self._create_oauth2_session_called)
-        self.assertTrue(self._fetch_token_called)
-        self.assertTrue(self._get_userinfo_called)
-        self.assertEqual(login_redirect_url, "/")
-        self.assertIsNotNone(user)
+        assert self._create_oauth2_session_called
+        assert self._fetch_token_called
+        assert self._get_userinfo_called
+        assert login_redirect_url == "/"
+        assert user is not None
 
     def test_callback_nonce_validation_with_bad_nonce(self):
         self.trans.set_cookie(value=self.test_state, name=custos_authnz.STATE_COOKIE_NAME)
@@ -366,33 +367,35 @@ class CustosAuthnzTestCase(unittest.TestCase):
                 trans=self.trans,
                 login_redirect_url="http://localhost:8000/",
             )
-        self.assertTrue(self._fetch_token_called)
-        self.assertFalse(self._get_userinfo_called)
+        assert self._fetch_token_called
+        assert not self._get_userinfo_called
 
     def test_callback_user_not_created_when_does_not_exists(self):
         self.trans.set_cookie(value=self.test_state, name=custos_authnz.STATE_COOKIE_NAME)
         self.trans.set_cookie(value=self.test_nonce, name=custos_authnz.NONCE_COOKIE_NAME)
 
-        self.assertIsNone(
+        assert (
             self.trans.sa_session.query(CustosAuthnzToken)
             .filter_by(external_user_id=self.test_user_id, provider=self.custos_authnz.config["provider"])
             .one_or_none()
+            is None
         )
-        self.assertEqual(0, len(self.trans.sa_session.items))
+        assert 0 == len(self.trans.sa_session.items)
         login_redirect_url, user = self.custos_authnz.callback(
             state_token="xxx", authz_code=self.test_code, trans=self.trans, login_redirect_url="http://localhost:8000/"
         )
-        self.assertIsNone(user)
-        self.assertTrue("http://localhost:8000/root/login?confirm=true&custos_token=" in login_redirect_url)
-        self.assertTrue(self._fetch_token_called)
+        assert user is None
+        assert "http://localhost:8000/root/login?confirm=true&custos_token=" in login_redirect_url
+        assert self._fetch_token_called
 
     def test_create_user(self):
-        self.assertIsNone(
+        assert (
             self.trans.sa_session.query(CustosAuthnzToken)
             .filter_by(external_user_id=self.test_user_id, provider=self.custos_authnz.config["provider"])
             .one_or_none()
+            is None
         )
-        self.assertEqual(0, len(self.trans.sa_session.items))
+        assert 0 == len(self.trans.sa_session.items)
 
         test_id_token = unicodify(
             jwt.encode(
@@ -418,31 +421,31 @@ class CustosAuthnzTestCase(unittest.TestCase):
         login_redirect_url, user = self.custos_authnz.create_user(
             token=json.dumps(self._raw_token), trans=self.trans, login_redirect_url="http://localhost:8000/"
         )
-        self.assertEqual(login_redirect_url, "http://localhost:8000/")
+        assert login_redirect_url == "http://localhost:8000/"
         self.trans.set_user(user)
-        self.assertEqual(2, len(self.trans.sa_session.items), "Session has new User & new CustosAuthnzToken")
+        assert 2 == len(self.trans.sa_session.items), "Session has new User & new CustosAuthnzToken"
         added_user = self.trans.get_user()
-        self.assertIsInstance(added_user, User)
-        self.assertEqual(self.test_username, added_user.username)
-        self.assertEqual(self.test_email, added_user.email)
-        self.assertIsNotNone(added_user.password)
+        assert isinstance(added_user, User)
+        assert self.test_username == added_user.username
+        assert self.test_email == added_user.email
+        assert added_user.password is not None
         # Verify added_custos_authnz_token
         added_custos_authnz_token = self.trans.sa_session.items[1]
-        self.assertIsInstance(added_custos_authnz_token, CustosAuthnzToken)
-        self.assertIs(user, added_custos_authnz_token.user)
-        self.assertEqual(self.test_access_token, added_custos_authnz_token.access_token)
-        self.assertEqual(test_id_token, added_custos_authnz_token.id_token)
-        self.assertEqual(self.test_refresh_token, added_custos_authnz_token.refresh_token)
+        assert isinstance(added_custos_authnz_token, CustosAuthnzToken)
+        assert user is added_custos_authnz_token.user
+        assert self.test_access_token == added_custos_authnz_token.access_token
+        assert test_id_token == added_custos_authnz_token.id_token
+        assert self.test_refresh_token == added_custos_authnz_token.refresh_token
         expected_expiration_time = datetime.now() + timedelta(seconds=self.test_expires_in)
         expiration_timedelta = expected_expiration_time - added_custos_authnz_token.expiration_time
-        self.assertTrue(expiration_timedelta.total_seconds() < 1)
+        assert expiration_timedelta.total_seconds() < 1
         expected_refresh_expiration_time = datetime.now() + timedelta(seconds=self.test_refresh_expires_in)
         refresh_expiration_timedelta = (
             expected_refresh_expiration_time - added_custos_authnz_token.refresh_expiration_time
         )
-        self.assertTrue(refresh_expiration_timedelta.total_seconds() < 1)
-        self.assertEqual(self.custos_authnz.config["provider"], added_custos_authnz_token.provider)
-        self.assertTrue(self.trans.sa_session.flush_called)
+        assert refresh_expiration_timedelta.total_seconds() < 1
+        assert self.custos_authnz.config["provider"] == added_custos_authnz_token.provider
+        assert self.trans.sa_session.flush_called
 
     def test_callback_galaxy_user_not_created_when_user_logged_in_and_no_custos_authnz_token_exists(self):
         """
@@ -453,24 +456,25 @@ class CustosAuthnzTestCase(unittest.TestCase):
         self.trans.set_cookie(value=self.test_nonce, name=custos_authnz.NONCE_COOKIE_NAME)
         self.trans.user = User()
 
-        self.assertIsNone(
+        assert (
             self.trans.sa_session.query(CustosAuthnzToken)
             .filter_by(external_user_id=self.test_user_id, provider=self.custos_authnz.config["provider"])
             .one_or_none()
+            is None
         )
-        self.assertEqual(0, len(self.trans.sa_session.items))
+        assert 0 == len(self.trans.sa_session.items)
         login_redirect_url, user = self.custos_authnz.callback(
             state_token="xxx", authz_code=self.test_code, trans=self.trans, login_redirect_url="http://localhost:8000/"
         )
-        self.assertTrue(self._fetch_token_called)
-        self.assertTrue(self._get_userinfo_called)
-        self.assertEqual(1, len(self.trans.sa_session.items), "Session has new CustosAuthnzToken")
+        assert self._fetch_token_called
+        assert self._get_userinfo_called
+        assert 1 == len(self.trans.sa_session.items), "Session has new CustosAuthnzToken"
         # Verify added_custos_authnz_token
         added_custos_authnz_token = self.trans.sa_session.items[0]
-        self.assertIsInstance(added_custos_authnz_token, CustosAuthnzToken)
-        self.assertIs(user, added_custos_authnz_token.user)
-        self.assertIs(user, self.trans.user)
-        self.assertTrue(self.trans.sa_session.flush_called)
+        assert isinstance(added_custos_authnz_token, CustosAuthnzToken)
+        assert user is added_custos_authnz_token.user
+        assert user is self.trans.user
+        assert self.trans.sa_session.flush_called
 
     def test_callback_galaxy_user_not_created_when_custos_authnz_token_exists(self):
         self.trans.set_cookie(value=self.test_state, name=custos_authnz.STATE_COOKIE_NAME)
@@ -493,44 +497,45 @@ class CustosAuthnzTestCase(unittest.TestCase):
 
         self.trans.sa_session._query.custos_authnz_token = existing_custos_authnz_token
 
-        self.assertIsNotNone(
+        assert (
             self.trans.sa_session.query(CustosAuthnzToken)
             .filter_by(external_user_id=self.test_user_id, provider=self.custos_authnz.config["provider"])
             .one_or_none()
+            is not None
         )
-        self.assertEqual(0, len(self.trans.sa_session.items))
+        assert 0 == len(self.trans.sa_session.items)
         login_redirect_url, user = self.custos_authnz.callback(
             state_token="xxx", authz_code=self.test_code, trans=self.trans, login_redirect_url="http://localhost:8000/"
         )
-        self.assertTrue(self._fetch_token_called)
-        self.assertTrue(self._get_userinfo_called)
+        assert self._fetch_token_called
+        assert self._get_userinfo_called
         # Make sure query was called with correct parameters
-        self.assertEqual(self.test_user_id, self.trans.sa_session._query.external_user_id)
-        self.assertEqual(self.custos_authnz.config["provider"], self.trans.sa_session._query.provider)
-        self.assertEqual(1, len(self.trans.sa_session.items), "Session has updated CustosAuthnzToken")
+        assert self.test_user_id == self.trans.sa_session._query.external_user_id
+        assert self.custos_authnz.config["provider"] == self.trans.sa_session._query.provider
+        assert 1 == len(self.trans.sa_session.items), "Session has updated CustosAuthnzToken"
         session_custos_authnz_token = self.trans.sa_session.items[0]
-        self.assertIsInstance(session_custos_authnz_token, CustosAuthnzToken)
-        self.assertIs(
-            existing_custos_authnz_token, session_custos_authnz_token, "existing CustosAuthnzToken should be updated"
-        )
+        assert isinstance(session_custos_authnz_token, CustosAuthnzToken)
+        assert (
+            existing_custos_authnz_token is session_custos_authnz_token
+        ), "existing CustosAuthnzToken should be updated"
         # Verify both that existing CustosAuthnzToken has the correct values and different values than before
-        self.assertEqual(self.test_access_token, session_custos_authnz_token.access_token)
-        self.assertNotEqual(old_access_token, session_custos_authnz_token.access_token)
-        self.assertEqual(self.test_id_token, session_custos_authnz_token.id_token)
-        self.assertNotEqual(old_id_token, session_custos_authnz_token.id_token)
-        self.assertEqual(self.test_refresh_token, session_custos_authnz_token.refresh_token)
-        self.assertNotEqual(old_refresh_token, session_custos_authnz_token.refresh_token)
+        assert self.test_access_token == session_custos_authnz_token.access_token
+        assert old_access_token != session_custos_authnz_token.access_token
+        assert self.test_id_token == session_custos_authnz_token.id_token
+        assert old_id_token != session_custos_authnz_token.id_token
+        assert self.test_refresh_token == session_custos_authnz_token.refresh_token
+        assert old_refresh_token != session_custos_authnz_token.refresh_token
         expected_expiration_time = datetime.now() + timedelta(seconds=self.test_expires_in)
         expiration_timedelta = expected_expiration_time - session_custos_authnz_token.expiration_time
-        self.assertTrue(expiration_timedelta.total_seconds() < 1)
-        self.assertNotEqual(old_expiration_time, session_custos_authnz_token.expiration_time)
+        assert expiration_timedelta.total_seconds() < 1
+        assert old_expiration_time != session_custos_authnz_token.expiration_time
         expected_refresh_expiration_time = datetime.now() + timedelta(seconds=self.test_refresh_expires_in)
         refresh_expiration_timedelta = (
             expected_refresh_expiration_time - session_custos_authnz_token.refresh_expiration_time
         )
-        self.assertTrue(refresh_expiration_timedelta.total_seconds() < 1)
-        self.assertNotEqual(old_refresh_expiration_time, session_custos_authnz_token.refresh_expiration_time)
-        self.assertTrue(self.trans.sa_session.flush_called)
+        assert refresh_expiration_timedelta.total_seconds() < 1
+        assert old_refresh_expiration_time != session_custos_authnz_token.refresh_expiration_time
+        assert self.trans.sa_session.flush_called
 
     def test_disconnect(self):
         custos_authnz_token = CustosAuthnzToken(
@@ -550,22 +555,22 @@ class CustosAuthnzTestCase(unittest.TestCase):
 
         success, message, redirect_uri = self.custos_authnz.disconnect(provider, self.trans, email, "/")
 
-        self.assertEqual(1, len(self.trans.sa_session.deleted))
+        assert 1 == len(self.trans.sa_session.deleted)
         deleted_token = self.trans.sa_session.deleted[0]
-        self.assertIs(custos_authnz_token, deleted_token)
-        self.assertTrue(self.trans.sa_session.flush_called)
-        self.assertTrue(success)
-        self.assertEqual("", message)
-        self.assertEqual("/", redirect_uri)
+        assert custos_authnz_token is deleted_token
+        assert self.trans.sa_session.flush_called
+        assert success
+        assert "" == message
+        assert "/" == redirect_uri
 
     def test_disconnect_when_no_associated_provider(self):
         self.trans.user = User()
         success, message, redirect_uri = self.custos_authnz.disconnect("Custos", self.trans, "/")
-        self.assertEqual(0, len(self.trans.sa_session.deleted))
-        self.assertFalse(self.trans.sa_session.flush_called)
-        self.assertFalse(success)
-        self.assertNotEqual("", message)
-        self.assertIsNone(redirect_uri)
+        assert 0 == len(self.trans.sa_session.deleted)
+        assert not self.trans.sa_session.flush_called
+        assert not success
+        assert "" != message
+        assert redirect_uri is None
 
     def test_disconnect_when_more_than_one_associated_token_for_provider(self):
         self.trans.user = User(email=self.test_email, username=self.test_username)
@@ -593,15 +598,15 @@ class CustosAuthnzTestCase(unittest.TestCase):
 
         success, message, redirect_uri = self.custos_authnz.disconnect("Custos", self.trans, "/")
 
-        self.assertEqual(0, len(self.trans.sa_session.deleted))
-        self.assertFalse(self.trans.sa_session.flush_called)
-        self.assertFalse(success)
-        self.assertNotEqual("", message)
-        self.assertIsNone(redirect_uri)
+        assert 0 == len(self.trans.sa_session.deleted)
+        assert not self.trans.sa_session.flush_called
+        assert not success
+        assert "" != message
+        assert redirect_uri is None
 
     def test_logout_with_redirect(self):
 
         logout_redirect_url = "http://localhost:8080/post-logout"
         redirect_url = self.custos_authnz.logout(self.trans, logout_redirect_url)
 
-        self.assertEqual(redirect_url, "https://test-end-session-endpoint?redirect_uri=" + quote(logout_redirect_url))
+        assert redirect_url == "https://test-end-session-endpoint?redirect_uri=" + quote(logout_redirect_url)

--- a/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
+++ b/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
@@ -97,17 +97,16 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_brokenDestYML(self, lc):
-        self.assertRaises(
-            JobMappingException,
-            map_tool_to_destination,
-            runJob,
-            theApp,
-            vanillaTool,
-            "user@email.com",
-            True,
-            broken_default_dest_path,
-            job_conf_path,
-        )
+        with self.assertRaises(JobMappingException):
+            map_tool_to_destination(
+                runJob,
+                theApp,
+                vanillaTool,
+                "user@email.com",
+                True,
+                broken_default_dest_path,
+                job_conf_path,
+            )
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -119,28 +118,26 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_filesize_empty(self, lc):
-        self.assertRaises(
-            JobMappingException,
-            map_tool_to_destination,
-            emptyJob,
-            theApp,
-            vanillaTool,
-            "user@email.com",
-            True,
-            path,
-            job_conf_path,
-        )
-        self.assertRaises(
-            JobMappingException,
-            map_tool_to_destination,
-            emptyJob,
-            theApp,
-            vanillaTool,
-            "user@email.com",
-            True,
-            priority_path,
-            job_conf_path,
-        )
+        with self.assertRaises(JobMappingException):
+            map_tool_to_destination(
+                emptyJob,
+                theApp,
+                vanillaTool,
+                "user@email.com",
+                True,
+                path,
+                job_conf_path,
+            )
+        with self.assertRaises(JobMappingException):
+            map_tool_to_destination(
+                emptyJob,
+                theApp,
+                vanillaTool,
+                "user@email.com",
+                True,
+                priority_path,
+                job_conf_path,
+            )
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -162,28 +159,26 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_filesize_zero(self, lc):
-        self.assertRaises(
-            JobMappingException,
-            map_tool_to_destination,
-            zeroJob,
-            theApp,
-            vanillaTool,
-            "user@email.com",
-            True,
-            path,
-            job_conf_path,
-        )
-        self.assertRaises(
-            JobMappingException,
-            map_tool_to_destination,
-            zeroJob,
-            theApp,
-            vanillaTool,
-            "user@email.com",
-            True,
-            priority_path,
-            job_conf_path,
-        )
+        with self.assertRaises(JobMappingException):
+            map_tool_to_destination(
+                zeroJob,
+                theApp,
+                vanillaTool,
+                "user@email.com",
+                True,
+                path,
+                job_conf_path,
+            )
+        with self.assertRaises(JobMappingException):
+            map_tool_to_destination(
+                zeroJob,
+                theApp,
+                vanillaTool,
+                "user@email.com",
+                True,
+                priority_path,
+                job_conf_path,
+            )
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -203,28 +198,26 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_filesize_fail(self, lc):
-        self.assertRaises(
-            JobMappingException,
-            map_tool_to_destination,
-            failJob,
-            theApp,
-            vanillaTool,
-            "user@email.com",
-            True,
-            path,
-            job_conf_path,
-        )
-        self.assertRaises(
-            JobMappingException,
-            map_tool_to_destination,
-            failJob,
-            theApp,
-            vanillaTool,
-            "user@email.com",
-            True,
-            priority_path,
-            job_conf_path,
-        )
+        with self.assertRaises(JobMappingException):
+            map_tool_to_destination(
+                failJob,
+                theApp,
+                vanillaTool,
+                "user@email.com",
+                True,
+                path,
+                job_conf_path,
+            )
+        with self.assertRaises(JobMappingException):
+            map_tool_to_destination(
+                failJob,
+                theApp,
+                vanillaTool,
+                "user@email.com",
+                True,
+                priority_path,
+                job_conf_path,
+            )
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -473,7 +466,8 @@ class TestDynamicToolDestination(unittest.TestCase):
     # ================================Invalid yaml files==============================
     @log_capture()
     def test_no_file(self, lc):
-        self.assertRaises(IOError, dt.parse_yaml, path="")
+        with self.assertRaises(IOError):
+            dt.parse_yaml(path="")
         lc.check_present()
 
     @log_capture()
@@ -1360,8 +1354,10 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     # ================================Testing str_to_bytes==========================
     def test_str_to_bytes_invalid(self):
-        self.assertRaises(dt.MalformedYMLException, dt.str_to_bytes, "1d")
-        self.assertRaises(dt.MalformedYMLException, dt.str_to_bytes, "1 d")
+        with self.assertRaises(dt.MalformedYMLException):
+            dt.str_to_bytes("1d")
+        with self.assertRaises(dt.MalformedYMLException):
+            dt.str_to_bytes("1 d")
 
     def test_str_to_bytes_valid(self):
         assert dt.str_to_bytes("-1") == -1
@@ -1380,12 +1376,16 @@ class TestDynamicToolDestination(unittest.TestCase):
     # ==============================Testing bytes_to_str=============================
     def test_bytes_to_str_invalid(self):
         testValue = ""
-        self.assertRaises(ValueError, dt.bytes_to_str, testValue)
+        with self.assertRaises(ValueError):
+            dt.bytes_to_str(testValue)
         testValue = "5564fads"
-        self.assertRaises(ValueError, dt.bytes_to_str, testValue)
+        with self.assertRaises(ValueError):
+            dt.bytes_to_str(testValue)
         testValue = "45.0.1"
-        self.assertRaises(ValueError, dt.bytes_to_str, testValue)
-        self.assertRaises(ValueError, dt.bytes_to_str, "1 024")
+        with self.assertRaises(ValueError):
+            dt.bytes_to_str(testValue)
+        with self.assertRaises(ValueError):
+            dt.bytes_to_str("1 024")
 
     def test_bytes_to_str_valid(self):
         assert dt.bytes_to_str(-1) == "Infinity"

--- a/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
+++ b/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
@@ -247,11 +247,11 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_filesize_run(self, lc):
         job = map_tool_to_destination(runJob, theApp, vanillaTool, "user@email.com", True, path, job_conf_path)
-        self.assertEqual(job, "Destination1")
+        assert job == "Destination1"
         priority_job = map_tool_to_destination(
             runJob, theApp, vanillaTool, "user@email.com", True, priority_path, job_conf_path
         )
-        self.assertEqual(priority_job, "Destination1_high")
+        assert priority_job == "Destination1_high"
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -276,11 +276,11 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_default_tool(self, lc):
         job = map_tool_to_destination(runJob, theApp, defaultTool, "user@email.com", True, path, job_conf_path)
-        self.assertEqual(job, "cluster_default")
+        assert job == "cluster_default"
         priority_job = map_tool_to_destination(
             runJob, theApp, defaultTool, "user@email.com", True, priority_path, job_conf_path
         )
-        self.assertEqual(priority_job, "cluster_default_high")
+        assert priority_job == "cluster_default_high"
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -313,11 +313,11 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_arguments_tool(self, lc):
         job = map_tool_to_destination(argJob, theApp, argTool, "user@email.com", True, path, job_conf_path)
-        self.assertEqual(job, "Destination6")
+        assert job == "Destination6"
         priority_job = map_tool_to_destination(
             argJob, theApp, argTool, "user@email.com", True, priority_path, job_conf_path
         )
-        self.assertEqual(priority_job, "Destination6_med")
+        assert priority_job == "Destination6_med"
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -336,11 +336,11 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_arguments_arg_not_found(self, lc):
         job = map_tool_to_destination(argNotFoundJob, theApp, argTool, "user@email.com", True, path, job_conf_path)
-        self.assertEqual(job, "cluster_default")
+        assert job == "cluster_default"
         priority_job = map_tool_to_destination(
             argNotFoundJob, theApp, argTool, "user@email.com", True, priority_path, job_conf_path
         )
-        self.assertEqual(priority_job, "cluster_default_high")
+        assert priority_job == "cluster_default_high"
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -359,11 +359,11 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_tool_not_found(self, lc):
         job = map_tool_to_destination(runJob, theApp, unTool, "user@email.com", True, path, job_conf_path)
-        self.assertEqual(job, "cluster_default")
+        assert job == "cluster_default"
         priority_job = map_tool_to_destination(
             runJob, theApp, unTool, "user@email.com", True, priority_path, job_conf_path
         )
-        self.assertEqual(priority_job, "cluster_default_high")
+        assert priority_job == "cluster_default_high"
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -392,11 +392,11 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_fasta(self, lc):
         job = map_tool_to_destination(dbJob, theApp, dbTool, "user@email.com", True, path, job_conf_path)
-        self.assertEqual(job, "Destination4")
+        assert job == "Destination4"
         priority_job = map_tool_to_destination(
             dbJob, theApp, dbTool, "user@email.com", True, priority_path, job_conf_path
         )
-        self.assertEqual(priority_job, "Destination4_high")
+        assert priority_job == "Destination4_high"
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -419,11 +419,11 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_fasta_count(self, lc):
         job = map_tool_to_destination(dbcountJob, theApp, dbTool, "user@email.com", True, path, job_conf_path)
-        self.assertEqual(job, "Destination4")
+        assert job == "Destination4"
         priority_job = map_tool_to_destination(
             dbcountJob, theApp, dbTool, "user@email.com", True, priority_path, job_conf_path
         )
-        self.assertEqual(priority_job, "Destination4_high")
+        assert priority_job == "Destination4_high"
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -446,7 +446,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_no_verbose(self, lc):
         job = map_tool_to_destination(runJob, theApp, noVBTool, "user@email.com", True, no_verbose_path, job_conf_path)
-        self.assertEqual(job, "Destination1")
+        assert job == "Destination1"
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running 'test_no_verbose' with 'Destination1'.")
@@ -455,7 +455,7 @@ class TestDynamicToolDestination(unittest.TestCase):
     @log_capture()
     def test_authorized_user(self, lc):
         job = map_tool_to_destination(runJob, theApp, usersTool, "user@email.com", True, users_test_path, job_conf_path)
-        self.assertEqual(job, "special_cluster")
+        assert job == "special_cluster"
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running 'test_users' with 'special_cluster'."),
@@ -466,7 +466,7 @@ class TestDynamicToolDestination(unittest.TestCase):
         job = map_tool_to_destination(
             runJob, theApp, usersTool, "userblah@email.com", True, users_test_path, job_conf_path
         )
-        self.assertEqual(job, "lame_cluster")
+        assert job == "lame_cluster"
 
         lc.check_present(("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running 'test_users' with 'lame_cluster'."))
 
@@ -491,11 +491,11 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_empty_file(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest2, job_conf_path=job_conf_path, test=True), {})
+        assert dt.parse_yaml(path=yt.ivYMLTest2, job_conf_path=job_conf_path, test=True) == {}
 
     @log_capture()
     def test_no_tool_name(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest3, job_conf_path=job_conf_path, test=True), yt.iv3dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest3, job_conf_path=job_conf_path, test=True) == yt.iv3dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -508,7 +508,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_rule_type(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest4, job_conf_path=job_conf_path, test=True), yt.ivDict)
+        assert dt.parse_yaml(path=yt.ivYMLTest4, job_conf_path=job_conf_path, test=True) == yt.ivDict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "No rule_type found for rule 1 in 'spades'."),
@@ -517,7 +517,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_rule_lower_bound(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest51, job_conf_path=job_conf_path, test=True), yt.ivDict)
+        assert dt.parse_yaml(path=yt.ivYMLTest51, job_conf_path=job_conf_path, test=True) == yt.ivDict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Missing bounds for rule 1 in 'spades'. Ignoring rule."),
@@ -526,7 +526,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_rule_upper_bound(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest52, job_conf_path=job_conf_path, test=True), yt.ivDict)
+        assert dt.parse_yaml(path=yt.ivYMLTest52, job_conf_path=job_conf_path, test=True) == yt.ivDict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Missing bounds for rule 1 in 'spades'. Ignoring rule."),
@@ -535,7 +535,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_rule_arg(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest53, job_conf_path=job_conf_path, test=True), yt.ivDict53)
+        assert dt.parse_yaml(path=yt.ivYMLTest53, job_conf_path=job_conf_path, test=True) == yt.ivDict53
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -548,7 +548,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_bad_rule_type(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest6, job_conf_path=job_conf_path, test=True), yt.ivDict)
+        assert dt.parse_yaml(path=yt.ivYMLTest6, job_conf_path=job_conf_path, test=True) == yt.ivDict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -561,7 +561,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_no_err_msg(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest91, job_conf_path=job_conf_path, test=True), yt.iv91dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest91, job_conf_path=job_conf_path, test=True) == yt.iv91dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -602,7 +602,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_arguments_no_err_msg(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest12, job_conf_path=job_conf_path, test=True), yt.iv12dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest12, job_conf_path=job_conf_path, test=True) == yt.iv12dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -615,7 +615,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_arguments_no_args(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest131, job_conf_path=job_conf_path, test=True), yt.iv131dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest131, job_conf_path=job_conf_path, test=True) == yt.iv131dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -628,7 +628,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_arguments_no_arg(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest132, job_conf_path=job_conf_path, test=True), yt.iv132dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest132, job_conf_path=job_conf_path, test=True) == yt.iv132dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -641,14 +641,14 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_multiple_jobs(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest133, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest133, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Missing a fail_message for rule 1 in 'smalt'.")
         )
 
     @log_capture()
     def test_return_rule_for_multiple_jobs(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest133, job_conf_path=job_conf_path, test=True), yt.iv133dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest133, job_conf_path=job_conf_path, test=True) == yt.iv133dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -661,14 +661,14 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_no_destination(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest134, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest134, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "No destination specified for rule 1 in 'spades'.")
         )
 
     @log_capture()
     def test_return_rule_for_no_destination(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest134, job_conf_path=job_conf_path, test=True), yt.iv134dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest134, job_conf_path=job_conf_path, test=True) == yt.iv134dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -681,7 +681,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_reversed_bounds(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest135, job_conf_path=job_conf_path, test=True), yt.iv135dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest135, job_conf_path=job_conf_path, test=True) == yt.iv135dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -694,7 +694,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_missing_tool_fields(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest136, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest136, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             (
                 "galaxy.jobs.dynamic_tool_destination",
@@ -705,7 +705,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_missing_tool_fields(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest136, job_conf_path=job_conf_path, test=True), yt.iv136dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest136, job_conf_path=job_conf_path, test=True) == yt.iv136dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -718,14 +718,14 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_blank_tool(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest137, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest137, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Config section for tool 'spades' is blank!")
         )
 
     @log_capture()
     def test_return_rule_for_blank_tool(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest137, job_conf_path=job_conf_path, test=True), yt.iv137dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest137, job_conf_path=job_conf_path, test=True) == yt.iv137dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Config section for tool 'spades' is blank!"),
@@ -734,7 +734,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_malformed_users(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest138, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest138, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             (
                 "galaxy.jobs.dynamic_tool_destination",
@@ -750,7 +750,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_malformed_users(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest138, job_conf_path=job_conf_path, test=True), yt.iv138dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest138, job_conf_path=job_conf_path, test=True) == yt.iv138dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -768,12 +768,12 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_no_users(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest139, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest139, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Couldn't find a list under 'users:'!"))
 
     @log_capture()
     def test_return_rule_for_no_users(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest139, job_conf_path=job_conf_path, test=True), yt.iv139dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest139, job_conf_path=job_conf_path, test=True) == yt.iv139dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Couldn't find a list under 'users:'! Ignoring rule."),
@@ -782,7 +782,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_malformed_user_email(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest140, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest140, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             (
                 "galaxy.jobs.dynamic_tool_destination",
@@ -803,7 +803,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_malformed_user_email(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest140, job_conf_path=job_conf_path, test=True), yt.iv140dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest140, job_conf_path=job_conf_path, test=True) == yt.iv140dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -826,7 +826,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_empty_users(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest141, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest141, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             (
                 "galaxy.jobs.dynamic_tool_destination",
@@ -847,7 +847,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_empty_users(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest141, job_conf_path=job_conf_path, test=True), yt.iv141dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest141, job_conf_path=job_conf_path, test=True) == yt.iv141dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -870,7 +870,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_bad_num_input_datasets_bounds(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest142, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest142, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             (
                 "galaxy.jobs.dynamic_tool_destination",
@@ -882,7 +882,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_bad_num_input_datasets_bound(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest142, job_conf_path=job_conf_path, test=True), yt.iv142dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest142, job_conf_path=job_conf_path, test=True) == yt.iv142dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -895,7 +895,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_bool_for_worse_num_input_datasets_bounds(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest143, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest143, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             (
                 "galaxy.jobs.dynamic_tool_destination",
@@ -906,7 +906,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_return_rule_for_worse_num_input_datasets_bound(self, lc):
-        self.assertEqual(dt.parse_yaml(path=yt.ivYMLTest143, job_conf_path=job_conf_path, test=True), yt.iv143dict)
+        assert dt.parse_yaml(path=yt.ivYMLTest143, job_conf_path=job_conf_path, test=True) == yt.iv143dict
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
             (
@@ -1283,7 +1283,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_invalid_default_dest_valid_tool_default_dest_bool(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest172, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest172, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             (
                 "galaxy.jobs.dynamic_tool_destination",
@@ -1294,7 +1294,7 @@ class TestDynamicToolDestination(unittest.TestCase):
 
     @log_capture()
     def test_valid_default_dest_invalid_tool_default_dest_bool(self, lc):
-        self.assertFalse(dt.parse_yaml(path=yt.ivYMLTest173, job_conf_path=job_conf_path, test=True, return_bool=True))
+        assert not dt.parse_yaml(path=yt.ivYMLTest173, job_conf_path=job_conf_path, test=True, return_bool=True)
         lc.check_present(
             (
                 "galaxy.jobs.dynamic_tool_destination",
@@ -1311,21 +1311,21 @@ class TestDynamicToolDestination(unittest.TestCase):
     # ================================Valid yaml files==============================
     @log_capture()
     def test_parse_valid_yml(self, lc):
-        self.assertEqual(dt.parse_yaml(yt.vYMLTest1, job_conf_path=job_conf_path, test=True), yt.vdictTest1_yml)
-        self.assertEqual(dt.parse_yaml(yt.vYMLTest2, job_conf_path=job_conf_path, test=True), yt.vdictTest2_yml)
-        self.assertEqual(dt.parse_yaml(yt.vYMLTest3, job_conf_path=job_conf_path, test=True), yt.vdictTest3_yml)
-        self.assertTrue(dt.parse_yaml(yt.vYMLTest4, job_conf_path=job_conf_path, test=True, return_bool=True))
-        self.assertEqual(dt.parse_yaml(yt.vYMLTest4, job_conf_path=job_conf_path, test=True), yt.vdictTest4_yml)
-        self.assertTrue(dt.parse_yaml(yt.vYMLTest5, job_conf_path=job_conf_path, test=True, return_bool=True))
-        self.assertEqual(dt.parse_yaml(yt.vYMLTest5, job_conf_path=job_conf_path, test=True), yt.vdictTest5_yml)
-        self.assertTrue(dt.parse_yaml(yt.vYMLTest6, job_conf_path=job_conf_path, test=True, return_bool=True))
-        self.assertEqual(dt.parse_yaml(yt.vYMLTest6, job_conf_path=job_conf_path, test=True), yt.vdictTest6_yml)
-        self.assertTrue(dt.parse_yaml(yt.vYMLTest7, job_conf_path=job_conf_path, test=True, return_bool=True))
-        self.assertEqual(dt.parse_yaml(yt.vYMLTest7, job_conf_path=job_conf_path, test=True), yt.vdictTest7_yml)
-        self.assertTrue(dt.parse_yaml(yt.vYMLTest160, job_conf_path=job_conf_path, test=True, return_bool=True))
-        self.assertEqual(dt.parse_yaml(yt.vYMLTest160, job_conf_path=job_conf_path, test=True), yt.vdictTest160_yml)
-        self.assertTrue(dt.parse_yaml(yt.vYMLTest164, job_conf_path=job_conf_path, test=True, return_bool=True))
-        self.assertEqual(dt.parse_yaml(yt.vYMLTest164, job_conf_path=job_conf_path, test=True), yt.vdictTest164_yml)
+        assert dt.parse_yaml(yt.vYMLTest1, job_conf_path=job_conf_path, test=True) == yt.vdictTest1_yml
+        assert dt.parse_yaml(yt.vYMLTest2, job_conf_path=job_conf_path, test=True) == yt.vdictTest2_yml
+        assert dt.parse_yaml(yt.vYMLTest3, job_conf_path=job_conf_path, test=True) == yt.vdictTest3_yml
+        assert dt.parse_yaml(yt.vYMLTest4, job_conf_path=job_conf_path, test=True, return_bool=True)
+        assert dt.parse_yaml(yt.vYMLTest4, job_conf_path=job_conf_path, test=True) == yt.vdictTest4_yml
+        assert dt.parse_yaml(yt.vYMLTest5, job_conf_path=job_conf_path, test=True, return_bool=True)
+        assert dt.parse_yaml(yt.vYMLTest5, job_conf_path=job_conf_path, test=True) == yt.vdictTest5_yml
+        assert dt.parse_yaml(yt.vYMLTest6, job_conf_path=job_conf_path, test=True, return_bool=True)
+        assert dt.parse_yaml(yt.vYMLTest6, job_conf_path=job_conf_path, test=True) == yt.vdictTest6_yml
+        assert dt.parse_yaml(yt.vYMLTest7, job_conf_path=job_conf_path, test=True, return_bool=True)
+        assert dt.parse_yaml(yt.vYMLTest7, job_conf_path=job_conf_path, test=True) == yt.vdictTest7_yml
+        assert dt.parse_yaml(yt.vYMLTest160, job_conf_path=job_conf_path, test=True, return_bool=True)
+        assert dt.parse_yaml(yt.vYMLTest160, job_conf_path=job_conf_path, test=True) == yt.vdictTest160_yml
+        assert dt.parse_yaml(yt.vYMLTest164, job_conf_path=job_conf_path, test=True, return_bool=True)
+        assert dt.parse_yaml(yt.vYMLTest164, job_conf_path=job_conf_path, test=True) == yt.vdictTest164_yml
 
         lc.check_present(
             ("galaxy.jobs.dynamic_tool_destination", "DEBUG", "Running config validation..."),
@@ -1364,18 +1364,18 @@ class TestDynamicToolDestination(unittest.TestCase):
         self.assertRaises(dt.MalformedYMLException, dt.str_to_bytes, "1 d")
 
     def test_str_to_bytes_valid(self):
-        self.assertEqual(dt.str_to_bytes("-1"), -1)
-        self.assertEqual(dt.str_to_bytes("1"), value)
-        self.assertEqual(dt.str_to_bytes(156), 156)
-        self.assertEqual(dt.str_to_bytes("1 B"), value)
-        self.assertEqual(dt.str_to_bytes("1 KB"), valueK)
-        self.assertEqual(dt.str_to_bytes("1 MB"), valueM)
-        self.assertEqual(dt.str_to_bytes("1 gB"), valueG)
-        self.assertEqual(dt.str_to_bytes("1 Tb"), valueT)
-        self.assertEqual(dt.str_to_bytes("1 pb"), valueP)
-        self.assertEqual(dt.str_to_bytes("1 EB"), valueE)
-        self.assertEqual(dt.str_to_bytes("1 ZB"), valueZ)
-        self.assertEqual(dt.str_to_bytes("1 YB"), valueY)
+        assert dt.str_to_bytes("-1") == -1
+        assert dt.str_to_bytes("1") == value
+        assert dt.str_to_bytes(156) == 156
+        assert dt.str_to_bytes("1 B") == value
+        assert dt.str_to_bytes("1 KB") == valueK
+        assert dt.str_to_bytes("1 MB") == valueM
+        assert dt.str_to_bytes("1 gB") == valueG
+        assert dt.str_to_bytes("1 Tb") == valueT
+        assert dt.str_to_bytes("1 pb") == valueP
+        assert dt.str_to_bytes("1 EB") == valueE
+        assert dt.str_to_bytes("1 ZB") == valueZ
+        assert dt.str_to_bytes("1 YB") == valueY
 
     # ==============================Testing bytes_to_str=============================
     def test_bytes_to_str_invalid(self):
@@ -1388,39 +1388,39 @@ class TestDynamicToolDestination(unittest.TestCase):
         self.assertRaises(ValueError, dt.bytes_to_str, "1 024")
 
     def test_bytes_to_str_valid(self):
-        self.assertEqual(dt.bytes_to_str(-1), "Infinity")
-        self.assertEqual(dt.bytes_to_str(value), "1.00 B")
-        self.assertEqual(dt.bytes_to_str(valueK), "1.00 KB")
-        self.assertEqual(dt.bytes_to_str(valueM), "1.00 MB")
-        self.assertEqual(dt.bytes_to_str(valueG), "1.00 GB")
-        self.assertEqual(dt.bytes_to_str(valueT), "1.00 TB")
-        self.assertEqual(dt.bytes_to_str(valueP), "1.00 PB")
-        self.assertEqual(dt.bytes_to_str(valueE), "1.00 EB")
-        self.assertEqual(dt.bytes_to_str(valueZ), "1.00 ZB")
-        self.assertEqual(dt.bytes_to_str(valueY), "1.00 YB")
+        assert dt.bytes_to_str(-1) == "Infinity"
+        assert dt.bytes_to_str(value) == "1.00 B"
+        assert dt.bytes_to_str(valueK) == "1.00 KB"
+        assert dt.bytes_to_str(valueM) == "1.00 MB"
+        assert dt.bytes_to_str(valueG) == "1.00 GB"
+        assert dt.bytes_to_str(valueT) == "1.00 TB"
+        assert dt.bytes_to_str(valueP) == "1.00 PB"
+        assert dt.bytes_to_str(valueE) == "1.00 EB"
+        assert dt.bytes_to_str(valueZ) == "1.00 ZB"
+        assert dt.bytes_to_str(valueY) == "1.00 YB"
 
-        self.assertEqual(dt.bytes_to_str(10, "B"), "10.00 B")
-        self.assertEqual(dt.bytes_to_str(1000000, "KB"), "976.56 KB")
-        self.assertEqual(dt.bytes_to_str(1000000000, "MB"), "953.67 MB")
-        self.assertEqual(dt.bytes_to_str(1000000000000, "GB"), "931.32 GB")
-        self.assertEqual(dt.bytes_to_str(1000000000000000, "TB"), "909.49 TB")
-        self.assertEqual(dt.bytes_to_str(1000000000000000000, "PB"), "888.18 PB")
-        self.assertEqual(dt.bytes_to_str(1000000000000000000000, "EB"), "867.36 EB")
-        self.assertEqual(dt.bytes_to_str(1000000000000000000000000, "ZB"), "847.03 ZB")
+        assert dt.bytes_to_str(10, "B") == "10.00 B"
+        assert dt.bytes_to_str(1000000, "KB") == "976.56 KB"
+        assert dt.bytes_to_str(1000000000, "MB") == "953.67 MB"
+        assert dt.bytes_to_str(1000000000000, "GB") == "931.32 GB"
+        assert dt.bytes_to_str(1000000000000000, "TB") == "909.49 TB"
+        assert dt.bytes_to_str(1000000000000000000, "PB") == "888.18 PB"
+        assert dt.bytes_to_str(1000000000000000000000, "EB") == "867.36 EB"
+        assert dt.bytes_to_str(1000000000000000000000000, "ZB") == "847.03 ZB"
 
-        self.assertEqual(dt.bytes_to_str(value, "KB"), "1.00 B")
-        self.assertEqual(dt.bytes_to_str(valueK, "MB"), "1.00 KB")
-        self.assertEqual(dt.bytes_to_str(valueM, "GB"), "1.00 MB")
-        self.assertEqual(dt.bytes_to_str(valueG, "TB"), "1.00 GB")
-        self.assertEqual(dt.bytes_to_str(valueT, "PB"), "1.00 TB")
-        self.assertEqual(dt.bytes_to_str(valueP, "EB"), "1.00 PB")
-        self.assertEqual(dt.bytes_to_str(valueE, "ZB"), "1.00 EB")
-        self.assertEqual(dt.bytes_to_str(valueZ, "YB"), "1.00 ZB")
+        assert dt.bytes_to_str(value, "KB") == "1.00 B"
+        assert dt.bytes_to_str(valueK, "MB") == "1.00 KB"
+        assert dt.bytes_to_str(valueM, "GB") == "1.00 MB"
+        assert dt.bytes_to_str(valueG, "TB") == "1.00 GB"
+        assert dt.bytes_to_str(valueT, "PB") == "1.00 TB"
+        assert dt.bytes_to_str(valueP, "EB") == "1.00 PB"
+        assert dt.bytes_to_str(valueE, "ZB") == "1.00 EB"
+        assert dt.bytes_to_str(valueZ, "YB") == "1.00 ZB"
 
-        self.assertEqual(dt.bytes_to_str("1"), "1.00 B")
-        self.assertEqual(dt.bytes_to_str("\t\t1000000"), "976.56 KB")
-        self.assertEqual(dt.bytes_to_str("1000000000\n"), "953.67 MB")
-        self.assertEqual(dt.bytes_to_str(1024, "fda"), "1.00 KB")
+        assert dt.bytes_to_str("1") == "1.00 B"
+        assert dt.bytes_to_str("\t\t1000000") == "976.56 KB"
+        assert dt.bytes_to_str("1000000000\n") == "953.67 MB"
+        assert dt.bytes_to_str(1024, "fda") == "1.00 KB"
 
 
 if __name__ == "__main__":

--- a/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
+++ b/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
@@ -1421,7 +1421,3 @@ class TestDynamicToolDestination(unittest.TestCase):
         assert dt.bytes_to_str("\t\t1000000") == "976.56 KB"
         assert dt.bytes_to_str("1000000000\n") == "953.67 MB"
         assert dt.bytes_to_str(1024, "fda") == "1.00 KB"
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -173,10 +173,10 @@ class TestCommandFactory(TestCase):
 
     def _assert_command_is(self, expected_command, **command_kwds):
         command = self.__command(**command_kwds)
-        self.assertEqual(command, expected_command)
+        assert command == expected_command
 
     def __assert_tool_script_is(self, expected_command):
-        self.assertEqual(open(self.__tool_script).read(), expected_command)
+        assert open(self.__tool_script).read() == expected_command
 
     @property
     def __tool_script(self):

--- a/test/unit/app/managers/base.py
+++ b/test/unit/app/managers/base.py
@@ -118,9 +118,3 @@ class CreatesCollectionsMixin:
             #    src = 'ldda'#?
             identifier_list.append(dict(src=src, name=element.name, id=element.id))
         return identifier_list
-
-
-# =============================================================================
-if __name__ == "__main__":
-    # or more generally, nosetests test_resourcemanagers.py -s -v
-    unittest.main()

--- a/test/unit/app/managers/base.py
+++ b/test/unit/app/managers/base.py
@@ -54,31 +54,25 @@ class BaseTestCase(unittest.TestCase):
     TYPES_NEEDING_NO_SERIALIZERS = (str, bool, type(None), int, float)
 
     def assertKeys(self, obj, key_list):
-        self.assertEqual(sorted(obj.keys()), sorted(key_list))
+        assert sorted(obj.keys()) == sorted(key_list)
 
     def assertHasKeys(self, obj, key_list):
         for key in key_list:
             if key not in obj:
                 self.fail("Missing key: " + key)
-        else:
-            self.assertTrue(True, "keys found in object")
 
     def assertNullableBasestring(self, item):
         if not isinstance(item, (str, type(None))):
             self.fail("Non-nullable basestring: " + str(type(item)))
         # TODO: len mod 8 and hex re
-        self.assertTrue(True, "is nullable basestring: " + str(item))
 
     def assertEncodedId(self, item):
         if not isinstance(item, str):
             self.fail("Non-string: " + str(type(item)))
         # TODO: len mod 8 and hex re
-        self.assertTrue(True, "is id: " + item)
 
     def assertNullableEncodedId(self, item):
-        if item is None:
-            self.assertTrue(True, "nullable id is None")
-        else:
+        if item is not None:
             self.assertEncodedId(item)
 
     def assertDate(self, item):
@@ -86,33 +80,29 @@ class BaseTestCase(unittest.TestCase):
             self.fail("Non-string: " + str(type(item)))
         # TODO: no great way to parse this fully (w/o python-dateutil)
         # TODO: re?
-        self.assertTrue(True, "is date: " + item)
 
     def assertUUID(self, item):
         if not isinstance(item, str):
             self.fail("Non-string: " + str(type(item)))
         # TODO: re for d4d76d69-80d4-4ed7-80c7-211ebcc1a358
-        self.assertTrue(True, "is uuid: " + item)
 
-    def assertORMFilter(self, item, msg=None):
+    def assertORMFilter(self, item):
         if not isinstance(
             item.filter, (sqlalchemy.sql.elements.BinaryExpression, sqlalchemy.sql.elements.BooleanClauseList)
         ):
             self.fail("Not an orm filter: " + str(type(item.filter)))
-        self.assertTrue(True, msg or ("is an orm filter: " + str(item.filter)))
 
-    def assertORMFunctionFilter(self, item, msg=None):
+    def assertORMFunctionFilter(self, item):
         assert item.filter_type == "orm_function"
         assert callable(item.filter)
 
-    def assertFnFilter(self, item, msg=None):
+    def assertFnFilter(self, item):
         if not item.filter or not callable(item.filter):
             self.fail("Not a fn filter: " + str(type(item.filter)))
-        self.assertTrue(True, msg or ("is a fn filter: " + str(item.filter)))
 
     def assertIsJsonifyable(self, item):
         # TODO: use galaxy's override
-        self.assertIsInstance(json.dumps(item), str)
+        assert isinstance(json.dumps(item), str)
 
 
 class CreatesCollectionsMixin:

--- a/test/unit/app/managers/test_CollectionManager.py
+++ b/test/unit/app/managers/test_CollectionManager.py
@@ -42,43 +42,43 @@ class DatasetCollectionManagerTestCase(BaseTestCase, CreatesCollectionsMixin):
         hdca = self.collection_manager.create(
             self.trans, history, "test collection", "list", element_identifiers=element_identifiers
         )
-        self.assertIsInstance(hdca, model.HistoryDatasetCollectionAssociation)
-        self.assertEqual(hdca.name, "test collection")
-        self.assertEqual(hdca.hid, 4)
-        self.assertFalse(hdca.deleted)
-        self.assertTrue(hdca.visible)
+        assert isinstance(hdca, model.HistoryDatasetCollectionAssociation)
+        assert hdca.name == "test collection"
+        assert hdca.hid == 4
+        assert not hdca.deleted
+        assert hdca.visible
 
         self.log("should contain an underlying, well-formed DatasetCollection")
-        self.assertIsInstance(hdca.collection, model.DatasetCollection)
+        assert isinstance(hdca.collection, model.DatasetCollection)
         collection = hdca.collection
-        self.assertEqual(collection.collection_type, "list")
-        self.assertEqual(collection.state, "ok")
-        self.assertEqual(len(collection.dataset_instances), 3)
-        self.assertEqual(len(collection.elements), 3)
+        assert collection.collection_type == "list"
+        assert collection.state == "ok"
+        assert len(collection.dataset_instances) == 3
+        assert len(collection.elements) == 3
 
         self.log("and that collection should have three well-formed Elements")
-        self.assertIsInstance(collection.elements[0], model.DatasetCollectionElement)
-        self.assertEqual(collection.elements[0].element_identifier, "one")
-        self.assertEqual(collection.elements[0].element_index, 0)
-        self.assertEqual(collection.elements[0].element_type, "hda")
-        self.assertEqual(collection.elements[0].element_object, hda1)
+        assert isinstance(collection.elements[0], model.DatasetCollectionElement)
+        assert collection.elements[0].element_identifier == "one"
+        assert collection.elements[0].element_index == 0
+        assert collection.elements[0].element_type == "hda"
+        assert collection.elements[0].element_object == hda1
 
-        self.assertIsInstance(collection.elements[1], model.DatasetCollectionElement)
-        self.assertEqual(collection.elements[1].element_identifier, "two")
-        self.assertEqual(collection.elements[1].element_index, 1)
-        self.assertEqual(collection.elements[1].element_type, "hda")
-        self.assertEqual(collection.elements[1].element_object, hda2)
+        assert isinstance(collection.elements[1], model.DatasetCollectionElement)
+        assert collection.elements[1].element_identifier == "two"
+        assert collection.elements[1].element_index == 1
+        assert collection.elements[1].element_type == "hda"
+        assert collection.elements[1].element_object == hda2
 
-        self.assertIsInstance(collection.elements[2], model.DatasetCollectionElement)
-        self.assertEqual(collection.elements[2].element_identifier, "three")
-        self.assertEqual(collection.elements[2].element_index, 2)
-        self.assertEqual(collection.elements[2].element_type, "hda")
-        self.assertEqual(collection.elements[2].element_object, hda3)
+        assert isinstance(collection.elements[2], model.DatasetCollectionElement)
+        assert collection.elements[2].element_identifier == "three"
+        assert collection.elements[2].element_index == 2
+        assert collection.elements[2].element_type == "hda"
+        assert collection.elements[2].element_object == hda3
 
         self.log("should be able to create a new Collection via objects")
         elements = dict(one=hda1, two=hda2, three=hda3)
         hdca2 = self.collection_manager.create(self.trans, history, "test collection 2", "list", elements=elements)
-        self.assertIsInstance(hdca2, model.HistoryDatasetCollectionAssociation)
+        assert isinstance(hdca2, model.HistoryDatasetCollectionAssociation)
 
     def test_update_from_dict(self):
         owner = self.user_manager.create(**user2_data)
@@ -105,19 +105,19 @@ class DatasetCollectionManagerTestCase(BaseTestCase, CreatesCollectionsMixin):
                 # 'annotations'      : [?]
             },
         )
-        self.assertEqual(hdca.name, "New Name")
-        self.assertTrue(hdca.deleted)
-        self.assertFalse(hdca.visible)
+        assert hdca.name == "New Name"
+        assert hdca.deleted
+        assert not hdca.visible
 
         tag_names = hdca.make_tag_string_list()
-        self.assertEqual(tag_names, ["name:one", "group:two", "three"])
-        # self.assertEqual( hdca.annotations, [ 'one', 'two', 'three' ] )
+        assert tag_names == ["name:one", "group:two", "three"]
+        # assert hdca.annotations == ["one", "two", "three"]
 
     # def test_validation( self ):
-    #    self.log( "should be able to change the name" )
-    #    self.log( "should be able to set deleted" )
-    #    self.log( "should be able to set visible" )
-    #    self.log( "should be able to set tags" )
+    #    self.log("should be able to change the name")
+    #    self.log("should be able to set deleted")
+    #    self.log("should be able to set visible")
+    #    self.log("should be able to set tags")
 
 
 # =============================================================================

--- a/test/unit/app/managers/test_CollectionManager.py
+++ b/test/unit/app/managers/test_CollectionManager.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 """
 """
-import unittest
-
 from galaxy import model
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.datasets import DatasetManager
@@ -118,9 +116,3 @@ class DatasetCollectionManagerTestCase(BaseTestCase, CreatesCollectionsMixin):
     #    self.log("should be able to set deleted")
     #    self.log("should be able to set visible")
     #    self.log("should be able to set tags")
-
-
-# =============================================================================
-if __name__ == "__main__":
-    # or more generally, nosetests test_resourcemanagers.py -s -v
-    unittest.main()

--- a/test/unit/app/managers/test_DatasetManager.py
+++ b/test/unit/app/managers/test_DatasetManager.py
@@ -84,7 +84,8 @@ class DatasetManagerTestCase(BaseTestCase):
 
         self.log("should raise an error when purging a dataset if config does not allow")
         assert not item1.purged
-        self.assertRaises(exceptions.ConfigDoesNotAllowException, self.dataset_manager.purge, item1)
+        with self.assertRaises(exceptions.ConfigDoesNotAllowException):
+            self.dataset_manager.purge(item1)
         assert not item1.purged
 
     def test_create_with_no_permissions(self):
@@ -272,12 +273,12 @@ class DatasetSerializerTestCase(BaseTestCase):
 
         self.log("permissions should be not returned for non-managing users")
         not_my_supervisor = self.user_manager.create(**user3_data)
-        self.assertRaises(
-            SkipAttribute, self.dataset_serializer.serialize_permissions, dataset, "perms", user=not_my_supervisor
-        )
+        with self.assertRaises(SkipAttribute):
+            self.dataset_serializer.serialize_permissions(dataset, "perms", user=not_my_supervisor)
 
         self.log("permissions should not be returned for anon users")
-        self.assertRaises(SkipAttribute, self.dataset_serializer.serialize_permissions, dataset, "perms", user=None)
+        with self.assertRaises(SkipAttribute):
+            self.dataset_serializer.serialize_permissions(dataset, "perms", user=None)
 
         self.log("permissions should be returned for admin users")
         permissions = self.dataset_serializer.serialize_permissions(dataset, "perms", user=self.admin_user)

--- a/test/unit/app/managers/test_DatasetManager.py
+++ b/test/unit/app/managers/test_DatasetManager.py
@@ -1,6 +1,5 @@
 """
 """
-import unittest
 from unittest import mock
 
 import sqlalchemy
@@ -317,8 +316,3 @@ class DatasetSerializerTestCase(BaseTestCase):
 #   DatasetAssociationSerializer,
 #   DatasetAssociationDeserializer,
 #   DatasetAssociationFilterParser
-
-# =============================================================================
-if __name__ == "__main__":
-    # or more generally, nosetests test_resourcemanagers.py -s -v
-    unittest.main()

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 import sqlalchemy
@@ -684,9 +683,3 @@ class HDAFilterParserTestCase(HDATestCase):
 
 #     def test_data_type_filters( self ):
 #         pass
-
-
-# =============================================================================
-if __name__ == "__main__":
-    # or more generally, nosetests test_resourcemanagers.py -s -v
-    unittest.main()

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -46,21 +46,21 @@ class HDAManagerTestCase(HDATestCase):
 
         self.log("should be able to query")
         hdas = self.trans.sa_session.query(hda_model).all()
-        self.assertEqual(self.hda_manager.list(), hdas)
-        self.assertEqual(self.hda_manager.one(filters=(hda_model.id == hda1.id)), hda1)
-        self.assertEqual(self.hda_manager.by_id(hda1.id), hda1)
-        self.assertEqual(self.hda_manager.by_ids([hda2.id, hda1.id]), [hda2, hda1])
+        assert self.hda_manager.list() == hdas
+        assert self.hda_manager.one(filters=(hda_model.id == hda1.id)) == hda1
+        assert self.hda_manager.by_id(hda1.id) == hda1
+        assert self.hda_manager.by_ids([hda2.id, hda1.id]) == [hda2, hda1]
 
         self.log("should be able to limit and offset")
-        self.assertEqual(self.hda_manager.list(limit=1), hdas[0:1])
-        self.assertEqual(self.hda_manager.list(offset=1), hdas[1:])
-        self.assertEqual(self.hda_manager.list(limit=1, offset=1), hdas[1:2])
+        assert self.hda_manager.list(limit=1) == hdas[0:1]
+        assert self.hda_manager.list(offset=1) == hdas[1:]
+        assert self.hda_manager.list(limit=1, offset=1) == hdas[1:2]
 
-        self.assertEqual(self.hda_manager.list(limit=0), [])
-        self.assertEqual(self.hda_manager.list(offset=3), [])
+        assert self.hda_manager.list(limit=0) == []
+        assert self.hda_manager.list(offset=3) == []
 
         self.log("should be able to order")
-        self.assertEqual(self.hda_manager.list(order_by=sqlalchemy.desc(hda_model.create_time)), [hda3, hda2, hda1])
+        assert self.hda_manager.list(order_by=sqlalchemy.desc(hda_model.create_time)) == [hda3, hda2, hda1]
 
     def test_create(self):
         owner = self.user_manager.create(**user2_data)
@@ -70,25 +70,25 @@ class HDAManagerTestCase(HDATestCase):
 
         self.log("should be able to create a new HDA with a specified history and dataset")
         hda1 = self.hda_manager.create(history=history1, dataset=dataset1)
-        self.assertIsInstance(hda1, model.HistoryDatasetAssociation)
-        self.assertEqual(hda1, self.trans.sa_session.query(model.HistoryDatasetAssociation).get(hda1.id))
-        self.assertEqual(hda1.history, history1)
-        self.assertEqual(hda1.dataset, dataset1)
-        self.assertEqual(hda1.hid, 1)
+        assert isinstance(hda1, model.HistoryDatasetAssociation)
+        assert hda1 == self.trans.sa_session.query(model.HistoryDatasetAssociation).get(hda1.id)
+        assert hda1.history == history1
+        assert hda1.dataset == dataset1
+        assert hda1.hid == 1
 
         self.log("should be able to create a new HDA with only a specified history and no dataset")
         hda2 = self.hda_manager.create(history=history1)
-        self.assertIsInstance(hda2, model.HistoryDatasetAssociation)
-        self.assertIsInstance(hda2.dataset, model.Dataset)
-        self.assertEqual(hda2.history, history1)
-        self.assertEqual(hda2.hid, 2)
+        assert isinstance(hda2, model.HistoryDatasetAssociation)
+        assert isinstance(hda2.dataset, model.Dataset)
+        assert hda2.history == history1
+        assert hda2.hid == 2
 
         self.log("should be able to create a new HDA with no history and no dataset")
         hda3 = self.hda_manager.create(hid=None)
-        self.assertIsInstance(hda3, model.HistoryDatasetAssociation)
-        self.assertIsInstance(hda3.dataset, model.Dataset, msg="dataset will be auto created")
-        self.assertIsNone(hda3.history, msg="history will be None")
-        self.assertEqual(hda3.hid, None, msg="should allow setting hid to None (or any other value)")
+        assert isinstance(hda3, model.HistoryDatasetAssociation)
+        assert isinstance(hda3.dataset, model.Dataset), "dataset will be auto created"
+        assert hda3.history is None, "history will be None"
+        assert hda3.hid is None, "should allow setting hid to None (or any other value)"
 
     def test_hda_tags(self):
         owner = self.user_manager.create(**user2_data)
@@ -100,7 +100,7 @@ class HDAManagerTestCase(HDATestCase):
         tags_to_set = ["tag-one", "tag-two"]
         self.hda_manager.set_tags(hda1, tags_to_set, user=owner)
         tag_str_array = self.hda_manager.get_tags(hda1)
-        self.assertEqual(sorted(tags_to_set), sorted(tag_str_array))
+        assert sorted(tags_to_set) == sorted(tag_str_array)
 
     def test_hda_annotation(self):
         owner = self.user_manager.create(**user2_data)
@@ -111,7 +111,7 @@ class HDAManagerTestCase(HDATestCase):
         self.log("should be able to set annotation on an hda")
         annotation = "an annotation or анотація"
         self.hda_manager.annotate(hda1, annotation, user=owner)
-        self.assertEqual(self.hda_manager.annotation(hda1), annotation)
+        assert self.hda_manager.annotation(hda1) == annotation
 
     def test_copy_from_hda(self):
         owner = self.user_manager.create(**user2_data)
@@ -121,12 +121,12 @@ class HDAManagerTestCase(HDATestCase):
 
         self.log("should be able to copy an HDA")
         hda2 = self.hda_manager.copy(hda1, history=history1)
-        self.assertIsInstance(hda2, model.HistoryDatasetAssociation)
-        self.assertEqual(hda2, self.trans.sa_session.query(model.HistoryDatasetAssociation).get(hda2.id))
-        self.assertEqual(hda2.name, hda1.name)
-        self.assertEqual(hda2.history, hda1.history)
-        self.assertEqual(hda2.dataset, hda1.dataset)
-        self.assertNotEqual(hda2, hda1)
+        assert isinstance(hda2, model.HistoryDatasetAssociation)
+        assert hda2 == self.trans.sa_session.query(model.HistoryDatasetAssociation).get(hda2.id)
+        assert hda2.name == hda1.name
+        assert hda2.history == hda1.history
+        assert hda2.dataset == hda1.dataset
+        assert hda2 != hda1
 
         self.log("tags should be copied between HDAs")
         tagged = self.hda_manager.create(history=history1, dataset=self.dataset_manager.create())
@@ -135,7 +135,7 @@ class HDAManagerTestCase(HDATestCase):
 
         hda2 = self.hda_manager.copy(tagged, history=history1)
         tag_str_array = self.hda_manager.get_tags(hda2)
-        self.assertEqual(sorted(tags_to_set), sorted(tag_str_array))
+        assert sorted(tags_to_set) == sorted(tag_str_array)
 
         self.log("annotations should be copied between HDAs")
         annotated = self.hda_manager.create(history=history1, dataset=self.dataset_manager.create())
@@ -144,7 +144,7 @@ class HDAManagerTestCase(HDATestCase):
 
         hda3 = self.hda_manager.copy(annotated, history=history1)
         hda3_annotation = self.hda_manager.annotation(hda3)
-        self.assertEqual(annotation, hda3_annotation)
+        assert annotation == hda3_annotation
 
     # def test_copy_from_ldda( self ):
     #    owner = self.user_manager.create( self.trans, **user2_data )
@@ -160,11 +160,11 @@ class HDAManagerTestCase(HDATestCase):
         item1 = self.hda_manager.create(history=history1, dataset=dataset1)
 
         self.log("should be able to delete and undelete an hda")
-        self.assertFalse(item1.deleted)
-        self.assertEqual(self.hda_manager.delete(item1), item1)
-        self.assertTrue(item1.deleted)
-        self.assertEqual(self.hda_manager.undelete(item1), item1)
-        self.assertFalse(item1.deleted)
+        assert not item1.deleted
+        assert self.hda_manager.delete(item1) == item1
+        assert item1.deleted
+        assert self.hda_manager.undelete(item1) == item1
+        assert not item1.deleted
 
     def test_purge_allowed(self):
         self.trans.app.config.allow_user_dataset_purge = True
@@ -175,10 +175,10 @@ class HDAManagerTestCase(HDATestCase):
         item1 = self.hda_manager.create(history=history1, dataset=dataset1)
 
         self.log("should purge an hda if config does allow")
-        self.assertFalse(item1.purged)
+        assert not item1.purged
         self.hda_manager.purge(item1)
-        self.assertTrue(item1.deleted)
-        self.assertTrue(item1.purged)
+        assert item1.deleted
+        assert item1.purged
 
     def test_purge_not_allowed(self):
         self.trans.app.config.allow_user_dataset_purge = False
@@ -189,10 +189,10 @@ class HDAManagerTestCase(HDATestCase):
         item1 = self.hda_manager.create(history=history1, dataset=dataset1)
 
         self.log("should raise an error when purging an hda if config does not allow")
-        self.assertFalse(item1.purged)
+        assert not item1.purged
         self.assertRaises(exceptions.ConfigDoesNotAllowException, self.hda_manager.purge, item1)
-        self.assertFalse(item1.deleted)
-        self.assertFalse(item1.purged)
+        assert not item1.deleted
+        assert not item1.purged
 
     def test_ownable(self):
         owner = self.user_manager.create(**user2_data)
@@ -203,8 +203,8 @@ class HDAManagerTestCase(HDATestCase):
         item1 = self.hda_manager.create(history=history1, dataset=dataset1)
 
         self.log("should be able to poll whether a given user owns an item")
-        self.assertTrue(self.hda_manager.is_owner(item1, owner))
-        self.assertFalse(self.hda_manager.is_owner(item1, non_owner))
+        assert self.hda_manager.is_owner(item1, owner)
+        assert not self.hda_manager.is_owner(item1, non_owner)
 
         self.log("should raise an error when checking ownership with non-owner")
         self.assertRaises(exceptions.ItemOwnershipException, self.hda_manager.error_unless_owner, item1, non_owner)
@@ -213,10 +213,10 @@ class HDAManagerTestCase(HDATestCase):
         self.assertRaises(exceptions.ItemOwnershipException, self.hda_manager.error_unless_owner, item1, None)
 
         self.log("should not raise an error when checking ownership with owner")
-        self.assertEqual(self.hda_manager.error_unless_owner(item1, owner), item1)
+        assert self.hda_manager.error_unless_owner(item1, owner) == item1
 
         self.log("should not raise an error when checking ownership with admin")
-        self.assertEqual(self.hda_manager.error_unless_owner(item1, self.admin_user), item1)
+        assert self.hda_manager.error_unless_owner(item1, self.admin_user) == item1
 
     def test_accessible(self):
         owner = self.user_manager.create(**user2_data)
@@ -229,13 +229,13 @@ class HDAManagerTestCase(HDATestCase):
         self.log("(by default, dataset permissions are lax) should be accessible to all")
 
         for user in self.user_manager.list():
-            self.assertTrue(self.hda_manager.is_accessible(item1, user))
+            assert self.hda_manager.is_accessible(item1, user)
 
         self.log("after setting a dataset to private (one user) permissions, access should be allowed for that user")
         # for this test, set restrictive access permissions
         self.dataset_manager.permissions.set_private_to_one_user(dataset1, owner)
         accessible = self.hda_manager.get_accessible(item1.id, owner, current_history=self.trans.history)
-        self.assertEqual(accessible, item1)
+        assert accessible == item1
 
         self.log(
             "after setting a dataset to private (one user) permissions, "
@@ -256,7 +256,7 @@ class HDAManagerTestCase(HDATestCase):
         history2 = self.history_manager.create(name="history2", user=non_owner)
         self.trans.set_history(history2)
         item2 = self.hda_manager.copy(item1, history=history2)
-        self.assertIsInstance(item2, model.HistoryDatasetAssociation)
+        assert isinstance(item2, model.HistoryDatasetAssociation)
         self.assertRaises(
             exceptions.ItemAccessibilityException,
             self.hda_manager.get_accessible,
@@ -289,15 +289,15 @@ class HDAManagerTestCase(HDATestCase):
 
         self.log("should not raise an error when checking ownership on anonymous' own dataset")
         # need to pass the current history for comparison
-        self.assertTrue(self.hda_manager.is_owner(item1, anon_user, current_history=self.trans.history))
+        assert self.hda_manager.is_owner(item1, anon_user, current_history=self.trans.history)
         item = self.hda_manager.error_unless_owner(item1, anon_user, current_history=self.trans.history)
-        self.assertEqual(item, item1)
+        assert item == item1
         item = self.hda_manager.get_owned(item1.id, anon_user, current_history=self.trans.history)
-        self.assertEqual(item, item1)
+        assert item == item1
 
         self.log("should raise an error when checking ownership on anonymous' dataset with other user")
         non_owner = self.user_manager.create(**user3_data)
-        self.assertFalse(self.hda_manager.is_owner(item1, non_owner))
+        assert not self.hda_manager.is_owner(item1, non_owner)
         self.assertRaises(exceptions.ItemOwnershipException, self.hda_manager.error_unless_owner, item1, non_owner)
         self.assertRaises(exceptions.ItemOwnershipException, self.hda_manager.get_owned, item1.id, non_owner)
 
@@ -311,7 +311,7 @@ class HDAManagerTestCase(HDATestCase):
         item1 = self.hda_manager.create(history=history1, dataset=dataset1)
 
         # datasets are public by default
-        self.assertTrue(self.hda_manager.is_accessible(item1, anon_user))
+        assert self.hda_manager.is_accessible(item1, anon_user)
         # for this test, set restrictive access permissions
         dataset_owner = self.user_manager.create(**user3_data)
         self.dataset_manager.permissions.set_private_to_one_user(dataset1, dataset_owner)
@@ -320,7 +320,7 @@ class HDAManagerTestCase(HDATestCase):
             "anonymous users should not be able to access datasets within their own histories if "
             + "permissions do not allow"
         )
-        self.assertFalse(self.hda_manager.is_accessible(item1, anon_user))
+        assert not self.hda_manager.is_accessible(item1, anon_user)
         self.assertRaises(
             exceptions.ItemAccessibilityException, self.hda_manager.error_unless_accessible, item1, anon_user
         )
@@ -329,14 +329,14 @@ class HDAManagerTestCase(HDATestCase):
             "those users with access permissions should still be allowed access to datasets "
             + "within anon users' histories"
         )
-        self.assertTrue(self.hda_manager.is_accessible(item1, dataset_owner))
+        assert self.hda_manager.is_accessible(item1, dataset_owner)
 
     def test_error_if_uploading(self):
         hda = self._create_vanilla_hda()
 
         hda.state = model.Dataset.states.OK
         self.log("should not raise an error when calling error_if_uploading and in a non-uploading state")
-        self.assertEqual(self.hda_manager.error_if_uploading(hda), hda)
+        assert self.hda_manager.error_if_uploading(hda) == hda
 
         hda.state = model.Dataset.states.UPLOAD
         self.log("should raise an error when calling error_if_uploading and in the uploading state")
@@ -346,13 +346,13 @@ class HDAManagerTestCase(HDATestCase):
         hda = self._create_vanilla_hda()
 
         self.log("data conversion status should reflect state")
-        self.assertEqual(self.hda_manager.data_conversion_status(None), hda.conversion_messages.NO_DATA)
+        assert self.hda_manager.data_conversion_status(None) == hda.conversion_messages.NO_DATA
         hda.state = model.Dataset.states.ERROR
-        self.assertEqual(self.hda_manager.data_conversion_status(hda), hda.conversion_messages.ERROR)
+        assert self.hda_manager.data_conversion_status(hda) == hda.conversion_messages.ERROR
         hda.state = model.Dataset.states.QUEUED
-        self.assertEqual(self.hda_manager.data_conversion_status(hda), hda.conversion_messages.PENDING)
+        assert self.hda_manager.data_conversion_status(hda) == hda.conversion_messages.PENDING
         hda.state = model.Dataset.states.OK
-        self.assertEqual(self.hda_manager.data_conversion_status(hda), None)
+        assert self.hda_manager.data_conversion_status(hda) is None
 
     # def test_text_data( self ):
 
@@ -380,13 +380,13 @@ class HDASerializerTestCase(HDATestCase):
         default_view = self.hda_serializer.serialize_to_view(hda, default_view="summary")
         self.assertKeys(default_view, self.hda_serializer.views["summary"])
 
-        # self.log( 'should have a detailed view' )
-        # detailed_view = self.hda_serializer.serialize_to_view( hda, view='detailed' )
-        # self.assertKeys( detailed_view, self.hda_serializer.views[ 'detailed' ] )
+        # self.log("should have a detailed view")
+        # detailed_view = self.hda_serializer.serialize_to_view(hda, view="detailed")
+        # self.assertKeys(detailed_view, self.hda_serializer.views["detailed"])
 
-        # self.log( 'should have a extended view' )
-        # extended_view = self.hda_serializer.serialize_to_view( hda, view='extended' )
-        # self.assertKeys( extended_view, self.hda_serializer.views[ 'extended' ] )
+        # self.log("should have a extended view")
+        # extended_view = self.hda_serializer.serialize_to_view(hda, view="extended")
+        # self.assertKeys(extended_view, self.hda_serializer.views["extended"])
 
         self.log("should have a inaccessible view")
         inaccessible_view = self.hda_serializer.serialize_to_view(hda, view="inaccessible")
@@ -405,8 +405,6 @@ class HDASerializerTestCase(HDATestCase):
                 or (is_metadata(key))
             ):
                 self.fail(f"no serializer for: {key} ({instantiated_attribute})")
-        else:
-            self.assertTrue(True, "all serializable keys have a serializer")
 
     def test_views_and_keys(self):
         hda = self._create_vanilla_hda()
@@ -431,33 +429,33 @@ class HDASerializerTestCase(HDATestCase):
         self.assertDate(serialized["update_time"])
 
         # dataset association
-        self.assertIsInstance(serialized["dataset"], dict)
+        assert isinstance(serialized["dataset"], dict)
         self.assertEncodedId(serialized["dataset_id"])
         self.assertUUID(serialized["uuid"])
-        self.assertIsInstance(serialized["file_name"], str)
-        self.assertIsInstance(serialized["extra_files_path"], str)
-        self.assertIsInstance(serialized["size"], int)
-        self.assertIsInstance(serialized["file_size"], int)
-        self.assertIsInstance(serialized["nice_size"], str)
+        assert isinstance(serialized["file_name"], str)
+        assert isinstance(serialized["extra_files_path"], str)
+        assert isinstance(serialized["size"], int)
+        assert isinstance(serialized["file_size"], int)
+        assert isinstance(serialized["nice_size"], str)
         # TODO: these should be tested w/copy
         self.assertNullableEncodedId(serialized["copied_from_history_dataset_association_id"])
         self.assertNullableEncodedId(serialized["copied_from_library_dataset_dataset_association_id"])
         self.assertNullableBasestring(serialized["info"])
         self.assertNullableBasestring(serialized["blurb"])
         self.assertNullableBasestring(serialized["peek"])
-        self.assertIsInstance(serialized["meta_files"], list)
+        assert isinstance(serialized["meta_files"], list)
         self.assertNullableEncodedId(serialized["parent_id"])
-        self.assertEqual(serialized["designation"], None)
-        self.assertIsInstance(serialized["genome_build"], str)
-        self.assertIsInstance(serialized["data_type"], str)
+        assert serialized["designation"] is None
+        assert isinstance(serialized["genome_build"], str)
+        assert isinstance(serialized["data_type"], str)
 
         # hda
         self.assertEncodedId(serialized["history_id"])
-        self.assertEqual(serialized["type_id"], "dataset-" + serialized["id"])
+        assert serialized["type_id"] == "dataset-" + serialized["id"]
 
-        self.assertIsInstance(serialized["resubmitted"], bool)
-        self.assertIsInstance(serialized["display_apps"], list)
-        self.assertIsInstance(serialized["display_types"], list)
+        assert isinstance(serialized["resubmitted"], bool)
+        assert isinstance(serialized["display_apps"], list)
+        assert isinstance(serialized["display_types"], list)
 
         # remapped
         self.assertNullableBasestring(serialized["misc_info"])
@@ -466,16 +464,16 @@ class HDASerializerTestCase(HDATestCase):
         self.assertNullableBasestring(serialized["file_path"])
 
         # identities
-        self.assertEqual(serialized["model_class"], "HistoryDatasetAssociation")
-        self.assertEqual(serialized["history_content_type"], "dataset")
-        self.assertEqual(serialized["hda_ldda"], "hda")
-        self.assertEqual(serialized["accessible"], True)
-        self.assertEqual(serialized["api_type"], "file")
-        self.assertEqual(serialized["type"], "file")
+        assert serialized["model_class"] == "HistoryDatasetAssociation"
+        assert serialized["history_content_type"] == "dataset"
+        assert serialized["hda_ldda"] == "hda"
+        assert serialized["accessible"] is True
+        assert serialized["api_type"] == "file"
+        assert serialized["type"] == "file"
 
-        self.assertIsInstance(serialized["url"], str)
-        self.assertIsInstance(serialized["urls"], dict)
-        self.assertIsInstance(serialized["download_url"], str)
+        assert isinstance(serialized["url"], str)
+        assert isinstance(serialized["urls"], dict)
+        assert isinstance(serialized["download_url"], str)
 
         self.log("serialized should jsonify well")
         self.assertIsJsonifyable(serialized)
@@ -487,26 +485,26 @@ class HDASerializerTestCase(HDATestCase):
 
         self.log("file_name should be included if app configured to do so")
         # this is on by default in galaxy_mock
-        self.assertTrue(self.app.config.expose_dataset_path)
+        assert self.app.config.expose_dataset_path
         # ... so non-admin user CAN get file_name
         serialized = self.hda_serializer.serialize(hda, keys, user=None)
-        self.assertTrue("file_name" in serialized)
+        assert "file_name" in serialized
         serialized = self.hda_serializer.serialize(hda, keys, user=owner)
-        self.assertTrue("file_name" in serialized)
+        assert "file_name" in serialized
 
         self.log("file_name should be skipped for non-admin when not exposed by config")
         self.app.config.expose_dataset_path = False
         serialized = self.hda_serializer.serialize(hda, keys, user=None)
-        self.assertFalse("file_name" in serialized)
+        assert not ("file_name" in serialized)
         serialized = self.hda_serializer.serialize(hda, keys, user=owner)
-        self.assertFalse("file_name" in serialized)
+        assert not ("file_name" in serialized)
 
         self.log("file_name should be sent for admin in either case")
         serialized = self.hda_serializer.serialize(hda, keys, user=self.admin_user)
-        self.assertTrue("file_name" in serialized)
+        assert "file_name" in serialized
         self.app.config.expose_dataset_path = True
         serialized = self.hda_serializer.serialize(hda, keys, user=self.admin_user)
-        self.assertTrue("file_name" in serialized)
+        assert "file_name" in serialized
 
     def test_serializing_inaccessible(self):
         owner = self.user_manager.create(**user2_data)
@@ -522,7 +520,7 @@ class HDASerializerTestCase(HDATestCase):
         self.dataset_manager.permissions.set_private_to_one_user(dataset1, owner)
         # request random crap
         serialized = self.hda_serializer.serialize_to_view(item1, view="detailed", keys=["file_path"], user=non_owner)
-        self.assertEqual(sorted(keys_in_inaccessible_view), sorted(serialized.keys()))
+        assert sorted(keys_in_inaccessible_view) == sorted(serialized.keys())
 
     # TODO: test extra_files_path as well
 
@@ -537,17 +535,17 @@ class HDADeserializerTestCase(HDATestCase):
         hda = self._create_vanilla_hda()
 
         self.log("should raise when deserializing deleted from non-bool")
-        self.assertFalse(hda.deleted)
+        assert not hda.deleted
         self.assertRaises(
             exceptions.RequestParameterInvalidException, self.hda_deserializer.deserialize, hda, {"deleted": None}
         )
-        self.assertFalse(hda.deleted)
+        assert not hda.deleted
         self.log("should be able to deserialize deleted from True")
         self.hda_deserializer.deserialize(hda, {"deleted": True})
-        self.assertTrue(hda.deleted)
+        assert hda.deleted
         self.log("should be able to reverse by deserializing deleted from False")
         self.hda_deserializer.deserialize(hda, {"deleted": False})
-        self.assertFalse(hda.deleted)
+        assert not hda.deleted
 
     def test_deserialize_purge(self):
         hda = self._create_vanilla_hda()
@@ -556,38 +554,38 @@ class HDADeserializerTestCase(HDATestCase):
         self.assertRaises(
             exceptions.RequestParameterInvalidException, self.hda_deserializer.deserialize, hda, {"purged": None}
         )
-        self.assertFalse(hda.purged)
+        assert not hda.purged
         self.log("should be able to deserialize purged from True")
         self.hda_deserializer.deserialize(hda, {"purged": True})
-        self.assertTrue(hda.purged)
+        assert hda.purged
         # TODO: should this raise an error?
         self.log("should NOT be able to deserialize purged from False (will remain True)")
         self.hda_deserializer.deserialize(hda, {"purged": False})
-        self.assertTrue(hda.purged)
+        assert hda.purged
 
     def test_deserialize_visible(self):
         hda = self._create_vanilla_hda()
 
         self.log("should raise when deserializing from non-bool")
-        self.assertTrue(hda.visible)
+        assert hda.visible
         self.assertRaises(
             exceptions.RequestParameterInvalidException, self.hda_deserializer.deserialize, hda, {"visible": "None"}
         )
-        self.assertTrue(hda.visible)
+        assert hda.visible
         self.log("should be able to deserialize from False")
         self.hda_deserializer.deserialize(hda, {"visible": False})
-        self.assertFalse(hda.visible)
+        assert not hda.visible
         self.log("should be able to reverse by deserializing from True")
         self.hda_deserializer.deserialize(hda, {"visible": True})
-        self.assertTrue(hda.visible)
+        assert hda.visible
 
     def test_deserialize_genome_build(self):
         hda = self._create_vanilla_hda()
 
-        self.assertIsInstance(hda.dbkey, str)
+        assert isinstance(hda.dbkey, str)
         self.log('should deserialize to "?" from None')
         self.hda_deserializer.deserialize(hda, {"genome_build": None})
-        self.assertEqual(hda.dbkey, "?")
+        assert hda.dbkey == "?"
         self.log("should raise when deserializing from non-string")
         self.assertRaises(
             exceptions.RequestParameterInvalidException, self.hda_deserializer.deserialize, hda, {"genome_build": 12}
@@ -595,10 +593,10 @@ class HDADeserializerTestCase(HDATestCase):
         self.log("should be able to deserialize from unicode")
         date_palm = "نخيل التمر"
         self.hda_deserializer.deserialize(hda, {"genome_build": date_palm})
-        self.assertEqual(hda.dbkey, date_palm)
+        assert hda.dbkey == date_palm
         self.log("should be deserializable from empty string")
         self.hda_deserializer.deserialize(hda, {"genome_build": ""})
-        self.assertEqual(hda.dbkey, "")
+        assert hda.dbkey == ""
 
     def test_deserialize_name(self):
         hda = self._create_vanilla_hda()
@@ -613,14 +611,14 @@ class HDADeserializerTestCase(HDATestCase):
         )
         # self.log( 'should deserialize to empty string from None' )
         # self.hda_deserializer.deserialize( hda, { 'name': None } )
-        # self.assertEqual( hda.name, '' )
+        # assert hda.name == ""
         self.log("should be able to deserialize from unicode")
         olive = "ελιά"
         self.hda_deserializer.deserialize(hda, {"name": olive})
-        self.assertEqual(hda.name, olive)
+        assert hda.name == olive
         self.log("should be deserializable from empty string")
         self.hda_deserializer.deserialize(hda, {"name": ""})
-        self.assertEqual(hda.name, "")
+        assert hda.name == ""
 
     def test_deserialize_info(self):
         hda = self._create_vanilla_hda()
@@ -636,10 +634,10 @@ class HDADeserializerTestCase(HDATestCase):
         self.log("should be able to deserialize from unicode")
         rice = "飯"
         self.hda_deserializer.deserialize(hda, {"info": rice})
-        self.assertEqual(hda.info, rice)
+        assert hda.info == rice
         self.log("should be deserializable from empty string")
         self.hda_deserializer.deserialize(hda, {"info": ""})
-        self.assertEqual(hda.info, "")
+        assert hda.info == ""
 
 
 # =============================================================================

--- a/test/unit/app/managers/test_HDCAManager.py
+++ b/test/unit/app/managers/test_HDCAManager.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 from galaxy.managers import (
@@ -102,9 +101,3 @@ class HDCASerializerTestCase(HDCATestCase):
         self.log("should be able to use keys on their own")
         serialized = serializer.serialize_to_view(item, keys=only_keys)
         self.assertKeys(serialized, only_keys)
-
-
-# =============================================================================
-if __name__ == "__main__":
-    # or more generally, nosetests test_resourcemanagers.py -s -v
-    unittest.main()

--- a/test/unit/app/managers/test_HDCAManager.py
+++ b/test/unit/app/managers/test_HDCAManager.py
@@ -88,8 +88,6 @@ class HDCASerializerTestCase(HDCATestCase):
                 or (isinstance(instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS))
             ):
                 self.fail(f"no serializer for: {key} ({instantiated_attribute})")
-        else:
-            self.assertTrue(True, "all serializable keys have a serializer")
 
     def test_views_and_keys(self):
         serializer = self.hdca_serializer

--- a/test/unit/app/managers/test_HistoryContentsManager.py
+++ b/test/unit/app/managers/test_HistoryContentsManager.py
@@ -59,53 +59,53 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         history = self.history_manager.create(name="history", user=user2)
 
         self.log("calling contents on an empty history should return an empty list")
-        self.assertEqual([], list(self.contents_manager.contents(history)))
+        assert [] == list(self.contents_manager.contents(history))
 
         self.log("calling contents on an history with hdas should return those in order of their hids")
         hdas = [self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)]
         random.shuffle(hdas)
         ordered_hda_contents = list(self.contents_manager.contents(history))
-        self.assertEqual([hda.hid for hda in ordered_hda_contents], [1, 2, 3])
+        assert [hda.hid for hda in ordered_hda_contents] == [1, 2, 3]
 
         self.log("calling contents on an history with both hdas and collections should return both")
         hdca = self.add_list_collection_to_history(history, hdas)
         all_contents = list(self.contents_manager.contents(history))
-        self.assertEqual(all_contents, list(ordered_hda_contents) + [hdca])
+        assert all_contents == list(ordered_hda_contents) + [hdca]
 
     def test_contained(self):
         user2 = self.user_manager.create(**user2_data)
         history = self.history_manager.create(name="history", user=user2)
 
         self.log("calling contained on an empty history should return an empty list")
-        self.assertEqual([], list(self.contents_manager.contained(history)))
+        assert [] == list(self.contents_manager.contained(history))
 
         self.log("calling contained on an history with both hdas and collections should return only hdas")
         hdas = [self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)]
         self.add_list_collection_to_history(history, hdas)
-        self.assertEqual(list(self.contents_manager.contained(history)), hdas)
+        assert list(self.contents_manager.contained(history)) == hdas
 
     def test_copy_elements_on_collection_creation(self):
         user2 = self.user_manager.create(**user2_data)
         history = self.history_manager.create(name="history", user=user2)
         hdas = [self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)]
         hdca = self.add_list_collection_to_history(history, hdas)
-        self.assertEqual(hdas, hdca.dataset_instances)
+        assert hdas == hdca.dataset_instances
 
         hdca = self.add_list_collection_to_history(history, hdas, copy_elements=True)
-        self.assertNotEqual(hdas, hdca.dataset_instances)
+        assert hdas != hdca.dataset_instances
 
     def test_subcontainers(self):
         user2 = self.user_manager.create(**user2_data)
         history = self.history_manager.create(name="history", user=user2)
 
         self.log("calling subcontainers on an empty history should return an empty list")
-        self.assertEqual([], list(self.contents_manager.subcontainers(history)))
+        assert [] == list(self.contents_manager.subcontainers(history))
 
         self.log("calling subcontainers on an history with both hdas and collections should return only collections")
         hdas = [self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)]
         hdca = self.add_list_collection_to_history(history, hdas)
         subcontainers = list(self.contents_manager.subcontainers(history))
-        self.assertEqual(subcontainers, [hdca])
+        assert subcontainers == [hdca]
 
     def test_limit_and_offset(self):
         user2 = self.user_manager.create(**user2_data)
@@ -118,14 +118,14 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
 
         self.log("should be able to limit and offset")
         results = self.contents_manager.contents(history)
-        self.assertEqual(results, contents)
+        assert results == contents
 
-        self.assertEqual(self.contents_manager.contents(history, limit=4), contents[0:4])
-        self.assertEqual(self.contents_manager.contents(history, offset=3), contents[3:])
-        self.assertEqual(self.contents_manager.contents(history, limit=4, offset=4), contents[4:8])
+        assert self.contents_manager.contents(history, limit=4) == contents[0:4]
+        assert self.contents_manager.contents(history, offset=3) == contents[3:]
+        assert self.contents_manager.contents(history, limit=4, offset=4) == contents[4:8]
 
-        self.assertEqual(self.contents_manager.contents(history, limit=0), [])
-        self.assertEqual(self.contents_manager.contents(history, offset=len(contents)), [])
+        assert self.contents_manager.contents(history, limit=0) == []
+        assert self.contents_manager.contents(history, offset=len(contents)) == []
 
     def test_orm_filtering(self):
         parse_filter = self.history_contents_filters.parse_filter
@@ -146,17 +146,15 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
 
         # TODO: cross db compat?
         filters = [parse_filter("deleted", "eq", "True")]
-        self.assertEqual(self.contents_manager.contents(history, filters=filters), deleted)
+        assert self.contents_manager.contents(history, filters=filters) == deleted
 
         # even stranger that sqlalx can use the first model in the union (HDA) for columns across the union
         HDA = self.hda_manager.model_class
-        self.assertEqual(
-            self.contents_manager.contents(history, filters=[parsed_filter("orm", HDA.deleted == true())]), deleted
-        )
+        assert self.contents_manager.contents(history, filters=[parsed_filter("orm", HDA.deleted == true())]) == deleted
         filter_limited_contents = self.contents_manager.contents(
             history, filters=[parsed_filter("orm", HDA.deleted == true())], limit=2, offset=1
         )
-        self.assertEqual(filter_limited_contents, deleted[1:])
+        assert filter_limited_contents == deleted[1:]
 
         self.log("should allow filter on visible")
         contents[2].visible = False
@@ -166,25 +164,25 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         self.app.model.context.flush()
 
         filters = [parse_filter("visible", "eq", "False")]
-        self.assertEqual(self.contents_manager.contents(history, filters=filters), invisible)
-        self.assertEqual(
-            self.contents_manager.contents(history, filters=[parsed_filter("orm", HDA.visible == false())]), invisible
+        assert self.contents_manager.contents(history, filters=filters) == invisible
+        assert (
+            self.contents_manager.contents(history, filters=[parsed_filter("orm", HDA.visible == false())]) == invisible
         )
         filter_limited_contents = self.contents_manager.contents(
             history, filters=[parsed_filter("orm", HDA.visible == false())], limit=2, offset=1
         )
-        self.assertEqual(filter_limited_contents, invisible[1:])
+        assert filter_limited_contents == invisible[1:]
 
         self.log("should allow filtering more than one attribute")
         deleted_and_invisible = [contents[6]]
         filters = [parse_filter("deleted", "eq", "True"), parse_filter("visible", "eq", "False")]
-        self.assertEqual(self.contents_manager.contents(history, filters=filters), deleted_and_invisible)
-        self.assertEqual(
+        assert self.contents_manager.contents(history, filters=filters) == deleted_and_invisible
+        assert (
             self.contents_manager.contents(
                 history,
                 filters=[parsed_filter("orm", HDA.deleted == true()), parsed_filter("orm", HDA.visible == false())],
-            ),
-            deleted_and_invisible,
+            )
+            == deleted_and_invisible
         )
         offset_too_far = self.contents_manager.contents(
             history,
@@ -192,19 +190,19 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
             limit=2,
             offset=1,
         )
-        self.assertEqual(offset_too_far, [])
+        assert offset_too_far == []
 
         self.log("should allow filtering more than one attribute")
         deleted_and_invisible = [contents[6]]
         # note the two syntaxes both work
         filters = [parse_filter("deleted", "eq", "True"), parse_filter("visible", "eq", "False")]
-        self.assertEqual(self.contents_manager.contents(history, filters=filters), deleted_and_invisible)
-        self.assertEqual(
+        assert self.contents_manager.contents(history, filters=filters) == deleted_and_invisible
+        assert (
             self.contents_manager.contents(
                 history,
                 filters=[parsed_filter("orm", HDA.deleted == true()), parsed_filter("orm", HDA.visible == false())],
-            ),
-            deleted_and_invisible,
+            )
+            == deleted_and_invisible
         )
         offset_too_far = self.contents_manager.contents(
             history,
@@ -212,17 +210,16 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
             limit=2,
             offset=1,
         )
-        self.assertEqual(offset_too_far, [])
+        assert offset_too_far == []
 
         self.log("should allow filtering using like")
         # find 'hda-4'
-        self.assertEqual(
-            [contents[4]], self.contents_manager.contents(history, filters=[parsed_filter("orm", HDA.name.like("%-4"))])
+        assert [contents[4]] == self.contents_manager.contents(
+            history, filters=[parsed_filter("orm", HDA.name.like("%-4"))]
         )
         # the collections added above have the default name 'test collection'
-        self.assertEqual(
-            self.contents_manager.subcontainers(history),
-            self.contents_manager.contents(history, filters=[parsed_filter("orm", HDA.name.like("%collect%"))]),
+        assert self.contents_manager.subcontainers(history) == self.contents_manager.contents(
+            history, filters=[parsed_filter("orm", HDA.name.like("%collect%"))]
         )
 
     def test_order_by(self):
@@ -235,10 +232,10 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         contents.append(self.add_list_collection_to_history(history, contents[4:6]))
 
         self.log("should default to hid order_by")
-        self.assertEqual(self.contents_manager.contents(history), contents)
+        assert self.contents_manager.contents(history) == contents
 
         self.log("should allow asc, desc order_by")
-        self.assertEqual(self.contents_manager.contents(history, order_by=desc("hid")), contents[::-1])
+        assert self.contents_manager.contents(history, order_by=desc("hid")) == contents[::-1]
 
         def get_create_time(item):
             create_time = getattr(item, "create_time", None)
@@ -249,14 +246,14 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         self.log("should allow create_time order_by")
         newest_first = sorted(contents, key=get_create_time, reverse=True)
         results = self.contents_manager.contents(history, order_by=desc("create_time"))
-        self.assertEqual(newest_first, results)
+        assert newest_first == results
 
         self.log("should allow update_time order_by")
         # change the oldest created to update the update_time
         contents[0].name = "zany and/or wacky"
         self.app.model.context.flush()
         results = self.contents_manager.contents(history, order_by=desc("update_time"))
-        self.assertEqual(contents[0], results[0])
+        assert contents[0] == results[0]
 
     def test_update_time_filter(self):
         user2 = self.user_manager.create(**user2_data)
@@ -282,7 +279,7 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         results = self.contents_manager.contents(
             history, filters=[parsed_filter("orm", column("update_time") >= update_time)]
         )
-        self.assertEqual(results, [contents[3]])
+        assert results == [contents[3]]
 
     def test_filtered_counting(self):
         parse_filter = self.history_contents_filters.parse_filter
@@ -306,14 +303,12 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         self.app.model.context.flush()
 
         HDA = self.hda_manager.model_class
-        self.assertEqual(
-            self.contents_manager.contents_count(history, filters=[parsed_filter("orm", HDA.deleted == true())]), 3
-        )
+        assert self.contents_manager.contents_count(history, filters=[parsed_filter("orm", HDA.deleted == true())]) == 3
         filters = [parse_filter("visible", "eq", "False")]
-        self.assertEqual(self.contents_manager.contents_count(history, filters=filters), 3)
+        assert self.contents_manager.contents_count(history, filters=filters) == 3
 
         filters = [parse_filter("deleted", "eq", "True"), parse_filter("visible", "eq", "False")]
-        self.assertEqual(self.contents_manager.contents_count(history, filters=filters), 1)
+        assert self.contents_manager.contents_count(history, filters=filters) == 1
 
     def test_type_id(self):
         user2 = self.user_manager.create(**user2_data)
@@ -326,13 +321,13 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
 
         self.log("should be able to use eq and in with hybrid type_id")
         filters = [parsed_filter("orm", column("type_id") == "dataset-2")]
-        self.assertEqual(self.contents_manager.contents(history, filters=filters), [contents[1]])
+        assert self.contents_manager.contents(history, filters=filters) == [contents[1]]
         filters = [parsed_filter("orm", column("type_id").in_(["dataset-1", "dataset-3"]))]
-        self.assertEqual(self.contents_manager.contents(history, filters=filters), [contents[0], contents[2]])
+        assert self.contents_manager.contents(history, filters=filters) == [contents[0], contents[2]]
         filters = [parsed_filter("orm", column("type_id") == "dataset_collection-1")]
-        self.assertEqual(self.contents_manager.contents(history, filters=filters), [contents[3]])
+        assert self.contents_manager.contents(history, filters=filters) == [contents[3]]
         filters = [parsed_filter("orm", column("type_id").in_(["dataset-2", "dataset_collection-2"]))]
-        self.assertEqual(self.contents_manager.contents(history, filters=filters), [contents[1], contents[6]])
+        assert self.contents_manager.contents(history, filters=filters) == [contents[1], contents[6]]
 
 
 class HistoryContentsFilterParserTestCase(HistoryAsContainerBaseTestCase):
@@ -343,32 +338,31 @@ class HistoryContentsFilterParserTestCase(HistoryAsContainerBaseTestCase):
     def test_date_parser(self):
         # -- seconds and milliseconds from epoch
         self.log("should be able to parse epoch seconds")
-        self.assertEqual(
-            self.filter_parser.parse_date("1234567890"), datetime.datetime.fromtimestamp(1234567890).isoformat(sep=" ")
+        assert self.filter_parser.parse_date("1234567890") == datetime.datetime.fromtimestamp(1234567890).isoformat(
+            sep=" "
         )
 
         self.log("should be able to parse floating point epoch seconds.milliseconds")
-        self.assertEqual(
-            self.filter_parser.parse_date("1234567890.123"),
-            datetime.datetime.fromtimestamp(1234567890.123).isoformat(sep=" "),
-        )
+        assert self.filter_parser.parse_date("1234567890.123") == datetime.datetime.fromtimestamp(
+            1234567890.123
+        ).isoformat(sep=" ")
 
         self.log("should error if bad epoch is used")
         self.assertRaises(ValueError, self.filter_parser.parse_date, "0x000234")
 
         # -- datetime strings
         self.log("should allow date alone")
-        self.assertEqual(self.filter_parser.parse_date("2009-02-13"), "2009-02-13")
+        assert self.filter_parser.parse_date("2009-02-13") == "2009-02-13"
 
         self.log("should allow date and time")
-        self.assertEqual(self.filter_parser.parse_date("2009-02-13 18:13:00"), "2009-02-13 18:13:00")
-        self.assertEqual(self.filter_parser.parse_date("2009-02-13T18:13:00"), "2009-02-13 18:13:00")
-        self.assertEqual(self.filter_parser.parse_date("2009-02-13T18:13:00Z"), "2009-02-13 18:13:00")
+        assert self.filter_parser.parse_date("2009-02-13 18:13:00") == "2009-02-13 18:13:00"
+        assert self.filter_parser.parse_date("2009-02-13T18:13:00") == "2009-02-13 18:13:00"
+        assert self.filter_parser.parse_date("2009-02-13T18:13:00Z") == "2009-02-13 18:13:00"
 
         self.log("should allow date and time with milliseconds")
-        self.assertEqual(self.filter_parser.parse_date("2009-02-13 18:13:00.123"), "2009-02-13 18:13:00.123")
-        self.assertEqual(self.filter_parser.parse_date("2009-02-13T18:13:00.123"), "2009-02-13 18:13:00.123")
-        self.assertEqual(self.filter_parser.parse_date("2009-02-13T18:13:00.123Z"), "2009-02-13 18:13:00.123")
+        assert self.filter_parser.parse_date("2009-02-13 18:13:00.123") == "2009-02-13 18:13:00.123"
+        assert self.filter_parser.parse_date("2009-02-13T18:13:00.123") == "2009-02-13 18:13:00.123"
+        assert self.filter_parser.parse_date("2009-02-13T18:13:00.123Z") == "2009-02-13 18:13:00.123"
 
         self.log("should error if timezone is added")
         self.assertRaises(ValueError, self.filter_parser.parse_date, "2009-02-13T18:13:00.123+0700")

--- a/test/unit/app/managers/test_HistoryContentsManager.py
+++ b/test/unit/app/managers/test_HistoryContentsManager.py
@@ -347,7 +347,8 @@ class HistoryContentsFilterParserTestCase(HistoryAsContainerBaseTestCase):
         ).isoformat(sep=" ")
 
         self.log("should error if bad epoch is used")
-        self.assertRaises(ValueError, self.filter_parser.parse_date, "0x000234")
+        with self.assertRaises(ValueError):
+            self.filter_parser.parse_date("0x000234")
 
         # -- datetime strings
         self.log("should allow date alone")
@@ -364,11 +365,15 @@ class HistoryContentsFilterParserTestCase(HistoryAsContainerBaseTestCase):
         assert self.filter_parser.parse_date("2009-02-13T18:13:00.123Z") == "2009-02-13 18:13:00.123"
 
         self.log("should error if timezone is added")
-        self.assertRaises(ValueError, self.filter_parser.parse_date, "2009-02-13T18:13:00.123+0700")
+        with self.assertRaises(ValueError):
+            self.filter_parser.parse_date("2009-02-13T18:13:00.123+0700")
 
         self.log("should error if locale is used")
-        self.assertRaises(ValueError, self.filter_parser.parse_date, "Fri Feb 13 18:31:30 2009")
+        with self.assertRaises(ValueError):
+            self.filter_parser.parse_date("Fri Feb 13 18:31:30 2009")
 
         self.log("should error if wrong milliseconds format is used")
-        self.assertRaises(ValueError, self.filter_parser.parse_date, "2009-02-13 18:13:00.")
-        self.assertRaises(ValueError, self.filter_parser.parse_date, "2009-02-13 18:13:00.1234567")
+        with self.assertRaises(ValueError):
+            self.filter_parser.parse_date("2009-02-13 18:13:00.")
+        with self.assertRaises(ValueError):
+            self.filter_parser.parse_date("2009-02-13 18:13:00.1234567")

--- a/test/unit/app/managers/test_HistoryContentsManager.py
+++ b/test/unit/app/managers/test_HistoryContentsManager.py
@@ -2,7 +2,6 @@
 """
 import datetime
 import random
-import unittest
 
 from sqlalchemy import (
     column,
@@ -373,8 +372,3 @@ class HistoryContentsFilterParserTestCase(HistoryAsContainerBaseTestCase):
         self.log("should error if wrong milliseconds format is used")
         self.assertRaises(ValueError, self.filter_parser.parse_date, "2009-02-13 18:13:00.")
         self.assertRaises(ValueError, self.filter_parser.parse_date, "2009-02-13 18:13:00.1234567")
-
-
-if __name__ == "__main__":
-    # or more generally, nosetests test_resourcemanagers.py -s -v
-    unittest.main()

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -46,36 +46,34 @@ class HistoryManagerTestCase(BaseTestCase):
 
         self.log("should be able to create a new history")
         history1 = self.history_manager.create(name="history1", user=user2)
-        self.assertIsInstance(history1, model.History)
-        self.assertEqual(history1.name, "history1")
-        self.assertEqual(history1.user, user2)
-        self.assertEqual(history1, self.trans.sa_session.query(model.History).get(history1.id))
-        self.assertEqual(
-            history1, self.trans.sa_session.query(model.History).filter(model.History.name == "history1").one()
-        )
-        self.assertEqual(history1, self.trans.sa_session.query(model.History).filter(model.History.user == user2).one())
+        assert isinstance(history1, model.History)
+        assert history1.name == "history1"
+        assert history1.user == user2
+        assert history1 == self.trans.sa_session.query(model.History).get(history1.id)
+        assert history1 == self.trans.sa_session.query(model.History).filter(model.History.name == "history1").one()
+        assert history1 == self.trans.sa_session.query(model.History).filter(model.History.user == user2).one()
 
         history2 = self.history_manager.copy(history1, user=user3)
 
         self.log("should be able to query")
         histories = self.trans.sa_session.query(model.History).all()
-        self.assertEqual(self.history_manager.one(filters=(model.History.id == history1.id)), history1)
-        self.assertEqual(self.history_manager.list(), histories)
-        self.assertEqual(self.history_manager.by_id(history1.id), history1)
-        self.assertEqual(self.history_manager.by_ids([history2.id, history1.id]), [history2, history1])
+        assert self.history_manager.one(filters=(model.History.id == history1.id)) == history1
+        assert self.history_manager.list() == histories
+        assert self.history_manager.by_id(history1.id) == history1
+        assert self.history_manager.by_ids([history2.id, history1.id]) == [history2, history1]
 
         self.log("should be able to limit and offset")
-        self.assertEqual(self.history_manager.list(limit=1), histories[0:1])
-        self.assertEqual(self.history_manager.list(offset=1), histories[1:])
-        self.assertEqual(self.history_manager.list(limit=1, offset=1), histories[1:2])
+        assert self.history_manager.list(limit=1) == histories[0:1]
+        assert self.history_manager.list(offset=1) == histories[1:]
+        assert self.history_manager.list(limit=1, offset=1) == histories[1:2]
 
-        self.assertEqual(self.history_manager.list(limit=0), [])
-        self.assertEqual(self.history_manager.list(offset=3), [])
+        assert self.history_manager.list(limit=0) == []
+        assert self.history_manager.list(offset=3) == []
 
         self.log("should be able to order")
         history3 = self.history_manager.create(name="history3", user=user2)
         name_first_then_time = (model.History.name, sqlalchemy.desc(model.History.create_time))
-        self.assertEqual(self.history_manager.list(order_by=name_first_then_time), [history2, history1, history3])
+        assert self.history_manager.list(order_by=name_first_then_time) == [history2, history1, history3]
 
     def test_copy(self):
         user2 = self.user_manager.create(**user2_data)
@@ -95,17 +93,17 @@ class HistoryManagerTestCase(BaseTestCase):
         self.hda_manager.annotate(hda, hda_annotation, user=user2)
 
         history2 = self.history_manager.copy(history1, user=user3)
-        self.assertIsInstance(history2, model.History)
-        self.assertEqual(history2.user, user3)
-        self.assertEqual(history2, self.trans.sa_session.query(model.History).get(history2.id))
-        self.assertEqual(history2.name, history1.name)
-        self.assertNotEqual(history2, history1)
+        assert isinstance(history2, model.History)
+        assert history2.user == user3
+        assert history2 == self.trans.sa_session.query(model.History).get(history2.id)
+        assert history2.name == history1.name
+        assert history2 != history1
 
         copied_hda = history2.datasets[0]
         copied_hda_tags = self.hda_manager.get_tags(copied_hda)
-        self.assertEqual(sorted(hda_tags), sorted(copied_hda_tags))
+        assert sorted(hda_tags) == sorted(copied_hda_tags)
         copied_hda_annotation = self.hda_manager.annotation(copied_hda)
-        self.assertEqual(hda_annotation, copied_hda_annotation)
+        assert hda_annotation == copied_hda_annotation
 
     def test_has_user(self):
         owner = self.user_manager.create(**user2_data)
@@ -117,7 +115,7 @@ class HistoryManagerTestCase(BaseTestCase):
 
         self.log("should be able to list items by user")
         user_histories = self.history_manager.by_user(owner)
-        self.assertEqual(user_histories, [item1, item2])
+        assert user_histories == [item1, item2]
 
     def test_ownable(self):
         owner = self.user_manager.create(**user2_data)
@@ -126,21 +124,21 @@ class HistoryManagerTestCase(BaseTestCase):
         item1 = self.history_manager.create(user=owner)
 
         self.log("should be able to poll whether a given user owns an item")
-        self.assertTrue(self.history_manager.is_owner(item1, owner))
-        self.assertFalse(self.history_manager.is_owner(item1, non_owner))
+        assert self.history_manager.is_owner(item1, owner)
+        assert not self.history_manager.is_owner(item1, non_owner)
 
         self.log("should raise an error when checking ownership with non-owner")
         self.assertRaises(exceptions.ItemOwnershipException, self.history_manager.error_unless_owner, item1, non_owner)
         self.assertRaises(exceptions.ItemOwnershipException, self.history_manager.get_owned, item1.id, non_owner)
 
         self.log("should not raise an error when checking ownership with owner")
-        self.assertEqual(self.history_manager.error_unless_owner(item1, owner), item1)
-        self.assertEqual(self.history_manager.get_owned(item1.id, owner), item1)
+        assert self.history_manager.error_unless_owner(item1, owner) == item1
+        assert self.history_manager.get_owned(item1.id, owner) == item1
 
         self.log("should not raise an error when checking ownership with admin")
-        self.assertTrue(self.history_manager.is_owner(item1, self.admin_user))
-        self.assertEqual(self.history_manager.error_unless_owner(item1, self.admin_user), item1)
-        self.assertEqual(self.history_manager.get_owned(item1.id, self.admin_user), item1)
+        assert self.history_manager.is_owner(item1, self.admin_user)
+        assert self.history_manager.error_unless_owner(item1, self.admin_user) == item1
+        assert self.history_manager.get_owned(item1.id, self.admin_user) == item1
 
     def test_accessible(self):
         owner = self.user_manager.create(**user2_data)
@@ -149,9 +147,9 @@ class HistoryManagerTestCase(BaseTestCase):
         non_owner = self.user_manager.create(**user3_data)
 
         self.log("should be inaccessible by default except to owner")
-        self.assertTrue(self.history_manager.is_accessible(item1, owner))
-        self.assertTrue(self.history_manager.is_accessible(item1, self.admin_user))
-        self.assertFalse(self.history_manager.is_accessible(item1, non_owner))
+        assert self.history_manager.is_accessible(item1, owner)
+        assert self.history_manager.is_accessible(item1, self.admin_user)
+        assert not self.history_manager.is_accessible(item1, non_owner)
 
         self.log("should raise an error when checking accessibility with non-owner")
         self.assertRaises(
@@ -162,13 +160,13 @@ class HistoryManagerTestCase(BaseTestCase):
         )
 
         self.log("should not raise an error when checking ownership with owner")
-        self.assertEqual(self.history_manager.error_unless_accessible(item1, owner), item1)
-        self.assertEqual(self.history_manager.get_accessible(item1.id, owner), item1)
+        assert self.history_manager.error_unless_accessible(item1, owner) == item1
+        assert self.history_manager.get_accessible(item1.id, owner) == item1
 
         self.log("should not raise an error when checking ownership with admin")
-        self.assertTrue(self.history_manager.is_accessible(item1, self.admin_user))
-        self.assertEqual(self.history_manager.error_unless_accessible(item1, self.admin_user), item1)
-        self.assertEqual(self.history_manager.get_accessible(item1.id, self.admin_user), item1)
+        assert self.history_manager.is_accessible(item1, self.admin_user)
+        assert self.history_manager.error_unless_accessible(item1, self.admin_user) == item1
+        assert self.history_manager.get_accessible(item1.id, self.admin_user) == item1
 
     def test_importable(self):
         owner = self.user_manager.create(**user2_data)
@@ -178,27 +176,27 @@ class HistoryManagerTestCase(BaseTestCase):
         item1 = self.history_manager.create(user=owner)
 
         self.log("should not be importable by default")
-        self.assertFalse(item1.importable)
-        self.assertIsNone(item1.slug)
+        assert not item1.importable
+        assert item1.slug is None
 
         self.log("should be able to make importable (accessible by link) to all users")
         accessible = self.history_manager.make_importable(item1)
-        self.assertEqual(accessible, item1)
-        self.assertIsNotNone(accessible.slug)
-        self.assertTrue(accessible.importable)
+        assert accessible == item1
+        assert accessible.slug is not None
+        assert accessible.importable
 
         for user in self.user_manager.list():
-            self.assertTrue(self.history_manager.is_accessible(accessible, user))
+            assert self.history_manager.is_accessible(accessible, user)
 
         self.log("should be able to make non-importable/inaccessible again")
         inaccessible = self.history_manager.make_non_importable(accessible)
-        self.assertEqual(inaccessible, accessible)
-        self.assertIsNotNone(inaccessible.slug)
-        self.assertFalse(inaccessible.importable)
+        assert inaccessible == accessible
+        assert inaccessible.slug is not None
+        assert not inaccessible.importable
 
-        self.assertTrue(self.history_manager.is_accessible(inaccessible, owner))
-        self.assertFalse(self.history_manager.is_accessible(inaccessible, non_owner))
-        self.assertTrue(self.history_manager.is_accessible(inaccessible, self.admin_user))
+        assert self.history_manager.is_accessible(inaccessible, owner)
+        assert not self.history_manager.is_accessible(inaccessible, non_owner)
+        assert self.history_manager.is_accessible(inaccessible, self.admin_user)
 
     def test_published(self):
         owner = self.user_manager.create(**user2_data)
@@ -208,34 +206,34 @@ class HistoryManagerTestCase(BaseTestCase):
         item1 = self.history_manager.create(user=owner)
 
         self.log("should not be published by default")
-        self.assertFalse(item1.published)
-        self.assertIsNone(item1.slug)
+        assert not item1.published
+        assert item1.slug is None
 
         self.log("should be able to publish (listed publicly) to all users")
         published = self.history_manager.publish(item1)
-        self.assertEqual(published, item1)
-        self.assertTrue(published.published)
+        assert published == item1
+        assert published.published
         # note: publishing sets importable to true as well
-        self.assertTrue(published.importable)
-        self.assertIsNotNone(published.slug)
+        assert published.importable
+        assert published.slug is not None
 
         for user in self.user_manager.list():
-            self.assertTrue(self.history_manager.is_accessible(published, user))
+            assert self.history_manager.is_accessible(published, user)
 
         self.log("should be able to make non-importable/inaccessible again")
         unpublished = self.history_manager.unpublish(published)
-        self.assertEqual(unpublished, published)
-        self.assertFalse(unpublished.published)
+        assert unpublished == published
+        assert not unpublished.published
         # note: unpublishing does not make non-importable, you must explicitly do that separately
-        self.assertTrue(published.importable)
+        assert published.importable
         self.history_manager.make_non_importable(unpublished)
-        self.assertFalse(published.importable)
+        assert not published.importable
         # note: slug still remains after unpublishing
-        self.assertIsNotNone(unpublished.slug)
+        assert unpublished.slug is not None
 
-        self.assertTrue(self.history_manager.is_accessible(unpublished, owner))
-        self.assertFalse(self.history_manager.is_accessible(unpublished, non_owner))
-        self.assertTrue(self.history_manager.is_accessible(unpublished, self.admin_user))
+        assert self.history_manager.is_accessible(unpublished, owner)
+        assert not self.history_manager.is_accessible(unpublished, non_owner)
+        assert self.history_manager.is_accessible(unpublished, self.admin_user)
 
     def test_sharable(self):
         owner = self.user_manager.create(**user2_data)
@@ -246,23 +244,23 @@ class HistoryManagerTestCase(BaseTestCase):
         # third_party = self.user_manager.create( **user4_data )
 
         self.log("should be unshared by default")
-        self.assertEqual(self.history_manager.get_share_assocs(item1), [])
-        self.assertEqual(item1.slug, None)
+        assert self.history_manager.get_share_assocs(item1) == []
+        assert item1.slug is None
 
         self.log("should be able to share with specific users")
         share_assoc = self.history_manager.share_with(item1, non_owner)
-        self.assertIsInstance(share_assoc, model.HistoryUserShareAssociation)
-        self.assertTrue(self.history_manager.is_accessible(item1, non_owner))
-        self.assertEqual(len(self.history_manager.get_share_assocs(item1)), 1)
-        self.assertEqual(len(self.history_manager.get_share_assocs(item1, user=non_owner)), 1)
-        self.assertIsInstance(item1.slug, str)
+        assert isinstance(share_assoc, model.HistoryUserShareAssociation)
+        assert self.history_manager.is_accessible(item1, non_owner)
+        assert len(self.history_manager.get_share_assocs(item1)) == 1
+        assert len(self.history_manager.get_share_assocs(item1, user=non_owner)) == 1
+        assert isinstance(item1.slug, str)
 
         self.log("should be able to unshare with specific users")
         share_assoc = self.history_manager.unshare_with(item1, non_owner)
-        self.assertIsInstance(share_assoc, model.HistoryUserShareAssociation)
-        self.assertFalse(self.history_manager.is_accessible(item1, non_owner))
-        self.assertEqual(self.history_manager.get_share_assocs(item1), [])
-        self.assertEqual(self.history_manager.get_share_assocs(item1, user=non_owner), [])
+        assert isinstance(share_assoc, model.HistoryUserShareAssociation)
+        assert not self.history_manager.is_accessible(item1, non_owner)
+        assert self.history_manager.get_share_assocs(item1) == []
+        assert self.history_manager.get_share_assocs(item1, user=non_owner) == []
 
     # TODO: test slug formation
 
@@ -273,36 +271,26 @@ class HistoryManagerTestCase(BaseTestCase):
         self.log("should not allow access and owner for anon user on a history by another anon user (None)")
         anon_history1 = self.history_manager.create(user=None)
         # do not set the trans.history!
-        self.assertFalse(self.history_manager.is_owner(anon_history1, anon_user, current_history=self.trans.history))
-        self.assertFalse(
-            self.history_manager.is_accessible(anon_history1, anon_user, current_history=self.trans.history)
-        )
+        assert not self.history_manager.is_owner(anon_history1, anon_user, current_history=self.trans.history)
+        assert not self.history_manager.is_accessible(anon_history1, anon_user, current_history=self.trans.history)
 
         self.log("should allow access and owner for anon user on a history if it's the session's current history")
         anon_history2 = self.history_manager.create(user=anon_user)
         self.trans.set_history(anon_history2)
-        self.assertTrue(self.history_manager.is_owner(anon_history2, anon_user, current_history=self.trans.history))
-        self.assertTrue(
-            self.history_manager.is_accessible(anon_history2, anon_user, current_history=self.trans.history)
-        )
+        assert self.history_manager.is_owner(anon_history2, anon_user, current_history=self.trans.history)
+        assert self.history_manager.is_accessible(anon_history2, anon_user, current_history=self.trans.history)
 
         self.log("should not allow owner or access for anon user on someone elses history")
         owner = self.user_manager.create(**user2_data)
         someone_elses = self.history_manager.create(user=owner)
-        self.assertFalse(self.history_manager.is_owner(someone_elses, anon_user, current_history=self.trans.history))
-        self.assertFalse(
-            self.history_manager.is_accessible(someone_elses, anon_user, current_history=self.trans.history)
-        )
+        assert not self.history_manager.is_owner(someone_elses, anon_user, current_history=self.trans.history)
+        assert not self.history_manager.is_accessible(someone_elses, anon_user, current_history=self.trans.history)
 
         self.log("should allow access for anon user if the history is published or importable")
         self.history_manager.make_importable(someone_elses)
-        self.assertTrue(
-            self.history_manager.is_accessible(someone_elses, anon_user, current_history=self.trans.history)
-        )
+        assert self.history_manager.is_accessible(someone_elses, anon_user, current_history=self.trans.history)
         self.history_manager.publish(someone_elses)
-        self.assertTrue(
-            self.history_manager.is_accessible(someone_elses, anon_user, current_history=self.trans.history)
-        )
+        assert self.history_manager.is_accessible(someone_elses, anon_user, current_history=self.trans.history)
 
     def test_delete_and_purge(self):
         user2 = self.user_manager.create(**user2_data)
@@ -312,19 +300,19 @@ class HistoryManagerTestCase(BaseTestCase):
         self.trans.set_history(history1)
 
         self.log("should allow deletion and undeletion")
-        self.assertFalse(history1.deleted)
+        assert not history1.deleted
 
         self.history_manager.delete(history1)
-        self.assertTrue(history1.deleted)
+        assert history1.deleted
 
         self.history_manager.undelete(history1)
-        self.assertFalse(history1.deleted)
+        assert not history1.deleted
 
         self.log("should allow purging")
         history2 = self.history_manager.create(name="history2", user=user2)
         self.history_manager.purge(history2)
-        self.assertTrue(history2.deleted)
-        self.assertTrue(history2.purged)
+        assert history2.deleted
+        assert history2.purged
 
     def test_current(self):
         user2 = self.user_manager.create(**user2_data)
@@ -335,11 +323,11 @@ class HistoryManagerTestCase(BaseTestCase):
         history2 = self.history_manager.create(name="history2", user=user2)
 
         self.log("should be able to set or get the current history for a user")
-        self.assertEqual(self.history_manager.get_current(self.trans), history1)
-        self.assertEqual(self.history_manager.set_current(self.trans, history2), history2)
-        self.assertEqual(self.history_manager.get_current(self.trans), history2)
-        self.assertEqual(self.history_manager.set_current_by_id(self.trans, history1.id), history1)
-        self.assertEqual(self.history_manager.get_current(self.trans), history1)
+        assert self.history_manager.get_current(self.trans) == history1
+        assert self.history_manager.set_current(self.trans, history2) == history2
+        assert self.history_manager.get_current(self.trans) == history2
+        assert self.history_manager.set_current_by_id(self.trans, history1.id) == history1
+        assert self.history_manager.get_current(self.trans) == history1
 
     def test_most_recently_used(self):
         user2 = self.user_manager.create(**user2_data)
@@ -350,9 +338,9 @@ class HistoryManagerTestCase(BaseTestCase):
         history2 = self.history_manager.create(name="history2", user=user2)
 
         self.log("should be able to get the most recently used (updated) history for a given user")
-        self.assertEqual(self.history_manager.most_recent(user2), history2)
+        assert self.history_manager.most_recent(user2) == history2
         self.history_manager.update(history1, {"name": "new name"})
-        self.assertEqual(self.history_manager.most_recent(user2), history1)
+        assert self.history_manager.most_recent(user2) == history1
 
     def test_rating(self):
         user2 = self.user_manager.create(**user2_data)
@@ -360,33 +348,33 @@ class HistoryManagerTestCase(BaseTestCase):
         item = manager.create(name="history1", user=user2)
 
         self.log("should properly handle no ratings")
-        self.assertEqual(manager.rating(item, user2), None)
-        self.assertEqual(manager.ratings(item), [])
-        self.assertEqual(manager.ratings_avg(item), 0)
-        self.assertEqual(manager.ratings_count(item), 0)
+        assert manager.rating(item, user2) is None
+        assert manager.ratings(item) == []
+        assert manager.ratings_avg(item) == 0
+        assert manager.ratings_count(item) == 0
 
         self.log("should allow rating by user")
         manager.rate(item, user2, 5)
-        self.assertEqual(manager.rating(item, user2), 5)
-        self.assertEqual(manager.ratings(item), [5])
-        self.assertEqual(manager.ratings_avg(item), 5)
-        self.assertEqual(manager.ratings_count(item), 1)
+        assert manager.rating(item, user2) == 5
+        assert manager.ratings(item) == [5]
+        assert manager.ratings_avg(item) == 5
+        assert manager.ratings_count(item) == 1
 
         self.log("should allow updating")
         manager.rate(item, user2, 4)
-        self.assertEqual(manager.rating(item, user2), 4)
-        self.assertEqual(manager.ratings(item), [4])
-        self.assertEqual(manager.ratings_avg(item), 4)
-        self.assertEqual(manager.ratings_count(item), 1)
+        assert manager.rating(item, user2) == 4
+        assert manager.ratings(item) == [4]
+        assert manager.ratings_avg(item) == 4
+        assert manager.ratings_count(item) == 1
 
         self.log("should reflect multiple reviews")
         user3 = self.user_manager.create(**user3_data)
-        self.assertEqual(manager.rating(item, user3), None)
+        assert manager.rating(item, user3) is None
         manager.rate(item, user3, 1)
-        self.assertEqual(manager.rating(item, user3), 1)
-        self.assertEqual(manager.ratings(item), [4, 1])
-        self.assertEqual(manager.ratings_avg(item), 2.5)
-        self.assertEqual(manager.ratings_count(item), 2)
+        assert manager.rating(item, user3) == 1
+        assert manager.ratings(item) == [4, 1]
+        assert manager.ratings_avg(item) == 2.5
+        assert manager.ratings_count(item) == 2
 
 
 # =============================================================================
@@ -428,8 +416,6 @@ class HistorySerializerTestCase(BaseTestCase):
                 or (isinstance(instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS))
             ):
                 self.fail(f"no serializer for: {key} ({instantiated_attribute})")
-        else:
-            self.assertTrue(True, "all serializable keys have a serializer")
 
     def test_views_and_keys(self):
         user2 = self.user_manager.create(**user2_data)
@@ -457,12 +443,12 @@ class HistorySerializerTestCase(BaseTestCase):
         self.history_manager.share_with(history1, non_owner)
         serialized = self.history_serializer.serialize(history1, ["users_shared_with"], user=user2)
         self.assertKeys(serialized, ["users_shared_with"])
-        self.assertIsInstance(serialized["users_shared_with"], list)
-        self.assertEqual(serialized["users_shared_with"][0], self.app.security.encode_id(non_owner.id))
+        assert isinstance(serialized["users_shared_with"], list)
+        assert serialized["users_shared_with"][0] == self.app.security.encode_id(non_owner.id)
 
         self.log("should not return users_shared_with if the requester is not the owner")
         serialized = self.history_serializer.serialize(history1, ["users_shared_with"], user=non_owner)
-        self.assertFalse(hasattr(serialized, "users_shared_with"))
+        assert not hasattr(serialized, "users_shared_with")
 
     def test_purgable(self):
         user2 = self.user_manager.create(**user2_data)
@@ -471,19 +457,19 @@ class HistorySerializerTestCase(BaseTestCase):
         self.log("deleted and purged should be returned in their default states")
         keys = ["deleted", "purged"]
         serialized = self.history_serializer.serialize(history1, keys)
-        self.assertEqual(serialized["deleted"], False)
-        self.assertEqual(serialized["purged"], False)
+        assert serialized["deleted"] is False
+        assert serialized["purged"] is False
 
         self.log("deleted and purged should return their current state")
         self.history_manager.delete(history1)
         serialized = self.history_serializer.serialize(history1, keys)
-        self.assertEqual(serialized["deleted"], True)
-        self.assertEqual(serialized["purged"], False)
+        assert serialized["deleted"] is True
+        assert serialized["purged"] is False
 
         self.history_manager.purge(history1)
         serialized = self.history_serializer.serialize(history1, keys)
-        self.assertEqual(serialized["deleted"], True)
-        self.assertEqual(serialized["purged"], True)
+        assert serialized["deleted"] is True
+        assert serialized["purged"] is True
 
     def test_history_serializers(self):
         user2 = self.user_manager.create(**user2_data)
@@ -492,8 +478,8 @@ class HistorySerializerTestCase(BaseTestCase):
         serialized = self.history_serializer.serialize(history1, all_keys, user=user2)
 
         self.log("everything serialized should be of the proper type")
-        self.assertIsInstance(serialized["size"], int)
-        self.assertIsInstance(serialized["nice_size"], str)
+        assert isinstance(serialized["size"], int)
+        assert isinstance(serialized["nice_size"], str)
 
         self.log("serialized should jsonify well")
         self.assertIsJsonifyable(serialized)
@@ -531,44 +517,35 @@ class HistorySerializerTestCase(BaseTestCase):
         ready_states = [(state, False) for state in [dataset_states.OK, dataset_states.OK]]
 
         self.log("a history's serialized state should be running if any of its datasets are running")
-        self.assertEqual(
-            "running",
-            self._history_state_from_states_and_deleted(user2, ready_states + [(dataset_states.RUNNING, False)]),
+        assert "running" == self._history_state_from_states_and_deleted(
+            user2, ready_states + [(dataset_states.RUNNING, False)]
         )
-        self.assertEqual(
-            "running",
-            self._history_state_from_states_and_deleted(
-                user2, ready_states + [(dataset_states.SETTING_METADATA, False)]
-            ),
+        assert "running" == self._history_state_from_states_and_deleted(
+            user2, ready_states + [(dataset_states.SETTING_METADATA, False)]
         )
-        self.assertEqual(
-            "running",
-            self._history_state_from_states_and_deleted(user2, ready_states + [(dataset_states.UPLOAD, False)]),
+        assert "running" == self._history_state_from_states_and_deleted(
+            user2, ready_states + [(dataset_states.UPLOAD, False)]
         )
 
         self.log("a history's serialized state should be queued if any of its datasets are queued")
-        self.assertEqual(
-            "queued",
-            self._history_state_from_states_and_deleted(user2, ready_states + [(dataset_states.QUEUED, False)]),
+        assert "queued" == self._history_state_from_states_and_deleted(
+            user2, ready_states + [(dataset_states.QUEUED, False)]
         )
 
         self.log("a history's serialized state should be error if any of its datasets are errored")
-        self.assertEqual(
-            "error", self._history_state_from_states_and_deleted(user2, ready_states + [(dataset_states.ERROR, False)])
+        assert "error" == self._history_state_from_states_and_deleted(
+            user2, ready_states + [(dataset_states.ERROR, False)]
         )
-        self.assertEqual(
-            "error",
-            self._history_state_from_states_and_deleted(
-                user2, ready_states + [(dataset_states.FAILED_METADATA, False)]
-            ),
+        assert "error" == self._history_state_from_states_and_deleted(
+            user2, ready_states + [(dataset_states.FAILED_METADATA, False)]
         )
 
         self.log("a history's serialized state should be ok if *all* of its datasets are ok")
-        self.assertEqual("ok", self._history_state_from_states_and_deleted(user2, ready_states))
+        assert "ok" == self._history_state_from_states_and_deleted(user2, ready_states)
 
         self.log("a history's serialized state should be not be affected by deleted datasets")
-        self.assertEqual(
-            "ok", self._history_state_from_states_and_deleted(user2, ready_states + [(dataset_states.RUNNING, True)])
+        assert "ok" == self._history_state_from_states_and_deleted(
+            user2, ready_states + [(dataset_states.RUNNING, True)]
         )
 
     def test_contents(self):
@@ -578,25 +555,25 @@ class HistorySerializerTestCase(BaseTestCase):
         self.log("a history with no contents should be properly reflected in empty, etc.")
         keys = ["empty", "count", "state_ids", "state_details", "state", "hdas"]
         serialized = self.history_serializer.serialize(history1, keys)
-        self.assertEqual(serialized["state"], "new")
-        self.assertEqual(serialized["empty"], True)
-        self.assertEqual(serialized["count"], 0)
-        self.assertEqual(sum(serialized["state_details"].values()), 0)
-        self.assertEqual(serialized["state_ids"]["ok"], [])
-        self.assertIsInstance(serialized["hdas"], list)
+        assert serialized["state"] == "new"
+        assert serialized["empty"] is True
+        assert serialized["count"] == 0
+        assert sum(serialized["state_details"].values()) == 0
+        assert serialized["state_ids"]["ok"] == []
+        assert isinstance(serialized["hdas"], list)
 
         self.log("a history with contents should be properly reflected in empty, etc.")
         hda1 = self.hda_manager.create(history=history1)
         self.hda_manager.update(hda1, dict(state="ok"))
 
         serialized = self.history_serializer.serialize(history1, keys)
-        self.assertEqual(serialized["state"], "ok")
-        self.assertEqual(serialized["empty"], False)
-        self.assertEqual(serialized["count"], 1)
-        self.assertEqual(serialized["state_details"]["ok"], 1)
-        self.assertIsInstance(serialized["state_ids"]["ok"], list)
-        self.assertIsInstance(serialized["hdas"], list)
-        self.assertIsInstance(serialized["hdas"][0], str)
+        assert serialized["state"] == "ok"
+        assert serialized["empty"] is False
+        assert serialized["count"] == 1
+        assert serialized["state_details"]["ok"] == 1
+        assert isinstance(serialized["state_ids"]["ok"], list)
+        assert isinstance(serialized["hdas"], list)
+        assert isinstance(serialized["hdas"][0], str)
 
         serialized = self.history_serializer.serialize(history1, ["contents"])
         self.assertHasKeys(serialized["contents"][0], ["id", "name", "state", "create_time"])
@@ -613,17 +590,17 @@ class HistorySerializerTestCase(BaseTestCase):
 
         self.log("serialization should reflect no ratings")
         serialized = serializer.serialize(item, ["user_rating", "community_rating"], user=user2)
-        self.assertEqual(serialized["user_rating"], None)
-        self.assertEqual(serialized["community_rating"]["count"], 0)
-        self.assertEqual(serialized["community_rating"]["average"], 0.0)
+        assert serialized["user_rating"] is None
+        assert serialized["community_rating"]["count"] == 0
+        assert serialized["community_rating"]["average"] == 0.0
 
         self.log("serialization should reflect ratings")
         manager.rate(item, user2, 1)
         manager.rate(item, user3, 4)
         serialized = serializer.serialize(item, ["user_rating", "community_rating"], user=user2)
-        self.assertEqual(serialized["user_rating"], 1)
-        self.assertEqual(serialized["community_rating"]["count"], 2)
-        self.assertEqual(serialized["community_rating"]["average"], 2.5)
+        assert serialized["user_rating"] == 1
+        assert serialized["community_rating"]["count"] == 2
+        assert serialized["community_rating"]["average"] == 2.5
         self.assertIsJsonifyable(serialized)
 
         self.log("serialization of user_rating without user should error")
@@ -645,14 +622,14 @@ class HistoryDeserializerTestCase(BaseTestCase):
 
         self.log("deserialization should allow ratings change")
         deserializer.deserialize(item, {"user_rating": 4}, user=user2)
-        self.assertEqual(manager.rating(item, user2), 4)
-        self.assertEqual(manager.ratings(item), [4])
-        self.assertEqual(manager.ratings_avg(item), 4)
-        self.assertEqual(manager.ratings_count(item), 1)
+        assert manager.rating(item, user2) == 4
+        assert manager.ratings(item) == [4]
+        assert manager.ratings_avg(item) == 4
+        assert manager.ratings_count(item) == 1
 
         self.log("deserialization should fail silently on community_rating")
         deserializer.deserialize(item, {"community_rating": 4}, user=user2)
-        self.assertEqual(manager.ratings_count(item), 1)
+        assert manager.ratings_count(item) == 1
 
     def test_sharable(self):
         manager = self.history_manager
@@ -666,19 +643,19 @@ class HistoryDeserializerTestCase(BaseTestCase):
         non_owner_id = self.app.security.encode_id(non_owner.id)
         deserializer.deserialize(item, {"users_shared_with": [non_owner_id]}, user=user2)
         user_shares = manager.get_share_assocs(item)
-        self.assertEqual(len(user_shares), 1)
-        self.assertEqual(user_shares[0].user_id, non_owner.id)
+        assert len(user_shares) == 1
+        assert user_shares[0].user_id == non_owner.id
 
         self.log("re-adding an existing user id should do nothing")
         deserializer.deserialize(item, {"users_shared_with": [non_owner_id, non_owner_id]}, user=user2)
         user_shares = manager.get_share_assocs(item)
-        self.assertEqual(len(user_shares), 1)
-        self.assertEqual(user_shares[0].user_id, non_owner.id)
+        assert len(user_shares) == 1
+        assert user_shares[0].user_id == non_owner.id
 
         self.log("should allow removing a share by not having it in users_shared_with")
         deserializer.deserialize(item, {"users_shared_with": []}, user=user2)
         user_shares = manager.get_share_assocs(item)
-        self.assertEqual(len(user_shares), 0)
+        assert len(user_shares) == 0
 
         self.log("adding a bad user id should error")
         self.assertRaises(
@@ -689,7 +666,7 @@ class HistoryDeserializerTestCase(BaseTestCase):
         non_user_id = self.app.security.encode_id(99)
         deserializer.deserialize(item, {"users_shared_with": [non_user_id]}, user=user2)
         user_shares = manager.get_share_assocs(item)
-        self.assertEqual(len(user_shares), 0)
+        assert len(user_shares) == 0
 
 
 # =============================================================================
@@ -705,10 +682,10 @@ class HistoryFiltersTestCase(BaseTestCase):
             [("name", "eq", "wot"), ("deleted", "eq", "True"), ("annotation", "has", "hrrmm")]
         )
         self.log("both orm and fn filters should be parsed and returned")
-        self.assertEqual(len(filters), 3)
+        assert len(filters) == 3
 
         self.log("values should be parsed")
-        self.assertIsInstance(filters[1].filter.right, sqlalchemy.sql.elements.True_)
+        assert isinstance(filters[1].filter.right, sqlalchemy.sql.elements.True_)
 
     def test_parse_filters_invalid_filters(self):
         self.log("should error on non-column attr")
@@ -764,21 +741,21 @@ class HistoryFiltersTestCase(BaseTestCase):
             ]
         )
         histories = self.history_manager.list(filters=filters)
-        self.assertEqual(histories, [history1, history2, history3])
+        assert histories == [history1, history2, history3]
 
         filters = self.filter_parser.parse_filters(
             [
                 ("name", "like", "%2"),
             ]
         )
-        self.assertEqual(self.history_manager.list(filters=filters), [history2])
+        assert self.history_manager.list(filters=filters) == [history2]
 
         filters = self.filter_parser.parse_filters(
             [
                 ("name", "eq", "history2"),
             ]
         )
-        self.assertEqual(self.history_manager.list(filters=filters), [history2])
+        assert self.history_manager.list(filters=filters) == [history2]
 
         self.history_manager.update(history1, dict(deleted=True))
         filters = self.filter_parser.parse_filters(
@@ -786,14 +763,14 @@ class HistoryFiltersTestCase(BaseTestCase):
                 ("deleted", "eq", "True"),
             ]
         )
-        self.assertEqual(self.history_manager.list(filters=filters), [history1])
+        assert self.history_manager.list(filters=filters) == [history1]
         filters = self.filter_parser.parse_filters(
             [
                 ("deleted", "eq", "False"),
             ]
         )
-        self.assertEqual(self.history_manager.list(filters=filters), [history2, history3])
-        self.assertEqual(self.history_manager.list(), [history1, history2, history3])
+        assert self.history_manager.list(filters=filters) == [history2, history3]
+        assert self.history_manager.list() == [history1, history2, history3]
 
         self.history_manager.update(history3, dict(deleted=True))
         self.history_manager.update(history1, dict(importable=True))
@@ -804,8 +781,8 @@ class HistoryFiltersTestCase(BaseTestCase):
                 ("importable", "eq", "True"),
             ]
         )
-        self.assertEqual(self.history_manager.list(filters=filters), [history1])
-        self.assertEqual(self.history_manager.list(), [history1, history2, history3])
+        assert self.history_manager.list(filters=filters) == [history1]
+        assert self.history_manager.list() == [history1, history2, history3]
 
     def test_fn_filter_parsing(self):
         user2 = self.user_manager.create(**user2_data)
@@ -823,10 +800,10 @@ class HistoryFiltersTestCase(BaseTestCase):
         history3.add_item_annotation(self.trans.sa_session, user2, history3, "All work and no play")
         self.trans.sa_session.flush()
 
-        self.assertTrue(anno_filter(history3))
-        self.assertFalse(anno_filter(history2))
+        assert anno_filter(history3)
+        assert not anno_filter(history2)
 
-        self.assertEqual(self.history_manager.list(filters=filters), [history3])
+        assert self.history_manager.list(filters=filters) == [history3]
 
         self.log("should allow combinations of orm and fn filters")
         self.history_manager.update(history3, dict(importable=True))
@@ -842,24 +819,24 @@ class HistoryFiltersTestCase(BaseTestCase):
                 ]
             )
         )
-        self.assertEqual(shining_examples, [history3])
+        assert shining_examples == [history3]
 
     def test_fn_filter_currying(self):
         self.filter_parser.fn_filter_parsers = {"name_len": {"op": {"lt": lambda i, v: len(i.name) < v}, "val": int}}
         self.log("should be 2 filters now")
-        self.assertEqual(len(self.filter_parser.fn_filter_parsers), 1)
+        assert len(self.filter_parser.fn_filter_parsers) == 1
         filters = self.filter_parser.parse_filters([("name_len", "lt", "4")])
         self.log("should have parsed out a single filter")
-        self.assertEqual(len(filters), 1)
+        assert len(filters) == 1
 
         filter_ = filters[0].filter
         fake = mock.Mock()
         fake.name = "123"
         self.log("123 should return true through the filter")
-        self.assertTrue(filter_(fake))
+        assert filter_(fake)
         fake.name = "1234"
         self.log("1234 should return false through the filter")
-        self.assertFalse(filter_(fake))
+        assert not filter_(fake)
 
     def test_list(self):
         """
@@ -887,78 +864,78 @@ class HistoryFiltersTestCase(BaseTestCase):
         deleted_and_annotated = [history2, history3]
 
         self.log("no offset, no limit should work")
-        self.assertEqual(self.history_manager.list(offset=None, limit=None), all_histories)
-        self.assertEqual(self.history_manager.list(), all_histories)
+        assert self.history_manager.list(offset=None, limit=None) == all_histories
+        assert self.history_manager.list() == all_histories
         self.log("no offset, limit should work")
-        self.assertEqual(self.history_manager.list(limit=2), [history1, history2])
+        assert self.history_manager.list(limit=2) == [history1, history2]
         self.log("offset, no limit should work")
-        self.assertEqual(self.history_manager.list(offset=1), [history2, history3, history4])
+        assert self.history_manager.list(offset=1) == [history2, history3, history4]
         self.log("offset, limit should work")
-        self.assertEqual(self.history_manager.list(offset=1, limit=1), [history2])
+        assert self.history_manager.list(offset=1, limit=1) == [history2]
 
         self.log("zero limit should return empty list")
-        self.assertEqual(self.history_manager.list(limit=0), [])
+        assert self.history_manager.list(limit=0) == []
         self.log("past len offset should return empty list")
-        self.assertEqual(self.history_manager.list(offset=len(all_histories)), [])
+        assert self.history_manager.list(offset=len(all_histories)) == []
         self.log("negative limit should return full list")
-        self.assertEqual(self.history_manager.list(limit=-1), all_histories)
+        assert self.history_manager.list(limit=-1) == all_histories
         self.log("negative offset should return full list")
-        self.assertEqual(self.history_manager.list(offset=-1), all_histories)
+        assert self.history_manager.list(offset=-1) == all_histories
 
         filters = [model.History.deleted == true()]
         self.log("orm filtered, no offset, no limit should work")
         found = self.history_manager.list(filters=filters)
-        self.assertEqual(found, [history1, history2, history3])
+        assert found == [history1, history2, history3]
         self.log("orm filtered, no offset, limit should work")
         found = self.history_manager.list(filters=filters, limit=2)
-        self.assertEqual(found, [history1, history2])
+        assert found == [history1, history2]
         self.log("orm filtered, offset, no limit should work")
         found = self.history_manager.list(filters=filters, offset=1)
-        self.assertEqual(found, [history2, history3])
+        assert found == [history2, history3]
         self.log("orm filtered, offset, limit should work")
         found = self.history_manager.list(filters=filters, offset=1, limit=1)
-        self.assertEqual(found, [history2])
+        assert found == [history2]
 
         filters = self.filter_parser.parse_filters([("annotation", "has", test_annotation)])
         self.log("fn filtered, no offset, no limit should work")
         found = self.history_manager.list(filters=filters)
-        self.assertEqual(found, [history2, history3, history4])
+        assert found == [history2, history3, history4]
         self.log("fn filtered, no offset, limit should work")
         found = self.history_manager.list(filters=filters, limit=2)
-        self.assertEqual(found, [history2, history3])
+        assert found == [history2, history3]
         self.log("fn filtered, offset, no limit should work")
         found = self.history_manager.list(filters=filters, offset=1)
-        self.assertEqual(found, [history3, history4])
+        assert found == [history3, history4]
         self.log("fn filtered, offset, limit should work")
         found = self.history_manager.list(filters=filters, offset=1, limit=1)
-        self.assertEqual(found, [history3])
+        assert found == [history3]
 
         filters = self.filter_parser.parse_filters([("deleted", "eq", "True"), ("annotation", "has", test_annotation)])
         self.log("orm and fn filtered, no offset, no limit should work")
         found = self.history_manager.list(filters=filters)
-        self.assertEqual(found, [history2, history3])
+        assert found == [history2, history3]
         self.log("orm and fn filtered, no offset, limit should work")
         found = self.history_manager.list(filters=filters, limit=1)
-        self.assertEqual(found, [history2])
+        assert found == [history2]
         self.log("orm and fn filtered, offset, no limit should work")
         found = self.history_manager.list(filters=filters, offset=1)
-        self.assertEqual(found, [history3])
+        assert found == [history3]
         self.log("orm and fn filtered, offset, limit should work")
         found = self.history_manager.list(filters=filters, offset=1, limit=1)
-        self.assertEqual(found, [history3])
+        assert found == [history3]
 
         self.log("orm and fn filtered, zero limit should return empty list")
         found = self.history_manager.list(filters=filters, limit=0)
-        self.assertEqual(found, [])
+        assert found == []
         self.log("orm and fn filtered, past len offset should return empty list")
         found = self.history_manager.list(filters=filters, offset=len(deleted_and_annotated))
-        self.assertEqual(found, [])
+        assert found == []
         self.log("orm and fn filtered, negative limit should return full list")
         found = self.history_manager.list(filters=filters, limit=-1)
-        self.assertEqual(found, deleted_and_annotated)
+        assert found == deleted_and_annotated
         self.log("orm and fn filtered, negative offset should return full list")
         found = self.history_manager.list(filters=filters, offset=-1)
-        self.assertEqual(found, deleted_and_annotated)
+        assert found == deleted_and_annotated
 
     # TODO: eq, ge, le
     # def test_ratings( self ):

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -127,8 +127,10 @@ class HistoryManagerTestCase(BaseTestCase):
         assert not self.history_manager.is_owner(item1, non_owner)
 
         self.log("should raise an error when checking ownership with non-owner")
-        self.assertRaises(exceptions.ItemOwnershipException, self.history_manager.error_unless_owner, item1, non_owner)
-        self.assertRaises(exceptions.ItemOwnershipException, self.history_manager.get_owned, item1.id, non_owner)
+        with self.assertRaises(exceptions.ItemOwnershipException):
+            self.history_manager.error_unless_owner(item1, non_owner)
+        with self.assertRaises(exceptions.ItemOwnershipException):
+            self.history_manager.get_owned(item1.id, non_owner)
 
         self.log("should not raise an error when checking ownership with owner")
         assert self.history_manager.error_unless_owner(item1, owner) == item1
@@ -151,12 +153,10 @@ class HistoryManagerTestCase(BaseTestCase):
         assert not self.history_manager.is_accessible(item1, non_owner)
 
         self.log("should raise an error when checking accessibility with non-owner")
-        self.assertRaises(
-            exceptions.ItemAccessibilityException, self.history_manager.error_unless_accessible, item1, non_owner
-        )
-        self.assertRaises(
-            exceptions.ItemAccessibilityException, self.history_manager.get_accessible, item1.id, non_owner
-        )
+        with self.assertRaises(exceptions.ItemAccessibilityException):
+            self.history_manager.error_unless_accessible(item1, non_owner)
+        with self.assertRaises(exceptions.ItemAccessibilityException):
+            self.history_manager.get_accessible(item1.id, non_owner)
 
         self.log("should not raise an error when checking ownership with owner")
         assert self.history_manager.error_unless_accessible(item1, owner) == item1
@@ -603,7 +603,8 @@ class HistorySerializerTestCase(BaseTestCase):
         self.assertIsJsonifyable(serialized)
 
         self.log("serialization of user_rating without user should error")
-        self.assertRaises(base.ModelSerializingError, serializer.serialize, item, ["user_rating"])
+        with self.assertRaises(base.ModelSerializingError):
+            serializer.serialize(item, ["user_rating"])
 
 
 # =============================================================================
@@ -657,9 +658,8 @@ class HistoryDeserializerTestCase(BaseTestCase):
         assert len(user_shares) == 0
 
         self.log("adding a bad user id should error")
-        self.assertRaises(
-            exceptions.MalformedId, deserializer.deserialize, item, {"users_shared_with": [None]}, user=user2
-        )
+        with self.assertRaises(exceptions.MalformedId):
+            deserializer.deserialize(item, {"users_shared_with": [None]}, user=user2)
 
         self.log("adding a non-existing user id should do nothing")
         non_user_id = self.app.security.encode_id(99)
@@ -688,45 +688,40 @@ class HistoryFiltersTestCase(BaseTestCase):
 
     def test_parse_filters_invalid_filters(self):
         self.log("should error on non-column attr")
-        self.assertRaises(
-            exceptions.RequestParameterInvalidException,
-            self.filter_parser.parse_filters,
-            [
-                ("merp", "eq", "wot"),
-            ],
-        )
+        with self.assertRaises(exceptions.RequestParameterInvalidException):
+            self.filter_parser.parse_filters(
+                [
+                    ("merp", "eq", "wot"),
+                ],
+            )
         self.log("should error on non-allowlisted attr")
-        self.assertRaises(
-            exceptions.RequestParameterInvalidException,
-            self.filter_parser.parse_filters,
-            [
-                ("user_id", "eq", "wot"),
-            ],
-        )
+        with self.assertRaises(exceptions.RequestParameterInvalidException):
+            self.filter_parser.parse_filters(
+                [
+                    ("user_id", "eq", "wot"),
+                ],
+            )
         self.log("should error on non-allowlisted op")
-        self.assertRaises(
-            exceptions.RequestParameterInvalidException,
-            self.filter_parser.parse_filters,
-            [
-                ("name", "lt", "wot"),
-            ],
-        )
+        with self.assertRaises(exceptions.RequestParameterInvalidException):
+            self.filter_parser.parse_filters(
+                [
+                    ("name", "lt", "wot"),
+                ],
+            )
         self.log("should error on non-listed fn op")
-        self.assertRaises(
-            exceptions.RequestParameterInvalidException,
-            self.filter_parser.parse_filters,
-            [
-                ("annotation", "like", "wot"),
-            ],
-        )
+        with self.assertRaises(exceptions.RequestParameterInvalidException):
+            self.filter_parser.parse_filters(
+                [
+                    ("annotation", "like", "wot"),
+                ],
+            )
         self.log("should error on val parsing error")
-        self.assertRaises(
-            exceptions.RequestParameterInvalidException,
-            self.filter_parser.parse_filters,
-            [
-                ("deleted", "eq", "wot"),
-            ],
-        )
+        with self.assertRaises(exceptions.RequestParameterInvalidException):
+            self.filter_parser.parse_filters(
+                [
+                    ("deleted", "eq", "wot"),
+                ],
+            )
 
     def test_orm_filter_parsing(self):
         user2 = self.user_manager.create(**user2_data)

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -1,6 +1,5 @@
 """
 """
-import unittest
 from unittest import mock
 
 import sqlalchemy
@@ -940,9 +939,3 @@ class HistoryFiltersTestCase(BaseTestCase):
     # TODO: eq, ge, le
     # def test_ratings( self ):
     #     pass
-
-
-# =============================================================================
-if __name__ == "__main__":
-    # or more generally, nosetests test_resourcemanagers.py -s -v
-    unittest.main()

--- a/test/unit/app/managers/test_TagHandler.py
+++ b/test/unit/app/managers/test_TagHandler.py
@@ -24,7 +24,7 @@ class TagHandlerTestCase(BaseTestCase):
         return self.app.hda_manager.create(history=history1)
 
     def _check_tag_list(self, tags, expected_tags):
-        self.assertEqual(len(tags), len(expected_tags))
+        assert len(tags) == len(expected_tags)
         actual_tags = []
         for tag in tags:
             if tag.user_value:
@@ -94,7 +94,7 @@ class TagHandlerTestCase(BaseTestCase):
         tags = ["tag1"]
         self.tag_handler.set_tags_from_list(self.user, hda, tags)
         self.tag_handler.delete_item_tags(user=self.user, item=hda)
-        self.assertEqual(hda.tags, [])
+        assert hda.tags == []
 
     def test_unique_constraint_applied(self):
         tag_name = "abc"
@@ -106,9 +106,9 @@ class TagHandlerTestCase(BaseTestCase):
         hda = self._create_vanilla_hda()
         tags = ["tag1"]
         self.tag_handler.set_tags_from_list(self.user, hda, tags)
-        self.assertTrue(self.tag_handler.item_has_tag(self.user, item=hda, tag="tag1"))
+        assert self.tag_handler.item_has_tag(self.user, item=hda, tag="tag1")
         # ItemTagAssociation
-        self.assertTrue(self.tag_handler.item_has_tag(self.user, item=hda, tag=hda.tags[0]))
+        assert self.tag_handler.item_has_tag(self.user, item=hda, tag=hda.tags[0])
         # Tag
-        self.assertTrue(self.tag_handler.item_has_tag(self.user, item=hda, tag=hda.tags[0].tag))
-        self.assertFalse(self.tag_handler.item_has_tag(self.user, item=hda, tag="tag2"))
+        assert self.tag_handler.item_has_tag(self.user, item=hda, tag=hda.tags[0].tag)
+        assert not self.tag_handler.item_has_tag(self.user, item=hda, tag="tag2")

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -67,17 +67,15 @@ class UserManagerTestCase(BaseTestCase):
         self.user_manager.create(**user2_data)
 
         self.log("emails must be unique")
-        self.assertRaises(
-            exceptions.Conflict,
-            self.user_manager.create,
-            **dict(email="user2@user2.user2", username="user2a", password=default_password),
-        )
+        with self.assertRaises(exceptions.Conflict):
+            self.user_manager.create(
+                **dict(email="user2@user2.user2", username="user2a", password=default_password),
+            )
         self.log("usernames must be unique")
-        self.assertRaises(
-            exceptions.Conflict,
-            self.user_manager.create,
-            **dict(email="user2a@user2.user2", username="user2", password=default_password),
-        )
+        with self.assertRaises(exceptions.Conflict):
+            self.user_manager.create(
+                **dict(email="user2a@user2.user2", username="user2", password=default_password),
+            )
 
     def test_trimming(self):
         self.log("emails must be trimmed")
@@ -114,7 +112,8 @@ class UserManagerTestCase(BaseTestCase):
         assert self.user_manager.is_admin(self.admin_user)
         assert not self.user_manager.is_admin(user2)
         assert self.user_manager.admins() == [self.admin_user]
-        self.assertRaises(exceptions.AdminRequiredException, self.user_manager.error_unless_admin, user2)
+        with self.assertRaises(exceptions.AdminRequiredException):
+            self.user_manager.error_unless_admin(user2)
         assert self.user_manager.error_unless_admin(self.admin_user) == self.admin_user
 
     def test_anonymous(self):
@@ -333,23 +332,21 @@ class UserDeserializerTestCase(BaseTestCase):
             trans=self.trans,
         )
         assert "Public name cannot be empty" in str(exception)
-        self.assertRaises(
-            base_manager.ModelDeserializingError,
-            self.deserializer.deserialize,
-            user,
-            {"username": "f,d,r,"},
-            trans=self.trans,
-        )
+        with self.assertRaises(base_manager.ModelDeserializingError):
+            self.deserializer.deserialize(
+                user,
+                {"username": "f,d,r,"},
+                trans=self.trans,
+            )
 
         self.log("usernames must be unique")
         self.user_manager.create(**user3_data)
-        self.assertRaises(
-            base_manager.ModelDeserializingError,
-            self.deserializer.deserialize,
-            user,
-            {"username": "user3"},
-            trans=self.trans,
-        )
+        with self.assertRaises(base_manager.ModelDeserializingError):
+            self.deserializer.deserialize(
+                user,
+                {"username": "user3"},
+                trans=self.trans,
+            )
 
         self.log("username should be updatable")
         new_name = "double-plus-good"

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -3,7 +3,6 @@ User Manager testing.
 
 Executable directly using: python -m test.unit.managers.test_UserManager
 """
-import unittest
 from datetime import datetime
 
 from sqlalchemy import desc
@@ -375,8 +374,3 @@ class AdminUserFilterParserTestCase(BaseTestCase):
         self.assertORMFilter(self.filter_parser.parse_filter("active", "eq", True))
         self.assertORMFilter(self.filter_parser.parse_filter("disk_usage", "le", 500000.00))
         self.assertORMFilter(self.filter_parser.parse_filter("disk_usage", "ge", 500000.00))
-
-
-# =============================================================================
-if __name__ == "__main__":
-    unittest.main()

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -34,37 +34,35 @@ lowercase_email_user = dict(email="user5@user5.user5", username="user5", passwor
 class UserManagerTestCase(BaseTestCase):
     def test_framework(self):
         self.log("(for testing) should have admin_user, and admin_user is current")
-        self.assertEqual(self.trans.user, self.admin_user)
+        assert self.trans.user == self.admin_user
 
     def test_base(self):
         self.log("should be able to create a user")
         user2 = self.user_manager.create(**user2_data)
-        self.assertIsInstance(user2, model.User)
-        self.assertIsNotNone(user2.id)
-        self.assertEqual(user2.email, user2_data["email"])
-        self.assertTrue(check_password(default_password, user2.password))
+        assert isinstance(user2, model.User)
+        assert user2.id is not None
+        assert user2.email == user2_data["email"]
+        assert check_password(default_password, user2.password)
 
         user3 = self.user_manager.create(**user3_data)
 
         self.log("should be able to query")
         users = self.trans.sa_session.query(model.User).all()
-        self.assertEqual(self.user_manager.list(), users)
+        assert self.user_manager.list() == users
 
-        self.assertEqual(self.user_manager.by_id(user2.id), user2)
-        self.assertEqual(self.user_manager.by_ids([user3.id, user2.id]), [user3, user2])
+        assert self.user_manager.by_id(user2.id) == user2
+        assert self.user_manager.by_ids([user3.id, user2.id]) == [user3, user2]
 
         self.log("should be able to limit and offset")
-        self.assertEqual(self.user_manager.list(limit=1), users[0:1])
-        self.assertEqual(self.user_manager.list(offset=1), users[1:])
-        self.assertEqual(self.user_manager.list(limit=1, offset=1), users[1:2])
+        assert self.user_manager.list(limit=1) == users[0:1]
+        assert self.user_manager.list(offset=1) == users[1:]
+        assert self.user_manager.list(limit=1, offset=1) == users[1:2]
 
-        self.assertEqual(self.user_manager.list(limit=0), [])
-        self.assertEqual(self.user_manager.list(offset=3), [])
+        assert self.user_manager.list(limit=0) == []
+        assert self.user_manager.list(offset=3) == []
 
         self.log("should be able to order")
-        self.assertEqual(
-            self.user_manager.list(order_by=(desc(model.User.create_time))), [user3, user2, self.admin_user]
-        )
+        assert self.user_manager.list(order_by=(desc(model.User.create_time))) == [user3, user2, self.admin_user]
 
     def test_invalid_create(self):
         self.user_manager.create(**user2_data)
@@ -91,8 +89,8 @@ class UserManagerTestCase(BaseTestCase):
             password=default_password,
             confirm=default_password,
         )
-        self.assertIsNone(message)
-        self.assertEqual(user2b.email, "user2b@user2.user2")
+        assert message is None
+        assert user2b.email == "user2b@user2.user2"
         self.log("usernames must be trimmed")
         user2c, message = self.user_manager.register(
             self.trans,
@@ -101,24 +99,24 @@ class UserManagerTestCase(BaseTestCase):
             password=default_password,
             confirm=default_password,
         )
-        self.assertIsNone(message)
-        self.assertEqual(user2c.username, "user2c")
+        assert message is None
+        assert user2c.username == "user2c"
 
     def test_email_queries(self):
         user2 = self.user_manager.create(**user2_data)
 
         self.log("should be able to query by email")
-        self.assertEqual(self.user_manager.by_email(user2_data["email"]), user2)
+        assert self.user_manager.by_email(user2_data["email"]) == user2
 
     def test_admin(self):
         user2 = self.user_manager.create(**user2_data)
 
         self.log("should be able to test whether admin")
-        self.assertTrue(self.user_manager.is_admin(self.admin_user))
-        self.assertFalse(self.user_manager.is_admin(user2))
-        self.assertEqual(self.user_manager.admins(), [self.admin_user])
+        assert self.user_manager.is_admin(self.admin_user)
+        assert not self.user_manager.is_admin(user2)
+        assert self.user_manager.admins() == [self.admin_user]
         self.assertRaises(exceptions.AdminRequiredException, self.user_manager.error_unless_admin, user2)
-        self.assertEqual(self.user_manager.error_unless_admin(self.admin_user), self.admin_user)
+        assert self.user_manager.error_unless_admin(self.admin_user) == self.admin_user
 
     def test_anonymous(self):
         anon = None
@@ -126,69 +124,69 @@ class UserManagerTestCase(BaseTestCase):
 
         self.log("should be able to tell if a user is anonymous")
         self.assertRaises(exceptions.AuthenticationFailed, self.user_manager.error_if_anonymous, anon)
-        self.assertEqual(self.user_manager.error_if_anonymous(user2), user2)
+        assert self.user_manager.error_if_anonymous(user2) == user2
 
     def test_current(self):
         user2 = self.user_manager.create(**user2_data)
 
         self.log("should be able to tell if a user is the current (trans) user")
-        self.assertEqual(self.user_manager.current_user(self.trans), self.admin_user)
-        self.assertNotEqual(self.user_manager.current_user(self.trans), user2)
+        assert self.user_manager.current_user(self.trans) == self.admin_user
+        assert self.user_manager.current_user(self.trans) != user2
 
     def test_change_password(self):
         self.log("should be able to change password")
         user2 = self.user_manager.create(**user2_data)
         encoded_id = self.app.security.encode_id(user2.id)
-        self.assertIsInstance(user2, model.User)
-        self.assertIsNotNone(user2.id)
-        self.assertEqual(user2.email, user2_data["email"])
-        self.assertTrue(check_password(default_password, user2.password))
+        assert isinstance(user2, model.User)
+        assert user2.id is not None
+        assert user2.email == user2_data["email"]
+        assert check_password(default_password, user2.password)
         user, message = self.user_manager.change_password(self.trans)
-        self.assertEqual(message, "Please provide a token or a user and password.")
+        assert message == "Please provide a token or a user and password."
         user, message = self.user_manager.change_password(self.trans, id=encoded_id, current=changed_password)
-        self.assertEqual(message, "Invalid current password.")
+        assert message == "Invalid current password."
         user, message = self.user_manager.change_password(
             self.trans, id=encoded_id, current=default_password, password=changed_password, confirm=default_password
         )
-        self.assertEqual(message, "Passwords do not match.")
+        assert message == "Passwords do not match."
         user, message = self.user_manager.change_password(
             self.trans, id=encoded_id, current=default_password, password=default_password, confirm=changed_password
         )
-        self.assertEqual(message, "Passwords do not match.")
+        assert message == "Passwords do not match."
         user, message = self.user_manager.change_password(
             self.trans, id=encoded_id, current=default_password, password=changed_password, confirm=changed_password
         )
-        self.assertFalse(check_password(default_password, user2.password))
-        self.assertTrue(check_password(changed_password, user2.password))
+        assert not check_password(default_password, user2.password)
+        assert check_password(changed_password, user2.password)
         reset_user, prt = self.user_manager.get_reset_token(self.trans, user2.email)
         user, message = self.user_manager.change_password(
             self.trans, token=prt.token, password=default_password, confirm=default_password
         )
-        self.assertTrue(check_password(default_password, user2.password))
-        self.assertFalse(check_password(changed_password, user2.password))
+        assert check_password(default_password, user2.password)
+        assert not check_password(changed_password, user2.password)
         prt.expiration_time = datetime.utcnow()
         user, message = self.user_manager.change_password(
             self.trans, token=prt.token, password=default_password, confirm=default_password
         )
-        self.assertEqual(message, "Invalid or expired password reset token, please request a new one.")
+        assert message == "Invalid or expired password reset token, please request a new one."
 
     def test_login(self):
         self.log("should be able to validate user credentials")
         user2 = self.user_manager.create(**user2_data)
         self.app.security.encode_id(user2.id)
-        self.assertIsInstance(user2, model.User)
-        self.assertIsNotNone(user2.id)
-        self.assertEqual(user2.email, user2_data["email"])
-        self.assertTrue(check_password(default_password, user2.password))
+        assert isinstance(user2, model.User)
+        assert user2.id is not None
+        assert user2.email == user2_data["email"]
+        assert check_password(default_password, user2.password)
 
     def test_empty_password(self):
         self.log("should be able to create a user with no password")
         user = self.user_manager.create(email="user@nopassword.com", username="nopassword")
-        self.assertIsNotNone(user.id)
-        self.assertIsNotNone(user.password)
+        assert user.id is not None
+        assert user.password is not None
         # should not be able to login with a null or empty password
-        self.assertFalse(check_password("", user.password))
-        self.assertFalse(check_password(None, user.password))
+        assert not check_password("", user.password)
+        assert not check_password(None, user.password)
 
     def test_get_user_by_identity(self):
         # return None if username/email not found
@@ -246,8 +244,6 @@ class UserSerializerTestCase(BaseTestCase):
                 or (isinstance(instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS))
             ):
                 self.fail(f"no serializer for: {key} ({instantiated_attribute})")
-        else:
-            self.assertTrue(True, "all serializable keys have a serializer")
 
     def test_views_and_keys(self):
         user = self.user_manager.create(**user2_data)
@@ -270,15 +266,15 @@ class UserSerializerTestCase(BaseTestCase):
         self.assertEncodedId(serialized["id"])
         self.assertDate(serialized["create_time"])
         self.assertDate(serialized["update_time"])
-        self.assertIsInstance(serialized["deleted"], bool)
-        self.assertIsInstance(serialized["purged"], bool)
+        assert isinstance(serialized["deleted"], bool)
+        assert isinstance(serialized["purged"], bool)
 
-        # self.assertIsInstance( serialized[ 'active' ], bool )
-        self.assertIsInstance(serialized["is_admin"], bool)
-        self.assertIsInstance(serialized["total_disk_usage"], float)
-        self.assertIsInstance(serialized["nice_total_disk_usage"], str)
-        self.assertIsInstance(serialized["quota_percent"], (type(None), float))
-        self.assertIsInstance(serialized["tags_used"], list)
+        # assert isinstance(serialized['active'], bool)
+        assert isinstance(serialized["is_admin"], bool)
+        assert isinstance(serialized["total_disk_usage"], float)
+        assert isinstance(serialized["nice_total_disk_usage"], str)
+        assert isinstance(serialized["quota_percent"], (type(None), float))
+        assert isinstance(serialized["tags_used"], list)
 
         self.log("serialized should jsonify well")
         self.assertIsJsonifyable(serialized)
@@ -300,11 +296,11 @@ class CurrentUserSerializerTestCase(BaseTestCase):
         self.assertKeys(serialized, ["id", "total_disk_usage", "nice_total_disk_usage", "quota_percent"])
 
         self.log("anonymous's id should be None")
-        self.assertEqual(serialized["id"], None)
+        assert serialized["id"] is None
         self.log("everything serialized should be of the proper type")
-        self.assertIsInstance(serialized["total_disk_usage"], float)
-        self.assertIsInstance(serialized["nice_total_disk_usage"], str)
-        self.assertIsInstance(serialized["quota_percent"], (type(None), float))
+        assert isinstance(serialized["total_disk_usage"], float)
+        assert isinstance(serialized["nice_total_disk_usage"], str)
+        assert isinstance(serialized["quota_percent"], (type(None), float))
 
         self.log("serialized should jsonify well")
         self.assertIsJsonifyable(serialized)
@@ -320,7 +316,6 @@ class UserDeserializerTestCase(BaseTestCase):
         try:
             fn(*args, **kwargs)
         except exception_class as exception:
-            self.assertTrue(True)
             return exception
         raise AssertionError(f"{exception_class.__name__} not raised")
 
@@ -338,7 +333,7 @@ class UserDeserializerTestCase(BaseTestCase):
             {"username": ""},
             trans=self.trans,
         )
-        self.assertTrue("Public name cannot be empty" in str(exception))
+        assert "Public name cannot be empty" in str(exception)
         self.assertRaises(
             base_manager.ModelDeserializingError,
             self.deserializer.deserialize,
@@ -360,7 +355,7 @@ class UserDeserializerTestCase(BaseTestCase):
         self.log("username should be updatable")
         new_name = "double-plus-good"
         self.deserializer.deserialize(user, {"username": new_name}, trans=self.trans)
-        self.assertEqual(self.user_manager.by_id(user.id).username, new_name)
+        assert self.user_manager.by_id(user.id).username == new_name
 
 
 # =============================================================================

--- a/test/unit/app/tools/test_actions.py
+++ b/test/unit/app/tools/test_actions.py
@@ -77,7 +77,7 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesTools):
 
     def test_output_label(self):
         _, output = self._simple_execute()
-        self.assertEqual(output["out1"].name, "Output (moo)")
+        assert output["out1"].name == "Output (moo)"
 
     def test_output_label_data(self):
         hda1 = self.__add_dataset()
@@ -92,12 +92,12 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesTools):
             tools_support.SIMPLE_CAT_TOOL_CONTENTS,
             incoming,
         )
-        self.assertEqual(output["out1"].name, "Test Tool on data 2 and data 1")
+        assert output["out1"].name == "Test Tool on data 2 and data 1"
 
     def test_object_store_ids(self):
         _, output = self._simple_execute(contents=TWO_OUTPUTS)
-        self.assertEqual(output["out1"].name, "Output (moo)")
-        self.assertEqual(output["out2"].name, "Output 2 (moo)")
+        assert output["out1"].name == "Output (moo)"
+        assert output["out2"].name == "Output 2 (moo)"
 
     def test_params_wrapped(self):
         hda1 = self.__add_dataset()
@@ -106,7 +106,7 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesTools):
             incoming=dict(repeat1=[dict(param1=hda1)]),
         )
         # Again this is a stupid way to ensure data parameters are wrapped.
-        self.assertEqual(output["out1"].name, "Output (%s)" % hda1.dataset.get_file_name())
+        assert output["out1"].name == f"Output ({hda1.dataset.get_file_name()})"
 
     def test_inactive_user_job_create_failure(self):
         self.trans.user_is_active = False

--- a/test/unit/app/tools/test_collect_primary_datasets.py
+++ b/test/unit/app/tools/test_collect_primary_datasets.py
@@ -43,7 +43,7 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesTools)
 
         datasets = self._collect()
         assert DEFAULT_TOOL_OUTPUT in datasets
-        self.assertEqual(len(datasets[DEFAULT_TOOL_OUTPUT]), 2)
+        assert len(datasets[DEFAULT_TOOL_OUTPUT]) == 2
 
         # Test default order of collection.
         assert list(datasets[DEFAULT_TOOL_OUTPUT].keys()) == ["test1", "test2"]
@@ -74,7 +74,7 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesTools)
 
         datasets = self._collect()
         assert DEFAULT_TOOL_OUTPUT in datasets
-        self.assertEqual(len(datasets[DEFAULT_TOOL_OUTPUT]), 3)
+        assert len(datasets[DEFAULT_TOOL_OUTPUT]) == 3
 
         # Test default order of collection.
         assert list(datasets[DEFAULT_TOOL_OUTPUT].keys()) == ["test1", "test2", "test3"]
@@ -113,7 +113,7 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesTools)
 
         datasets = self._collect()
         assert DEFAULT_TOOL_OUTPUT in datasets
-        self.assertEqual(len(datasets[DEFAULT_TOOL_OUTPUT]), 3)
+        assert len(datasets[DEFAULT_TOOL_OUTPUT]) == 3
 
         # Test default order of collection.
         assert list(datasets[DEFAULT_TOOL_OUTPUT].keys()) == ["test1", "test2", "test3"]

--- a/test/unit/app/tools/test_column_parameters.py
+++ b/test/unit/app/tools/test_column_parameters.py
@@ -42,19 +42,19 @@ class DataColumnParameterTestCase(BaseParameterTestCase):
         assert value == ["1", "2", "3"]
 
     def test_get_initial_value_default(self):
-        self.assertEqual("1", self.param.get_initial_value(self.trans, {"input_tsv": self.build_ready_hda()}))
+        assert "1" == self.param.get_initial_value(self.trans, {"input_tsv": self.build_ready_hda()})
 
     def test_get_initial_value_override_legacy(self):
         self.other_attributes = "default_value='2'"
-        self.assertEqual("2", self.param.get_initial_value(self.trans, {"input_tsv": self.build_ready_hda()}))
+        assert "2" == self.param.get_initial_value(self.trans, {"input_tsv": self.build_ready_hda()})
 
     def test_get_initial_value_override_newstyle(self):
         self.other_attributes = "value='2'"
-        self.assertEqual("2", self.param.get_initial_value(self.trans, {"input_tsv": self.build_ready_hda()}))
+        assert "2" == self.param.get_initial_value(self.trans, {"input_tsv": self.build_ready_hda()})
 
     def test_get_initial_value_override_newstyle_strips_c(self):
         self.other_attributes = "value='c2'"
-        self.assertEqual("2", self.param.get_initial_value(self.trans, {"input_tsv": self.build_ready_hda()}))
+        assert "2" == self.param.get_initial_value(self.trans, {"input_tsv": self.build_ready_hda()})
 
     def setUp(self):
         super().setUp()

--- a/test/unit/app/tools/test_data_parameters.py
+++ b/test/unit/app/tools/test_data_parameters.py
@@ -32,7 +32,7 @@ class DataToolParameterTestCase(BaseParameterTestCase):
         # Selection is Optional. may be selected with other stuff,
         # not sure the UI should really allow this but easy enough
         # to just filter it out.
-        self.assertEqual([hda], self.param.to_python("%s,None" % hda.id, self.app))
+        assert [hda] == self.param.to_python(f"{hda.id},None", self.app)
 
     def test_field_filter_on_types(self):
         hda1 = MockHistoryDatasetAssociation(name="hda1", id=1)
@@ -176,8 +176,7 @@ class DataToolParameterTestCase(BaseParameterTestCase):
             optional_text = ""
             if self.optional:
                 optional_text = 'optional="True"'
-            template_xml = """<param name="data2" type="data" format="txt" %s %s></param>"""
-            param_str = template_xml % (multi_text, optional_text)
+            param_str = f"""<param name="data2" type="data" format="txt" {multi_text} {optional_text}></param>"""
             self._param = self._parameter_for(tool=self.mock_tool, xml=param_str)
 
         return self._param

--- a/test/unit/app/tools/test_evaluation.py
+++ b/test/unit/app/tools/test_evaluation.py
@@ -54,9 +54,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self._setup_test_bwa_job()
         self._set_compute_environment()
         command_line = self.evaluator.build()[0]
-        self.assertEqual(
-            command_line, "bwa --thresh=4 --in=/galaxy/files/dataset_1.dat --out=/galaxy/files/dataset_2.dat"
-        )
+        assert command_line == "bwa --thresh=4 --in=/galaxy/files/dataset_1.dat --out=/galaxy/files/dataset_2.dat"
 
     def test_repeat_evaluation(self):
         repeat = Repeat()
@@ -69,19 +67,19 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.tool._command_line = "prog1 #for $r_i in $r # $r_i.thresh#end for#"
         self._set_compute_environment()
         command_line = self.evaluator.build()[0]
-        self.assertEqual(command_line, "prog1  4 5")
+        assert command_line == "prog1  4 5"
 
     def test_eval_galaxy_url(self):
         self.tool._command_line = "prog1 $__galaxy_url__"
         self._set_compute_environment()
         command_line = self.evaluator.build()[0]
-        self.assertEqual(command_line, "prog1 %s" % TEST_GALAXY_URL)
+        assert command_line == f"prog1 {TEST_GALAXY_URL}"
 
     def test_eval_history_id(self):
         self.tool._command_line = "prog1 '$__history_id__'"
         self._set_compute_environment()
         command_line = self.evaluator.build()[0]
-        self.assertEqual(command_line, "prog1 '%s'" % self.app.security.encode_id(42))
+        assert command_line == f"prog1 '{self.app.security.encode_id(42)}'"
 
     def test_conditional_evaluation(self):
         select_xml = XML("""<param name="always_true" type="select"><option value="true">True</option></param>""")
@@ -101,7 +99,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.tool._command_line = "prog1 --thresh=${c.thresh} --test_param=${c.always_true}"
         self._set_compute_environment()
         command_line = self.evaluator.build()[0]
-        self.assertEqual(command_line, "prog1 --thresh=4 --test_param=true")
+        assert command_line == "prog1 --thresh=4 --test_param=true"
 
     def test_evaluation_of_optional_datasets(self):
         # Make sure optional dataset don't cause evaluation to break and
@@ -113,7 +111,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.tool._command_line = "prog1 --opt_input='${input1}'"
         self._set_compute_environment()
         command_line = self.evaluator.build()[0]
-        self.assertEqual(command_line, "prog1 --opt_input='None'")
+        assert command_line == "prog1 --opt_input='None'"
 
     def test_evaluation_with_path_rewrites_wrapped(self):
         self.tool.check_values = True
@@ -128,28 +126,28 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         # splitting, config.outputs_to_working_directory). This tests that
         # functionality.
         self._setup_test_bwa_job()
-        job_path_1 = "%s/dataset_1.dat" % self.test_directory
-        job_path_2 = "%s/dataset_2.dat" % self.test_directory
+        job_path_1 = f"{self.test_directory}/dataset_1.dat"
+        job_path_2 = f"{self.test_directory}/dataset_2.dat"
         self._set_compute_environment(
             input_paths=[DatasetPath(1, "/galaxy/files/dataset_1.dat", false_path=job_path_1)],
             output_paths=[DatasetPath(2, "/galaxy/files/dataset_2.dat", false_path=job_path_2)],
         )
         command_line = self.evaluator.build()[0]
-        self.assertEqual(command_line, f"bwa --thresh=4 --in={job_path_1} --out={job_path_2}")
+        assert command_line == f"bwa --thresh=4 --in={job_path_1} --out={job_path_2}"
 
     def test_configfiles_evaluation(self):
         self.tool.config_files.append(("conf1", None, "$thresh"))
         self.tool._command_line = "prog1 $conf1"
         self._set_compute_environment()
         command_line, _, extra_filenames, _ = self.evaluator.build()
-        self.assertEqual(len(extra_filenames), 1)
+        assert len(extra_filenames) == 1
         config_filename = extra_filenames[0]
         config_basename = os.path.basename(config_filename)
         # Verify config file written into working directory.
-        self.assertEqual(os.path.join(self.test_directory, "configs", config_basename), config_filename)
+        assert os.path.join(self.test_directory, "configs", config_basename) == config_filename
         # Verify config file contents are evaluated against parameters.
         assert open(config_filename).read() == "4"
-        self.assertEqual(command_line, "prog1 %s" % config_filename)
+        assert command_line == f"prog1 {config_filename}"
 
     def test_arbitrary_path_rewriting_wrapped(self):
         self.tool.check_values = True
@@ -182,7 +180,7 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         self.tool._command_line = "prog1 $index_path.fields.path"
         self._set_compute_environment(unstructured_path_rewrites={"/old": "/new"})
         command_line = self.evaluator.build()[0]
-        self.assertEqual(command_line, "prog1 /new/path/human")
+        assert command_line == "prog1 /new/path/human"
 
     def test_version_command(self):
         self.tool.version_string_cmd = "echo v.1.1"
@@ -205,11 +203,11 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
 
     def _assert_template_property_is(self, expression, value):
         self.tool._command_line = "test.exe"
-        self.tool.config_files.append(("conf1", None, """%s""" % expression))
+        self.tool.config_files.append(("conf1", None, f"""{expression}"""))
         self._set_compute_environment()
         extra_filenames = self.evaluator.build()[2]
         config_filename = extra_filenames[0]
-        self.assertEqual(open(config_filename).read(), value)
+        assert open(config_filename).read() == value
 
     def _set_compute_environment(self, **kwds):
         if "working_directory" not in kwds:

--- a/test/unit/app/tools/test_parameter_parsing.py
+++ b/test/unit/app/tools/test_parameter_parsing.py
@@ -25,7 +25,7 @@ class ProcessKeyTestCase(TestCase):
                 {"inner_repeat": [{"data_table_column_value": "bla3"}, {"data_table_column_value": "bla4"}]},
             ]
         }
-        self.assertEqual(nested_dict, expected_dict)
+        assert nested_dict == expected_dict
 
     def test_process_key_2(self):
         nested_dict: Dict[str, Any] = {}
@@ -40,7 +40,7 @@ class ProcessKeyTestCase(TestCase):
             "data_tables": [{"columns": [{"data_table_column_value": "Amel_HAv3.1"}]}],
             "directory_content": [],
         }
-        self.assertEqual(nested_dict, expected_dict)
+        assert nested_dict == expected_dict
 
 
 class ParameterParsingTestCase(BaseParameterTestCase):

--- a/test/unit/app/tools/test_parameter_parsing.py
+++ b/test/unit/app/tools/test_parameter_parsing.py
@@ -144,7 +144,8 @@ class ParameterParsingTestCase(BaseParameterTestCase):
         assert param.value == "9"
         assert param.type == "integer"
         param.validate(8)
-        self.assertRaises(Exception, lambda: param.validate(10))
+        with self.assertRaises(ValueError):
+            param.validate(10)
 
     def test_float_params(self):
         param = self._parameter_for(
@@ -156,7 +157,8 @@ class ParameterParsingTestCase(BaseParameterTestCase):
         assert param.value == "9"
         assert param.type == "float"
         param.validate(8.1)
-        self.assertRaises(Exception, lambda: param.validate(10.0))
+        with self.assertRaises(ValueError):
+            param.validate(10.0)
 
     def test_boolean_params(self):
         param = self._parameter_for(

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -68,11 +68,11 @@ class BaseToolBoxTestCase(unittest.TestCase, UsesTools):
     _toolbox: Optional[SimplifiedToolBox] = None
 
     @property
-    def integerated_tool_panel_path(self):
+    def integrated_tool_panel_path(self):
         return os.path.join(self.test_directory, "integrated_tool_panel.xml")
 
     def assert_integerated_tool_panel(self, exists=True):
-        does_exist = os.path.exists(self.integerated_tool_panel_path)
+        does_exist = os.path.exists(self.integrated_tool_panel_path)
         if exists:
             assert does_exist
         else:
@@ -605,7 +605,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         self.toolbox  # create toolbox
         assert not self.reindexed
 
-        os.remove(self.integerated_tool_panel_path)
+        os.remove(self.integrated_tool_panel_path)
 
 
 def reload_callback(test_case):

--- a/test/unit/app/visualizations/plugins/test_VisualizationPlugin.py
+++ b/test/unit/app/visualizations/plugins/test_VisualizationPlugin.py
@@ -1,8 +1,6 @@
 """
 Test lib/galaxy/visualization/plugins/plugin.
 """
-import unittest
-
 from galaxy.app_unittest_utils import galaxy_mock
 from galaxy.util import clean_multiline_string
 from galaxy.visualization.plugins import (
@@ -158,6 +156,3 @@ class VisualizationsPlugin_TestCase(VisualizationsBase_TestCase):
 
 # -----------------------------------------------------------------------------
 # TODO: config parser tests (in separate file)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/unit/app/visualizations/plugins/test_VisualizationPlugin.py
+++ b/test/unit/app/visualizations/plugins/test_VisualizationPlugin.py
@@ -28,16 +28,16 @@ class VisualizationsPlugin_TestCase(VisualizationsBase_TestCase):
             }
         )
         plugin = self.plugin_class(galaxy_mock.MockApp(), vis_dir.root_path, "myvis", {})
-        self.assertEqual(plugin.name, "myvis")
-        self.assertEqual(plugin.path, vis_dir.root_path)
-        self.assertEqual(plugin.config, {})
-        self.assertEqual(plugin.base_url, "myvis")
+        assert plugin.name == "myvis"
+        assert plugin.path == vis_dir.root_path
+        assert plugin.config == {}
+        assert plugin.base_url == "myvis"
         # template
-        self.assertTrue(plugin.serves_templates)
-        self.assertEqual(plugin.template_path, vis_dir.root_path + "/templates")
-        self.assertEqual(plugin.template_lookup.__class__.__name__, "TemplateLookup")
+        assert plugin.serves_templates
+        assert plugin.template_path == vis_dir.root_path + "/templates"
+        assert plugin.template_lookup.__class__.__name__ == "TemplateLookup"
         # resource parser
-        self.assertIsInstance(plugin.resource_parser, resource_parser.ResourceParser)
+        assert isinstance(plugin.resource_parser, resource_parser.ResourceParser)
 
     def test_init_with_context(self):
         """
@@ -52,8 +52,8 @@ class VisualizationsPlugin_TestCase(VisualizationsBase_TestCase):
         )
         context = dict(base_url="u/wot/m8", template_cache_dir="template_cache", additional_template_paths=["one"])
         plugin = self.plugin_class(galaxy_mock.MockApp(), vis_dir.root_path, "myvis", {}, context=context)
-        self.assertEqual(plugin.base_url, "u/wot/m8/myvis")
-        self.assertEqual(plugin.template_lookup.__class__.__name__, "TemplateLookup")
+        assert plugin.base_url == "u/wot/m8/myvis"
+        assert plugin.template_lookup.__class__.__name__ == "TemplateLookup"
 
     def test_init_without_static_or_templates(self):
         """
@@ -61,7 +61,7 @@ class VisualizationsPlugin_TestCase(VisualizationsBase_TestCase):
         """
         vis_dir = galaxy_mock.MockDir({"config": {"vis1.xml": ""}})
         plugin = self.plugin_class(galaxy_mock.MockApp(), vis_dir.root_path, "myvis", dict())
-        self.assertFalse(plugin.serves_templates)
+        assert not plugin.serves_templates
         # not sure what this would do, but...
 
     def test_build_render_vars_default(self):
@@ -73,36 +73,36 @@ class VisualizationsPlugin_TestCase(VisualizationsBase_TestCase):
         plugin = self.plugin_class(galaxy_mock.MockApp(), "", "myvis", config)
 
         render_vars = plugin._build_render_vars(config)
-        self.assertEqual(render_vars["visualization_name"], plugin.name)
-        self.assertEqual(render_vars["visualization_display_name"], plugin.config["name"])
-        self.assertEqual(render_vars["title"], None)
-        self.assertEqual(render_vars["saved_visualization"], None)
-        self.assertEqual(render_vars["visualization_id"], None)
-        self.assertEqual(render_vars["query"], {})
-        self.assertIsInstance(render_vars["config"], vis_utils.OpenObject)
-        self.assertEqual(render_vars["config"].__dict__, {})
+        assert render_vars["visualization_name"] == plugin.name
+        assert render_vars["visualization_display_name"] == plugin.config["name"]
+        assert render_vars["title"] is None
+        assert render_vars["saved_visualization"] is None
+        assert render_vars["visualization_id"] is None
+        assert render_vars["query"] == {}
+        assert isinstance(render_vars["config"], vis_utils.OpenObject)
+        assert render_vars["config"].__dict__ == {}
 
     def test_build_config(self):
         """ """
         plugin_config: dict = dict()
         plugin = self.plugin_class(galaxy_mock.MockApp(), "", "myvis", plugin_config)
         config = plugin._build_config({})
-        self.assertIsInstance(config, vis_utils.OpenObject)
-        self.assertEqual(config.__dict__, {})
+        assert isinstance(config, vis_utils.OpenObject)
+        assert config.__dict__ == {}
 
         # existing should flow through
         plugin_config = dict()
         plugin = self.plugin_class(galaxy_mock.MockApp(), "", "myvis", plugin_config)
         existing_config = dict(wat=1)
         config = plugin._build_config(existing_config)
-        self.assertEqual(config.wat, 1)
+        assert config.wat == 1
 
         # unlisted/non-param kwargs should NOT overwrite existing
         plugin_config = dict()
         plugin = self.plugin_class(galaxy_mock.MockApp(), "", "myvis", plugin_config)
         existing_config = dict(wat=1)
         config = plugin._build_config(existing_config, wat=2)
-        self.assertEqual(config.wat, 1)
+        assert config.wat == 1
 
         # listed/param kwargs *should* overwrite existing
         plugin_config = dict(
@@ -114,7 +114,7 @@ class VisualizationsPlugin_TestCase(VisualizationsBase_TestCase):
         existing_config = dict(wat=1)
         # send as string like a query would - should be parsed
         config = plugin._build_config(existing_config, wat="2")
-        self.assertEqual(config.wat, 2)
+        assert config.wat == 2
 
     def test_render(self):
         """ """
@@ -152,8 +152,8 @@ class VisualizationsPlugin_TestCase(VisualizationsBase_TestCase):
         plugin.template_lookup = plugin._build_template_lookup(mock_app_dir.root_path)
 
         response = plugin.render(trans=galaxy_mock.MockTrans(app=mock_app))
-        self.assertIsInstance(response, str)
-        self.assertEqual(response.strip(), "True")
+        assert isinstance(response, str)
+        assert response.strip() == "True"
 
 
 # -----------------------------------------------------------------------------

--- a/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
+++ b/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
@@ -2,7 +2,6 @@
 Test lib/galaxy/visualization/plugins/registry.
 """
 import os
-import unittest
 
 from galaxy.app_unittest_utils import galaxy_mock
 from galaxy.util import (
@@ -178,6 +177,3 @@ class VisualizationsRegistry_TestCase(VisualizationsBase_TestCase):
 
 # -----------------------------------------------------------------------------
 # TODO: config parser tests (in separate file)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
+++ b/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
@@ -51,22 +51,22 @@ class VisualizationsRegistry_TestCase(VisualizationsBase_TestCase):
         plugin_mgr = VisualizationsRegistry(mock_app, directories_setting=vis_reg_path, template_cache_dir=None)
 
         expected_plugins_path = os.path.join(glx_dir, vis_reg_path)
-        self.assertEqual(plugin_mgr.base_url, "visualizations")
-        self.assertEqual(plugin_mgr.directories, [expected_plugins_path])
+        assert plugin_mgr.base_url == "visualizations"
+        assert plugin_mgr.directories == [expected_plugins_path]
 
         scatterplot = plugin_mgr.plugins["scatterplot"]
-        self.assertEqual(scatterplot.name, "scatterplot")
-        self.assertEqual(scatterplot.path, os.path.join(expected_plugins_path, "scatterplot"))
-        self.assertEqual(scatterplot.base_url, "/".join((plugin_mgr.base_url, scatterplot.name)))
-        self.assertTrue(scatterplot.serves_templates)
-        self.assertEqual(scatterplot.template_path, os.path.join(scatterplot.path, "templates"))
-        self.assertEqual(scatterplot.template_lookup.__class__.__name__, "TemplateLookup")
+        assert scatterplot.name == "scatterplot"
+        assert scatterplot.path == os.path.join(expected_plugins_path, "scatterplot")
+        assert scatterplot.base_url == "/".join((plugin_mgr.base_url, scatterplot.name))
+        assert scatterplot.serves_templates
+        assert scatterplot.template_path == os.path.join(scatterplot.path, "templates")
+        assert scatterplot.template_lookup.__class__.__name__ == "TemplateLookup"
 
         trackster = plugin_mgr.plugins["trackster"]
-        self.assertEqual(trackster.name, "trackster")
-        self.assertEqual(trackster.path, os.path.join(expected_plugins_path, "trackster"))
-        self.assertEqual(trackster.base_url, "/".join((plugin_mgr.base_url, trackster.name)))
-        self.assertFalse(trackster.serves_templates)
+        assert trackster.name == "trackster"
+        assert trackster.path == os.path.join(expected_plugins_path, "trackster")
+        assert trackster.base_url == "/".join((plugin_mgr.base_url, trackster.name))
+        assert not trackster.serves_templates
 
     def test_plugin_load(self):
         """"""
@@ -103,17 +103,17 @@ class VisualizationsRegistry_TestCase(VisualizationsBase_TestCase):
         expected_plugins_path = os.path.join(mock_app_dir.root_path, "plugins")
         expected_plugin_names = ["vis1", "vis2"]
 
-        self.assertEqual(plugin_mgr.base_url, "visualizations")
-        self.assertEqual(plugin_mgr.directories, [expected_plugins_path])
-        self.assertEqual(sorted(plugin_mgr.plugins.keys()), expected_plugin_names)
+        assert plugin_mgr.base_url == "visualizations"
+        assert plugin_mgr.directories == [expected_plugins_path]
+        assert sorted(plugin_mgr.plugins.keys()) == expected_plugin_names
 
         vis1 = plugin_mgr.plugins["vis1"]
-        self.assertEqual(vis1.name, "vis1")
-        self.assertEqual(vis1.path, os.path.join(expected_plugins_path, "vis1"))
-        self.assertEqual(vis1.base_url, "/".join((plugin_mgr.base_url, vis1.name)))
-        self.assertTrue(vis1.serves_templates)
-        self.assertEqual(vis1.template_path, os.path.join(vis1.path, "templates"))
-        self.assertEqual(vis1.template_lookup.__class__.__name__, "TemplateLookup")
+        assert vis1.name == "vis1"
+        assert vis1.path == os.path.join(expected_plugins_path, "vis1")
+        assert vis1.base_url == "/".join((plugin_mgr.base_url, vis1.name))
+        assert vis1.serves_templates
+        assert vis1.template_path == os.path.join(vis1.path, "templates")
+        assert vis1.template_lookup.__class__.__name__ == "TemplateLookup"
 
         vis1_as_dict = vis1.to_dict()
         assert vis1_as_dict["specs"]
@@ -126,10 +126,10 @@ class VisualizationsRegistry_TestCase(VisualizationsBase_TestCase):
         assert "pdf" in exports
 
         vis2 = plugin_mgr.plugins["vis2"]
-        self.assertEqual(vis2.name, "vis2")
-        self.assertEqual(vis2.path, os.path.join(expected_plugins_path, "vis2"))
-        self.assertEqual(vis2.base_url, "/".join((plugin_mgr.base_url, vis2.name)))
-        self.assertFalse(vis2.serves_templates)
+        assert vis2.name == "vis2"
+        assert vis2.path == os.path.join(expected_plugins_path, "vis2")
+        assert vis2.base_url == "/".join((plugin_mgr.base_url, vis2.name))
+        assert not vis2.serves_templates
 
         mock_app_dir.remove()
         template_cache_dir
@@ -163,16 +163,16 @@ class VisualizationsRegistry_TestCase(VisualizationsBase_TestCase):
         )
         script_entry = plugin_mgr.plugins["jstest"]
 
-        self.assertIsInstance(script_entry, plugin.ScriptVisualizationPlugin)
-        self.assertEqual(script_entry.name, "jstest")
-        self.assertTrue(script_entry.serves_templates)
+        assert isinstance(script_entry, plugin.ScriptVisualizationPlugin)
+        assert script_entry.name == "jstest"
+        assert script_entry.serves_templates
 
         trans = galaxy_mock.MockTrans()
         script_entry._set_up_template_plugin(mock_app_dir.root_path, [addtional_templates_dir])
         response = script_entry._render({}, trans=trans, embedded=True)
-        self.assertTrue('src="bler"' in response)
-        self.assertTrue('type="text/javascript"' in response)
-        self.assertTrue('data-main="one"' in response)
+        assert 'src="bler"' in response
+        assert 'type="text/javascript"' in response
+        assert 'data-main="one"' in response
         mock_app_dir.remove()
 
 

--- a/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
+++ b/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
@@ -83,19 +83,19 @@ class Test_BaseDataProvider(BaseTestCase):
         provider = self.provider_class(source)
         data = list(provider)
         log.debug("data: %s", str(data))
-        self.assertEqual(data, [str(x) for x in range(1, 10)])
+        assert data == [str(x) for x in range(1, 10)]
 
         source = (str(x) for x in range(1, 10))
         provider = self.provider_class(source)
         data = list(provider)
         log.debug("data: %s", str(data))
-        self.assertEqual(data, [str(x) for x in range(1, 10)])
+        assert data == [str(x) for x in range(1, 10)]
 
         source = (str(x) for x in range(1, 10))
         provider = self.provider_class(source)
         data = list(provider)
         log.debug("data: %s", str(data))
-        self.assertEqual(data, [str(x) for x in range(1, 10)])
+        assert data == [str(x) for x in range(1, 10)]
 
     def test_validate_source(self):
         """validate_source should throw an error if the source doesn't have attr '__iter__'"""
@@ -127,7 +127,7 @@ class Test_BaseDataProvider(BaseTestCase):
         provider = self.provider_class(source)
         data = provider.readlines()
         log.debug("data: %s", str(data))
-        self.assertEqual(data, [str(x) for x in range(1, 10)])
+        assert data == [str(x) for x in range(1, 10)]
 
     def test_stringio(self):
         """should work with StringIO"""
@@ -143,25 +143,25 @@ class Test_BaseDataProvider(BaseTestCase):
         data = list(provider)
         log.debug("data: %s", str(data))
         # provider should call close on file
-        self.assertEqual(data, self.parses_default_content_as())
-        self.assertTrue(source.closed)
+        assert data == self.parses_default_content_as()
+        assert source.closed
 
     def test_file(self):
         """should work with files"""
         (contents, provider, data) = self.contents_provider_and_data()
-        self.assertEqual(data, self.parses_default_content_as())
+        assert data == self.parses_default_content_as()
         # provider should call close on file
-        self.assertTrue(hasattr(provider.source, "read"))
-        self.assertTrue(provider.source.closed)
+        assert hasattr(provider.source, "read")
+        assert provider.source.closed
 
 
 class Test_FilteredDataProvider(Test_BaseDataProvider):
     provider_class: Type[base.DataProvider] = base.FilteredDataProvider
 
     def assertCounters(self, provider, read, valid, returned):
-        self.assertEqual(provider.num_data_read, read)
-        self.assertEqual(provider.num_valid_data_read, valid)
-        self.assertEqual(provider.num_data_returned, returned)
+        assert provider.num_data_read == read
+        assert provider.num_valid_data_read == valid
+        assert provider.num_data_returned == returned
 
     def test_counters(self):
         """should count: lines read, lines that passed the filter, lines returned"""
@@ -188,57 +188,57 @@ class Test_LimitedOffsetDataProvider(Test_FilteredDataProvider):
     def test_offset_1(self):
         """when offset is 1, should skip first"""
         (contents, provider, data) = self.contents_provider_and_data(offset=1)
-        self.assertEqual(data, self.parses_default_content_as()[1:])
+        assert data == self.parses_default_content_as()[1:]
         self.assertCounters(provider, 3, 3, 2)
 
     def test_offset_all(self):
         """when offset >= num lines, should return empty list"""
         (contents, provider, data) = self.contents_provider_and_data(offset=4)
-        self.assertEqual(data, [])
+        assert data == []
         self.assertCounters(provider, 3, 3, 0)
 
     def test_offset_none(self):
         """when offset is 0, should return all"""
         (contents, provider, data) = self.contents_provider_and_data(offset=0)
-        self.assertEqual(data, self.parses_default_content_as())
+        assert data == self.parses_default_content_as()
         self.assertCounters(provider, 3, 3, 3)
 
     def test_offset_negative(self):
         """when offset is negative, should return all"""
         (contents, provider, data) = self.contents_provider_and_data(offset=-1)
-        self.assertEqual(data, self.parses_default_content_as())
+        assert data == self.parses_default_content_as()
         self.assertCounters(provider, 3, 3, 3)
 
     def test_limit_1(self):
         """when limit is one, should return first"""
         (contents, provider, data) = self.contents_provider_and_data(limit=1)
-        self.assertEqual(data, self.parses_default_content_as()[:1])
+        assert data == self.parses_default_content_as()[:1]
         self.assertCounters(provider, 1, 1, 1)
 
     def test_limit_all(self):
         """when limit >= num lines, should return all"""
         (contents, provider, data) = self.contents_provider_and_data(limit=4)
-        self.assertEqual(data, self.parses_default_content_as())
+        assert data == self.parses_default_content_as()
         self.assertCounters(provider, 3, 3, 3)
 
     def test_limit_zero(self):
         """when limit >= num lines, should return empty list"""
         (contents, provider, data) = self.contents_provider_and_data(limit=0)
-        self.assertEqual(data, [])
+        assert data == []
         self.assertCounters(provider, 0, 0, 0)
 
     def test_limit_none(self):
         """when limit is None, should return all"""
         (contents, provider, data) = self.contents_provider_and_data(limit=None)
-        self.assertEqual(data, self.parses_default_content_as())
+        assert data == self.parses_default_content_as()
         self.assertCounters(provider, 3, 3, 3)
 
     # TODO: somehow re-use tmpfile here
     def test_limit_with_offset(self):
         def limit_offset_combo(limit, offset, data_should_be, read, valid, returned):
             (contents, provider, data) = self.contents_provider_and_data(limit=limit, offset=offset)
-            self.assertEqual(data, data_should_be)
-            # self.assertCounters( provider, read, valid, returned )
+            assert data == data_should_be
+            # self.assertCounters(provider, read, valid, returned)
 
         result_data = self.parses_default_content_as()
         test_data = [
@@ -265,8 +265,8 @@ class Test_LimitedOffsetDataProvider(Test_FilteredDataProvider):
                 return string
 
             (contents, provider, data) = self.contents_provider_and_data(limit=limit, offset=offset, filter_fn=only_ts)
-            self.assertEqual(data, data_should_be)
-            # self.assertCounters( provider, read, valid, returned )
+            assert data == data_should_be
+            # self.assertCounters(provider, read, valid, returned)
 
         result_data = [c for c in self.parses_default_content_as() if c.lower().startswith("t")]
         test_data = [
@@ -322,7 +322,7 @@ class Test_MultiSourceDataProvider(BaseTestCase):
         log.debug("provider: %s", provider)
         data = list(provider)
         log.debug("data: %s", str(data))
-        self.assertEqual("".join(data), "".join(contents))
+        assert "".join(data) == "".join(contents)
 
     def test_multiple_compound_sources(self):
         # clean the following contents, write them to tmpfiles, open them,
@@ -365,7 +365,7 @@ class Test_MultiSourceDataProvider(BaseTestCase):
         log.debug("provider: %s", provider)
         data = list(provider)
         log.debug("data: %s", str(data))
-        self.assertEqual("".join(data), "Two\nThree\nNine\nEleven\n")
+        assert "".join(data) == "Two\nThree\nNine\nEleven\n"
 
 
 class TempFileCache:

--- a/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
+++ b/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
@@ -104,8 +104,10 @@ class Test_BaseDataProvider(BaseTestCase):
             return self.provider_class(source)
 
         # two objects without __iter__ method: build in function and int
-        self.assertRaises(exceptions.InvalidDataProviderSource, non_iterator_dprov, sum)
-        self.assertRaises(exceptions.InvalidDataProviderSource, non_iterator_dprov, 40)
+        with self.assertRaises(exceptions.InvalidDataProviderSource):
+            non_iterator_dprov(sum)
+        with self.assertRaises(exceptions.InvalidDataProviderSource):
+            non_iterator_dprov(40)
 
     def test_writemethods(self):
         """should throw an error if any write methods are called"""
@@ -117,9 +119,12 @@ class Test_BaseDataProvider(BaseTestCase):
             method = getattr(provider, method_name)
             return method(*args)
 
-        self.assertRaises(NotImplementedError, call_method, provider, "truncate", 20)
-        self.assertRaises(NotImplementedError, call_method, provider, "write", "bler")
-        self.assertRaises(NotImplementedError, call_method, provider, "writelines", ["one", "two"])
+        with self.assertRaises(NotImplementedError):
+            call_method(provider, "truncate", 20)
+        with self.assertRaises(NotImplementedError):
+            call_method(provider, "write", "bler")
+        with self.assertRaises(NotImplementedError):
+            call_method(provider, "writelines", ["one", "two"])
 
     def test_readlines(self):
         """readlines should return all the data in list form"""

--- a/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
+++ b/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
@@ -395,7 +395,3 @@ class TempFileCache:
                 log.debug("unlinking tmpfile: %s", tmpfile)
                 os.unlink(tmpfile)
         self._content_dict = {}
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/unit/data/datatypes/dataproviders/test_line_dataproviders.py
+++ b/test/unit/data/datatypes/dataproviders/test_line_dataproviders.py
@@ -3,7 +3,6 @@ Unit tests for base DataProviders.
 .. seealso:: galaxy.datatypes.dataproviders.base
 """
 import logging
-import unittest
 from typing import Type
 
 from galaxy.datatypes.dataproviders import (
@@ -310,7 +309,3 @@ class Test_BlockDataProvider(test_base_dataproviders.Test_FilteredDataProvider):
         )
         assert data == [{"id": "One", "seq": "ABCD"}, {"id": "Two", "seq": "ABCDEFGH"}]
         self.assertCounters(provider, 2, 2, 2)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/unit/data/datatypes/dataproviders/test_line_dataproviders.py
+++ b/test/unit/data/datatypes/dataproviders/test_line_dataproviders.py
@@ -52,8 +52,8 @@ class Test_FilteredLineDataProvider(test_base_dataproviders.Test_FilteredDataPro
     def test_limit_with_offset(self):
         def limit_offset_combo(limit, offset, data_should_be, read, valid, returned):
             (contents, provider, data) = self.contents_provider_and_data(limit=limit, offset=offset)
-            self.assertEqual(data, data_should_be)
-            # self.assertCounters( provider, read, valid, returned )
+            assert data == data_should_be
+            # self.assertCounters(provider, read, valid, returned)
 
         result_data = self.parses_default_content_as()
         test_data = [
@@ -75,22 +75,24 @@ class Test_FilteredLineDataProvider(test_base_dataproviders.Test_FilteredDataPro
     def test_provide_blank(self):
         """should return blank lines if ``provide_blank`` is true."""
         (contents, provider, data) = self.contents_provider_and_data(provide_blank=True)
-        self.assertEqual(data, ["One", "", "Two", "Three"])
+        assert data == ["One", "", "Two", "Three"]
         self.assertCounters(provider, 7, 4, 4)
 
     def test_strip_lines(self):
         """should return unstripped lines if ``strip_lines`` is false."""
         (contents, provider, data) = self.contents_provider_and_data(strip_lines=False)
-        self.assertEqual(data, ["One\n", "\n", "    Two\n", "Three\n"])
+        assert data == ["One\n", "\n", "    Two\n", "Three\n"]
         self.assertCounters(provider, 7, 4, 4)
 
     def test_comment_char(self):
         """should return unstripped lines if ``strip_lines`` is false."""
         (contents, provider, data) = self.contents_provider_and_data(comment_char="T")
-        self.assertEqual(
-            data,
-            ["# this should be stripped out", "One", "# as should blank lines", "# preceding/trailing whitespace too"],
-        )
+        assert data == [
+            "# this should be stripped out",
+            "One",
+            "# as should blank lines",
+            "# preceding/trailing whitespace too",
+        ]
         self.assertCounters(provider, 7, 4, 4)
 
 
@@ -109,36 +111,36 @@ class Test_RegexLineDataProvider(Test_FilteredLineDataProvider):
     def test_regex(self):
         """should return lines matching regex (AFTER strip, comments, blanks)."""
         (contents, provider, data) = self.contents_provider_and_data(regex_list=[r"^O"])
-        self.assertEqual(data, ["One"])
+        assert data == ["One"]
         self.assertCounters(provider, 7, 1, 1)
 
     def test_regex_list(self):
         """should return regex matches using more than one regex by ORing them."""
         (contents, provider, data) = self.contents_provider_and_data(regex_list=[r"^O", r"T"])
-        self.assertEqual(data, ["One", "Two", "Three"])
+        assert data == ["One", "Two", "Three"]
         self.assertCounters(provider, 7, 3, 3)
 
     def test_inverse(self):
         """should return inverse matches when ``invert`` is true."""
         (contents, provider, data) = self.contents_provider_and_data(regex_list=[r"^O"], invert=True)
-        self.assertEqual(data, ["Two", "Three"])
+        assert data == ["Two", "Three"]
         self.assertCounters(provider, 7, 2, 2)
 
     def test_regex_no_match(self):
         """should return empty if no regex matches."""
         (contents, provider, data) = self.contents_provider_and_data(regex_list=[r"^Z"])
-        self.assertEqual(data, [])
+        assert data == []
         self.assertCounters(provider, 7, 0, 0)
 
     def test_regex_w_limit_offset(self):
         """regex should play well with limit and offset"""
         (contents, provider, data) = self.contents_provider_and_data(regex_list=[r"^T"], limit=1)
-        self.assertEqual(data, ["Two"])
+        assert data == ["Two"]
         # TODO: once again, valid data, returned data is off
         self.assertCounters(provider, 6, 1, 1)
 
         (contents, provider, data) = self.contents_provider_and_data(regex_list=[r"^T"], limit=1, offset=1)
-        self.assertEqual(data, ["Three"])
+        assert data == ["Three"]
         self.assertCounters(provider, 7, 2, 1)
 
 
@@ -169,11 +171,11 @@ class Test_BlockDataProvider(test_base_dataproviders.Test_FilteredDataProvider):
     def test_file(self):
         """should work with files"""
         (contents, provider, data) = self.contents_provider_and_data()
-        self.assertEqual(data, self.parses_default_content_as())
-        self.assertTrue(isinstance(provider.source, line.FilteredLineDataProvider))
-        self.assertTrue(hasattr(provider.source.source, "read"))
+        assert data == self.parses_default_content_as()
+        assert isinstance(provider.source, line.FilteredLineDataProvider)
+        assert hasattr(provider.source.source, "read")
         # provider should call close on file
-        self.assertTrue(provider.source.source.closed)
+        assert provider.source.source.closed
 
     def test_counters(self):
         """should count: lines read, lines that passed the filter, lines returned"""
@@ -192,7 +194,7 @@ class Test_BlockDataProvider(test_base_dataproviders.Test_FilteredDataProvider):
 
         (contents, provider, data) = self.contents_provider_and_data(filter_fn=filter_ts)
         # no block fns here, so will parse as lines
-        self.assertEqual(data, [["One"], ["ABCD"], ["ABCD"], ["EFGH"]])
+        assert data == [["One"], ["ABCD"], ["ABCD"], ["EFGH"]]
         self.assertCounters(provider, 4, 4, 4)
 
     def test_new_block_delim_fn(self):
@@ -206,7 +208,7 @@ class Test_BlockDataProvider(test_base_dataproviders.Test_FilteredDataProvider):
         (contents, provider, data) = self.contents_provider_and_data(
             strip_lines=False, strip_newlines=True, new_block_delim_fn=is_not_indented
         )
-        self.assertEqual(data, [["One", "    ABCD"], ["Two", "    ABCD", "    EFGH"], ["Three"]])
+        assert data == [["One", "    ABCD"], ["Two", "    ABCD", "    EFGH"], ["Three"]]
         self.assertCounters(provider, 3, 3, 3)
 
     def test_block_filter_fn(self):
@@ -229,7 +231,7 @@ class Test_BlockDataProvider(test_base_dataproviders.Test_FilteredDataProvider):
         (contents, provider, data) = self.contents_provider_and_data(
             strip_lines=False, strip_newlines=True, new_block_delim_fn=is_not_indented, block_filter_fn=no_tw
         )
-        self.assertEqual(data, [["One", "    ABCD"], ["Three"]])
+        assert data == [["One", "    ABCD"], ["Three"]]
         self.assertCounters(provider, 3, 2, 2)
 
     def test_hack_block_filter_fn(self):
@@ -250,7 +252,7 @@ class Test_BlockDataProvider(test_base_dataproviders.Test_FilteredDataProvider):
         (contents, provider, data) = self.contents_provider_and_data(
             strip_lines=False, strip_newlines=True, new_block_delim_fn=is_not_indented, block_filter_fn=empty_block
         )
-        self.assertEqual(data, [{"header": "One", "data": ["ABCD"]}, {"header": "Two", "data": ["ABCD", "EFGH"]}])
+        assert data == [{"header": "One", "data": ["ABCD"]}, {"header": "Two", "data": ["ABCD", "EFGH"]}]
         self.assertCounters(provider, 3, 2, 2)
 
     def test_block_filter_fn_w_limit_offset(self):
@@ -272,7 +274,7 @@ class Test_BlockDataProvider(test_base_dataproviders.Test_FilteredDataProvider):
             block_filter_fn=empty_block,
             limit=1,
         )
-        self.assertEqual(data, [["One", "    ABCD"]])
+        assert data == [["One", "    ABCD"]]
         self.assertCounters(provider, 1, 1, 1)
         (contents, provider, data) = self.contents_provider_and_data(
             strip_lines=False,
@@ -282,7 +284,7 @@ class Test_BlockDataProvider(test_base_dataproviders.Test_FilteredDataProvider):
             limit=2,
             offset=1,
         )
-        self.assertEqual(data, [["Two", "    ABCD", "    EFGH"]])
+        assert data == [["Two", "    ABCD", "    EFGH"]]
         self.assertCounters(provider, 3, 2, 1)
 
     def test_simple_example(self):
@@ -306,7 +308,7 @@ class Test_BlockDataProvider(test_base_dataproviders.Test_FilteredDataProvider):
         (contents, provider, data) = self.contents_provider_and_data(
             contents=file_contents, new_block_delim_fn=fasta_header, block_filter_fn=id_seq
         )
-        self.assertEqual(data, [{"id": "One", "seq": "ABCD"}, {"id": "Two", "seq": "ABCDEFGH"}])
+        assert data == [{"id": "One", "seq": "ABCD"}, {"id": "Two", "seq": "ABCDEFGH"}]
         self.assertCounters(provider, 2, 2, 2)
 
 

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -1050,9 +1050,3 @@ class MockObjectStore:
 
     def update_from_file(self, *arg, **kwds):
         pass
-
-
-def get_suite():
-    suite = unittest.TestSuite()
-    suite.addTest(MappingTests("test_basic"))
-    return suite

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -310,7 +310,7 @@ class MappingTests(BaseModelTestCase):
             .first()
             .collection
         )
-        self.assertEqual(len(loaded_dataset_collection.elements), 2)
+        assert len(loaded_dataset_collection.elements) == 2
         assert loaded_dataset_collection.collection_type == "pair"
         assert loaded_dataset_collection["left"] == dce1
         assert loaded_dataset_collection["right"] == dce2
@@ -332,7 +332,7 @@ class MappingTests(BaseModelTestCase):
 
         # TODO:
         # loaded_dataset_collection = self.query( model.DatasetCollection ).filter( model.DatasetCollection.name == "LibraryCollectionTest1" ).first()
-        # self.assertEqual(len(loaded_dataset_collection.datasets), 2)
+        # assert len(loaded_dataset_collection.datasets) == 2
         # assert loaded_dataset_collection.collection_type == "pair"
 
     def test_nested_collection_attributes(self):
@@ -606,7 +606,7 @@ class MappingTests(BaseModelTestCase):
             )
             return list(map(lambda hda: hda.name, history.contents_iter(**kwds)))
 
-        self.assertEqual(contents_iter_names(), ["1", "2", "3", "4"])
+        assert contents_iter_names() == ["1", "2", "3", "4"]
         assert contents_iter_names(deleted=False) == ["1", "2"]
         assert contents_iter_names(visible=True) == ["1", "3"]
         assert contents_iter_names(visible=False) == ["2", "4"]

--- a/test/unit/security/test_vault.py
+++ b/test/unit/security/test_vault.py
@@ -21,12 +21,12 @@ class VaultTestBase:
 
     def test_read_write_secret(self):
         self.vault.write_secret("my/test/secret", "hello world")
-        self.assertEqual(self.vault.read_secret("my/test/secret"), "hello world")  # type: ignore
+        assert self.vault.read_secret("my/test/secret") == "hello world"  # type: ignore
 
     def test_overwrite_secret(self):
         self.vault.write_secret("my/new/secret", "hello world")
         self.vault.write_secret("my/new/secret", "hello overwritten")
-        self.assertEqual(self.vault.read_secret("my/new/secret"), "hello overwritten")  # type: ignore
+        assert self.vault.read_secret("my/new/secret") == "hello overwritten"  # type: ignore
 
     def test_valid_paths(self):
         with self.assertRaises(InvalidVaultKeyException):  # type: ignore
@@ -37,7 +37,7 @@ class VaultTestBase:
             self.vault.write_secret("my/ /new/secret", "hello world")
         # leading and trailing slashes should be ignored
         self.vault.write_secret("/my/new/secret with space/", "hello overwritten")
-        self.assertEqual(self.vault.read_secret("my/new/secret with space"), "hello overwritten")  # type: ignore
+        assert self.vault.read_secret("my/new/secret with space") == "hello overwritten"  # type: ignore
 
 
 VAULT_CONF_HASHICORP = os.path.join(os.path.dirname(__file__), "fixtures/vault_conf_hashicorp.yml")
@@ -85,7 +85,7 @@ class TestDatabaseVault(VaultTestBase, unittest.TestCase):
         # should succeed after rotation
         app.config.vault_config_file = VAULT_CONF_DATABASE_ROTATED  # type: ignore
         vault = VaultFactory.from_app(app)
-        self.assertEqual(vault.read_secret("my/rotated/secret"), "hello rotated")
+        assert vault.read_secret("my/rotated/secret") == "hello rotated"
 
     def test_wrong_keys(self):
         config = GalaxyDataTestConfig(vault_config_file=VAULT_CONF_DATABASE)

--- a/test/unit/shed_unit/test_tool_panel_manager.py
+++ b/test/unit/shed_unit/test_tool_panel_manager.py
@@ -178,7 +178,7 @@ class ToolPanelManagerTestCase(BaseToolBoxTestCase):
         )
 
     def _verify_tool_confs(self):
-        self._assert_valid_xml(self.integerated_tool_panel_path)
+        self._assert_valid_xml(self.integrated_tool_panel_path)
         self._assert_valid_xml(os.path.join(self.test_directory, "tool_conf.xml"))
 
     def _assert_valid_xml(self, filename):

--- a/test/unit/webapps/test_login.py
+++ b/test/unit/webapps/test_login.py
@@ -33,38 +33,38 @@ class LoginControllerTestCase(TestCase):
     def test_login(self):
         user2 = self.user_manager.create(**user2_data)
         self.app.security.encode_id(user2.id)
-        self.assertIsInstance(user2, model.User)
-        self.assertIsNotNone(user2.id)
-        self.assertEqual(user2.email, user2_data["email"])
-        self.assertTrue(check_password(default_password, user2.password))
+        assert isinstance(user2, model.User)
+        assert user2.id is not None
+        assert user2.email == user2_data["email"]
+        assert check_password(default_password, user2.password)
 
         controller = User(self.app)
         response = json.loads(controller.login(self.trans))
-        self.assertEqual(response["err_msg"], "Please specify a username and password.")
+        assert response["err_msg"] == "Please specify a username and password."
         response = json.loads(
             controller.login(self.trans, payload={"login": user2.email, "password": changed_password})
         )
-        self.assertEqual(response["err_msg"], "Invalid password.")
+        assert response["err_msg"] == "Invalid password."
         response = json.loads(
             controller.login(self.trans, payload={"login": user2.username, "password": changed_password})
         )
-        self.assertEqual(response["err_msg"], "Invalid password.")
+        assert response["err_msg"] == "Invalid password."
         user2.deleted = True
         response = json.loads(
             controller.login(self.trans, payload={"login": user2.username, "password": default_password})
         )
-        self.assertEqual(
-            response["err_msg"],
-            "This account has been marked deleted, contact your local Galaxy administrator to restore the account. Contact: admin@email.to.",
+        assert (
+            response["err_msg"]
+            == "This account has been marked deleted, contact your local Galaxy administrator to restore the account. Contact: admin@email.to."
         )
         user2.deleted = False
         user2.external = True
         response = json.loads(
             controller.login(self.trans, payload={"login": user2.username, "password": default_password})
         )
-        self.assertEqual(
-            response["err_msg"],
-            "This account was created for use with an external authentication method, contact your local Galaxy administrator to activate it. Contact: admin@email.to.",
+        assert (
+            response["err_msg"]
+            == "This account was created for use with an external authentication method, contact your local Galaxy administrator to activate it. Contact: admin@email.to."
         )
         user2.external = False
         self.trans.app.config.password_expiration_period = timedelta(days=1)
@@ -72,15 +72,15 @@ class LoginControllerTestCase(TestCase):
         response = json.loads(
             controller.login(self.trans, payload={"login": user2.username, "password": default_password})
         )
-        self.assertEqual(response["message"], "Your password has expired. Please reset or change it to access Galaxy.")
-        self.assertEqual(response["expired_user"], self.trans.security.encode_id(user2.id))
+        assert response["message"] == "Your password has expired. Please reset or change it to access Galaxy."
+        assert response["expired_user"] == self.trans.security.encode_id(user2.id)
         self.trans.app.config.password_expiration_period = timedelta(days=10)
         response = json.loads(
             controller.login(self.trans, payload={"login": user2.username, "password": default_password})
         )
-        self.assertEqual(response["message"], "Your password will expire in 11 day(s).")
+        assert response["message"] == "Your password will expire in 11 day(s)."
         self.trans.app.config.password_expiration_period = timedelta(days=100)
         response = json.loads(
             controller.login(self.trans, payload={"login": user2.username, "password": default_password})
         )
-        self.assertEqual(response["message"], "Success.")
+        assert response["message"] == "Success."

--- a/test/unit/webapps/test_webapp_base.py
+++ b/test/unit/webapps/test_webapp_base.py
@@ -104,7 +104,3 @@ class GalaxyWebTransaction_Headers_TestCase(unittest.TestCase):
         trans.request.headers["Origin"] = "http://öbb.at"
         trans.set_cors_headers()
         assert trans.response.headers["access-control-allow-origin"] == "http://öbb.at"
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/unit/webapps/test_webapp_base.py
+++ b/test/unit/webapps/test_webapp_base.py
@@ -38,30 +38,30 @@ class GalaxyWebTransaction_Headers_TestCase(unittest.TestCase):
         return trans
 
     def assert_cors_header_equals(self, headers, should_be):
-        self.assertEqual(headers.get("access-control-allow-origin", None), should_be)
+        assert headers.get("access-control-allow-origin", None) == should_be
 
     def assert_cors_header_missing(self, headers):
-        self.assertFalse("access-control-allow-origin" in headers)
+        assert not ("access-control-allow-origin" in headers)
 
     def test_parse_allowed_origin_hostnames(self):
         """Should return a list of (possibly) mixed strings and regexps"""
         config = CORSParsingMockConfig()
 
         # falsy listify value should return None
-        self.assertEqual(config._parse_allowed_origin_hostnames({"allowed_origin_hostnames": ""}), None)
+        assert config._parse_allowed_origin_hostnames({"allowed_origin_hostnames": ""}) is None
 
         # should parse regex if using fwd slashes, string otherwise
         hostnames = config._parse_allowed_origin_hostnames(
             {"allowed_origin_hostnames": r"/host\d{2}/,geocities.com,miskatonic.edu"}
         )
-        self.assertTrue(isinstance(hostnames[0], re.Pattern))
-        self.assertTrue(isinstance(hostnames[1], str))
-        self.assertTrue(isinstance(hostnames[2], str))
+        assert isinstance(hostnames[0], re.Pattern)
+        assert isinstance(hostnames[1], str)
+        assert isinstance(hostnames[2], str)
 
     def test_default_set_cors_headers(self):
         """No CORS headers should be set (or even checked) by default"""
         trans = self._new_trans(allowed_origin_hostnames=None)
-        self.assertTrue(isinstance(trans, Webapp.GalaxyWebTransaction))
+        assert isinstance(trans, Webapp.GalaxyWebTransaction)
 
         trans.request.headers["Origin"] = "http://lisaskelprecipes.pinterest.com?id=kelpcake"
         trans.set_cors_headers()
@@ -103,7 +103,7 @@ class GalaxyWebTransaction_Headers_TestCase(unittest.TestCase):
         trans = self._new_trans(allowed_origin_hostnames=r"/öbb\.at/")
         trans.request.headers["Origin"] = "http://öbb.at"
         trans.set_cors_headers()
-        self.assertEqual(trans.response.headers["access-control-allow-origin"], "http://öbb.at")
+        assert trans.response.headers["access-control-allow-origin"] == "http://öbb.at"
 
 
 if __name__ == "__main__":

--- a/test/unit/workflows/test_extract_summary.py
+++ b/test/unit/workflows/test_extract_summary.py
@@ -29,8 +29,8 @@ class TestWorkflowExtractSummary(unittest.TestCase):
         job_dict, warnings = extract.summarize(trans=self.trans)
         assert len(job_dict) == 2
         assert not warnings
-        self.assertEqual(job_dict[hda1.job], [("out1", hda1), ("out2", hda2)])
-        self.assertEqual(job_dict[hda3.job], [("out3", hda3)])
+        assert job_dict[hda1.job] == [("out1", hda1), ("out2", hda2)]
+        assert job_dict[hda3.job] == [("out3", hda3)]
 
     def test_finds_original_job_if_copied(self):
         hda = MockHda()
@@ -42,7 +42,7 @@ class TestWorkflowExtractSummary(unittest.TestCase):
         job_dict, warnings = extract.summarize(trans=self.trans)
         assert not warnings
         assert len(job_dict) == 1
-        self.assertEqual(job_dict[hda.job], [("out1", derived_hda_2)])
+        assert job_dict[hda.job] == [("out1", derived_hda_2)]
 
     def test_fake_job_hda(self):
         """Fakes job if creating_job_associations is empty."""

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -87,7 +87,7 @@ class WorkflowProgressTestCase(unittest.TestCase):
                 workflow_invocation_step.workflow_step_id = step_id
                 workflow_invocation_step.state = "scheduled"
                 workflow_invocation_step.workflow_step = self._step(i)
-                self.assertEqual(step_id, self._step(i).id)
+                assert step_id == self._step(i).id
                 # workflow_invocation_step.workflow_invocation = self.invocation
                 self.invocation.steps.append(workflow_invocation_step)
 


### PR DESCRIPTION
(excluding ``self.assertRaises*()``).

Also:
- Remove ``unittest.main()`` calls.
- Use ``self.assertRaises*()`` as a context manager.
- Remove unused ``get_suite()`` functions.

These simple refactorings are the first steps towards moving away from subclassing tests from standard library's `unittest.TestCase`.
The reason for this is to enable the use of pytest plugins (e.g. [pytest-memray](https://pytest-memray.readthedocs.io/)) that use [features that don't work in `unittest.TestCase` subclasses](https://docs.pytest.org/en/7.1.x/how-to/unittest.html#pytest-features-in-unittest-testcase-subclasses).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
