### PR TITLE
Fix ``validation_dataset_metadata_in_file`` framework test

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -35,6 +35,7 @@ ATTRIB_VALIDATOR_COMPATIBILITY = {
         "dataset_metadata_in_data_table",
         "dataset_metadata_not_in_data_table",
         "dataset_metadata_in_file",
+        "dataset_metadata_in_range",
     ],
     "metadata_column": [
         "dataset_metadata_in_data_table",
@@ -377,6 +378,20 @@ def lint_inputs(tool_xml, lint_ctx):
             ):
                 lint_ctx.error(
                     f"Parameter [{param_name}]: '{vtype}' validators need to define the 'table_name' attribute",
+                    node=validator,
+                )
+            if (
+                vtype
+                in [
+                    "dataset_metadata_in_data_table",
+                    "dataset_metadata_not_in_data_table",
+                    "dataset_metadata_in_file",
+                    "dataset_metadata_in_range",
+                ]
+                and "metadata_name" not in validator.attrib
+            ):
+                lint_ctx.error(
+                    f"Parameter [{param_name}]: '{vtype}' validators need to define the 'metadata_name' attribute",
                     node=validator,
                 )
 

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4416,7 +4416,7 @@ if ``type`` is ``dataset_metadata_in_file``. File should be present Galaxy's
         <xs:attribute name="metadata_name" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">Target metadata attribute name for
-``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table`` and ``dataset_metadata_in_file`` options.</xs:documentation>
+``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table``, ``dataset_metadata_in_file`` and ``dataset_metadata_in_range`` options.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="metadata_column" type="xs:string">

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -723,9 +723,9 @@ class MetadataInFileColumnValidator(Validator):
         filename = elem.get("filename", None)
         if filename:
             filename = f"{param.tool.app.config.tool_data_path}/{filename.strip()}"
-        metadata_name = elem.get("metadata_name", None)
-        if metadata_name:
-            metadata_name = metadata_name.strip()
+        metadata_name = elem.get("metadata_name")
+        assert metadata_name, f"Required 'metadata_name' attribute missing from {elem.get('type')} validator."
+        metadata_name = metadata_name.strip()
         metadata_column = int(elem.get("metadata_column", 0))
         split = elem.get("split", "\t")
         message = elem.get("message", f"Value for metadata {metadata_name} was not found in {filename}.")
@@ -847,9 +847,9 @@ class MetadataInDataTableColumnValidator(ValueInDataTableColumnValidator):
         table_name = elem.get("table_name", None)
         assert table_name, "You must specify a table_name."
         tool_data_table = param.tool.app.tool_data_tables[table_name]
-        metadata_name = elem.get("metadata_name", None)
-        if metadata_name:
-            metadata_name = metadata_name.strip()
+        metadata_name = elem.get("metadata_name")
+        assert metadata_name, f"Required 'metadata_name' attribute missing from {elem.get('type')} validator."
+        metadata_name = metadata_name.strip()
         # TODO rename to column?
         metadata_column = elem.get("metadata_column", 0)
         try:
@@ -907,8 +907,8 @@ class MetadataInRangeValidator(InRangeValidator):
 
     @classmethod
     def from_element(cls, param, elem):
-        metadata_name = elem.get("metadata_name", None)
-        assert metadata_name, "dataset_metadata_in_range validator requires metadata_name attribute."
+        metadata_name = elem.get("metadata_name")
+        assert metadata_name, f"Required 'metadata_name' attribute missing from {elem.get('type')} validator."
         metadata_name = metadata_name.strip()
         ret = cls(
             metadata_name,

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -720,9 +720,10 @@ class MetadataInFileColumnValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        filename = elem.get("filename", None)
-        if filename:
-            filename = f"{param.tool.app.config.tool_data_path}/{filename.strip()}"
+        filename = elem.get("filename")
+        assert filename, f"Required 'filename' attribute missing from {elem.get('type')} validator."
+        filename = f"{param.tool.app.config.tool_data_path}/{filename.strip()}"
+        assert os.path.exists(filename), f"File {filename} specified by the 'filename' attribute not found"
         metadata_name = elem.get("metadata_name")
         assert metadata_name, f"Required 'metadata_name' attribute missing from {elem.get('type')} validator."
         metadata_name = metadata_name.strip()
@@ -748,11 +749,12 @@ class MetadataInFileColumnValidator(Validator):
         super().__init__(message, negate)
         self.metadata_name = metadata_name
         self.valid_values = set()
-        for line in open(filename):
-            if line_startswith is None or line.startswith(line_startswith):
-                fields = line.split(split)
-                if metadata_column < len(fields):
-                    self.valid_values.add(fields[metadata_column].strip())
+        with open(filename) as fh:
+            for line in fh:
+                if line_startswith is None or line.startswith(line_startswith):
+                    fields = line.split(split)
+                    if metadata_column < len(fields):
+                        self.valid_values.add(fields[metadata_column].strip())
 
     def validate(self, value, trans=None):
         if not value:
@@ -772,8 +774,8 @@ class ValueInDataTableColumnValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        table_name = elem.get("table_name", None)
-        assert table_name, "You must specify a table_name."
+        table_name = elem.get("table_name")
+        assert table_name, f"Required 'table_name' attribute missing from {elem.get('type')} validator."
         tool_data_table = param.tool.app.tool_data_tables[table_name]
         column = elem.get("metadata_column", 0)
         try:
@@ -844,8 +846,8 @@ class MetadataInDataTableColumnValidator(ValueInDataTableColumnValidator):
 
     @classmethod
     def from_element(cls, param, elem):
-        table_name = elem.get("table_name", None)
-        assert table_name, "You must specify a table_name."
+        table_name = elem.get("table_name")
+        assert table_name, f"Required 'table_name' attribute missing from {elem.get('type')} validator."
         tool_data_table = param.tool.app.tool_data_tables[table_name]
         metadata_name = elem.get("metadata_name")
         assert metadata_name, f"Required 'metadata_name' attribute missing from {elem.get('type')} validator."

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -44,7 +44,7 @@ class Validator(abc.ABC):
         param elem the validator element
         return an object of a Validator subclass that corresponds to the type attribute of the validator element
         """
-        _type = elem.get("type", None)
+        _type = elem.get("type")
         assert _type is not None, "Required 'type' attribute missing from validator"
         return validator_types[_type].from_element(param, elem)
 
@@ -129,7 +129,7 @@ class RegexValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        return cls(elem.get("message", None), elem.text, elem.get("negate", "false"))
+        return cls(elem.get("message"), elem.text, elem.get("negate", "false"))
 
     def __init__(self, message, expression, negate):
         if message is None:
@@ -154,7 +154,7 @@ class ExpressionValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        return cls(elem.get("message", None), elem.text, elem.get("negate", "false"))
+        return cls(elem.get("message"), elem.text, elem.get("negate", "false"))
 
     def __init__(self, message, expression, negate):
         if message is None:
@@ -214,7 +214,7 @@ class InRangeValidator(ExpressionValidator):
     @classmethod
     def from_element(cls, param, elem):
         return cls(
-            elem.get("message", None),
+            elem.get("message"),
             elem.get("min"),
             elem.get("max"),
             elem.get("exclude_min", "false"),
@@ -289,7 +289,7 @@ class LengthValidator(InRangeValidator):
 
     @classmethod
     def from_element(cls, param, elem):
-        return cls(elem.get("message", None), elem.get("min", None), elem.get("max", None), elem.get("negate", "false"))
+        return cls(elem.get("message"), elem.get("min"), elem.get("max"), elem.get("negate", "false"))
 
     def __init__(self, message, length_min, length_max, negate):
         if message is None:
@@ -346,7 +346,7 @@ class DatasetOkValidator(Validator):
     @classmethod
     def from_element(cls, param, elem):
         negate = elem.get("negate", "false")
-        message = elem.get("message", None)
+        message = elem.get("message")
         if message is None:
             if negate == "false":
                 message = "The selected dataset is still being generated, select another dataset or wait until it is completed"
@@ -404,7 +404,7 @@ class DatasetEmptyValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        message = elem.get("message", None)
+        message = elem.get("message")
         negate = elem.get("negate", "false")
         if not message:
             message = f"The selected dataset is {'non-' if negate == 'true' else ''}empty, this tool expects {'non-' if negate=='false' else ''}empty files."
@@ -462,7 +462,7 @@ class DatasetExtraFilesPathEmptyValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        message = elem.get("message", None)
+        message = elem.get("message")
         negate = elem.get("negate", "false")
         if not message:
             message = f"The selected dataset's extra_files_path directory is {'non-' if negate == 'true' else ''}empty or does {'not ' if negate == 'false' else ''}exist, this tool expects {'non-' if negate == 'false' else ''}empty extra_files_path directories associated with the selected input."
@@ -534,7 +534,7 @@ class MetadataValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        message = elem.get("message", None)
+        message = elem.get("message")
         return cls(
             message=message, check=elem.get("check", ""), skip=elem.get("skip", ""), negate=elem.get("negate", "false")
         )
@@ -607,7 +607,7 @@ class UnspecifiedBuildValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        message = elem.get("message", None)
+        message = elem.get("message")
         negate = elem.get("negate", "false")
         if not message:
             message = f"{'Unspecified' if negate == 'false' else 'Specified'} genome build, click the pencil icon in the history item to {'set' if negate == 'false' else 'remove'} the genome build"
@@ -655,7 +655,7 @@ class NoOptionsValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        message = elem.get("message", None)
+        message = elem.get("message")
         negate = elem.get("negate", "false")
         if not message:
             message = f"{'No options' if negate == 'false' else 'Options'} available for selection"
@@ -694,7 +694,7 @@ class EmptyTextfieldValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        message = elem.get("message", None)
+        message = elem.get("message")
         negate = elem.get("negate", "false")
         if not message:
             if negate == "false":
@@ -730,7 +730,7 @@ class MetadataInFileColumnValidator(Validator):
         metadata_column = int(elem.get("metadata_column", 0))
         split = elem.get("split", "\t")
         message = elem.get("message", f"Value for metadata {metadata_name} was not found in {filename}.")
-        line_startswith = elem.get("line_startswith", None)
+        line_startswith = elem.get("line_startswith")
         if line_startswith:
             line_startswith = line_startswith.strip()
         negate = elem.get("negate", "false")
@@ -914,7 +914,7 @@ class MetadataInRangeValidator(InRangeValidator):
         metadata_name = metadata_name.strip()
         ret = cls(
             metadata_name,
-            elem.get("message", None),
+            elem.get("message"),
             elem.get("min"),
             elem.get("max"),
             elem.get("exclude_min", "false"),

--- a/test/functional/tools/validation_dataset_metadata_in_file.xml
+++ b/test/functional/tools/validation_dataset_metadata_in_file.xml
@@ -4,12 +4,12 @@ echo 'Hello World' > out1
     ]]></command>
     <inputs>
         <!-- test dataset_metadata_in_file validator with and without negation
-             the test also uses the data table fasta_indexes.loc, but it could be any file in the tool data dir -->
+             the test also uses the loc file all_fasta.loc.sample, but it could be any file in the tool data dir -->
         <param name="value" type="data" format="data">
-            <validator type="dataset_metadata_in_file" filename="fasta_indexes.loc" metadata_name="dbkey" metadata_column="1"/>
+            <validator type="dataset_metadata_in_file" filename="all_fasta.loc.sample" line_startswith="#h" metadata_name="dbkey" metadata_column="1"/>
         </param>
         <param name="value_neg" type="data" format="data">
-            <validator type="dataset_metadata_in_file" filename="fasta_indexes.loc" line_startswith="h" metadata_name="dbkey" metadata_column="1" negate="true"/>
+            <validator type="dataset_metadata_in_file" filename="all_fasta.loc.sample" line_startswith="#h" metadata_name="dbkey" metadata_column="1" negate="true"/>
         </param>
     </inputs>
     <outputs>

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -364,17 +364,17 @@ INPUTS_VALIDATOR_CORRECT = """
             <validator type="metadata" check="md1,md2" skip="md3,md4" message="custom validation message" negate="true"/>
             <validator type="unspecified_build" message="custom validation message" negate="true"/>
             <validator type="dataset_ok_validator" message="custom validation message" negate="true"/>
-            <validator type="dataset_metadata_in_range" min="0" max="100" exclude_min="true" exclude_max="true" message="custom validation message" negate="true"/>
-            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split=","  message="custom validation message" negate="true"/>
-            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" message="custom validation message" negate="true"/>
+            <validator type="dataset_metadata_in_range" metadata_name="sequences" min="0" max="100" exclude_min="true" exclude_max="true" message="custom validation message" negate="true"/>
+            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split="," metadata_name="dbkey" message="custom validation message" negate="true"/>
+            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" metadata_name="dbkey" message="custom validation message" negate="true"/>
         </param>
         <param name="collection_param" type="collection">
             <validator type="metadata" check="md1,md2" skip="md3,md4" message="custom validation message"/>
             <validator type="unspecified_build" message="custom validation message"/>
             <validator type="dataset_ok_validator" message="custom validation message"/>
-            <validator type="dataset_metadata_in_range" min="0" max="100" exclude_min="true" exclude_max="true" message="custom validation message"/>
-            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split=","  message="custom validation message"/>
-            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" message="custom validation message"/>
+            <validator type="dataset_metadata_in_range" metadata_name="sequences" min="0" max="100" exclude_min="true" exclude_max="true" message="custom validation message"/>
+            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split="," metadata_name="dbkey" message="custom validation message"/>
+            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" metadata_name="dbkey" message="custom validation message"/>
         </param>
         <param name="text_param" type="text">
             <validator type="regex">reg.xp</validator>

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -361,40 +361,40 @@ INPUTS_VALIDATOR_CORRECT = """
 <tool>
     <inputs>
         <param name="data_param" type="data" format="data">
-            <validator type="metadata" check="md1,md2" skip="md3,md4" message="cutom validation message" negate="true"/>
-            <validator type="unspecified_build" message="cutom validation message" negate="true"/>
-            <validator type="dataset_ok_validator" message="cutom validation message" negate="true"/>
-            <validator type="dataset_metadata_in_range" min="0" max="100" exclude_min="true" exclude_max="true" message="cutom validation message" negate="true"/>
-            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split=","  message="cutom validation message" negate="true"/>
-            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" message="cutom validation message" negate="true"/>
+            <validator type="metadata" check="md1,md2" skip="md3,md4" message="custom validation message" negate="true"/>
+            <validator type="unspecified_build" message="custom validation message" negate="true"/>
+            <validator type="dataset_ok_validator" message="custom validation message" negate="true"/>
+            <validator type="dataset_metadata_in_range" min="0" max="100" exclude_min="true" exclude_max="true" message="custom validation message" negate="true"/>
+            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split=","  message="custom validation message" negate="true"/>
+            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" message="custom validation message" negate="true"/>
         </param>
         <param name="collection_param" type="collection">
-            <validator type="metadata" check="md1,md2" skip="md3,md4" message="cutom validation message"/>
-            <validator type="unspecified_build" message="cutom validation message"/>
-            <validator type="dataset_ok_validator" message="cutom validation message"/>
-            <validator type="dataset_metadata_in_range" min="0" max="100" exclude_min="true" exclude_max="true" message="cutom validation message"/>
-            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split=","  message="cutom validation message"/>
-            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" message="cutom validation message"/>
+            <validator type="metadata" check="md1,md2" skip="md3,md4" message="custom validation message"/>
+            <validator type="unspecified_build" message="custom validation message"/>
+            <validator type="dataset_ok_validator" message="custom validation message"/>
+            <validator type="dataset_metadata_in_range" min="0" max="100" exclude_min="true" exclude_max="true" message="custom validation message"/>
+            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split=","  message="custom validation message"/>
+            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" message="custom validation message"/>
         </param>
         <param name="text_param" type="text">
             <validator type="regex">reg.xp</validator>
-            <validator type="length" min="0" max="100" message="cutom validation message"/>
-            <validator type="empty_field" message="cutom validation message"/>
-            <validator type="value_in_data_table" table_name="datatable_name" metadata_column="3" message="cutom validation message"/>
-            <validator type="expression" message="cutom validation message">somepythonexpression</validator>
+            <validator type="length" min="0" max="100" message="custom validation message"/>
+            <validator type="empty_field" message="custom validation message"/>
+            <validator type="value_in_data_table" table_name="datatable_name" metadata_column="3" message="custom validation message"/>
+            <validator type="expression" message="custom validation message">somepythonexpression</validator>
         </param>
         <param name="select_param" type="select">
             <options from_data_table="bowtie2_indexes"/>
             <validator type="no_options" negate="true"/>
             <validator type="regex" negate="true">reg.xp</validator>
-            <validator type="length" min="0" max="100" message="cutom validation message" negate="true"/>
-            <validator type="empty_field" message="cutom validation message" negate="true"/>
-            <validator type="value_in_data_table" table_name="datatable_name" metadata_column="3" message="cutom validation message" negate="true"/>
-            <validator type="expression" message="cutom validation message" negate="true">somepythonexpression</validator>
+            <validator type="length" min="0" max="100" message="custom validation message" negate="true"/>
+            <validator type="empty_field" message="custom validation message" negate="true"/>
+            <validator type="value_in_data_table" table_name="datatable_name" metadata_column="3" message="custom validation message" negate="true"/>
+            <validator type="expression" message="custom validation message" negate="true">somepythonexpression</validator>
         </param>
         <param name="int_param" type="integer">
             <validator type="in_range" min="0" max="100" exclude_min="true" exclude_max="true" negate="true"/>
-            <validator type="expression" message="cutom validation message">somepythonexpression</validator>
+            <validator type="expression" message="custom validation message">somepythonexpression</validator>
         </param>
     </inputs>
 </tool>


### PR DESCRIPTION
Use a loc file that actually exists in the param validators of the `test/functional/tools/validation_dataset_metadata_in_file.xml` test tool. Previously, the test tool was failing to load and was not tested at all during framework tests on GitHub Actions (note that the collected tests increase from 333 to 335).

Also:
- Improve error messages when parsing param validators
- Make `metadata_name` a required attribute of `dataset_metadata_in_data_table`, `dataset_metadata_not_in_data_table`, `dataset_metadata_in_file`, `dataset_metadata_in_range` validators
- Cleanups and typo fixes

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
