### PR TITLE
[22.05] Fix tool recommendations display

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -101,6 +101,7 @@ import FormDisplay from "components/Form/FormDisplay";
 import FormElement from "components/Form/FormElement";
 import ToolEntryPoints from "components/ToolEntryPoints/ToolEntryPoints";
 import ToolSuccess from "./ToolSuccess";
+import ToolRecommendation from "../ToolRecommendation";
 import UserHistories from "components/providers/UserHistories";
 import Webhook from "components/Common/Webhook";
 
@@ -115,6 +116,7 @@ export default {
         FormElement,
         ToolEntryPoints,
         ToolSuccess,
+        ToolRecommendation,
         UserHistories,
         Webhook,
     },


### PR DESCRIPTION
I've noticed that tool recommendations are no longer displayed after executing a tool, on usegalaxy.fr/.eu/.org
After debugging on .fr, I found a problem in the Vue code, fixed in this PR hopefully = the recommendation component was not imported

I tested this on 22.01, but it seems to be still present in 22.05 and dev too

(also, not sure it's relevant, but I had to update manually the httplib2 package in galaxy virtualenv because of an incompatibility with pyparsing >3.0 https://github.com/httplib2/httplib2/issues/207)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. execute a tool on an instance where tool recommendations are enabled
  2. the recommendations should display with this patch

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
