### PR TITLE
Do not load sample config file; assign correct config paths

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -45,7 +45,6 @@ from galaxy.util.custom_logging import LOGLV_TRACE
 from galaxy.util.dynamic import HasDynamicProperties
 from galaxy.util.facts import get_facts
 from galaxy.util.properties import (
-    find_config_file,
     read_properties_from_file,
     running_from_source,
 )
@@ -285,7 +284,7 @@ class BaseAppConfiguration(HasDynamicProperties):
 
     def _set_config_base(self, config_kwargs):
         def _set_global_conf():
-            self.config_file = find_config_file("galaxy")
+            self.config_file = config_kwargs.get("__file__", None)
             self.global_conf = config_kwargs.get("global_conf")
             self.global_conf_parser = configparser.ConfigParser()
             if not self.config_file and self.global_conf and "__file__" in self.global_conf:

--- a/lib/galaxy/main_config.py
+++ b/lib/galaxy/main_config.py
@@ -24,17 +24,17 @@ def default_relative_config_paths_for(app_name: str) -> List[str]:
     return paths
 
 
-def absolute_config_path(path, galaxy_root):
-    if path and not os.path.isabs(path):
+def absolute_config_path(path, galaxy_root: Optional[str]) -> Optional[str]:
+    if path and not os.path.isabs(path) and galaxy_root:
         path = os.path.join(galaxy_root, path)
     return path
 
 
-def config_is_ini(config_file):
-    return config_file and (config_file.endswith(".ini") or config_file.endswith(".ini.sample"))
+def config_is_ini(config_file: Optional[str]) -> bool:
+    return bool(config_file and (config_file.endswith(".ini") or config_file.endswith(".ini.sample")))
 
 
-def find_config(supplied_config, galaxy_root, app_name="galaxy"):
+def find_config(supplied_config: Optional[str], galaxy_root: Optional[str], app_name: str = "galaxy") -> Optional[str]:
     if supplied_config:
         return supplied_config
 

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -11,13 +11,6 @@ def appconfig():
     return config.GalaxyAppConfiguration(override_tempdir=False)
 
 
-@pytest.fixture
-def mock_config_file(monkeypatch):
-    # Set this to return None to force the creation of base config directories
-    # in _set_config_directories(). Used to test the values of these directories only.
-    monkeypatch.setattr(config, "find_config_file", lambda x: None)
-
-
 def test_root(appconfig):
     assert appconfig.root == os.path.abspath(".")
 
@@ -31,7 +24,7 @@ def test_common_base_config(appconfig):
     assert appconfig.sample_config_dir == expected_path
 
 
-def test_base_config_if_running_from_source(monkeypatch, mock_config_file):
+def test_base_config_if_running_from_source(monkeypatch):
     # Simulated condition: running from source, config_file is None.
     monkeypatch.setattr(config, "running_from_source", True)
     appconfig = config.GalaxyAppConfiguration(override_tempdir=False)
@@ -41,7 +34,7 @@ def test_base_config_if_running_from_source(monkeypatch, mock_config_file):
     assert appconfig.managed_config_dir == appconfig.config_dir
 
 
-def test_base_config_if_running_not_from_source(monkeypatch, mock_config_file):
+def test_base_config_if_running_not_from_source(monkeypatch):
     # Simulated condition: running not from source, config_file is None.
     monkeypatch.setattr(config, "running_from_source", False)
     appconfig = config.GalaxyAppConfiguration(override_tempdir=False)


### PR DESCRIPTION
Fixes #14633: when `GALAXY_CONFIG_FILE` is set, there will be no warning message that config file was not found.

This also solves 2 bigger problems:
1. Previously, if a config file was not set and the default config did not exist (e.g. starting up a clean clone), Galaxy would load the sample config file. This is no longer necessary: all defaults are loaded from the config schema. Besides, a sample config file should not be a requirement for starting the app, I think.

    This is solved by simply allowing the `__file__` attribute passed from `fast_factory.py` to be `None`, and excluding `galaxy.yml.samle` from the list of default config files in `main_config.py`. The same default values are loaded.

2. Previously, if the `GALAXY_CONFIG_FILE` was set to a location other than the default, the following happened:
    - `app.galaxy.config.config_file` was set to `None` if a default file did not exist, or to the default file's location if that file existed. Even though the config values were read from the correct config file, reloading the config at runtime would not work, since the correct config file would not be watched. (In addition, `config.config_file` is also referenced in `jobs/__init__.py` and `tools/actions/metadata.py`)
    - `config_dir` if not set, would be assigned the value of the parent directory *of the default config file's location* regardless of whether the default file was present or not. Furthermore, all the paths that are resolved with respect to `config_dir`, were set based on this incorrect value.

    This is solved by using the value of the `__file__` attribute as the initial location of the config file (instead of calling `find_confg_file()` once again). All config paths are now set correctly.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
1. insert a breakpoint at the end of GalaxyAppConfiguration [constructor](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/config/__init__.py#L728).
2. Run galaxy with default config: `GALAXY_CONFIG_FILE=config/galaxy.yml uvicorn --app-dir lib --factory galaxy.webapps.galaxy.fast_factory:factory`
3. Check the value of `self.config_file` and self.config_dir`
4. Repeat steps 2, 3 with a different config
5. Run galaxy without a config file: `GALAXY_ROOT_DIR=. uvicorn --app-dir lib --factory galaxy.webapps.galaxy.fast_factory:factory` with the default config present
6. Check the value of `self.config_file` and self.config_dir`
7. Remove the default config and repeat step 5, 6

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
