### PR TITLE
Migrate index and show tool shed repositories endpoints to Pydantic and FastAPI

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2206,6 +2206,54 @@ class ToolShedRepositoryChangeset(ToolShedRepository):
     changeset_revision: str
 
 
+class InstalledRepositoryToolShedStatus(Model):
+    # See https://github.com/galaxyproject/galaxy/issues/10453
+    latest_installable_revision: str = Field(
+        name="Latest installed revision", description="Most recent version avialable on the tool shed"
+    )
+    revision_update: str
+    revision_upgrade: Optional[str]
+    repository_deprecated: str = Field(
+        name="Repository deprecated", description="Repository has been depreciated on the tool shed"
+    )
+
+
+class InstalledToolShedRepository(Model):
+    model_class: str = ModelClassField("ToolShedRepository")
+    id: EncodedDatabaseIdField = Field(
+        ...,
+        title="ID",
+        description="Encoded ID of the install tool shed repository.",
+    )
+    status: str
+    name: str = Field(name="Name", description="Name of repository")
+    owner: str = Field(name="Owner", description="Owner of repository")
+    deleted: bool
+    # This should be an int... but it would break backward compatiblity. Probably switch it at some point anyway?
+    ctx_rev: str = Field(
+        name="Changeset revision number",
+        description="The linearized 0-based index of the changeset on the tool shed (0, 1, 2,...)",
+    )
+    error_message: str = Field("Installation error message, the empty string means no error was recorded")
+    installed_changeset_revision: str = Field(
+        name="Installed changeset revision",
+        description="Initially installed changeset revision. Used to construct path to repository within Galaxies filesystem. Does not change if a repository is updated.",
+    )
+    tool_shed: str = Field(name="Tool shed", description="Hostname of the tool shed this was installed from")
+    dist_to_shed: bool
+    uninstalled: bool
+    changeset_revision: str = Field(
+        name="Changeset revision", description="Changeset revision of the repository - a mercurial commit hash"
+    )
+    tool_shed_status: Optional[InstalledRepositoryToolShedStatus] = Field(
+        name="Latest updated status from the tool shed"
+    )
+
+
+class InstalledToolShedRepositories(Model):
+    __root__: List[InstalledToolShedRepository]
+
+
 CheckForUpdatesResponseStatusT = Literal["ok", "error"]
 
 

--- a/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
@@ -1,16 +1,18 @@
 import json
 import logging
 from time import strftime
-from typing import Optional
+from typing import (
+    List,
+    Optional,
+)
 
+from fastapi import (
+    Path,
+    Query,
+)
 from paste.httpexceptions import (
     HTTPBadRequest,
     HTTPForbidden,
-)
-from sqlalchemy import (
-    and_,
-    cast,
-    Integer,
 )
 
 from galaxy import (
@@ -18,9 +20,12 @@ from galaxy import (
     util,
 )
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.model.tool_shed_install import ToolShedRepository
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.schema import CheckForUpdatesResponse
+from galaxy.schema.schema import (
+    CheckForUpdatesResponse,
+    InstalledToolShedRepositories,
+    InstalledToolShedRepository,
+)
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
 from galaxy.tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
 from galaxy.tool_shed.galaxy_install.metadata.installed_repository_metadata_manager import (
@@ -36,14 +41,16 @@ from galaxy.tool_shed.util.tool_util import generate_message_for_invalid_tools
 from galaxy.web import (
     expose_api,
     require_admin,
-    url_for,
 )
 from galaxy.webapps.galaxy.api import (
     BaseGalaxyAPIController,
     depends,
     Router,
 )
-from galaxy.webapps.galaxy.services.tool_shed_repositories import ToolShedRepositoriesService
+from galaxy.webapps.galaxy.services.tool_shed_repositories import (
+    InstalledToolShedRepositoryIndexRequest,
+    ToolShedRepositoriesService,
+)
 
 log = logging.getLogger(__name__)
 
@@ -64,6 +71,8 @@ def get_message_for_no_shed_tool_config():
 class ToolShedRepositoriesController(BaseGalaxyAPIController):
     """RESTful controller for interactions with tool shed repositories."""
 
+    service: ToolShedRepositoriesService = depends(ToolShedRepositoriesService)
+
     def __ensure_can_install_repos(self, trans):
         # Make sure this Galaxy instance is configured with a shed-related tool panel configuration file.
         if not have_shed_tool_conf_for_install(self.app):
@@ -75,49 +84,6 @@ class ToolShedRepositoriesController(BaseGalaxyAPIController):
             raise exceptions.AdminRequiredException(
                 "You are not authorized to request the latest installable revision for a repository in this Galaxy instance."
             )
-
-    def __get_value_mapper(self, trans, tool_shed_repository):
-        value_mapper = {
-            "id": trans.security.encode_id(tool_shed_repository.id),
-            "error_message": tool_shed_repository.error_message or "",
-        }
-        return value_mapper
-
-    @expose_api
-    def index(self, trans: ProvidesUserContext, **kwd):
-        """
-        GET /api/tool_shed_repositories
-        Display a list of dictionaries containing information about installed tool shed repositories.
-        """
-        # Example URL: http://localhost:8763/api/tool_shed_repositories
-        clause_list = []
-        if "name" in kwd:
-            clause_list.append(ToolShedRepository.table.c.name == kwd.get("name"))
-        if "owner" in kwd:
-            clause_list.append(ToolShedRepository.table.c.owner == kwd.get("owner"))
-        if "changeset" in kwd:
-            clause_list.append(ToolShedRepository.table.c.changeset_revision == kwd.get("changeset"))
-        if "deleted" in kwd:
-            clause_list.append(ToolShedRepository.table.c.deleted == util.asbool(kwd.get("deleted")))
-        if "uninstalled" in kwd:
-            clause_list.append(ToolShedRepository.table.c.uninstalled == util.asbool(kwd.get("uninstalled")))
-        tool_shed_repository_dicts = []
-        query = (
-            trans.install_model.context.query(ToolShedRepository)
-            .order_by(ToolShedRepository.table.c.name)
-            .order_by(cast(ToolShedRepository.ctx_rev, Integer).desc())
-        )
-        if len(clause_list) > 0:
-            query = query.filter(and_(*clause_list))
-        for tool_shed_repository in query.all():
-            tool_shed_repository_dict = tool_shed_repository.to_dict(
-                value_mapper=self.__get_value_mapper(trans, tool_shed_repository)
-            )
-            tool_shed_repository_dict["url"] = url_for(
-                controller="tool_shed_repositories", action="show", id=trans.security.encode_id(tool_shed_repository.id)
-            )
-            tool_shed_repository_dicts.append(tool_shed_repository_dict)
-        return tool_shed_repository_dicts
 
     @require_admin
     @expose_api
@@ -175,18 +141,10 @@ class ToolShedRepositoriesController(BaseGalaxyAPIController):
         self.__ensure_can_install_repos(trans)
         irm = InstallRepositoryManager(self.app)
         installed_tool_shed_repositories = irm.install(tool_shed_url, name, owner, changeset_revision, payload)
-
-        def to_dict(tool_shed_repository):
-            tool_shed_repository_dict = tool_shed_repository.as_dict(
-                value_mapper=self.__get_value_mapper(trans, tool_shed_repository)
-            )
-            tool_shed_repository_dict["url"] = url_for(
-                controller="tool_shed_repositories", action="show", id=trans.security.encode_id(tool_shed_repository.id)
-            )
-            return tool_shed_repository_dict
-
         if installed_tool_shed_repositories:
-            return list(map(to_dict, installed_tool_shed_repositories))
+            return InstalledToolShedRepositories(
+                __root__=list(map(self.service._show, installed_tool_shed_repositories))
+            )
         message = "No repositories were installed, possibly because the selected repository has already been installed."
         return dict(status="ok", message=message)
 
@@ -285,9 +243,9 @@ class ToolShedRepositoriesController(BaseGalaxyAPIController):
             if isinstance(installed_tool_shed_repositories, dict):
                 # We encountered an error.
                 return installed_tool_shed_repositories
-            elif isinstance(installed_tool_shed_repositories, list):
-                all_installed_tool_shed_repositories.extend(installed_tool_shed_repositories)
-        return all_installed_tool_shed_repositories
+            elif isinstance(installed_tool_shed_repositories, InstalledToolShedRepositories):
+                all_installed_tool_shed_repositories.extend(installed_tool_shed_repositories.__root__)
+        return InstalledToolShedRepositories(__root__=all_installed_tool_shed_repositories)
 
     @require_admin
     @expose_api
@@ -426,56 +384,53 @@ class ToolShedRepositoriesController(BaseGalaxyAPIController):
         results["stop_time"] = stop_time
         return json.dumps(results, sort_keys=True, indent=4)
 
-    @expose_api
-    def show(self, trans, id, **kwd):
-        """
-        GET /api/tool_shed_repositories/{encoded_tool_shed_repsository_id}
 
-        Display a dictionary containing information about a specified tool_shed_repository.
+InstalledToolShedRepositoryIDPathParam: DecodedDatabaseIdField = Path(
+    ...,
+    title="Installed Tool Shed Repository ID",
+    description="The encoded database identifier of the installed Tool Shed Repository.",
+)
 
-        .. code-block::
+NameQueryParam: Optional[str] = Query(default=None, title="Name", description="Filter by repository name.")
 
-            {
-                id: (string) Galaxy ID
-                status: (string) Installation status
-                name: (string) Repository name
-                deleted: (bool) Repository deleted
-                ctx_rev: (int) Changeset revision number (0, 1, 2...)
-                error_message: (string) Installation error message
-                installed_changeset_revision: (string) Initially installed changeset revision. Used to construct path to repository within Galaxies filesystem. Does not change if a repository is updated.
-                tool_shed: (string) Repository toolshed hostname
-                dist_to_shed: (bool)
-                url: (string) API url of repository
-                uninstalled: (bool) Tool has been uninstalled
-                owner: (string) Repository owner within toolshed
-                changeset_revision: (string) Changeset revision of repository
-                include_datatypes: (bool) Repository includes installed datatypes
-                tool_shed_status: (dict) See https://github.com/galaxyproject/galaxy/issues/10453
-                    latest_installable_revision: (string) Most recent version available on toolshed
-                    revision_update: (string)
-                    revision_upgrade: (string)
-                    repository_deprecated: (string) Repository has been depreciated
-            }
+OwnerQueryParam: Optional[str] = Query(default=None, title="Owner", description="Filter by repository owner.")
 
-        :param id: the encoded id of the ToolShedRepository object
-        """
-        # Example URL: http://localhost:8763/api/tool_shed_repositories/df7a1f0c02a5b08e
-        tool_shed_repository = get_tool_shed_repository_by_id(self.app, id)
-        if tool_shed_repository is None:
-            log.debug(f"Unable to locate tool_shed_repository record for id {id}.")
-            return {}
-        tool_shed_repository_dict = tool_shed_repository.as_dict(
-            value_mapper=self.__get_value_mapper(trans, tool_shed_repository)
-        )
-        tool_shed_repository_dict["url"] = url_for(
-            controller="tool_shed_repositories", action="show", id=trans.security.encode_id(tool_shed_repository.id)
-        )
-        return tool_shed_repository_dict
+ChangesetQueryParam: Optional[str] = Query(default=None, title="Changeset", description="Filter by changeset revision.")
+
+DeletedQueryParam: Optional[bool] = Query(
+    default=None, title="Deleted?", description="Filter by whether the repository has been deleted."
+)
+
+UninstalledQueryParam: Optional[bool] = Query(
+    default=None, title="Uninstalled?", description="Filter by whether the repository has been uninstalled."
+)
 
 
 @router.cbv
 class FastAPIToolShedRepositories:
     service: ToolShedRepositoriesService = depends(ToolShedRepositoriesService)
+
+    @router.get(
+        "/api/tool_shed_repositories",
+        summary="Lists installed tool shed repositories.",
+        response_description="A list of installed tool shed repository objects.",
+    )
+    def index(
+        self,
+        name: Optional[str] = NameQueryParam,
+        owner: Optional[str] = OwnerQueryParam,
+        changeset: Optional[str] = ChangesetQueryParam,
+        deleted: Optional[bool] = DeletedQueryParam,
+        uninstalled: Optional[bool] = UninstalledQueryParam,
+    ) -> List[InstalledToolShedRepository]:
+        request = InstalledToolShedRepositoryIndexRequest(
+            name=name,
+            owner=owner,
+            changeset=changeset,
+            deleted=deleted,
+            uninstalled=uninstalled,
+        )
+        return self.service.index(request)
 
     @router.get(
         "/api/tool_shed_repositories/check_for_updates",
@@ -485,3 +440,13 @@ class FastAPIToolShedRepositories:
     )
     def check_for_updates(self, id: Optional[DecodedDatabaseIdField] = None) -> CheckForUpdatesResponse:
         return self.service.check_for_updates(id and int(id))
+
+    @router.get(
+        "/api/tool_shed_repositories/{id}",
+        summary="Show installed tool shed repository.",
+    )
+    def show(
+        self,
+        id: DecodedDatabaseIdField = InstalledToolShedRepositoryIDPathParam,
+    ) -> InstalledToolShedRepository:
+        return self.service.show(id)

--- a/lib/galaxy/webapps/galaxy/services/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/services/tool_shed_repositories.py
@@ -1,9 +1,36 @@
-from typing import Optional
+from typing import (
+    List,
+    Optional,
+)
+
+from pydantic import BaseModel
+from sqlalchemy import (
+    and_,
+    cast,
+    Integer,
+)
 
 from galaxy.model.scoped_session import install_model_scoped_session
-from galaxy.schema.schema import CheckForUpdatesResponse
-from galaxy.tool_shed.util.repository_util import check_for_updates
+from galaxy.model.tool_shed_install import ToolShedRepository
+from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.schema import (
+    CheckForUpdatesResponse,
+    InstalledToolShedRepository,
+)
+from galaxy.tool_shed.util.repository_util import (
+    check_for_updates,
+    get_tool_shed_repository_by_decoded_id,
+)
 from galaxy.util.tool_shed.tool_shed_registry import Registry
+from galaxy.web import url_for
+
+
+class InstalledToolShedRepositoryIndexRequest(BaseModel):
+    name: Optional[str] = None
+    owner: Optional[str] = None
+    changeset: Optional[str] = None
+    deleted: Optional[bool] = None
+    uninstalled: Optional[bool] = None
 
 
 class ToolShedRepositoriesService:
@@ -15,6 +42,42 @@ class ToolShedRepositoriesService:
         self._install_model_context = install_model_context
         self._tool_shed_registry = tool_shed_registry
 
+    def index(self, request: InstalledToolShedRepositoryIndexRequest) -> List[InstalledToolShedRepository]:
+        clause_list = []
+        if request.name is not None:
+            clause_list.append(ToolShedRepository.table.c.name == request.name)
+        if request.owner is not None:
+            clause_list.append(ToolShedRepository.table.c.owner == request.owner)
+        if request.changeset is not None:
+            clause_list.append(ToolShedRepository.table.c.changeset_revision == request.changeset)
+        if request.deleted is not None:
+            clause_list.append(ToolShedRepository.table.c.deleted == request.deleted)
+        if request.uninstalled is not None:
+            clause_list.append(ToolShedRepository.table.c.uninstalled == request.uninstalled)
+        query = (
+            self._install_model_context.query(ToolShedRepository)
+            .order_by(ToolShedRepository.table.c.name)
+            .order_by(cast(ToolShedRepository.ctx_rev, Integer).desc())
+        )
+        if len(clause_list) > 0:
+            query = query.filter(and_(*clause_list))
+        index = []
+        for repository in query.all():
+            index.append(self._show(repository))
+        return index
+
+    def show(self, repository_id: DecodedDatabaseIdField) -> InstalledToolShedRepository:
+        tool_shed_repository = get_tool_shed_repository_by_decoded_id(self._install_model_context, int(repository_id))
+        return self._show(tool_shed_repository)
+
     def check_for_updates(self, repository_id: Optional[int]) -> CheckForUpdatesResponse:
         message, status = check_for_updates(self._tool_shed_registry, self._install_model_context, repository_id)
         return CheckForUpdatesResponse(message=message, status=status)
+
+    def _show(self, tool_shed_repository: ToolShedRepository) -> InstalledToolShedRepository:
+        tool_shed_repository_dict = tool_shed_repository.as_dict()
+        encoded_id = DecodedDatabaseIdField.encode(tool_shed_repository.id)
+        tool_shed_repository_dict["id"] = encoded_id
+        tool_shed_repository_dict["error_message"] = tool_shed_repository.error_message or ""
+        tool_shed_repository_dict["url"] = url_for("tool_shed_repositories", id=encoded_id)
+        return InstalledToolShedRepository(**tool_shed_repository_dict)

--- a/lib/galaxy_test/base/uses_shed_api.py
+++ b/lib/galaxy_test/base/uses_shed_api.py
@@ -1,4 +1,11 @@
+from typing import (
+    Any,
+    Callable,
+    Dict,
+)
 from unittest import SkipTest
+
+from requests import Response
 
 from galaxy.tool_util.verify.interactor import GalaxyInteractorApi
 from galaxy.util import unicodify
@@ -6,27 +13,29 @@ from galaxy_test.base.api_asserts import assert_status_code_is
 
 DEFAULT_TOOL_SHED_URL = "https://toolshed.g2.bx.psu.edu"
 
+OperationT = Callable[[Dict[str, Any]], Response]
+
 
 class UsesShedApi:
     @property
     def galaxy_interactor(self) -> GalaxyInteractorApi:
         ...
 
-    def delete_repo_request(self, payload):
+    def delete_repo_request(self, payload: Dict[str, Any]) -> Response:
         return self.galaxy_interactor._delete("tool_shed_repositories", data=payload, admin=True)
 
-    def install_repo_request(self, payload):
+    def install_repo_request(self, payload: Dict[str, Any]) -> Response:
         return self.galaxy_interactor._post(
             "tool_shed_repositories/new/install_repository_revision", data=payload, admin=True
         )
 
-    def repository_operation(self, operation, owner, name, changeset, tool_shed_url=DEFAULT_TOOL_SHED_URL):
+    def repository_operation(self, operation: OperationT, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL) -> Dict[str, Any]:
         payload = {"tool_shed_url": tool_shed_url, "name": name, "owner": owner, "changeset_revision": changeset}
         create_response = operation(payload)
         assert_status_code_is(create_response, 200)
         return create_response.json()
 
-    def install_repository(self, owner, name, changeset, tool_shed_url=DEFAULT_TOOL_SHED_URL):
+    def install_repository(self, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL) -> Dict[str, Any]:
         try:
             return self.repository_operation(
                 operation=self.install_repo_request,
@@ -40,7 +49,7 @@ class UsesShedApi:
                 raise SkipTest(f"Toolshed '{tool_shed_url}' unavailable")
             raise
 
-    def uninstall_repository(self, owner, name, changeset, tool_shed_url=DEFAULT_TOOL_SHED_URL):
+    def uninstall_repository(self, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL) -> Dict[str, Any]:
         return self.repository_operation(
             operation=self.delete_repo_request, owner=owner, name=name, changeset=changeset, tool_shed_url=tool_shed_url
         )

--- a/lib/galaxy_test/base/uses_shed_api.py
+++ b/lib/galaxy_test/base/uses_shed_api.py
@@ -4,6 +4,8 @@ from galaxy.tool_util.verify.interactor import GalaxyInteractorApi
 from galaxy.util import unicodify
 from galaxy_test.base.api_asserts import assert_status_code_is
 
+DEFAULT_TOOL_SHED_URL = "https://toolshed.g2.bx.psu.edu"
+
 
 class UsesShedApi:
     @property
@@ -18,13 +20,13 @@ class UsesShedApi:
             "tool_shed_repositories/new/install_repository_revision", data=payload, admin=True
         )
 
-    def repository_operation(self, operation, owner, name, changeset, tool_shed_url="https://toolshed.g2.bx.psu.edu"):
+    def repository_operation(self, operation, owner, name, changeset, tool_shed_url=DEFAULT_TOOL_SHED_URL):
         payload = {"tool_shed_url": tool_shed_url, "name": name, "owner": owner, "changeset_revision": changeset}
         create_response = operation(payload)
         assert_status_code_is(create_response, 200)
         return create_response.json()
 
-    def install_repository(self, owner, name, changeset, tool_shed_url="https://toolshed.g2.bx.psu.edu"):
+    def install_repository(self, owner, name, changeset, tool_shed_url=DEFAULT_TOOL_SHED_URL):
         try:
             return self.repository_operation(
                 operation=self.install_repo_request,
@@ -38,7 +40,7 @@ class UsesShedApi:
                 raise SkipTest(f"Toolshed '{tool_shed_url}' unavailable")
             raise
 
-    def uninstall_repository(self, owner, name, changeset, tool_shed_url="https://toolshed.g2.bx.psu.edu"):
+    def uninstall_repository(self, owner, name, changeset, tool_shed_url=DEFAULT_TOOL_SHED_URL):
         return self.repository_operation(
             operation=self.delete_repo_request, owner=owner, name=name, changeset=changeset, tool_shed_url=tool_shed_url
         )

--- a/lib/galaxy_test/base/uses_shed_api.py
+++ b/lib/galaxy_test/base/uses_shed_api.py
@@ -2,6 +2,8 @@ from typing import (
     Any,
     Callable,
     Dict,
+    List,
+    Optional,
 )
 from unittest import SkipTest
 
@@ -29,13 +31,17 @@ class UsesShedApi:
             "tool_shed_repositories/new/install_repository_revision", data=payload, admin=True
         )
 
-    def repository_operation(self, operation: OperationT, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL) -> Dict[str, Any]:
+    def repository_operation(
+        self, operation: OperationT, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL
+    ) -> Dict[str, Any]:
         payload = {"tool_shed_url": tool_shed_url, "name": name, "owner": owner, "changeset_revision": changeset}
         create_response = operation(payload)
         assert_status_code_is(create_response, 200)
         return create_response.json()
 
-    def install_repository(self, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL) -> Dict[str, Any]:
+    def install_repository(
+        self, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL
+    ) -> Dict[str, Any]:
         try:
             return self.repository_operation(
                 operation=self.install_repo_request,
@@ -49,7 +55,41 @@ class UsesShedApi:
                 raise SkipTest(f"Toolshed '{tool_shed_url}' unavailable")
             raise
 
-    def uninstall_repository(self, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL) -> Dict[str, Any]:
+    def uninstall_repository(
+        self, owner: str, name: str, changeset: str, tool_shed_url: str = DEFAULT_TOOL_SHED_URL
+    ) -> Dict[str, Any]:
         return self.repository_operation(
             operation=self.delete_repo_request, owner=owner, name=name, changeset=changeset, tool_shed_url=tool_shed_url
         )
+
+    def index_repositories(
+        self, owner: Optional[str] = None, name: Optional[str] = None, changeset: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        params: Dict[str, str] = {}
+        if owner is not None:
+            params["owner"] = owner
+        if name is not None:
+            params["name"] = name
+        if changeset is not None:
+            params["changeset"] = changeset
+        params["deleted"] = "false"
+        params["uninstalled"] = "false"
+        response = self.galaxy_interactor._get("tool_shed_repositories", params, admin=True)
+        response.raise_for_status()
+        return response.json()
+
+    def get_installed_repository_for(
+        self, owner: Optional[str] = None, name: Optional[str] = None, changeset: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        index = self.index_repositories(owner, name, changeset)
+        if len(index) == 0:
+            return None
+        elif len(index) > 1:
+            raise AssertionError(f"expected at most one repository in response {index}")
+        else:
+            return index[0]
+
+    def get_installed_repository(self, id: str) -> Dict[str, Any]:
+        response = self.galaxy_interactor._get(f"tool_shed_repositories/{id}", admin=True)
+        response.raise_for_status()
+        return response.json()

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -61,7 +61,7 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         self.uninstall_repository(*repo)
 
     def test_repository_update(self):
-        response = self._install_repository(revision=REVISION_4, version="0.0.3")[0]
+        response = self._install_repository(revision=REVISION_4, version="0.0.3", allow_upgraded=True)[0]
         assert int(response["ctx_rev"]) >= 4
         latest_revision = response["changeset_revision"]
         repo_response = self._get("/api/tool_shed_repositories/%s" % response["id"]).json()
@@ -100,12 +100,16 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
             shed_config.write(shed_text)
         self._get("/api/tool_shed_repositories/check_for_updates", data={"id": response["id"]}, admin=True).json()
         # At this point things should look like there is minor update available
-        repo_response = self._get("/api/tool_shed_repositories/%s" % response["id"]).json()
-        assert repo_response["tool_shed_status"]["revision_update"] == "True"
-        assert repo_response["changeset_revision"] == REVISION_3
-        assert repo_response["ctx_rev"] == "3"
+        repo_response = self._get("/api/tool_shed_repositories/%s" % response["id"])
+        repo_response.raise_for_status()
+        repo_json = repo_response.json()
+        assert repo_json["tool_shed_status"]["revision_update"] == "True"
+        assert repo_json["changeset_revision"] == REVISION_3
+        assert repo_json["ctx_rev"] == "3"
         # now install revision 4 (or newer) (a.k.a a minor update)
-        response = self._install_repository(revision=REVISION_4, version="0.0.3", verify_tool_absent=False)[0]
+        response = self._install_repository(
+            revision=REVISION_4, version="0.0.3", verify_tool_absent=False, allow_upgraded=True
+        )[0]
         assert response["changeset_revision"] == latest_revision
         assert response["installed_changeset_revision"] == REVISION_3
         # should be 4 or newer
@@ -120,14 +124,27 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
             "err_msg" in response
         ), f"Expected an error message after tool install but response was {response.content}"
         assert response["err_msg"]
+        assert self.get_installed_repository_for(REPO.owner, REPO.name, REPO.changeset) is None
 
-    def _install_repository(self, revision=None, version="0.0.2", verify_tool_absent=True):
+    def _install_repository(self, revision=None, version="0.0.2", verify_tool_absent=True, allow_upgraded=False):
         if verify_tool_absent:
             response = self.get_tool(assert_ok=False)
             assert response["err_msg"]
-        install_response = self.install_repository(REPO.owner, REPO.name, revision or REPO.changeset)
+        owner = REPO.owner
+        name = REPO.name
+        revision = revision or REPO.changeset
+        install_response = self.install_repository(owner, name, revision)
         tool = self.get_tool()
         assert tool.get("version") == version, tool
+        if not allow_upgraded:
+            install_repository = self.get_installed_repository_for(owner, name, revision)
+            assert install_repository
+            assert self.get_installed_repository(install_repository["id"])
+        else:
+            # Maybe there was a newer changeset with the same version - that is fine, just make
+            # sure we installed this repo at some version.
+            installed_repositories = self.index_repositories(owner, name)
+            assert len(installed_repositories) > 0
         return install_response
 
     def get_tool(self, assert_ok=True):


### PR DESCRIPTION
Builds on infrastructure setup in #14719

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
