### PR TITLE
Extend security docs

### DIFF
--- a/doc/source/admin/security.md
+++ b/doc/source/admin/security.md
@@ -3,9 +3,9 @@
 ### Protect Galaxy against data loss due to misbehaving tools
 
 Tools have access to the paths of input and output data sets which are stored in
-``file_path``. If tools use reference data stored in data tables also data in
+``file_path``. If tools use reference data stored in data tables, they have access also to data in
 ``tool_data_path`` and ``shed_tool_data_path`` (plus data referred in hand
-crafted data tables and refgenie configuration). 
+crafted loc files and refgenie configuration). 
 
 By default the credentials used for running tools are the same as for running
 Galaxy. Thus it is possible that a tool modifies data in Galaxy's ``file_path``.
@@ -20,6 +20,6 @@ There are three approaches to protect Galaxy against these risks:
 
 - Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will execute in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
 - Use [Pulsar](https://pulsar.readthedocs.io/) to stage inputs and outputs.
-- If containers or pulsar are not an option the following strategy is suggested. Use different credentials for running tools which can be configured using the ``real_system_username`` config variable. Note that this implies ``outputs_to_working_directory``. Furthermore (in particular) ``file_path``, ``tool_data_path`` should be made writable only by the user running Galaxy. 
+- If containers and Pulsar are not an option, it is possible to use different credentials for running tools. This can be configured using the ``real_system_username`` config variable. Note that this implies ``outputs_to_working_directory``. Furthermore, check that files in directories like ``file_path`` and ``tool_data_path`` are writable only by the user running Galaxy. 
 
 More information on pulsar configuration can be found in the [job configuration](jobs.md) documentation, and the other two are explained in [using a compute cluster](cluster.md).

--- a/doc/source/admin/security.md
+++ b/doc/source/admin/security.md
@@ -20,6 +20,6 @@ There are three approaches to protect Galaxy against these risks:
 
 - Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will execute in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
 - Use [Pulsar](https://pulsar.readthedocs.io/) to stage inputs and outputs.
-- If containers and Pulsar are not an option, it is possible to use different credentials for running tools. This can be configured using the ``real_system_username`` config variable. Note that this implies ``outputs_to_working_directory``. Furthermore, check that files in directories like ``file_path`` and ``tool_data_path`` are writable only by the user running Galaxy. 
+- If containers and Pulsar are not an option, it is possible to use different credentials for running tools. This can be configured using the ``real_system_username`` config variable. Note that you also need to enable ``outputs_to_working_directory`` when enabling ``real_system_username``. Furthermore, check that files in directories like ``file_path`` and ``tool_data_path`` are writable only by the user running Galaxy. 
 
 More information on pulsar configuration can be found in the [job configuration](jobs.md) documentation, and the other two are explained in [using a compute cluster](cluster.md).

--- a/doc/source/admin/security.md
+++ b/doc/source/admin/security.md
@@ -3,9 +3,13 @@
 ### Protect Galaxy against data loss due to misbehaving tools
 
 Tools have access to the paths of input and output data sets which are stored in
-``file_path`` and by default the credentials used for running tools are the same
-as for running Galaxy. Thus it is possible that a tool modifies data in Galaxy's
-``file_path``. Examples of such potential changes are:
+``file_path``. If tools use reference data stored in data tables also data in
+``tool_data_path`` and ``shed_tool_data_path`` (plus data referred in hand
+crafted data tables and refgenie configuration). 
+
+By default the credentials used for running tools are the same as for running
+Galaxy. Thus it is possible that a tool modifies data in Galaxy's ``file_path``.
+Examples of such potential changes are:
 
 - Creation of additional files, e.g. indices, which is a problem for cleaning up data, because Galaxy does not know about these files.
 - Removal of tool input or output files. This will create problems with other tools using these datasets (note that most tool repositories use CI tests to to avoid this, but the problem may still occur).
@@ -14,7 +18,7 @@ Note that a tool only knows the paths to its inputs and outputs, but if using th
 
 There are three approaches to protect Galaxy against these risks:
 
-- Use different credentials for running tools. This can be configured using the ``real_system_username`` config variable.
+- Use different credentials for running tools and make ``file_path``, ``tool_data_path`` writable only by the user running Galaxy. This can be configured using the ``real_system_username`` config variable. Note that this implies ``outputs_to_working_directory``.
 - Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will execute in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
 - Use [Pulsar](https://pulsar.readthedocs.io/) to stage inputs and outputs.
 

--- a/doc/source/admin/security.md
+++ b/doc/source/admin/security.md
@@ -18,8 +18,8 @@ Note that a tool only knows the paths to its inputs and outputs, but if using th
 
 There are three approaches to protect Galaxy against these risks:
 
-- Use different credentials for running tools and make ``file_path``, ``tool_data_path`` writable only by the user running Galaxy. This can be configured using the ``real_system_username`` config variable. Note that this implies ``outputs_to_working_directory``.
 - Configure Galaxy to run jobs in a container and enable ``outputs_to_working_directory``. Then the tool will execute in an environment that allows write access only for the job working dir. All other paths will be accessible read only. 
 - Use [Pulsar](https://pulsar.readthedocs.io/) to stage inputs and outputs.
+- If containers or pulsar are not an option the following strategy is suggested. Use different credentials for running tools which can be configured using the ``real_system_username`` config variable. Note that this implies ``outputs_to_working_directory``. Furthermore (in particular) ``file_path``, ``tool_data_path`` should be made writable only by the user running Galaxy. 
 
 More information on pulsar configuration can be found in the [job configuration](jobs.md) documentation, and the other two are explained in [using a compute cluster](cluster.md).


### PR DESCRIPTION
by adding data referred by data tables



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
