### PR TITLE
Skip 2 unit tests if bio.tools is down

### DIFF
--- a/lib/galaxy/tool_util/unittest_utils/__init__.py
+++ b/lib/galaxy/tool_util/unittest_utils/__init__.py
@@ -1,10 +1,15 @@
+from functools import wraps
 from typing import (
+    Any,
     Callable,
     Dict,
     Optional,
     Union,
 )
+from unittest import SkipTest
 from unittest.mock import Mock
+
+import requests
 
 
 def mock_trans(has_user=True, is_admin=False):
@@ -26,3 +31,24 @@ def t_data_downloader_for(content: Union[Dict[Optional[str], bytes], bytes]) -> 
             return content
 
     return get_content
+
+
+def is_site_up(url: str) -> bool:
+    try:
+        response = requests.get(url, timeout=10)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def skip_if_site_down(url: str) -> Callable:
+    def method_wrapper(method: Callable):
+        @wraps(method)
+        def wrapped_method(*args, **kwargs) -> Any:
+            if not is_site_up(url):
+                raise SkipTest(f"Test depends on [{url}] being up and it appears to be down.")
+            return method(*args, **kwargs)
+
+        return wrapped_method
+
+    return method_wrapper

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -5,6 +5,7 @@ import urllib.parse
 import pytest
 from tusclient import client
 
+from galaxy.tool_util.unittest_utils import skip_if_site_down
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy_test.base.constants import (
     ONE_TO_SIX_ON_WINDOWS,
@@ -16,7 +17,6 @@ from galaxy_test.base.constants import (
 from galaxy_test.base.populators import (
     DatasetPopulator,
     skip_if_github_down,
-    skip_if_site_down,
     skip_without_datatype,
     stage_inputs,
     uses_test_history,

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -85,6 +85,7 @@ from galaxy.tool_util.cwl.util import (
     output_to_cwl_json,
     tool_response_to_output,
 )
+from galaxy.tool_util.unittest_utils import skip_if_site_down
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy.tool_util.verify.wait import (
     timeout_type,
@@ -186,26 +187,6 @@ def skip_without_datatype(extension):
         def wrapped_method(api_test_case, *args, **kwargs):
             _raise_skip_if(not has_datatype(api_test_case))
             method(api_test_case, *args, **kwargs)
-
-        return wrapped_method
-
-    return method_wrapper
-
-
-def is_site_up(url):
-    try:
-        response = requests.get(url, timeout=10)
-        return response.status_code == 200
-    except Exception:
-        return False
-
-
-def skip_if_site_down(url):
-    def method_wrapper(method):
-        @wraps(method)
-        def wrapped_method(*args, **kwargs):
-            _raise_skip_if(not is_site_up(url), f"Test depends on [{url}] being up and it appears to be down.")
-            method(*args, **kwargs)
 
         return wrapped_method
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -118,9 +118,9 @@ SKIP_FLAKEY_TESTS_ON_ERROR = os.environ.get("GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ER
 
 def flakey(method):
     @wraps(method)
-    def wrapped_method(test_case, *args, **kwargs):
+    def wrapped_method(*args, **kwargs):
         try:
-            method(test_case, *args, **kwargs)
+            method(*args, **kwargs)
         except unittest.SkipTest:
             raise
         except Exception:
@@ -203,9 +203,9 @@ def is_site_up(url):
 def skip_if_site_down(url):
     def method_wrapper(method):
         @wraps(method)
-        def wrapped_method(api_test_case, *args, **kwargs):
+        def wrapped_method(*args, **kwargs):
             _raise_skip_if(not is_site_up(url), f"Test depends on [{url}] being up and it appears to be down.")
-            method(api_test_case, *args, **kwargs)
+            method(*args, **kwargs)
 
         return wrapped_method
 

--- a/lib/galaxy_test/selenium/test_data_source_tools.py
+++ b/lib/galaxy_test/selenium/test_data_source_tools.py
@@ -1,4 +1,4 @@
-from galaxy_test.base.populators import skip_if_site_down
+from galaxy.tool_util.unittest_utils import skip_if_site_down
 from .framework import (
     managed_history,
     selenium_test,

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -33,8 +33,11 @@ include_package_data = True
 install_requires =
     galaxy-util>=22.1
     lxml
+    MarkupSafe
+    packaging
     pydantic
     PyYAML
+    requests
     sortedcontainers
     typing-extensions
 packages = find:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --doctest-continue-on-failure
+addopts = --doctest-continue-on-failure --verbosity=1
 asyncio_mode = auto
 log_level = DEBUG
 # Install pytest-memray and set memray to true here to enable memory profiling of tests

--- a/test/unit/tool_util/biotools/test_metadata_source.py
+++ b/test/unit/tool_util/biotools/test_metadata_source.py
@@ -4,6 +4,7 @@ from galaxy.tool_util.biotools.source import (
     get_biotools_metadata_source,
     GitContentBiotoolsMetadataSource,
 )
+from galaxy.tool_util.unittest_utils import skip_if_site_down
 from ._util import content_dir
 
 
@@ -17,6 +18,7 @@ def test_git_content():
     assert missing_entry is None
 
 
+@skip_if_site_down("https://bio.tools/")
 def test_api_content():
     metadata_source = ApiBiotoolsMetadataSource()
     bwa_entry = metadata_source.get_biotools_metadata("bwa")
@@ -27,6 +29,7 @@ def test_api_content():
     assert missing_entry is None
 
 
+@skip_if_site_down("https://bio.tools/")
 def test_cascade_content():
     config = BiotoolsMetadataSourceConfig()
     config.content_directory = content_dir


### PR DESCRIPTION
Also:
- Set default [verbosity](https://docs.pytest.org/en/7.1.x/how-to/output.html#verbosity) of pytest to 1. This is equivalent to the `-v` option, which e.g. shows each test inside a file as a separate line in the output, showing the reason why a test was skipped.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
