### PR TITLE
Allow path-based interactive tools using nginx proxy

### DIFF
--- a/doc/source/admin/special_topics/interactivetools.rst
+++ b/doc/source/admin/special_topics/interactivetools.rst
@@ -123,7 +123,12 @@ section (serving port 443):
             proxy_pass http://localhost:4002/$5$is_args$args;
 	}
 
-In both cases, you will most likely also want to replace localhost with your server domain (or possibly ``127.0.0.1``).
+This example config works for default values of `interactivetools_base_path` and `interactivetools_prefix` as defined in
+`galaxy.yml`. For other values, you will need to adjust the regex and rename patterns accordingly. This solution also
+requires `interactivetools_shorten_url` to be set to `false` (not default).
+
+In both nginx config examples, you will most likely also want to replace localhost with your server domain (or possibly
+``127.0.0.1``).
 
 You will also need to enable a docker destination in the job_conf.xml file.
 An example ``job_conf.xml`` file as seen in ``config/job_conf.xml.interactivetools``:

--- a/lib/galaxy/managers/interactivetool.py
+++ b/lib/galaxy/managers/interactivetool.py
@@ -319,8 +319,7 @@ class InteractiveToolManager:
                 rval = f"/{rval}/{entry_point_prefix}/access/{entry_point_class}/{entry_point_encoded_id}/{entry_point.token}/"
         if entry_point.entry_url:
             rval = f"{rval.rstrip('/')}/{entry_point.entry_url.lstrip('/')}"
-        if rval[0] != "/":
-            rval = f"/{rval}"
+        rval = '/' + rval.lstrip('/')
         return rval
 
     def access_entry_point_target(self, trans, entry_point_id):

--- a/lib/galaxy/managers/interactivetool.py
+++ b/lib/galaxy/managers/interactivetool.py
@@ -319,7 +319,7 @@ class InteractiveToolManager:
                 rval = f"/{rval}/{entry_point_prefix}/access/{entry_point_class}/{entry_point_encoded_id}/{entry_point.token}/"
         if entry_point.entry_url:
             rval = f"{rval.rstrip('/')}/{entry_point.entry_url.lstrip('/')}"
-        rval = '/' + rval.lstrip('/')
+        rval = "/" + rval.lstrip("/")
         return rval
 
     def access_entry_point_target(self, trans, entry_point_id):


### PR DESCRIPTION
Fixed issue causing the path of the path-based interactive tool entry point IRI to begin with two slashes (when `interactivetools_base_path` has the default value `/`). Additionally added documentation for how to set up path-based interactive tools using a nginx proxy (while we are waiting for a fix for stand-alone galaxy deployments, see: https://github.com/galaxyproject/galaxy/issues/14690)  

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ x ] Instructions for manual testing are as follows:
  1. Set up a plain, stand-alone Galaxy with the configuration described in `galaxy.yml.interactivetools` and `job_conf.xml.interactivetools`.
  2. Run an interactive tool with `requires_domain=False` (which is a bit cumbersome, as I don't think any of the bundled ones support that).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
