### PR TITLE
Replace ``unittest.TestCase`` with pytest-based partial re-implementation

### DIFF
--- a/doc/source/dev/debugging_tests.md
+++ b/doc/source/dev/debugging_tests.md
@@ -34,13 +34,13 @@ The following instructions assume that you have cloned your Galaxy fork into ~/g
 ![VS Code Tests](tests.png)
 9. Expand integration/unit tests, select a test to display its source code in editor, add a breakpoint, and start the debugger by clicking on the debug icon (next to test name)
 
-## Debugging tests within github actions
+## Debugging tests within GitHub actions
 
 Sometimes it is necessary to debug tests that work locally. There are a few different strategies one could employ.
 The first step is often to exclude the workflow runs that are passing, so that you don't waste time waiting for your test.
-To do this you can delete all the workflow files in .github/workflows/*.yaml except for the one that sets up the failing test.
+To do this you can delete all the workflow YAML files in `.github/workflows/` except for the one that sets up the failing test.
 
-If the yaml file has a strategy section that sets up multiple tests keep just the one that contains the failing test.
+If the YAML file has a strategy section that sets up multiple tests keep just the one that contains the failing test.
 If the test never finishes, add `-s` to the options that `run_tests.sh` pass to `pytest` (i.e. `-s` needs to be after a `--`), so you can see live output.
 This diff here adds `-s` and disables strategies that are already passing:
 
@@ -73,3 +73,14 @@ If that's not enough and you need to snoop around the process, halting it and in
 and run the test manually. You can do this by injecting a step that inserts an ssh session via [tmate](https://github.com/mxschmitt/action-tmate#use-registered-public-ssh-keys), then use your favorite tools like py-spy or similar to look at the test while it's failing or getting stuck.
 
 Note that you probably don't want to do this on a PR branch, where all your tests are still going to run. Instead run this only against your fork.
+
+# Debugging tests that run out of memory
+
+You can profile the memory used in tests by installing
+[pytest-memray](https://pytest-memray.readthedocs.io/) in your virtual
+environment, activating it by setting `memray = true` in `pytest.ini`, then run
+the problematic tests in the usual way. After the tests finish, a report is
+produced by memray.
+
+Note that `pytest-memray` cannot profile test classes that inherit from
+`unittest.TestCase` .

--- a/lib/galaxy/datatypes/anvio.py
+++ b/lib/galaxy/datatypes/anvio.py
@@ -5,7 +5,6 @@ https://github.com/merenlab/anvio
 import glob
 import logging
 import os
-import sys
 from typing import Optional
 
 from galaxy.datatypes.metadata import MetadataElement
@@ -168,9 +167,3 @@ class AnvioSamplesDB(AnvioDB):
     _anvio_basename = "SAMPLES.db"
     MetadataElement(name="anvio_basename", default=_anvio_basename, desc="Basename", readonly=True)
     file_ext = "anvio_samples_db"
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod(sys.modules[__name__])

--- a/lib/galaxy/datatypes/assembly.py
+++ b/lib/galaxy/datatypes/assembly.py
@@ -7,7 +7,6 @@ for velvet assembler tool in galaxy
 import logging
 import os
 import re
-import sys
 
 from galaxy.datatypes import (
     data,
@@ -242,9 +241,3 @@ class Velvet(Html):
     def set_meta(self, dataset, **kwd):
         Html.set_meta(self, dataset, **kwd)
         self.regenerate_primary_file(dataset)
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod(sys.modules[__name__])

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -9,7 +9,6 @@ import os
 import shutil
 import struct
 import subprocess
-import sys
 import tarfile
 import tempfile
 import zipfile
@@ -4196,9 +4195,3 @@ class HexrdEtaOmeNpz(Npz):
             return dataset.peek
         except Exception:
             return "Binary Numpy npz file (%s)" % (nice_size(dataset.get_size()))
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod(sys.modules[__name__])

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -1236,9 +1236,3 @@ class AllegroLOD(LinkageStudies):
                 return False
 
         return True
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod(sys.modules[__name__])

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -1727,9 +1727,3 @@ class ScIdx(Tabular):
         if count >= 1:
             return True
         return False
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod(sys.modules[__name__])

--- a/lib/galaxy/datatypes/mothur.py
+++ b/lib/galaxy/datatypes/mothur.py
@@ -3,7 +3,6 @@ Mothur Metagenomics Datatypes
 """
 import logging
 import re
-import sys
 
 from galaxy.datatypes.data import Text
 from galaxy.datatypes.metadata import MetadataElement
@@ -1064,9 +1063,3 @@ class SffFlow(Tabular):
         except Exception as exc:
             out = f"Can't create peek: {unicodify(exc)}"
         return out
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod(sys.modules[__name__])

--- a/lib/galaxy/datatypes/neo4j.py
+++ b/lib/galaxy/datatypes/neo4j.py
@@ -2,7 +2,6 @@
 Neo4j Composite Dataset
 """
 import logging
-import sys
 
 from galaxy.datatypes.data import Data
 from galaxy.datatypes.images import Html
@@ -132,9 +131,3 @@ class Neo4jDBzip(Neo4j, Data):
         self.add_composite_file(
             "%s.zip", description="neostore zip", substitute_name_with_metadata="reference_name", is_binary=True
         )
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod(sys.modules[__name__])

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -10,7 +10,6 @@ import os
 import re
 import shutil
 import struct
-import sys
 import tempfile
 import zipfile
 from functools import partial
@@ -942,9 +941,3 @@ DECOMPRESSION_FUNCTIONS: Dict[str, Decompress] = dict(gzip=gzip.GzipFile, bz2=bz
 
 class InappropriateDatasetContentError(Exception):
     pass
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod(sys.modules[__name__])

--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -5,7 +5,6 @@ searches for tests for packages in the bioconda-recipes repo and on Anaconda, lo
 
 A shallow search (default for singularity and conda generation scripts) just checks once on Anaconda for the specified version.
 """
-# import doctest
 import json
 import logging
 import tarfile

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1852,9 +1852,3 @@ class StructuredExecutionTimer:
     @property
     def elapsed(self):
         return time.time() - self.begin
-
-
-if __name__ == "__main__":
-    import doctest
-
-    doctest.testmod(sys.modules[__name__], verbose=False)

--- a/lib/galaxy/util/unittest.py
+++ b/lib/galaxy/util/unittest.py
@@ -1,0 +1,45 @@
+import pytest
+
+
+class TestCase:
+    """Partial re-implementation of standard library unittest.TestCase using
+    pytest methods
+    See https://docs.pytest.org/en/latest/how-to/xunit_setup.html for a
+    description of the pytest setup/teardown methods.
+
+    Most assert*() methods of unittest.TestCase are not reimplemented here on
+    purpose, normal assert statements should be used instead."""
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def setup_class(cls):
+        cls.setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    @classmethod
+    def teardown_class(cls):
+        cls.tearDownClass()
+
+    def setUp(self):
+        pass
+
+    def setup_method(self):
+        self.setUp()
+
+    def tearDown(self):
+        pass
+
+    def teardown_method(self):
+        self.tearDown()
+
+    def assertRaises(self, exception):
+        return pytest.raises(exception)
+
+    def assertRaisesRegex(self, exception, regex):
+        return pytest.raises(exception, match=regex)

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -42,7 +42,7 @@ class BaseHistories:
         assert len(contents) == n, contents
 
 
-class HistoriesApiTestCase(ApiTestCase, BaseHistories):
+class TestHistoriesApi(ApiTestCase, BaseHistories):
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
@@ -556,7 +556,7 @@ class ImportExportTests(BaseHistories):
             elements_checker(imported_collection_metadata["elements"])
 
 
-class ImportExportHistoryTestCase(ApiTestCase, ImportExportTests):
+class TestImportExportHistory(ApiTestCase, ImportExportTests):
     task_based = False
 
     def setUp(self):
@@ -564,7 +564,7 @@ class ImportExportHistoryTestCase(ApiTestCase, ImportExportTests):
         self._set_up_populators()
 
 
-class SharingHistoryTestCase(ApiTestCase, BaseHistories, SharingApiTests):
+class TestSharingHistory(ApiTestCase, BaseHistories, SharingApiTests):
     """Tests specific for the particularities of sharing Histories."""
 
     api_name = "histories"

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -19,7 +19,6 @@ from galaxy_test.base.api_asserts import (
 )
 from galaxy_test.base.populators import (
     BaseDatasetCollectionPopulator,
-    BaseDatasetPopulator,
     DatasetCollectionPopulator,
     DatasetPopulator,
     LibraryPopulator,
@@ -54,7 +53,7 @@ MINIMAL_TOOL_NO_ID = {
 
 
 class TestsTools:
-    dataset_populator: BaseDatasetPopulator
+    dataset_populator: DatasetPopulator
     dataset_collection_populator: BaseDatasetCollectionPopulator
 
     def _build_pair(self, history_id, contents):

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2360,9 +2360,9 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             new_collections = (
                 len([c for c in history_contents if c["history_content_type"] == "dataset_collection"]) - 1
             )
-            assert new_collections == 2, (
-                "Expected to generate 4 new, filtered collections, but got %d collections" % new_collections
-            )
+            assert (
+                new_collections == 2
+            ), f"Expected to generate 4 new, filtered collections, but got {new_collections} collections"
             assert (
                 filtered_collection["collection_type"] == discarded_collection["collection_type"] == "list:list"
             ), filtered_collection

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -225,7 +225,7 @@ class GalaxyTestSeleniumContext(GalaxySeleniumContext):
     """Extend GalaxySeleniumContext with Selenium-aware galaxy_test.base.populators."""
 
     @property
-    def dataset_populator(self) -> populators.BaseDatasetPopulator:
+    def dataset_populator(self) -> "SeleniumSessionDatasetPopulator":
         """A dataset populator connected to the Galaxy session described by Selenium context."""
         return SeleniumSessionDatasetPopulator(self)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,8 @@
 addopts = --doctest-continue-on-failure
 asyncio_mode = auto
 log_level = DEBUG
+# Install pytest-memray and set memray to true here to enable memory profiling of tests
+# memray = true
 pythonpath = lib
 markers =
   data_manager: marks test as a data_manager test

--- a/test/integration/cloudauthz/test_cloudauthz.py
+++ b/test/integration/cloudauthz/test_cloudauthz.py
@@ -1,6 +1,6 @@
 """
 You may run this test using the following command:
-./run_tests.sh test/integration/cloudauthz/test_cloudauthz.py:DefineCloudAuthzTestCase.test_post_cloudauthz_without_authn -s
+./run_tests.sh test/integration/cloudauthz/test_cloudauthz.py:TestDefineCloudAuthz.test_post_cloudauthz_without_authn -s
 """
 
 import json
@@ -8,7 +8,7 @@ import json
 from galaxy_test.driver import integration_util
 
 
-class DefineCloudAuthzTestCase(integration_util.IntegrationTestCase):
+class TestDefineCloudAuthz(integration_util.IntegrationTestCase):
     framework_tool_and_types = True
 
     def test_post_cloudauthz_without_authn(self):

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -51,6 +51,7 @@ def stop_minio(container_name):
 
 class BaseObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase):
 
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
 
     @classmethod

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -67,7 +67,7 @@ class BaseObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase):
             dir_name = os.path.basename(path)
             os.path.join(temp_directory, dir_name)
             os.makedirs(path)
-            setattr(cls, "%s_path" % dir_name, path)
+            setattr(cls, f"{dir_name}_path", path)
 
     def setUp(self):
         super().setUp()
@@ -85,7 +85,7 @@ class BaseSwiftObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
 
     @classmethod
     def setUpClass(cls):
-        cls.container_name = "%s_container" % cls.__name__
+        cls.container_name = f"{cls.__name__}_container"
         start_minio(cls.container_name)
         super().setUpClass()
 

--- a/test/integration/objectstore/test_jobs.py
+++ b/test/integration/objectstore/test_jobs.py
@@ -39,7 +39,7 @@ DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template(
 TEST_INPUT_FILES_CONTENT = "1 2 3"
 
 
-class ObjectStoreJobsIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+class TestObjectStoreJobsIntegration(BaseObjectStoreIntegrationTestCase):
     # setup by _configure_object_store
     files1_path: str
     files2_path: str

--- a/test/integration/objectstore/test_mixed_store_by.py
+++ b/test/integration/objectstore/test_mixed_store_by.py
@@ -32,7 +32,7 @@ DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template(
 TEST_INPUT_FILES_CONTENT = "1 2 3"
 
 
-class MixedStoreByObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+class TestMixedStoreByObjectStoreIntegration(BaseObjectStoreIntegrationTestCase):
     # setup by _configure_object_store
     files1_path: str
     files2_path: str

--- a/test/integration/objectstore/test_remote_objectstore_cache_operations.py
+++ b/test/integration/objectstore/test_remote_objectstore_cache_operations.py
@@ -9,7 +9,7 @@ from ._base import (
 )
 
 
-class CacheOperationTestCase(BaseSwiftObjectStoreIntegrationTestCase):
+class TestCacheOperation(BaseSwiftObjectStoreIntegrationTestCase):
     def tearDown(self):
         shutil.rmtree(self.object_store_cache_path)
         os.mkdir(self.object_store_cache_path)

--- a/test/integration/objectstore/test_selection.py
+++ b/test/integration/objectstore/test_selection.py
@@ -48,7 +48,7 @@ DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template(
 )
 
 
-class ObjectStoreSelectionIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+class TestObjectStoreSelectionIntegration(BaseObjectStoreIntegrationTestCase):
     # populated by config_object_store
     files_default_path: str
     files_static_path: str

--- a/test/integration/objectstore/test_swift_objectstore.py
+++ b/test/integration/objectstore/test_swift_objectstore.py
@@ -27,9 +27,9 @@ TEST_TOOL_IDS = [
 ]
 
 
-class SwiftObjectStoreIntegrationTestCase(BaseSwiftObjectStoreIntegrationTestCase):
+class TestSwiftObjectStoreIntegration(BaseSwiftObjectStoreIntegrationTestCase):
     pass
 
 
-instance = integration_util.integration_module_instance(SwiftObjectStoreIntegrationTestCase)
+instance = integration_util.integration_module_instance(TestSwiftObjectStoreIntegration)
 test_tools = integration_util.integration_tool_runner(TEST_TOOL_IDS)

--- a/test/integration/test_async_downloads.py
+++ b/test/integration/test_async_downloads.py
@@ -4,18 +4,18 @@ from io import BytesIO
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
-    uses_test_history,
 )
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
 
-class AsyncDownloadsIntegrationTestCase(IntegrationTestCase):
+class TestAsyncDownloadsIntegration(IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
-    @uses_test_history(require_new=True)
     def test_async_collection_download(self, history_id):
         fetch_response = self.dataset_collection_populator.create_list_in_history(history_id, direct_upload=True).json()
         dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)

--- a/test/integration/test_celery_tasks.py
+++ b/test/integration/test_celery_tasks.py
@@ -30,7 +30,9 @@ def process_page(request: CreatePagePayload):
     return f"content_format is {request.content_format} with annotation {request.annotation}"
 
 
-class CeleryTasksIntegrationTestCase(IntegrationTestCase):
+class TestCeleryTasksIntegration(IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/test/integration/test_chained_dynamic_destinations.py
+++ b/test/integration/test_chained_dynamic_destinations.py
@@ -10,7 +10,7 @@ SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 CHAINED_DYNDESTS_JOB_CONFIG = os.path.join(SCRIPT_DIRECTORY, "chained_dyndest_job_conf.xml")
 
 
-class ChainedDynamicDestinationIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+class TestChainedDynamicDestinationIntegration(BaseJobEnvironmentIntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_change_datatype_with_store_by_id.py
+++ b/test/integration/test_change_datatype_with_store_by_id.py
@@ -1,4 +1,4 @@
-from galaxy_test.api.test_workflows import ChangeDatatypeTestCase
+from galaxy_test.api import test_workflows
 from galaxy_test.base.populators import (
     DatasetPopulator,
     WorkflowPopulator,
@@ -6,9 +6,12 @@ from galaxy_test.base.populators import (
 from galaxy_test.driver import integration_util
 
 
-class ChangeDatatypeStoreByIdIntegrationTestCase(integration_util.IntegrationTestCase, ChangeDatatypeTestCase):
+class TestChangeDatatypeStoreByIdIntegration(
+    integration_util.IntegrationTestCase, test_workflows.ChangeDatatypeTestCase
+):
     """Test changing datatype with object_store_store_by: id."""
 
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
 
     @classmethod

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -153,17 +153,17 @@ class SecureShell:
     shell_plugin = "SecureShell"
 
 
-class ParamikoCliSlurmIntegrationTestCase(SlurmSetup, ParamikoShell, AbstractTestCases.BaseCliIntegrationTestCase):
+class TestParamikoCliSlurmIntegration(SlurmSetup, ParamikoShell, AbstractTestCases.BaseCliIntegrationTestCase):
     pass
 
 
-class ShellJobCliSlurmIntegrationTestCase(SlurmSetup, SecureShell, AbstractTestCases.BaseCliIntegrationTestCase):
+class TestShellJobCliSlurmIntegration(SlurmSetup, SecureShell, AbstractTestCases.BaseCliIntegrationTestCase):
     pass
 
 
-class ParamikoCliOpenPBSIntegrationTestCase(OpenPBSSetup, ParamikoShell, AbstractTestCases.BaseCliIntegrationTestCase):
+class TestParamikoCliOpenPBSIntegration(OpenPBSSetup, ParamikoShell, AbstractTestCases.BaseCliIntegrationTestCase):
     pass
 
 
-class ShellJobCliOpenPBSIntegrationTestCase(OpenPBSSetup, SecureShell, AbstractTestCases.BaseCliIntegrationTestCase):
+class TestShellJobCliOpenPBSIntegration(OpenPBSSetup, SecureShell, AbstractTestCases.BaseCliIntegrationTestCase):
     pass

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 import tempfile
 import time
-import unittest
 from typing import (
     ClassVar,
     NamedTuple,
@@ -97,43 +96,42 @@ def cli_job_config(remote_connection, shell_plugin="ParamikoShell", job_plugin="
     return job_conf.name
 
 
-@integration_util.skip_unless_docker()
-class BaseCliIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
-    container_name: ClassVar[str]
-    jobs_directory: ClassVar[str]
-    remote_connection: ClassVar[RemoteConnection]
-    image: ClassVar[str]
-    shell_plugin: ClassVar[str]
-    job_plugin: ClassVar[str]
+class AbstractTestCases:
+    @integration_util.skip_unless_docker()
+    class BaseCliIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+        container_name: ClassVar[str]
+        jobs_directory: ClassVar[str]
+        remote_connection: ClassVar[RemoteConnection]
+        image: ClassVar[str]
+        shell_plugin: ClassVar[str]
+        job_plugin: ClassVar[str]
 
-    @classmethod
-    def setUpClass(cls):
-        if cls is BaseCliIntegrationTestCase:
-            raise unittest.SkipTest("Base class")
-        cls.container_name = f"{cls.__name__}_container"
-        cls.jobs_directory = tempfile.mkdtemp()
-        cls.remote_connection = start_ssh_docker(
-            container_name=cls.container_name, jobs_directory=cls.jobs_directory, image=cls.image
-        )
-        super().setUpClass()
+        @classmethod
+        def setUpClass(cls):
+            cls.container_name = f"{cls.__name__}_container"
+            cls.jobs_directory = tempfile.mkdtemp()
+            cls.remote_connection = start_ssh_docker(
+                container_name=cls.container_name, jobs_directory=cls.jobs_directory, image=cls.image
+            )
+            super().setUpClass()
 
-    @classmethod
-    def tearDownClass(cls):
-        stop_ssh_docker(cls.container_name, cls.remote_connection)
-        super().tearDownClass()
+        @classmethod
+        def tearDownClass(cls):
+            stop_ssh_docker(cls.container_name, cls.remote_connection)
+            super().tearDownClass()
 
-    @classmethod
-    def handle_galaxy_config_kwds(cls, config):
-        config["jobs_directory"] = cls.jobs_directory
-        config["file_path"] = cls.jobs_directory
-        config["job_config_file"] = cli_job_config(
-            remote_connection=cls.remote_connection, shell_plugin=cls.shell_plugin, job_plugin=cls.job_plugin
-        )
+        @classmethod
+        def handle_galaxy_config_kwds(cls, config):
+            config["jobs_directory"] = cls.jobs_directory
+            config["file_path"] = cls.jobs_directory
+            config["job_config_file"] = cli_job_config(
+                remote_connection=cls.remote_connection, shell_plugin=cls.shell_plugin, job_plugin=cls.job_plugin
+            )
 
-    @skip_without_tool("job_environment_default")
-    def test_running_cli_job(self):
-        job_env = self._run_and_get_environment_properties()
-        assert job_env.some_env == "42"
+        @skip_without_tool("job_environment_default")
+        def test_running_cli_job(self):
+            job_env = self._run_and_get_environment_properties()
+            assert job_env.some_env == "42"
 
 
 @pytest.mark.xfail(reason="Container entrypoint occasionally fails to set default queue")
@@ -155,17 +153,17 @@ class SecureShell:
     shell_plugin = "SecureShell"
 
 
-class ParamikoCliSlurmIntegrationTestCase(SlurmSetup, ParamikoShell, BaseCliIntegrationTestCase):
+class ParamikoCliSlurmIntegrationTestCase(SlurmSetup, ParamikoShell, AbstractTestCases.BaseCliIntegrationTestCase):
     pass
 
 
-class ShellJobCliSlurmIntegrationTestCase(SlurmSetup, SecureShell, BaseCliIntegrationTestCase):
+class ShellJobCliSlurmIntegrationTestCase(SlurmSetup, SecureShell, AbstractTestCases.BaseCliIntegrationTestCase):
     pass
 
 
-class ParamikoCliOpenPBSIntegrationTestCase(OpenPBSSetup, ParamikoShell, BaseCliIntegrationTestCase):
+class ParamikoCliOpenPBSIntegrationTestCase(OpenPBSSetup, ParamikoShell, AbstractTestCases.BaseCliIntegrationTestCase):
     pass
 
 
-class ShellJobCliOpenPBSIntegrationTestCase(OpenPBSSetup, SecureShell, BaseCliIntegrationTestCase):
+class ShellJobCliOpenPBSIntegrationTestCase(OpenPBSSetup, SecureShell, AbstractTestCases.BaseCliIntegrationTestCase):
     pass

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -110,7 +110,7 @@ class BaseCliIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
     def setUpClass(cls):
         if cls is BaseCliIntegrationTestCase:
             raise unittest.SkipTest("Base class")
-        cls.container_name = "%s_container" % cls.__name__
+        cls.container_name = f"{cls.__name__}_container"
         cls.jobs_directory = tempfile.mkdtemp()
         cls.remote_connection = start_ssh_docker(
             container_name=cls.container_name, jobs_directory=cls.jobs_directory, image=cls.image

--- a/test/integration/test_config_options_users.py
+++ b/test/integration/test_config_options_users.py
@@ -12,7 +12,7 @@ class _BaseUserExposeIntegerationTestCase(integration_util.IntegrationTestCase):
         return users
 
 
-class DefaultUserExposeIntegrationTestCase(_BaseUserExposeIntegerationTestCase):
+class TestDefaultUserExposeIntegration(_BaseUserExposeIntegerationTestCase):
     def test_defaults(self):
         original_user_ids = self.original_user_ids()
         self.galaxy_interactor.ensure_user_with_email("defaultuserexposetest@galaxyproject.org")
@@ -22,7 +22,7 @@ class DefaultUserExposeIntegrationTestCase(_BaseUserExposeIntegerationTestCase):
         assert len(new_users) == 0
 
 
-class EmailUserExposeIntegrationTestCase(_BaseUserExposeIntegerationTestCase):
+class TestEmailUserExposeIntegration(_BaseUserExposeIntegerationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -39,7 +39,7 @@ class EmailUserExposeIntegrationTestCase(_BaseUserExposeIntegerationTestCase):
         assert "last_password_change" not in user
 
 
-class UsernameUserExposeIntegrationTestCase(_BaseUserExposeIntegerationTestCase):
+class TestUsernameUserExposeIntegration(_BaseUserExposeIntegerationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_config_schema.py
+++ b/test/integration/test_config_schema.py
@@ -1,7 +1,7 @@
 from galaxy_test.driver import integration_util
 
 
-class ConfigSchemaTestCase(integration_util.IntegrationTestCase):
+class TestConfigSchema(integration_util.IntegrationTestCase):
     def test_schema_path_resolution_graph(self):
         # Run schema's validation method; throws error if schema invalid
         schema = self._app.config.schema

--- a/test/integration/test_configuration_decode.py
+++ b/test/integration/test_configuration_decode.py
@@ -2,7 +2,7 @@ from galaxy_test.base.populators import LibraryPopulator
 from galaxy_test.driver import integration_util
 
 
-class ConfigurationDecodeIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestConfigurationDecodeIntegration(integration_util.IntegrationTestCase):
     def setUp(self):
         super().setUp()
         self.library_populator = LibraryPopulator(self.galaxy_interactor)

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -60,7 +60,7 @@ def skip_if_container_type_unavailable(cls):
         raise unittest.SkipTest(f"Executable '{cls.container_type}' not found on PATH")
 
 
-class DockerizedJobsIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
+class TestDockerizedJobsIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
 
     job_config_file = DOCKERIZED_JOB_CONFIG_FILE
     build_mulled_resolver = "build_mulled"
@@ -152,7 +152,7 @@ class DockerizedJobsIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         assert status[0]["container_description"]["identifier"].startswith("quay.io/local/mulled-v2-")
 
 
-class MappingContainerResolverTestCase(integration_util.IntegrationTestCase):
+class TestMappingContainerResolver(integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
     container_type = "docker"
@@ -195,7 +195,7 @@ class MappingContainerResolverTestCase(integration_util.IntegrationTestCase):
         assert "0.7.15-r1140" in output
 
 
-class InlineContainerConfigurationTestCase(MappingContainerResolverTestCase):
+class TestInlineContainerConfiguration(TestMappingContainerResolver):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -218,7 +218,7 @@ class InlineContainerConfigurationTestCase(MappingContainerResolverTestCase):
         config["container_resolvers"] = container_resolvers_config
 
 
-class InlineJobEnvironmentContainerResolverTestCase(integration_util.IntegrationTestCase):
+class TestInlineJobEnvironmentContainerResolver(integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
     container_type = "docker"
@@ -251,8 +251,8 @@ class InlineJobEnvironmentContainerResolverTestCase(integration_util.Integration
 # Singularity 2.4 in the official Vagrant issue has some problems running this test
 # case by default because subdirectories of /tmp don't bind correctly. Overridding
 # TMPDIR can fix this.
-# TMPDIR=/home/vagrant/tmp/ pytest test/integration/test_containerized_jobs.py::SingularityJobsIntegrationTestCase
-class SingularityJobsIntegrationTestCase(DockerizedJobsIntegrationTestCase):
+# TMPDIR=/home/vagrant/tmp/ pytest test/integration/test_containerized_jobs.py::TestSingularityJobsIntegration
+class TestSingularityJobsIntegration(TestDockerizedJobsIntegration):
 
     job_config_file = SINGULARITY_JOB_CONFIG_FILE
     build_mulled_resolver = "build_mulled_singularity"

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -57,7 +57,7 @@ def disable_dependency_resolution(config):
 
 def skip_if_container_type_unavailable(cls):
     if not which(cls.container_type):
-        raise unittest.SkipTest("Executable '%s' not found on PATH" % cls.container_type)
+        raise unittest.SkipTest(f"Executable '{cls.container_type}' not found on PATH")
 
 
 class DockerizedJobsIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
@@ -123,8 +123,6 @@ class DockerizedJobsIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         assert job_env.home.endswith("/home")
 
     def test_build_mulled(self):
-        if not which("docker"):
-            raise unittest.SkipTest("Docker not found on PATH, required for building images via involucro")
         resolver_type = self.build_mulled_resolver
         tool_ids = ["mulled_example_multi_1"]
         endpoint = "dependency_resolvers/toolbox/install"

--- a/test/integration/test_data_manager.py
+++ b/test/integration/test_data_manager.py
@@ -64,7 +64,7 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         config["tool_data_path"] = cls.shed_tool_data_dir
         config["watch_tool_data_dir"] = True
         cls.username = cls.get_secure_ascii_digits()
-        config["admin_users"] = "%s@galaxy.org" % cls.username
+        config["admin_users"] = f"{cls.username}@galaxy.org"
 
     @skip_if_toolshed_down
     def test_data_manager_installation_table_reload(self):
@@ -73,7 +73,7 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         """
         self.install_repository("devteam", "data_manager_fetch_genome_dbkeys_all_fasta", "14eb0fc65c62")
         self.install_repository("devteam", "data_manager_sam_fasta_index_builder", "cc4ef4d38cf9")
-        with self._different_user(email="%s@galaxy.org" % self.username):
+        with self._different_user(email=f"{self.username}@galaxy.org"):
             with self.dataset_populator.test_history() as history_id:
                 run_response = self.dataset_populator.run_tool_raw(
                     tool_id=FETCH_TOOL_ID,
@@ -99,7 +99,7 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         keys = ["dbkey_source|dbkey", "dbkey_source|dbkey_name", "sequence_id", "sequence_name"]
         for key in keys:
             inputs[key] = "unique_dbkey_value"
-        with self._different_user(email="%s@galaxy.org" % self.username):
+        with self._different_user(email=f"{self.username}@galaxy.org"):
             with self.dataset_populator.test_history() as history_id:
                 # First run should work
                 run_response = self.dataset_populator.run_tool_raw(
@@ -126,7 +126,7 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         Test that data_manager_manual works, which uses a significant amount of Galaxy-internal code
         """
         self.install_repository("iuc", "data_manager_manual", "1ed87dee9e68")
-        with self._different_user(email="%s@galaxy.org" % self.username):
+        with self._different_user(email=f"{self.username}@galaxy.org"):
             with self.dataset_populator.test_history() as history_id:
                 run_response = self.dataset_populator.run_tool_raw(
                     tool_id=DATA_MANAGER_MANUAL_ID,
@@ -156,7 +156,7 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         self.install_repository("iuc", "data_manager_manual", "1ed87dee9e68")
         inputs = FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT.copy()
         inputs["dbkey_source|dbkey"] = "another_unique_dbkey_value"
-        with self._different_user(email="%s@galaxy.org" % self.username):
+        with self._different_user(email=f"{self.username}@galaxy.org"):
             with self.dataset_populator.test_history() as history_id:
                 run_response = self.dataset_populator.run_tool_raw(
                     tool_id=FETCH_TOOL_ID,

--- a/test/integration/test_data_manager.py
+++ b/test/integration/test_data_manager.py
@@ -41,7 +41,7 @@ DATA_MANAGER_MANUAL_INPUT = {
 }
 
 
-class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesShed):
+class TestDataManagerIntegration(integration_util.IntegrationTestCase, UsesShed):
 
     """Test data manager installation and table reload through the API"""
 

--- a/test/integration/test_data_manager_refgenie.py
+++ b/test/integration/test_data_manager_refgenie.py
@@ -49,7 +49,7 @@ SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 REFGENIE_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "refgenie.yml")
 
 
-class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesShed):
+class TestDataManagerIntegration(integration_util.IntegrationTestCase, UsesShed):
 
     """Test data manager installation and table reload through the API"""
 

--- a/test/integration/test_data_manager_refgenie.py
+++ b/test/integration/test_data_manager_refgenie.py
@@ -71,7 +71,7 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         config["tool_data_path"] = cls.shed_tool_data_dir
         config["watch_tool_data_dir"] = True
         cls.username = cls.get_secure_ascii_digits()
-        config["admin_users"] = "%s@galaxy.org" % cls.username
+        config["admin_users"] = f"{cls.username}@galaxy.org"
         config["refgenie_config_file"] = REFGENIE_CONFIG_FILE
 
     def test_data_manager_manual_refgenie(self):
@@ -79,7 +79,7 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         Test that data_manager_manual works with refgenie enabled, which uses a significant amount of Galaxy-internal code
         """
         self.install_repository("iuc", "data_manager_manual", "1ed87dee9e68")
-        with self._different_user(email="%s@galaxy.org" % self.username):
+        with self._different_user(email=f"{self.username}@galaxy.org"):
             with self.dataset_populator.test_history() as history_id:
                 run_response = self.dataset_populator.run_tool_raw(
                     tool_id=DATA_MANAGER_MANUAL_ID,
@@ -104,7 +104,7 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         Test that data_manager_manual works with refgenie enabled, with a table defined first by refgenie
         """
         self.install_repository("iuc", "data_manager_manual", "1ed87dee9e68")
-        with self._different_user(email="%s@galaxy.org" % self.username):
+        with self._different_user(email=f"{self.username}@galaxy.org"):
             with self.dataset_populator.test_history() as history_id:
                 run_response = self.dataset_populator.run_tool_raw(
                     tool_id=DATA_MANAGER_MANUAL_ID,

--- a/test/integration/test_datatype_upload.py
+++ b/test/integration/test_datatype_upload.py
@@ -16,9 +16,9 @@ from galaxy_test.driver import integration_util
 from .test_upload_configuration_options import BaseUploadContentConfigurationInstance
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
-TEST_FILE_DIR = "%s/../../lib/galaxy/datatypes/test" % SCRIPT_DIRECTORY
+TEST_FILE_DIR = f"{SCRIPT_DIRECTORY}/../../lib/galaxy/datatypes/test"
 TestData = collections.namedtuple("TestData", "path datatype uploadable")
-GALAXY_ROOT = os.path.abspath("%s/../../" % SCRIPT_DIRECTORY)
+GALAXY_ROOT = os.path.abspath(f"{SCRIPT_DIRECTORY}/../../")
 DATATYPES_CONFIG = os.path.join(GALAXY_ROOT, "lib/galaxy/config/sample/datatypes_conf.xml.sample")
 PARENT_SNIFFER_MAP = {"fastqsolexa": "fastq"}
 
@@ -29,7 +29,7 @@ def find_datatype(registry, filename):
     for extension in sorted_extensions:
         if filename.endswith(extension) or filename.startswith(extension):
             return registry.datatypes_by_extension[extension]
-    raise Exception("Couldn't guess datatype for file '%s'" % filename)
+    raise Exception(f"Couldn't guess datatype for file '{filename}'")
 
 
 def collect_test_data(registry):

--- a/test/integration/test_default_permissions.py
+++ b/test/integration/test_default_permissions.py
@@ -2,7 +2,7 @@ from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
 
-class DefaultPermissionsIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestDefaultPermissionsIntegration(integration_util.IntegrationTestCase):
     expected_access_status_code = 200
 
     def setUp(self):
@@ -25,11 +25,11 @@ class DefaultPermissionsIntegrationTestCase(integration_util.IntegrationTestCase
             assert details_response.status_code == self.expected_access_status_code, details_response.content
 
 
-class PrivateDefaultPermissionsIntegrationTestCase(DefaultPermissionsIntegrationTestCase):
+class TestPrivateDefaultPermissionsIntegration(TestDefaultPermissionsIntegration):
     new_user_dataset_access_role_default_private = True
     expected_access_status_code = 403
 
 
-class PublicDefaultPermissionsIntegrationTestCase(DefaultPermissionsIntegrationTestCase):
+class TestPublicDefaultPermissionsIntegration(TestDefaultPermissionsIntegration):
     new_user_dataset_access_role_default_private = False
     expected_access_status_code = 200

--- a/test/integration/test_dynamic_edam_loading.py
+++ b/test/integration/test_dynamic_edam_loading.py
@@ -7,7 +7,7 @@ SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 MOCK_BIOTOOLS_CONTENT = os.path.join(SCRIPT_DIRECTORY, "mock_biotools_content")
 
 
-class DynamicEdamLoadingIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestDynamicEdamLoadingIntegration(integration_util.IntegrationTestCase):
     """Test mapping over tools with extended metadata enabled."""
 
     framework_tool_and_types = True

--- a/test/integration/test_edam_toolbox.py
+++ b/test/integration/test_edam_toolbox.py
@@ -1,7 +1,7 @@
 from galaxy_test.driver import integration_util
 
 
-class EdamToolboxIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestEdamToolboxIntegration(integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
 
@@ -31,7 +31,7 @@ class EdamToolboxIntegrationTestCase(integration_util.IntegrationTestCase):
         assert edam_panel_view["view_type"] == "ontology"
 
 
-class EdamToolboxDefaultIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestEdamToolboxDefaultIntegration(integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
 

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -42,7 +42,9 @@ TEST_TOOL_IDS = [
 ]
 
 
-class ExtendedMetadataIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestExtendedMetadataIntegration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
@@ -91,7 +93,9 @@ class ExtendedMetadataIntegrationTestCase(integration_util.IntegrationTestCase):
         assert dataset["created_from_basename"] == "4.bed"
 
 
-class ExtendedMetadataDeferredIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestExtendedMetadataDeferredIntegration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/test/integration/test_extended_metadata_mapping.py
+++ b/test/integration/test_extended_metadata_mapping.py
@@ -2,14 +2,14 @@ from galaxy_test.api.test_tools import TestsTools
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
-    uses_test_history,
 )
 from galaxy_test.driver import integration_util
 
 
-class ExtendedMetadataMappingIntegrationTestCase(integration_util.IntegrationTestCase, TestsTools):
+class TestExtendedMetadataMappingIntegration(integration_util.IntegrationTestCase, TestsTools):
     """Test mapping over tools with extended metadata enabled."""
 
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
 
     @classmethod
@@ -23,7 +23,6 @@ class ExtendedMetadataMappingIntegrationTestCase(integration_util.IntegrationTes
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
-    @uses_test_history()
     def test_map_over_collection(self, history_id):
         hdca_id = self._build_pair(history_id, ["123", "456"])
         inputs = {

--- a/test/integration/test_fail_job_tool_unavailable.py
+++ b/test/integration/test_fail_job_tool_unavailable.py
@@ -56,7 +56,7 @@ steps:
         time.sleep(5)
         self._app.toolbox.remove_tool_by_id("cat1")
         self.dataset_populator.wait_for_history(self.history_id, assert_ok=False)
-        state_details = self.galaxy_interactor.get("histories/%s" % self.history_id).json()["state_details"]
+        state_details = self.galaxy_interactor.get(f"histories/{self.history_id}").json()["state_details"]
         assert state_details["running"] == 0
         assert state_details["ok"] == 1
         assert state_details["error"] == 1
@@ -64,5 +64,5 @@ steps:
             history_id=self.history_id, assert_ok=False, details=True
         )
         assert failed_hda["state"] == "error"
-        job = self.galaxy_interactor.get("jobs/%s" % failed_hda["creating_job"]).json()
+        job = self.galaxy_interactor.get("jobs/{}".format(failed_hda["creating_job"])).json()
         assert job["state"] == "error"

--- a/test/integration/test_fail_job_tool_unavailable.py
+++ b/test/integration/test_fail_job_tool_unavailable.py
@@ -7,8 +7,8 @@ from galaxy_test.base.populators import (
 from galaxy_test.driver import integration_util
 
 
-class FailJobWhenToolUnavailableTestCase(integration_util.IntegrationTestCase):
-
+class TestFailJobWhenToolUnavailable(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
     require_admin_user = True
 
     def setUp(self):

--- a/test/integration/test_fluent_metrics.py
+++ b/test/integration/test_fluent_metrics.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from galaxy_test.driver import integration_util
 
 
-class FluentMetricsIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestFluentMetricsIntegration(integration_util.IntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_galaxy_interactor.py
+++ b/test/integration/test_galaxy_interactor.py
@@ -5,7 +5,7 @@ from packaging.version import Version
 from galaxy_test.driver import integration_util
 
 
-class GalaxyInteractorTestCase(integration_util.IntegrationTestCase):
+class TestGalaxyInteractor(integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
 

--- a/test/integration/test_genomes.py
+++ b/test/integration/test_genomes.py
@@ -26,7 +26,7 @@ def get_key(has_len_file=True):
     return BUILDS_DATA[pos].split("\t")[0]
 
 
-class GenomesTestCase(integration_util.IntegrationTestCase):
+class TestGenomes(integration_util.IntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_handler_assignment_methods.py
+++ b/test/integration/test_handler_assignment_methods.py
@@ -46,7 +46,7 @@ class BaseHandlerAssignmentMethodIntegrationTestCase(integration_util.Integratio
         config["tool_dependency_dir"] = "none"
 
 
-class DBPreassignHandlerAssignmentMethodIntegrationTestCase(BaseHandlerAssignmentMethodIntegrationTestCase):
+class TestDBPreassignHandlerAssignmentMethodIntegration(BaseHandlerAssignmentMethodIntegrationTestCase):
     def setUp(self):
         self._with_handlers_config(assign_with="db-preassign", handlers=[{"id": "main"}])
         super().setUp()
@@ -56,7 +56,7 @@ class DBPreassignHandlerAssignmentMethodIntegrationTestCase(BaseHandlerAssignmen
         self._run_tool_test(tool_id)
 
 
-class DBTransactionIsolationHandlerAssignmentMethodIntegrationTestCase(BaseHandlerAssignmentMethodIntegrationTestCase):
+class TestDBTransactionIsolationHandlerAssignmentMethodIntegration(BaseHandlerAssignmentMethodIntegrationTestCase):
     def setUp(self):
         self._with_handlers_config(assign_with="db-transaction-isolation", handlers=[{"id": "main"}])
         super().setUp()
@@ -67,7 +67,7 @@ class DBTransactionIsolationHandlerAssignmentMethodIntegrationTestCase(BaseHandl
         self._run_tool_test(tool_id)
 
 
-class DBSkipLockedHandlerAssignmentMethodIntegrationTestCase(BaseHandlerAssignmentMethodIntegrationTestCase):
+class TestDBSkipLockedHandlerAssignmentMethodIntegration(BaseHandlerAssignmentMethodIntegrationTestCase):
     def setUp(self):
         self._with_handlers_config(assign_with="db-skip-locked", handlers=[{"id": "main"}])
         super().setUp()

--- a/test/integration/test_handler_assignment_methods.py
+++ b/test/integration/test_handler_assignment_methods.py
@@ -12,10 +12,12 @@ class WritesConfig:
     def _with_handlers_config(self, assign_with=None, default=None, handlers=None):
         handlers = handlers or []
         template = {
-            "assign_with": ' assign_with="%s"' % assign_with if assign_with is not None else "",
-            "default": ' default="%s"' % default if default is not None else "",
+            "assign_with": f' assign_with="{assign_with}"' if assign_with is not None else "",
+            "default": f' default="{default}"' if default is not None else "",
             "handlers": "\n".join(
-                '<handler id="{id}"{tags}/>'.format(id=x["id"], tags=' tags="%s"' % x["tags"] if "tags" in x else "")
+                '<handler id="{id}"{tags}/>'.format(
+                    id=x["id"], tags=' tags="{}"'.format(x["tags"]) if "tags" in x else ""
+                )
                 for x in handlers
             ),
         }

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -15,7 +15,7 @@ from galaxy_test.base.populators import (
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
 
-class ImportExportHistoryOutputsToWorkingDirIntegrationTestCase(ImportExportTests, IntegrationTestCase):
+class TestImportExportHistoryOutputsToWorkingDirIntegration(ImportExportTests, IntegrationTestCase):
     task_based = False
     framework_tool_and_types = True
 
@@ -29,7 +29,7 @@ class ImportExportHistoryOutputsToWorkingDirIntegrationTestCase(ImportExportTest
         self._set_up_populators()
 
 
-class ImportExportHistoryViaTasksIntegrationTestCase(ImportExportTests, IntegrationTestCase, UsesCeleryTasks):
+class TestImportExportHistoryViaTasksIntegration(ImportExportTests, IntegrationTestCase, UsesCeleryTasks):
     task_based = True
     framework_tool_and_types = True
 
@@ -49,7 +49,8 @@ class ImportExportHistoryViaTasksIntegrationTestCase(ImportExportTests, Integrat
         )
 
 
-class ImportExportHistoryContentsViaTasksIntegrationTestCase(IntegrationTestCase, UsesCeleryTasks):
+class TestImportExportHistoryContentsViaTasksIntegration(IntegrationTestCase, UsesCeleryTasks):
+    dataset_populator: DatasetPopulator
     task_based = True
     framework_tool_and_types = True
 

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -53,11 +53,11 @@ class BaseInteractiveToolsIntegrationTestCase(ContainerizedIntegrationTestCase):
                 print(e)
                 return None
 
-        content = wait_on(get_hosted_content, "realtime hosted content at %s" % target)
+        content = wait_on(get_hosted_content, f"realtime hosted content at {target}")
         return content
 
     def entry_point_target(self, entry_point_id):
-        entry_point_access_response = self._get("entry_points/%s/access" % entry_point_id)
+        entry_point_access_response = self._get(f"entry_points/{entry_point_id}/access")
         api_asserts.assert_status_code_is(entry_point_access_response, 200)
         access_json = entry_point_access_response.json()
         api_asserts.assert_has_key(access_json, "target")
@@ -81,7 +81,7 @@ class BaseInteractiveToolsIntegrationTestCase(ContainerizedIntegrationTestCase):
         return wait_on(active_entry_points, "entry points to become active", timeout=120)
 
     def entry_points_for_job(self, job_id):
-        entry_points_response = self._get("entry_points?job_id=%s" % job_id)
+        entry_points_response = self._get(f"entry_points?job_id={job_id}")
         api_asserts.assert_status_code_is(entry_points_response, 200)
         return entry_points_response.json()
 

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -135,11 +135,11 @@ class RunsInterativeToolTests:
         assert not it_output_details["deleted"]
 
 
-class InteractiveToolsIntegrationTestCase(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
+class TestInteractiveToolsIntegration(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
     pass
 
 
-class InteractiveToolsPulsarIntegrationTestCase(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
+class TestInteractiveToolsPulsarIntegration(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE_DOCKER
@@ -147,13 +147,13 @@ class InteractiveToolsPulsarIntegrationTestCase(BaseInteractiveToolsIntegrationT
         disable_dependency_resolution(config)
 
 
-class InteractiveToolsRemoteProxyIntegrationTestCase(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
+class TestInteractiveToolsRemoteProxyIntegration(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
     """
     $ cd gx-it-proxy
     $ ./lib/createdb.js --sessions $HOME/gxitexproxy.sqlite
     $ ./lib/main.js --port 9001 --ip 0.0.0.0 --verbose --sessions $HOME/gxitexproxy.sqlite
     $ # Need to create new DB for each test I think, duplicate IDs are the problem I think because each test starts at 1
-    $ GALAXY_TEST_EXTERNAL_PROXY_HOST="localhost:9001" GALAXY_TEST_EXTERNAL_PROXY_MAP="$HOME/gxitexproxy.sqlite" pytest -s test/integration/test_interactivetools_api.py::InteractiveToolsRemoteProxyIntegrationTestCase
+    $ GALAXY_TEST_EXTERNAL_PROXY_HOST="localhost:9001" GALAXY_TEST_EXTERNAL_PROXY_MAP="$HOME/gxitexproxy.sqlite" pytest -s test/integration/test_interactivetools_api.py::TestInteractiveToolsRemoteProxyIntegration
     """
 
     @classmethod
@@ -173,9 +173,7 @@ class InteractiveToolsRemoteProxyIntegrationTestCase(BaseInteractiveToolsIntegra
 @integration_util.skip_unless_kubernetes()
 @integration_util.skip_unless_amqp()
 @integration_util.skip_if_github_workflow()
-class KubeInteractiveToolsRemoteProxyIntegrationTestCase(
-    BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests
-):
+class TestKubeInteractiveToolsRemoteProxyIntegration(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
     """
     $ git clone https://github.com/galaxyproject/gx-it-proxy.git $HOME/gx-it-proxy
     $ cd $HOME/gx-it-proxy/docker/k8s
@@ -187,7 +185,7 @@ class KubeInteractiveToolsRemoteProxyIntegrationTestCase(
     $ ./lib/createdb.js --sessions $HOME/gxitk8proxy.sqlite
     $ ./lib/main.js --port 9002 --ip 0.0.0.0 --verbose --sessions $HOME/gxitk8proxy.sqlite --forwardIP localhost --forwardPort 8910 &
     $ cd back/to/galaxy
-    $ GALAXY_TEST_K8S_EXTERNAL_PROXY_HOST="localhost:9002" GALAXY_TEST_K8S_EXTERNAL_PROXY_MAP="$HOME/gxitk8proxy.sqlite" pytest -s test/integration/test_interactivetools_api.py::KubeInteractiveToolsRemoteProxyIntegrationTestCase
+    $ GALAXY_TEST_K8S_EXTERNAL_PROXY_HOST="localhost:9002" GALAXY_TEST_K8S_EXTERNAL_PROXY_MAP="$HOME/gxitk8proxy.sqlite" pytest -s test/integration/test_interactivetools_api.py::TestKubeInteractiveToolsRemoteProxyIntegration
     """
 
     @classmethod

--- a/test/integration/test_job_environments.py
+++ b/test/integration/test_job_environments.py
@@ -66,7 +66,7 @@ class BaseJobEnvironmentIntegrationTestCase(integration_util.IntegrationTestCase
         """Extension point that lets subclasses investigate the completed job."""
 
 
-class DefaultJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+class TestDefaultJobEnvironmentIntegration(BaseJobEnvironmentIntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -119,7 +119,7 @@ class DefaultJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTest
         assert job_env.home == os.path.join(job_directory, "home"), job_env.home
 
 
-class EmbeddedPulsarDefaultJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+class TestEmbeddedPulsarDefaultJobEnvironmentIntegration(BaseJobEnvironmentIntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -149,7 +149,7 @@ class EmbeddedPulsarDefaultJobEnvironmentIntegrationTestCase(BaseJobEnvironmentI
         assert not job_env.tmp.startswith(job_directory)
 
 
-class TmpDirToTrueJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+class TestTmpDirToTrueJobEnvironmentIntegration(BaseJobEnvironmentIntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -167,7 +167,7 @@ class TmpDirToTrueJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegratio
         assert job_env.tmp.startswith(job_directory), job_env
 
 
-class TmpDirAsShellCommandJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+class TestTmpDirAsShellCommandJobEnvironmentIntegration(BaseJobEnvironmentIntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -185,7 +185,7 @@ class TmpDirAsShellCommandJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIn
         assert basename.startswith("cooltmp"), job_env.tmp
 
 
-class SharedHomeJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+class TestSharedHomeJobEnvironmentIntegration(BaseJobEnvironmentIntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -222,7 +222,7 @@ class SharedHomeJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationT
         assert job_env.home == os.path.join(job_directory, "home"), job_env.home
 
 
-class JobIOEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+class TestJobIOEnvironmentIntegration(BaseJobEnvironmentIntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_job_files.py
+++ b/test/integration/test_job_files.py
@@ -32,7 +32,7 @@ TEST_INPUT_TEXT = "test input content\n"
 TEST_FILE_IO = io.StringIO("some initial text data")
 
 
-class JobFilesIntegerationTestCase(integration_util.IntegrationTestCase):
+class TestJobFilesIntegeration(integration_util.IntegrationTestCase):
     initialized = False
 
     @classmethod
@@ -46,14 +46,14 @@ class JobFilesIntegerationTestCase(integration_util.IntegrationTestCase):
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
-        if not JobFilesIntegerationTestCase.initialized:
+        if not TestJobFilesIntegeration.initialized:
             history_id = self.dataset_populator.new_history()
             sa_session = self.sa_session
             assert len(sa_session.query(model.HistoryDatasetAssociation).all()) == 0
             self.dataset_populator.new_dataset(history_id, content=TEST_INPUT_TEXT, wait=True)
             assert len(sa_session.query(model.HistoryDatasetAssociation).all()) == 1
             self.input_hda = sa_session.query(model.HistoryDatasetAssociation).all()[0]
-            JobFilesIntegerationTestCase.initialized = True
+            TestJobFilesIntegeration.initialized = True
 
     def test_read_by_state(self):
         job, _, _ = self.create_static_job_with_state("running")

--- a/test/integration/test_job_recovery.py
+++ b/test/integration/test_job_recovery.py
@@ -10,7 +10,8 @@ DELAY_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "delay_job_conf.yml")
 SIMPLE_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "simple_job_conf.xml")
 
 
-class JobRecoveryBeforeHandledIntegerationTestCase(integration_util.IntegrationTestCase):
+class TestJobRecoveryBeforeHandledIntegeration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
 
     def setUp(self):
@@ -39,7 +40,8 @@ class JobRecoveryBeforeHandledIntegerationTestCase(integration_util.IntegrationT
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
 
 
-class JobRecoveryAfterHandledIntegerationTestCase(integration_util.IntegrationTestCase):
+class TestJobRecoveryAfterHandledIntegeration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
 
     def setUp(self):

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -42,7 +42,7 @@ class _BaseResubmissionIntegerationTestCase(integration_util.IntegrationTestCase
         assert exception_thrown
 
 
-class JobResubmissionIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+class TestJobResubmissionIntegration(_BaseResubmissionIntegerationTestCase):
 
     framework_tool_and_types = True
 
@@ -175,7 +175,7 @@ class JobResubmissionIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
         )
 
 
-class JobResubmissionDefaultIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+class TestJobResubmissionDefaultIntegration(_BaseResubmissionIntegerationTestCase):
 
     framework_tool_and_types = True
 
@@ -190,7 +190,7 @@ class JobResubmissionDefaultIntegrationTestCase(_BaseResubmissionIntegerationTes
         self._assert_job_passes(resource_parameters={"test_name": "test_default_resubmission"})
 
 
-class JobResubmissionDynamicIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+class TestJobResubmissionDynamicIntegration(_BaseResubmissionIntegerationTestCase):
 
     framework_tool_and_types = True
 
@@ -204,7 +204,7 @@ class JobResubmissionDynamicIntegrationTestCase(_BaseResubmissionIntegerationTes
 
 
 # Verify the test tool fails if only a small amount of memory is allocated.
-class JobResubmissionSmallMemoryIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+class TestJobResubmissionSmallMemoryIntegration(_BaseResubmissionIntegerationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -216,7 +216,7 @@ class JobResubmissionSmallMemoryIntegrationTestCase(_BaseResubmissionIntegeratio
 
 # Verify the test tool will resubmit on failure tested above and will then pass with
 # proper resubmission condition.
-class JobResubmissionSmallMemoryResubmitsToLargeIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+class TestJobResubmissionSmallMemoryResubmitsToLargeIntegration(_BaseResubmissionIntegerationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -227,7 +227,7 @@ class JobResubmissionSmallMemoryResubmitsToLargeIntegrationTestCase(_BaseResubmi
 
 
 # Verify the test tool fails with an exit code issue.
-class JobResubmissionToolDetectedErrorIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+class TestJobResubmissionToolDetectedErrorIntegration(_BaseResubmissionIntegerationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -239,7 +239,7 @@ class JobResubmissionToolDetectedErrorIntegrationTestCase(_BaseResubmissionInteg
 
 # Verify the test tool will resubmit on failure tested above and will then pass in
 # an environment without a tool indicated error.
-class JobResubmissionToolDetectedErrorResubmitsIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+class TestJobResubmissionToolDetectedErrorResubmitsIntegration(_BaseResubmissionIntegerationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -250,7 +250,7 @@ class JobResubmissionToolDetectedErrorResubmitsIntegrationTestCase(_BaseResubmis
 
 
 # Verify that a failure to connect to pulsar can trigger a resubmit
-class JobResubmissionPulsarIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+class TestJobResubmissionPulsarIntegration(_BaseResubmissionIntegerationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -176,7 +176,7 @@ class KubernetesDatasetPopulator(DatasetPopulator):
 
 
 @integration_util.skip_unless_kubernetes()
-class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
+class TestKubernetesIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
     def setUp(self):
         super().setUp()
         self.dataset_populator = KubernetesDatasetPopulator(self.galaxy_interactor)

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -169,7 +169,9 @@ class KubernetesDatasetPopulator(DatasetPopulator):
         try:
             super().wait_for_history(*args, **kwargs)
         except AssertionError:
-            print("Kubernetes status:\n %s" % unicodify(subprocess.check_output(["kubectl", "describe", "nodes"])))
+            print(
+                "Kubernetes status:\n {}".format(unicodify(subprocess.check_output(["kubectl", "describe", "nodes"])))
+            )
             raise
 
 
@@ -299,7 +301,7 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
             assert status["status"]["active"] == 1
 
             output = unicodify(subprocess.check_output(["kubectl", "delete", "job", external_id, "-o", "name"]))
-            assert "job.batch/%s" % external_id in output
+            assert f"job.batch/{external_id}" in output
 
             result = self.dataset_populator.wait_for_tool_run(
                 run_response=running_response, history_id=history_id, assert_ok=False
@@ -381,7 +383,7 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
 
         # Tool is mapped to destination without cleanup, make sure job still exists in kubernetes API
         job_dict = running_response["jobs"][0]
-        job = self.galaxy_interactor.get("jobs/%s" % job_dict["id"], admin=True).json()
+        job = self.galaxy_interactor.get("jobs/{}".format(job_dict["id"]), admin=True).json()
         external_id = job["external_id"]
         output = unicodify(subprocess.check_output(["kubectl", "get", "job", external_id, "-o", "json"]))
         status = json.loads(output)

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -209,7 +209,7 @@ class KubernetesDependencyResolutionIntegrationTestCase(BaseKubernetesStagingTes
 
 
 def set_infrastucture_url(config):
-    infrastructure_url = "http://%s:$GALAXY_WEB_PORT" % GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST
+    infrastructure_url = f"http://{GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST}:$GALAXY_WEB_PORT"
     config["galaxy_infrastructure_url"] = infrastructure_url
 
 

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -124,7 +124,7 @@ def job_config(template_str, jobs_directory):
 @integration_util.skip_unless_kubernetes()
 @integration_util.skip_unless_amqp()
 @integration_util.skip_if_github_workflow()
-class BaseKubernetesStagingTest(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
+class TestKubernetesStaging(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
     def setUp(self):
         super().setUp()
         self.dataset_populator = KubernetesDatasetPopulator(self.galaxy_interactor)
@@ -137,7 +137,7 @@ class BaseKubernetesStagingTest(BaseJobEnvironmentIntegrationTestCase, MulledJob
         super().setUpClass()
 
 
-class KubernetesStagingContainerIntegrationTestCase(CancelsJob, BaseKubernetesStagingTest):
+class TestKubernetesStagingContainerIntegration(CancelsJob, TestKubernetesStaging):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["jobs_directory"] = cls.jobs_directory
@@ -189,7 +189,7 @@ class KubernetesStagingContainerIntegrationTestCase(CancelsJob, BaseKubernetesSt
         return active
 
 
-class KubernetesDependencyResolutionIntegrationTestCase(BaseKubernetesStagingTest):
+class TestKubernetesDependencyResolutionIntegration(TestKubernetesStaging):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["jobs_directory"] = cls.jobs_directory

--- a/test/integration/test_local_job_cancellation.py
+++ b/test/integration/test_local_job_cancellation.py
@@ -31,7 +31,7 @@ class CancelsJob:
         )
 
 
-class LocalJobCancellationTestCase(CancelsJob, integration_util.IntegrationTestCase):
+class TestLocalJobCancellation(CancelsJob, integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
 

--- a/test/integration/test_local_job_cancellation.py
+++ b/test/integration/test_local_job_cancellation.py
@@ -25,7 +25,7 @@ class CancelsJob:
 
     def _wait_for_job_running(self, job_id):
         self.galaxy_interactor.wait_for(
-            lambda: self._get("jobs/%s" % job_id).json()["state"] != "running",
+            lambda: self._get(f"jobs/{job_id}").json()["state"] != "running",
             what="Wait for job to start running",
             maxseconds=60,
         )
@@ -53,7 +53,7 @@ class LocalJobCancellationTestCase(CancelsJob, integration_util.IntegrationTestC
             sa_session.add(job)
             sa_session.flush()
             self.galaxy_interactor.wait_for(
-                lambda: self._get("jobs/%s" % job_id).json()["state"] != "error",
+                lambda: self._get(f"jobs/{job_id}").json()["state"] != "error",
                 what="Wait for job to end in error",
                 maxseconds=60,
             )

--- a/test/integration/test_materialize_dataset_instance_tasks.py
+++ b/test/integration/test_materialize_dataset_instance_tasks.py
@@ -11,12 +11,13 @@ from galaxy_test.base.api import UsesCeleryTasks
 from galaxy_test.base.populators import (
     DatasetPopulator,
     LibraryPopulator,
-    uses_test_history,
 )
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
 
-class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, UsesCeleryTasks):
+class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesCeleryTasks):
+    dataset_populator: DatasetPopulator
+
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -34,7 +35,6 @@ class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, U
         self.library_populator = LibraryPopulator(self.galaxy_interactor)
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
-    @uses_test_history(require_new=True)
     def test_materialize_history_dataset(self, history_id: str):
         as_list = self.dataset_populator.create_contents_from_store(
             history_id,
@@ -54,7 +54,6 @@ class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, U
         assert new_hda_details["state"] == "ok"
         assert not new_hda_details["deleted"]
 
-    @uses_test_history(require_new=True)
     def test_materialize_gxfiles_uri(self, history_id: str):
         as_list = self.dataset_populator.create_contents_from_store(
             history_id,
@@ -75,7 +74,6 @@ class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, U
         assert new_hda_details["state"] == "ok"
         assert not new_hda_details["deleted"]
 
-    @uses_test_history(require_new=True)
     def test_materialize_history_dataset_bam(self, history_id: str):
         as_list = self.dataset_populator.create_contents_from_store(
             history_id,
@@ -107,7 +105,6 @@ class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, U
         assert ">chrM" in new_hda_details["metadata_reference_names"]
         assert "metadata_bam_index" in new_hda_details
 
-    @uses_test_history(require_new=True)
     def test_materialize_library_dataset(self, history_id: str):
         response = self.library_populator.create_from_store(store_dict=one_ld_library_deferred_model_store_dict())
         assert isinstance(response, list)
@@ -126,7 +123,6 @@ class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, U
         assert new_hda_details["state"] == "ok"
         assert not new_hda_details["deleted"]
 
-    @uses_test_history(require_new=True)
     def test_upload_vs_materialize_simplest_upload(self, history_id: str):
         item = {"src": "url", "url": "gxfiles://testdatafiles//simple_line_no_newline.txt", "ext": "txt"}
         output = self.dataset_populator.fetch_hda(history_id, item)
@@ -141,7 +137,6 @@ class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, U
         content = self.dataset_populator.get_history_dataset_content(new_history_id, hid=2, assert_ok=False)
         assert content == "This is a line of text."
 
-    @uses_test_history(require_new=True)
     def test_upload_vs_materialize_to_posix_lines(self, history_id: str):
         item = {
             "src": "url",
@@ -167,7 +162,6 @@ class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, U
         content = self.dataset_populator.get_history_dataset_content(new_history_id, hid=2, assert_ok=False)
         assert content == "This is a line of text.\n"
 
-    @uses_test_history(require_new=True)
     def test_upload_vs_materialize_space_to_tab(self, history_id: str):
         item = {
             "src": "url",
@@ -193,7 +187,6 @@ class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, U
         content = self.dataset_populator.get_history_dataset_content(new_history_id, hid=2, assert_ok=False)
         assert content == "This\tis\ta\tline\tof\ttext."
 
-    @uses_test_history(require_new=True)
     def test_upload_vs_materialize_to_posix_and_space_to_tab(self, history_id: str):
         item = {
             "src": "url",
@@ -220,7 +213,6 @@ class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, U
         content = self.dataset_populator.get_history_dataset_content(new_history_id, hid=2, assert_ok=False)
         assert content == "This\tis\ta\tline\tof\ttext.\n"
 
-    @uses_test_history(require_new=True)
     def test_upload_vs_materialize_grooming(self, history_id: str):
         item = {
             "src": "url",

--- a/test/integration/test_max_discovered_files.py
+++ b/test/integration/test_max_discovered_files.py
@@ -3,9 +3,10 @@ from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
 
-class MaxDiscoveredFilesTestCase(integration_util.IntegrationTestCase):
+class TestMaxDiscoveredFiles(integration_util.IntegrationTestCase):
     """Describe a Galaxy test instance with embedded pulsar configured."""
 
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
     max_discovered_files = 9
 
@@ -33,7 +34,7 @@ class MaxDiscoveredFilesTestCase(integration_util.IntegrationTestCase):
             )
 
 
-class ExtendedMetadataMaxDiscoveredFilesTestCase(MaxDiscoveredFilesTestCase):
+class TestExtendedMetadataMaxDiscoveredFiles(TestMaxDiscoveredFiles):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["max_discovered_files"] = cls.max_discovered_files

--- a/test/integration/test_model_store_scripts.py
+++ b/test/integration/test_model_store_scripts.py
@@ -11,8 +11,9 @@ from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
 
-class ModelStoreScriptsIntegrationTestCase(IntegrationTestCase):
+class TestModelStoreScriptsIntegration(IntegrationTestCase):
     # TODO: test build_objects also...
+    dataset_populator: DatasetPopulator
 
     def setUp(self):
         super().setUp()

--- a/test/integration/test_page_revision_json_encoding.py
+++ b/test/integration/test_page_revision_json_encoding.py
@@ -11,7 +11,9 @@ from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
 
-class PageJsonEncodingIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestPageJsonEncodingIntegration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/test/integration/test_page_revision_json_encoding.py
+++ b/test/integration/test_page_revision_json_encoding.py
@@ -21,20 +21,20 @@ class PageJsonEncodingIntegrationTestCase(integration_util.IntegrationTestCase):
         request = dict(
             slug="mypage",
             title="MY PAGE",
-            content="""<p>Page!<div class="embedded-item" id="History-%s"></div></p>""" % self.history_id,
+            content=f"""<p>Page!<div class="embedded-item" id="History-{self.history_id}"></div></p>""",
         )
         page_response = self._post("pages", request, json=True)
         api_asserts.assert_status_code_is_ok(page_response)
         sa_session = self._app.model.context
         page_revision = sa_session.query(model.PageRevision).filter_by(content_format="html").all()[0]
         assert '''id="History-1"''' in page_revision.content, page_revision.content
-        assert '''id="History-%s"''' % self.history_id not in page_revision.content, page_revision.content
+        assert f'''id="History-{self.history_id}"''' not in page_revision.content, page_revision.content
 
-        show_page_response = self._get("pages/%s" % page_response.json()["id"])
+        show_page_response = self._get("pages/{}".format(page_response.json()["id"]))
         api_asserts.assert_status_code_is_ok(show_page_response)
         content = show_page_response.json()["content"]
         assert '''id="History-1"''' not in content, content
-        assert '''id="History-%s"''' % self.history_id in content, content
+        assert f'''id="History-{self.history_id}"''' in content, content
 
     def test_page_encoding_markdown(self):
         dataset = self.dataset_populator.new_dataset(self.history_id)
@@ -43,9 +43,10 @@ class PageJsonEncodingIntegrationTestCase(integration_util.IntegrationTestCase):
             slug="mypage-markdown",
             title="MY PAGE",
             content="""```galaxy
-history_dataset_display(history_dataset_id=%s)
-```"""
-            % dataset["id"],
+history_dataset_display(history_dataset_id={})
+```""".format(
+                dataset["id"]
+            ),
             content_format="markdown",
         )
         page_response = self._post("pages", request, json=True)
@@ -59,10 +60,10 @@ history_dataset_display(history_dataset_id=1)
             in page_revision.content
         ), page_revision.content
         assert (
-            """::: history_dataset_display history_dataset_id=%s""" % dataset_id not in page_revision.content
+            f"""::: history_dataset_display history_dataset_id={dataset_id}""" not in page_revision.content
         ), page_revision.content
 
-        show_page_response = self._get("pages/%s" % page_response.json()["id"])
+        show_page_response = self._get("pages/{}".format(page_response.json()["id"]))
         api_asserts.assert_status_code_is_ok(show_page_response)
         content = show_page_response.json()["content"]
         assert (
@@ -73,8 +74,9 @@ history_dataset_display(history_dataset_id=1)
         ), content
         assert (
             """```galaxy
-history_dataset_display(history_dataset_id=%s)
-```"""
-            % dataset_id
+history_dataset_display(history_dataset_id={})
+```""".format(
+                dataset_id
+            )
             in content
         ), content

--- a/test/integration/test_panel_views.py
+++ b/test/integration/test_panel_views.py
@@ -6,7 +6,7 @@ THIS_DIR = os.path.dirname(__file__)
 PANEL_VIEWS_DIR_1 = os.path.join(THIS_DIR, "panel_views_1")
 
 
-class PanelViewsFromDirectoryIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestPanelViewsFromDirectoryIntegration(integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
     allow_tool_conf_override = False
@@ -112,7 +112,7 @@ class PanelViewsFromDirectoryIntegrationTestCase(integration_util.IntegrationTes
         assert len(tools) == 2, len(tools)
 
 
-class PanelViewsFromConfigIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestPanelViewsFromConfigIntegration(integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
 

--- a/test/integration/test_pulsar_embedded_containers.py
+++ b/test/integration/test_pulsar_embedded_containers.py
@@ -35,19 +35,19 @@ class BaseEmbeddedPulsarContainerIntegrationTestCase(integration_util.Integratio
         super().setUpClass()
 
 
-class EmbeddedSingularityPulsarIntegrationTestCase(BaseEmbeddedPulsarContainerIntegrationTestCase, MulledJobTestCases):
+class TestEmbeddedSingularityPulsarIntegration(BaseEmbeddedPulsarContainerIntegrationTestCase, MulledJobTestCases):
     # singularity passes $HOME by default
     default_container_home_dir = os.environ.get("HOME", "/")
     job_config_file = EMBEDDED_PULSAR_JOB_CONFIG_FILE_SINGULARITY
     container_type = "singularity"
 
 
-class EmbeddedDockerPulsarIntegrationTestCase(BaseEmbeddedPulsarContainerIntegrationTestCase, MulledJobTestCases):
+class TestEmbeddedDockerPulsarIntegration(BaseEmbeddedPulsarContainerIntegrationTestCase, MulledJobTestCases):
     job_config_file = EMBEDDED_PULSAR_JOB_CONFIG_FILE_DOCKER
     container_type = "docker"
 
 
-instance = integration_util.integration_module_instance(EmbeddedSingularityPulsarIntegrationTestCase)
+instance = integration_util.integration_module_instance(TestEmbeddedSingularityPulsarIntegration)
 
 test_tools = integration_util.integration_tool_runner(
     [

--- a/test/integration/test_quota.py
+++ b/test/integration/test_quota.py
@@ -2,7 +2,7 @@ from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
 
-class QuotaIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestQuotaIntegration(integration_util.IntegrationTestCase):
     require_admin_user = True
 
     @classmethod

--- a/test/integration/test_remote_files.py
+++ b/test/integration/test_remote_files.py
@@ -24,6 +24,7 @@ USER_EMAIL = "user@bx.psu.edu"
 
 
 class ConfiguresRemoteFilesIntegrationTestCase(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
     library_dir: ClassVar[str]
     user_library_dir: ClassVar[str]
     ftp_upload_dir: ClassVar[str]
@@ -68,7 +69,7 @@ class ConfiguresRemoteFilesIntegrationTestCase(integration_util.IntegrationTestC
         return ftp_dir
 
 
-class RemoteFilesIntegrationTestCase(ConfiguresRemoteFilesIntegrationTestCase):
+class TestRemoteFilesIntegration(ConfiguresRemoteFilesIntegrationTestCase):
     def test_index(self):
         index = self.galaxy_interactor.get("remote_files?target=importdir").json()
         self._assert_index_empty(index)
@@ -255,7 +256,7 @@ class RemoteFilesIntegrationTestCase(ConfiguresRemoteFilesIntegrationTestCase):
         assert c["li_attr"]["full_path"] == "subdir1/c"
 
 
-class RemoteFilesNotConfiguredIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestRemoteFilesNotConfiguredIntegration(integration_util.IntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_remote_files_histories.py
+++ b/test/integration/test_remote_files_histories.py
@@ -4,7 +4,7 @@ import os
 from .test_remote_files import ConfiguresRemoteFilesIntegrationTestCase
 
 
-class RemoteFilesHistoryImportExportIntegrationTestCase(ConfiguresRemoteFilesIntegrationTestCase):
+class TestRemoteFilesHistoryImportExportIntegration(ConfiguresRemoteFilesIntegrationTestCase):
 
     framework_tool_and_types = True
 

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -15,7 +15,9 @@ from galaxy_test.driver.integration_setup import (
 )
 
 
-class PosixFileSourceIntegrationTestCase(PosixFileSourceSetup, integration_util.IntegrationTestCase):
+class TestPosixFileSourceIntegration(PosixFileSourceSetup, integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self._write_file_fixtures()

--- a/test/integration/test_resolvers.py
+++ b/test/integration/test_resolvers.py
@@ -71,7 +71,7 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase):
         tool_id = "legacy_R"
         dataset_populator = DatasetPopulator(self.galaxy_interactor)
         history_id = dataset_populator.new_history()
-        endpoint = "tools/%s/install_dependencies" % tool_id
+        endpoint = f"tools/{tool_id}/install_dependencies"
         data = {"id": tool_id}
         create_response = self._post(endpoint, data=data, admin=True)
         self._assert_status_code_is(create_response, 200)
@@ -86,25 +86,25 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase):
 
     def test_conda_install_through_tools_api(self):
         tool_id = "mulled_example_multi_1"
-        endpoint = "tools/%s/install_dependencies" % tool_id
+        endpoint = f"tools/{tool_id}/install_dependencies"
         data = {"id": tool_id}
         create_response = self._post(endpoint, data=data, admin=True)
         self._assert_status_code_is(create_response, 200)
         response = create_response.json()
         assert any(True for d in response if d["dependency_type"] == "conda")
-        endpoint = "tools/%s/build_dependency_cache" % tool_id
+        endpoint = f"tools/{tool_id}/build_dependency_cache"
         create_response = self._post(endpoint, data=data, admin=True)
         self._assert_status_code_is(create_response, 200)
 
     def test_uninstall_through_tools_api(self):
         tool_id = "mulled_example_multi_1"
-        endpoint = "tools/%s/dependencies" % tool_id
+        endpoint = f"tools/{tool_id}/dependencies"
         data = {"id": tool_id}
         create_response = self._post(endpoint, data=data, admin=True)
         self._assert_status_code_is(create_response, 200)
         response = create_response.json()
         assert any(True for d in response if d["dependency_type"] == "conda")
-        endpoint = "tools/%s/dependencies" % tool_id
+        endpoint = f"tools/{tool_id}/dependencies"
         create_response = self._delete(endpoint, data=data, admin=True)
         self._assert_status_code_is(create_response, 200)
         response = create_response.json()
@@ -112,7 +112,7 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase):
 
     def _uninstall_mulled_example_multi_1(self, resolver_type=None):
         tool_id = "mulled_example_multi_1"
-        endpoint = "tools/%s/dependencies" % tool_id
+        endpoint = f"tools/{tool_id}/dependencies"
         data = {"id": tool_id, "resolver_type": resolver_type}
         create_response = self._delete(endpoint, data=data, admin=True)
         self._assert_status_code_is(create_response, 200)
@@ -124,7 +124,7 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase):
         self._uninstall_mulled_example_multi_1(resolver_type="conda")
         # Now do the actual test
         tool_id = "mulled_example_multi_1"
-        endpoint = "tools/%s/dependencies" % tool_id
+        endpoint = f"tools/{tool_id}/dependencies"
         data = {"id": tool_id, "resolver_type": "conda"}
         create_response = self._post(endpoint, data=data, admin=True)
         self._assert_status_code_is(create_response, 200)
@@ -142,9 +142,9 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase):
 
     def _assert_dependency_type(self, response, type="conda", exact=True):
         if "dependency_type" not in response:
-            raise Exception("Response [%s] did not contain key 'dependency_type'" % response)
+            raise Exception(f"Response [{response}] did not contain key 'dependency_type'")
         dependency_type = response["dependency_type"]
         assert dependency_type == type, f"Dependency type [{dependency_type}] not the expected value [{type}]"
         if "exact" not in response:
-            raise Exception("Response [%s] did not contain key 'exact'" % response)
+            raise Exception(f"Response [{response}] did not contain key 'exact'")
         assert response["exact"] is exact

--- a/test/integration/test_resolvers.py
+++ b/test/integration/test_resolvers.py
@@ -9,7 +9,7 @@ from galaxy_test.driver import integration_util
 GNUPLOT = {"version": "4.6", "type": "package", "name": "gnuplot"}
 
 
-class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestCondaResolutionIntegration(integration_util.IntegrationTestCase):
 
     """Test conda dependency resolution through API."""
 

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -25,8 +25,7 @@ def skip_unless_module(module):
         available = False
     if available:
         return lambda func: func
-    template = "Module %s could not be loaded, dependent test skipped."
-    return unittest.skip(template % module)
+    return unittest.skip(f"Module {module} could not be loaded, dependent test skipped.")
 
 
 class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
@@ -55,13 +54,13 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
         self._scripts_check_argparse_help(script)
 
         history_id = self.dataset_populator.new_history()
-        delete_response = self.dataset_populator._delete("histories/%s" % history_id)
+        delete_response = self.dataset_populator._delete(f"histories/{history_id}")
         assert delete_response.status_code == 200
         assert delete_response.json()["purged"] is False
         config_file = self.write_config_file()
         output = self._scripts_check_output(script, ["-c", config_file, "--days", "0", "--purge_histories"])
         print(output)
-        history_response = self.dataset_populator._get("histories/%s" % history_id)
+        history_response = self.dataset_populator._get(f"histories/{history_id}")
         assert history_response.status_code == 200
         assert history_response.json()["purged"] is True, history_response.json()
 
@@ -72,7 +71,7 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
         self._scripts_check_argparse_help(script)
 
         history_id = self.dataset_populator.new_history()
-        delete_response = self.dataset_populator._delete("histories/%s" % history_id)
+        delete_response = self.dataset_populator._delete(f"histories/{history_id}")
         assert delete_response.status_code == 200
         assert delete_response.json()["purged"] is False
         config_file = self.write_config_file()
@@ -80,7 +79,7 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
             script, ["-c", config_file, "--older-than", "0", "--sequence", "purge_deleted_histories"]
         )
         print(output)
-        history_response = self.dataset_populator._get("histories/%s" % history_id)
+        history_response = self.dataset_populator._get(f"histories/{history_id}")
         assert history_response.status_code == 200
         assert history_response.json()["purged"] is True, history_response.json()
 
@@ -130,7 +129,7 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
         self._scripts_check_output(script, ["-c", config_file, "-g", grt_config_file, "-r", self.config_dir])
         report_files = os.listdir(self.config_dir)
         json_files = [j for j in report_files if j.endswith(".json")]
-        assert len(json_files) == 1, "Expected one json report file in [%s]" % json_files
+        assert len(json_files) == 1, f"Expected one json report file in [{json_files}]"
         json_file = os.path.join(self.config_dir, json_files[0])
         with open(json_file) as f:
             export = json.load(f)

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -16,7 +16,7 @@ from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
 
-class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestScriptsIntegration(integration_util.IntegrationTestCase):
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -5,7 +5,6 @@ import json
 import os
 import subprocess
 import tempfile
-import unittest
 
 import yaml
 
@@ -15,17 +14,6 @@ from galaxy.util import (
 )
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
-
-
-def skip_unless_module(module):
-    available = True
-    try:
-        __import__(module)
-    except ImportError:
-        available = False
-    if available:
-        return lambda func: func
-    return unittest.skip(f"Module {module} could not be loaded, dependent test skipped.")
 
 
 class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):

--- a/test/integration/test_shed_tool_tests.py
+++ b/test/integration/test_shed_tool_tests.py
@@ -3,7 +3,7 @@ from galaxy_test.driver import integration_util
 from galaxy_test.driver.uses_shed import UsesShed
 
 
-class ToolShedToolTestIntegrationTestCase(integration_util.IntegrationTestCase, UsesShed):
+class TestToolShedToolTestIntegration(integration_util.IntegrationTestCase, UsesShed):
 
     """Test data manager installation and table reload through the API"""
 

--- a/test/integration/test_tool_data_delete.py
+++ b/test/integration/test_tool_data_delete.py
@@ -17,7 +17,7 @@ THIS_DIR = os.path.dirname(__file__)
 SOURCE_TOOL_DATA_DIRECTORY = os.path.join(THIS_DIR, os.pardir, "functional", "tool-data")
 
 
-class AdminToolDataIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestAdminToolDataIntegration(integration_util.IntegrationTestCase):
     require_admin_user = True
 
     def setUp(self):

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -116,7 +116,7 @@ class NonAdminsCannotPasteFilePathTestCase(BaseUploadContentConfigurationTestCas
 
     def test_disallowed_for_primary_file(self):
         payload = self.dataset_populator.upload_payload(
-            self.history_id, "file://%s/1.RData" % TEST_DATA_DIRECTORY, file_type="binary"
+            self.history_id, f"file://{TEST_DATA_DIRECTORY}/1.RData", file_type="binary"
         )
         create_response = self.dataset_populator.tools_post(payload)
         # Ideally this would be 403 but the tool API endpoint isn't using
@@ -134,7 +134,7 @@ class NonAdminsCannotPasteFilePathTestCase(BaseUploadContentConfigurationTestCas
             extra_inputs={
                 "files_1|url_paste": "roadmaps content",
                 "files_1|type": "upload_dataset",
-                "files_2|url_paste": "file://%s" % path,
+                "files_2|url_paste": f"file://{path}",
                 "files_2|type": "upload_dataset",
             },
         )
@@ -171,7 +171,7 @@ class NonAdminsCannotPasteFilePathTestCase(BaseUploadContentConfigurationTestCas
     def test_disallowed_for_fetch_urls(self):
         path = os.path.join(TEST_DATA_DIRECTORY, "1.txt")
         assert os.path.exists(path)
-        elements = [{"src": "url", "url": "file://%s" % path}]
+        elements = [{"src": "url", "url": f"file://{path}"}]
         target = {
             "destination": {"type": "hdca"},
             "elements": elements,
@@ -194,7 +194,7 @@ class AdminsCanPasteFilePathsTestCase(BaseUploadContentConfigurationTestCase):
     def test_admin_path_paste(self):
         payload = self.dataset_populator.upload_payload(
             self.history_id,
-            "file://%s/random-file" % TEST_DATA_DIRECTORY,
+            f"file://{TEST_DATA_DIRECTORY}/random-file",
         )
         create_response = self.dataset_populator.tools_post(payload)
         # Is admin - so this should work fine!
@@ -202,7 +202,7 @@ class AdminsCanPasteFilePathsTestCase(BaseUploadContentConfigurationTestCase):
 
     def test_admin_path_paste_libraries(self):
         library = self.library_populator.new_private_library("pathpasteallowedlibraries")
-        path = "%s/1.txt" % TEST_DATA_DIRECTORY
+        path = f"{TEST_DATA_DIRECTORY}/1.txt"
         assert os.path.exists(path)
         payload, files = self.library_populator.create_dataset_request(
             library, upload_option="upload_paths", paths=path
@@ -215,7 +215,7 @@ class AdminsCanPasteFilePathsTestCase(BaseUploadContentConfigurationTestCase):
 
     def test_admin_path_paste_libraries_link(self):
         library = self.library_populator.new_private_library("pathpasteallowedlibraries")
-        path = "%s/1.txt" % TEST_DATA_DIRECTORY
+        path = f"{TEST_DATA_DIRECTORY}/1.txt"
         assert os.path.exists(path)
         payload, files = self.library_populator.create_dataset_request(
             library, upload_option="upload_paths", paths=path, link_data=True
@@ -241,7 +241,7 @@ class AdminsCanPasteFilePathsTestCase(BaseUploadContentConfigurationTestCase):
 
     def test_admin_fetch_file_url(self):
         path = os.path.join(TEST_DATA_DIRECTORY, "1.txt")
-        elements = [{"src": "url", "url": "file://%s" % path}]
+        elements = [{"src": "url", "url": f"file://{path}"}]
         target = {
             "destination": {"type": "hdca"},
             "elements": elements,
@@ -263,14 +263,14 @@ class DefaultBinaryContentFiltersTestCase(BaseUploadContentConfigurationTestCase
 
     def test_random_binary_allowed(self):
         dataset = self.dataset_populator.new_dataset(
-            self.history_id, "file://%s/random-file" % TEST_DATA_DIRECTORY, file_type="auto", wait=True
+            self.history_id, f"file://{TEST_DATA_DIRECTORY}/random-file", file_type="auto", wait=True
         )
         dataset = self.dataset_populator.get_history_dataset_details(self.history_id, dataset=dataset)
         assert dataset["file_ext"] == "binary", dataset
 
     def test_gzipped_html_content_blocked_by_default(self):
         dataset = self.dataset_populator.new_dataset(
-            self.history_id, "file://%s/bad.html.gz" % TEST_DATA_DIRECTORY, file_type="auto", wait=True, assert_ok=False
+            self.history_id, f"file://{TEST_DATA_DIRECTORY}/bad.html.gz", file_type="auto", wait=True, assert_ok=False
         )
         dataset = self.dataset_populator.get_history_dataset_details(self.history_id, dataset=dataset, assert_ok=False)
         assert dataset["file_size"] == 0
@@ -288,7 +288,7 @@ class DisableContentCheckingTestCase(BaseUploadContentConfigurationTestCase):
 
     def test_gzipped_html_content_now_allowed(self):
         dataset = self.dataset_populator.new_dataset(
-            self.history_id, "file://%s/bad.html.gz" % TEST_DATA_DIRECTORY, file_type="auto", wait=True
+            self.history_id, f"file://{TEST_DATA_DIRECTORY}/bad.html.gz", file_type="auto", wait=True
         )
         dataset = self.dataset_populator.get_history_dataset_details(self.history_id, dataset=dataset)
         # Same file was empty above!
@@ -307,7 +307,7 @@ class AutoDecompressTestCase(BaseUploadContentConfigurationTestCase):
     def test_auto_decompress_off(self):
         dataset = self.dataset_populator.new_dataset(
             self.history_id,
-            "file://%s/1.sam.gz" % TEST_DATA_DIRECTORY,
+            f"file://{TEST_DATA_DIRECTORY}/1.sam.gz",
             file_type="auto",
             auto_decompress=False,
             wait=True,
@@ -317,7 +317,7 @@ class AutoDecompressTestCase(BaseUploadContentConfigurationTestCase):
 
     def test_auto_decompress_on(self):
         dataset = self.dataset_populator.new_dataset(
-            self.history_id, "file://%s/1.sam.gz" % TEST_DATA_DIRECTORY, file_type="auto", wait=True
+            self.history_id, f"file://{TEST_DATA_DIRECTORY}/1.sam.gz", file_type="auto", wait=True
         )
         dataset = self.dataset_populator.get_history_dataset_details(self.history_id, dataset=dataset)
         assert dataset["file_ext"] == "sam", dataset
@@ -475,7 +475,7 @@ class TemplatedFtpDirectoryUploadConfigurationTestCase(SimpleFtpUploadConfigurat
         config["ftp_upload_dir_template"] = "${ftp_upload_dir}/moo_${ftp_upload_dir_identifier}_cow"
 
     def _get_user_ftp_path(self):
-        return os.path.join(self.ftp_dir(), "moo_%s_cow" % TEST_USER)
+        return os.path.join(self.ftp_dir(), f"moo_{TEST_USER}_cow")
 
 
 class DisableFtpPurgeUploadConfigurationTestCase(BaseFtpUploadConfigurationTestCase):
@@ -934,7 +934,7 @@ class TestDirectoryAndCompressedTypes(BaseUploadContentConfigurationTestCase):
     def test_tar_to_directory(self):
         dataset = self.dataset_populator.new_dataset(
             self.history_id,
-            "file://%s/testdir.tar" % TEST_DATA_DIRECTORY,
+            f"file://{TEST_DATA_DIRECTORY}/testdir.tar",
             file_type="tar",
             auto_decompress=False,
             wait=True,

--- a/test/integration/test_vault_extra_prefs.py
+++ b/test/integration/test_vault_extra_prefs.py
@@ -15,7 +15,7 @@ from galaxy_test.driver import integration_util
 TEST_USER_EMAIL = "vault_test_user@bx.psu.edu"
 
 
-class ExtraUserPreferencesTestCase(integration_util.IntegrationTestCase):
+class TestExtraUserPreferences(integration_util.IntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_vault_file_source.py
+++ b/test/integration/test_vault_file_source.py
@@ -11,7 +11,8 @@ FILE_SOURCES_VAULT_CONF = os.path.join(SCRIPT_DIRECTORY, "file_sources_conf_vaul
 VAULT_CONF = os.path.join(SCRIPT_DIRECTORY, "vault_conf.yml")
 
 
-class VaultFileSourceIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestVaultFileSourceIntegration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
     USER_1_APP_VAULT_ENTRY = "randomvaultuser1@universe.com"
     USER_2_APP_VAULT_ENTRY = "randomvaultuser2@universe.com"
 

--- a/test/integration/test_web_framework_config.py
+++ b/test/integration/test_web_framework_config.py
@@ -11,7 +11,7 @@ class BaseWebFrameworkTestCase(integration_util.IntegrationTestCase):
         return options_response
 
 
-class CorsDefaultIntegrationTestCase(BaseWebFrameworkTestCase):
+class TestCorsDefaultIntegration(BaseWebFrameworkTestCase):
     def test_options(self):
         headers = {
             "Access-Control-Request-Method": "GET",
@@ -32,7 +32,7 @@ class CorsDefaultIntegrationTestCase(BaseWebFrameworkTestCase):
         assert "access-control-allow-origin" not in options_response.headers
 
 
-class AllowOriginIntegrationTestCase(BaseWebFrameworkTestCase):
+class TestAllowOriginIntegration(BaseWebFrameworkTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_webdav.py
+++ b/test/integration/test_webdav.py
@@ -18,7 +18,9 @@ skip_if_no_webdav = pytest.mark.skipif(not os.environ.get("GALAXY_TEST_WEBDAV"),
 
 
 @skip_if_no_webdav
-class WebDavIntegrationTestCase(integration_util.IntegrationTestCase):
+class TestWebDavIntegration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_work_queue_put_failure.py
+++ b/test/integration/test_work_queue_put_failure.py
@@ -16,7 +16,9 @@ execution:
 """
 
 
-class WorkQueuePutFailureTestCase(integration_util.IntegrationTestCase):
+class TestWorkQueuePutFailure(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/test/integration/test_work_queue_put_failure.py
+++ b/test/integration/test_work_queue_put_failure.py
@@ -39,6 +39,6 @@ class WorkQueuePutFailureTestCase(integration_util.IntegrationTestCase):
         # Set fetch_data to false so we don't bypass the job queue
         self.dataset_populator.new_dataset(self.history_id, fetch_data=False, content="1 2 3")
         self.dataset_populator.wait_for_history(self.history_id, assert_ok=False)
-        state_details = self.galaxy_interactor.get("histories/%s" % self.history_id).json()["state_details"]
+        state_details = self.galaxy_interactor.get(f"histories/{self.history_id}").json()["state_details"]
         assert state_details["running"] == 0
         assert state_details["error"] == 1

--- a/test/integration/test_workflow_handler_configuration.py
+++ b/test/integration/test_workflow_handler_configuration.py
@@ -117,10 +117,10 @@ class BaseWorkflowHandlerConfigurationTestCase(integration_util.IntegrationTestC
         hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3")
         index_map = {"0": dict(src="hda", id=hda1["id"])}
         request = {}
-        request["history"] = "hist_id=%s" % history_id
+        request["history"] = f"hist_id={history_id}"
         request["inputs"] = dumps(index_map)
         request["inputs_by"] = "step_index"
-        url = "workflows/%s/invocations" % (workflow_id)
+        url = f"workflows/{workflow_id}/invocations"
         for _ in range(n):
             self._post(url, data=request)
 

--- a/test/integration/test_workflow_handler_configuration.py
+++ b/test/integration/test_workflow_handler_configuration.py
@@ -97,7 +97,7 @@ def config_file(template, assign_with=""):
 
 
 class BaseWorkflowHandlerConfigurationTestCase(integration_util.IntegrationTestCase):
-
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
     assign_with = ""
 
@@ -139,7 +139,7 @@ class BaseWorkflowHandlerConfigurationTestCase(integration_util.IntegrationTestC
         return self._app.workflow_scheduling_manager.request_monitor is not None
 
 
-class HistoryRestrictionConfigurationTestCase(BaseWorkflowHandlerConfigurationTestCase):
+class TestHistoryRestrictionConfiguration(BaseWorkflowHandlerConfigurationTestCase):
 
     # Assign with db-preassign. Would also work with grabbing assignment, but we don't start grabber.
     assign_with = "db-preassign"
@@ -156,7 +156,7 @@ class HistoryRestrictionConfigurationTestCase(BaseWorkflowHandlerConfigurationTe
         assert JOB_HANDLER_PATTERN.match(workflow_invocations[0].handler)
 
 
-class HistoryParallelConfigurationTestCase(BaseWorkflowHandlerConfigurationTestCase):
+class TestHistoryParallelConfiguration(BaseWorkflowHandlerConfigurationTestCase):
 
     # Assign with db-preassign. Would also work with grabbing assignment, but we don't start grabber.
     assign_with = "db-preassign"
@@ -180,7 +180,7 @@ class HistoryParallelConfigurationTestCase(BaseWorkflowHandlerConfigurationTestC
 
 
 # Setup an explicit workflow handler and make sure this is assigned to that.
-class WorkflowSchedulerHandlerAssignment(BaseWorkflowHandlerConfigurationTestCase):
+class TestWorkflowSchedulerHandlerAssignment(BaseWorkflowHandlerConfigurationTestCase):
 
     # Assign with db-preassign. Would also work with grabbing assignment, but we don't start grabber.
     assign_with = "db-preassign"
@@ -207,7 +207,7 @@ class WorkflowSchedulerHandlerAssignment(BaseWorkflowHandlerConfigurationTestCas
 #  - If a workflow scheduler conf is defined and assign_with is set to db-skip-locked, invocation handler is correctly set
 #  - If a workflow scheduler conf is defined and assign_with is set to db-transaction-isolation, invocation handler is correctly set
 #  - If a workflow scheduler conf is defined and the process is not listed as a handler, it is not workflow scheduler.
-class DefaultWorkflowHandlerOnTestCase(BaseWorkflowHandlerConfigurationTestCase):
+class TestDefaultWorkflowHandlerOn(BaseWorkflowHandlerConfigurationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         # Override so we don't setup a job conf like in the base class.
@@ -217,7 +217,7 @@ class DefaultWorkflowHandlerOnTestCase(BaseWorkflowHandlerConfigurationTestCase)
         assert self.is_app_workflow_scheduler
 
 
-class DefaultWorkflowHandlerIfJobHandlerOnTestCase(BaseWorkflowHandlerConfigurationTestCase):
+class TestDefaultWorkflowHandlerIfJobHandlerOn(BaseWorkflowHandlerConfigurationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -227,7 +227,7 @@ class DefaultWorkflowHandlerIfJobHandlerOnTestCase(BaseWorkflowHandlerConfigurat
         assert self.is_app_workflow_scheduler
 
 
-class JobHandlerAsWorkflowHandlerWithDbSkipLocked(BaseWorkflowHandlerConfigurationTestCase):
+class TestJobHandlerAsWorkflowHandlerWithDbSkipLocked(BaseWorkflowHandlerConfigurationTestCase):
 
     assign_with = "db-skip-locked"
 
@@ -246,7 +246,7 @@ class JobHandlerAsWorkflowHandlerWithDbSkipLocked(BaseWorkflowHandlerConfigurati
         assert self.is_app_workflow_scheduler
 
 
-class JobHandlerAsWorkflowHandlerWithDbSkipLockedAttachToPool(JobHandlerAsWorkflowHandlerWithDbSkipLocked):
+class TestJobHandlerAsWorkflowHandlerWithDbSkipLockedAttachToPool(TestJobHandlerAsWorkflowHandlerWithDbSkipLocked):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["job_config_file"] = config_file(POOL_JOB_CONFIG_TEMPLATE, assign_with=cls.assign_with)
@@ -254,7 +254,7 @@ class JobHandlerAsWorkflowHandlerWithDbSkipLockedAttachToPool(JobHandlerAsWorkfl
         config["attach_to_pools"] = ["job-handlers"]
 
 
-class DefaultWorkflowHandlerIfJobHandlerOffTestCase(BaseWorkflowHandlerConfigurationTestCase):
+class TestDefaultWorkflowHandlerIfJobHandlerOff(BaseWorkflowHandlerConfigurationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -264,7 +264,7 @@ class DefaultWorkflowHandlerIfJobHandlerOffTestCase(BaseWorkflowHandlerConfigura
         assert not self.is_app_workflow_scheduler
 
 
-class ExplicitWorkflowHandlersOnTestCase(BaseWorkflowHandlerConfigurationTestCase):
+class TestExplicitWorkflowHandlersOn(BaseWorkflowHandlerConfigurationTestCase):
 
     assign_with = ""
 
@@ -281,7 +281,7 @@ class ExplicitWorkflowHandlersOnTestCase(BaseWorkflowHandlerConfigurationTestCas
 
 
 @integration_util.skip_unless_postgres()
-class WorkflowSchedulerHandlerAssignmentDbSkipLocked(ExplicitWorkflowHandlersOnTestCase):
+class TestWorkflowSchedulerHandlerAssignmentDbSkipLocked(TestExplicitWorkflowHandlersOn):
 
     assign_with = "db-skip-locked"
 
@@ -293,12 +293,12 @@ class WorkflowSchedulerHandlerAssignmentDbSkipLocked(ExplicitWorkflowHandlersOnT
 
 
 @integration_util.skip_unless_postgres()
-class WorkflowSchedulerHandlerAssignmentDbTransactionIsolation(WorkflowSchedulerHandlerAssignmentDbSkipLocked):
+class TestWorkflowSchedulerHandlerAssignmentDbTransactionIsolation(TestWorkflowSchedulerHandlerAssignmentDbSkipLocked):
 
     assign_with = "db-transaction-isolation"
 
 
-class ExplicitWorkflowHandlersOffTestCase(BaseWorkflowHandlerConfigurationTestCase):
+class TestExplicitWorkflowHandlersOff(BaseWorkflowHandlerConfigurationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -311,7 +311,7 @@ class ExplicitWorkflowHandlersOffTestCase(BaseWorkflowHandlerConfigurationTestCa
         assert not self.is_app_workflow_scheduler
 
 
-class ExplicitWorkflowHandlersOffPoolTestCase(BaseWorkflowHandlerConfigurationTestCase):
+class TestExplicitWorkflowHandlersOffPool(BaseWorkflowHandlerConfigurationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration/test_workflow_invocation.py
+++ b/test/integration/test_workflow_invocation.py
@@ -8,8 +8,8 @@ from galaxy_test.base.uses_shed_api import UsesShedApi
 from galaxy_test.driver import integration_util
 
 
-class WorkflowInvocationTestCase(integration_util.IntegrationTestCase, UsesShedApi):
-
+class TestWorkflowInvocation(integration_util.IntegrationTestCase, UsesShedApi):
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
     require_admin_user = False
 

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -38,7 +38,7 @@ steps:
 """
 
 
-class WorkflowRefactoringIntegrationTestCase(integration_util.IntegrationTestCase, UsesShedApi):
+class TestWorkflowRefactoringIntegration(integration_util.IntegrationTestCase, UsesShedApi):
 
     framework_tool_and_types = True
 

--- a/test/integration/test_workflow_scheduling_options.py
+++ b/test/integration/test_workflow_scheduling_options.py
@@ -11,8 +11,8 @@ from galaxy_test.base.populators import (
 from galaxy_test.driver import integration_util
 
 
-class MaximumWorkflowInvocationDurationTestCase(integration_util.IntegrationTestCase):
-
+class TestMaximumWorkflowInvocationDuration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
 
     def setUp(self):
@@ -46,8 +46,8 @@ class MaximumWorkflowInvocationDurationTestCase(integration_util.IntegrationTest
         assert state == "failed", state
 
 
-class MaximumWorkflowJobsPerSchedulingIterationTestCase(integration_util.IntegrationTestCase):
-
+class TestMaximumWorkflowJobsPerSchedulingIteration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
 
     def setUp(self):

--- a/test/integration/test_workflow_scheduling_options.py
+++ b/test/integration/test_workflow_scheduling_options.py
@@ -32,10 +32,10 @@ class MaximumWorkflowInvocationDurationTestCase(integration_util.IntegrationTest
         hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3")
         index_map = {"0": dict(src="hda", id=hda1["id"])}
         request = {}
-        request["history"] = "hist_id=%s" % history_id
+        request["history"] = f"hist_id={history_id}"
         request["inputs"] = dumps(index_map)
         request["inputs_by"] = "step_index"
-        url = "workflows/%s/invocations" % (workflow_id)
+        url = f"workflows/{workflow_id}/invocations"
         invocation_response = self._post(url, data=request)
         invocation_url = url + "/" + invocation_response.json()["id"]
         time.sleep(5)

--- a/test/integration/test_workflow_sync.py
+++ b/test/integration/test_workflow_sync.py
@@ -13,7 +13,7 @@ from galaxy_test.base.workflow_fixtures import WORKFLOW_SIMPLE_CAT_TWICE
 from galaxy_test.driver import integration_util
 
 
-class WorkflowSyncTestCase(integration_util.IntegrationTestCase):
+class TestWorkflowSync(integration_util.IntegrationTestCase):
 
     framework_tool_and_types = True
     require_admin_user = True

--- a/test/integration/test_workflow_tasks.py
+++ b/test/integration/test_workflow_tasks.py
@@ -22,10 +22,8 @@ from galaxy_test.driver.integration_setup import PosixFileSourceSetup
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
 
-class WorkflowTasksIntegrationTestCase(
-    PosixFileSourceSetup, IntegrationTestCase, UsesCeleryTasks, RunsWorkflowFixtures
-):
-
+class TestWorkflowTasksIntegration(PosixFileSourceSetup, IntegrationTestCase, UsesCeleryTasks, RunsWorkflowFixtures):
+    dataset_populator: DatasetPopulator
     framework_tool_and_types = True
 
     @classmethod

--- a/test/integration_selenium/framework.py
+++ b/test/integration_selenium/framework.py
@@ -1,5 +1,10 @@
+from typing import TYPE_CHECKING
+
 from galaxy_test.driver import integration_util
 from galaxy_test.selenium import framework
+
+if TYPE_CHECKING:
+    from galaxy_test.selenium.framework import SeleniumSessionDatasetPopulator
 
 selenium_test = framework.selenium_test
 
@@ -7,6 +12,8 @@ selenium_test = framework.selenium_test
 class SeleniumIntegrationTestCase(
     integration_util.IntegrationTestCase, framework.TestWithSeleniumMixin, framework.UsesLibraryAssertions
 ):
+    dataset_populator: "SeleniumSessionDatasetPopulator"
+
     def setUp(self):
         super().setUp()
         self.setup_selenium()

--- a/test/integration_selenium/test_admin_dependencies.py
+++ b/test/integration_selenium/test_admin_dependencies.py
@@ -6,7 +6,7 @@ from .framework import (
 )
 
 
-class AdminDependencyContainersTestCase(SeleniumIntegrationTestCase):
+class TestAdminDependencyContainers(SeleniumIntegrationTestCase):
     requires_admin = True
 
     @selenium_test

--- a/test/integration_selenium/test_dataset_details_source_transforms.py
+++ b/test/integration_selenium/test_dataset_details_source_transforms.py
@@ -1,11 +1,17 @@
+from typing import TYPE_CHECKING
+
 from galaxy_test.driver.integration_setup import PosixFileSourceSetup
 from .framework import (
     selenium_test,
     SeleniumIntegrationTestCase,
 )
 
+if TYPE_CHECKING:
+    from galaxy_test.selenium.framework import SeleniumSessionDatasetPopulator
 
-class DatasetSourceTransformSeleniumIntegrationTestCase(PosixFileSourceSetup, SeleniumIntegrationTestCase):
+
+class TestDatasetSourceTransformSeleniumIntegration(PosixFileSourceSetup, SeleniumIntegrationTestCase):
+    dataset_populator: "SeleniumSessionDatasetPopulator"
     ensure_registered = True
     include_test_data_dir = True
 
@@ -82,7 +88,7 @@ class DatasetSourceTransformSeleniumIntegrationTestCase(PosixFileSourceSetup, Se
         self._write_file_fixtures()
 
 
-class DatasetSourceTransformInModelStoreSeleniumIntegrationTestCase(DatasetSourceTransformSeleniumIntegrationTestCase):
+class TestDatasetSourceTransformInModelStoreSeleniumIntegration(TestDatasetSourceTransformSeleniumIntegration):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration_selenium/test_edam_tool_panel_views.py
+++ b/test/integration_selenium/test_edam_tool_panel_views.py
@@ -5,7 +5,7 @@ from .framework import (
 )
 
 
-class EdamToolPanelViewsSeleniumIntegrationTestCase(SeleniumIntegrationTestCase):
+class TestEdamToolPanelViewsSeleniumIntegration(SeleniumIntegrationTestCase):
 
     ensure_registered = True  # to test workflow editor
 

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -6,7 +6,7 @@ from .framework import (
 )
 
 
-class HistoryImportExportFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestCase):
+class TestHistoryImportExportFtpSeleniumIntegration(SeleniumIntegrationTestCase):
     ensure_registered = True
 
     @classmethod

--- a/test/integration_selenium/test_pages_pdf_export.py
+++ b/test/integration_selenium/test_pages_pdf_export.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class PagesPdfExportSeleniumIntegrationTestCase(SeleniumIntegrationTestCase):
+class TestPagesPdfExportSeleniumIntegration(SeleniumIntegrationTestCase):
     ensure_registered = True
 
     @classmethod

--- a/test/integration_selenium/test_toolbox_filters.py
+++ b/test/integration_selenium/test_toolbox_filters.py
@@ -10,7 +10,7 @@ TEST_FILTER_MODULES = "galaxy.selenium.toolbox"
 TEST_SECTION_FILTERS = "filters:restrict_test"
 
 
-class ToolboxFiltersSeleniumIntegrationTestCase(SeleniumIntegrationTestCase):
+class TestToolboxFiltersSeleniumIntegration(SeleniumIntegrationTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/integration_selenium/test_trs_import.py
+++ b/test/integration_selenium/test_trs_import.py
@@ -25,7 +25,7 @@ TRS_VERSION_WORKFLOWHUB = "4"
 WORKFLOW_NAME = "COVID-19: variation analysis on ARTIC PE data"
 
 
-class TrsImportTestCase(SeleniumIntegrationTestCase):
+class TestTrsImport(SeleniumIntegrationTestCase):
     ensure_registered = True
 
     @classmethod

--- a/test/integration_selenium/test_upload_file_sources.py
+++ b/test/integration_selenium/test_upload_file_sources.py
@@ -1,11 +1,18 @@
+from typing import TYPE_CHECKING
+
 from galaxy_test.driver.integration_setup import PosixFileSourceSetup
 from .framework import (
     selenium_test,
     SeleniumIntegrationTestCase,
 )
 
+if TYPE_CHECKING:
+    from galaxy_test.selenium.framework import SeleniumSessionDatasetPopulator
 
-class PosixFileSourceSeleniumIntegrationTestCase(PosixFileSourceSetup, SeleniumIntegrationTestCase):
+
+class TestPosixFileSourceSeleniumIntegration(PosixFileSourceSetup, SeleniumIntegrationTestCase):
+    dataset_populator: "SeleniumSessionDatasetPopulator"
+
     # For simplicity, otherwise need to setup a different file_sources_config_file
     requires_admin = True
 

--- a/test/integration_selenium/test_upload_ftp.py
+++ b/test/integration_selenium/test_upload_ftp.py
@@ -6,7 +6,7 @@ from .framework import (
 )
 
 
-class UploadFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestCase):
+class TestUploadFtpSeleniumIntegration(SeleniumIntegrationTestCase):
     ensure_registered = True
 
     @classmethod

--- a/test/integration_selenium/test_workflow_repository_tool_update.py
+++ b/test/integration_selenium/test_workflow_repository_tool_update.py
@@ -1,11 +1,17 @@
+from typing import TYPE_CHECKING
+
 from galaxy_test.driver.uses_shed import UsesShed
 from .framework import (
     selenium_test,
     SeleniumIntegrationTestCase,
 )
 
+if TYPE_CHECKING:
+    from galaxy_test.selenium.framework import SeleniumSessionDatasetPopulator
 
-class WorkflowEditorToolUpgradeWithToolShedToolTestCase(SeleniumIntegrationTestCase, UsesShed):
+
+class TestWorkflowEditorToolUpgradeWithToolShedTool(SeleniumIntegrationTestCase, UsesShed):
+    dataset_populator: "SeleniumSessionDatasetPopulator"
     requires_admin = True
 
     @classmethod

--- a/test/integration_selenium/test_workflow_run_target.py
+++ b/test/integration_selenium/test_workflow_run_target.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from galaxy_test.base.workflow_fixtures import WORKFLOW_SIMPLE_CAT_TWICE
 from galaxy_test.selenium.framework import (
     managed_history,
@@ -9,12 +11,16 @@ from .framework import (
     SeleniumIntegrationTestCase,
 )
 
+if TYPE_CHECKING:
+    from galaxy_test.selenium.framework import SeleniumSessionDatasetPopulator
 
-class WorkflowRunTargetNewSeleniumIntegrationTestCase(
-    SeleniumIntegrationTestCase, RunsWorkflows, UsesHistoryItemAssertions
-):
+
+class BaseWorkflowRunTargetTestCase(SeleniumIntegrationTestCase, RunsWorkflows, UsesHistoryItemAssertions):
+    dataset_populator: "SeleniumSessionDatasetPopulator"
     ensure_registered = True
 
+
+class TestWorkflowRunTargetNewSeleniumIntegration(BaseWorkflowRunTargetTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -39,11 +45,7 @@ class WorkflowRunTargetNewSeleniumIntegrationTestCase(
         self.assert_item_summary_includes(2, "2 sequences")
 
 
-class WorkflowRunTargetCurrentSeleniumIntegrationTestCase(
-    SeleniumIntegrationTestCase, RunsWorkflows, UsesHistoryItemAssertions
-):
-    ensure_registered = True
-
+class TestWorkflowRunTargetCurrentSeleniumIntegration(BaseWorkflowRunTargetTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)
@@ -67,11 +69,7 @@ class WorkflowRunTargetCurrentSeleniumIntegrationTestCase(
         self.assert_item_summary_includes(2, "2 sequences")
 
 
-class WorkflowRunTargetSelectNewSeleniumIntegrationTestCase(
-    SeleniumIntegrationTestCase, RunsWorkflows, UsesHistoryItemAssertions
-):
-    ensure_registered = True
-
+class TestWorkflowRunTargetSelectNewSeleniumIntegration(BaseWorkflowRunTargetTestCase):
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         super().handle_galaxy_config_kwds(config)

--- a/test/unit/app/authnz/test_custos_authnz.py
+++ b/test/unit/app/authnz/test_custos_authnz.py
@@ -237,6 +237,7 @@ class CustosAuthnzTestCase(unittest.TestCase):
 
     def tearDown(self):
         requests.get = self.orig_requests_get
+        os.environ.pop("OAUTHLIB_INSECURE_TRANSPORT", None)
 
     def test_parse_config(self):
         assert self.custos_authnz.config["verify_ssl"]
@@ -298,15 +299,15 @@ class CustosAuthnzTestCase(unittest.TestCase):
             },
         )
         self.setupMocks()
-        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT", None) is None
+        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT") is None
         self.custos_authnz.authenticate(self.trans)
-        assert "1" == os.environ["OAUTHLIB_INSECURE_TRANSPORT"]
+        assert os.environ["OAUTHLIB_INSECURE_TRANSPORT"] == "1"
 
     def test_authenticate_does_not_set_env_var_when_https_redirect(self):
         assert self.custos_authnz.config["redirect_uri"].startswith("https:")
-        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT", None) is None
+        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT") is None
         self.custos_authnz.authenticate(self.trans)
-        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT", None) is None
+        assert os.environ.get("OAUTHLIB_INSECURE_TRANSPORT") is None
 
     def test_callback_verify_with_state_cookie(self):
         """Verify that state from cookie is passed to OAuth2Session constructor."""

--- a/test/unit/app/authnz/test_custos_authnz.py
+++ b/test/unit/app/authnz/test_custos_authnz.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
 import os
-import unittest
 import uuid
 from datetime import (
     datetime,
@@ -24,9 +23,10 @@ from galaxy.model import (
     User,
 )
 from galaxy.util import unicodify
+from galaxy.util.unittest import TestCase
 
 
-class CustosAuthnzTestCase(unittest.TestCase):
+class TestCustosAuthnz(TestCase):
 
     _create_oauth2_session_called = False
     _fetch_token_called = False

--- a/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
+++ b/test/unit/app/jobs/dynamic_tool_destination/test_dynamic_tool_destination.py
@@ -1,12 +1,12 @@
 import logging
 import os
-import unittest
 
 from testfixtures.logcapture import log_capture
 
 import galaxy.jobs.dynamic_tool_destination as dt
 from galaxy.jobs.dynamic_tool_destination import map_tool_to_destination
 from galaxy.jobs.mapper import JobMappingException
+from galaxy.util.unittest import TestCase
 from . import (
     mockGalaxy as mg,
     ymltests as yt,
@@ -88,7 +88,7 @@ valueZ = valueE * 1024
 valueY = valueZ * 1024
 
 
-class TestDynamicToolDestination(unittest.TestCase):
+class TestDynamicToolDestination(TestCase):
     def setUp(self):
         self.maxDiff = None
         self.logger = logging.getLogger()

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -6,7 +6,6 @@ from typing import (
     List,
     Tuple,
 )
-from unittest import TestCase
 
 from galaxy.jobs.command_factory import (
     build_command,
@@ -15,6 +14,7 @@ from galaxy.jobs.command_factory import (
 )
 from galaxy.tool_util.deps.container_classes import TRAP_KILL_CONTAINER
 from galaxy.util.bunch import Bunch
+from galaxy.util.unittest import TestCase
 
 MOCK_COMMAND_LINE = "/opt/galaxy/tools/bowtie /mnt/galaxyData/files/000/input000.dat"
 TEST_METADATA_LINE = "set_metadata_and_stuff.sh"

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -119,7 +119,7 @@ class TestCommandFactory(TestCase):
         self._test_set_metadata()
 
     def test_strips_trailing_semicolons(self):
-        self.job_wrapper.command_line = "%s;" % MOCK_COMMAND_LINE
+        self.job_wrapper.command_line = f"{MOCK_COMMAND_LINE};"
         self._test_set_metadata()
 
     def _test_set_metadata(self):

--- a/test/unit/app/jobs/test_job_configuration.py
+++ b/test/unit/app/jobs/test_job_configuration.py
@@ -37,7 +37,7 @@ class BaseJobConfXmlParserTestCase(unittest.TestCase):
     def setUp(self):
         self.temp_directory = tempfile.mkdtemp()
         self.config = mock.Mock(
-            job_config_file=os.path.join(self.temp_directory, "job_conf.%s" % self.extension),
+            job_config_file=os.path.join(self.temp_directory, f"job_conf.{self.extension}"),
             use_tasked_jobs=False,
             job_resource_params_file="/tmp/fake_absent_path",
             config_dict={},
@@ -79,10 +79,12 @@ class BaseJobConfXmlParserTestCase(unittest.TestCase):
     def _with_handlers_config(self, assign_with=None, default=None, handlers=None, base_pools=None):
         handlers = handlers or []
         template = {
-            "assign_with": ' assign_with="%s"' % assign_with if assign_with is not None else "",
-            "default": ' default="%s"' % default if default is not None else "",
+            "assign_with": f' assign_with="{assign_with}"' if assign_with is not None else "",
+            "default": f' default="{default}"' if default is not None else "",
             "handlers": "\n".join(
-                '<handler id="{id}"{tags}/>'.format(id=x["id"], tags=' tags="%s"' % x["tags"] if "tags" in x else "")
+                '<handler id="{id}"{tags}/>'.format(
+                    id=x["id"], tags=' tags="{}"'.format(x["tags"]) if "tags" in x else ""
+                )
                 for x in handlers
             ),
         }
@@ -111,7 +113,7 @@ class BaseJobConfXmlParserTestCase(unittest.TestCase):
         self._write_config(contents)
 
     def _write_config(self, contents):
-        with open(os.path.join(self.temp_directory, "job_conf.%s" % self.extension), "w") as f:
+        with open(os.path.join(self.temp_directory, f"job_conf.{self.extension}"), "w") as f:
             f.write(contents)
 
     def _with_advanced_config(self):

--- a/test/unit/app/jobs/test_job_configuration.py
+++ b/test/unit/app/jobs/test_job_configuration.py
@@ -2,7 +2,6 @@ import datetime
 import os
 import shutil
 import tempfile
-import unittest
 from unittest import mock
 
 from pykwalify.core import Core
@@ -14,6 +13,7 @@ from galaxy.util import (
     galaxy_directory,
     galaxy_samples_directory,
 )
+from galaxy.util.unittest import TestCase
 from galaxy.web_stack import ApplicationStack
 from galaxy.web_stack.handlers import HANDLER_ASSIGNMENT_METHODS
 
@@ -31,7 +31,7 @@ class TestApplicationStack(ApplicationStack):
         return HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED
 
 
-class BaseJobConfXmlParserTestCase(unittest.TestCase):
+class BaseJobConfXmlParserTestCase(TestCase):
     extension = "xml"
 
     def setUp(self):
@@ -123,7 +123,7 @@ class BaseJobConfXmlParserTestCase(unittest.TestCase):
             self._write_config_from(ADVANCED_JOB_CONF_YAML)
 
 
-class SimpleJobConfXmlParserTestCase(BaseJobConfXmlParserTestCase):
+class TestSimpleJobConfXmlParser(BaseJobConfXmlParserTestCase):
     extension = "xml"
 
     def test_load_simple_runner(self):
@@ -239,7 +239,7 @@ class SimpleJobConfXmlParserTestCase(BaseJobConfXmlParserTestCase):
             assert self.job_config.destinations[name]
 
 
-class AdvancedJobConfXmlParserTestCase(BaseJobConfXmlParserTestCase):
+class TestAdvancedJobConfXmlParser(BaseJobConfXmlParserTestCase):
     def test_disable_job_metrics(self):
         self._with_advanced_config()
         self.job_config.destinations["multicore_local"]
@@ -350,7 +350,7 @@ class AdvancedJobConfXmlParserTestCase(BaseJobConfXmlParserTestCase):
         assert self.job_config.resource_groups["memoryonly"] == ["memory"]
 
 
-class AdvancedJobConfYamlParserTestCase(AdvancedJobConfXmlParserTestCase):
+class TestAdvancedJobConfYamlParser(TestAdvancedJobConfXmlParser):
     extension = "yml"
 
 

--- a/test/unit/app/jobs/test_job_wrapper.py
+++ b/test/unit/app/jobs/test_job_wrapper.py
@@ -6,7 +6,6 @@ from typing import (
     Dict,
     Type,
 )
-from unittest import TestCase
 
 from galaxy.app_unittest_utils.tools_support import UsesApp
 from galaxy.jobs import (
@@ -22,6 +21,7 @@ from galaxy.model import (
 from galaxy.objectstore import ObjectStore
 from galaxy.tools import ToolBox
 from galaxy.util.bunch import Bunch
+from galaxy.util.unittest import TestCase
 
 TEST_TOOL_ID = "cufftest"
 TEST_VERSION_COMMAND = "bwa --version"
@@ -86,12 +86,12 @@ class AbstractTestCases:
             pass
 
 
-class JobWrapperTestCase(AbstractTestCases.BaseWrapperTestCase):
+class TestJobWrapper(AbstractTestCases.BaseWrapperTestCase):
     def _wrapper(self):
         return JobWrapper(self.job, self.queue)  # type: ignore[arg-type]
 
 
-class TaskWrapperTestCase(AbstractTestCases.BaseWrapperTestCase):
+class TestTaskWrapper(AbstractTestCases.BaseWrapperTestCase):
     def setUp(self):
         super().setUp()
         self.task = Task(self.job, self.working_directory, "prepare_bwa_job.sh")

--- a/test/unit/app/jobs/test_runner_local.py
+++ b/test/unit/app/jobs/test_runner_local.py
@@ -139,7 +139,7 @@ class MockJobWrapper:
         self.job.id = 1
         self.output_paths = ["/tmp/output1.dat"]
         self.mock_metadata_path = os.path.abspath(os.path.join(test_directory, "METADATA_SET"))
-        self.metadata_command = "touch %s" % self.mock_metadata_path
+        self.metadata_command = f"touch {self.mock_metadata_path}"
         self.galaxy_virtual_env = None
         self.shell = "/bin/bash"
         self.cleanup_job = "never"

--- a/test/unit/app/jobs/test_runner_local.py
+++ b/test/unit/app/jobs/test_runner_local.py
@@ -2,7 +2,6 @@ import os
 import threading
 import time
 from typing import Optional
-from unittest import TestCase
 
 import psutil
 
@@ -13,6 +12,7 @@ from galaxy import (
 from galaxy.app_unittest_utils.tools_support import UsesTools
 from galaxy.jobs.runners import local
 from galaxy.util import bunch
+from galaxy.util.unittest import TestCase
 
 
 class TestLocalJobRunner(TestCase, UsesTools):

--- a/test/unit/app/managers/base.py
+++ b/test/unit/app/managers/base.py
@@ -58,17 +58,14 @@ class BaseTestCase(unittest.TestCase):
 
     def assertHasKeys(self, obj, key_list):
         for key in key_list:
-            if key not in obj:
-                self.fail("Missing key: " + key)
+            assert key in obj
 
     def assertNullableBasestring(self, item):
-        if not isinstance(item, (str, type(None))):
-            self.fail("Non-nullable basestring: " + str(type(item)))
+        assert isinstance(item, (str, type(None)))
         # TODO: len mod 8 and hex re
 
     def assertEncodedId(self, item):
-        if not isinstance(item, str):
-            self.fail("Non-string: " + str(type(item)))
+        assert isinstance(item, str)
         # TODO: len mod 8 and hex re
 
     def assertNullableEncodedId(self, item):
@@ -76,29 +73,25 @@ class BaseTestCase(unittest.TestCase):
             self.assertEncodedId(item)
 
     def assertDate(self, item):
-        if not isinstance(item, str):
-            self.fail("Non-string: " + str(type(item)))
+        assert isinstance(item, str)
         # TODO: no great way to parse this fully (w/o python-dateutil)
         # TODO: re?
 
     def assertUUID(self, item):
-        if not isinstance(item, str):
-            self.fail("Non-string: " + str(type(item)))
+        assert isinstance(item, str)
         # TODO: re for d4d76d69-80d4-4ed7-80c7-211ebcc1a358
 
     def assertORMFilter(self, item):
-        if not isinstance(
+        assert isinstance(
             item.filter, (sqlalchemy.sql.elements.BinaryExpression, sqlalchemy.sql.elements.BooleanClauseList)
-        ):
-            self.fail("Not an orm filter: " + str(type(item.filter)))
+        ), "Not an orm filter"
 
     def assertORMFunctionFilter(self, item):
         assert item.filter_type == "orm_function"
         assert callable(item.filter)
 
     def assertFnFilter(self, item):
-        if not item.filter or not callable(item.filter):
-            self.fail("Not a fn filter: " + str(type(item.filter)))
+        assert item.filter and callable(item.filter), "Not a fn filter"
 
     def assertIsJsonifyable(self, item):
         # TODO: use galaxy's override

--- a/test/unit/app/managers/base.py
+++ b/test/unit/app/managers/base.py
@@ -2,12 +2,12 @@
 """
 
 import json
-import unittest
 
 import sqlalchemy
 
 from galaxy.app_unittest_utils import galaxy_mock
 from galaxy.managers.users import UserManager
+from galaxy.util.unittest import TestCase
 
 # =============================================================================
 admin_email = "admin@admin.admin"
@@ -16,7 +16,7 @@ default_password = "123456"
 
 
 # =============================================================================
-class BaseTestCase(unittest.TestCase):
+class BaseTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         print("\n", "-" * 20, "begin class", cls)

--- a/test/unit/app/managers/test_CollectionManager.py
+++ b/test/unit/app/managers/test_CollectionManager.py
@@ -18,7 +18,7 @@ user3_data = dict(email="user3@user3.user3", username="user3", password=default_
 
 
 # =============================================================================
-class DatasetCollectionManagerTestCase(BaseTestCase, CreatesCollectionsMixin):
+class TestDatasetCollectionManager(BaseTestCase, CreatesCollectionsMixin):
     def set_up_managers(self):
         super().set_up_managers()
         self.dataset_manager = self.app[DatasetManager]

--- a/test/unit/app/managers/test_DatasetManager.py
+++ b/test/unit/app/managers/test_DatasetManager.py
@@ -226,11 +226,9 @@ class DatasetSerializerTestCase(BaseTestCase):
         self.log("should have a serializer for all serializable keys")
         for key in self.dataset_serializer.serializable_keyset:
             instantiated_attribute = getattr(dataset, key, None)
-            if not (
-                (key in self.dataset_serializer.serializers)
-                or (isinstance(instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS))
-            ):
-                self.fail(f"no serializer for: {key} ({instantiated_attribute})")
+            assert key in self.dataset_serializer.serializers or isinstance(
+                instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS
+            ), f"No serializer for: {key} ({instantiated_attribute})"
 
     def test_views_and_keys(self):
         dataset = self.dataset_manager.create()

--- a/test/unit/app/managers/test_DatasetManager.py
+++ b/test/unit/app/managers/test_DatasetManager.py
@@ -23,7 +23,7 @@ user3_data = dict(email="user3@user3.user3", username="user3", password=default_
 
 
 # =============================================================================
-class DatasetManagerTestCase(BaseTestCase):
+class TestDatasetManager(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.dataset_manager = DatasetManager(self.app)
@@ -187,7 +187,7 @@ class DatasetManagerTestCase(BaseTestCase):
         assert not self.dataset_manager.permissions.access.is_permitted(dataset, None)
 
 
-# class DatasetRBACPermissionsTestCase(BaseTestCase):
+# class TestDatasetRBACPermissions(BaseTestCase):
 #     def set_up_managers(self):
 #         super().set_up_managers()
 #         self.dataset_manager = DatasetManager(self.app)
@@ -205,7 +205,7 @@ def testable_url_for(*a, **k):
 
 
 @mock.patch("galaxy.managers.datasets.DatasetSerializer.url_for", testable_url_for)
-class DatasetSerializerTestCase(BaseTestCase):
+class TestDatasetSerializer(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.dataset_manager = DatasetManager(self.app)

--- a/test/unit/app/managers/test_DatasetManager.py
+++ b/test/unit/app/managers/test_DatasetManager.py
@@ -187,21 +187,18 @@ class DatasetManagerTestCase(BaseTestCase):
         assert not self.dataset_manager.permissions.access.is_permitted(dataset, None)
 
 
-# =============================================================================
-class DatasetRBACPermissionsTestCase(BaseTestCase):
-    def set_up_managers(self):
-        super().set_up_managers()
-        self.dataset_manager = DatasetManager(self.app)
-
-    # def test_manage( self ):
-    #     self.log("should be able to create a new Dataset")
-    #     dataset1 = self.dataset_manager.create()
-    #     assert isinstance(dataset1, model.Dataset)
-    #     assert dataset1 == self.app.model.context.query(model.Dataset).get(dataset1.id)
-    #
+# class DatasetRBACPermissionsTestCase(BaseTestCase):
+#     def set_up_managers(self):
+#         super().set_up_managers()
+#         self.dataset_manager = DatasetManager(self.app)
+#
+#     def test_manage( self ):
+#         self.log("should be able to create a new Dataset")
+#         dataset1 = self.dataset_manager.create()
+#         assert isinstance(dataset1, model.Dataset)
+#         assert dataset1 == self.app.model.context.query(model.Dataset).get(dataset1.id)
 
 
-# =============================================================================
 # web.url_for doesn't work well in the framework
 def testable_url_for(*a, **k):
     return f"(fake url): {a}, {k}"

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -400,12 +400,11 @@ class HDASerializerTestCase(HDATestCase):
         self.log("should have a serializer for all serializable keys")
         for key in self.hda_serializer.serializable_keyset:
             instantiated_attribute = getattr(hda, key, None)
-            if not (
-                (key in self.hda_serializer.serializers)
-                or (isinstance(instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS))
-                or (is_metadata(key))
-            ):
-                self.fail(f"no serializer for: {key} ({instantiated_attribute})")
+            assert (
+                key in self.hda_serializer.serializers
+                or isinstance(instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS)
+                or is_metadata(key)
+            ), f"No serializer for: {key} ({instantiated_attribute})"
 
     def test_views_and_keys(self):
         hda = self._create_vanilla_hda()

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -34,7 +34,7 @@ class HDATestCase(BaseTestCase):
 
 
 # =============================================================================
-class HDAManagerTestCase(HDATestCase):
+class TestHDAManager(HDATestCase):
     def test_base(self):
         hda_model = model.HistoryDatasetAssociation
         owner = self.user_manager.create(**user2_data)
@@ -365,7 +365,7 @@ def testable_url_for(*a, **k):
 
 
 @mock.patch("galaxy.managers.hdas.HDASerializer.url_for", testable_url_for)
-class HDASerializerTestCase(HDATestCase):
+class TestHDASerializer(HDATestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.hda_serializer = hdas.HDASerializer(self.app)
@@ -526,7 +526,7 @@ class HDASerializerTestCase(HDATestCase):
 
 
 # =============================================================================
-class HDADeserializerTestCase(HDATestCase):
+class TestHDADeserializer(HDATestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.hda_deserializer = hdas.HDADeserializer(self.app)
@@ -633,7 +633,7 @@ class HDADeserializerTestCase(HDATestCase):
 
 
 # =============================================================================
-class HDAFilterParserTestCase(HDATestCase):
+class TestHDAFilterParser(HDATestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.filter_parser = hdas.HDAFilterParser(self.app)

--- a/test/unit/app/managers/test_HDCAManager.py
+++ b/test/unit/app/managers/test_HDCAManager.py
@@ -82,11 +82,9 @@ class HDCASerializerTestCase(HDCATestCase):
         self.log("should have a serializer for all serializable keys")
         for key in serializer.serializable_keyset:
             instantiated_attribute = getattr(item, key, None)
-            if not (
-                (key in serializer.serializers)
-                or (isinstance(instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS))
-            ):
-                self.fail(f"no serializer for: {key} ({instantiated_attribute})")
+            assert key in serializer.serializers or isinstance(
+                instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS
+            ), f"No serializer for: {key} ({instantiated_attribute})"
 
     def test_views_and_keys(self):
         serializer = self.hdca_serializer

--- a/test/unit/app/managers/test_HDCAManager.py
+++ b/test/unit/app/managers/test_HDCAManager.py
@@ -58,7 +58,7 @@ def testable_url_for(*a, **k):
 
 
 @mock.patch("galaxy.managers.hdcas.HDCASerializer.url_for", testable_url_for)
-class HDCASerializerTestCase(HDCATestCase):
+class TestHDCASerializer(HDCATestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.hdca_serializer = hdcas.HDCASerializer(self.app)

--- a/test/unit/app/managers/test_HistoryContentsManager.py
+++ b/test/unit/app/managers/test_HistoryContentsManager.py
@@ -52,7 +52,7 @@ class HistoryAsContainerBaseTestCase(BaseTestCase, CreatesCollectionsMixin):
 
 
 # =============================================================================
-class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
+class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
     def test_contents(self):
         user2 = self.user_manager.create(**user2_data)
         history = self.history_manager.create(name="history", user=user2)
@@ -329,7 +329,7 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         assert self.contents_manager.contents(history, filters=filters) == [contents[1], contents[6]]
 
 
-class HistoryContentsFilterParserTestCase(HistoryAsContainerBaseTestCase):
+class TestHistoryContentsFilterParser(HistoryAsContainerBaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.filter_parser = history_contents.HistoryContentsFilters(self.app)

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -28,7 +28,7 @@ user4_data = dict(email="user4@user4.user4", username="user4", password=default_
 parsed_filter = base.ModelFilterParser.parsed_filter
 
 
-class HistoryManagerTestCase(BaseTestCase):
+class TestHistoryManager(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.history_manager = self.app[HistoryManager]
@@ -384,7 +384,7 @@ def testable_url_for(*a, **k):
 
 @mock.patch("galaxy.managers.histories.HistorySerializer.url_for", testable_url_for)
 @mock.patch("galaxy.managers.hdas.HDASerializer.url_for", testable_url_for)
-class HistorySerializerTestCase(BaseTestCase):
+class TestHistorySerializer(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.history_manager = self.app[HistoryManager]
@@ -606,7 +606,7 @@ class HistorySerializerTestCase(BaseTestCase):
 
 
 # =============================================================================
-class HistoryDeserializerTestCase(BaseTestCase):
+class TestHistoryDeserializer(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.history_manager = self.app[HistoryManager]
@@ -667,7 +667,7 @@ class HistoryDeserializerTestCase(BaseTestCase):
 
 
 # =============================================================================
-class HistoryFiltersTestCase(BaseTestCase):
+class TestHistoryFilters(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.history_manager = self.app[HistoryManager]

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -410,11 +410,9 @@ class HistorySerializerTestCase(BaseTestCase):
         self.log("should have a serializer for all serializable keys")
         for key in self.history_serializer.serializable_keyset:
             instantiated_attribute = getattr(history1, key, None)
-            if not (
-                (key in self.history_serializer.serializers)
-                or (isinstance(instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS))
-            ):
-                self.fail(f"no serializer for: {key} ({instantiated_attribute})")
+            assert key in self.history_serializer.serializers or isinstance(
+                instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS
+            ), f"No serializer for: {key} ({instantiated_attribute})"
 
     def test_views_and_keys(self):
         user2 = self.user_manager.create(**user2_data)

--- a/test/unit/app/managers/test_TagHandler.py
+++ b/test/unit/app/managers/test_TagHandler.py
@@ -10,7 +10,7 @@ user2_data = dict(email="user2@user2.user2", username="user2", password=default_
 
 
 # =============================================================================
-class TagHandlerTestCase(BaseTestCase):
+class TestTagHandler(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.app.hda_manager = self.app[hdas.HDAManager]

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -30,7 +30,7 @@ lowercase_email_user = dict(email="user5@user5.user5", username="user5", passwor
 
 
 # =============================================================================
-class UserManagerTestCase(BaseTestCase):
+class TestUserManager(BaseTestCase):
     def test_framework(self):
         self.log("(for testing) should have admin_user, and admin_user is current")
         assert self.trans.user == self.admin_user
@@ -121,7 +121,8 @@ class UserManagerTestCase(BaseTestCase):
         user2 = self.user_manager.create(**user2_data)
 
         self.log("should be able to tell if a user is anonymous")
-        self.assertRaises(exceptions.AuthenticationFailed, self.user_manager.error_if_anonymous, anon)
+        with self.assertRaises(exceptions.AuthenticationFailed):
+            self.user_manager.error_if_anonymous(anon)
         assert self.user_manager.error_if_anonymous(user2) == user2
 
     def test_current(self):
@@ -218,7 +219,7 @@ class UserManagerTestCase(BaseTestCase):
 
 
 # =============================================================================
-class UserSerializerTestCase(BaseTestCase):
+class TestUserSerializer(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.user_serializer = users.UserSerializer(self.app)
@@ -276,7 +277,7 @@ class UserSerializerTestCase(BaseTestCase):
         self.assertIsJsonifyable(serialized)
 
 
-class CurrentUserSerializerTestCase(BaseTestCase):
+class TestCurrentUserSerializer(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.history_manager = self.app[histories.HistoryManager]
@@ -303,7 +304,7 @@ class CurrentUserSerializerTestCase(BaseTestCase):
 
 
 # =============================================================================
-class UserDeserializerTestCase(BaseTestCase):
+class TestUserDeserializer(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.deserializer = users.UserDeserializer(self.app)
@@ -353,7 +354,7 @@ class UserDeserializerTestCase(BaseTestCase):
 
 
 # =============================================================================
-class AdminUserFilterParserTestCase(BaseTestCase):
+class TestAdminUserFilterParser(BaseTestCase):
     def set_up_managers(self):
         super().set_up_managers()
         self.filter_parser = users.AdminUserFilterParser(self.app)

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -237,11 +237,9 @@ class UserSerializerTestCase(BaseTestCase):
         self.log("should have a serializer for all serializable keys")
         for key in self.user_serializer.serializable_keyset:
             instantiated_attribute = getattr(user, key, None)
-            if not (
-                (key in self.user_serializer.serializers)
-                or (isinstance(instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS))
-            ):
-                self.fail(f"no serializer for: {key} ({instantiated_attribute})")
+            assert key in self.user_serializer.serializers or isinstance(
+                instantiated_attribute, self.TYPES_NEEDING_NO_SERIALIZERS
+            ), f"No serializer for: {key} ({instantiated_attribute})"
 
     def test_views_and_keys(self):
         user = self.user_manager.create(**user2_data)

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -84,7 +84,7 @@ class BaseExportTestCase(BaseTestCase):
         return collection
 
 
-class ToBasicMarkdownTestCase(BaseExportTestCase):
+class TestToBasicMarkdown(BaseExportTestCase):
     def setUp(self):
         super().setUp()
         self.test_dataset_path = None
@@ -329,7 +329,7 @@ job_metrics(job_id=1)
         return to_basic_markdown(self.trans, example)
 
 
-class ReadyExportTestCase(BaseExportTestCase):
+class TestReadyExport(BaseExportTestCase):
     def test_ready_dataset_display(self):
         hda = self._new_hda()
         example = """

--- a/test/unit/app/managers/test_markdown_export.py
+++ b/test/unit/app/managers/test_markdown_export.py
@@ -280,7 +280,7 @@ invocation_time(invocation_id=1)
         invocation = self._new_invocation()
         self.app.workflow_manager.get_invocation.side_effect = [invocation]  # type: ignore[attr-defined,union-attr]
         result = self._to_basic(example)
-        assert "\n    %s" % invocation.create_time.isoformat() in result
+        assert f"\n    {invocation.create_time.isoformat()}" in result
 
     def test_job_parameters(self):
         job = model.Job()

--- a/test/unit/app/test_remote_shell.py
+++ b/test/unit/app/test_remote_shell.py
@@ -15,9 +15,10 @@ from galaxy.security.ssh_util import (
     generate_ssh_keys,
     SSHKeys,
 )
+from galaxy.util.unittest import TestCase
 
 
-class TestCliInterface(unittest.TestCase):
+class TestCliInterface(TestCase):
     ssh_keys: SSHKeys
     username: str
     shell_params: Dict[str, Any]

--- a/test/unit/app/tools/test_actions.py
+++ b/test/unit/app/tools/test_actions.py
@@ -1,5 +1,4 @@
 import string
-import unittest
 from typing import cast
 
 from galaxy import model
@@ -13,6 +12,7 @@ from galaxy.tools.actions import (
     on_text_for_names,
 )
 from galaxy.util import XML
+from galaxy.util.unittest import TestCase
 
 # I cannot think of a saner way to test if data is being wrapped than use a
 # data param in the output label - though you would probably never want to do
@@ -58,7 +58,7 @@ def test_on_text_for_names():
     assert_on_text_is("data 1 and data 2", "data 1", "data 1", "data 2")
 
 
-class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesTools):
+class TestDefaultToolAction(TestCase, tools_support.UsesTools):
     def setUp(self):
         self.setup_app()
         history = model.History()

--- a/test/unit/app/tools/test_collect_primary_datasets.py
+++ b/test/unit/app/tools/test_collect_primary_datasets.py
@@ -1,6 +1,5 @@
 import json
 import os
-import unittest
 from typing import cast
 
 from galaxy import (
@@ -15,12 +14,13 @@ from galaxy.tool_util.provided_metadata import (
     LegacyToolProvidedMetadata,
     NullToolProvidedMetadata,
 )
+from galaxy.util.unittest import TestCase
 
 DEFAULT_TOOL_OUTPUT = "out1"
 DEFAULT_EXTRA_NAME = "test1"
 
 
-class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesTools):
+class TestCollectPrimaryDatasets(TestCase, tools_support.UsesTools):
     def setUp(self):
         self.setup_app()
         object_store = cast(ObjectStore, MockObjectStore())

--- a/test/unit/app/tools/test_collect_primary_datasets.py
+++ b/test/unit/app/tools/test_collect_primary_datasets.py
@@ -349,7 +349,7 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesTools)
         collected = self._collect(**kwargs)
         assert DEFAULT_TOOL_OUTPUT in collected, f"No such key [{DEFAULT_TOOL_OUTPUT}], in {collected}"
         output_files = collected[DEFAULT_TOOL_OUTPUT]
-        assert DEFAULT_EXTRA_NAME in output_files, "No such key [%s]" % DEFAULT_EXTRA_NAME
+        assert DEFAULT_EXTRA_NAME in output_files, f"No such key [{DEFAULT_EXTRA_NAME}]"
         return output_files[DEFAULT_EXTRA_NAME]
 
     def _collect(self, job_working_directory=None):
@@ -394,7 +394,7 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesTools)
             object["filename"] = name
         line = json.dumps(object)
         with open(os.path.join(self.test_directory, "galaxy.json"), "a") as f:
-            f.write("%s\n" % line)
+            f.write(f"{line}\n")
 
     def _setup_extra_file(self, **kwargs):
         path = kwargs.get("path", None)
@@ -403,9 +403,8 @@ class CollectPrimaryDatasetsTestCase(unittest.TestCase, tools_support.UsesTools)
             name = kwargs.get("name", DEFAULT_EXTRA_NAME)
             visible = kwargs.get("visible", "visible")
             ext = kwargs.get("ext", "data")
-            template_args = (self.hda.id, name, visible, ext)
             directory = kwargs.get("directory", self.test_directory)
-            path = os.path.join(directory, "primary_%s_%s_%s_%s" % template_args)
+            path = os.path.join(directory, f"primary_{self.hda.id}_{name}_{visible}_{ext}")
             if "dbkey" in kwargs:
                 path = "{}_{}".format(path, kwargs["dbkey"])
         if not path:

--- a/test/unit/app/tools/test_column_parameters.py
+++ b/test/unit/app/tools/test_column_parameters.py
@@ -7,7 +7,7 @@ from galaxy.util import bunch
 from .util import BaseParameterTestCase
 
 
-class DataColumnParameterTestCase(BaseParameterTestCase):
+class TestDataColumnParameter(BaseParameterTestCase):
     def test_not_optional_by_default(self):
         assert not self.__param_optional()
 

--- a/test/unit/app/tools/test_column_parameters.py
+++ b/test/unit/app/tools/test_column_parameters.py
@@ -99,8 +99,7 @@ class DataColumnParameterTestCase(BaseParameterTestCase):
             data_ref_text = ""
             if self.set_data_ref:
                 data_ref_text = 'data_ref="input_tsv"'
-            template_xml = """<param name="my_name" type="%s" %s %s %s %s></param>"""
-            param_str = template_xml % (self.type, data_ref_text, multi_text, optional_text, self.other_attributes)
+            param_str = f"""<param name="my_name" type="{self.type}" {data_ref_text} {multi_text} {optional_text} {self.other_attributes}></param>"""
             self._param = self._parameter_for(xml=param_str)
             self._param.ref_input = bunch.Bunch(formats=[datatypes_registry.get_datatype_by_extension("tabular")])
 

--- a/test/unit/app/tools/test_data_parameters.py
+++ b/test/unit/app/tools/test_data_parameters.py
@@ -9,7 +9,7 @@ from galaxy.app_unittest_utils import galaxy_mock
 from .util import BaseParameterTestCase
 
 
-class DataToolParameterTestCase(BaseParameterTestCase):
+class TestDataToolParameter(BaseParameterTestCase):
     def test_to_python_none_values(self):
         assert self.param.to_python(None, self.app) is None
         assert self.param.to_python("None", self.app) is None

--- a/test/unit/app/tools/test_dataset_matcher.py
+++ b/test/unit/app/tools/test_dataset_matcher.py
@@ -168,7 +168,7 @@ class DatasetMatcherTestCase(TestCase, UsesApp):
                       <filter type="add_value" value="bar" />
                       <filter type="add_value" value="baz" />
                     </options>"""
-            param_xml = XML("""<param name="data2" type="data" format="txt">%s</param>""" % option_xml)
+            param_xml = XML(f"""<param name="data2" type="data" format="txt">{option_xml}</param>""")
             self.param = basic.DataToolParameter(
                 self.tool,
                 param_xml,

--- a/test/unit/app/tools/test_dataset_matcher.py
+++ b/test/unit/app/tools/test_dataset_matcher.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 from galaxy import model
 from galaxy.app_unittest_utils.tools_support import UsesApp
 from galaxy.tools.parameters import (
@@ -10,6 +8,7 @@ from galaxy.util import (
     bunch,
     XML,
 )
+from galaxy.util.unittest import TestCase
 from .test_data_parameters import MockHistoryDatasetAssociation
 
 
@@ -20,7 +19,7 @@ class MockTool:
         self.valid_input_states = model.Dataset.valid_input_states
 
 
-class DatasetMatcherTestCase(TestCase, UsesApp):
+class TestDatasetMatcher(TestCase, UsesApp):
     def test_hda_mismatches(self):
         # Datasets not visible are not "valid" for param.
         self.mock_hda.visible = False

--- a/test/unit/app/tools/test_evaluation.py
+++ b/test/unit/app/tools/test_evaluation.py
@@ -1,5 +1,4 @@
 import os
-from unittest import TestCase
 
 from galaxy.app_unittest_utils.tools_support import UsesApp
 from galaxy.job_execution.compute_environment import SimpleComputeEnvironment
@@ -30,6 +29,7 @@ from galaxy.tools.parameters.grouping import (
 )
 from galaxy.util import XML
 from galaxy.util.bunch import Bunch
+from galaxy.util.unittest import TestCase
 
 # To Test:
 # - param_file handling.
@@ -37,7 +37,7 @@ TEST_TOOL_DIRECTORY = "/path/to/the/tool"
 TEST_GALAXY_URL = "http://mycool.galaxyproject.org:8456"
 
 
-class ToolEvaluatorTestCase(TestCase, UsesApp):
+class TestToolEvaluator(TestCase, UsesApp):
     def setUp(self):
         self.setup_app()
         self.tool = MockTool(self.app)

--- a/test/unit/app/tools/test_execution.py
+++ b/test/unit/app/tools/test_execution.py
@@ -2,7 +2,6 @@
 """
 from collections import OrderedDict
 from typing import cast
-from unittest import TestCase
 
 import webob.exc
 
@@ -11,6 +10,7 @@ from galaxy.app_unittest_utils import tools_support
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.util.bunch import Bunch
+from galaxy.util.unittest import TestCase
 
 BASE_REPEAT_TOOL_CONTENTS = """<tool id="test_tool" name="Test Tool">
     <command>echo "$param1" #for $r in $repeat# "$r.param2" #end for# &lt; $out1</command>
@@ -33,7 +33,7 @@ REPEAT_COLLECTION_PARAM_CONTENTS = BASE_REPEAT_TOOL_CONTENTS % (
 )
 
 
-class ToolExecutionTestCase(TestCase, tools_support.UsesTools):
+class TestToolExecution(TestCase, tools_support.UsesTools):
     tool_action: "MockAction"
 
     def setUp(self):

--- a/test/unit/app/tools/test_execution.py
+++ b/test/unit/app/tools/test_execution.py
@@ -27,9 +27,9 @@ BASE_REPEAT_TOOL_CONTENTS = """<tool id="test_tool" name="Test Tool">
 """
 
 # Tool with a repeat parameter, to test state update.
-REPEAT_TOOL_CONTENTS = BASE_REPEAT_TOOL_CONTENTS % """<param type="text" name="param2" value="" />"""
-REPEAT_COLLECTION_PARAM_CONTENTS = (
-    BASE_REPEAT_TOOL_CONTENTS % """<param type="data_collection" name="param2" collection_type="paired" />"""
+REPEAT_TOOL_CONTENTS = BASE_REPEAT_TOOL_CONTENTS % ("""<param type="text" name="param2" value="" />""",)
+REPEAT_COLLECTION_PARAM_CONTENTS = BASE_REPEAT_TOOL_CONTENTS % (
+    """<param type="data_collection" name="param2" collection_type="paired" />""",
 )
 
 

--- a/test/unit/app/tools/test_metadata.py
+++ b/test/unit/app/tools/test_metadata.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-import unittest
 
 from galaxy import model
 from galaxy.app_unittest_utils import tools_support
@@ -11,9 +10,10 @@ from galaxy.util import (
     galaxy_directory,
     safe_makedirs,
 )
+from galaxy.util.unittest import TestCase
 
 
-class MetadataTestCase(unittest.TestCase, tools_support.UsesTools):
+class TestMetadata(TestCase, tools_support.UsesTools):
     def setUp(self):
         super().setUp()
         self.setup_app()

--- a/test/unit/app/tools/test_metadata.py
+++ b/test/unit/app/tools/test_metadata.py
@@ -88,8 +88,7 @@ class MetadataTestCase(unittest.TestCase, tools_support.UsesTools):
         }
         command = self.metadata_command(output_datasets)
         self._write_galaxy_json(
-            """{"type": "dataset", "dataset_id": "%s", "name": "my dynamic name", "ext": "fasta", "info": "my dynamic info"}"""
-            % output_dataset.dataset.id
+            f"""{{"type": "dataset", "dataset_id": "{output_dataset.dataset.id}", "name": "my dynamic name", "ext": "fasta", "info": "my dynamic info"}}"""
         )
         self._write_output_dataset_contents(output_dataset, ">seq1\nGCTGCATG\n")
         self._write_job_files()
@@ -127,8 +126,7 @@ class MetadataTestCase(unittest.TestCase, tools_support.UsesTools):
         }
         command = self.metadata_command(output_datasets)
         self._write_galaxy_json(
-            """{"type": "dataset", "dataset_id": "%s", "name": "my dynamic name", "ext": "fasta", "info": "my dynamic info", "metadata": {"sequences": 42}}"""
-            % output_dataset.dataset.id
+            f"""{{"type": "dataset", "dataset_id": "{output_dataset.dataset.id}", "name": "my dynamic name", "ext": "fasta", "info": "my dynamic info", "metadata": {{"sequences": 42}}}}"""
         )
         self._write_output_dataset_contents(output_dataset, ">seq1\nGCTGCATG\n")
         self._write_job_files()

--- a/test/unit/app/tools/test_parameter_parsing.py
+++ b/test/unit/app/tools/test_parameter_parsing.py
@@ -2,13 +2,12 @@ from typing import (
     Any,
     Dict,
 )
-from unittest import TestCase
 
 from galaxy.tools.parameters.meta import process_key
 from .util import BaseParameterTestCase
 
 
-class ProcessKeyTestCase(TestCase):
+class TestProcessKey:
     def test_process_key(self):
         nested_dict: Dict[str, Any] = {}
         d = {
@@ -43,7 +42,7 @@ class ProcessKeyTestCase(TestCase):
         assert nested_dict == expected_dict
 
 
-class ParameterParsingTestCase(BaseParameterTestCase):
+class TestParameterParsing(BaseParameterTestCase):
     """Test the parsing of XML for most parameter types - in many
     ways these are not very good tests since they break the abstraction
     established by the tools. The docs tests in basic.py are better but

--- a/test/unit/app/tools/test_parameter_validation.py
+++ b/test/unit/app/tools/test_parameter_validation.py
@@ -1,7 +1,7 @@
 from .util import BaseParameterTestCase
 
 
-class ParameterValidationTestCase(BaseParameterTestCase):
+class TestParameterValidation(BaseParameterTestCase):
     def test_simple_ExpressionValidator(self):
         p = self._parameter_for(
             xml="""

--- a/test/unit/app/tools/test_select_parameters.py
+++ b/test/unit/app/tools/test_select_parameters.py
@@ -87,8 +87,7 @@ class SelectToolParameterTestCase(BaseParameterTestCase):
             data_ref_text = ""
             if self.set_data_ref:
                 data_ref_text = 'data_ref="input_bam"'
-            template_xml = """<param name="my_name" type="%s" %s %s %s>%s</param>"""
-            param_str = template_xml % (self.type, data_ref_text, multi_text, optional_text, options_text)
+            param_str = f"""<param name="my_name" type="{self.type}" {data_ref_text} {multi_text} {optional_text}>{options_text}</param>"""
             self._param = self._parameter_for(xml=param_str)
 
         return self._param

--- a/test/unit/app/tools/test_select_parameters.py
+++ b/test/unit/app/tools/test_select_parameters.py
@@ -7,7 +7,7 @@ from galaxy.tools.parameters import basic
 from .util import BaseParameterTestCase
 
 
-class SelectToolParameterTestCase(BaseParameterTestCase):
+class TestSelectToolParameter(BaseParameterTestCase):
     def test_validated_values(self):
         self.options_xml = """<options><filter type="data_meta" ref="input_bam" key="dbkey"/></options>"""
         with pytest.raises(ValueError) as exc_info:
@@ -52,8 +52,7 @@ class SelectToolParameterTestCase(BaseParameterTestCase):
         assert ("testname2", "testpath2", False) in self.param.get_options(self.trans, {"input_bam": "testpath2"})
         assert len(self.param.get_options(self.trans, {"input_bam": "testpath3"})) == 0
 
-    # TODO: Good deal of overlap here with DataToolParameterTestCase,
-    # refactor.
+    # TODO: Good deal of overlap here with TestDataToolParameter, refactor.
     def setUp(self):
         super().setUp()
         self.test_history = model.History()

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -105,7 +105,7 @@ class BaseToolBoxTestCase(unittest.TestCase, UsesTools):
             "tools": [
                 {
                     "add_to_tool_panel": False,  # to have repository.includes_tools_for_display_in_tool_panel=False in InstalledRepositoryManager.activate_repository()
-                    "guid": "github.com/galaxyproject/example/test_tool/0.%s" % changeset,
+                    "guid": f"github.com/galaxyproject/example/test_tool/0.{changeset}",
                     "tool_config": "tool.xml",
                 }
             ],
@@ -173,7 +173,7 @@ class BaseToolBoxTestCase(unittest.TestCase, UsesTools):
 
     def _init_dynamic_tool_conf(self):
         # Add a dynamic tool conf (such as a ToolShed managed one) to list of configs.
-        self._add_config("""<toolbox tool_path="%s"></toolbox>""" % self.test_directory)
+        self._add_config(f"""<toolbox tool_path="{self.test_directory}"></toolbox>""")
 
     def _tool_conf_path(self, name="tool_conf.xml"):
         path = os.path.join(self.test_directory, name)
@@ -447,7 +447,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
 
     def test_tool_dir(self):
         self._init_tool()
-        self._add_config("""<toolbox><tool_dir dir="%s" /></toolbox>""" % self.test_directory)
+        self._add_config(f"""<toolbox><tool_dir dir="{self.test_directory}" /></toolbox>""")
 
         toolbox = self.toolbox
         assert toolbox.get_tool("test_tool") is not None
@@ -462,7 +462,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
     def test_workflow_in_panel(self):
         stored_workflow = self.__test_workflow()
         encoded_id = self.app.security.encode_id(stored_workflow.id)
-        self._add_config("""<toolbox><workflow id="%s" /></toolbox>""" % encoded_id)
+        self._add_config(f"""<toolbox><workflow id="{encoded_id}" /></toolbox>""")
         assert len(self.toolbox._tool_panel) == 1
         panel_workflow = next(iter(self.toolbox._tool_panel.values()))
         assert panel_workflow == stored_workflow.latest_workflow
@@ -472,7 +472,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         stored_workflow = self.__test_workflow()
         encoded_id = self.app.security.encode_id(stored_workflow.id)
         self._add_config(
-            """<toolbox><section id="tid" name="TID"><workflow id="%s" /></section></toolbox>""" % encoded_id
+            f"""<toolbox><section id="tid" name="TID"><workflow id="{encoded_id}" /></section></toolbox>"""
         )
         assert len(self.toolbox._tool_panel) == 1
         section = self.toolbox._tool_panel["tid"]

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -4,7 +4,6 @@ import logging
 import os
 import string
 import time
-import unittest
 from typing import Optional
 
 import pytest
@@ -22,6 +21,7 @@ from galaxy.tool_util.unittest_utils.sample_data import (
 )
 from galaxy.tools import ToolBox
 from galaxy.tools.cache import ToolCache
+from galaxy.util.unittest import TestCase
 
 log = logging.getLogger(__name__)
 
@@ -64,7 +64,7 @@ class SimplifiedToolBox(ToolBox):
         self.app.watchers.start()
 
 
-class BaseToolBoxTestCase(unittest.TestCase, UsesTools):
+class BaseToolBoxTestCase(TestCase, UsesTools):
     _toolbox: Optional[SimplifiedToolBox] = None
 
     @property
@@ -187,7 +187,7 @@ class BaseToolBoxTestCase(unittest.TestCase, UsesTools):
         self.reindexed = True
 
 
-class ToolBoxTestCase(BaseToolBoxTestCase):
+class TestToolBox(BaseToolBoxTestCase):
     def test_load_file(self):
         self._init_tool()
         self._add_config("""<toolbox><tool file="tool.xml" /></toolbox>""")

--- a/test/unit/app/tools/util.py
+++ b/test/unit/app/tools/util.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 from galaxy import model
 from galaxy.app_unittest_utils.tools_support import UsesApp
 from galaxy.tools.parameters import basic
@@ -7,6 +5,7 @@ from galaxy.util import (
     bunch,
     XML,
 )
+from galaxy.util.unittest import TestCase
 
 
 class BaseParameterTestCase(TestCase, UsesApp):

--- a/test/unit/app/visualizations/plugins/__init__.py
+++ b/test/unit/app/visualizations/plugins/__init__.py
@@ -1,9 +1,9 @@
-import unittest
-
 import routes
 
+from galaxy.util.unittest import TestCase
 
-class VisualizationsBase_TestCase(unittest.TestCase):
+
+class VisualizationsBase_TestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         routes.Mapper()

--- a/test/unit/app/visualizations/plugins/test_VisualizationPlugin.py
+++ b/test/unit/app/visualizations/plugins/test_VisualizationPlugin.py
@@ -11,7 +11,7 @@ from galaxy.visualization.plugins import (
 from . import VisualizationsBase_TestCase
 
 
-class VisualizationsPlugin_TestCase(VisualizationsBase_TestCase):
+class TestVisualizationsPlugin(VisualizationsBase_TestCase):
     plugin_class = vis_plugin.VisualizationPlugin
 
     def test_default_init(self):

--- a/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
+++ b/test/unit/app/visualizations/plugins/test_VisualizationsRegistry.py
@@ -43,7 +43,7 @@ config1 = """\
 """
 
 
-class VisualizationsRegistry_TestCase(VisualizationsBase_TestCase):
+class TestVisualizationsRegistry(VisualizationsBase_TestCase):
     def test_plugin_load_from_repo(self):
         """should attempt load if criteria met"""
         mock_app = galaxy_mock.MockApp(root=glx_dir)

--- a/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
+++ b/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
@@ -4,7 +4,6 @@ Unit tests for base DataProviders.
 """
 import os
 import tempfile
-import unittest
 from io import StringIO
 from typing import Type
 
@@ -13,6 +12,7 @@ from galaxy.datatypes.dataproviders import (
     exceptions,
 )
 from galaxy.util import clean_multiline_string
+from galaxy.util.unittest import TestCase
 
 # TODO: fix imports there after dist and retry
 # TODO: fix off by ones in FilteredDataProvider counters
@@ -43,7 +43,7 @@ class TempFileCache:
         self._content_dict = {}
 
 
-class BaseTestCase(unittest.TestCase):
+class BaseTestCase(TestCase):
     default_file_contents = """
             One
             Two

--- a/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
+++ b/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
@@ -2,7 +2,6 @@
 Unit tests for base DataProviders.
 .. seealso:: galaxy.datatypes.dataproviders.base
 """
-import logging
 import os
 import tempfile
 import unittest
@@ -15,11 +14,33 @@ from galaxy.datatypes.dataproviders import (
 )
 from galaxy.util import clean_multiline_string
 
-log = logging.getLogger(__name__)
-
 # TODO: fix imports there after dist and retry
 # TODO: fix off by ones in FilteredDataProvider counters
 # currently because of dataproviders.dataset importing galaxy.model this doesn't work
+
+
+class TempFileCache:
+    """
+    Creates and caches tempfiles with/based-on the given contents.
+    """
+
+    def __init__(self):
+        self._content_dict = {}
+
+    def create_tmpfile(self, contents):
+        if contents not in self._content_dict:
+            # create a named tmp and write contents to it, return filename
+            with tempfile.NamedTemporaryFile(delete=False, mode="w+") as tmpfile:
+                tmpfile.write(contents)
+                tmpfile_name = tmpfile.name
+            self._content_dict[contents] = tmpfile_name
+        return self._content_dict[contents]
+
+    def clear(self):
+        for tmpfile in self._content_dict.values():
+            if os.path.exists(tmpfile):
+                os.unlink(tmpfile)
+        self._content_dict = {}
 
 
 class BaseTestCase(unittest.TestCase):
@@ -28,32 +49,19 @@ class BaseTestCase(unittest.TestCase):
             Two
             Three
         """
+    tmpfiles: TempFileCache
 
     @classmethod
     def setUpClass(cls):
-        log.debug("CLASS %s %s", ("_" * 40), cls.__name__)
+        cls.tmpfiles = TempFileCache()
 
     @classmethod
     def tearDownClass(cls):
-        log.debug("CLASS %s %s\n\n", ("_" * 40), cls.__name__)
-
-    def __init__(self, *args):
-        unittest.TestCase.__init__(self, *args)
-        self.tmpfiles = TempFileCache()
-
-    def setUp(self):
-        log.debug("BEGIN %s %s", ("." * 40), self._testMethodName)
-        if self._testMethodDoc:
-            log.debug(' """%s"""', self._testMethodDoc.strip())
-
-    def tearDown(self):
-        self.tmpfiles.clear()
-        log.debug("END\n")
+        cls.tmpfiles.clear()
 
     def format_tmpfile_contents(self, contents=None):
         contents = contents or self.default_file_contents
         contents = clean_multiline_string(contents)
-        log.debug("file contents:\n%s", contents)
         return contents
 
     def parses_default_content_as(self):
@@ -73,28 +81,23 @@ class Test_BaseDataProvider(BaseTestCase):
         if not source:
             source = open(filename)
         provider = self.provider_class(source, *provider_args, **provider_kwargs)
-        log.debug("provider: %s", provider)
         data = list(provider)
-        log.debug("data: %s", str(data))
         return (contents, provider, data)
 
     def test_iterators(self):
         source = (str(x) for x in range(1, 10))
         provider = self.provider_class(source)
         data = list(provider)
-        log.debug("data: %s", str(data))
         assert data == [str(x) for x in range(1, 10)]
 
         source = (str(x) for x in range(1, 10))
         provider = self.provider_class(source)
         data = list(provider)
-        log.debug("data: %s", str(data))
         assert data == [str(x) for x in range(1, 10)]
 
         source = (str(x) for x in range(1, 10))
         provider = self.provider_class(source)
         data = list(provider)
-        log.debug("data: %s", str(data))
         assert data == [str(x) for x in range(1, 10)]
 
     def test_validate_source(self):
@@ -131,7 +134,6 @@ class Test_BaseDataProvider(BaseTestCase):
         source = (str(x) for x in range(1, 10))
         provider = self.provider_class(source)
         data = provider.readlines()
-        log.debug("data: %s", str(data))
         assert data == [str(x) for x in range(1, 10)]
 
     def test_stringio(self):
@@ -146,7 +148,6 @@ class Test_BaseDataProvider(BaseTestCase):
         source = StringIO(contents)
         provider = self.provider_class(source)
         data = list(provider)
-        log.debug("data: %s", str(data))
         # provider should call close on file
         assert data == self.parses_default_content_as()
         assert source.closed
@@ -259,7 +260,6 @@ class Test_LimitedOffsetDataProvider(Test_FilteredDataProvider):
             (3, 2, result_data[2:3], 1, 1, 1),
         ]
         for test in test_data:
-            log.debug("limit_offset_combo: %s", ", ".join(str(e) for e in test))
             limit_offset_combo(*test)
 
     def test_limit_with_offset_and_filter(self):
@@ -284,7 +284,6 @@ class Test_LimitedOffsetDataProvider(Test_FilteredDataProvider):
             (1, 2, result_data[2:3], 0, 0, 0),
         ]
         for test in test_data:
-            log.debug("limit_offset_combo: %s", ", ".join(str(e) for e in test))
             limit_offset_combo(*test)
 
 
@@ -324,9 +323,7 @@ class Test_MultiSourceDataProvider(BaseTestCase):
         source_list = [open(self.tmpfiles.create_tmpfile(c)) for c in contents]
 
         provider = self.provider_class(source_list)
-        log.debug("provider: %s", provider)
         data = list(provider)
-        log.debug("data: %s", str(data))
         assert "".join(data) == "".join(contents)
 
     def test_multiple_compound_sources(self):
@@ -367,36 +364,5 @@ class Test_MultiSourceDataProvider(BaseTestCase):
             base.FilteredDataProvider(source_list_f[2], filter_fn=no_youtube),
         ]
         provider = self.provider_class(source_list)
-        log.debug("provider: %s", provider)
         data = list(provider)
-        log.debug("data: %s", str(data))
         assert "".join(data) == "Two\nThree\nNine\nEleven\n"
-
-
-class TempFileCache:
-    """
-    Creates and caches tempfiles with/based-on the given contents.
-    """
-
-    def __init__(self):
-        self._content_dict = {}
-
-    def create_tmpfile(self, contents):
-        if contents not in self._content_dict:
-            # create a named tmp and write contents to it, return filename
-            with tempfile.NamedTemporaryFile(delete=False, mode="w+") as tmpfile:
-                tmpfile.write(contents)
-                tmpfile_name = tmpfile.name
-            log.debug("created tmpfile.name: %s", tmpfile_name)
-            self._content_dict[contents] = tmpfile_name
-
-        else:
-            log.debug("(cached): %s", self._content_dict[contents])
-        return self._content_dict[contents]
-
-    def clear(self):
-        for tmpfile in self._content_dict.values():
-            if os.path.exists(tmpfile):
-                log.debug("unlinking tmpfile: %s", tmpfile)
-                os.unlink(tmpfile)
-        self._content_dict = {}

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -1,7 +1,6 @@
 import collections
 import os
 import random
-import unittest
 import uuid
 from tempfile import NamedTemporaryFile
 from typing import List
@@ -23,6 +22,7 @@ from galaxy.model.orm.util import (
     get_object_session,
 )
 from galaxy.model.security import GalaxyRBACAgent
+from galaxy.util.unittest import TestCase
 
 datatypes_registry = galaxy.datatypes.registry.Registry()
 datatypes_registry.load_datatypes()
@@ -37,7 +37,7 @@ skip_if_not_postgres_base = pytest.mark.skipif(
 )
 
 
-class BaseModelTestCase(unittest.TestCase):
+class BaseModelTestCase(TestCase):
     model: mapping.GalaxyModelMapping
 
     @classmethod
@@ -76,7 +76,7 @@ class BaseModelTestCase(unittest.TestCase):
         cls.model.session.expunge_all()
 
 
-class MappingTests(BaseModelTestCase):
+class TestMappings(BaseModelTestCase):
     def test_ratings(self):
         user_email = "rater@example.com"
         u = model.User(email=user_email, password="password")
@@ -991,7 +991,7 @@ class MappingTests(BaseModelTestCase):
 
 
 @skip_if_not_postgres_base
-class PostgresMappingTests(MappingTests):
+class TestPostgresMappings(TestMappings):
     @classmethod
     def _db_uri(cls):
         base = os.environ.get("GALAXY_TEST_UNIT_MAPPING_URI_POSTGRES_BASE")

--- a/test/unit/data/test_mutable_json_column.py
+++ b/test/unit/data/test_mutable_json_column.py
@@ -4,7 +4,7 @@ from galaxy import model
 from .test_galaxy_mapping import BaseModelTestCase
 
 
-class MutableColumnTest(BaseModelTestCase):
+class TestMutableColumn(BaseModelTestCase):
     def persist_and_reload(self, item):
         item_id = item.id
         self.model.session.flush()

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -3,7 +3,7 @@ from galaxy.quota import DatabaseQuotaAgent
 from .test_galaxy_mapping import BaseModelTestCase
 
 
-class CalculateUsageTestCase(BaseModelTestCase):
+class TestCalculateUsage(BaseModelTestCase):
     def test_calculate_usage(self):
         u = model.User(email="calc_usage@example.com", password="password")
         self.persist(u)
@@ -35,7 +35,7 @@ class CalculateUsageTestCase(BaseModelTestCase):
         assert u.calculate_disk_usage() == 10
 
 
-class QuotaTestCase(BaseModelTestCase):
+class TestQuota(BaseModelTestCase):
     def setUp(self):
         super().setUp()
         model = self.model

--- a/test/unit/security/test_vault.py
+++ b/test/unit/security/test_vault.py
@@ -1,8 +1,8 @@
 import os
 import string
 import tempfile
-import unittest
 
+import pytest
 from cryptography.fernet import InvalidToken
 
 from galaxy.model.unittest_utils.data_app import (
@@ -14,6 +14,7 @@ from galaxy.security.vault import (
     Vault,
     VaultFactory,
 )
+from galaxy.util.unittest import TestCase
 
 
 class AbstractTestCases:
@@ -26,7 +27,7 @@ class AbstractTestCases:
     classes even if they are abstract, and therefore their tests fails.
     """
 
-    class VaultTestBase(unittest.TestCase):
+    class VaultTestBase(TestCase):
         vault: Vault
 
         def test_read_write_secret(self):
@@ -53,9 +54,9 @@ class AbstractTestCases:
 VAULT_CONF_HASHICORP = os.path.join(os.path.dirname(__file__), "fixtures/vault_conf_hashicorp.yml")
 
 
-@unittest.skipIf(
+@pytest.mark.skipif(
     not os.environ.get("VAULT_ADDRESS") or not os.environ.get("VAULT_TOKEN"),
-    "VAULT_ADDRESS and VAULT_TOKEN env vars not set",
+    reason="VAULT_ADDRESS and VAULT_TOKEN env vars not set",
 )
 class TestHashicorpVault(AbstractTestCases.VaultTestBase):
     def setUp(self) -> None:
@@ -113,9 +114,9 @@ class TestDatabaseVault(AbstractTestCases.VaultTestBase):
 VAULT_CONF_CUSTOS = os.path.join(os.path.dirname(__file__), "fixtures/vault_conf_custos.yml")
 
 
-@unittest.skipIf(
+@pytest.mark.skipif(
     not os.environ.get("CUSTOS_CLIENT_ID") or not os.environ.get("CUSTOS_CLIENT_SECRET"),
-    "CUSTOS_CLIENT_ID and CUSTOS_CLIENT_SECRET env vars not set",
+    reason="CUSTOS_CLIENT_ID and CUSTOS_CLIENT_SECRET env vars not set",
 )
 class TestCustosVault(AbstractTestCases.VaultTestBase):
     def setUp(self) -> None:

--- a/test/unit/security/test_vault.py
+++ b/test/unit/security/test_vault.py
@@ -16,28 +16,38 @@ from galaxy.security.vault import (
 )
 
 
-class VaultTestBase:
-    vault: Vault
+class AbstractTestCases:
+    """Test classes that should not be collected.
 
-    def test_read_write_secret(self):
-        self.vault.write_secret("my/test/secret", "hello world")
-        assert self.vault.read_secret("my/test/secret") == "hello world"  # type: ignore
+    Classes derived from unittest.TestCase are collected only if they are at the
+    module level: https://stackoverflow.com/a/25695512/4503125
 
-    def test_overwrite_secret(self):
-        self.vault.write_secret("my/new/secret", "hello world")
-        self.vault.write_secret("my/new/secret", "hello overwritten")
-        assert self.vault.read_secret("my/new/secret") == "hello overwritten"  # type: ignore
+    This workaround is needed because unittest/pytest try to collect test
+    classes even if they are abstract, and therefore their tests fails.
+    """
 
-    def test_valid_paths(self):
-        with self.assertRaises(InvalidVaultKeyException):  # type: ignore
-            self.vault.write_secret("", "hello world")
-        with self.assertRaises(InvalidVaultKeyException):  # type: ignore
-            self.vault.write_secret("my//new/secret", "hello world")
-        with self.assertRaises(InvalidVaultKeyException):  # type: ignore
-            self.vault.write_secret("my/ /new/secret", "hello world")
-        # leading and trailing slashes should be ignored
-        self.vault.write_secret("/my/new/secret with space/", "hello overwritten")
-        assert self.vault.read_secret("my/new/secret with space") == "hello overwritten"  # type: ignore
+    class VaultTestBase(unittest.TestCase):
+        vault: Vault
+
+        def test_read_write_secret(self):
+            self.vault.write_secret("my/test/secret", "hello world")
+            assert self.vault.read_secret("my/test/secret") == "hello world"  # type: ignore
+
+        def test_overwrite_secret(self):
+            self.vault.write_secret("my/new/secret", "hello world")
+            self.vault.write_secret("my/new/secret", "hello overwritten")
+            assert self.vault.read_secret("my/new/secret") == "hello overwritten"  # type: ignore
+
+        def test_valid_paths(self):
+            with self.assertRaises(InvalidVaultKeyException):  # type: ignore
+                self.vault.write_secret("", "hello world")
+            with self.assertRaises(InvalidVaultKeyException):  # type: ignore
+                self.vault.write_secret("my//new/secret", "hello world")
+            with self.assertRaises(InvalidVaultKeyException):  # type: ignore
+                self.vault.write_secret("my/ /new/secret", "hello world")
+            # leading and trailing slashes should be ignored
+            self.vault.write_secret("/my/new/secret with space/", "hello overwritten")
+            assert self.vault.read_secret("my/new/secret with space") == "hello overwritten"  # type: ignore
 
 
 VAULT_CONF_HASHICORP = os.path.join(os.path.dirname(__file__), "fixtures/vault_conf_hashicorp.yml")
@@ -47,7 +57,7 @@ VAULT_CONF_HASHICORP = os.path.join(os.path.dirname(__file__), "fixtures/vault_c
     not os.environ.get("VAULT_ADDRESS") or not os.environ.get("VAULT_TOKEN"),
     "VAULT_ADDRESS and VAULT_TOKEN env vars not set",
 )
-class TestHashicorpVault(VaultTestBase, unittest.TestCase):
+class TestHashicorpVault(AbstractTestCases.VaultTestBase):
     def setUp(self) -> None:
         with tempfile.NamedTemporaryFile(mode="w", prefix="vault_hashicorp", delete=False) as tempconf, open(
             VAULT_CONF_HASHICORP
@@ -70,7 +80,7 @@ VAULT_CONF_DATABASE_ROTATED = os.path.join(os.path.dirname(__file__), "fixtures/
 VAULT_CONF_DATABASE_INVALID = os.path.join(os.path.dirname(__file__), "fixtures/vault_conf_database_invalid_keys.yml")
 
 
-class TestDatabaseVault(VaultTestBase, unittest.TestCase):
+class TestDatabaseVault(AbstractTestCases.VaultTestBase):
     def setUp(self) -> None:
         config = GalaxyDataTestConfig(vault_config_file=VAULT_CONF_DATABASE)
         app = GalaxyDataTestApp(config=config)
@@ -107,7 +117,7 @@ VAULT_CONF_CUSTOS = os.path.join(os.path.dirname(__file__), "fixtures/vault_conf
     not os.environ.get("CUSTOS_CLIENT_ID") or not os.environ.get("CUSTOS_CLIENT_SECRET"),
     "CUSTOS_CLIENT_ID and CUSTOS_CLIENT_SECRET env vars not set",
 )
-class TestCustosVault(VaultTestBase, unittest.TestCase):
+class TestCustosVault(AbstractTestCases.VaultTestBase):
     def setUp(self) -> None:
         with tempfile.NamedTemporaryFile(mode="w", prefix="vault_custos", delete=False) as tempconf, open(
             VAULT_CONF_CUSTOS

--- a/test/unit/shed_unit/test_installed_repository_manager.py
+++ b/test/unit/shed_unit/test_installed_repository_manager.py
@@ -31,7 +31,7 @@ class ToolShedRepoBaseTestCase(BaseToolBoxTestCase):
         return self._repo_install(changeset="1", config_filename=self.config_files[0])
 
 
-class InstallRepositoryManagerTestCase(ToolShedRepoBaseTestCase):
+class TestInstallRepositoryManager(ToolShedRepoBaseTestCase):
     def setUp(self):
         super().setUp()
         self.irm = InstallRepositoryManager(self.app)
@@ -89,7 +89,7 @@ class InstallRepositoryManagerTestCase(ToolShedRepoBaseTestCase):
         assert repository.changeset_revision == changeset_revision
 
 
-class InstalledRepositoryManagerTestCase(ToolShedRepoBaseTestCase):
+class TestInstalledRepositoryManager(ToolShedRepoBaseTestCase):
     def setUp(self):
         super().setUp()
         self.irm = InstalledRepositoryManager(self.app)

--- a/test/unit/shed_unit/test_installed_repository_manager.py
+++ b/test/unit/shed_unit/test_installed_repository_manager.py
@@ -124,8 +124,7 @@ class InstalledRepositoryManagerTestCase(ToolShedRepoBaseTestCase):
             description=repository.description,
             installed_changeset_revision=repository.installed_changeset_revision,
             ctx_rev=repository.changeset_revision,
-            repository_clone_url="https://github.com/galaxyproject/example/test_tool/0.%s"
-            % repository.installed_changeset_revision,  # not needed if owner is given
+            repository_clone_url=f"https://github.com/galaxyproject/example/test_tool/0.{repository.installed_changeset_revision}",  # not needed if owner is given
             status=repository.status,
             metadata_dict=None,
             current_changeset_revision=str(int(repository.changeset_revision) + 1),

--- a/test/unit/shed_unit/test_tool_panel_manager.py
+++ b/test/unit/shed_unit/test_tool_panel_manager.py
@@ -74,10 +74,10 @@ class ToolPanelManagerTestCase(BaseToolBoxTestCase):
         previous_guid = None
         for v in "1", "2", "3":
             self.__toolbox = self.get_new_toolbox()
-            changeset = "0123456789abcde%s" % v
-            guid = DEFAULT_GUID + ("v/%s" % v)
-            tool = self._init_ts_tool(guid=guid, filename="tool_v%s.xml" % v, version=v)
-            tool_path = self._tool_path(name="tool_v%s.xml" % v)
+            changeset = f"0123456789abcde{v}"
+            guid = DEFAULT_GUID + (f"v/{v}")
+            tool = self._init_ts_tool(guid=guid, filename=f"tool_v{v}.xml", version=v)
+            tool_path = self._tool_path(name=f"tool_v{v}.xml")
             new_tools = [{"guid": guid, "tool_config": tool_path}]
             self._repo_install(changeset)
             repository_tools_tups = [
@@ -107,8 +107,8 @@ class ToolPanelManagerTestCase(BaseToolBoxTestCase):
             # New GUID replaced old one in tool panel but both
             # appear in integrated tool panel.
             if previous_guid:
-                assert ("tool_%s" % previous_guid) not in section.panel_items()
-            assert ("tool_%s" % guid) in self.toolbox._integrated_tool_panel["tid1"].panel_items()
+                assert (f"tool_{previous_guid}") not in section.panel_items()
+            assert (f"tool_{guid}") in self.toolbox._integrated_tool_panel["tid1"].panel_items()
             previous_guid = guid
 
     def test_uninstall_in_section(self):
@@ -185,8 +185,9 @@ class ToolPanelManagerTestCase(BaseToolBoxTestCase):
         try:
             parse_xml(filename)
         except Exception:
-            message_template = "file %s does not contain valid XML, content %s"
-            message = message_template % (filename, open(filename).read())
+            with open(filename) as fh:
+                content = fh.read()
+            message = f"file {filename} does not contain valid XML, content {content}"
             raise AssertionError(message)
 
     def _init_ts_tool(self, guid=DEFAULT_GUID, **kwds):

--- a/test/unit/shed_unit/test_tool_panel_manager.py
+++ b/test/unit/shed_unit/test_tool_panel_manager.py
@@ -11,7 +11,7 @@ from ..app.tools.test_toolbox import (
 DEFAULT_GUID = "123456"
 
 
-class ToolPanelManagerTestCase(BaseToolBoxTestCase):
+class TestToolPanelManager(BaseToolBoxTestCase):
     def get_new_toolbox(self):
         return SimplifiedToolBox(self)
 

--- a/test/unit/tool_util/test_output_checker.py
+++ b/test/unit/tool_util/test_output_checker.py
@@ -1,4 +1,3 @@
-from unittest import TestCase
 from unittest.mock import Mock
 
 from galaxy.tool_util.output_checker import (
@@ -9,9 +8,10 @@ from galaxy.tool_util.parser.stdio import (
     StdioErrorLevel,
     ToolStdioRegex,
 )
+from galaxy.util.unittest import TestCase
 
 
-class OutputCheckerTestCase(TestCase):
+class TestOutputChecker(TestCase):
     def setUp(self):
         self.tool = Mock(
             stdio_regexes=[],

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -2,12 +2,12 @@ import os
 import os.path
 import shutil
 import tempfile
-import unittest
 from math import isinf
 from typing import Optional
 
 from galaxy.tool_util.parser.factory import get_tool_source
 from galaxy.util import galaxy_directory
+from galaxy.util.unittest import TestCase
 
 TOOL_XML_1 = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
@@ -216,7 +216,7 @@ def get_test_tool_source(source_file_name=None, source_contents=None, macro_cont
     return tool_source
 
 
-class BaseLoaderTestCase(unittest.TestCase):
+class BaseLoaderTestCase(TestCase):
     source_file_name: Optional[str] = None
     source_contents: Optional[str] = None
 
@@ -243,7 +243,7 @@ class BaseLoaderTestCase(unittest.TestCase):
         )
 
 
-class XmlExpressionLoaderTestCase(BaseLoaderTestCase):
+class TestXmlExpressionLoader(BaseLoaderTestCase):
     source_file_name = "expression.xml"
     source_contents = TOOL_EXPRESSION_XML_1
 
@@ -254,12 +254,7 @@ class XmlExpressionLoaderTestCase(BaseLoaderTestCase):
         assert self._tool_source.parse_tool_type() == "expression"
 
 
-class YamlExpressionLoaderTestCase(BaseLoaderTestCase):
-    source_file_name = "expression.yml"
-    source_contents = TOOL_EXPRESSION_XML_1
-
-
-class XmlLoaderTestCase(BaseLoaderTestCase):
+class TestXmlLoader(BaseLoaderTestCase):
     source_file_name = "bwa.xml"
     source_contents = TOOL_XML_1
 
@@ -430,7 +425,7 @@ class XmlLoaderTestCase(BaseLoaderTestCase):
         assert creator2["name"] == "Galaxy IUC"
 
 
-class YamlLoaderTestCase(BaseLoaderTestCase):
+class TestYamlLoader(BaseLoaderTestCase):
     source_file_name = "bwa.yml"
     source_contents = TOOL_YAML_1
 
@@ -560,7 +555,7 @@ class YamlLoaderTestCase(BaseLoaderTestCase):
         assert self._tool_source.parse_sanitize() is True
 
 
-class DataSourceLoaderTestCase(BaseLoaderTestCase):
+class TestDataSourceLoader(BaseLoaderTestCase):
     source_file_name = "ds.xml"
     source_contents = """<?xml version="1.0"?>
 <tool name="YeastMine" id="yeastmine" tool_type="data_source">
@@ -609,7 +604,7 @@ class DataSourceLoaderTestCase(BaseLoaderTestCase):
         assert not self._tool_source.parse_hidden()
 
 
-class ApplyRulesToolLoaderTestCase(BaseLoaderTestCase):
+class TestApplyRulesToolLoader(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "lib/galaxy/tools/apply_rules.xml")
     source_contents = None
 
@@ -625,7 +620,7 @@ class ApplyRulesToolLoaderTestCase(BaseLoaderTestCase):
         assert len(output_collections) == 1
 
 
-class BuildListToolLoaderTestCase(BaseLoaderTestCase):
+class TestBuildListToolLoader(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "lib/galaxy/tools/build_list.xml")
     source_contents = None
 
@@ -635,7 +630,7 @@ class BuildListToolLoaderTestCase(BaseLoaderTestCase):
         assert tool_module[1] == "BuildListCollectionTool"
 
 
-class ExpressionTestToolLoaderTestCase(BaseLoaderTestCase):
+class TestExpressionTestToolLoader(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/expression_null_handling_boolean.xml")
     source_contents = None
 
@@ -664,7 +659,7 @@ class ExpressionTestToolLoaderTestCase(BaseLoaderTestCase):
         assert output0["attributes"]["object"] is None
 
 
-class ExpressionOutputDataToolLoaderTestCase(BaseLoaderTestCase):
+class TestExpressionOutputDataToolLoader(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/expression_pick_larger_file.xml")
     source_contents = None
 
@@ -676,7 +671,7 @@ class ExpressionOutputDataToolLoaderTestCase(BaseLoaderTestCase):
         assert tool_output.from_expression == "output"
 
 
-class SpecialToolLoaderTestCase(BaseLoaderTestCase):
+class TestSpecialToolLoader(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "lib/galaxy/tools/imp_exp/exp_history_to_archive.xml")
     source_contents = None
 
@@ -698,7 +693,7 @@ class SpecialToolLoaderTestCase(BaseLoaderTestCase):
         assert action[1] == "ExportHistoryToolAction"
 
 
-class CollectionTestCase(BaseLoaderTestCase):
+class TestCollection(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/collection_two_paired.xml")
     source_contents = None
 
@@ -712,7 +707,7 @@ class CollectionTestCase(BaseLoaderTestCase):
         assert len(output_collections) == 0
 
 
-class CollectionOutputXmlTestCase(BaseLoaderTestCase):
+class TestCollectionOutputXml(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/collection_creates_pair.xml")
     source_contents = None
 
@@ -721,7 +716,7 @@ class CollectionOutputXmlTestCase(BaseLoaderTestCase):
         assert len(output_collections) == 1
 
 
-class CollectionOutputYamlTestCase(BaseLoaderTestCase):
+class TestCollectionOutputYaml(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/collection_creates_pair_y.yml")
     source_contents = None
 
@@ -730,7 +725,7 @@ class CollectionOutputYamlTestCase(BaseLoaderTestCase):
         assert len(output_collections) == 1
 
 
-class EnvironmentVariablesTestCase(BaseLoaderTestCase):
+class TestEnvironmentVariables(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/environment_variables.xml")
     source_contents = None
 
@@ -740,7 +735,7 @@ class EnvironmentVariablesTestCase(BaseLoaderTestCase):
         assert len(tests) == 1
 
 
-class ExpectationsTestCase(BaseLoaderTestCase):
+class TestExpectations(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/detect_errors.xml")
     source_contents = None
 
@@ -753,7 +748,7 @@ class ExpectationsTestCase(BaseLoaderTestCase):
         assert len(test_0["stdout"]) == 2
 
 
-class ExpectationsCommandVersionTestCase(BaseLoaderTestCase):
+class TestExpectationsCommandVersion(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/job_properties.xml")
     source_contents = None
 
@@ -765,7 +760,7 @@ class ExpectationsCommandVersionTestCase(BaseLoaderTestCase):
         assert len(test_0["command_version"]) == 1
 
 
-class QcStdioTestCase(BaseLoaderTestCase):
+class TestQcStdio(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/qc_stdout.xml")
     source_contents = None
 

--- a/test/unit/tool_util/test_required_files.py
+++ b/test/unit/tool_util/test_required_files.py
@@ -99,7 +99,7 @@ class BaseRequiredFilesTestCase(BaseLoaderTestCase):
 
 
 # directly include just one file that is there
-class RequiredFiles1TestCase(BaseRequiredFilesTestCase):
+class TestRequiredFiles1(BaseRequiredFilesTestCase):
     source_contents = TOOL_REQUIRED_FILES_XML_1
 
     def test_expected_files(self):
@@ -109,7 +109,7 @@ class RequiredFiles1TestCase(BaseRequiredFilesTestCase):
 
 
 # include a glob and exclude a file in the glob
-class RequiredFiles2TestCase(BaseRequiredFilesTestCase):
+class TestRequiredFiles2(BaseRequiredFilesTestCase):
     source_contents = TOOL_REQUIRED_FILES_XML_2
 
     def test_expected_files(self):
@@ -119,7 +119,7 @@ class RequiredFiles2TestCase(BaseRequiredFilesTestCase):
 
 
 # include a glob with multiple matches
-class RequiredFiles3TestCase(BaseRequiredFilesTestCase):
+class TestRequiredFiles3(BaseRequiredFilesTestCase):
     source_contents = TOOL_REQUIRED_FILES_XML_3
 
     def test_expected_files(self):
@@ -130,7 +130,7 @@ class RequiredFiles3TestCase(BaseRequiredFilesTestCase):
 
 
 # include a file with regex and exclude with glob
-class RequiredFiles4TestCase(BaseRequiredFilesTestCase):
+class TestRequiredFiles4(BaseRequiredFilesTestCase):
     source_contents = TOOL_REQUIRED_FILES_XML_4
 
     def test_expected_files(self):
@@ -139,7 +139,7 @@ class RequiredFiles4TestCase(BaseRequiredFilesTestCase):
         assert "my_script.R" in files
 
 
-class HgExcludedByDefaultTestCase(BaseRequiredFilesTestCase):
+class TestHgExcludedByDefault(BaseRequiredFilesTestCase):
     source_contents = TOOL_REQUIRED_FILES_XML_3
 
     def test_expected_files(self):
@@ -149,7 +149,7 @@ class HgExcludedByDefaultTestCase(BaseRequiredFilesTestCase):
         assert "my_script.R" in files
 
 
-class HgExclusionDisabledTestCase(BaseRequiredFilesTestCase):
+class TestHgExclusionDisabled(BaseRequiredFilesTestCase):
     source_contents = TOOL_REQUIRED_FILES_XML_DISABLED_DEFAULT_EXCLUSIONS
 
     def test_expected_files(self):

--- a/test/unit/util/test_compression_util.py
+++ b/test/unit/util/test_compression_util.py
@@ -1,14 +1,14 @@
 import shutil
 import tempfile
-import unittest
 
 from galaxy.util.compression_utils import (
     CompressedFile,
     get_fileobj_raw,
 )
+from galaxy.util.unittest import TestCase
 
 
-class CompressionUtilTestCase(unittest.TestCase):
+class TestCompressionUtil(TestCase):
     def test_compression_safety(self):
         self.assert_safety("test-data/unsafe.tar", False)
         self.assert_safety("test-data/unsafe_relative_symlink.tar", False)

--- a/test/unit/util/test_unittest.py
+++ b/test/unit/util/test_unittest.py
@@ -1,0 +1,26 @@
+from galaxy.util.unittest import TestCase
+
+
+class TestTestCase(TestCase):
+    j: str
+
+    @classmethod
+    def setUpClass(cls):
+        cls.j = "foo"
+
+    def setUp(self):
+        self.i = 1
+
+    def test_setUpClass(self):
+        assert self.j == "foo"
+
+    def test_setUp(self):
+        assert self.i == 1
+
+    def test_assertRaises(self):
+        with self.assertRaises(ZeroDivisionError):
+            1 / 0
+
+    def test_assertRaisesRegex(self):
+        with self.assertRaisesRegex(ZeroDivisionError, "^division .* zero"):
+            1 / 0

--- a/test/unit/webapps/test_login.py
+++ b/test/unit/webapps/test_login.py
@@ -3,12 +3,12 @@ from datetime import (
     datetime,
     timedelta,
 )
-from unittest import TestCase
 
 from galaxy import model
 from galaxy.app_unittest_utils import galaxy_mock
 from galaxy.managers.users import UserManager
 from galaxy.security.passwords import check_password
+from galaxy.util.unittest import TestCase
 from galaxy.webapps.galaxy.controllers.user import User
 
 admin_email = "admin@admin.admin"
@@ -18,7 +18,7 @@ changed_password = "654321"
 user2_data = dict(email="user2@user2.user2", username="user2", password=default_password)
 
 
-class LoginControllerTestCase(TestCase):
+class TestLoginController(TestCase):
     def setUp(self):
         admin_users_list = [u for u in admin_users.split(",") if u]
         self.trans = galaxy_mock.MockTrans(admin_users=admin_users, admin_users_list=admin_users_list)

--- a/test/unit/webapps/test_webapp_base.py
+++ b/test/unit/webapps/test_webapp_base.py
@@ -3,7 +3,6 @@ Unit tests for ``galaxy.web.framework.webapp``
 """
 import logging
 import re
-import unittest
 
 import galaxy.config
 from galaxy.app_unittest_utils import galaxy_mock
@@ -28,7 +27,7 @@ class CORSParsingMockConfig(galaxy_mock.MockAppConfig):
         return galaxy.config.Configuration._parse_allowed_origin_hostnames(hostnames)
 
 
-class GalaxyWebTransaction_Headers_TestCase(unittest.TestCase):
+class TestGalaxyWebTransactionHeaders:
     def _new_trans(self, allowed_origin_hostnames=None):
         app = galaxy_mock.MockApp()
         app.config = CORSParsingMockConfig(allowed_origin_hostnames=allowed_origin_hostnames)

--- a/test/unit/workflows/test_extract_summary.py
+++ b/test/unit/workflows/test_extract_summary.py
@@ -1,12 +1,11 @@
-import unittest
-
 from galaxy import model
+from galaxy.util.unittest import TestCase
 from galaxy.workflow import extract
 
 UNDEFINED_JOB = object()
 
 
-class TestWorkflowExtractSummary(unittest.TestCase):
+class TestWorkflowExtractSummary(TestCase):
     def setUp(self):
         self.history = MockHistory()
         self.trans = MockTrans(self.history)

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -1,6 +1,5 @@
-import unittest
-
 from galaxy import model
+from galaxy.util.unittest import TestCase
 from galaxy.workflow.run import WorkflowProgress
 from .workflow_support import (
     MockApp,
@@ -64,7 +63,7 @@ steps:
 UNSCHEDULED_STEP = object()
 
 
-class WorkflowProgressTestCase(unittest.TestCase):
+class TestWorkflowProgress(TestCase):
     def setUp(self):
         self.app = MockApp()
         self.inputs_by_step_id = {}


### PR DESCRIPTION
in unit, integration and integration Selenium tests.

Also:
- Rename `FooBarTestCase` test classes as `TestFooBar`. These were collected by pytest only because they were `unittest.TestCase` derived, but normally pytest collects only test classes whose name starts with `Test`, see  https://docs.pytest.org/en/7.1.x/reference/reference.html#confval-python_classes
- Misc test fixes
- Document how to profile memory use in tests

The reason for this is to enable the use of pytest plugins (e.g. [pytest-memray](https://pytest-memray.readthedocs.io/)) that use [features that don't work in `unittest.TestCase` subclasses](https://docs.pytest.org/en/7.1.x/how-to/unittest.html#pytest-features-in-unittest-testcase-subclasses).

N.B.: regarding the renaming of `FooBarTestCase` test classes, I'm only renaming those the actually contain `test_` methods, which, I think, makes it easier to distinguish between "real" and "abstract" test classes, but I can change them all if there's a preference.
Additionally/Alternatively, we could set `python_classes = Test* *TestCase` in `pytest.ini` if we don't want to risk missing by mistake the collection of some test classes by pytest.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
