### PR TITLE
Disable integrity check for CWL relocate script

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -12,6 +12,7 @@ from galaxy import util
 from galaxy.job_execution.output_collect import default_exit_code_file
 from galaxy.jobs.runners.util.job_script import (
     INTEGRITY_INJECTION,
+    ScriptIntegrityChecks,
     write_script,
 )
 from galaxy.tool_util.deps.container_classes import (
@@ -141,7 +142,7 @@ def build_command(
         relocate_contents = (
             "from galaxy_ext.cwl.handle_outputs import relocate_dynamic_outputs; relocate_dynamic_outputs()"
         )
-        write_script(relocate_script_file, relocate_contents, job_wrapper.job_io)
+        write_script(relocate_script_file, relocate_contents, ScriptIntegrityChecks(check_job_script_integrity=False))
         commands_builder.append_command(SETUP_GALAXY_FOR_METADATA)
         commands_builder.append_command(f"python '{relocate_script_file}'")
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -21,11 +21,11 @@ from galaxy.job_execution.output_collect import (
     default_exit_code_file,
     read_exit_code_from,
 )
-from galaxy.job_execution.setup import JobIO
 from galaxy.jobs.command_factory import build_command
 from galaxy.jobs.runners.util import runner_states
 from galaxy.jobs.runners.util.env import env_to_statement
 from galaxy.jobs.runners.util.job_script import (
+    DescribesScriptIntegrityChecks,
     job_script,
     write_script,
 )
@@ -278,7 +278,7 @@ class BaseJobRunner:
         return True
 
     # Runners must override the job handling methods
-    def queue_job(self, job_wrapper):
+    def queue_job(self, job_wrapper: "MinimalJobWrapper") -> None:
         raise NotImplementedError()
 
     def stop_job(self, job_wrapper):
@@ -474,7 +474,7 @@ class BaseJobRunner:
         options.update(**kwds)
         return job_script(**options)
 
-    def write_executable_script(self, path: str, contents: str, job_io: JobIO):
+    def write_executable_script(self, path: str, contents: str, job_io: DescribesScriptIntegrityChecks) -> None:
         write_script(path, contents, job_io)
 
     def _find_container(

--- a/lib/galaxy/jobs/runners/aws.py
+++ b/lib/galaxy/jobs/runners/aws.py
@@ -8,7 +8,10 @@ import os
 import re
 import time
 from queue import Empty
-from typing import Set
+from typing import (
+    Set,
+    TYPE_CHECKING,
+)
 
 from galaxy import model
 from galaxy.job_execution.output_collect import default_exit_code_file
@@ -21,6 +24,9 @@ from galaxy.util import (
     smart_str,
     unicodify,
 )
+
+if TYPE_CHECKING:
+    from galaxy.jobs import MinimalJobWrapper
 
 BOTO3_IMPORT_MSG = (
     "The Python 'boto3' package is required to use "
@@ -579,7 +585,7 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
         parsed_params["platform"] = platform
         return parsed_params
 
-    def write_command(self, job_wrapper):
+    def write_command(self, job_wrapper: "MinimalJobWrapper") -> str:
         # Create command script instead passing it in the container
         # preventing wrong characters parsing.
         command_line = job_wrapper.runner_command_line

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -8,6 +8,10 @@ import subprocess
 import tempfile
 import threading
 from time import sleep
+from typing import (
+    Tuple,
+    TYPE_CHECKING,
+)
 
 from galaxy import model
 from galaxy.job_execution.output_collect import default_exit_code_file
@@ -21,6 +25,9 @@ from .util.process_groups import (
     check_pg,
     kill_pg,
 )
+
+if TYPE_CHECKING:
+    from galaxy.jobs import MinimalJobWrapper
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +56,7 @@ class LocalJobRunner(BaseJobRunner):
 
         super().__init__(app, nworkers)
 
-    def __command_line(self, job_wrapper):
+    def __command_line(self, job_wrapper: "MinimalJobWrapper") -> Tuple[str, str]:
         """ """
         command_line = job_wrapper.runner_command_line
 


### PR DESCRIPTION
Also:
- Add type annotation to script writing methods and functions calling them.

Partially from https://github.com/galaxyproject/galaxy/pull/12909

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
