### PR TITLE
Removed unnecessary page reload on the workflow list page

### DIFF
--- a/client/src/components/Workflow/WorkflowIndexActions.test.js
+++ b/client/src/components/Workflow/WorkflowIndexActions.test.js
@@ -2,33 +2,40 @@ import WorkflowIndexActions from "./WorkflowIndexActions";
 import { shallowMount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import { ROOT_COMPONENT } from "utils/navigation";
+import VueRouter from "vue-router";
 
 import "jest-location-mock";
 
 const localVue = getLocalVue(true);
+localVue.use(VueRouter);
 
-describe("WorkflowIndexActions.vue", () => {
+const router = new VueRouter();
+
+function getCurrentPath($router) {
+    return $router.history.current.path;
+}
+
+describe("WorkflowIndexActions", () => {
     let wrapper;
+    let $router;
 
     beforeEach(async () => {
-        const propsData = {
-            root: "/root/",
-        };
         wrapper = shallowMount(WorkflowIndexActions, {
-            propsData,
             localVue,
+            router,
         });
+        $router = wrapper.vm.$router;
     });
 
     describe("naviation", () => {
         it("should create a workflow when create is clicked", async () => {
             await wrapper.find(ROOT_COMPONENT.workflows.new_button.selector).trigger("click");
-            expect(window.location).toBeAt("/root/workflows/create");
+            expect(getCurrentPath($router)).toBe("/workflows/create");
         });
 
         it("should import a workflow when create is clicked", async () => {
             await wrapper.find(ROOT_COMPONENT.workflows.import_button.selector).trigger("click");
-            expect(window.location).toBeAt("/root/workflows/import");
+            expect(getCurrentPath($router)).toBe("/workflows/import");
         });
 
         it("should localize button text", async () => {

--- a/client/src/components/Workflow/WorkflowIndexActions.vue
+++ b/client/src/components/Workflow/WorkflowIndexActions.vue
@@ -24,12 +24,6 @@ export default {
         BButton,
         FontAwesomeIcon,
     },
-    props: {
-        root: {
-            type: String,
-            required: true,
-        },
-    },
     methods: {
         navigateToCreate: function () {
             this.$router.push("/workflows/create");

--- a/client/src/components/Workflow/WorkflowIndexActions.vue
+++ b/client/src/components/Workflow/WorkflowIndexActions.vue
@@ -32,10 +32,10 @@ export default {
     },
     methods: {
         navigateToCreate: function () {
-            window.location.assign(`${this.root}workflows/create`);
+            this.$router.push(`${this.root}workflows/create`);
         },
         navigateToImport: function () {
-            window.location.assign(`${this.root}workflows/import`);
+            this.$router.push(`${this.root}workflows/import`);
         },
     },
 };

--- a/client/src/components/Workflow/WorkflowIndexActions.vue
+++ b/client/src/components/Workflow/WorkflowIndexActions.vue
@@ -32,10 +32,10 @@ export default {
     },
     methods: {
         navigateToCreate: function () {
-            this.$router.push(`${this.root}workflows/create`);
+            this.$router.push("/workflows/create");
         },
         navigateToImport: function () {
-            this.$router.push(`${this.root}workflows/import`);
+            this.$router.push("/workflows/import");
         },
     },
 };


### PR DESCRIPTION
Removed the unnecessary page reload on the workflow list page using $router.push instead of window.location. This PR is related to the issue #13854.
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
