### PR TITLE
Make HTTP request object available to `AuthManager`

### DIFF
--- a/doc/source/admin/authentication.md
+++ b/doc/source/admin/authentication.md
@@ -38,9 +38,9 @@ The provided sample configuration file has numerous commented out examples and s
 of documentation on configuring these plugins.
 
 It is relatively straight-forward to add a custom authenticator to the framework. In this example, we will demonstrate 
-a new authenticator based on LDAP authenticator that performs custom checks besides password verification for 
-authenticating a user to Galaxy instance. First, we will create authenticator source file in directory 
-`lib/galaxy/auth/providers/ldap_custom.py` with following content
+a new authenticator based on the LDAP authenticator that performs custom checks besides password verification for 
+authenticating a user on the Galaxy instance. First, we will create an authenticator source file
+`lib/galaxy/auth/providers/ldap_custom.py` with the following content:
 
 ```
 import logging
@@ -76,15 +76,15 @@ class LDAPCustom(LDAP):
             white_listed_ips = options.get("white-listed-ips")
             # Convert them into a list
             white_listed_ips = white_listed_ips.split(' ')
-            # Convert user remote IP into IPv4Network object
-            user_remote_ip_obj = ipaddress.IPv4Network(user_remote_ip)
+            # Convert user remote IP into IPv4Address object
+            user_remote_ip_obj = ipaddress.IPv4Address(user_remote_ip)
             white_listed_ip_objs = [ipaddress.IPv4Network(ip) for ip in white_listed_ip_objs]
             # Make sure white_listed_ip_objs is not empty
             if white_listed_ip_objs:
                 # Effectively we are checking if remote ip network subnet
                 # is subset of allowed subnets. If at least one subnet matches,
                 # we allow user to authenticate
-                allowed = any([user_remote_ip_obj.subnet_of(sn) for sn in white_listed_ip_objs])
+                allowed = any(user_remote_ip_obj in sn for sn in white_listed_ip_objs)
                 if not allowed:
                     log.info("LDAP authentication: User remote IP is not listed in whitelisted IPs")
                     return failure_mode, "", ""

--- a/lib/galaxy/auth/providers/__init__.py
+++ b/lib/galaxy/auth/providers/__init__.py
@@ -18,6 +18,12 @@ class AuthProvider(metaclass=abc.ABCMeta):
         """
         Check that the user credentials are correct.
 
+        Besides checking password, it is possible to perform custom checks
+        like filtering client remote IP address using request argument. We can
+        get the remote IP address of the client using request.remote_addr and
+        check if the IP is in whitelisted IPs and deny the authentication if
+        it is not.
+
         NOTE: Used within auto-registration to check it is ok to register this
         user.
 
@@ -29,6 +35,8 @@ class AuthProvider(metaclass=abc.ABCMeta):
         :type   password: str
         :param  options: options provided in auth_config_file
         :type   options: dict
+        :param  request: HTTP request object
+        :type   request: GalaxyWebTransaction.request
         :returns:   True: accept user, False: reject user and None: reject user
             and don't try any other providers.  str, str are the email and
             username to register with if accepting. The optional dict may
@@ -42,6 +50,12 @@ class AuthProvider(metaclass=abc.ABCMeta):
         Same as authenticate() method, except an User object is provided instead
         of a username.
 
+        Besides checking password, it is possible to perform custom checks
+        like filtering client remote IP address using request argument. We can
+        get the remote IP address of the client using request.remote_addr and
+        check if the IP is in whitelisted IPs and deny the authentication if
+        it is not.
+
         NOTE: used on normal login to check authentication and update user
         details if required.
 
@@ -51,6 +65,8 @@ class AuthProvider(metaclass=abc.ABCMeta):
         :type   password: str
         :param  options: options provided in auth_config_file
         :type   options: dict
+        :param  request: HTTP request object
+        :type   request: GalaxyWebTransaction.request
         :returns:   True: accept user, False: reject user and None: reject user
             and don't try any other providers
         :rtype:     bool

--- a/lib/galaxy/auth/providers/__init__.py
+++ b/lib/galaxy/auth/providers/__init__.py
@@ -14,7 +14,7 @@ class AuthProvider(metaclass=abc.ABCMeta):
         """Short string providing labelling this plugin"""
 
     @abc.abstractmethod
-    def authenticate(self, email, username, password, options):
+    def authenticate(self, email, username, password, options, request):
         """
         Check that the user credentials are correct.
 
@@ -37,7 +37,7 @@ class AuthProvider(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def authenticate_user(self, user, password, options):
+    def authenticate_user(self, user, password, options, request):
         """
         Same as authenticate() method, except an User object is provided instead
         of a username.

--- a/lib/galaxy/auth/providers/__init__.py
+++ b/lib/galaxy/auth/providers/__init__.py
@@ -19,7 +19,7 @@ class AuthProvider(metaclass=abc.ABCMeta):
         Check that the user credentials are correct.
 
         Besides checking password, it is possible to perform custom checks
-        like filtering client remote IP address using request argument. We can
+        like filtering client remote IP address using the request argument. We can
         get the remote IP address of the client using request.remote_addr and
         check if the IP is in whitelisted IPs and deny the authentication if
         it is not.
@@ -51,7 +51,7 @@ class AuthProvider(metaclass=abc.ABCMeta):
         of a username.
 
         Besides checking password, it is possible to perform custom checks
-        like filtering client remote IP address using request argument. We can
+        like filtering client remote IP address using the request argument. We can
         get the remote IP address of the client using request.remote_addr and
         check if the IP is in whitelisted IPs and deny the authentication if
         it is not.

--- a/lib/galaxy/auth/providers/alwaysreject.py
+++ b/lib/galaxy/auth/providers/alwaysreject.py
@@ -17,13 +17,13 @@ class AlwaysReject(AuthProvider):
 
     plugin_type = "alwaysreject"
 
-    def authenticate(self, email, username, password, options):
+    def authenticate(self, email, username, password, options, request):
         """
         See abstract method documentation.
         """
         return (None, "", "")
 
-    def authenticate_user(self, user, password, options):
+    def authenticate_user(self, user, password, options, request):
         """
         See abstract method documentation.
         """

--- a/lib/galaxy/auth/providers/ldap_ad.py
+++ b/lib/galaxy/auth/providers/ldap_ad.py
@@ -209,7 +209,7 @@ class LDAP(AuthProvider):
 
         return failure_mode, params
 
-    def authenticate(self, email, username, password, options):
+    def authenticate(self, email, username, password, options, request):
         """
         See abstract method documentation.
         """
@@ -275,11 +275,11 @@ class LDAP(AuthProvider):
         log.debug("LDAP authentication successful")
         return True
 
-    def authenticate_user(self, user, password, options):
+    def authenticate_user(self, user, password, options, request):
         """
         See abstract method documentation.
         """
-        return self.authenticate(user.email, user.username, password, options)[0]
+        return self.authenticate(user.email, user.username, password, options, request)[0]
 
 
 class ActiveDirectory(LDAP):

--- a/lib/galaxy/auth/providers/localdb.py
+++ b/lib/galaxy/auth/providers/localdb.py
@@ -15,13 +15,13 @@ class LocalDB(AuthProvider):
 
     plugin_type = "localdb"
 
-    def authenticate(self, email, username, password, options):
+    def authenticate(self, email, username, password, options, request):
         """
         See abstract method documentation.
         """
         return (False, "", "")  # it can never auto-create based of localdb (chicken-egg)
 
-    def authenticate_user(self, user, password, options):
+    def authenticate_user(self, user, password, options, request):
         """
         See abstract method documentation.
         """

--- a/lib/galaxy/auth/providers/pam_auth.py
+++ b/lib/galaxy/auth/providers/pam_auth.py
@@ -58,7 +58,7 @@ class PAM(AuthProvider):
 
     plugin_type = "PAM"
 
-    def authenticate(self, email, username, password, options):
+    def authenticate(self, email, username, password, options, request):
         pam_username = None
         auto_register_username = None
         auto_register_email = None
@@ -156,8 +156,8 @@ class PAM(AuthProvider):
             )
             return False, "", ""
 
-    def authenticate_user(self, user, password, options):
-        return self.authenticate(user.email, user.username, password, options)[0]
+    def authenticate_user(self, user, password, options, request):
+        return self.authenticate(user.email, user.username, password, options, request)[0]
 
 
 __all__ = ("PAM",)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -98,7 +98,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
 
         if message:
             return None, message
-        message, status = trans.app.auth_manager.check_registration_allowed(email, username, password)
+        message, status = trans.app.auth_manager.check_registration_allowed(email, username, password, trans.request)
         if message:
             return None, message
         if subscribe:
@@ -467,7 +467,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         else:
             user = self.by_id(self.app.security.decode_id(id))
             if user:
-                message = self.app.auth_manager.check_change_password(user, current)
+                message = self.app.auth_manager.check_change_password(user, current, trans.request)
                 if message:
                     return None, message
                 message = self.__set_password(trans, user, password, confirm)

--- a/lib/galaxy/webapps/galaxy/api/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/api/authenticate.py
@@ -55,4 +55,4 @@ class AuthenticationController(BaseGalaxyAPIController):
 
         :raises: ObjectNotFound, HTTPBadRequest
         """
-        return self.authentication_service.get_api_key(trans.environ)
+        return self.authentication_service.get_api_key(trans.environ, trans.request)

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -173,7 +173,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
             if trans.app.config.error_email_to is not None:
                 message += f" Contact: {trans.app.config.error_email_to}."
             return self.message_exception(trans, message, sanitize=False)
-        elif not trans.app.auth_manager.check_password(user, password):
+        elif not trans.app.auth_manager.check_password(user, password, trans.request):
             return self.message_exception(trans, "Invalid password.")
         elif trans.app.config.user_activation_on and not user.active:  # activation is ON and the user is INACTIVE
             if trans.app.config.activation_grace_period != 0:  # grace period is ON

--- a/lib/galaxy/webapps/galaxy/services/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/services/authenticate.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from galaxy import exceptions
 from galaxy.auth import AuthManager
+from galaxy.web.framework.base import Request
 from galaxy.managers.api_keys import ApiKeyManager
 from galaxy.managers.users import UserManager
 from galaxy.util import (
@@ -29,14 +30,14 @@ class AuthenticationService:
         self._auth_manager = auth_manager
         self._api_keys_manager = api_keys_manager
 
-    def get_api_key(self, environ: Dict[str, Any]) -> APIKeyResponse:
+    def get_api_key(self, environ: Dict[str, Any], request: Request) -> APIKeyResponse:
         auth_header = environ.get("HTTP_AUTHORIZATION")
         identity, password = self._decode_baseauth(auth_header)
         # check if this is an email address or username
         user = self._user_manager.get_user_by_identity(identity)
         if not user:
             raise exceptions.ObjectNotFound("The user does not exist.")
-        is_valid_user = self._auth_manager.check_password(user, password)
+        is_valid_user = self._auth_manager.check_password(user, password, request)
         if is_valid_user:
             key = self._api_keys_manager.get_or_create_api_key(user)
             return APIKeyResponse(api_key=key)

--- a/lib/galaxy/webapps/galaxy/services/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/services/authenticate.py
@@ -11,13 +11,13 @@ from pydantic import BaseModel
 
 from galaxy import exceptions
 from galaxy.auth import AuthManager
-from galaxy.web.framework.base import Request
 from galaxy.managers.api_keys import ApiKeyManager
 from galaxy.managers.users import UserManager
 from galaxy.util import (
     smart_str,
     unicodify,
 )
+from galaxy.web.framework.base import Request
 
 
 class APIKeyResponse(BaseModel):

--- a/lib/tool_shed/webapp/api/authenticate.py
+++ b/lib/tool_shed/webapp/api/authenticate.py
@@ -40,4 +40,4 @@ class ToolShedAuthenticationController(BaseShedAPIController):
 
         :raises: ObjectNotFound, HTTPBadRequest
         """
-        return self.authentication_service.get_api_key(trans.environ)
+        return self.authentication_service.get_api_key(trans.environ, trans.request)

--- a/lib/tool_shed/webapp/controllers/user.py
+++ b/lib/tool_shed/webapp/controllers/user.py
@@ -137,7 +137,9 @@ class User(BaseUser):
             status = "error"
         else:
             # check user is allowed to register
-            message, status = trans.app.auth_manager.check_registration_allowed(email, username, password)
+            message, status = trans.app.auth_manager.check_registration_allowed(
+                email, username, password, trans.request
+            )
             if not message:
                 # Create the user, save all the user info and login to Galaxy
                 if params.get("create_user_button", False):

--- a/test/unit/auth/test_auth.py
+++ b/test/unit/auth/test_auth.py
@@ -12,8 +12,10 @@ def test_localdb():
     user = User(email="testmail", username="tester")
     user.set_password_cleartext("test123")
     t = LocalDB()
-    reject = t.authenticate_user(user, "wrong", {"redact_username_in_logs": False})
-    accept = t.authenticate_user(user, "test123", {"redact_username_in_logs": False})
+    # Passing None as request object should not really mess up the tests as we
+    # are not using any logic related to request object in AuthManager
+    reject = t.authenticate_user(user, "wrong", {"redact_username_in_logs": False}, None)
+    accept = t.authenticate_user(user, "test123", {"redact_username_in_logs": False}, None)
     assert reject is False
     assert accept is True
     # Password must conform to policy (length etc)

--- a/test/unit/auth/test_auth.py
+++ b/test/unit/auth/test_auth.py
@@ -5,7 +5,7 @@ from galaxy.model import User
 
 def test_alwaysreject():
     t = AlwaysReject()
-    assert t.authenticate("testmail", "testuser", "secret", dict()) == (None, "", "")
+    assert t.authenticate("testmail", "testuser", "secret", dict(), None) == (None, "", "")
 
 
 def test_localdb():


### PR DESCRIPTION
This PR enhances the `AuthManager` slightly by making the HTTP request object available to the abstract class. The reason is that we might want to add some custom logic to existing authentication using this request object. In our case, we need to control the IP address of the client in the authentication and authorization flow. So the changes from this PR will expose request object to `authenticate` and `authenticate_user` methods of `AuthManager`. 

In principle, this PR does not add any custom logic to existing Auth providers.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  
## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
