### PR TITLE
implement undeleting a workflow

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -486,7 +486,7 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
             if self.check_security(trans, inv, check_ownership=True, check_accessible=False)
         ]
         return invocations, total_matches
-    
+
     def delete(self, stored_workflow, flush=True):
         """Mark the given workflow deleted."""
         super().delete(stored_workflow, flush=flush)

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -489,10 +489,6 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
         ]
         return invocations, total_matches
 
-    def delete(self, stored_workflow, flush=True):
-        """Mark the given workflow deleted."""
-        super().delete(stored_workflow, flush=flush)
-
 
 CreatedWorkflow = namedtuple("CreatedWorkflow", ["stored_workflow", "workflow", "missing_tools"])
 

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -42,6 +42,7 @@ from galaxy import (
     util,
 )
 from galaxy.job_execution.actions.post import ActionBox
+from galaxy.managers import deletable
 from galaxy.managers import sharable
 from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesUserContext
@@ -107,7 +108,7 @@ INDEX_SEARCH_FILTERS = {
 }
 
 
-class WorkflowsManager(sharable.SharableModelManager):
+class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManagerMixin):
     """Handle CRUD type operations related to workflows. More interesting
     stuff regarding workflow execution, step sorting, etc... can be found in
     the galaxy.workflow module.
@@ -485,6 +486,10 @@ class WorkflowsManager(sharable.SharableModelManager):
             if self.check_security(trans, inv, check_ownership=True, check_accessible=False)
         ]
         return invocations, total_matches
+    
+    def delete(self, stored_workflow, flush=True):
+        """Mark the given workflow deleted."""
+        super().delete(stored_workflow, flush=flush)
 
 
 CreatedWorkflow = namedtuple("CreatedWorkflow", ["stored_workflow", "workflow", "missing_tools"])

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -42,8 +42,10 @@ from galaxy import (
     util,
 )
 from galaxy.job_execution.actions.post import ActionBox
-from galaxy.managers import deletable
-from galaxy.managers import sharable
+from galaxy.managers import (
+    deletable,
+    sharable,
+)
 from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.executables import artifact_class

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1412,7 +1412,8 @@ class FastAPIWorkflows:
         trans: ProvidesUserContext = DependsOnTrans,
         workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam,
     ):
-        workflow_to_delete = self.workflows_manager.get_stored_workflow(trans, workflow_id, check_ownership=True)
+        workflow_to_delete = self.workflows_manager.get_stored_workflow(trans, workflow_id)
+        self.workflows_manager.check_security(trans, workflow_to_delete)
         self.workflows_manager.delete(workflow_to_delete)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -1425,7 +1426,8 @@ class FastAPIWorkflows:
         trans: ProvidesUserContext = DependsOnTrans,
         workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam,
     ):
-        workflow_to_undelete = self.workflows_manager.get_stored_workflow(trans, workflow_id, check_ownership=True)
+        workflow_to_undelete = self.workflows_manager.get_stored_workflow(trans, workflow_id)
+        self.workflows_manager.check_security(trans, workflow_to_undelete)
         self.workflows_manager.undelete(workflow_to_undelete)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1413,9 +1413,7 @@ class FastAPIWorkflows:
         trans: ProvidesUserContext = DependsOnTrans,
         workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam,
     ):
-        workflow_to_delete = self.workflows_manager.get_stored_workflow(trans, workflow_id)
-        if workflow_to_delete.user != trans.user and not trans.user_is_admin:
-            raise exceptions.InsufficientPermissionsException()
+        workflow_to_delete = self.workflows_manager.get_stored_workflow(trans, workflow_id, check_ownership=True)
         self.workflows_manager.delete(workflow_to_delete)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -1428,9 +1426,7 @@ class FastAPIWorkflows:
         trans: ProvidesUserContext = DependsOnTrans,
         workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam,
     ):
-        workflow_to_undelete = self.workflows_manager.get_stored_workflow(trans, workflow_id)
-        if workflow_to_undelete.user != trans.user and not trans.user_is_admin:
-            raise exceptions.InsufficientPermissionsException()
+        workflow_to_undelete = self.workflows_manager.get_stored_workflow(trans, workflow_id, check_ownership=True)
         self.workflows_manager.undelete(workflow_to_undelete)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -42,7 +42,6 @@ from galaxy.managers.jobs import (
 from galaxy.managers.workflows import (
     MissingToolsException,
     RefactorRequest,
-    WorkflowContentsManager,
     WorkflowCreateOptions,
     WorkflowsManager,
     WorkflowUpdateOptions,

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1241,7 +1241,6 @@ SkipStepCountsQueryParam: bool = Query(
 class FastAPIWorkflows:
     service: WorkflowsService = depends(WorkflowsService)
     invocations_service: InvocationsService = depends(InvocationsService)
-    workflows_manager: WorkflowsManager = depends(WorkflowsManager)
 
     @router.get(
         "/api/workflows",
@@ -1412,9 +1411,7 @@ class FastAPIWorkflows:
         trans: ProvidesUserContext = DependsOnTrans,
         workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam,
     ):
-        workflow_to_delete = self.workflows_manager.get_stored_workflow(trans, workflow_id)
-        self.workflows_manager.check_security(trans, workflow_to_delete)
-        self.workflows_manager.delete(workflow_to_delete)
+        self.service.delete(trans, workflow_id)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @router.post(
@@ -1426,9 +1423,7 @@ class FastAPIWorkflows:
         trans: ProvidesUserContext = DependsOnTrans,
         workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam,
     ):
-        workflow_to_undelete = self.workflows_manager.get_stored_workflow(trans, workflow_id)
-        self.workflows_manager.check_security(trans, workflow_to_undelete)
-        self.workflows_manager.undelete(workflow_to_undelete)
+        self.service.undelete(trans, workflow_id)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     # TODO: remove this endpoint after 23.1 release

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1243,7 +1243,6 @@ class FastAPIWorkflows:
     service: WorkflowsService = depends(WorkflowsService)
     invocations_service: InvocationsService = depends(InvocationsService)
     workflows_manager: WorkflowsManager = depends(WorkflowsManager)
-    workflow_contents_manager: WorkflowContentsManager = depends(WorkflowContentsManager)
 
     @router.get(
         "/api/workflows",
@@ -1418,7 +1417,7 @@ class FastAPIWorkflows:
         if workflow_to_delete.user != trans.user and not trans.user_is_admin:
             raise exceptions.InsufficientPermissionsException()
         self.workflows_manager.delete(workflow_to_delete)
-        return self.workflow_contents_manager.workflow_to_dict(trans, workflow_to_delete, style="instance")
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @router.post(
         "/api/workflows/{workflow_id}/undelete",
@@ -1433,7 +1432,7 @@ class FastAPIWorkflows:
         if workflow_to_undelete.user != trans.user and not trans.user_is_admin:
             raise exceptions.InsufficientPermissionsException()
         self.workflows_manager.undelete(workflow_to_undelete)
-        return self.workflow_contents_manager.workflow_to_dict(trans, workflow_to_undelete, style="instance")
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     # TODO: remove this endpoint after 23.1 release
     @router.get(

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -43,7 +43,6 @@ from galaxy.managers.workflows import (
     MissingToolsException,
     RefactorRequest,
     WorkflowCreateOptions,
-    WorkflowsManager,
     WorkflowUpdateOptions,
 )
 from galaxy.model.item_attrs import UsesAnnotations

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -464,11 +464,25 @@ class WorkflowsAPIController(
         Delete a specified workflow
         """
         workflow_to_delete = self.__get_stored_workflow(trans, id, **kwd)
-        # check to see if user has permissions to selected workflow
         if workflow_to_delete.user != trans.user and not trans.user_is_admin:
             raise exceptions.InsufficientPermissionsException()
         self.workflow_manager.delete(workflow_to_delete)
         return self.workflow_contents_manager.workflow_to_dict(trans, workflow_to_delete, style="instance")
+
+    @expose_api
+    def undelete(self, trans: ProvidesUserContext, id, **kwd):
+        """
+        POST /api/workflows/{encoded_workflow_id}/undelete
+        Undelete the workflow with the given ``id``
+
+        :param id: the encoded id of the user to be undeleted
+        :type  id: str
+        """
+        workflow_to_undelete = self.__get_stored_workflow(trans, id, **kwd)
+        if workflow_to_undelete.user != trans.user and not trans.user_is_admin:
+            raise exceptions.InsufficientPermissionsException()
+        self.workflow_manager.undelete(workflow_to_undelete)
+        return self.workflow_contents_manager.workflow_to_dict(trans, workflow_to_undelete, style="instance")
 
     @expose_api
     def import_new_workflow_deprecated(self, trans: GalaxyWebTransaction, payload, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -42,8 +42,8 @@ from galaxy.managers.jobs import (
 from galaxy.managers.workflows import (
     MissingToolsException,
     RefactorRequest,
-    WorkflowCreateOptions,
     WorkflowContentsManager,
+    WorkflowCreateOptions,
     WorkflowsManager,
     WorkflowUpdateOptions,
 )

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1408,7 +1408,7 @@ class FastAPIWorkflows:
     def delete_workflow(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam
+        workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam,
     ):
         workflow_to_delete = self.service._workflows_manager.get_stored_workflow(trans, workflow_id)
         if workflow_to_delete.user != trans.user and not trans.user_is_admin:
@@ -1423,7 +1423,7 @@ class FastAPIWorkflows:
     def undelete_workflow(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam
+        workflow_id: DecodedDatabaseIdField = StoredWorkflowIDPathParam,
     ):
         workflow_to_undelete = self.service._workflows_manager.get_stored_workflow(trans, workflow_id)
         if workflow_to_undelete.user != trans.user and not trans.user_is_admin:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -461,23 +461,14 @@ class WorkflowsAPIController(
     def delete(self, trans: ProvidesUserContext, id, **kwd):
         """
         DELETE /api/workflows/{encoded_workflow_id}
-        Deletes a specified workflow
-        Author: rpark
-
-        copied from galaxy.web.controllers.workflows.py (delete)
+        Delete a specified workflow
         """
-        stored_workflow = self.__get_stored_workflow(trans, id, **kwd)
-
+        workflow_to_delete = self.__get_stored_workflow(trans, id, **kwd)
         # check to see if user has permissions to selected workflow
-        if stored_workflow.user != trans.user and not trans.user_is_admin:
+        if workflow_to_delete.user != trans.user and not trans.user_is_admin:
             raise exceptions.InsufficientPermissionsException()
-
-        # Mark a workflow as deleted
-        stored_workflow.deleted = True
-        trans.sa_session.flush()
-
-        # TODO: Unsure of response message to let api know that a workflow was successfully deleted
-        return f"Workflow '{stored_workflow.name}' successfully deleted"
+        self.workflow_manager.delete(workflow_to_delete)
+        return self.workflow_contents_manager.workflow_to_dict(trans, workflow_to_delete, style="instance")
 
     @expose_api
     def import_new_workflow_deprecated(self, trans: GalaxyWebTransaction, payload, **kwd):

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -576,13 +576,6 @@ def populate_api_routes(webapp, app):
         controller="workflows",
         conditions=dict(method=["POST"]),
     )
-    webapp.mapper.connect(
-        "undelete_workflow",
-        "/api/workflows/{id}/undelete",
-        action="undelete",
-        controller="workflows",
-        conditions=dict(method=["POST"]),
-    )
 
     webapp.mapper.resource_with_deleted("user", "users", path_prefix="/api")
     webapp.mapper.resource("visualization", "visualizations", path_prefix="/api")

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -576,6 +576,13 @@ def populate_api_routes(webapp, app):
         controller="workflows",
         conditions=dict(method=["POST"]),
     )
+    webapp.mapper.connect(
+        "undelete_workflow",
+        "/api/workflows/{id}/undelete",
+        action="undelete",
+        controller="workflows",
+        conditions=dict(method=["POST"]),
+    )
 
     webapp.mapper.resource_with_deleted("user", "users", path_prefix="/api")
     webapp.mapper.resource("visualization", "visualizations", path_prefix="/api")

--- a/lib/galaxy/webapps/galaxy/services/workflows.py
+++ b/lib/galaxy/webapps/galaxy/services/workflows.py
@@ -99,6 +99,16 @@ class WorkflowsService(ServiceBase):
             return workflows, total_matches
         return rval, total_matches
 
+    def delete(self, trans, workflow_id):
+        workflow_to_delete = self._workflows_manager.get_stored_workflow(trans, workflow_id)
+        self._workflows_manager.check_security(trans, workflow_to_delete)
+        self._workflows_manager.delete(workflow_to_delete)
+
+    def undelete(self, trans, workflow_id):
+        workflow_to_undelete = self._workflows_manager.get_stored_workflow(trans, workflow_id)
+        self._workflows_manager.check_security(trans, workflow_to_undelete)
+        self._workflows_manager.undelete(workflow_to_undelete)
+
     def __get_full_shed_url(self, url):
         for shed_url in self._tool_shed_registry.tool_sheds.values():
             if url in shed_url:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -21,7 +21,7 @@ from requests import (
     delete,
     get,
     post,
-    put
+    put,
 )
 
 from galaxy.exceptions import error_codes

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -412,7 +412,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         assert [w for w in workflow_index if w["id"] == workflow_id]
         workflow_url = self._api_url(f"workflows/{workflow_id}", use_key=True)
         delete_response = delete(workflow_url)
-        self._assert_status_code_is(delete_response, 200)
+        self._assert_status_code_is(delete_response, 204)
         workflow_index = self._get("workflows").json()
         assert not [w for w in workflow_index if w["id"] == workflow_id]
         workflow_index = self._get("workflows?show_deleted=true").json()

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -370,7 +370,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         self._assert_user_has_workflow_with_name(workflow_name)
         workflow_url = self._api_url(f"workflows/{workflow_id}", use_key=True)
         delete_response = delete(workflow_url)
-        self._assert_status_code_is(delete_response, 200)
+        self._assert_status_code_is(delete_response, 204)
         # Make sure workflow is no longer in index by default.
         assert workflow_name not in self._workflow_names()
 
@@ -389,7 +389,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         delete(workflow_delete_url)
         workflow_undelete_url = self._api_url(f"workflows/{workflow_id}/undelete", use_key=True)
         undelete_response = post(workflow_undelete_url)
-        self._assert_status_code_is(undelete_response, 200)
+        self._assert_status_code_is(undelete_response, 204)
         assert workflow_name in self._workflow_names()
 
     def test_other_cannot_undelete(self):


### PR DESCRIPTION
Implement new API endpoint for undeleting workflows and port delete and undelete to fastapi. 

I'll port more of the workflow controller to fastAPI in a subsequent PR. ~~I'll also add a bit more refactoring since it is probably not cool to access manager through a service like this.~~

We talked with @assuntad23 about the UI for this and given how often (not) this is going to be used we are thinking about putting this as a search filter -- i.e. something like `is:deleted`.

part of  #6493
## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
