### PR TITLE
[22.05] Fix old style workflow parameter regression in Number entry

### DIFF
--- a/client/src/components/Form/Elements/FormNumber.vue
+++ b/client/src/components/Form/Elements/FormNumber.vue
@@ -10,7 +10,7 @@
                     v-model="currentValue"
                     :step="step"
                     size="sm"
-                    type="number"
+                    :type="fieldType"
                     @change="onInputChange"
                     @keydown.190.capture="onFloatInput"
                     @keydown.110.capture="onFloatInput" />
@@ -43,6 +43,10 @@ export default {
             required: false,
             default: undefined,
         },
+        workflowBuildingMode: {
+            type: Boolean,
+            default: false,
+        },
     },
     data() {
         return {
@@ -64,6 +68,9 @@ export default {
                     this.$emit("input", newVal);
                 }
             },
+        },
+        fieldType() {
+            return this.workflowBuildingMode ? "text" : "number";
         },
         isRangeValid() {
             return !isNaN(this.min) && !isNaN(this.max) && this.max > this.min;

--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -10,7 +10,8 @@
         :collapsed-disable-text="collapsedDisableText"
         :collapsed-disable-icon="collapsedDisableIcon"
         :on-change="onChange"
-        :on-change-form="onChangeForm" />
+        :on-change-form="onChangeForm"
+        :workflow-building-mode="workflowBuildingMode" />
 </template>
 
 <script>
@@ -69,6 +70,10 @@ export default {
         replaceParams: {
             type: Object,
             default: null,
+        },
+        workflowBuildingMode: {
+            type: Boolean,
+            default: false,
         },
     },
     data() {

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -29,7 +29,8 @@
                 v-model="currentValue"
                 :max="attrs.max"
                 :min="attrs.min"
-                :type="type" />
+                :type="type"
+                :workflow-building-mode="workflowBuildingMode" />
             <FormColor v-else-if="type == 'color'" :id="id" v-model="currentValue" />
             <FormDirectory v-else-if="type == 'directory_uri'" v-model="currentValue" />
             <FormParameter
@@ -138,6 +139,10 @@ export default {
         connectedDisableIcon: {
             type: String,
             default: "fa fa-arrows-h",
+        },
+        workflowBuildingMode: {
+            type: Boolean,
+            default: false,
         },
     },
     data() {

--- a/client/src/components/Form/FormInputs.vue
+++ b/client/src/components/Form/FormInputs.vue
@@ -138,6 +138,10 @@ export default {
             type: Function,
             required: true,
         },
+        workflowBuildingMode: {
+            type: Boolean,
+            default: false,
+        },
     },
     methods: {
         getPrefix(name, index) {

--- a/client/src/components/Form/FormInputs.vue
+++ b/client/src/components/Form/FormInputs.vue
@@ -75,6 +75,7 @@
                 :collapsed-enable-icon="collapsedEnableIcon"
                 :collapsed-disable-text="collapsedDisableText"
                 :collapsed-disable-icon="collapsedDisableIcon"
+                :workflow-building-mode="workflowBuildingMode"
                 @change="onChange" />
         </div>
     </div>

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -33,7 +33,7 @@
                     :errors="errors"
                     text-enable="Set in Advance"
                     text-disable="Set at Runtime"
-                    workflow-building-mode="true"
+                    :workflow-building-mode="true"
                     @onChange="onChange" />
                 <FormSection
                     :id="nodeId"

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -33,6 +33,7 @@
                     :errors="errors"
                     text-enable="Set in Advance"
                     text-disable="Set at Runtime"
+                    workflow-building-mode="true"
                     @onChange="onChange" />
                 <FormSection
                     :id="nodeId"


### PR DESCRIPTION
The backend validates and handles all this correctly but using a type 'number' for the field here is overzealous input sanitization and prevents entry of workflow params in the editor.   This change passes through `workflowBuildingMode` to parameters to allow for differing behavior.  The old ui-slider.js explicitly allowed for entry of this prior to replacement in https://github.com/galaxyproject/galaxy/pull/12937/files#diff-1af6da7af367d1c2f7c4e296406359c4e1c81ad137744a7065a93c748806c159L113.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
