### PR TITLE
Outline modernizing tool shed repositories API.

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2194,6 +2194,28 @@ class GroupUserListModel(Model):
     __root__: List[GroupUserModel]
 
 
+class ToolShedRepository(Model):
+    tool_shed_url: str = Field(
+        title="Tool Shed URL", default="https://toolshed.g2.bx.psu.edu/", description="Tool Shed target"
+    )
+    name: str = Field(name="Name", description="Name of repository")
+    owner: str = Field(name="Owner", description="Owner of repository")
+
+
+class ToolShedRepositoryChangeset(ToolShedRepository):
+    changeset_revision: str
+
+
+CheckForUpdatesResponseStatusT = Literal["ok", "error"]
+
+
+class CheckForUpdatesResponse(Model):
+    status: CheckForUpdatesResponseStatusT = Field(title="Status", description="'ok' or 'error'")
+    message: str = Field(
+        title="Message", description="Unstructured description of tool shed updates discovered or failure"
+    )
+
+
 # Libraries -----------------------------------------------------------------
 
 

--- a/lib/galaxy/util/tool_shed/tool_shed_registry.py
+++ b/lib/galaxy/util/tool_shed/tool_shed_registry.py
@@ -75,3 +75,17 @@ class Registry:
                 return self.tool_sheds_auth[shed_name]
         log.debug(f"Invalid url '{str(url)}' received by tool shed registry's url_auth method.")
         return None
+
+    def get_tool_shed_url(self, tool_shed: str) -> Optional[str]:
+        """
+        The value of tool_shed is something like: toolshed.g2.bx.psu.edu.  We need the URL to this tool shed, which is
+        something like: http://toolshed.g2.bx.psu.edu/
+        """
+        cleaned_tool_shed = common_util.remove_protocol_from_tool_shed_url(tool_shed)
+        for shed_url in self.tool_sheds.values():
+            if shed_url.find(cleaned_tool_shed) >= 0:
+                if shed_url.endswith("/"):
+                    shed_url = shed_url.rstrip("/")
+                return shed_url
+        # The tool shed from which the repository was originally installed must no longer be configured in tool_sheds_conf.xml.
+        return None

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1181,14 +1181,6 @@ def populate_api_routes(webapp, app):
     )
 
     webapp.mapper.connect(
-        "check_for_updates",
-        "/api/tool_shed_repositories/check_for_updates",
-        controller="tool_shed_repositories",
-        action="check_for_updates",
-        conditions=dict(method=["GET"]),
-    )
-
-    webapp.mapper.connect(
         "tool_shed_repository",
         "/api/tool_shed_repositories",
         controller="tool_shed_repositories",

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -92,7 +92,12 @@ class AdminToolshed(AdminGalaxy):
         if "operation" in kwd:
             operation = kwd.pop("operation").lower()
             if operation == "update tool shed status":
-                message, status = repository_util.check_for_updates(trans.app, trans.install_model, kwd.get("id"))
+                repository_id = kwd.get("id")
+                if repository_id:
+                    repository_id = trans.security.decode_id(repository_id)
+                message, status = repository_util.check_for_updates(
+                    trans.app.tool_shed_registry, trans.install_model, repository_id
+                )
         if message and status:
             kwd["message"] = util.sanitize_text(message)
             kwd["status"] = "success" if status in ["ok", "done", "success"] else "error"

--- a/lib/galaxy/webapps/galaxy/services/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/services/tool_shed_repositories.py
@@ -1,0 +1,20 @@
+from typing import Optional
+
+from galaxy.model.scoped_session import install_model_scoped_session
+from galaxy.schema.schema import CheckForUpdatesResponse
+from galaxy.tool_shed.util.repository_util import check_for_updates
+from galaxy.util.tool_shed.tool_shed_registry import Registry
+
+
+class ToolShedRepositoriesService:
+    def __init__(
+        self,
+        install_model_context: install_model_scoped_session,
+        tool_shed_registry: Registry,
+    ):
+        self._install_model_context = install_model_context
+        self._tool_shed_registry = tool_shed_registry
+
+    def check_for_updates(self, repository_id: Optional[int]) -> CheckForUpdatesResponse:
+        message, status = check_for_updates(self._tool_shed_registry, self._install_model_context, repository_id)
+        return CheckForUpdatesResponse(message=message, status=status)

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -14,8 +14,6 @@ from galaxy import (
     web,
 )
 from galaxy.tool_shed.util.repository_util import (
-    check_for_updates,
-    check_or_update_tool_shed_status_for_installed_repository,
     create_or_update_tool_shed_repository,
     extract_components_from_tuple,
     generate_tool_shed_repository_install_dir,
@@ -593,8 +591,6 @@ def validate_repository_name(app, name, user):
 
 __all__ = (
     "change_repository_name_in_hgrc_file",
-    "check_for_updates",
-    "check_or_update_tool_shed_status_for_installed_repository",
     "create_or_update_tool_shed_repository",
     "create_repo_info_dict",
     "create_repository_admin_role",

--- a/test/unit/shed_unit/test_installed_repository_manager.py
+++ b/test/unit/shed_unit/test_installed_repository_manager.py
@@ -40,6 +40,7 @@ class TestInstallRepositoryManager(ToolShedRepoBaseTestCase):
 
     def test_tool_shed_repository_install(self):
         hg_util.clone_repository = MagicMock(return_value=(True, None))
+        repository_util.get_tool_shed_status_for = MagicMock(return_value={"revision_update": "true"})
         self._install_tool_shed_repository(start_status="New", end_status="Installed", changeset_revision="1")
         hg_util.clone_repository.assert_called_with(
             "github.com/repos/galaxyproject/example",
@@ -49,9 +50,7 @@ class TestInstallRepositoryManager(ToolShedRepoBaseTestCase):
 
     def test_tool_shed_repository_update(self):
         common_util.get_tool_shed_url_from_tool_shed_registry = MagicMock(return_value="https://github.com")
-        repository_util.get_tool_shed_status_for_installed_repository = MagicMock(
-            return_value={"revision_update": "false"}
-        )
+        repository_util.get_tool_shed_status_for = MagicMock(return_value={"revision_update": "false"})
         hg_util.pull_repository = MagicMock()
         hg_util.update_repository = MagicMock(return_value=(True, None))
         self._install_tool_shed_repository(start_status="Installed", end_status="Installed", changeset_revision="2")


### PR DESCRIPTION
Builds on #14693 and migrates a simple endpoint to Pydandic models, a DI injected service layer, refactored utility code with decoded IDs and reduced dependency on ``app`` && ``trans``, and FastAPI controller.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
