### PR TITLE
Disable multi-view create hook hiding toolbox.  

### DIFF
--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -59,11 +59,6 @@ export default {
             filter: "",
         };
     },
-    created() {
-        return setTimeout(() => {
-            document.getElementById("left").__vue__.hide();
-        }, 1000);
-    },
     methods: {
         updateFilter(filter) {
             this.filter = filter;


### PR DESCRIPTION
From conversation in ui/ux matrix chat.  We may want to reconsder doing this reactively (and at the panel/route level in a generic way) based on breakpoints or some other behavior in the future. 

If a user *wants* more space, they can always toggle the panel closed, but right now the loss of context (and required extra actions to re-open the panel prior to moving on) make this overly disruptive to always do automatically.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Click multiview, note it doesn't hide toolbox anymore.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
