### PR TITLE
Configurable get IP method for container monitor

### DIFF
--- a/lib/galaxy/job_execution/container_monitor.py
+++ b/lib/galaxy/job_execution/container_monitor.py
@@ -15,7 +15,6 @@ from galaxy.tool_util.deps import docker_util
 from galaxy.util import DEFAULT_SOCKET_TIMEOUT
 from galaxy.util.sockets import get_ip
 
-
 GetIpCallable = Callable[[], str]
 
 

--- a/lib/galaxy/job_execution/container_monitor.py
+++ b/lib/galaxy/job_execution/container_monitor.py
@@ -7,12 +7,16 @@ import tempfile
 import time
 import traceback
 from functools import partial
+from typing import Callable
 
 import requests
 
 from galaxy.tool_util.deps import docker_util
 from galaxy.util import DEFAULT_SOCKET_TIMEOUT
 from galaxy.util.sockets import get_ip
+
+
+GetIpCallable = Callable[[], str]
 
 
 def parse_ports(container_name, connection_configuration):
@@ -28,7 +32,7 @@ def parse_ports(container_name, connection_configuration):
                 return ports_raw
 
 
-def get_ip_command(cmd):
+def get_ip_command(cmd) -> str:
     return subprocess.check_output(shlex.split(cmd), text=True).strip()
 
 
@@ -48,6 +52,7 @@ def main():
     if container_type != "docker":
         raise Exception(f"Monitoring container type [{container_type}], not yet implemented.")
 
+    _get_ip: GetIpCallable
     if get_ip_method is not None:
         method, arg = [e.strip() for e in get_ip_method.split(":", 1)]
         if method == "command":

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2286,8 +2286,7 @@ class MinimalJobWrapper(HasResourceParameters):
             container_config_dict["callback_url"] = callback_url
 
         if get_ip_method:
-            assert get_ip_method.startswith('command:'), \
-                f"Unsupported get_ip_method: {get_ip_method}"
+            assert get_ip_method.startswith("command:"), f"Unsupported get_ip_method: {get_ip_method}"
             container_config_dict["get_ip_method"] = get_ip_method
 
         with open(container_config, "w") as f:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2286,6 +2286,8 @@ class MinimalJobWrapper(HasResourceParameters):
             container_config_dict["callback_url"] = callback_url
 
         if get_ip_method:
+            assert get_ip_method.startswith('command:'), \
+                f"Unsupported get_ip_method: {get_ip_method}"
             container_config_dict["get_ip_method"] = get_ip_method
 
         with open(container_config, "w") as f:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2263,6 +2263,7 @@ class MinimalJobWrapper(HasResourceParameters):
 
         exec_dir = kwds.get("exec_dir", os.path.abspath(os.getcwd()))
         monitor_command = self.get_destination_configuration("container_monitor_command")
+        get_ip_method = self.get_destination_configuration("container_monitor_get_ip_method")
         work_dir = self.working_directory
         configs_dir = ensure_configs_directory(work_dir)
         container_config = os.path.join(configs_dir, "container_config.json")
@@ -2283,6 +2284,9 @@ class MinimalJobWrapper(HasResourceParameters):
             endpoint_base = "%s/api/jobs/%s/ports?job_key=%s"
             callback_url = endpoint_base % (galaxy_url, encoded_job_id, job_key)
             container_config_dict["callback_url"] = callback_url
+
+        if get_ip_method:
+            container_config_dict["get_ip_method"] = get_ip_method
 
         with open(container_config, "w") as f:
             json.dump(container_config_dict, f)

--- a/lib/galaxy/util/sockets.py
+++ b/lib/galaxy/util/sockets.py
@@ -5,7 +5,7 @@ import sys
 from galaxy.util import commands
 
 
-def get_ip():
+def get_ip() -> str:
     if sys.platform == "darwin":
         # If we're on OSX it is likely that the docker host is localhost.
         return socket.gethostbyname(socket.gethostname())

--- a/test/unit/app/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/app/jobs/job_conf.sample_advanced.yml
@@ -538,6 +538,11 @@ execution:
       # package if you wish to install it somewhere (e.g. on a Pulsar server)
       #container_monitor_command: python /path/to/galaxy/lib/galaxy_ext/container_monitor/monitor.py
 
+      # The method used by the container monitor script used to determine the
+      # node IP. The default if unset is galaxy.util.sockets.get_ip(). Set to
+      # 'command: <command>' to execute a command on the node and use its output
+      #container_monitor_get_ip_method: null
+
     singularity_local:
       runner: local
       # Enable Singularity execution of tools with the follow property.


### PR DESCRIPTION
Allow for admins to define an arbitrary command (e.g. `tailscale ip -4`) when getting an interactive tool's entry point IP address.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Set `container_monitor_result: callback` and `container_monitor_get_ip_method: command:/bin/echo 192.0.2.0`
  2. Run an interactive tool
  3. Confirm that the `host` column of the `interactivetool_entry_point` table is updated to `192.0.2.0`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
