### PR TITLE
Make connect_args for SQLAlchemy's engine configurable

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -57,10 +57,19 @@
 
 :Description:
     By default, Galaxy uses a SQLite database at
-    '<data_dir>/universe.sqlite'.  You may use a SQLAlchemy connection
+    '<data_dir>/universe.sqlite'. You may use a SQLAlchemy connection
     string to specify an external database instead.
     Sample default
     'sqlite:///<data_dir>/universe.sqlite?isolation_level=IMMEDIATE'
+    You may specify additional options that will be passed to the
+    SQLAlchemy database engine by using the prefix
+    "database_engine_option_". For some of these options, default
+    values are provided (e.g. see database_engine_option_pool_size,
+    etc.).
+    The same applies to `install_database_connection`, for which you
+    should use the "install_database_engine_option_" prefix.
+    For more options, please check SQLAlchemy's documentation at
+    https://docs.sqlalchemy.org/en/14/core/engines.html?highlight=create_engine#sqlalchemy.create_engine
 :Default: ``None``
 :Type: str
 
@@ -590,22 +599,6 @@
     <config_dir>.
 :Default: ``tool_sheds_conf.xml``
 :Type: str
-
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``load_tool_shed_datatypes``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    This option controls whether legacy datatypes are loaded from
-    installed tool shed repositories. We're are in the process of
-    disabling Tool Shed datatypes. This option with a default of true
-    will be added in 22.01, we will disable the datatypes on the big
-    public servers during that release. This option will be switched
-    to False by default in 22.05 and this broken functionality will be
-    removed all together during some future release.
-:Default: ``true``
-:Type: bool
 
 
 ~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -210,10 +210,18 @@ galaxy:
   #cache_dir: cache
 
   # By default, Galaxy uses a SQLite database at
-  # '<data_dir>/universe.sqlite'.  You may use a SQLAlchemy connection
+  # '<data_dir>/universe.sqlite'. You may use a SQLAlchemy connection
   # string to specify an external database instead.
   # Sample default
   # 'sqlite:///<data_dir>/universe.sqlite?isolation_level=IMMEDIATE'
+  # You may specify additional options that will be passed to the
+  # SQLAlchemy database engine by using the prefix
+  # "database_engine_option_". For some of these options, default values
+  # are provided (e.g. see database_engine_option_pool_size, etc.).
+  # The same applies to `install_database_connection`, for which you
+  # should use the "install_database_engine_option_" prefix.
+  # For more options, please check SQLAlchemy's documentation at
+  # https://docs.sqlalchemy.org/en/14/core/engines.html?highlight=create_engine#sqlalchemy.create_engine
   #database_connection: null
 
   # If the server logs errors about not having enough database pool

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -64,11 +64,21 @@ mapping:
         type: str
         required: false
         desc: |
-          By default, Galaxy uses a SQLite database at '<data_dir>/universe.sqlite'.  You
-          may use a SQLAlchemy connection string to specify an external database
-          instead.
+          By default, Galaxy uses a SQLite database at '<data_dir>/universe.sqlite'. You
+          may use a SQLAlchemy connection string to specify an external database instead.
 
           Sample default 'sqlite:///<data_dir>/universe.sqlite?isolation_level=IMMEDIATE'
+
+          You may specify additional options that will be passed to the SQLAlchemy
+          database engine by using the prefix "database_engine_option_". For some of these
+          options, default values are provided (e.g. see database_engine_option_pool_size,
+          etc.).
+
+          The same applies to `install_database_connection`, for which you should use the
+          "install_database_engine_option_" prefix.
+
+          For more options, please check SQLAlchemy's documentation at
+          https://docs.sqlalchemy.org/en/14/core/engines.html?highlight=create_engine#sqlalchemy.create_engine
 
       database_engine_option_pool_size:
         type: int

--- a/lib/galaxy/model/orm/engine_factory.py
+++ b/lib/galaxy/model/orm/engine_factory.py
@@ -4,6 +4,7 @@ import os
 import threading
 import time
 from multiprocessing.util import register_after_fork
+from typing import Dict
 
 from sqlalchemy import (
     create_engine,
@@ -99,6 +100,7 @@ def build_engine(
                 except AttributeError:
                     pass
 
+    engine_options = engine_options or {}
     engine_options = set_sqlite_connect_args(engine_options, url)
     engine = create_engine(url, **engine_options)
 
@@ -122,14 +124,13 @@ def build_engine(
     return engine
 
 
-def set_sqlite_connect_args(engine_options, url):
+def set_sqlite_connect_args(engine_options: Dict, url: str):
     """
     Add or update `connect_args` in `engine_options` if db is sqlite.
     Set check_same_thread to False for sqlite, handled by request-specific session.
     See https://fastapi.tiangolo.com/tutorial/sql-databases/#note
     """
-    if url and url.startswith("sqlite://"):
-        engine_options = engine_options or {}
+    if url.startswith("sqlite://"):
         connect_args = engine_options.setdefault("connect_args", {})
         connect_args["check_same_thread"] = False
     return engine_options

--- a/test/unit/data/model/test_engine_factory.py
+++ b/test/unit/data/model/test_engine_factory.py
@@ -1,0 +1,39 @@
+from galaxy.model.orm.engine_factory import set_sqlite_connect_args
+
+SQLITE_URL = "sqlite://foo.db"
+NON_SQLITE_URL = "foo://foo.db"
+
+
+class TestSetSqliteConnectArgs:
+    def test_engine_options_none(self):
+        engine_options = None
+        updated = set_sqlite_connect_args(engine_options, SQLITE_URL)
+        assert updated == {"connect_args": {"check_same_thread": False}}
+
+    def test_engine_options_empty(self):
+        engine_options = {}
+        updated = set_sqlite_connect_args(engine_options, SQLITE_URL)
+        assert updated == {"connect_args": {"check_same_thread": False}}
+
+    def test_update_nonempty_engine_options(self):
+        engine_options = {"foo": "some foo"}
+        updated = set_sqlite_connect_args(engine_options, SQLITE_URL)
+        assert len(updated) == 2
+        assert updated["foo"] == "some foo"
+        assert updated["connect_args"] == {"check_same_thread": False}
+
+    def test_overwrite_connect_args(self):
+        engine_options = {"foo": "some foo", "connect_args": {"check_same_thread": True}}
+        updated = set_sqlite_connect_args(engine_options, SQLITE_URL)
+        assert len(updated) == 2
+        assert updated["foo"] == "some foo"
+        assert updated["connect_args"] == {"check_same_thread": False}
+
+    def test_update_nonempty_connect_args(self):
+        engine_options = {"foo": "some foo", "connect_args": {"bar": "some bar"}}
+        updated = set_sqlite_connect_args(engine_options, SQLITE_URL)
+        assert len(updated) == 2
+        assert updated["foo"] == "some foo"
+        assert len(updated["connect_args"]) == 2
+        assert updated["connect_args"]["check_same_thread"] is False
+        assert updated["connect_args"]["bar"] == "some bar"

--- a/test/unit/data/model/test_engine_factory.py
+++ b/test/unit/data/model/test_engine_factory.py
@@ -5,11 +5,6 @@ NON_SQLITE_URL = "foo://foo.db"
 
 
 class TestSetSqliteConnectArgs:
-    def test_engine_options_none(self):
-        engine_options = None
-        updated = set_sqlite_connect_args(engine_options, SQLITE_URL)
-        assert updated == {"connect_args": {"check_same_thread": False}}
-
     def test_engine_options_empty(self):
         engine_options = {}  # type: ignore[var-annotated]
         updated = set_sqlite_connect_args(engine_options, SQLITE_URL)

--- a/test/unit/data/model/test_engine_factory.py
+++ b/test/unit/data/model/test_engine_factory.py
@@ -11,7 +11,7 @@ class TestSetSqliteConnectArgs:
         assert updated == {"connect_args": {"check_same_thread": False}}
 
     def test_engine_options_empty(self):
-        engine_options = {}
+        engine_options = {}  # type: ignore[var-annotated]
         updated = set_sqlite_connect_args(engine_options, SQLITE_URL)
         assert updated == {"connect_args": {"check_same_thread": False}}
 


### PR DESCRIPTION
This addresses ~14697~ #14568 and related discussion in https://github.com/usegalaxy-eu/infrastructure-playbook/pull/420, specifically [this](https://github.com/usegalaxy-eu/infrastructure-playbook/pull/420#issuecomment-1250822229).

Will this work? (ping @mira-miracoli, @bgruening, @hexylena)

Example for `galaxy.yml`:
```yaml
  database_engine_option_connect_args: 
    ssl:
      cert: '/path/to/client-cert'
      key: '/path/to/client-key'
      ca: '/path/to/ca-cert'
```

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
