### PR TITLE
[22.05] Fixed typo for quota default change

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -870,7 +870,7 @@ class AdminGalaxy(controller.JSAppLauncher):
                 "inputs": [
                     {
                         "name": "default",
-                        "label": "Assign, increase by amount, or decrease by amount?",
+                        "label": "Is this quota a default for a class of users (if yes, what type)?",
                         "options": default_options,
                         "value": default_value,
                         "help": "Warning: Any users or groups associated with this quota will be disassociated.",


### PR DESCRIPTION
Hello! 👋🏼 

I fixed a typo in the admin page for changing quota defaults. This is what it looked like before:

![image](https://user-images.githubusercontent.com/48773001/192377418-054caf1a-2139-459a-85cf-a5828de1587b.png)

The "Assign, [...]" text is inaccurate, because I am setting if a quota is default (see the options), not changing the amount of a quota.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
