### PR TITLE
improve UX of admin job page

### DIFF
--- a/client/src/components/admin/JobLock.vue
+++ b/client/src/components/admin/JobLock.vue
@@ -1,6 +1,6 @@
 <template>
-    <b-form-group label="Administrative Job Lock" label-for="prevent-job-dispatching">
-        <b-form-checkbox id="prevent-job-dispatching" v-model="jobLock" switch>
+    <b-form-group>
+        <b-form-checkbox id="prevent-job-dispatching" v-model="jobLock" switch size="lg">
             Job dispatching is currently
             <strong>{{ jobLockDisplay ? "locked" : "unlocked" }}</strong>
         </b-form-checkbox>

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -12,8 +12,8 @@
             completed jobs (in 'error' or 'ok' states).
         </p>
         <p>
-            You may choose to stop some of the displayed jobs and provide the user with message. Your stop message will
-            be displayed to the user as: "This job was stopped by an administrator:
+            You may choose to stop some of the displayed jobs and provide the user with a message. Your stop message
+            will be displayed to the user as: "This job was stopped by an administrator:
             <strong>&lt;YOUR MESSAGE&gt;</strong>
             For more information or help, report this error".
         </p>

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -4,44 +4,39 @@
         <b-alert v-if="message" :variant="status" show>
             {{ message }}
         </b-alert>
-        <p>
-            Unfinished jobs (in the state 'new', 'queued', 'running', or 'upload') and recently terminal jobs (in the
-            state 'error' or 'ok') are displayed on this page. The 'cutoff' input box will limit the display of jobs to
-            only those jobs that have had their state updated in the specified timeframe.
-        </p>
-        <p>
-            If any jobs are displayed, you may choose to stop them. Your stop message will be displayed to the user as:
-            "This job was stopped by an administrator: <strong>&lt;YOUR MESSAGE&gt;</strong> For more information or
-            help, report this error".
-        </p>
-        <h3>Job Control</h3>
+        <h3>Job Lock</h3>
         <job-lock />
-        <h3>Job Details</h3>
+        <h3>Job Overview</h3>
+        <p>
+            Below are displayed unfinished jobs (in the state 'new', 'queued', 'running', or 'upload') and recently
+            terminal jobs (in the state 'error' or 'ok').
+        </p>
+        <p>
+            You may choose to stop some of the displayed jobs and provide the user with message. Your stop message will
+            be displayed to the user as: "This job was stopped by an administrator: <strong>&lt;YOUR MESSAGE&gt;</strong>
+            For more information or help, report this error".
+        </p>
         <b-row>
             <b-col class="col-sm-4">
                 <b-form-group
-                    label="Filters"
-                    label-for="show-all-running"
-                    description="Select whether or not to use the cutoff, or show all jobs.">
-                    <b-form-checkbox id="show-all-running" v-model="showAllRunning" switch @change="update">
-                        {{ showAllRunning ? "Showing all currently running jobs" : "Time cutoff applied to query" }}
+                    description="Select whether or not to use the cutoff below.">
+                    <b-form-checkbox id="show-all-running" v-model="showAllRunning" switch size="lg" @change="update">
+                        {{ showAllRunning ? "Showing all unfinished jobs" : "Time cutoff applied to query" }}
                     </b-form-checkbox>
                 </b-form-group>
                 <b-form name="jobs" @submit.prevent="onRefresh">
                     <b-form-group
                         v-show="!showAllRunning"
                         id="cutoff"
-                        label="Cutoff time period"
-                        description="in minutes">
+                        label="Cutoff in minutes"
+                        description="Display jobs that had their state updated in the given time period.">
                         <b-input-group>
                             <b-form-input id="cutoff" v-model="cutoffMin" type="number"> </b-form-input>
                         </b-input-group>
                     </b-form-group>
                 </b-form>
                 <b-form-group
-                    label="Filter Jobs"
-                    label-for="filter-regex"
-                    description="by strings or regular expressions">
+                    description="Use strings or regular expressions to search jobs.">
                     <b-input-group id="filter-regex">
                         <b-form-input v-model="filter" placeholder="Type to Search" @keyup.esc.native="filter = ''" />
                     </b-input-group>

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -13,13 +13,13 @@
         </p>
         <p>
             You may choose to stop some of the displayed jobs and provide the user with message. Your stop message will
-            be displayed to the user as: "This job was stopped by an administrator: <strong>&lt;YOUR MESSAGE&gt;</strong>
+            be displayed to the user as: "This job was stopped by an administrator:
+            <strong>&lt;YOUR MESSAGE&gt;</strong>
             For more information or help, report this error".
         </p>
         <b-row>
             <b-col class="col-sm-4">
-                <b-form-group
-                    description="Select whether or not to use the cutoff below.">
+                <b-form-group description="Select whether or not to use the cutoff below.">
                     <b-form-checkbox id="show-all-running" v-model="showAllRunning" switch size="lg" @change="update">
                         {{ showAllRunning ? "Showing all unfinished jobs" : "Time cutoff applied to query" }}
                     </b-form-checkbox>
@@ -35,8 +35,7 @@
                         </b-input-group>
                     </b-form-group>
                 </b-form>
-                <b-form-group
-                    description="Use strings or regular expressions to search jobs.">
+                <b-form-group description="Use strings or regular expressions to search jobs.">
                     <b-input-group id="filter-regex">
                         <b-form-input v-model="filter" placeholder="Type to Search" @keyup.esc.native="filter = ''" />
                     </b-input-group>

--- a/client/src/components/admin/Jobs.vue
+++ b/client/src/components/admin/Jobs.vue
@@ -8,8 +8,8 @@
         <job-lock />
         <h3>Job Overview</h3>
         <p>
-            Below are displayed unfinished jobs (in the state 'new', 'queued', 'running', or 'upload') and recently
-            terminal jobs (in the state 'error' or 'ok').
+            Below unfinished jobs are displayed (in the 'new', 'queued', 'running', or 'upload' states) and recently
+            completed jobs (in 'error' or 'ok' states).
         </p>
         <p>
             You may choose to stop some of the displayed jobs and provide the user with message. Your stop message will


### PR DESCRIPTION
- remove the label-for attribute which was the cause of the UX bug when the switch would be triggered by click on the form-group label
- deduplicate and reorder the interface
- clarify some language

fixes #13774

<img width="903" alt="Galaxy___martenson" src="https://user-images.githubusercontent.com/1814954/194652597-6cab763e-7c13-47fa-bf49-5e5736b8a6ef.png">

## How to test the changes?
This page is available for the instance admins under `galaxy_url/admin/jobs`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
