### PR TITLE
Fix ``test_get_alternative_versions`` unit test

### DIFF
--- a/test/unit/tool_util/mulled/test_get_tests.py
+++ b/test/unit/tool_util/mulled/test_get_tests.py
@@ -76,8 +76,8 @@ def test_open_recipe_file():
 
 @external_dependency_management
 def test_get_alternative_versions():
-    versions = get_alternative_versions("recipes/bamtools", "meta.yaml")
-    assert versions == ["recipes/bamtools/2.3.0/meta.yaml"]
+    versions = get_alternative_versions("recipes/bioblend", "meta.yaml")
+    assert versions == ["recipes/bioblend/0.7.0/meta.yaml"]
 
 
 @external_dependency_management


### PR DESCRIPTION
Fix the following error:

```
>       assert versions == ["recipes/bamtools/2.3.0/meta.yaml"]
E       AssertionError: assert [] == ['recipes/bam....0/meta.yaml']
E         Right contains one more item: 'recipes/bamtools/2.3.0/meta.yaml'
E         Full diff:
E         - ['recipes/bamtools/2.3.0/meta.yaml']
E         + []

test/unit/tool_util/mulled/test_get_tests.py:80: AssertionError
```

seen e.g. in https://github.com/galaxyproject/galaxy/actions/runs/3248610222/jobs/5330027550 and due to the removal of the `recipes/bamtools/2.3.0/meta.yaml` file in https://github.com/bioconda/bioconda-recipes/commit/b94d1bd9a146dcf0ddcf4224ffd265f17ff0a489#diff-d7df16f707f82264802dbbed7b281cb9a3d9053c21cd9bd79f3c8e56612bdc81

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
