### PR TITLE
Update history size tooltip

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -2,7 +2,7 @@
     <div class="history-size my-1 d-flex justify-content-between">
         <b-button
             v-b-tooltip.hover
-            title="Access Dashboard"
+            title="History Size"
             variant="link"
             size="sm"
             class="rounded-0 text-decoration-none"


### PR DESCRIPTION
Addressing following user feedback:

"We believe the on hover label (“Access Dashboard”) and directing the user to the storage dashboard here is a bit confusing. The amount here is representative of the total size of the history, not the user’s total storage allocation, however when the user clicks, it takes them to the storage dashboard with their storage allocation, not their history size. I think the label should say “History size” and if it directs the user to the storage dashboard it should represent that history size in a consumable way."

We need to follow up more on contextualizing the dashboard entrypoint after adding more functionality, but this change clarifies the tooltip.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
