### PR TITLE
Add a utility function that returns first available value for prefix+key set in the environment; fix bug

### DIFF
--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -31,6 +31,22 @@ from galaxy.util.path import (
 )
 
 
+def get_from_env(key: str, prefixes: Iterable[str], default: Optional[str] = None):
+    """
+    Return first available value for prefix+key set in the environment, or default.
+    An empty prefix is ignored.
+
+    Useful when we need to check against multiple prefixes sequentially,
+    returning the first available value.
+    """
+    for prefix in prefixes:
+        if prefix:
+            value = os.getenv(f"{prefix}{key}")
+            if value:
+                return value
+    return default
+
+
 def find_config_file(names, exts=None, dirs=None, include_samples=False):
     """Locate a config file in multiple directories, with multiple extensions.
 

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -14,6 +14,7 @@ from urllib.parse import (
 import pytest
 import requests
 
+from galaxy.util.properties import get_from_env
 from .api_asserts import (
     assert_error_code_is,
     assert_has_keys,
@@ -31,15 +32,8 @@ from .api_util import (
 from .interactor import TestCaseGalaxyInteractor as BaseInteractor
 
 CONFIG_PREFIXES = ["GALAXY_TEST_CONFIG_", "GALAXY_CONFIG_OVERRIDE_", "GALAXY_CONFIG_"]
-DEFAULT_CELERY_BROKER = "memory://"
-DEFAULT_CELERY_BACKEND = "rpc://localhost"
-for prefix in CONFIG_PREFIXES:
-    CELERY_BROKER = os.environ.get(f"{prefix}CELERY_BROKER", DEFAULT_CELERY_BROKER)
-    if CELERY_BROKER != DEFAULT_CELERY_BROKER:
-        break
-    CELERY_BACKEND = os.environ.get(f"{prefix}CELERY_BACKEND", DEFAULT_CELERY_BACKEND)
-    if CELERY_BACKEND != DEFAULT_CELERY_BACKEND:
-        break
+CELERY_BROKER = get_from_env("CELERY_BROKER", CONFIG_PREFIXES, "memory://")
+CELERY_BACKEND = get_from_env("CELERY_BACKEND", CONFIG_PREFIXES, "rpc://localhost")
 
 
 @pytest.fixture(scope="session")

--- a/test/unit/util/test_properties.py
+++ b/test/unit/util/test_properties.py
@@ -34,7 +34,7 @@ def test_get_from_env__empty_prefix_ignored(monkeypatch):
     monkeypatch.setenv("a", "a-without-prefix-is-set")
     assert os.getenv("a") == "a-without-prefix-is-set"
 
-    assert get_from_env("a", ["", None], "a-default") == "a-default"
+    assert get_from_env("a", ["", None], "a-default") == "a-default"  # type: ignore[list-item]
 
 
 @pytest.fixture

--- a/test/unit/util/test_properties.py
+++ b/test/unit/util/test_properties.py
@@ -1,8 +1,11 @@
+import os
+
 import pytest
 
 from galaxy.exceptions import InvalidFileFormatError
 from galaxy.util import properties
 from galaxy.util.properties import (
+    get_from_env,
     nice_config_parser,
     read_properties_from_file,
 )
@@ -10,6 +13,28 @@ from galaxy.util.properties import (
 KEY1, KEY2, KEY3, KEY4, KEY5, KEY6 = "k1", "k2", "k3", "k4", "k5", "k6"
 VAL1, VAL2, VAL3, VAL4, VAL5, VAL6 = 1, 2, 3, 4, 5, 6
 OTHER_SECTION = "other"
+
+
+def test_get_from_env(monkeypatch):
+    prefixes = ["pre1_", "pre2_", "pre3_"]
+
+    monkeypatch.setenv("pre1_a", "a-is-set")
+    monkeypatch.setenv("pre2_b", "b-is-set")
+
+    assert get_from_env("a", prefixes, "a-default") == "a-is-set"  # selected from first prefix
+    assert get_from_env("b", prefixes, "b-default") == "b-is-set"  # selected from second prefix
+    assert get_from_env("c", prefixes, "c-default") == "c-default"  # default
+
+
+def test_get_from_env__no_default(monkeypatch):
+    assert get_from_env("a", ["some", "random", "prefixes"]) is None
+
+
+def test_get_from_env__empty_prefix_ignored(monkeypatch):
+    monkeypatch.setenv("a", "a-without-prefix-is-set")
+    assert os.getenv("a") == "a-without-prefix-is-set"
+
+    assert get_from_env("a", ["", None], "a-default") == "a-default"
 
 
 @pytest.fixture


### PR DESCRIPTION
This fixes a bug in assigning values to `CELERY_BACKEND` and `CELERY_BROKER` in `galaxy_test/base/api.py`.

I've added a utility function + tests to handle similar cases. 
Note: the function sequentially checks a list of prefixes; however, if a prefix is empty (null or empty string), it will be ignored. The reason for that is that we don't want to accidentally assign a value based on a key that just happens to be set in the environment when we pass an empty prefix by mistake. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
