### PR TITLE
do not split "." but the path

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -453,7 +453,7 @@ class Data(metaclass=DataMeta):
                 mime = mimetypes.guess_type(file_path)[0]
                 if not mime:
                     try:
-                        mime = trans.app.datatypes_registry.get_mimetype_by_extension(".".split(file_path)[-1])
+                        mime = trans.app.datatypes_registry.get_mimetype_by_extension(file_path.split(".")[-1])
                     except Exception:
                         mime = "text/plain"
                 self._clean_and_set_mime_type(trans, mime, headers)

--- a/lib/galaxy/datatypes/display_applications/parameters.py
+++ b/lib/galaxy/datatypes/display_applications/parameters.py
@@ -214,7 +214,7 @@ class DisplayParameterValueWrapper:
         if self.parameter.guess_mime_type:
             mime, encoding = mimetypes.guess_type(self._url)
             if not mime:
-                mime = self.trans.app.datatypes_registry.get_mimetype_by_extension(".".split(self._url)[-1], None)
+                mime = self.trans.app.datatypes_registry.get_mimetype_by_extension(self._url.split(".")[-1], None)
             if mime:
                 return mime
         return "text/plain"
@@ -269,10 +269,10 @@ class DisplayDataValueWrapper(DisplayParameterValueWrapper):
             if not mime:
                 if action_param_extra:
                     mime = self.trans.app.datatypes_registry.get_mimetype_by_extension(
-                        ".".split(action_param_extra)[-1], None
+                        action_param_extra.split(".")[-1], None
                     )
                 if not mime:
-                    mime = self.trans.app.datatypes_registry.get_mimetype_by_extension(".".split(self._url)[-1], None)
+                    mime = self.trans.app.datatypes_registry.get_mimetype_by_extension(self._url.split(".")[-1], None)
             if mime:
                 return mime
         if hasattr(self.value, "get_mime"):


### PR DESCRIPTION
Befor `get_mimetype_by_extension` always got `"."` resulting in `"application/octet-stream"`. The except branch starting in the next line should never have been active (I guess the idea was that its raised for filenames wo extension)... but also I would not use `"text/plain"` for binaries.

This is all quite odd. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
