### PR TITLE
[22.01] Fix dataset provenance API when ``follow=False``

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/provenance.py
+++ b/lib/galaxy/webapps/galaxy/api/provenance.py
@@ -5,37 +5,35 @@ import logging
 
 from paste.httpexceptions import (
     HTTPBadRequest,
-    HTTPNotImplemented
+    HTTPNotImplemented,
 )
 
-from galaxy import (
-    web
-)
+from galaxy import web
 from galaxy.managers.hdas import HDAManager
-from . import BaseGalaxyAPIController, depends
+from galaxy.util import string_as_bool
+from . import (
+    BaseGalaxyAPIController,
+    depends,
+)
 
 log = logging.getLogger(__name__)
 
 
 class BaseProvenanceController(BaseGalaxyAPIController):
-    """
-    """
+    """ """
 
     @web.legacy_expose_api
     def index(self, trans, **kwd):
-        follow = kwd.get('follow', False)
+        follow = string_as_bool(kwd.get("follow", False))
         value = self._get_provenance(trans, self.provenance_item_class, kwd[self.provenance_item_id], follow)
         return value
 
     @web.legacy_expose_api
     def show(self, trans, elem_name, **kwd):
-        follow = kwd.get('follow', False)
-        value = self._get_provenance(trans, self.provenance_item_class, kwd[self.provenance_item_id], follow)
-        return value
+        raise HTTPNotImplemented()
 
     @web.legacy_expose_api
     def create(self, trans, tag_name, payload=None, **kwd):
-        payload = payload or {}
         raise HTTPNotImplemented()
 
     @web.legacy_expose_api

--- a/lib/galaxy_test/api/test_history_contents_provenance.py
+++ b/lib/galaxy_test/api/test_history_contents_provenance.py
@@ -1,5 +1,12 @@
-from galaxy_test.base.populators import DatasetPopulator
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    skip_without_tool,
+)
 from ._framework import ApiTestCase
+
+MINIMAL_PROV_KEYS = ("id", "uuid")
+OTHER_PROV_KEYS = ("job_id", "stdout", "stderr", "parameters", "tool_id")
+ALL_PROV_KEYS = MINIMAL_PROV_KEYS + OTHER_PROV_KEYS
 
 
 class TestProvenance(ApiTestCase):
@@ -8,9 +15,42 @@ class TestProvenance(ApiTestCase):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
-    def test_show_prov(self):
+    @skip_without_tool("cat1")
+    def test_get_prov(self):
         history_id = self.dataset_populator.new_history()
-        new_dataset1 = self.dataset_populator.new_dataset(history_id, content='for prov')
-        prov_response = self._get(f"histories/{history_id}/contents/{new_dataset1['id']}/provenance")
+        new_dataset1_id = self.dataset_populator.new_dataset(history_id, content="for prov")["id"]
+        inputs = {
+            "input1": {"src": "hda", "id": new_dataset1_id},
+        }
+        run_response = self.dataset_populator.run_tool("cat1", inputs=inputs, history_id=history_id)
+        output_hda_id = run_response["outputs"][0]["id"]
+        prov_response = self._get(f"histories/{history_id}/contents/{output_hda_id}/provenance")
         self._assert_status_code_is(prov_response, 200)
-        self._assert_has_keys(prov_response.json(), "job_id", "id", "stdout", "stderr", "parameters", "tool_id")
+        prov = prov_response.json()
+        # Check the top-level provenance info
+        self._assert_has_keys(prov, *ALL_PROV_KEYS)
+
+        # Check that the provenance info is not recursive when `follow` is not specified
+        prov_input1 = prov["parameters"]["input1"]
+        self._assert_has_keys(prov_input1, *MINIMAL_PROV_KEYS)
+        self._assert_not_has_keys(prov_input1, *OTHER_PROV_KEYS)
+
+        # Check that the provenance info is also not recursive when `follow=False`
+        prov_response = self._get(
+            f"histories/{history_id}/contents/{output_hda_id}/provenance",
+            {"follow": False},
+        )
+        self._assert_status_code_is(prov_response, 200)
+        prov2 = prov_response.json()
+        assert prov == prov2
+
+        # Check that the provenance info is recursive when `follow=True`
+        prov_response = self._get(
+            f"histories/{history_id}/contents/{output_hda_id}/provenance",
+            {"follow": True},
+        )
+        self._assert_status_code_is(prov_response, 200)
+        prov = prov_response.json()
+        self._assert_has_keys(prov, *ALL_PROV_KEYS)
+        prov_input1 = prov["parameters"]["input1"]
+        self._assert_has_keys(prov_input1, *ALL_PROV_KEYS)


### PR DESCRIPTION
Without the `string_as_bool()` fix, the updated test would fail at line 45 (`assert prov == prov2`) because the "False" string evaluates to `True`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
