### PR TITLE
Add shell wrapper for alembic CLI to match our documentation

### DIFF
--- a/scripts/run_alembic.py
+++ b/scripts/run_alembic.py
@@ -1,52 +1,9 @@
 #!/usr/bin/env python
 
 """
-Retrieves relevant configuration values and invokes the Alembic console runner.
-
-Must be executed from Galaxy's root directory.
-
-Use this script if you need to run migration operations on the Tool Shed
-Install data model (the *tsi* migration branch), or if you need access to the
-full scope of command line options provided by Alembic. For regular migration
-tasks, uses the db.sh script.
-
-We use branch labels to distinguish between the galaxy and the tool_shed_install models,
-so in most cases you'll need to identify the branch to which your command should be applied.
-Use these identifiers: `gxy` for galaxy, and `tsi` for tool_shed_install.
-
-To create a revision for galaxy:
-./scripts/run_alembic.py revision --head=gxy@head -m "your description"
-
-To create a revision for tool_shed_install:
-./scripts/run_alembic.py revision --head=tsi@head -m "your description"
-
-To upgrade:
-./scripts/run_alembic.py upgrade gxy@head  # upgrade gxy to head revision
-./scripts/run_alembic.py upgrade gxy@+1  # upgrade gxy to 1 revision above current
-./scripts/run_alembic.py upgrade [revision identifier]  # upgrade gxy to a specific revision
-./scripts/run_alembic.py upgrade [revision identifier]+1  # upgrade gxy to 1 revision above specific revision
-./scripts/run_alembic.py upgrade heads  # upgrade gxy and tsi to head revisions
-
-To downgrade:
-./scripts/run_alembic.py downgrade gxy@base  # downgrade gxy to base (database with empty alembic table)
-./scripts/run_alembic.py downgrade gxy@-1  # downgrade gxy to 1 revision below current
-./scripts/run_alembic.py downgrade [revision identifier]  # downgrade gxy to a specific revision
-./scripts/run_alembic.py downgrade [revision identifier]-1  # downgrade gxy to 1 revision below specific revision
-
-To pass a galaxy config file, use `--galaxy-config`
-
-You may also override the galaxy database url and/or the
-tool shed install database url, as well as the database_template
-and database_encoding configuration options with env vars:
-GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=my-db-url ./scripts/run_alembic.py ...
-GALAXY_INSTALL_CONFIG_OVERRIDE_DATABASE_CONNECTION=my-other-db-url ./scripts/run_alembic.py ...
-
-Further information:
-Galaxy migration documentation: lib/galaxy/model/migrations/README.md
-Alembic documentation: https://alembic.sqlalchemy.org
+This script is intended to be invoked by the scripts/run_alembic.sh script.
 """
 
-import logging
 import os.path
 import sys
 

--- a/scripts/run_alembic.sh
+++ b/scripts/run_alembic.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+#######
+# Database schema migration operaions via alembic's CLI runner.
+# Retrieves relevant configuration values and invokes the Alembic CLI runner.
+#
+# To pass a galaxy config file, use `--galaxy-config` 
+# (NOTE: the -c option is used by alembic's CLI runner for passing its own config file, alembic.ini)
+# 
+# You may also override the galaxy database url and/or the
+# tool shed install database url, as well as the database_template
+# and database_encoding configuration options with env vars:
+# GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=my-db-url ./scripts/run_alembic.py ...
+# GALAXY_INSTALL_CONFIG_OVERRIDE_DATABASE_CONNECTION=my-other-db-url ./scripts/run_alembic.py ...
+# 
+# For help, run `sh run_alembic.sh -h`. 
+#
+# Further information:
+# Galaxy migration documentation: lib/galaxy/model/migrations/README.md
+# Alembic documentation: https://alembic.sqlalchemy.org
+#######
+
+cd "$(dirname "$0")" || exit
+
+cd ..
+
+. ./scripts/common_startup_functions.sh
+
+setup_python
+
+python scripts/run_alembic.py "$@"


### PR DESCRIPTION
The documentation refers to `scripts/run_alembic.sh`, but after recent changes we only had `scripts/run_alembic.py`. 

Having the shell wrapper removes the need from running the script from the `scripts` directory, and keeps it consistent with the other scripts, such as `manage_db.sh` and `scripts/db_dev.sh`. 

I've also edited the inline docs, deleting usage examples that are available (and are better explained) in the main documentation. Inline documentation is now also consistent across these 3 scripts.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
