### PR TITLE
feat: mamba support for mulled-build

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -42,7 +42,7 @@ end
 
 local conda_image = VAR.CONDA_IMAGE
 if conda_image == '' then
-    conda_image = 'continuumio/miniconda3:latest'
+    conda_image = 'quay.io/condaforge/mambaforge:latest'
 end
 
 local conda_bin = VAR.CONDA_BIN

--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -45,6 +45,7 @@ if conda_image == '' then
     conda_image = 'continuumio/miniconda3:latest'
 end
 
+local conda_bin = VAR.CONDA_BIN
 
 local singularity_image = VAR.SINGULARITY_IMAGE
 if singularity_image == '' then
@@ -87,7 +88,7 @@ inv.task('build')
     .using(conda_image)
         .withHostConfig({binds = bind_args})
         .run('/bin/sh', '-c', preinstall
-            .. 'conda install '
+            .. conda_bin .. ' install '
             .. channel_args .. ' '
             .. target_args
             .. ' --strict-channel-priority -p /usr/local --copy --yes '

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -306,7 +306,7 @@ def mull_targets(
                 # then only run conda install if mamba is not already installed.
                 mamba_test = "[ '[]' = \"$( conda list --json --full-name mamba )\" ]"
         conda_install = f"""conda install {verbose} --yes {" ".join(f"'{spec}'" for spec in specs)}"""
-        involucro_args.extend(["-set", f"PREINSTALL=if {mamba_test} ; then {conda_install} ; fi"]}
+        involucro_args.extend(["-set", f"PREINSTALL=if {mamba_test} ; then {conda_install} ; fi"])
 
     involucro_args.append(command)
     if test_files:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -304,7 +304,7 @@ def mull_targets(
             if mamba_version == "" and not specs:
                 # If nothing but mamba without a specific version is requested,
                 # then only run conda install if mamba is not already installed.
-                mamba_test = f"[ '[]' = \"$( conda list --json --full-name mamba )\" ]"
+                mamba_test = "[ '[]' = \"$( conda list --json --full-name mamba )\" ]"
         conda_install = f"""conda install {verbose} --yes {" ".join(f"'{spec}'" for spec in specs)}"""
         involucro_args.extend(["-set", f"PREINSTALL=if {mamba_test} ; then {conda_install} ; fi"]}
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -305,7 +305,7 @@ def mull_targets(
                 # If nothing but mamba without a specific version is requested,
                 # then only run conda install if mamba is not already installed.
                 mamba_test = "[ '[]' = \"$( conda list --json --full-name mamba )\" ]"
-        conda_install = f"""conda install {verbose} -c conda-forge --yes {" ".join(f"'{spec}'" for spec in specs)}"""
+        conda_install = f"""conda install {verbose} --yes {" ".join(f"'{spec}'" for spec in specs)}"""
         involucro_args.extend(["-set", f"PREINSTALL=if {mamba_test} ; then {conda_install} ; fi"])
 
     involucro_args.append(command)

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -305,7 +305,7 @@ def mull_targets(
                 # If nothing but mamba without a specific version is requested,
                 # then only run conda install if mamba is not already installed.
                 mamba_test = "[ '[]' = \"$( conda list --json --full-name mamba )\" ]"
-        conda_install = f"""conda install {verbose} --yes {" ".join(f"'{spec}'" for spec in specs)}"""
+        conda_install = f"""conda install {verbose} -c conda-forge --yes {" ".join(f"'{spec}'" for spec in specs)}"""
         involucro_args.extend(["-set", f"PREINSTALL=if {mamba_test} ; then {conda_install} ; fi"])
 
     involucro_args.append(command)

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -29,7 +29,7 @@ def test_base_image_for_targets(target, version, base_image):
 
 @pytest.mark.parametrize("use_mamba", [False, True])
 @external_dependency_management
-def test_mulled_build_files_cli(target, tmpdir):
+def test_mulled_build_files_cli(use_mamba, tmpdir):
     singularity_image_dir = tmpdir.mkdir("singularity image dir")
     target = build_target("zlib")
     mull_targets(

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -27,11 +27,18 @@ def test_base_image_for_targets(target, version, base_image):
     assert base_image_for_targets([target], conda_context) == base_image
 
 
+@pytest.mark.parametrize("use_mamba", [False, True])
 @external_dependency_management
-def test_mulled_build_files_cli(tmpdir):
+def test_mulled_build_files_cli(target, tmpdir):
     singularity_image_dir = tmpdir.mkdir("singularity image dir")
     target = build_target("zlib")
-    mull_targets([target], command="build-and-test", singularity=True, singularity_image_dir=singularity_image_dir)
+    mull_targets(
+        [target],
+        command="build-and-test",
+        singularity=True,
+        use_mamba=use_mamba,
+        singularity_image_dir=singularity_image_dir,
+    )
     assert singularity_image_dir.join("zlib").exists()
 
 


### PR DESCRIPTION
This PR adds two command line args to mulled-build: `--use-mamba` and `--mamba-version`. While the latter is analogous to the already existing `--conda-version` argument, the former enables the use of mamba for package installation in mulled-build, instead of conda.

### Rationale

By also using Mamba in mulled, as it already happens in normal builds for Bioconda and conda-forge, we avoid discrepancies in the solver which make it very hard to debug sudden failures in the mulled build. Further, mamba is much faster in solving. Hopefully this will also help with a timeout that we currently see when trying to build bioconda-utils (https://github.com/bioconda/bioconda-recipes/pull/37331).

Above error makes this PR a bit pressing. A quick review, merge, and release would be highly appreciated.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
