### PR TITLE
Improve galaxy version extra file loading.

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -797,10 +797,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             with open(json_file) as f:
                 extra_info = json.load(f)
         except OSError:
-            log.info("Galaxy extra version JSON file %s not loaded.", json_file)
+            log.debug("Galaxy extra version JSON file %s not loaded.", json_file)
         else:
             self.version_extra = extra_info
-
         # Database related configuration
         self.check_migrate_databases = string_as_bool(kwargs.get("check_migrate_databases", True))
         if not self.database_connection:  # Provide default if not supplied by user

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -796,10 +796,13 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         try:
             with open(json_file) as f:
                 extra_info = json.load(f)
-        except OSError:
-            log.debug("Galaxy extra version JSON file %s not loaded.", json_file)
+        except FileNotFoundError:
+            log.debug("No extra version JSON file detected at %s", json_file)
+        except ValueError:
+            log.error("Error loading Galaxy extra version JSON file %s - details not loaded.", json_file)
         else:
             self.version_extra = extra_info
+
         # Database related configuration
         self.check_migrate_databases = string_as_bool(kwargs.get("check_migrate_databases", True))
         if not self.database_connection:  # Provide default if not supplied by user


### PR DESCRIPTION
This wasn't as obvious before because we only loaded this when the endpoint was hit, but now that we display it on the about page #14461 we load this once at startup.

This fixes the exceptions that are caught and has a separate message for when the file simply isn't configured (not an error, DEBUG log), or when it's busted (an ERROR).

I know someone else mentioned this either on matrix or an issue, but I'm not seeing it now -- if someone recalls this please link it up.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
