### PR TITLE
Update tool recommendation API using transformers (neural network)

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4958,7 +4958,7 @@
 :Description:
     Set remote path of the trained model (HDF5 file) for tool
     recommendation.
-:Default: ``https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model.hdf5``
+:Default: ``https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model_v_0.2.hdf5``
 :Type: str
 
 
@@ -4969,7 +4969,7 @@
 :Description:
     Set the number of predictions/recommendations to be made by the
     model
-:Default: ``10``
+:Default: ``20``
 :Type: int
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2651,11 +2651,11 @@ galaxy:
 
   # Set remote path of the trained model (HDF5 file) for tool
   # recommendation.
-  #tool_recommendation_model_path: https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model.hdf5
+  #tool_recommendation_model_path: https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model_v_0.2.hdf5
 
   # Set the number of predictions/recommendations to be made by the
   # model
-  #topk_recommendations: 10
+  #topk_recommendations: 20
 
   # Set path to the additional tool preferences from Galaxy admins. It
   # has two blocks. One for listing deprecated tools which will be

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3614,14 +3614,14 @@ mapping:
 
       tool_recommendation_model_path:
         type: str
-        default: 'https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model.hdf5'
+        default: 'https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model_v_0.2.hdf5'
         required: false
         desc: |
           Set remote path of the trained model (HDF5 file) for tool recommendation.
 
       topk_recommendations:
         type: int
-        default: 10
+        default: 20
         required: false
         desc: |
           Set the number of predictions/recommendations to be made by the model

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -282,9 +282,6 @@ class ConditionalDependencies:
     def check_influxdb(self):
         return "influxdb" in self.error_report_modules
 
-    def check_keras(self):
-        return asbool(self.config["enable_tool_recommendations"])
-
     def check_tensorflow(self):
         return asbool(self.config["enable_tool_recommendations"])
 

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -47,7 +47,7 @@ pygithub
 influxdb
 
 # Deep learning packages for tool recommendation
-tensorflow==2.9.1
+tensorflow==2.9.3
 
 # weasyprint has problematic requirements (cairo, Pango, see:
 # https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#linux)

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -47,7 +47,7 @@ pygithub
 influxdb
 
 # Deep learning packages for tool recommendation
-tensorflow==2.7.2
+tensorflow==2.9.1
 
 # weasyprint has problematic requirements (cairo, Pango, see:
 # https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#linux)

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -18,6 +18,12 @@ log = logging.getLogger(__name__)
 
 
 class ToolRecommendations:
+    max_seq_len = 25
+    ff_dim = 128
+    embed_dim = 128
+    num_heads = 4
+    dropout = 0.1
+
     def __init__(self):
         self.tool_recommendation_model_path = None
         self.admin_tool_recommendations_path = None
@@ -30,11 +36,6 @@ class ToolRecommendations:
         self.loaded_model = None
         self.compatible_tools = None
         self.standard_connections = None
-        self.max_seq_len = 25
-        self.ff_dim = 128
-        self.embed_dim = 128
-        self.num_heads = 4
-        self.dropout = 0.1
         self.model_ok = None
 
     def create_transformer_model(self, vocab_size):
@@ -96,15 +97,15 @@ class ToolRecommendations:
                     log.exception(e)
                     return None
 
-        inputs = Input(shape=(self.max_seq_len,))
-        embedding_layer = TokenAndPositionEmbedding(self.max_seq_len, vocab_size, self.embed_dim)
+        inputs = Input(shape=(ToolRecommendations.max_seq_len,))
+        embedding_layer = TokenAndPositionEmbedding(ToolRecommendations.max_seq_len, vocab_size, ToolRecommendations.embed_dim)
         x = embedding_layer(inputs)
-        transformer_block = TransformerBlock(self.embed_dim, self.num_heads, self.ff_dim)
+        transformer_block = TransformerBlock(ToolRecommendations.embed_dim, ToolRecommendations.num_heads, ToolRecommendations.ff_dim)
         x, weights = transformer_block(x)
         x = GlobalAveragePooling1D()(x)
-        x = Dropout(self.dropout)(x)
-        x = Dense(self.ff_dim, activation="relu")(x)
-        x = Dropout(self.dropout)(x)
+        x = Dropout(ToolRecommendations.dropout)(x)
+        x = Dense(ToolRecommendations.ff_dim, activation="relu")(x)
+        x = Dropout(ToolRecommendations.dropout)(x)
         outputs = Dense(vocab_size, activation="sigmoid")(x)
         return Model(inputs=inputs, outputs=[outputs, weights])
 

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -38,9 +38,20 @@ class ToolRecommendations:
         self.model_ok = None
 
     def create_transformer_model(self, vocab_size):
-        from tensorflow.keras.layers import MultiHeadAttention, LayerNormalization, Dropout, Layer
-        from tensorflow.keras.layers import Embedding, Input, GlobalAveragePooling1D, Dense
-        from tensorflow.keras.models import Sequential, Model
+        from tensorflow.keras.layers import (
+            Dense,
+            Dropout,
+            Embedding,
+            GlobalAveragePooling1D,
+            Input,
+            Layer,
+            LayerNormalization,
+            MultiHeadAttention
+        )
+        from tensorflow.keras.models import (
+            Model,
+            Sequential
+        )
 
         class TransformerBlock(Layer):
             def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -98,9 +98,13 @@ class ToolRecommendations:
                     return None
 
         inputs = Input(shape=(ToolRecommendations.max_seq_len,))
-        embedding_layer = TokenAndPositionEmbedding(ToolRecommendations.max_seq_len, vocab_size, ToolRecommendations.embed_dim)
+        embedding_layer = TokenAndPositionEmbedding(
+            ToolRecommendations.max_seq_len, vocab_size, ToolRecommendations.embed_dim
+        )
         x = embedding_layer(inputs)
-        transformer_block = TransformerBlock(ToolRecommendations.embed_dim, ToolRecommendations.num_heads, ToolRecommendations.ff_dim)
+        transformer_block = TransformerBlock(
+            ToolRecommendations.embed_dim, ToolRecommendations.num_heads, ToolRecommendations.ff_dim
+        )
         x, weights = transformer_block(x)
         x = GlobalAveragePooling1D()(x)
         x = Dropout(ToolRecommendations.dropout)(x)

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -369,13 +369,10 @@ class ToolRecommendations:
             # predict next tools for a test path
             try:
                 # use the same graph and session to predict
-                #with self.graph.as_default():
-                #with self.session.as_default():
                 print("tool_sequence: ", tool_sequence)
                 print("sample: ", sample)
                 sample = tf.convert_to_tensor(sample, dtype=tf.int64)
                 prediction, _ = self.loaded_model(sample, training=False)
-                #prediction = self.loaded_model.predict(sample)
                 print("Prediction: ", prediction)
             except Exception as e:
                 log.exception(e)
@@ -383,23 +380,13 @@ class ToolRecommendations:
             # get dimensions
             nw_dimension = prediction.shape[1]
             prediction = np.reshape(prediction, (nw_dimension,))
-            half_len = int(nw_dimension / 2)
             # get recommended tools from published workflows
             pub_t, pub_v = self.__separate_predictions(
                 self.standard_connections, prediction, last_tool_name, weight_values, topk
             )
-            # get recommended tools from normal workflows
-            '''c_t, c_v = self.__separate_predictions(
-                self.compatible_tools, prediction, last_tool_name, weight_values, topk
-            )'''
-            # combine predictions coming from different workflows
-            # promote recommended tools coming from published workflows
-            # to the top and then show other recommendations
-            #pub_t.extend(c_t)
-            #pub_v.extend(c_v)
             # remove duplicates if any
             pub_t = list(dict.fromkeys(pub_t))
-            #pub_v = list(dict.fromkeys(pub_v))
+            pub_v = list(dict.fromkeys(pub_v))
             prediction_data = self.__filter_tool_predictions(trans, prediction_data, pub_t, pub_v, last_tool_name)
             print("prediction_data: ", prediction_data)
         return prediction_data

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -53,7 +53,7 @@ class ToolRecommendations:
                 Model,
                 Sequential,
             )
-        except Exception e:
+        except Exception as e:
             log.exception(e)
             return None
 
@@ -92,7 +92,7 @@ class ToolRecommendations:
                     positions = self.pos_emb(positions)
                     x = self.token_emb(x)
                     return x + positions
-                except Exception e:
+                except Exception as e:
                     log.exception(e)
                     return None
 

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -46,12 +46,9 @@ class ToolRecommendations:
             Input,
             Layer,
             LayerNormalization,
-            MultiHeadAttention
+            MultiHeadAttention,
         )
-        from tensorflow.keras.models import (
-            Model,
-            Sequential
-        )
+        from tensorflow.keras.models import Model, Sequential
 
         class TransformerBlock(Layer):
             def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -46,14 +46,8 @@ class ToolRecommendations:
         class TransformerBlock(Layer):
             def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
                 super(TransformerBlock, self).__init__()
-                self.att = MultiHeadAttention(num_heads=num_heads,
-                    key_dim=embed_dim,
-                    dropout=rate,
-                )
-                self.ffn = Sequential(
-                    [Dense(ff_dim, activation="relu"),
-                    Dense(embed_dim),]
-                )
+                self.att = MultiHeadAttention(num_heads=num_heads, key_dim=embed_dim, dropout=rate)
+                self.ffn = Sequential([Dense(ff_dim, activation="relu"), Dense(embed_dim)])
                 self.layernorm1 = LayerNormalization(epsilon=1e-6)
                 self.layernorm2 = LayerNormalization(epsilon=1e-6)
                 self.dropout1 = Dropout(rate)
@@ -66,7 +60,6 @@ class ToolRecommendations:
                 ffn_output = self.ffn(out1)
                 ffn_output = self.dropout2(ffn_output, training=training)
                 return self.layernorm2(out1 + ffn_output), attention_scores
-
 
         class TokenAndPositionEmbedding(Layer):
             def __init__(self, maxlen, vocab_size, embed_dim):
@@ -109,7 +102,6 @@ class ToolRecommendations:
         """
         Create model and associated dictionaries for recommendations
         """
-        #import tensorflow as tf
         self.tool_recommendation_model_path = self.__download_model(remote_model_url)
         model_file = h5py.File(self.tool_recommendation_model_path, "r")
         self.reverse_dictionary = json.loads(model_file["reverse_dict"][()].decode("utf-8"))
@@ -251,7 +243,6 @@ class ToolRecommendations:
         """
         Get predicted tools. If predicted tools are less in number, combine them with published tools
         """
-        final_pred = list()
         t_intersect = list(set(predictions).intersection(set(base_tools)))
         t_diff = list(set(predictions).difference(set(base_tools)))
         t_intersect, u_intersect = self.__sort_by_usage(t_intersect, self.tool_weights_sorted, self.model_data_dictionary)

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -7,7 +7,6 @@ import os
 import h5py
 import numpy as np
 import requests
-
 import yaml
 
 from galaxy.tools.parameters import populate_state
@@ -54,7 +53,9 @@ class ToolRecommendations:
                 self.dropout2 = Dropout(rate)
 
             def call(self, inputs, training):
-                attn_output, attention_scores = self.att(inputs, inputs, inputs, return_attention_scores=True, training=training)
+                attn_output, attention_scores = self.att(
+                    inputs, inputs, inputs, return_attention_scores=True, training=training
+                )
                 attn_output = self.dropout1(attn_output, training=training)
                 out1 = self.layernorm1(inputs + attn_output)
                 ffn_output = self.ffn(out1)
@@ -69,6 +70,7 @@ class ToolRecommendations:
 
             def call(self, x):
                 import tensorflow as tf
+
                 maxlen = tf.shape(x)[-1]
                 positions = tf.range(start=0, limit=maxlen, delta=1)
                 positions = self.pos_emb(positions)
@@ -188,7 +190,9 @@ class ToolRecommendations:
         if last_tool_name in self.model_data_dictionary:
             last_tool_name_id = self.model_data_dictionary[last_tool_name]
             if last_tool_name_id in self.compatible_tools:
-                last_compatible_tools = [self.reverse_dictionary[t_id] for t_id in self.compatible_tools[last_tool_name_id]]
+                last_compatible_tools = [
+                    self.reverse_dictionary[t_id] for t_id in self.compatible_tools[last_tool_name_id]
+                ]
 
         prediction_data["is_deprecated"] = False
         # get the list of datatype extensions of the last tool of the tool sequence
@@ -245,7 +249,9 @@ class ToolRecommendations:
         """
         t_intersect = list(set(predictions).intersection(set(base_tools)))
         t_diff = list(set(predictions).difference(set(base_tools)))
-        t_intersect, u_intersect = self.__sort_by_usage(t_intersect, self.tool_weights_sorted, self.model_data_dictionary)
+        t_intersect, u_intersect = self.__sort_by_usage(
+            t_intersect, self.tool_weights_sorted, self.model_data_dictionary
+        )
         t_diff, u_diff = self.__sort_by_usage(t_diff, self.tool_weights_sorted, self.model_data_dictionary)
         t_intersect.extend(t_diff)
         u_intersect.extend(u_diff)
@@ -310,6 +316,7 @@ class ToolRecommendations:
             # predict next tools for a test path
             try:
                 import tensorflow as tf
+
                 sample = tf.convert_to_tensor(sample, dtype=tf.int64)
                 prediction, _ = self.loaded_model(sample, training=False)
             except Exception as e:

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -48,7 +48,10 @@ class ToolRecommendations:
             LayerNormalization,
             MultiHeadAttention,
         )
-        from tensorflow.keras.models import Model, Sequential
+        from tensorflow.keras.models import (
+            Model,
+            Sequential,
+        )
 
         class TransformerBlock(Layer):
             def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -38,20 +38,24 @@ class ToolRecommendations:
         self.model_ok = None
 
     def create_transformer_model(self, vocab_size):
-        from tensorflow.keras.layers import (
-            Dense,
-            Dropout,
-            Embedding,
-            GlobalAveragePooling1D,
-            Input,
-            Layer,
-            LayerNormalization,
-            MultiHeadAttention,
-        )
-        from tensorflow.keras.models import (
-            Model,
-            Sequential,
-        )
+        try:
+            from tensorflow.keras.layers import (
+                Dense,
+                Dropout,
+                Embedding,
+                GlobalAveragePooling1D,
+                Input,
+                Layer,
+                LayerNormalization,
+                MultiHeadAttention,
+            )
+            from tensorflow.keras.models import (
+                Model,
+                Sequential,
+            )
+        except Exception e:
+            log.exception(e)
+            return None
 
         class TransformerBlock(Layer):
             def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):
@@ -80,13 +84,17 @@ class ToolRecommendations:
                 self.pos_emb = Embedding(input_dim=maxlen, output_dim=embed_dim, mask_zero=True)
 
             def call(self, x):
-                import tensorflow as tf
+                try:
+                    import tensorflow as tf
 
-                maxlen = tf.shape(x)[-1]
-                positions = tf.range(start=0, limit=maxlen, delta=1)
-                positions = self.pos_emb(positions)
-                x = self.token_emb(x)
-                return x + positions
+                    maxlen = tf.shape(x)[-1]
+                    positions = tf.range(start=0, limit=maxlen, delta=1)
+                    positions = self.pos_emb(positions)
+                    x = self.token_emb(x)
+                    return x + positions
+                except Exception e:
+                    log.exception(e)
+                    return None
 
         inputs = Input(shape=(self.max_seq_len,))
         embedding_layer = TokenAndPositionEmbedding(self.max_seq_len, vocab_size, self.embed_dim)

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -127,56 +127,6 @@ class ToolRecommendations:
         self.compatible_tools = json.loads(model_file["compatible_tools"][()].decode("utf-8"))
         tool_weights = json.loads(model_file["class_weights"][()].decode("utf-8"))
         self.standard_connections = json.loads(model_file["standard_connections"][()].decode("utf-8"))
-        print("====================")
-        print(self.model_data_dictionary)
-        print("====================")
-        '''
-        if not self.graph:
-            
-            # import moves from the top of file: in case the tool recommendation feature is disabled,
-            # keras is not downloaded because of conditional requirement and Galaxy does not build
-            try:
-                import tensorflow as tf
-
-                tf.compat.v1.disable_v2_behavior()
-            except Exception:
-                trans.response.status = 400
-                return False
-            # set graph and session only once
-            if self.graph is None:
-                self.graph = tf.Graph()
-                self.session = tf.compat.v1.Session(graph=self.graph)
-            model_weights = list()
-            counter_layer_weights = 0
-            self.tool_recommendation_model_path = self.__download_model(remote_model_url)
-            # read the hdf5 attributes
-            trained_model = h5py.File(self.tool_recommendation_model_path, "r")
-            model_config = json.loads(trained_model["model_config"][()])
-            # set tensorflow's graph and session to maintain
-            # consistency between model load and predict methods
-            with self.graph.as_default():
-                with self.session.as_default():
-                    try:
-                        # iterate through all the attributes of the model to find weights of neural network layers
-                        for item in trained_model.keys():
-                            if "weight_" in item:
-                                weight = trained_model[f"weight_{str(counter_layer_weights)}"][()]
-                                model_weights.append(weight)
-                                counter_layer_weights += 1
-                        self.loaded_model = tf.keras.models.model_from_json(model_config)
-                        self.loaded_model.set_weights(model_weights)
-                    except Exception as e:
-                        log.exception(e)
-                        trans.response.status = 400
-                        return False
-            # set the dictionary of tools
-            self.model_data_dictionary = json.loads(trained_model["data_dictionary"][()])
-            self.reverse_dictionary = {v: k for k, v in self.model_data_dictionary.items()}
-            # set the list of compatible tools
-            self.compatible_tools = json.loads(trained_model["compatible_tools"][()])
-            tool_weights = json.loads(trained_model["class_weights"][()])
-            self.standard_connections = json.loads(trained_model["standard_connections"][()])
-            '''
         # sort the tools' usage dictionary
         tool_pos_sorted = [int(key) for key in tool_weights.keys()]
         for k in tool_pos_sorted:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -606,13 +606,10 @@ class WorkflowsAPIController(
             'tool_sequence' - comma separated sequence of tool ids
             'remote_model_url' - (optional) path to the deep learning model
         """
-        log = logging.getLogger(__name__)
         remote_model_url = payload.get("remote_model_url", trans.app.config.tool_recommendation_model_path)
         tool_sequence = payload.get("tool_sequence", "")
-        log.info(f"{tool_sequence} and {remote_model_url}")
-        print(remote_model_url, tool_sequence)
-        '''if "tool_sequence" not in payload or remote_model_url is None:
-            return'''
+        if "tool_sequence" not in payload or remote_model_url is None:
+            return
         tool_sequence, recommended_tools = self.tool_recommendations.get_predictions(
             trans, tool_sequence, remote_model_url
         )

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -606,10 +606,13 @@ class WorkflowsAPIController(
             'tool_sequence' - comma separated sequence of tool ids
             'remote_model_url' - (optional) path to the deep learning model
         """
+        log = logging.getLogger(__name__)
         remote_model_url = payload.get("remote_model_url", trans.app.config.tool_recommendation_model_path)
         tool_sequence = payload.get("tool_sequence", "")
-        if "tool_sequence" not in payload or remote_model_url is None:
-            return
+        log.info(f"{tool_sequence} and {remote_model_url}")
+        print(remote_model_url, tool_sequence)
+        '''if "tool_sequence" not in payload or remote_model_url is None:
+            return'''
         tool_sequence, recommended_tools = self.tool_recommendations.get_predictions(
             trans, tool_sequence, remote_model_url
         )

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -749,33 +749,6 @@ class TestWorkflowsApi(BaseWorkflowsApiTestCase, ChangeDatatypeTests):
             self._assert_user_has_workflow_with_name(name)
         return upload_response
 
-    def test_get_tool_predictions(self):
-        request = {
-            "tool_sequence": "Cut1",
-            "remote_model_url": "https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model_v_0.2.hdf5",
-        }
-        actual_recommendations = ["Filter1", "Grouping1"]
-        route = "workflows/get_tool_predictions"
-        response = self._post(route, data=request)
-        time.sleep(1)
-        recommendation_response = response.json()
-        is_empty = bool(recommendation_response["current_tool"])
-        if is_empty is False:
-            self._assert_status_code_is(response, 400)
-        else:
-            # check Ok response from the API
-            self._assert_status_code_is(response, 200)
-            recommendation_response = response.json()
-            # check the input tool sequence
-            assert recommendation_response["current_tool"] == request["tool_sequence"]
-            # check non-empty predictions list
-            predicted_tools = recommendation_response["predicted_data"]["children"]
-            assert len(predicted_tools) > 0
-            # check for the correct predictions
-            for tool in predicted_tools:
-                assert tool["tool_id"] in actual_recommendations
-                break
-
     def test_update(self):
         original_workflow = self.workflow_populator.load_workflow(name="test_import")
         uuids = {}

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -757,6 +757,7 @@ class TestWorkflowsApi(BaseWorkflowsApiTestCase, ChangeDatatypeTests):
         actual_recommendations = ["Filter1", "Grouping1"]
         route = "workflows/get_tool_predictions"
         response = self._post(route, data=request)
+        time.sleep(1)
         recommendation_response = response.json()
         is_empty = bool(recommendation_response["current_tool"])
         if is_empty is False:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -752,9 +752,9 @@ class TestWorkflowsApi(BaseWorkflowsApiTestCase, ChangeDatatypeTests):
     def test_get_tool_predictions(self):
         request = {
             "tool_sequence": "Cut1",
-            "remote_model_url": "https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model.hdf5",
+            "remote_model_url": "https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model_v_0.2.hdf5",
         }
-        actual_recommendations = ["Filter1", "cat1", "addValue", "comp1", "Grep1"]
+        actual_recommendations = ["Filter1", "Grouping1"]
         route = "workflows/get_tool_predictions"
         response = self._post(route, data=request)
         recommendation_response = response.json()


### PR DESCRIPTION
This PR updates the tool recommendation API in two ways:
- By adding a new model trained on the latest data (last 5 years' workflows and 1-year tools usage on Galaxy EU). The new model is here: https://github.com/galaxyproject/galaxy-test-data/pull/22
- Update the neural network architecture to a modern transformer-based architecture

The new model achieves better generalization in terms of predictions beyond training data, is faster (needs only half the amount of time compared to the existing RNN-based model) in converging and requires only 1/4 of the time for a prediction.

Some plots:

![model_load_time](https://user-images.githubusercontent.com/3022518/195872550-e5675c04-646d-40b7-a5bf-945935d9ea0f.png)

![training](https://user-images.githubusercontent.com/3022518/195872554-78a8e9e3-3305-4f62-b444-7a74829690f6.png)

Generalisation in prediction:

Let's take a tool: "anndata_import". In the training data (workflows from Galaxy EU), the following tools are following tools of "anndata_import":
scanpy_filter, anndata_inspect, anndata_manipulate, ucsc_cell_browser, scanpy_inspect, scanpy_filter_cells

Prediction by RNN: 'anndata_manipulate', 'scanpy_filter', 'scanpy_filter_cells', 'ucsc_cell_browser', 'scanpy_inspect', 'anndata_inspect', 'scanpy_plot', '**TransTermHP**', '**edu.tamu.cpt.gff3.require_sd**', 'scanpy_normalise_data', '**edu.tamu.cpt.genbank.shinefind**', '**gd_raxml'**, '**mmpbsa_mmgbsa**', '**edu.tamu.cpt.util.wigToBigWig**', '**edu.tamu.cpt2.util.glimmer3_to_gff3**', 'scmap_scmap_cluster', 'scmap_scmap_cell', 'tp_tail_tool', 'scanpy_filter_genes', '**nanocompore_sampcomp**'

Prediction by Transformer: 'scanpy_filter_cells', 'anndata_inspect', 'ucsc_cell_browser', 'scanpy_filter', 'scanpy_inspect', 'anndata_manipulate', 'scanpy_normalise_data', '**MergingDataClusterize**', '**gatk_bqsr**', 'scanpy_plot', 'anndata_ops', 'scanpy_remove_confounders', 'scanpy_integrate_harmony', '**splitTranscriptGff**', 'scanpy_normalize', 'scpred_get_feature_space', 'scanpy_find_variable_genes', 'scpred_predict_labels', '**rdpmulticlassifier**', 'scpred_eigen_decompose'

Both the models correctly predict the "true" tools of "anndata_import" but RNN predicts 8 (out of 20 predicted tools) incorrectly (ie these 8 tools do not belong to the single-cell field) while the Transformer prediction only 4 tools (again out of 20) that do not belong to the single-cell field. Incorrectly predicted tools are shown in bold.

There are many such examples that can be seen for tools or a sequence of tools. Currently, Transformers-based architectures are state-of-the-art for modelling sequences (https://arxiv.org/abs/1706.03762).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. First of all, this PR https://github.com/galaxyproject/galaxy-test-data/pull/22 that enable the new model to be downloaded in Galaxy via its config "tool_recommendation_model_path"
  2. Enable Galaxy config "enable_tool_recommendations" and set to "true"
  3. Enable another Galaxy config "tool_recommendation_model_path"
  4. Also, enable the last Galaxy config "topk_recommendations"
  5. Start the local Galaxy instance and navigate to the workflow editor page
  6. Select any tool and the tool recommendation arrow (top-right of tool's box) is displayed in a dropdown.

![featureC_deseq2](https://user-images.githubusercontent.com/3022518/195877522-7a234b37-6abe-41fd-9d72-0e36329fe873.png)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).


ping @bgruening 

thank you!