### PR TITLE
Generate somewhat valid SafeStringWrapper-wrapped class names

### DIFF
--- a/lib/galaxy/security/object_wrapper.py
+++ b/lib/galaxy/security/object_wrapper.py
@@ -168,7 +168,9 @@ def wrap_with_safe_string(value, no_wrap_classes=None):
         value_mod = inspect.getmodule(value)
         if value_mod:
             wrapped_class_name = f"{value_mod.__name__}.{wrapped_class_name}"
-        wrapped_class_name = f"SafeStringWrapper({wrapped_class_name}:{','.join(sorted(map(str, no_wrap_classes)))})"
+        wrapped_class_name = (
+            f"SafeStringWrapper__{wrapped_class_name}__{'__'.join(sorted([c.__name__ for c in no_wrap_classes]))}"
+        )
         do_wrap_func_name = f"__do_wrap_{wrapped_class_name}"
         do_wrap_func = __do_wrap
         global_dict = globals()

--- a/lib/galaxy/security/object_wrapper.py
+++ b/lib/galaxy/security/object_wrapper.py
@@ -169,7 +169,7 @@ def wrap_with_safe_string(value, no_wrap_classes=None):
         if value_mod:
             wrapped_class_name = f"{value_mod.__name__}.{wrapped_class_name}"
         wrapped_class_name = (
-            f"SafeStringWrapper__{wrapped_class_name}__{'__'.join(sorted([c.__name__ for c in no_wrap_classes]))}"
+            f"SafeStringWrapper__{wrapped_class_name}__{'__'.join(sorted(c.__name__ for c in no_wrap_classes))}"
         )
         do_wrap_func_name = f"__do_wrap_{wrapped_class_name}"
         do_wrap_func = __do_wrap


### PR DESCRIPTION
I don't think there's any downside, and the upside is that we can use https://github.com/kensho-technologies/pytest-annotate to kickstart type annotations. Applying collected annotations (e.g. `pyannotate --py3 --type-info ./annotations.json lib/galaxy/workflow/run.py` currently fails with:
```
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/.venv/bin/pyannotate", line 8, in <module>
    sys.exit(main())
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/pyannotate_tools/annotations/__main__.py", line 122, in main
    data = generate_annotations_json_string(
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/pyannotate_tools/annotations/main.py", line 60, in generate_annotations_json_string
    signature = unify_type_comments(item.type_comments)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/pyannotate_tools/annotations/main.py", line 27, in unify_type_comments
    arg_types, return_type = infer_annotation(type_comments)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/pyannotate_tools/annotations/infer.py", line 45, in infer_annotation
    arg_types, return_type = parse_type_comment(comment)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/pyannotate_tools/annotations/parse.py", line 216, in parse_type_comment
    return Parser(comment).parse()
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/pyannotate_tools/annotations/parse.py", line 225, in __init__
    self.tokens = tokenize(comment)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/pyannotate_tools/annotations/parse.py", line 193, in tokenize
    raise ParseError(original)
pyannotate_tools.annotations.parse.ParseError: Invalid type comment: (galaxy.app.UniverseApplication, Dict, Dict[str, galaxy.model.HistoryDatasetAssociation], Dict[Union[galaxy.security.object_wrapper:SafeStringWrapper(str:<class 'NoneType'>,<class 'NotImplementedType'>,<class 'bool'>,<class 'bytearray'>,<class 'ellipsis'>,<class 'galaxy.security.object_wrapper.SafeStringWrapper'>,<class 'galaxy.tools.wrappers.ToolParameterValueWrapper'>,<class 'numbers.Number'>), str], Union[galaxy.security.object_wrapper.CallableSafeStringWrapper, galaxy.security.object_wrapper:SafeStringWrapper(str:<class 'NoneType'>,<class 'NotImplementedType'>,<class 'bool'>,<class 'bytearray'>,<class 'ellipsis'>,<class 'galaxy.security.object_wrapper.SafeStringWrapper'>,<class 'galaxy.tools.wrappers.ToolParameterValueWrapper'>,<class 'numbers.Number'>), str]]) -> None
```
This fixes that.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
