### PR TITLE
[22.05] Point to new documentation instead of github issue

### DIFF
--- a/lib/galaxy/model/migrations/__init__.py
+++ b/lib/galaxy/model/migrations/__init__.py
@@ -74,7 +74,7 @@ class IncorrectVersionError(Exception):
     def __init__(self, model: str, expected_version: int) -> None:
         msg = f"Your {model} database version is incorrect; version {expected_version} is expected. "
         msg += "Manual update is required. "
-        msg += "Please see this issue: https://github.com/galaxyproject/galaxy/issues/13528"
+        msg += "Please see documentation: https://docs.galaxyproject.org/en/master/admin/db_migration.html#how-to-handle-migrations-incorrectversionerror"
         super().__init__(msg)
 
 


### PR DESCRIPTION
Update link in error message, now that we have proper documentation (which also points to that issue).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
