### PR TITLE
Update BioComputeObjectExportCard.vue

### DIFF
--- a/client/src/components/WorkflowInvocationState/Export/BioComputeObjectExportCard.vue
+++ b/client/src/components/WorkflowInvocationState/Export/BioComputeObjectExportCard.vue
@@ -51,7 +51,7 @@
                                 v-model="form.table"
                                 type="text"
                                 class="form-control"
-                                placeholder="BCO"
+                                placeholder="GALXY"
                                 required />
                         </div>
                         <div class="form-group">


### PR DESCRIPTION
Update default prefix to `GALXY`, a publicly available prefix to group Galaxy generated BCOs.

- [x] This is a refactoring of components with existing test coverage.
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
