### PR TITLE
Enable fine-grained celery configuration

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4771,7 +4771,8 @@
     `foo` is the function name of the task defined in the
     galaxy.celery.tasks module.
     The `broker_url` option, if unset, defaults to the value of
-    `amqp_internal_connection`.
+    `amqp_internal_connection`. The `result_backend` option must be
+    set if the `enable_celery_tasks` option is set.
     For details, see Celery documentation at
     https://docs.celeryq.dev/en/stable/userguide/configuration.html.
 :Default: ``{'task_routes': {'galaxy.fetch_data': 'galaxy.external', 'galaxy.set_job_metadata': 'galaxy.external'}}``

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4790,16 +4790,6 @@
 :Type: bool
 
 
-~~~~~~~~~~~~~~~~~~
-``celery_backend``
-~~~~~~~~~~~~~~~~~~
-
-:Description:
-    If set, it will be the results backend for Celery.
-:Default: ``None``
-:Type: str
-
-
 ~~~~~~~~~~~~~~
 ``use_pbkdf2``
 ~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4770,6 +4770,8 @@
     To refer to a task by name, use the template `galaxy.foo` where
     `foo` is the function name of the task defined in the
     galaxy.celery.tasks module.
+    The `broker_url` option, if unset, defaults to the value of
+    `amqp_internal_connection`.
     For details, see Celery documentation at
     https://docs.celeryq.dev/en/stable/userguide/configuration.html.
 :Default: ``{'task_routes': {'galaxy.fetch_data': 'galaxy.external', 'galaxy.set_job_metadata': 'galaxy.external'}}``
@@ -4786,16 +4788,6 @@
     see https://docs.galaxyproject.org/en/master/admin/production.html
 :Default: ``false``
 :Type: bool
-
-
-~~~~~~~~~~~~~~~~~
-``celery_broker``
-~~~~~~~~~~~~~~~~~
-
-:Description:
-    Celery broker (if unset falls back to amqp_internal_connection).
-:Default: ``None``
-:Type: str
 
 
 ~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -592,22 +592,6 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``load_tool_shed_datatypes``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    This option controls whether legacy datatypes are loaded from
-    installed tool shed repositories. We're are in the process of
-    disabling Tool Shed datatypes. This option with a default of true
-    will be added in 22.01, we will disable the datatypes on the big
-    public servers during that release. This option will be switched
-    to False by default in 22.05 and this broken functionality will be
-    removed all together during some future release.
-:Default: ``true``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~~
 ``watch_tools``
 ~~~~~~~~~~~~~~~
@@ -4775,6 +4759,21 @@
     the commented out line below).
 :Default: ``sqlalchemy+sqlite:///./database/control.sqlite?isolation_level=IMMEDIATE``
 :Type: str
+
+
+~~~~~~~~~~~~~~~
+``celery_conf``
+~~~~~~~~~~~~~~~
+
+:Description:
+    Configuration options passed to Celery.
+    To refer to a task by name, use the template `galaxy.foo` where
+    `foo` is the function name of the task defined in the
+    galaxy.celery.tasks module.
+    For details, see Celery documentation at
+    https://docs.celeryq.dev/en/stable/userguide/configuration.html.
+:Default: ``{'task_routes': {'galaxy.fetch_data': 'galaxy.external', 'galaxy.set_job_metadata': 'galaxy.external'}}``
+:Type: any
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -46,6 +46,19 @@ serialization.register(
 )
 
 
+class GalaxyCelery(Celery):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def gen_task_name(self, name, module):
+        # drop "celery.tasks" infix for less verbose task names:
+        # - galaxy.celery.tasks.do_foo >> galaxy.do_foo
+        # - galaxy.celery.tasks.subtasks.do_fuz >> galaxy.subtasks.do_fuz
+        if module.startswith("galaxy.celery.tasks"):
+            module = f"galaxy{module[19:]}"
+        return super().gen_task_name(name, module)
+
+
 def set_thread_app(app):
     APP_LOCAL.app = app
 
@@ -137,7 +150,7 @@ celery_app_kwd: Dict[str, Any] = {
 if backend:
     celery_app_kwd["backend"] = backend
 
-celery_app = Celery("galaxy", **celery_app_kwd)
+celery_app = GalaxyCelery("galaxy", **celery_app_kwd)
 celery_app.set_default()
 
 # apply Celery config options set in Galaxy

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -187,12 +187,9 @@ def init_celery_app():
 def config_celery_app(config, celery_app):
     # Apply settings from galaxy's config
     celery_app.conf.update(config.celery_conf)
-
     # Handle special cases
     if not celery_app.conf.broker_url:
         celery_app.conf.broker_url = config.amqp_internal_connection
-    if config.celery_backend:
-        celery_app.conf.results_backend = config.celery_backend
 
 
 def setup_periodic_tasks(config, celery_app):

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -140,6 +140,11 @@ if backend:
 celery_app = Celery("galaxy", **celery_app_kwd)
 celery_app.set_default()
 
+# apply Celery config options set in Galaxy
+config = get_config()
+if config and config.celery_conf:
+    celery_app.conf.update(config.celery_conf)
+
 # setup cron like tasks...
 beat_schedule: Dict[str, Dict[str, Any]] = {}
 

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -236,7 +236,3 @@ def galaxy_task(*args, action=None, **celery_task_kwd):
         return decorate(args[0])
     else:
         return decorate
-
-
-if __name__ == "__main__":
-    celery_app.start()

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -185,8 +185,12 @@ def init_celery_app():
 
 
 def config_celery_app(config, celery_app):
+    # Apply settings from galaxy's config
     celery_app.conf.update(config.celery_conf)
-    celery_app.conf.broker_url = config.celery_broker or config.amqp_internal_connection
+
+    # Handle special cases
+    if not celery_app.conf.broker_url:
+        celery_app.conf.broker_url = config.amqp_internal_connection
     if config.celery_backend:
         celery_app.conf.results_backend = config.celery_backend
 

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -186,7 +186,8 @@ def init_celery_app():
 
 def config_celery_app(config, celery_app):
     # Apply settings from galaxy's config
-    celery_app.conf.update(config.celery_conf)
+    if config.celery_conf:
+        celery_app.conf.update(config.celery_conf)
     # Handle special cases
     if not celery_app.conf.broker_url:
         celery_app.conf.broker_url = config.amqp_internal_connection

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2396,6 +2396,8 @@ galaxy:
   # To refer to a task by name, use the template `galaxy.foo` where
   # `foo` is the function name of the task defined in the
   # galaxy.celery.tasks module.
+  # The `broker_url` option, if unset, defaults to the value of
+  # `amqp_internal_connection`.
   # For details, see Celery documentation at
   # https://docs.celeryq.dev/en/stable/userguide/configuration.html.
   #celery_conf:
@@ -2407,9 +2409,6 @@ galaxy:
   # only if you have setup a Celery worker for Galaxy. For details, see
   # https://docs.galaxyproject.org/en/master/admin/production.html
   #enable_celery_tasks: false
-
-  # Celery broker (if unset falls back to amqp_internal_connection).
-  #celery_broker: null
 
   # If set, it will be the results backend for Celery.
   #celery_backend: null

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2410,9 +2410,6 @@ galaxy:
   # https://docs.galaxyproject.org/en/master/admin/production.html
   #enable_celery_tasks: false
 
-  # If set, it will be the results backend for Celery.
-  #celery_backend: null
-
   # Allow disabling pbkdf2 hashing of passwords for legacy situations.
   # This should normally be left enabled unless there is a specific
   # reason to disable it.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2397,7 +2397,8 @@ galaxy:
   # `foo` is the function name of the task defined in the
   # galaxy.celery.tasks module.
   # The `broker_url` option, if unset, defaults to the value of
-  # `amqp_internal_connection`.
+  # `amqp_internal_connection`. The `result_backend` option must be set
+  # if the `enable_celery_tasks` option is set.
   # For details, see Celery documentation at
   # https://docs.celeryq.dev/en/stable/userguide/configuration.html.
   #celery_conf:

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2392,6 +2392,17 @@ galaxy:
   # commented out line below).
   #amqp_internal_connection: sqlalchemy+sqlite:///./database/control.sqlite?isolation_level=IMMEDIATE
 
+  # Configuration options passed to Celery.
+  # To refer to a task by name, use the template `galaxy.foo` where
+  # `foo` is the function name of the task defined in the
+  # galaxy.celery.tasks module.
+  # For details, see Celery documentation at
+  # https://docs.celeryq.dev/en/stable/userguide/configuration.html.
+  #celery_conf:
+    task_routes:
+      galaxy.fetch_data: galaxy.external
+      galaxy.set_job_metadata: galaxy.external
+
   # Offload long-running tasks to a Celery task queue. Activate this
   # only if you have setup a Celery worker for Galaxy. For details, see
   # https://docs.galaxyproject.org/en/master/admin/production.html

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3480,6 +3480,7 @@ mapping:
           of the task defined in the galaxy.celery.tasks module.
 
           The `broker_url` option, if unset, defaults to the value of `amqp_internal_connection`.
+          The `result_backend` option must be set if the `enable_celery_tasks` option is set.
 
           For details, see Celery documentation at https://docs.celeryq.dev/en/stable/userguide/configuration.html.
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3469,8 +3469,17 @@ mapping:
       celery_conf:
         type: any
         required: false
+        default:
+          task_routes:
+            'galaxy.fetch_data': 'galaxy.external'
+            'galaxy.set_job_metadata': 'galaxy.external'
         desc: |
           Configuration options passed to Celery.
+
+          To refer to a task by name, use the template `galaxy.foo` where `foo` is the function name
+          of the task defined in the galaxy.celery.tasks module.
+
+          For details, see Celery documentation at https://docs.celeryq.dev/en/stable/userguide/configuration.html.
 
       enable_celery_tasks:
         type: bool

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3479,6 +3479,8 @@ mapping:
           To refer to a task by name, use the template `galaxy.foo` where `foo` is the function name
           of the task defined in the galaxy.celery.tasks module.
 
+          The `broker_url` option, if unset, defaults to the value of `amqp_internal_connection`.
+
           For details, see Celery documentation at https://docs.celeryq.dev/en/stable/userguide/configuration.html.
 
       enable_celery_tasks:
@@ -3489,12 +3491,6 @@ mapping:
           Offload long-running tasks to a Celery task queue.
           Activate this only if you have setup a Celery worker for Galaxy.
           For details, see https://docs.galaxyproject.org/en/master/admin/production.html
-
-      celery_broker:
-        type: str
-        required: false
-        desc: |
-          Celery broker (if unset falls back to amqp_internal_connection).
 
       celery_backend:
         type: str

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3492,12 +3492,6 @@ mapping:
           Activate this only if you have setup a Celery worker for Galaxy.
           For details, see https://docs.galaxyproject.org/en/master/admin/production.html
 
-      celery_backend:
-        type: str
-        required: false
-        desc: |
-          If set, it will be the results backend for Celery.
-
       use_pbkdf2:
         type: bool
         default: true

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3466,6 +3466,12 @@ mapping:
           will automatically create and use a separate sqlite database located in your
           <galaxy>/database folder (indicated in the commented out line below).
 
+      celery_conf:
+        type: any
+        required: false
+        desc: |
+          Configuration options passed to Celery.
+
       enable_celery_tasks:
         type: bool
         default: false

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -17,6 +17,7 @@ from queue import (
 
 import galaxy.jobs
 from galaxy import model
+from galaxy.exceptions import ConfigurationError
 from galaxy.job_execution.output_collect import (
     default_exit_code_file,
     read_exit_code_from,
@@ -378,6 +379,19 @@ class BaseJobRunner:
         #      yield (dataset_assoc, dataset_assoc.dataset)
         #  I don't understand the reworking it backwards.  -John
 
+    def _verify_celery_config(self):
+        if not self.app.config.enable_celery_tasks:
+            raise ConfigurationError("Can't request celery metadata without enabling celery tasks")
+        celery_conf = self.app.config.celery_conf
+        if not celery_conf:
+            raise ConfigurationError(
+                "Celery backend not set. Please set `result_backend` on the `celery_conf` config option."
+            )
+        else:
+            result_backend = celery_conf.get("result_backend", None)
+            if result_backend != "rpc://localhost":
+                raise ConfigurationError(f"Wrong celery backend: {result_backend}")
+
     def _handle_metadata_externally(self, job_wrapper: "MinimalJobWrapper", resolve_requirements: bool = False):
         """
         Set metadata externally. Used by the Pulsar job runner where this
@@ -396,10 +410,7 @@ class BaseJobRunner:
             )
             metadata_strategy = job_wrapper.metadata_strategy
             if "celery" in metadata_strategy:
-                if not self.app.config.enable_celery_tasks:
-                    raise Exception("CONFIG ERROR, can't request celery metadata without enabling celery tasks")
-                if not self.app.config.celery_backend == "rpc://localhost":
-                    raise Exception(f"Boo, wrong celery backend {self.app.config.celery_backend}")
+                self._verify_celery_config()
                 from galaxy.celery.tasks import set_job_metadata
 
                 # We're synchronously waiting for a task here. This means we have to have a result backend.

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -383,14 +383,10 @@ class BaseJobRunner:
         if not self.app.config.enable_celery_tasks:
             raise ConfigurationError("Can't request celery metadata without enabling celery tasks")
         celery_conf = self.app.config.celery_conf
-        if not celery_conf:
+        if not celery_conf and not celery_conf["result_backend"]:
             raise ConfigurationError(
                 "Celery backend not set. Please set `result_backend` on the `celery_conf` config option."
             )
-        else:
-            result_backend = celery_conf.get("result_backend", None)
-            if result_backend != "rpc://localhost":
-                raise ConfigurationError(f"Wrong celery backend: {result_backend}")
 
     def _handle_metadata_externally(self, job_wrapper: "MinimalJobWrapper", resolve_requirements: bool = False):
         """

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -180,19 +180,11 @@ def execute(
             raw_tool_source = tool.tool_source.to_string()
             async_result = (
                 setup_fetch_data.s(job_id, raw_tool_source=raw_tool_source)
-                # Should we route tasks to queues more dynamically ?
-                # That could be one way to route tasks to the resources
-                # that they require.
-                # Unfortunately it looks like discovering new queues or
-                # joining queues by a wildcard is not considered in scope
-                # for standard celery workers.
-                # We could implement that for ourselves though.
-                # For now we just hardcode galaxy.internal (default, with access to db etc) and galaxy.external (cancelable).
-                | fetch_data.s(job_id=job_id).set(queue="galaxy.external")
+                | fetch_data.s(job_id=job_id)
                 | set_job_metadata.s(
                     extended_metadata_collection="extended" in tool.app.config.metadata_strategy,
                     job_id=job_id,
-                ).set(queue="galaxy.external", link_error=finish_job.si(job_id=job_id, raw_tool_source=raw_tool_source))
+                ).set(link_error=finish_job.si(job_id=job_id, raw_tool_source=raw_tool_source))
                 | finish_job.si(job_id=job_id, raw_tool_source=raw_tool_source)
             )()
             job2.set_runner_external_id(async_result.task_id)

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -41,8 +41,8 @@ class UsesCeleryTasks:
     def handle_galaxy_config_kwds(cls, config):
         config["enable_celery_tasks"] = True
         config["metadata_strategy"] = f'{config.get("metadata_strategy", "directory")}_celery'
-        config["celery_backend"] = CELERY_BACKEND
         config.update({"celery_conf": {"broker_url": CELERY_BROKER}})
+        config.update({"celery_conf": {"result_backend": CELERY_BACKEND}})
 
     @pytest.fixture(autouse=True, scope="session")
     def _request_celery_app(self, celery_session_app, celery_config):

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -41,8 +41,8 @@ class UsesCeleryTasks:
     def handle_galaxy_config_kwds(cls, config):
         config["enable_celery_tasks"] = True
         config["metadata_strategy"] = f'{config.get("metadata_strategy", "directory")}_celery'
-        config["celery_broker"] = CELERY_BROKER
         config["celery_backend"] = CELERY_BACKEND
+        config.update({"celery_conf": {"broker_url": CELERY_BROKER}})
 
     @pytest.fixture(autouse=True, scope="session")
     def _request_celery_app(self, celery_session_app, celery_config):

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -790,7 +790,7 @@ def launch_gravity(port, gxit_port=None, galaxy_config=None):
     if "interactivetools_proxy_host" not in galaxy_config:
         galaxy_config["interactivetools_proxy_host"] = f"localhost:{gxit_port}"
     # Can't use in-memory celery broker, just fall back to sqlalchemy
-    galaxy_config.pop("celery_broker", None)
+    galaxy_config.update({"celery_conf": {"broker_url": None}})
     config = {
         "gravity": {
             "gunicorn": {"bind": f"localhost:{port}", "preload": "false"},

--- a/test/unit/test_celery.py
+++ b/test/unit/test_celery.py
@@ -1,0 +1,36 @@
+from galaxy.celery import (
+    celery_app,
+    DEFAULT_TASK_QUEUE,
+    GalaxyCelery,
+    TASKS_MODULES,
+)
+from galaxy.config import Configuration
+
+
+def test_default_configuration():
+    conf = celery_app.conf
+    galaxy_conf = Configuration()
+
+    assert conf.task_default_queue == DEFAULT_TASK_QUEUE
+    assert conf.include == TASKS_MODULES
+    assert conf.task_create_missing_queues is True
+    assert conf.timezone == "UTC"
+    assert conf.broker_url == galaxy_conf.amqp_internal_connection
+    assert conf.task_routes["galaxy.fetch_data"] == "galaxy.external"
+    assert conf.task_routes["galaxy.set_job_metadata"] == "galaxy.external"
+    assert conf.beat_schedule["prune-history-audit-table"] == {
+        "task": "galaxy.prune_history_audit_table",
+        "schedule": galaxy_conf.history_audit_table_prune_interval,
+    }
+    assert conf.beat_schedule["cleanup-short-term-storage"] == {
+        "task": "galaxy.cleanup_short_term_storage",
+        "schedule": galaxy_conf.short_term_storage_cleanup_interval,
+    }
+
+
+def test_galaxycelery_trim_module_name():
+    gc = GalaxyCelery()
+    assert gc.trim_module_name("notgalaxy.celery.tasks") == "notgalaxy.celery.tasks"
+    assert gc.trim_module_name("galaxy.notcelery.tasks") == "galaxy.notcelery.tasks"
+    assert gc.trim_module_name("galaxy.celery.tasks") == "galaxy"
+    assert gc.trim_module_name("galaxy.celery.tasks.nextlevel") == "galaxy.nextlevel"

--- a/test/unit/test_celery.py
+++ b/test/unit/test_celery.py
@@ -4,12 +4,12 @@ from galaxy.celery import (
     GalaxyCelery,
     TASKS_MODULES,
 )
-from galaxy.config import Configuration
+from galaxy.config import GalaxyAppConfiguration
 
 
 def test_default_configuration():
     conf = celery_app.conf
-    galaxy_conf = Configuration()
+    galaxy_conf = GalaxyAppConfiguration(override_tempdir=False)
 
     assert conf.task_default_queue == DEFAULT_TASK_QUEUE
     assert conf.include == TASKS_MODULES


### PR DESCRIPTION
### Updated description
The following modifications are included:
1. Celery options can be configured via the `celery_conf` config option. 
2. Routing of tasks to queues is no longer hard coded. Two default routes are set in the config schema, routing `fetch_data` and `set_job_metadata` tasks to the `galaxy.external` queue (both tasks are cancellable: see `abort_when_job_stops` in `tasks.py`). As this configuration is processed by Celery, all config options specified in Celery's configuration documentation should apply (although only a handful of essentials have been explicitly tested with Galaxy - so it is absolutely possible to misconfigure stuff).
    - When specifying a route for a task, refer to the task as `galaxy.TASK` where TASK is the name of the function in `galaxy.celery.tasks` wrapped in the `galaxy_task` decorator. If, at some point, there is a submodule under `galaxy.celery.tasks` (we don't have one at this time), simply use `galaxy.SUBMODULE.TASK`.
4. The default task queue is unchanged: everything not explicitly routed will be sent to `galaxy.internal` (set in the `galaxy.celery` module)
5. The `celery_backend` and `celery_broker` config options have been removed in favor of using Celery's configuration (e.g. to set the backend, use the `celery_conf: result_backend` setting, for broker, use `celery_conf: broker_url` - as per Celery docs)

**NOTE:** I've removed the following  comment from the code because after these changes it doesn't belong in that particular location. However, it's absolutely relevant for our future Celery development:
```
183 # Should we route tasks to queues more dynamically ?
184 # That could be one way to route tasks to the resources
185 # that they require.
186 # Unfortunately it looks like discovering new queues or
187 # joining queues by a wildcard is not considered in scope
188 # for standard celery workers.
189 # We could implement that for ourselves though.
```

### Previous description
This is a simple solution to #14634 and similar use cases. We can specify anything in `galaxy.yml`. Here's an example from Celery's docs:

```py
broker_transport_options = {
    'predefined_queues': {
        'my-q': {
            'url': 'https://ap-southeast-2.queue.amazonaws.com/123456/my-q',
            'access_key_id': 'xxx',
            'secret_access_key': 'xxx',
            'backoff_policy': {1: 10, 2: 20, 3: 40, 4: 80, 5: 320, 6: 640},
            'backoff_tasks': ['svc.tasks.tasks.task1']
        }
    },
}
```
can be specified as: 

```yaml
  celery_conf:
    broker_transport_options:
      predefined_queues:
        my-q:
          url: 'https://ap-southeast-2.queue.amazonaws.com/123456/my-q'
          access_key_id: 'xxx'
          secret_access_key: 'xxx'
          backoff_policy: 
            1: 10
            2: 20
            3: 40
            4: 80
            5: 320 
            6: 640 
          backoff_tasks: 
            - 'svc.tasks.tasks.task1'
```
The loaded configuration available at `celery_app.conf.broker_transport_options` will be the same.



I am new to Celery, and I don't have specific examples of how this may be unsafe (other than specifying an invalid configuration for Celery). However, it doesn't feel safe. One solution is to have a list of allowed Celery config options - then we can filter against this list in `galaxy.config` on config load. We can start with a short list of options and expand as needed.

TODO:
- [x] to consider: only allow setting options from a list of allowed Celery options (UPDATE: no need - see discussion)
- [x] add test(s)



## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

1. Add to `galaxy.yml`:
```yaml
celery_conf:
  task_routes:
    'galaxy.fetch_data': 'myfoo'

enable_celery_tasks: true
```
2. Launch Galaxy and 3 workers in 4 terminals:
```sh
$ GALAXY_CONFIG_FILE=config/galaxy.yml uvicorn --app-dir lib --factory galaxy.webapps.galaxy.fast_factory:factory

$ GALAXY_CONFIG_FILE=config/galaxy.yml PYTHONPATH=lib celery --app galaxy.celery worker --concurrency 2 --loglevel INFO --pool threads --queues galaxy.internal

$ GALAXY_CONFIG_FILE=config/galaxy.yml PYTHONPATH=lib celery --app galaxy.celery worker --concurrency 2 --loglevel INFO --pool threads --queues galaxy.external

$ GALAXY_CONFIG_FILE=config/galaxy.yml PYTHONPATH=lib celery --app galaxy.celery worker --concurrency 2 --loglevel INFO --pool threads --queues myfoo
```
3. Upload any data to your instance and observe the terminal output: tasks will be sent to appropriate queues (fetch_data > myfoo, set_job_metadata > galaxy.external, everything else > galaxy.internal)


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
