### PR TITLE
Accessibility issue fixes in workflow list/import interfaces

### DIFF
--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -17,6 +17,8 @@
                 size="sm"
                 :pressed="showAdvanced"
                 :variant="showAdvanced ? 'info' : 'secondary'"
+                :title="titleAdvanced | l"
+                data-description="toggle advanced search"
                 @click="onToggle">
                 <icon v-if="showAdvanced" icon="angle-double-up" />
                 <icon v-else icon="angle-double-down" />
@@ -68,6 +70,7 @@ export default {
             queryTimer: null,
             queryCurrent: null,
             titleClear: "clear search (esc)",
+            titleAdvanced: "toggle advanced search",
         };
     },
     watch: {

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -14,10 +14,10 @@
                     </b-button>
                     <b-button
                         v-else
+                        v-b-modal:copy-history-modal
                         size="sm"
                         variant="outline-info"
-                        title="Import this history"
-                        v-b-modal:copy-history-modal>
+                        title="Import this history">
                         Import this history
                     </b-button>
                 </div>
@@ -29,10 +29,10 @@
                     @view-collection="onViewCollection" />
                 <HistoryPanel
                     v-else
-                    v-on="handlers"
                     :history="history"
                     :writable="user.id == history.user_id"
                     :show-controls="false"
+                    v-on="handlers"
                     @view-collection="onViewCollection" />
                 <CopyModal id="copy-history-modal" :history="history" />
             </div>

--- a/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
@@ -60,16 +60,16 @@ export default {
             modelInputs: this.model.inputs,
         };
     },
+    computed: {
+        icon() {
+            return WorkflowIcons[this.model.step_type];
+        },
+    },
     watch: {
         validationScrollTo() {
             if (this.validationScrollTo.length > 0) {
                 this.expanded = true;
             }
-        },
-    },
-    computed: {
-        icon() {
-            return WorkflowIcons[this.model.step_type];
         },
     },
     methods: {

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -22,7 +22,11 @@
             icon="link" />
         <p v-if="workflow.description" class="workflow-dropdown-description">{{ workflow.description }}</p>
         <div class="dropdown-menu" aria-labelledby="workflow-dropdown">
-            <a v-if="!readOnly" class="dropdown-item" @click.prevent="$router.push(urlEdit)">
+            <a
+                v-if="!readOnly"
+                class="dropdown-item"
+                @keypress="$router.push(urlEdit)"
+                @click.prevent="$router.push(urlEdit)">
                 <span class="fa fa-edit fa-fw mr-1" />
                 <span v-localize>Edit</span>
             </a>
@@ -30,7 +34,11 @@
                 <span class="fa fa-copy fa-fw mr-1" />
                 <span v-localize>Copy</span>
             </a>
-            <a v-if="!readOnly" class="dropdown-item" @click.prevent="$router.push(urlInvocations)">
+            <a
+                v-if="!readOnly"
+                class="dropdown-item"
+                @keypress="$router.push(urlInvocations)"
+                @click.prevent="$router.push(urlInvocations)">
                 <span class="fa fa-list fa-fw mr-1" />
                 <span v-localize>Invocations</span>
             </a>
@@ -42,7 +50,11 @@
                 <span class="fa fa-signature fa-fw mr-1" />
                 <span v-localize>Rename</span>
             </a>
-            <a v-if="!readOnly" class="dropdown-item" @click.prevent="$router.push(urlShare)">
+            <a
+                v-if="!readOnly"
+                class="dropdown-item"
+                @keypress="$router.push(urlShare)"
+                @click.prevent="$router.push(urlShare)">
                 <span class="fa fa-share-alt fa-fw mr-1" />
                 <span v-localize>Share</span>
             </a>

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -1,7 +1,6 @@
 <template>
     <div>
         <b-link
-            id="workflow-dropdown"
             class="workflow-dropdown font-weight-bold"
             data-toggle="dropdown"
             aria-haspopup="true"

--- a/client/src/components/Workflow/WorkflowImport.vue
+++ b/client/src/components/Workflow/WorkflowImport.vue
@@ -4,7 +4,11 @@
             <b-alert :show="hasErrorMessage" variant="danger">{{ errorMessage }}</b-alert>
             <p>Please provide a Galaxy workflow export URL or a workflow file.</p>
             <b-form-group label="Archived Workflow URL">
-                <b-form-input id="workflow-import-url-input" v-model="sourceURL" type="url" />
+                <b-form-input
+                    id="workflow-import-url-input"
+                    v-model="sourceURL"
+                    aria-label="Workflow Import URL"
+                    type="url" />
                 If the workflow is accessible via a URL, enter the URL above and click Import.
             </b-form-group>
             <b-form-group label="Archived Workflow File">


### PR DESCRIPTION
Fixes a reused identifier in the workflow dropdown.
Adds keypress handlers for click-based routing in workflow dropdown.
Adds an aria label for text input on import -- there's a form group title that behaves as a label, but without an explicit label this is a violation.

Includes a bonus a11y fixi for sr text for the new advanced tool search toggle.
And some linting tweaks.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
