### PR TITLE
[22.05] Fix deleted library buttons visibility

### DIFF
--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -59,6 +59,7 @@
                     <textarea
                         v-if="row.item.editMode"
                         v-model="row.item.name"
+                        aria-label="Library name"
                         class="form-control input_library_name"
                         rows="3" />
 
@@ -90,7 +91,11 @@
                         icon="globe" />
                 </template>
                 <template v-slot:cell(buttons)="row">
-                    <b-button v-if="row.item.deleted" :title="'Undelete ' + row.item.name" @click="undelete(row.item)">
+                    <b-button
+                        v-if="row.item.deleted"
+                        size="sm"
+                        :title="'Undelete ' + row.item.name"
+                        @click="undelete(row.item)">
                         <font-awesome-icon icon="unlock" />
                         {{ titleUndelete }}
                     </b-button>
@@ -104,7 +109,7 @@
                         {{ titleSave }}
                     </b-button>
                     <b-button
-                        v-if="row.item.can_user_modify"
+                        v-if="row.item.can_user_modify && !row.item.deleted"
                         size="sm"
                         class="lib-btn edit_library_btn save_library_btn"
                         :title="`Edit ${row.item.name}`"
@@ -119,7 +124,7 @@
                         </div>
                     </b-button>
                     <b-button
-                        v-if="user.is_admin"
+                        v-if="user.is_admin && !row.item.deleted"
                         size="sm"
                         class="lib-btn permission_library_btn"
                         :title="'Permissions of ' + row.item.name"
@@ -128,7 +133,7 @@
                         Manage
                     </b-button>
                     <b-button
-                        v-if="user.is_admin && row.item.editMode"
+                        v-if="user.is_admin && row.item.editMode && !row.item.deleted"
                         size="sm"
                         class="lib-btn delete-lib-btn"
                         :title="`Delete ${row.item.name}`"


### PR DESCRIPTION
Fixes #14783

Also:
- Unify Undelete button size
- Fix aria-label warning

![Undelete-library](https://user-images.githubusercontent.com/46503462/195565131-f4b7dc94-6543-419b-a00d-bf5f7f15cea9.gif)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Follow the screencast or description in #14783

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
