### PR TITLE
Tool Shed and Tool Utility Cleanup

### DIFF
--- a/lib/galaxy/tool_shed/util/basic_util.py
+++ b/lib/galaxy/tool_shed/util/basic_util.py
@@ -1,8 +1,6 @@
 import logging
 import os
 import shutil
-import sys
-from string import Template
 
 import markupsafe
 
@@ -47,35 +45,6 @@ CMD ["/usr/bin/startup"]
 SELECTED_REPOSITORIES_TEMPLATE = """
 RUN install-repository "--url ${tool_shed_url} -o ${repository_owner} --name ${repository_name}"
 """
-
-
-def evaluate_template(text, install_environment):
-    """
-    Substitute variables defined in XML blocks from dependencies file.  The value of the received
-    repository_install_dir is the root installation directory of the repository that contains the
-    tool dependency.  The value of the received install_dir is the root installation directory of
-    the tool_dependency.
-    """
-    return Template(text).safe_substitute(get_env_var_values(install_environment))
-
-
-def get_env_var_values(install_environment):
-    """
-    Return a dictionary of values, some of which enable substitution of reserved words for the values.
-    The received install_enviroment object has 3 important attributes for reserved word substitution:
-    install_environment.tool_shed_repository_install_dir is the root installation directory of the repository
-    that contains the tool dependency being installed, install_environment.install_dir is the root
-    installation directory of the tool dependency, and install_environment.tmp_work_dir is the
-    temporary directory where the tool dependency compilation/installation is being processed.
-    """
-    env_var_dict = {}
-    env_var_dict["REPOSITORY_INSTALL_DIR"] = install_environment.tool_shed_repository_install_dir
-    env_var_dict["INSTALL_DIR"] = install_environment.install_dir
-    env_var_dict["TMP_WORK_DIR"] = install_environment.tmp_work_dir
-    env_var_dict["system_install"] = install_environment.install_dir
-    # If the Python interpreter is 64bit then we can safely assume that the underlying system is also 64bit.
-    env_var_dict["__is64bit__"] = sys.maxsize > 2**32
-    return env_var_dict
 
 
 def get_file_type_str(changeset_revision, file_type):
@@ -157,8 +126,6 @@ def to_html_string(text):
 __all__ = (
     "CHUNK_SIZE",
     "DOCKER_IMAGE_TEMPLATE",
-    "evaluate_template",
-    "get_env_var_values",
     "get_file_type_str",
     "INSTALLATION_LOG",
     "MAX_DISPLAY_SIZE",

--- a/lib/galaxy/tool_shed/util/repository_util.py
+++ b/lib/galaxy/tool_shed/util/repository_util.py
@@ -560,14 +560,6 @@ def get_repository_ids_requiring_prior_import_or_install(app, tsr_ids, repositor
     return prior_tsr_ids
 
 
-def get_repository_in_tool_shed(app, id, eagerload_columns=None):
-    """Get a repository on the tool shed side from the database via id."""
-    q = get_repository_query(app)
-    if eagerload_columns:
-        q = q.options(joinedload(*eagerload_columns))
-    return q.get(app.security.decode_id(id))
-
-
 def get_repository_owner(cleaned_repository_url):
     """Gvien a "cleaned" repository clone URL, return the owner of the repository."""
     items = cleaned_repository_url.split("/repos/")
@@ -757,7 +749,6 @@ __all__ = (
     "get_repository_dependency_types",
     "get_repository_for_dependency_relationship",
     "get_repository_ids_requiring_prior_import_or_install",
-    "get_repository_in_tool_shed",
     "get_repository_owner",
     "get_repository_owner_from_clone_url",
     "get_repository_query",

--- a/lib/galaxy/tool_util/toolbox/parser.py
+++ b/lib/galaxy/tool_util/toolbox/parser.py
@@ -14,6 +14,7 @@ from galaxy.util import (
     parse_xml,
     string_as_bool,
 )
+from galaxy.util.path import StrPath
 
 DEFAULT_MONITOR = False
 
@@ -39,7 +40,7 @@ class ToolConfSource(metaclass=ABCMeta):
 
 
 class XmlToolConfSource(ToolConfSource):
-    def __init__(self, config_filename):
+    def __init__(self, config_filename: StrPath):
         tree = parse_xml(config_filename)
         self.root = tree.getroot()
 
@@ -62,7 +63,7 @@ class XmlToolConfSource(ToolConfSource):
 
 
 class YamlToolConfSource(ToolConfSource):
-    def __init__(self, config_filename):
+    def __init__(self, config_filename: StrPath):
         with open(config_filename) as f:
             as_dict = yaml.safe_load(f)
         self.as_dict = as_dict
@@ -157,8 +158,8 @@ def ensure_tool_conf_item(xml_or_item):
             return ToolConfSection(attributes, items, elem=elem)
 
 
-def get_toolbox_parser(config_filename):
-    is_yaml = any(config_filename.endswith(e) for e in [".yml", ".yaml", ".json"])
+def get_toolbox_parser(config_filename: StrPath):
+    is_yaml = any(str(config_filename).endswith(e) for e in [".yml", ".yaml", ".json"])
     if is_yaml:
         return YamlToolConfSource(config_filename)
     else:

--- a/lib/tool_shed/util/basic_util.py
+++ b/lib/tool_shed/util/basic_util.py
@@ -1,8 +1,6 @@
 from galaxy.tool_shed.util.basic_util import (
     CHUNK_SIZE,
     DOCKER_IMAGE_TEMPLATE,
-    evaluate_template,
-    get_env_var_values,
     get_file_type_str,
     INSTALLATION_LOG,
     MAX_DISPLAY_SIZE,
@@ -20,8 +18,6 @@ from galaxy.tool_shed.util.basic_util import (
 __all__ = (
     "CHUNK_SIZE",
     "DOCKER_IMAGE_TEMPLATE",
-    "evaluate_template",
-    "get_env_var_values",
     "get_file_type_str",
     "INSTALLATION_LOG",
     "MAX_DISPLAY_SIZE",

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -5,6 +5,7 @@ import re
 
 from markupsafe import escape
 from sqlalchemy import false
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 
 import tool_shed.dependencies.repository
@@ -32,7 +33,6 @@ from galaxy.tool_shed.util.repository_util import (
     get_repository_dependency_types,
     get_repository_for_dependency_relationship,
     get_repository_ids_requiring_prior_import_or_install,
-    get_repository_in_tool_shed,
     get_repository_owner,
     get_repository_owner_from_clone_url,
     get_repository_query,
@@ -230,6 +230,14 @@ def generate_sharable_link_for_repository_in_tool_shed(repository, changeset_rev
     if changeset_revision:
         sharable_url += f"/{changeset_revision}"
     return sharable_url
+
+
+def get_repository_in_tool_shed(app, id, eagerload_columns=None):
+    """Get a repository on the tool shed side from the database via id."""
+    q = get_repository_query(app)
+    if eagerload_columns:
+        q = q.options(joinedload(*eagerload_columns))
+    return q.get(app.security.decode_id(id))
 
 
 def get_repo_info_dict(app, user, repository_id, changeset_revision):


### PR DESCRIPTION
- Move code used only in the tool shed into tool shed package.
- Remove unused code (helpers that were used by tool dependency installs)
- Some typing for tool box parser.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
