### PR TITLE
Rename `FooBarTestCase` test classes as `TestFooBar`

### DIFF
--- a/doc/source/dev/run_tests_help.txt
+++ b/doc/source/dev/run_tests_help.txt
@@ -45,10 +45,8 @@ The main test types are as follows:
    located in lib/tool_shed/test.
 
 Python testing is mostly done via pytest. Specific tests can be selected
-using the pytest selector syntax is described at https://docs.pytest.org/en/latest/usage.html.
-
-The spots these selectors can be used is described in the above usage documentation
-as test_path.  A few examples are shown below.
+using the syntax described at https://docs.pytest.org/en/latest/how-to/usage.html .
+A few examples are shown below.
 
 Run all API tests:
     ./run_tests.sh -api
@@ -56,16 +54,16 @@ Run all API tests:
 The same test as above can be run using pytest directly as follows:
     pytest lib/galaxy_test/api
 
-However when using pytest directly output options defined in this
+However, when using pytest directly, output options defined in this
 file aren't respected and a new Galaxy instance will be created for each
-TestCase class (this scripts optimizes it so all tests can share a Galaxy
+Test class (this scripts optimizes it so all tests can share a Galaxy
 instance).
 
 Run a full class of API tests:
-    ./run_tests.sh -api lib/galaxy_test/api/test_tools.py::ToolsTestCase
+    ./run_tests.sh -api lib/galaxy_test/api/test_tools.py::TestToolsApi
 
 Run a specific API test:
-    ./run_tests.sh -api lib/galaxy_test/api/test_tools.py::ToolsTestCase::test_map_over_with_output_format_actions
+    ./run_tests.sh -api lib/galaxy_test/api/test_tools.py::TestToolsApi::test_map_over_with_output_format_actions
 
 Run all selenium tests (Under Linux using Docker):
     # Start selenium chrome Docker container
@@ -73,14 +71,14 @@ Run all selenium tests (Under Linux using Docker):
     GALAXY_TEST_SELENIUM_REMOTE=1 ./run_tests.sh -selenium
 
 Run a specific selenium test (under Linux or Mac OS X after installing geckodriver or chromedriver):
-    ./run_tests.sh -selenium lib/galaxy_test/selenium/test_registration.py::RegistrationTestCase::test_reregister_username_fails
+    ./run_tests.sh -selenium lib/galaxy_test/selenium/test_registration.py::TestRegistration::test_reregister_username_fails
 
 Run a selenium test against a running server while watching client (fastest iterating on client tests):
     ./run.sh & # run Galaxy on 8080
     make client-watch & # watch for client changes
     export GALAXY_TEST_EXTERNAL=http://localhost:8080/  # Target tests at server.
     . .venv/bin/activate # source the virtualenv so can skip run_tests.sh.
-    pytest lib/galaxy_test/selenium/test_workflow_editor.py::WorkflowEditorTestCase::test_data_input
+    pytest lib/galaxy_test/selenium/test_workflow_editor.py::TestWorkflowEditor::test_data_input
 
 Note About Selenium Tests:
 
@@ -91,7 +89,7 @@ the PATH.
 More information on geckodriver can be found at
 https://github.com/mozilla/geckodriver and more information on
 chromedriver can be found at
-https://sites.google.com/a/chromium.org/chromedriver/.
+https://sites.google.com/chromium.org/driver/ .
 
 By default Galaxy will check the PATH for these and pick
 whichever it finds. This can be overridden by setting

--- a/lib/galaxy_test/api/test_authenticate.py
+++ b/lib/galaxy_test/api/test_authenticate.py
@@ -9,7 +9,7 @@ TEST_USER_EMAIL = "auth_user_test@bx.psu.edu"
 TEST_USER_PASSWORD = "testpassword1"
 
 
-class AuthenticationApiTestCase(ApiTestCase):
+class TestAuthenticateApi(ApiTestCase):
     def test_auth(self):
         self._setup_user(TEST_USER_EMAIL, TEST_USER_PASSWORD)
         baseauth_url = self._api_url("authenticate/baseauth", use_key=False)

--- a/lib/galaxy_test/api/test_configuration.py
+++ b/lib/galaxy_test/api/test_configuration.py
@@ -22,7 +22,7 @@ TEST_KEYS_FOR_ADMIN_ONLY = [
 ]
 
 
-class ConfigurationApiTestCase(ApiTestCase):
+class TestConfigurationApi(ApiTestCase):
     def test_whoami(self):
         response = self._get("whoami")
         self._assert_status_code_is(response, 200)

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -11,7 +11,7 @@ from galaxy_test.base.populators import (
 from ._framework import ApiTestCase
 
 
-class DatasetCollectionApiTestCase(ApiTestCase):
+class TestDatasetCollectionsApi(ApiTestCase):
     history_id: str
 
     def setUp(self):

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -34,7 +34,7 @@ COMPOSITE_DATA_FETCH_REQUEST_1 = {
 }
 
 
-class DatasetsApiTestCase(ApiTestCase):
+class TestDatasetsApi(ApiTestCase):
     history_id: str
 
     def setUp(self):

--- a/lib/galaxy_test/api/test_datatypes.py
+++ b/lib/galaxy_test/api/test_datatypes.py
@@ -7,7 +7,7 @@ from ._framework import ApiTestCase
 HIDDEN_DURING_UPLOAD_DATATYPE = "fli"
 
 
-class DatatypesApiTestCase(ApiTestCase):
+class TestDatatypesApi(ApiTestCase):
     def test_index(self):
         datatypes = self._index_datatypes()
         for common_type in ["tabular", "fasta"]:

--- a/lib/galaxy_test/api/test_display_applications.py
+++ b/lib/galaxy_test/api/test_display_applications.py
@@ -4,7 +4,7 @@ from typing import List
 from ._framework import ApiTestCase
 
 
-class DisplayApplicationsApiTestCase(ApiTestCase):
+class TestDisplayApplicationsApi(ApiTestCase):
     def test_index(self):
         response = self._get("display_applications")
         self._assert_status_code_is(response, 200)

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -13,7 +13,7 @@ from galaxy_test.base.populators import (
 from ._framework import ApiTestCase
 
 
-class FolderContentsApiTestCase(ApiTestCase):
+class TestFolderContentsApi(ApiTestCase):
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
@@ -338,7 +338,7 @@ class FolderContentsApiTestCase(ApiTestCase):
         assert len(contents) == expected_contents_count, "Expected number of contents doesn't match"
         return index_response
 
-    def _create_folder_in_library(self, name: str) -> Any:
+    def _create_folder_in_library(self, name: str) -> str:
         root_folder_id = self.library["root_folder_id"]
         return self._create_subfolder_in(root_folder_id, name)
 

--- a/lib/galaxy_test/api/test_folders.py
+++ b/lib/galaxy_test/api/test_folders.py
@@ -5,7 +5,9 @@ from galaxy_test.base.populators import (
 from ._framework import ApiTestCase
 
 
-class FoldersApiTestCase(ApiTestCase):
+class TestFoldersApi(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/lib/galaxy_test/api/test_framework.py
+++ b/lib/galaxy_test/api/test_framework.py
@@ -3,7 +3,7 @@
 from ._framework import ApiTestCase
 
 
-class ApiFrameworkTestCase(ApiTestCase):
+class TestApiFramework(ApiTestCase):
     def test_default_xframe_options(self):
         get_response = self._get("licenses")
         assert get_response.headers["x-frame-options"] == "SAMEORIGIN"

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -7,7 +7,9 @@ from galaxy_test.api._framework import ApiTestCase
 from galaxy_test.base.populators import DatasetPopulator
 
 
-class GroupRolesApiTestCase(ApiTestCase):
+class TestGroupRolesApi(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/lib/galaxy_test/api/test_group_users.py
+++ b/lib/galaxy_test/api/test_group_users.py
@@ -7,7 +7,9 @@ from galaxy_test.api._framework import ApiTestCase
 from galaxy_test.base.populators import DatasetPopulator
 
 
-class GroupUsersApiTestCase(ApiTestCase):
+class TestGroupUsersApi(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/lib/galaxy_test/api/test_groups.py
+++ b/lib/galaxy_test/api/test_groups.py
@@ -4,7 +4,9 @@ from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
 
-class GroupsApiTestCase(ApiTestCase):
+class TestGroupsApi(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -23,7 +23,9 @@ TEST_HASH_VALUE = "moocowpretendthisisahas"
 
 
 # TODO: Test anonymous access.
-class HistoryContentsApiTestCase(ApiTestCase):
+class TestHistoryContentsApi(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
@@ -900,7 +902,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
         assert sorted(collection["elements_datatypes"]) == sorted(expected_datatypes)
 
 
-class HistoryContentsApiNearTestCase(ApiTestCase):
+class TestHistoryContentsApiNear(ApiTestCase):
     """
     Test the /api/histories/{history_id}/contents/{direction}/{hid}/{limit} endpoint.
     """
@@ -1013,7 +1015,7 @@ class HistoryContentsApiNearTestCase(ApiTestCase):
             assert result[0]["hid"] == 8  # hid + 1
 
 
-class HistoryContentsApiBulkOperationTestCase(ApiTestCase):
+class TestHistoryContentsApiBulkOperation(ApiTestCase):
     """
     Test the `/api/histories/{history_id}/contents/bulk` endpoint and the new
     `count` special view for `/api/histories/{history_id}/contents?v=dev`

--- a/lib/galaxy_test/api/test_history_contents_provenance.py
+++ b/lib/galaxy_test/api/test_history_contents_provenance.py
@@ -10,6 +10,8 @@ ALL_PROV_KEYS = MINIMAL_PROV_KEYS + OTHER_PROV_KEYS
 
 
 class TestProvenance(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -22,7 +22,9 @@ from galaxy_test.base.populators import (
 from ._framework import ApiTestCase
 
 
-class JobsApiTestCase(ApiTestCase, TestsTools):
+class TestJobsApi(ApiTestCase, TestsTools):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -16,7 +16,9 @@ from galaxy_test.base.populators import (
 from ._framework import ApiTestCase
 
 
-class LibrariesApiTestCase(ApiTestCase):
+class TestLibrariesApi(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/lib/galaxy_test/api/test_licenses.py
+++ b/lib/galaxy_test/api/test_licenses.py
@@ -1,7 +1,7 @@
 from ._framework import ApiTestCase
 
 
-class LicensesApiTestCase(ApiTestCase):
+class TestLicensesApi(ApiTestCase):
     def test_index(self):
         response = self._get("licenses")
         self._assert_status_code_is(response, 200)

--- a/lib/galaxy_test/api/test_page_revisions.py
+++ b/lib/galaxy_test/api/test_page_revisions.py
@@ -1,8 +1,8 @@
 from galaxy.exceptions import error_codes
-from .test_pages import BasePageApiTestCase
+from .test_pages import BasePagesApiTestCase
 
 
-class PageRevisionsApiTestCase(BasePageApiTestCase):
+class TestPageRevisionsApi(BasePagesApiTestCase):
     def test_create(self):
         page_json = self._create_valid_page_with_slug("pr1")
         revision_data = dict(content="<p>NewContent!</p>")

--- a/lib/galaxy_test/api/test_pages.py
+++ b/lib/galaxy_test/api/test_pages.py
@@ -21,7 +21,9 @@ from galaxy_test.base.populators import (
 )
 
 
-class BasePageApiTestCase(ApiTestCase):
+class BasePagesApiTestCase(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
@@ -41,7 +43,7 @@ class BasePageApiTestCase(ApiTestCase):
         return self.dataset_populator.new_page_payload(**kwds)
 
 
-class PageApiTestCase(BasePageApiTestCase, SharingApiTests):
+class TestPagesApi(BasePagesApiTestCase, SharingApiTests):
 
     api_name = "pages"
 

--- a/lib/galaxy_test/api/test_roles.py
+++ b/lib/galaxy_test/api/test_roles.py
@@ -1,3 +1,9 @@
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+
 from galaxy.exceptions import error_codes
 from galaxy_test.base.api_asserts import (
     assert_error_code_is,
@@ -8,7 +14,9 @@ from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
 
-class RolesApiTestCase(ApiTestCase):
+class TestRolesApi(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
@@ -20,7 +28,7 @@ class RolesApiTestCase(ApiTestCase):
             assert isinstance(as_list, list)
             assert len(as_list) > 0
             for role in as_list:
-                RolesApiTestCase.check_role_dict(role)
+                self.check_role_dict(role)
 
         user_role_id = self.dataset_populator.user_private_role_id()
         with self._different_user():
@@ -46,7 +54,7 @@ class RolesApiTestCase(ApiTestCase):
         role_response = self._get(f"roles/{user_role_id}")
         assert_status_code_is(role_response, 200)
         role = role_response.json()
-        RolesApiTestCase.check_role_dict(role, assert_id=user_role_id)
+        self.check_role_dict(role, assert_id=user_role_id)
 
     def test_create_invalid_params(self):
         # In theory these low-level validation test cases could be handled in more
@@ -100,7 +108,7 @@ class RolesApiTestCase(ApiTestCase):
         response = self._post("roles", payload, admin=True, json=True)
         assert_status_code_is(response, 200)
         role = response.json()
-        RolesApiTestCase.check_role_dict(role)
+        self.check_role_dict(role)
 
         assert role["name"] == name
         assert role["description"] == description
@@ -135,7 +143,7 @@ class RolesApiTestCase(ApiTestCase):
         assert "administrator" in response_err["err_msg"]
 
     @staticmethod
-    def check_role_dict(role_dict, assert_id=None):
+    def check_role_dict(role_dict: Dict[str, Any], assert_id: Optional[str] = None):
         assert_has_keys(role_dict, "id", "name", "model_class", "url")
         assert role_dict["model_class"] == "Role"
         if assert_id is not None:

--- a/lib/galaxy_test/api/test_search.py
+++ b/lib/galaxy_test/api/test_search.py
@@ -4,7 +4,7 @@ from galaxy_test.base.populators import WorkflowPopulator
 from ._framework import ApiTestCase
 
 
-class SearchApiTestCase(ApiTestCase):
+class TestSearchApi(ApiTestCase):
     def test_search_workflows(self):
         workflow_populator = WorkflowPopulator(self.galaxy_interactor)
         workflow_id = workflow_populator.simple_workflow("test_for_search")

--- a/lib/galaxy_test/api/test_tool_data.py
+++ b/lib/galaxy_test/api/test_tool_data.py
@@ -10,7 +10,7 @@ import operator
 from ._framework import ApiTestCase
 
 
-class ToolDataApiTestCase(ApiTestCase):
+class TestToolDataApi(ApiTestCase):
     def test_admin_only(self):
         index_response = self._get("tool_data", admin=False)
         self._assert_status_code_is(index_response, 403)

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -124,7 +124,9 @@ class TestsTools:
             return create_response
 
 
-class ToolsTestCase(ApiTestCase, TestsTools):
+class TestToolsApi(ApiTestCase, TestsTools):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -24,7 +24,9 @@ from galaxy_test.base.populators import (
 from ._framework import ApiTestCase
 
 
-class ToolsUploadTestCase(ApiTestCase):
+class TestToolsUpload(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/lib/galaxy_test/api/test_tours.py
+++ b/lib/galaxy_test/api/test_tours.py
@@ -1,7 +1,7 @@
 from ._framework import ApiTestCase
 
 
-class TourApiTestCase(ApiTestCase):
+class TestToursApi(ApiTestCase):
     def test_index(self):
         response = self._get("tours")
         self._assert_status_code_is(response, 200)

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -16,7 +16,7 @@ TEST_USER_EMAIL_PURGE = "user_for_purge_test@bx.psu.edu"
 TEST_USER_EMAIL_UNDELETE = "user_for_undelete_test@bx.psu.edu"
 
 
-class UsersApiTestCase(ApiTestCase):
+class TestUsersApi(ApiTestCase):
     def test_index(self):
         self._setup_user(TEST_USER_EMAIL)
         all_users_response = self._get("users", admin=True)

--- a/lib/galaxy_test/api/test_visualizations.py
+++ b/lib/galaxy_test/api/test_visualizations.py
@@ -12,7 +12,7 @@ SHOW_KEYS = INDEX_KEYS + ["user_id", "model_class", "revisions", "latest_revisio
 REVISION_KEYS = ["id", "title", "visualization_id", "dbkey", "model_class", "config"]
 
 
-class VisualizationsApiTestCase(ApiTestCase, SharingApiTests):
+class TestVisualizationsApi(ApiTestCase, SharingApiTests):
 
     api_name = "visualizations"
 

--- a/lib/galaxy_test/api/test_webhooks.py
+++ b/lib/galaxy_test/api/test_webhooks.py
@@ -1,7 +1,7 @@
 from ._framework import ApiTestCase
 
 
-class WebhooksApiTestCase(ApiTestCase):
+class TestWebhooksApi(ApiTestCase):
     def setUp(self):
         super().setUp()
 

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -13,7 +13,7 @@ from galaxy_test.base.populators import (
 from .test_workflows import BaseWorkflowsApiTestCase
 
 
-class WorkflowExtractionApiTestCase(BaseWorkflowsApiTestCase):
+class TestWorkflowExtractionApi(BaseWorkflowsApiTestCase):
     history_id: str
 
     def setUp(self):
@@ -581,14 +581,14 @@ test_data:
         self._assert_status_code_is(prov_response, 200)
         return prov_response.json()["job_id"]
 
-    def __cat_job_id(self, history_id):
+    def __cat_job_id(self, history_id: str):
         data = dict(history_id=history_id, tool_id="cat1")
         jobs_response = self._get("jobs", data=data)
         self._assert_status_code_is(jobs_response, 200)
         cat1_job_id = jobs_response.json()[0]["id"]
         return cat1_job_id
 
-    def _run_tool_get_collection_and_job_id(self, history_id, tool_id, inputs):
+    def _run_tool_get_collection_and_job_id(self, history_id: str, tool_id, inputs):
         run_output1 = self.dataset_populator.run_tool(
             tool_id=tool_id,
             inputs=inputs,

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -165,6 +165,7 @@ input1:
 
 class BaseWorkflowsApiTestCase(ApiTestCase, RunsWorkflowFixtures):
     # TODO: Find a new file for this class.
+    dataset_populator: DatasetPopulator
 
     def setUp(self):
         super().setUp()
@@ -278,7 +279,7 @@ input1:
             assert details_dataset_new_col["metadata_startCol"] == 3
 
 
-class WorkflowsSharingApiTestCase(ApiTestCase, SharingApiTests):
+class TestWorkflowSharingApi(ApiTestCase, SharingApiTests):
 
     api_name = "workflows"
 
@@ -308,7 +309,9 @@ class WorkflowsSharingApiTestCase(ApiTestCase, SharingApiTests):
 # - Allow post to workflows/<workflow_id>/run in addition to posting to
 #    /workflows with id in payload.
 # - Much more testing obviously, always more testing.
-class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
+class TestWorkflowsApi(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
+    dataset_populator: DatasetPopulator
+
     def test_show_valid(self):
         workflow_id = self.workflow_populator.simple_workflow("dummy")
         workflow_id = self.workflow_populator.simple_workflow("test_regular")
@@ -3699,7 +3702,7 @@ outer_input:
 
     def test_workflow_stability(self):
         # Run this index stability test with following command:
-        #   ./run_tests.sh test/api/test_workflows.py:WorkflowsApiTestCase.test_workflow_stability
+        #   ./run_tests.sh test/api/test_workflows.py:TestWorkflowsApi.test_workflow_stability
         num_tests = 1
         for workflow_file in ["test_workflow_topoambigouity", "test_workflow_topoambigouity_auto_laidout"]:
             workflow = self.workflow_populator.load_workflow_from_resource(workflow_file)
@@ -5585,7 +5588,7 @@ input_c:
         return invocation_ids
 
 
-class AdminWorkflowsApiTestCase(BaseWorkflowsApiTestCase):
+class TestAdminWorkflowsApi(BaseWorkflowsApiTestCase):
 
     require_admin_user = True
 

--- a/lib/galaxy_test/api/test_workflows_cwl.py
+++ b/lib/galaxy_test/api/test_workflows_cwl.py
@@ -3,7 +3,7 @@ from galaxy_test.api.test_workflows import BaseWorkflowsApiTestCase
 from galaxy_test.base.populators import CwlPopulator
 
 
-class BaseCwlWorkflowTestCase(BaseWorkflowsApiTestCase):
+class BaseCwlWorkflowsApiTestCase(BaseWorkflowsApiTestCase):
     allow_path_paste = True
     require_admin_user = True
 

--- a/lib/galaxy_test/api/test_workflows_from_yaml.py
+++ b/lib/galaxy_test/api/test_workflows_from_yaml.py
@@ -15,7 +15,7 @@ from .test_workflows import BaseWorkflowsApiTestCase
 WORKFLOWS_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 
 
-class WorkflowsFromYamlApiTestCase(BaseWorkflowsApiTestCase):
+class TestWorkflowsFromYamlApi(BaseWorkflowsApiTestCase):
     def setUp(self):
         super().setUp()
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -459,7 +459,7 @@ class BaseDatasetPopulator(BasePopulator):
         outputs = fetch_response.json()["outputs"]
         return outputs
 
-    def fetch_hda(self, history_id, item: Dict[str, Any], wait: bool = True) -> Dict[str, Any]:
+    def fetch_hda(self, history_id: str, item: Dict[str, Any], wait: bool = True) -> Dict[str, Any]:
         hdas = self.fetch_hdas(history_id, [item], wait=wait)
         assert len(hdas) == 1
         return hdas[0]
@@ -2424,7 +2424,7 @@ class BaseDatasetCollectionPopulator:
             history_id=history_id, collection=pairs, collection_type="list:paired", name=name
         )
 
-    def nested_collection_identifiers(self, history_id, collection_type):
+    def nested_collection_identifiers(self, history_id: str, collection_type):
         rank_types = list(reversed(collection_type.split(":")))
         assert len(rank_types) > 0
         rank_type_0 = rank_types[0]
@@ -2485,7 +2485,7 @@ class BaseDatasetCollectionPopulator:
             ],
         )
 
-    def create_list_of_list_in_history(self, history_id, **kwds):
+    def create_list_of_list_in_history(self, history_id: str, **kwds):
         # create_nested_collection will generate nested collection from just datasets,
         # this function uses recursive generation of history hdcas.
         collection_type = kwds.pop("collection_type", "list:list")
@@ -2503,34 +2503,34 @@ class BaseDatasetCollectionPopulator:
             list = response.json()
         return response
 
-    def create_pair_in_history(self, history_id, wait=False, **kwds):
+    def create_pair_in_history(self, history_id: str, wait: bool = False, **kwds):
         payload = self.create_pair_payload(history_id, instance_type="history", **kwds)
         return self.__create(payload, wait=wait)
 
-    def create_list_in_history(self, history_id, wait=False, **kwds):
+    def create_list_in_history(self, history_id: str, wait: bool = False, **kwds):
         payload = self.create_list_payload(history_id, instance_type="history", **kwds)
         return self.__create(payload, wait=wait)
 
-    def upload_collection(self, history_id, collection_type, elements, wait=False, **kwds):
+    def upload_collection(self, history_id: str, collection_type, elements, wait: bool = False, **kwds):
         payload = self.__create_payload_fetch(history_id, collection_type, contents=elements, **kwds)
         return self.__create(payload, wait=wait)
 
-    def create_list_payload(self, history_id, **kwds):
+    def create_list_payload(self, history_id: str, **kwds):
         return self.__create_payload(history_id, identifiers_func=self.list_identifiers, collection_type="list", **kwds)
 
-    def create_pair_payload(self, history_id, **kwds):
+    def create_pair_payload(self, history_id: str, **kwds):
         return self.__create_payload(
             history_id, identifiers_func=self.pair_identifiers, collection_type="paired", **kwds
         )
 
-    def __create_payload(self, *args, **kwds):
+    def __create_payload(self, history_id: str, *args, **kwds):
         direct_upload = kwds.pop("direct_upload", True)
         if direct_upload:
-            return self.__create_payload_fetch(*args, **kwds)
+            return self.__create_payload_fetch(history_id, *args, **kwds)
         else:
-            return self.__create_payload_collection(*args, **kwds)
+            return self.__create_payload_collection(history_id, *args, **kwds)
 
-    def __create_payload_fetch(self, history_id, collection_type, **kwds):
+    def __create_payload_fetch(self, history_id: str, collection_type, **kwds):
         contents = None
         if "contents" in kwds:
             contents = kwds["contents"]
@@ -2601,7 +2601,7 @@ class BaseDatasetCollectionPopulator:
         )
         return dataset_collection
 
-    def __create_payload_collection(self, history_id, identifiers_func, collection_type, **kwds):
+    def __create_payload_collection(self, history_id: str, identifiers_func, collection_type, **kwds):
         contents = None
         if "contents" in kwds:
             contents = kwds["contents"]
@@ -2616,7 +2616,7 @@ class BaseDatasetCollectionPopulator:
         payload = dict(history_id=history_id, collection_type=collection_type, **kwds)
         return payload
 
-    def pair_identifiers(self, history_id, contents=None):
+    def pair_identifiers(self, history_id: str, contents=None):
         hda1, hda2 = self.__datasets(history_id, count=2, contents=contents)
 
         element_identifiers = [
@@ -2625,7 +2625,7 @@ class BaseDatasetCollectionPopulator:
         ]
         return element_identifiers
 
-    def list_identifiers(self, history_id, contents=None):
+    def list_identifiers(self, history_id: str, contents=None):
         count = 3 if contents is None else len(contents)
         # Contents can be a list of strings (with name auto-assigned here) or a list of
         # 2-tuples of form (name, dataset_content).
@@ -2653,7 +2653,7 @@ class BaseDatasetCollectionPopulator:
         else:
             return self.dataset_populator.fetch(payload, wait=wait)
 
-    def __datasets(self, history_id, count, contents=None):
+    def __datasets(self, history_id: str, count: int, contents=None):
         datasets = []
         for i in range(count):
             new_kwds = {}

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -7,6 +7,7 @@ testing configuration.
 import os
 from typing import (
     ClassVar,
+    Iterator,
     Optional,
     TYPE_CHECKING,
 )
@@ -181,7 +182,7 @@ class IntegrationInstance(UsesApiTestCaseMixin, UsesCeleryTasks):
         return os.path.realpath(os.path.join(cls._test_driver.galaxy_test_tmp_dir, name))
 
     @pytest.fixture
-    def history_id(self):
+    def history_id(self) -> Iterator[str]:
         assert self.dataset_populator
         with self.dataset_populator.test_history() as history_id:
             yield history_id

--- a/lib/galaxy_test/performance/test_workflow_framework_performance.py
+++ b/lib/galaxy_test/performance/test_workflow_framework_performance.py
@@ -17,7 +17,7 @@ GALAXY_TEST_PERFORMANCE_WORKFLOW_DEPTH = int(
 )
 
 
-class WorkflowFrameworkPerformanceTestCase(PerformanceTestCase):
+class TestWorkflowFrameworkPerformance(PerformanceTestCase):
     framework_tool_and_types = True
 
     def setUp(self):

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -5,7 +5,7 @@ from .framework import (
 )
 
 
-class AdminAppTestCase(SeleniumTestCase):
+class TestAdminApp(SeleniumTestCase):
 
     requires_admin = True
 

--- a/lib/galaxy_test/selenium/test_anon_history.py
+++ b/lib/galaxy_test/selenium/test_anon_history.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class AnonymousHistoriesTestCase(SeleniumTestCase):
+class TestAnonymousHistories(SeleniumTestCase):
     @selenium_test
     def test_anon_history_landing(self):
         self.home()

--- a/lib/galaxy_test/selenium/test_change_password.py
+++ b/lib/galaxy_test/selenium/test_change_password.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class ChangePasswordTestCase(SeleniumTestCase):
+class TestChangePassword(SeleniumTestCase):
     @selenium_test
     def test_change_password(self):
         self.home()

--- a/lib/galaxy_test/selenium/test_collection_builders.py
+++ b/lib/galaxy_test/selenium/test_collection_builders.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class CollectionBuildersTestCase(SeleniumTestCase):
+class TestCollectionBuilders(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class CollectionEditTestCase(SeleniumTestCase):
+class TestCollectionEdit(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_custom_builds.py
+++ b/lib/galaxy_test/selenium/test_custom_builds.py
@@ -5,7 +5,7 @@ from .framework import (
 )
 
 
-class CustomBuildsTestcase(SharedStateSeleniumTestCase):
+class TestCustomBuilds(SharedStateSeleniumTestCase):
     @selenium_test
     def test_build_add(self):
         self._login()
@@ -82,10 +82,10 @@ class CustomBuildsTestcase(SharedStateSeleniumTestCase):
         self.components.masthead.custom_builds.wait_for_and_click()
 
     def setup_shared_state(self):
-        CustomBuildsTestcase.user_email = self._get_random_email()
+        TestCustomBuilds.user_email = self._get_random_email()
         self.register(self.user_email)
 
-        CustomBuildsTestcase.build_name1 = self._get_random_name()
-        CustomBuildsTestcase.build_name2 = self._get_random_name()
-        CustomBuildsTestcase.build_key1 = self._get_random_name(len=5)
-        CustomBuildsTestcase.build_key2 = self._get_random_name(len=5)
+        TestCustomBuilds.build_name1 = self._get_random_name()
+        TestCustomBuilds.build_name2 = self._get_random_name()
+        TestCustomBuilds.build_key1 = self._get_random_name(len=5)
+        TestCustomBuilds.build_key2 = self._get_random_name(len=5)

--- a/lib/galaxy_test/selenium/test_data_source_tools.py
+++ b/lib/galaxy_test/selenium/test_data_source_tools.py
@@ -7,7 +7,7 @@ from .framework import (
 )
 
 
-class DataSourceTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
+class TestDataSource(SeleniumTestCase, UsesHistoryItemAssertions):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_dataset_metadata_download.py
+++ b/lib/galaxy_test/selenium/test_dataset_metadata_download.py
@@ -7,7 +7,7 @@ from .framework import (
 FIRST_HID = 1
 
 
-class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
+class TestHistoryDatasetState(SeleniumTestCase, UsesHistoryItemAssertions):
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_histories_list.py
+++ b/lib/galaxy_test/selenium/test_histories_list.py
@@ -5,7 +5,7 @@ from .framework import (
 )
 
 
-class SavedHistoriesTestCase(SharedStateSeleniumTestCase):
+class TestSavedHistories(SharedStateSeleniumTestCase):
     @selenium_test
     def test_histories_list(self):
         self._login()
@@ -264,15 +264,15 @@ class SavedHistoriesTestCase(SharedStateSeleniumTestCase):
         self.sleep_for(self.wait_types.UX_RENDER)
 
     def setup_shared_state(self):
-        SavedHistoriesTestCase.user_email = self._get_random_email()
-        SavedHistoriesTestCase.history1_name = self._get_random_name()
-        SavedHistoriesTestCase.history2_name = self._get_random_name()
-        SavedHistoriesTestCase.history3_name = self._get_random_name()
-        SavedHistoriesTestCase.history4_name = self._get_random_name()
-        SavedHistoriesTestCase.history2_tags = [self._get_random_name(len=5)]
-        SavedHistoriesTestCase.history3_tags = [self._get_random_name(len=5)]
-        SavedHistoriesTestCase.history4_tags = [self._get_random_name(len=5)]
-        SavedHistoriesTestCase.all_histories = [self.history1_name, self.history2_name, self.history3_name]
+        TestSavedHistories.user_email = self._get_random_email()
+        TestSavedHistories.history1_name = self._get_random_name()
+        TestSavedHistories.history2_name = self._get_random_name()
+        TestSavedHistories.history3_name = self._get_random_name()
+        TestSavedHistories.history4_name = self._get_random_name()
+        TestSavedHistories.history2_tags = [self._get_random_name(len=5)]
+        TestSavedHistories.history3_tags = [self._get_random_name(len=5)]
+        TestSavedHistories.history4_tags = [self._get_random_name(len=5)]
+        TestSavedHistories.all_histories = [self.history1_name, self.history2_name, self.history3_name]
 
         self.register(self.user_email)
         self.create_history(self.history2_name)

--- a/lib/galaxy_test/selenium/test_history_copy_elements.py
+++ b/lib/galaxy_test/selenium/test_history_copy_elements.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class HistoryCopyElementsTestCase(SeleniumTestCase):
+class TestHistoryCopyElements(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -22,7 +22,7 @@ TEST_DBKEY_TEXT = "Honeybee (Apis mellifera): apiMel3 (apiMel3)"
 FIRST_HID = 1
 
 
-class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
+class TestHistoryDatasetState(SeleniumTestCase, UsesHistoryItemAssertions):
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_history_export.py
+++ b/lib/galaxy_test/selenium/test_history_export.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class HistoryExportTestCase(SeleniumTestCase):
+class TestHistoryExport(SeleniumTestCase):
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class HistoryMultiViewTestCase(SeleniumTestCase):
+class TestHistoryMultiView(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_history_options.py
+++ b/lib/galaxy_test/selenium/test_history_options.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class HistoryOptionsTestCase(SeleniumTestCase):
+class TestHistoryOptions(SeleniumTestCase):
     @selenium_test
     def test_options(self):
         self.register()

--- a/lib/galaxy_test/selenium/test_history_panel.py
+++ b/lib/galaxy_test/selenium/test_history_panel.py
@@ -8,7 +8,7 @@ from .framework import (
 NEW_HISTORY_NAME = "New History Name"
 
 
-class HistoryPanelTestCase(SeleniumTestCase):
+class TestHistoryPanel(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_history_panel_collections.py
+++ b/lib/galaxy_test/selenium/test_history_panel_collections.py
@@ -10,7 +10,7 @@ from .framework import (
 )
 
 
-class HistoryPanelCollectionsTestCase(SeleniumTestCase):
+class TestHistoryPanelCollections(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_history_sharing.py
+++ b/lib/galaxy_test/selenium/test_history_sharing.py
@@ -7,7 +7,7 @@ from .framework import (
 VALID_LOGIN_RETRIES = 3
 
 
-class HistorySharingTestCase(SeleniumTestCase):
+class TestHistorySharing(SeleniumTestCase):
     @selenium_test
     def test_sharing_valid(self):
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history()
@@ -120,7 +120,7 @@ class HistorySharingTestCase(SeleniumTestCase):
         )
 
 
-class HistoryRequiresLoginSeleniumTestCase(SeleniumTestCase):
+class TestHistoryRequiresLoginSelenium(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_invocation_grid.py
+++ b/lib/galaxy_test/selenium/test_invocation_grid.py
@@ -7,7 +7,7 @@ from .framework import (
 )
 
 
-class InvocationGridSeleniumTestCase(SeleniumTestCase, TestsGalaxyPagers):
+class TestInvocationGridSelenium(SeleniumTestCase, TestsGalaxyPagers):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -8,7 +8,7 @@ from .framework import (
 )
 
 
-class LibraryContentsTestCase(SeleniumTestCase, UsesLibraryAssertions):
+class TestLibraryContents(SeleniumTestCase, UsesLibraryAssertions):
 
     requires_admin = True
 

--- a/lib/galaxy_test/selenium/test_library_landing.py
+++ b/lib/galaxy_test/selenium/test_library_landing.py
@@ -5,7 +5,7 @@ from .framework import (
 )
 
 
-class LibraryLandingTestCase(SeleniumTestCase):
+class TestLibraryLanding(SeleniumTestCase):
 
     requires_admin = True
 

--- a/lib/galaxy_test/selenium/test_library_to_collections.py
+++ b/lib/galaxy_test/selenium/test_library_to_collections.py
@@ -5,7 +5,7 @@ from .framework import (
 )
 
 
-class LibraryToCollectionsTestCase(SeleniumTestCase, UsesLibraryAssertions):
+class TestLibraryToCollections(SeleniumTestCase, UsesLibraryAssertions):
 
     requires_admin = True
 

--- a/lib/galaxy_test/selenium/test_login.py
+++ b/lib/galaxy_test/selenium/test_login.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class LoginTestCase(SeleniumTestCase):
+class TestLogin(SeleniumTestCase):
     @selenium_test
     def test_logging_in(self):
         email = self._get_random_email()

--- a/lib/galaxy_test/selenium/test_navigates_galaxy.py
+++ b/lib/galaxy_test/selenium/test_navigates_galaxy.py
@@ -6,7 +6,7 @@ from .framework import (
 )
 
 
-class NavigatesGalaxySeleniumTestCase(SeleniumTestCase):
+class TestNavigatesGalaxySelenium(SeleniumTestCase):
     """Test the Selenium test framework itself.
 
     Unlike the others test cases in this module, this test case tests the

--- a/lib/galaxy_test/selenium/test_pages.py
+++ b/lib/galaxy_test/selenium/test_pages.py
@@ -5,7 +5,7 @@ from .framework import (
 )
 
 
-class PagesTestCase(SeleniumTestCase):
+class TestPages(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_personal_information.py
+++ b/lib/galaxy_test/selenium/test_personal_information.py
@@ -4,7 +4,7 @@ from galaxy_test.selenium.framework import (
 )
 
 
-class ManageInformationTestCase(SeleniumTestCase):
+class TestManageInformation(SeleniumTestCase):
     @selenium_test
     def test_api_key(self):
         """
@@ -138,7 +138,7 @@ class ManageInformationTestCase(SeleniumTestCase):
         return address_form.find_element(self.by.CSS_SELECTOR, f"[data-label='{input_field_label}'] > input")
 
 
-class DeleteCurrentAccountTestCase(SeleniumTestCase):
+class TestDeleteCurrentAccount(SeleniumTestCase):
     @selenium_test
     def test_delete_account(self):
         email = self._get_random_email()

--- a/lib/galaxy_test/selenium/test_published_histories_grid.py
+++ b/lib/galaxy_test/selenium/test_published_histories_grid.py
@@ -7,7 +7,7 @@ from .framework import (
 )
 
 
-class HistoryGridTestCase(SharedStateSeleniumTestCase):
+class TestHistoryGrid(SharedStateSeleniumTestCase):
     @selenium_test
     def test_history_grid_histories(self):
         self.navigate_to_published_histories_page()
@@ -165,17 +165,17 @@ class HistoryGridTestCase(SharedStateSeleniumTestCase):
         tag2 = self._get_random_name(len=5)
         tag3 = self._get_random_name(len=5)
 
-        HistoryGridTestCase.user1_email = self._get_random_email("test1")
-        HistoryGridTestCase.user2_email = self._get_random_email("test2")
-        HistoryGridTestCase.history1_name = self._get_random_name()
-        HistoryGridTestCase.history2_name = self._get_random_name()
-        HistoryGridTestCase.history3_name = self._get_random_name()
-        HistoryGridTestCase.history4_name = self._get_random_name()
-        HistoryGridTestCase.history1_tags = [tag1, tag2]
-        HistoryGridTestCase.history2_tags = [tag3]
-        HistoryGridTestCase.history3_tags = [tag1]
-        HistoryGridTestCase.history3_annot = self._get_random_name()
-        HistoryGridTestCase.all_histories = [self.history1_name, self.history2_name, self.history3_name]
+        TestHistoryGrid.user1_email = self._get_random_email("test1")
+        TestHistoryGrid.user2_email = self._get_random_email("test2")
+        TestHistoryGrid.history1_name = self._get_random_name()
+        TestHistoryGrid.history2_name = self._get_random_name()
+        TestHistoryGrid.history3_name = self._get_random_name()
+        TestHistoryGrid.history4_name = self._get_random_name()
+        TestHistoryGrid.history1_tags = [tag1, tag2]
+        TestHistoryGrid.history2_tags = [tag3]
+        TestHistoryGrid.history3_tags = [tag1]
+        TestHistoryGrid.history3_annot = self._get_random_name()
+        TestHistoryGrid.all_histories = [self.history1_name, self.history2_name, self.history3_name]
 
         self.register(self.user1_email)
         self.create_history(self.history1_name)

--- a/lib/galaxy_test/selenium/test_registration.py
+++ b/lib/galaxy_test/selenium/test_registration.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class RegistrationTestCase(SeleniumTestCase):
+class TestRegistration(SeleniumTestCase):
     @selenium_test
     def test_landing(self):
         # loading galaxy homepage

--- a/lib/galaxy_test/selenium/test_sign_out.py
+++ b/lib/galaxy_test/selenium/test_sign_out.py
@@ -6,7 +6,7 @@ from .framework import (
 )
 
 
-class SignOutTestCase(SeleniumTestCase):
+class TestSignOut(SeleniumTestCase):
     @selenium_test
     def test_sign_out(self):
         email = self._get_random_email()

--- a/lib/galaxy_test/selenium/test_sizzle_loading.py
+++ b/lib/galaxy_test/selenium/test_sizzle_loading.py
@@ -4,7 +4,7 @@ from .framework import (
 )
 
 
-class SizzleLoadingTestCase(SeleniumTestCase):
+class TestSizzleLoading(SeleniumTestCase):
     @selenium_test
     def test_sizzle_loads(self):
         self.home()

--- a/lib/galaxy_test/selenium/test_tool_describing_tours.py
+++ b/lib/galaxy_test/selenium/test_tool_describing_tours.py
@@ -6,7 +6,7 @@ from .framework import (
 )
 
 
-class ToolDescribingToursTestCase(SeleniumTestCase):
+class TestToolDescribingTours(SeleniumTestCase):
     def setUp(self):
         super().setUp()
         self.home()

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -20,7 +20,7 @@ from .framework import (
 )
 
 
-class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
+class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
     def test_run_tool_verify_contents_by_peek(self):
         self._run_environment_test_tool()
@@ -176,7 +176,7 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.tool_form_execute()
 
 
-class LoggedInToolFormTestCase(SeleniumTestCase):
+class TestLoggedInToolForm(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -9,7 +9,7 @@ from .framework import (
 )
 
 
-class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
+class TestUploads(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
     def test_upload_file(self):
         self.perform_upload(self.get_filename("1.sam"))

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -25,7 +25,7 @@ from .framework import (
 )
 
 
-class WorkflowEditorTestCase(SeleniumTestCase, RunsWorkflows):
+class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_workflow_invocation_details.py
+++ b/lib/galaxy_test/selenium/test_workflow_invocation_details.py
@@ -6,7 +6,7 @@ from .framework import (
 )
 
 
-class WorkflowInvocationDetailsTestCase(SeleniumTestCase):
+class TestWorkflowInvocationDetails(SeleniumTestCase):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -10,7 +10,7 @@ from .framework import (
 )
 
 
-class WorkflowManagementTestCase(SeleniumTestCase, TestsGalaxyPagers, UsesWorkflowAssertions):
+class TestWorkflowManagement(SeleniumTestCase, TestsGalaxyPagers, UsesWorkflowAssertions):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -24,7 +24,7 @@ from .framework import (
 )
 
 
-class WorkflowRunTestCase(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows):
+class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows):
 
     ensure_registered = True
 

--- a/lib/galaxy_test/selenium/test_workflow_sharing.py
+++ b/lib/galaxy_test/selenium/test_workflow_sharing.py
@@ -6,7 +6,7 @@ from .framework import (
 )
 
 
-class WorkflowSharingRedirectTestCase(SeleniumTestCase):
+class TestWorkflowSharingRedirect(SeleniumTestCase):
 
     ensure_registered = True
 
@@ -36,7 +36,7 @@ class WorkflowSharingRedirectTestCase(SeleniumTestCase):
         self.wait_for_logged_in()
 
 
-class WorkflowSharingTestCase(SeleniumTestCase, UsesWorkflowAssertions):
+class TestWorkflowSharing(SeleniumTestCase, UsesWorkflowAssertions):
     @selenium_test
     def test_sharing_workflow_by_email(self):
         _, user2_email = self.setup_two_users_with_one_shared_workflow(screenshot=True)

--- a/lib/tool_shed/test/functional/test_1000_install_basic_repository.py
+++ b/lib/tool_shed/test/functional/test_1000_install_basic_repository.py
@@ -4,7 +4,7 @@ from ..base.twilltestcase import (
 )
 
 
-class BasicToolShedFeatures(ShedTwillTestCase):
+class TestBasicToolShedFeatures(ShedTwillTestCase):
     """Test installing a basic repository."""
 
     def test_0000_initiate_users(self):

--- a/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
@@ -13,7 +13,7 @@ category_name = "Test 0010 Repository With Tool Dependencies"
 log = logging.getLogger(__name__)
 
 
-class ToolWithToolDependencies(ShedTwillTestCase):
+class TestToolWithToolDependencies(ShedTwillTestCase):
     """Test installing a repository with tool dependencies."""
 
     def test_0000_initiate_users(self):

--- a/lib/tool_shed/test/functional/test_1020_install_repository_with_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1020_install_repository_with_repository_dependencies.py
@@ -12,7 +12,7 @@ emboss_repository_description = "Galaxy wrappers for Emboss version 5.0.0 tools 
 emboss_repository_long_description = "Galaxy wrappers for Emboss version 5.0.0 tools for test 0020"
 
 
-class ToolWithRepositoryDependencies(ShedTwillTestCase):
+class TestToolWithRepositoryDependencies(ShedTwillTestCase):
     """Test installing a repository with repository dependencies."""
 
     def test_0000_initiate_users(self):

--- a/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
@@ -16,7 +16,7 @@ emboss_repository_long_description = "Galaxy wrappers for Emboss version 5.0.0 t
 running_standalone = False
 
 
-class RepositoryWithDependencyRevisions(ShedTwillTestCase):
+class TestRepositoryWithDependencyRevisions(ShedTwillTestCase):
     """Test installing a repository with dependency revisions."""
 
     def test_0000_initiate_users(self):

--- a/lib/tool_shed/test/functional/test_1200_uninstall_and_reinstall_basic_repository.py
+++ b/lib/tool_shed/test/functional/test_1200_uninstall_and_reinstall_basic_repository.py
@@ -4,7 +4,7 @@ from ..base.twilltestcase import (
 )
 
 
-class UninstallingAndReinstallingRepositories(ShedTwillTestCase):
+class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
     """Test uninstalling and reinstalling a basic repository."""
 
     def test_0000_initiate_users(self):

--- a/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
@@ -6,7 +6,7 @@ from ..base.twilltestcase import (
 )
 
 
-class UninstallingAndReinstallingRepositories(ShedTwillTestCase):
+class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
     """Test uninstalling and reinstalling a repository with tool dependencies."""
 
     def test_0000_initiate_users(self):

--- a/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
@@ -16,7 +16,7 @@ emboss_repository_long_description = "Galaxy wrappers for Emboss version 5.0.0 t
 running_standalone = False
 
 
-class UninstallingAndReinstallingRepositories(ShedTwillTestCase):
+class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
     """Test uninstalling and reinstalling a repository with repository dependency revisions."""
 
     def test_0000_initiate_users(self):

--- a/lib/tool_shed/test/functional/test_galaxy_install.py
+++ b/lib/tool_shed/test/functional/test_galaxy_install.py
@@ -1,7 +1,7 @@
 from ..base.api import ShedApiTestCase
 
 
-class ShedGalaxyInstallApiTestCase(ShedApiTestCase):
+class TestShedGalaxyInstallApi(ShedApiTestCase):
     def test_install_simple_tool(self):
         populator = self.populator
         repository = populator.setup_column_maker_repo(prefix="repoformetadata")

--- a/lib/tool_shed/test/functional/test_shed_categories.py
+++ b/lib/tool_shed/test/functional/test_shed_categories.py
@@ -2,7 +2,7 @@ from galaxy_test.base.api_util import random_name
 from ..base.api import ShedApiTestCase
 
 
-class ShedCategoriesApiTestCase(ShedApiTestCase):
+class TestShedCategoriesApi(ShedApiTestCase):
     def test_create_requires_name(self):
         body = {}
         response = self.admin_api_interactor.post("categories", json=body)

--- a/lib/tool_shed/test/functional/test_shed_repositories.py
+++ b/lib/tool_shed/test/functional/test_shed_repositories.py
@@ -5,7 +5,7 @@ from ..base.api import ShedApiTestCase
 COLUMN_MAKER_PATH = resource_path(__package__, "../test_data/column_maker/column_maker.tar")
 
 
-class ShedRepositoriesApiTestCase(ShedApiTestCase):
+class TestShedRepositoriesApi(ShedApiTestCase):
     def test_create(self):
         populator = self.populator
         category_id = populator.new_category(prefix="testcreate").id

--- a/lib/tool_shed/test/functional/test_shed_tools.py
+++ b/lib/tool_shed/test/functional/test_shed_tools.py
@@ -1,7 +1,7 @@
 from ..base.api import ShedApiTestCase
 
 
-class ShedToolsApiTestCase(ShedApiTestCase):
+class TestShedToolsApi(ShedApiTestCase):
     def test_tool_search(self):
         populator = self.populator
         repository = populator.setup_column_maker_repo(prefix="toolsearch")

--- a/lib/tool_shed/test/functional/test_shed_users.py
+++ b/lib/tool_shed/test/functional/test_shed_users.py
@@ -11,7 +11,7 @@ from ..base.api import (
 from ..base.api_util import get_admin_api_key
 
 
-class ShedUsersApiTestCase(ShedApiTestCase):
+class TestShedUsersApi(ShedApiTestCase):
     def test_create_requires_admin(self):
         url = urljoin(self.url, "api/users")
         response = post(url)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -53,10 +53,8 @@ The main test types are as follows:
    located in lib/tool_shed/test.
 
 Python testing is mostly done via pytest. Specific tests can be selected
-using the pytest selector syntax is described at https://docs.pytest.org/en/latest/usage.html.
-
-The spots these selectors can be used is described in the above usage documentation
-as ``test_path``.  A few examples are shown below.
+using the syntax described at https://docs.pytest.org/en/latest/how-to/usage.html .
+A few examples are shown below.
 
 Run all API tests:
     ./run_tests.sh -api
@@ -64,16 +62,16 @@ Run all API tests:
 The same test as above can be run using pytest directly as follows:
     pytest lib/galaxy_test/api
 
-However when using pytest directly output options defined in this
+However, when using pytest directly, output options defined in this
 file aren't respected and a new Galaxy instance will be created for each
-TestCase class (this scripts optimizes it so all tests can share a Galaxy
+Test class (this scripts optimizes it so all tests can share a Galaxy
 instance).
 
 Run a full class of API tests:
-    ./run_tests.sh -api lib/galaxy_test/api/test_tools.py::ToolsTestCase
+    ./run_tests.sh -api lib/galaxy_test/api/test_tools.py::TestToolsApi
 
 Run a specific API test:
-    ./run_tests.sh -api lib/galaxy_test/api/test_tools.py::ToolsTestCase::test_map_over_with_output_format_actions
+    ./run_tests.sh -api lib/galaxy_test/api/test_tools.py::TestToolsApi::test_map_over_with_output_format_actions
 
 Run all selenium tests (Under Linux using Docker):
     # Start selenium chrome Docker container
@@ -81,14 +79,14 @@ Run all selenium tests (Under Linux using Docker):
     GALAXY_TEST_SELENIUM_REMOTE=1 ./run_tests.sh -selenium
 
 Run a specific selenium test (under Linux or Mac OS X after installing geckodriver or chromedriver):
-    ./run_tests.sh -selenium lib/galaxy_test/selenium/test_registration.py::RegistrationTestCase::test_reregister_username_fails
+    ./run_tests.sh -selenium lib/galaxy_test/selenium/test_registration.py::TestRegistration::test_reregister_username_fails
 
 Run a selenium test against a running server while watching client (fastest iterating on client tests):
     ./run.sh & # run Galaxy on 8080
     make client-watch & # watch for client changes
     export GALAXY_TEST_EXTERNAL=http://localhost:8080/  # Target tests at server.
     . .venv/bin/activate # source the virtualenv so can skip run_tests.sh.
-    pytest lib/galaxy_test/selenium/test_workflow_editor.py::WorkflowEditorTestCase::test_data_input
+    pytest lib/galaxy_test/selenium/test_workflow_editor.py::TestWorkflowEditor::test_data_input
 
 Note About Selenium Tests:
 
@@ -99,7 +97,7 @@ the PATH.
 More information on geckodriver can be found at
 https://github.com/mozilla/geckodriver and more information on
 chromedriver can be found at
-https://sites.google.com/a/chromium.org/chromedriver/.
+https://sites.google.com/chromium.org/driver/ .
 
 By default Galaxy will check the PATH for these and pick
 whichever it finds. This can be overridden by setting

--- a/scripts/cwl_conformance_to_test_cases.py
+++ b/scripts/cwl_conformance_to_test_cases.py
@@ -13,10 +13,10 @@ TEST_FILE_TEMPLATE = string.Template(
 
 import pytest
 
-from ..test_workflows_cwl import BaseCwlWorkflowTestCase
+from ..test_workflows_cwl import BaseCwlWorkflowsApiTestCase
 
 
-class CwlConformanceTestCase(BaseCwlWorkflowTestCase):
+class TestCwlConformance(BaseCwlWorkflowsApiTestCase):
     """Test case mapping to CWL conformance tests for version ${version}."""
 $tests'''
 )


### PR DESCRIPTION
… in API, framework, performance, Selenium and ToolShed tests

These tests are collected by pytest only because they are `unittest.TestCase` derived, but normally pytest collects only test classes whose name starts with `Test`, see https://docs.pytest.org/en/7.1.x/reference/reference.html#confval-python_classes

Also:
- Some type annotations

This PR contains the uncontroversial changes from https://github.com/galaxyproject/galaxy/pull/14739 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
