### PR TITLE
Cleanup hack in job files API for very old versions of Galaxy.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -142,15 +142,8 @@ class JobFilesAPIController(BaseGalaxyAPIController):
         https://gist.github.com/jmchilton/9103619.)
         """
         in_work_dir = self.__in_working_directory(job, path, trans.app)
-        allow_temp_dir_file = self.__is_allowed_temp_dir_file(trans.app, job, path)
-        if not in_work_dir and not allow_temp_dir_file and not self.__is_output_dataset_path(job, path):
+        if not in_work_dir and not self.__is_output_dataset_path(job, path):
             raise exceptions.ItemAccessibilityException("Job is not authorized to write to supplied path.")
-
-    def __is_allowed_temp_dir_file(self, app, job, path):
-        # grrr.. need to get away from new_file_path - these should be written
-        # to job working directory like metadata files.
-        in_temp_dir = util.in_directory(path, app.config.new_file_path)
-        return in_temp_dir and os.path.split(path)[-1].startswith("GALAXY_VERSION_")
 
     def __is_output_dataset_path(self, job, path):
         """Check if is an output path for this job or a file in the an


### PR DESCRIPTION
We don't write version file there anymore.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
 - The core functionality of this component is tested in test_job_files.py.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
