### PR TITLE
[22.01] Linter: allow ``metadata_name`` for ``dataset_metadata_in_range`` validator

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -26,7 +26,7 @@ ATTRIB_VALIDATOR_COMPATIBILITY = {
     "expression": ["substitute_value_in_message"],
     "table_name": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table"],
     "filename": ["dataset_metadata_in_file"],
-    "metadata_name": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "dataset_metadata_in_file"],
+    "metadata_name": ["dataset_metadata_in_range", "dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "dataset_metadata_in_file"],
     "metadata_column": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table", "dataset_metadata_in_file"],
     "line_startswith": ["dataset_metadata_in_file"],
     "min": ["in_range", "length", "dataset_metadata_in_range"],

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4364,7 +4364,7 @@ if ``type`` is ``dataset_metadata_in_file``. File should be present Galaxy's
         <xs:attribute name="metadata_name" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">Target metadata attribute name for
-``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table`` and ``dataset_metadata_in_file`` options.</xs:documentation>
+``dataset_metadata_in_range``, ``dataset_metadata_not_in_data_table`` and ``dataset_metadata_in_file`` options.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="metadata_column" type="xs:string">


### PR DESCRIPTION
forgotten here https://github.com/galaxyproject/galaxy/pull/12262 which was for 21.09, but I guess since 22.01 is now used in planemo it should be fine to target 22.01?

Just tought about deriving the list of allowed attributes by a lookup in the init functions of the validators, eg https://github.com/galaxyproject/galaxy/blob/fc491434ab8ee6863131f686c1e480b9a9ec899f/lib/galaxy/tools/parameters/validation.py#L159
We would need to import from `galaxy.tool`. Would this be fine?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
