### PR TITLE
Prevent number inputs (in tool forms) from binding wheel events. 

### DIFF
--- a/client/src/components/Form/Elements/FormNumber.vue
+++ b/client/src/components/Form/Elements/FormNumber.vue
@@ -8,6 +8,7 @@
                 <!-- regular dot and dot on numpad have different codes -->
                 <b-form-input
                     v-model="currentValue"
+                    :no-wheel="true"
                     :step="step"
                     size="sm"
                     type="number"


### PR DESCRIPTION
 This is disruptive when scrolling the tool form and can unintentionally change parameters prior to submission.

Fixes #14698 

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Use scroll wheel when number input has focus, observe window scrolls and value doesn't change.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
