### PR TITLE
[22.05] Fix disappearing right anchor

### DIFF
--- a/client/src/layout/panel.js
+++ b/client/src/layout/panel.js
@@ -143,7 +143,6 @@ const SidePanel = Backbone.View.extend({
             const whichSide = this.id;
             this.saved_size = this.$el.width();
             animation[whichSide] = -this.saved_size;
-            this.resize(0);
             this.$el.animate(animation, "fast", () => this.motionQueue--);
             animation[whichSide] = 0;
             this.$center().animate(animation, "fast", () => this.motionQueue--);


### PR DESCRIPTION
This fixes https://github.com/galaxyproject/galaxy/issues/14750.  The `resize(0)` bit was put in as a fix to prevent scrolling, but this doesn't seem to be an issue anymore in my testing with the rest of the layout.

When merging forward this whole file goes away and the issue is not present in component-based panel hiding.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. See linked issue.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
