### PR TITLE
Replace ``set-output`` commands with ``$GITHUB_OUTPUT`` environment file in GitHub workflows

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -67,7 +67,7 @@ jobs:
       - name: Run tests
         run: ./run_tests.sh --coverage --skip_flakey_fails -api lib/galaxy_test/api -- --num-shards=2 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           flags: api
           working-directory: 'galaxy root'

--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -17,10 +17,10 @@ jobs:
       # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
       - name: Set outputs
         id: commit
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Set branch name
         id: branch
-        run: echo "::set-output name=name::$(BRANCH_NAME=${GITHUB_REF##*/}; echo ${BRANCH_NAME/release_/})"
+        run: echo "name=$(BRANCH_NAME=${GITHUB_REF##*/}; echo ${BRANCH_NAME/release_/})" >> $GITHUB_OUTPUT
       - name: Build container image
         run: docker build . --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg IMAGE_TAG=${{ steps.branch.outputs.name }} -t galaxy/galaxy-min:${{ steps.branch.outputs.name }} -t quay.io/galaxyproject/galaxy-min:${{ steps.branch.outputs.name }} -f .k8s_ci.Dockerfile
       - name: Create auto-expiring one for per-commit auto repository

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -36,7 +36,7 @@ jobs:
       with:
         repository: galaxyproject/galaxy-test-data
         path: galaxy-test-data
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache venv dir

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -24,61 +24,61 @@ jobs:
       matrix:
         python-version: ['3.7']
     steps:
-    - if: github.event_name == 'schedule'
-      run: |
-        echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
-        echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
-    - uses: actions/checkout@v3
-      with:
-        path: 'galaxy root'
-    - name: Clone galaxyproject/galaxy-test-data
-      uses: actions/checkout@v3
-      with:
-        repository: galaxyproject/galaxy-test-data
-        path: galaxy-test-data
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Cache venv dir
-      uses: actions/cache@v3
-      id: pip-cache
-      with:
-        path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
-    - name: Move test data
-      run: rsync -av --remove-source-files --exclude .git galaxy-test-data/ 'galaxy root/test-data/'
-    - name: Install planemo
-      run: pip install planemo
-    - name: Determine converters to check
-      run: |
-        ls 'galaxy root'/lib/galaxy/datatypes/converters/*xml | grep -v -f 'galaxy root'/lib/galaxy/datatypes/converters/.tt_skip > tool_list.txt
-        echo "Skipping checks for the following converters:"
-        ls 'galaxy root'/lib/galaxy/datatypes/converters/*xml | grep -f 'galaxy root'/lib/galaxy/datatypes/converters/.tt_skip
-        echo "Checking only the following converters:"
-        cat tool_list.txt
-    - name: Lint converters
-      run: |
-        mapfile -t TOOL_ARRAY < tool_list.txt
-        for CONVERTER in "${TOOL_ARRAY[@]}"; do
-          planemo lint --skip citations,stdio,help --report_level warn "$CONVERTER"
-        done
-    - name: Run tests
-      run: |
-        mkdir -p json_output
-        EXIT_CODE=0
-        mapfile -t TOOL_ARRAY < tool_list.txt
-        for CONVERTER in "${TOOL_ARRAY[@]}"; do
-          json=$(mktemp -u -p json_output --suff .json)
-          planemo test --test_output_json "$json" --galaxy_python_version ${{ matrix.python-version }} --galaxy_root 'galaxy root' "$CONVERTER" || EXIT_CODE=$?
-        done
-        planemo merge_test_reports json_output/*.json tool_test_output.json
-        planemo test_reports tool_test_output.json --test_output tool_test_output.html
-        if [ "$EXIT_CODE" -ne 0 ]; then
-          echo "Unsuccessful tests found, inspect the 'Converter test results' artifact for details."
-          exit $EXIT_CODE
-        fi
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: Converter test results (${{ matrix.python-version }})
-        path: tool_test_output.html
+      - if: github.event_name == 'schedule'
+        run: |
+          echo "GALAXY_CONFIG_OVERRIDE_METADATA_STRATEGY=extended" >> $GITHUB_ENV
+          echo "GALAXY_CONFIG_OVERRIDE_OUTPUTS_TO_WORKING_DIRECTORY=true" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+        with:
+          path: 'galaxy root'
+      - name: Clone galaxyproject/galaxy-test-data
+        uses: actions/checkout@v3
+        with:
+          repository: galaxyproject/galaxy-test-data
+          path: galaxy-test-data
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache venv dir
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - name: Move test data
+        run: rsync -av --remove-source-files --exclude .git galaxy-test-data/ 'galaxy root/test-data/'
+      - name: Install planemo
+        run: pip install planemo
+      - name: Determine converters to check
+        run: |
+          ls 'galaxy root'/lib/galaxy/datatypes/converters/*xml | grep -v -f 'galaxy root'/lib/galaxy/datatypes/converters/.tt_skip > tool_list.txt
+          echo "Skipping checks for the following converters:"
+          ls 'galaxy root'/lib/galaxy/datatypes/converters/*xml | grep -f 'galaxy root'/lib/galaxy/datatypes/converters/.tt_skip
+          echo "Checking only the following converters:"
+          cat tool_list.txt
+      - name: Lint converters
+        run: |
+          mapfile -t TOOL_ARRAY < tool_list.txt
+          for CONVERTER in "${TOOL_ARRAY[@]}"; do
+            planemo lint --skip citations,stdio,help --report_level warn "$CONVERTER"
+          done
+      - name: Run tests
+        run: |
+          mkdir -p json_output
+          EXIT_CODE=0
+          mapfile -t TOOL_ARRAY < tool_list.txt
+          for CONVERTER in "${TOOL_ARRAY[@]}"; do
+            json=$(mktemp -u -p json_output --suff .json)
+            planemo test --test_output_json "$json" --galaxy_python_version ${{ matrix.python-version }} --galaxy_root 'galaxy root' "$CONVERTER" || EXIT_CODE=$?
+          done
+          planemo merge_test_reports json_output/*.json tool_test_output.json
+          planemo test_reports tool_test_output.json --test_output tool_test_output.html
+          if [ "$EXIT_CODE" -ne 0 ]; then
+            echo "Unsuccessful tests found, inspect the 'Converter test results' artifact for details."
+            exit $EXIT_CODE
+          fi
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Converter test results (${{ matrix.python-version }})
+          path: tool_test_output.html

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/cwl_conformance.yaml
+++ b/.github/workflows/cwl_conformance.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -58,7 +58,7 @@ jobs:
       - name: Run tests
         run: ./run_tests.sh --coverage --skip_flakey_fails -cwl lib/galaxy_test/api/cwl -- -m "${{ matrix.marker }} and ${{ matrix.conformance-version }}"
         working-directory: 'galaxy root'
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           flags: cwl-conformance
           working-directory: 'galaxy root'

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         id: pip-cache

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -22,12 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7']
         db: ['postgresql', 'sqlite']
         postgresql-version: ['13']
+        python-version: ['3.7']
         include:
           - db: postgresql
             postgresql-version: '9.6'
+            python-version: '3.7'
     services:
       postgres:
         image: postgres:${{ matrix.postgresql-version }}
@@ -61,11 +62,8 @@ jobs:
           key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-check-indexes
       - name: Install tox
         run: pip install tox
-      - name: Check indexes on postgresql
+      - name: Set database connection on PostgreSQL
         if: matrix.db == 'postgresql'
-        env:
-          GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
-        run: tox -e check_indexes
-      - name: Check indexes on sqlite
-        if: matrix.db == 'sqlite'
+        run: echo 'GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8' >> $GITHUB_ENV
+      - name: Check indexes
         run: tox -e check_indexes

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -38,34 +38,34 @@ jobs:
         ports:
           - 5432:5432
     steps:
-    - uses: actions/checkout@v3
-      with:
-        path: 'galaxy root'
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Get full Python version
-      id: full-python-version
-      shell: bash
-      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-    - name: Cache pip dir
-      uses: actions/cache@v3
-      id: pip-cache
-      with:
-        path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
-    - name: Cache tox env
-      uses: actions/cache@v3
-      with:
-        path: .tox
-        key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-check-indexes
-    - name: Install tox
-      run: pip install tox
-    - name: Check indexes on postgresql
-      if: matrix.db == 'postgresql'
-      env:
-        GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
-      run: tox -e check_indexes
-    - name: Check indexes on sqlite
-      if: matrix.db == 'sqlite'
-      run: tox -e check_indexes
+      - uses: actions/checkout@v3
+        with:
+          path: 'galaxy root'
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash
+        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+      - name: Cache pip dir
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - name: Cache tox env
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-check-indexes
+      - name: Install tox
+        run: pip install tox
+      - name: Check indexes on postgresql
+        if: matrix.db == 'postgresql'
+        env:
+          GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+        run: tox -e check_indexes
+      - name: Check indexes on sqlite
+        if: matrix.db == 'sqlite'
+        run: tox -e check_indexes

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         path: 'galaxy root'
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get full Python version

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -12,7 +12,7 @@ jobs:
         python-version: ['3.7']
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip dir

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip dir

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         id: pip-cache

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -30,7 +30,7 @@ jobs:
       with:
         path: 'galaxy root'
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get full Python version

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -26,33 +26,33 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-    - uses: actions/checkout@v3
-      with:
-        path: 'galaxy root'
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Get full Python version
-      id: full-python-version
-      shell: bash
-      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-    - name: Cache pip dir
-      uses: actions/cache@v3
-      id: pip-cache
-      with:
-        path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
-    - name: Cache tox env
-      uses: actions/cache@v3
-      with:
-        path: .tox
-        key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-first-startup
-    - uses: mvdbeek/gha-yarn-cache@master
-      with:
-        yarn-lock-file: 'galaxy root/client/yarn.lock'
-    - name: Install tox
-      run: pip install tox
-    - name: run tests
-      run: tox -e first_startup
-      working-directory: 'galaxy root'
+      - uses: actions/checkout@v3
+        with:
+          path: 'galaxy root'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash
+        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+      - name: Cache pip dir
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - name: Cache tox env
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-first-startup
+      - uses: mvdbeek/gha-yarn-cache@master
+        with:
+          yarn-lock-file: 'galaxy root/client/yarn.lock'
+      - name: Install tox
+        run: pip install tox
+      - name: run tests
+        run: tox -e first_startup
+        working-directory: 'galaxy root'

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         run: ./run_tests.sh --coverage --framework
         working-directory: 'galaxy root'
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           flags: framework
           working-directory: 'galaxy root'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         id: pip-cache

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -92,7 +92,7 @@ jobs:
           . .ci/minikube-test-setup/start_services.sh
           ./run_tests.sh --coverage -integration test/integration -- --num-shards=4 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           flags: integration
           working-directory: 'galaxy root'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -70,7 +70,7 @@ jobs:
       - name: Run tests
         run: ./run_tests.sh --coverage -integration test/integration_selenium
         working-directory: 'galaxy root'
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           flags: integration-selenium
           working-directory: 'galaxy root'

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -18,20 +18,20 @@ jobs:
       matrix:
         node: [16]
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup node
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node}}
-        cache: 'yarn'
-        cache-dependency-path: 'client/yarn.lock'
-    - run: yarn install --frozen-lockfile
-      working-directory: client
-    - name: Stage client libs (Gulp)
-      run: yarn run gulp client
-      working-directory: client
-    - name: Run Unit Tests
-      run: yarn run qunit
-      working-directory: client
-    - run: yarn jest
-      working-directory: client
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node}}
+          cache: 'yarn'
+          cache-dependency-path: 'client/yarn.lock'
+      - run: yarn install --frozen-lockfile
+        working-directory: client
+      - name: Stage client libs (Gulp)
+        run: yarn run gulp client
+        working-directory: client
+      - name: Run Unit Tests
+        run: yarn run qunit
+        working-directory: client
+      - run: yarn jest
+        working-directory: client

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,7 +24,7 @@ jobs:
         python-version: ['3.7', '3.10']
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -50,4 +50,4 @@ jobs:
       - name: Run mypy checks
         run: tox -e mypy
       - uses: psf/black@stable
-      - uses: jamescurtin/isort-action@master
+      - uses: isort/isort-action@master

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         id: pip-cache

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         id: pip-cache

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -19,31 +19,31 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-    - uses: actions/checkout@v3
-      with:
-        path: 'galaxy root'
-    - name: Get full Python version
-      id: full-python-version
-      shell: bash
-      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-    - name: Cache pip dir
-      uses: actions/cache@v3
-      id: pip-cache
-      with:
-        path: ~/Library/Caches/pip
-        # scripts/common_startup.sh creates a conda env for Galaxy containing Python 3.7
-        key: pip-cache-3.7-${{ hashFiles('galaxy root/requirements.txt') }}
-    - name: Cache tox env
-      uses: actions/cache@v3
-      with:
-        path: .tox
-        key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-osx
-    - name: Install and activate miniconda  # use this job to test using Python from a conda environment
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        activate-environment: ''
-    - name: Install tox
-      run: pip install tox
-    - name: run tests
-      run: tox -e first_startup
-      working-directory: 'galaxy root'
+      - uses: actions/checkout@v3
+        with:
+          path: 'galaxy root'
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash
+        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+      - name: Cache pip dir
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: ~/Library/Caches/pip
+          # scripts/common_startup.sh creates a conda env for Galaxy containing Python 3.7
+          key: pip-cache-3.7-${{ hashFiles('galaxy root/requirements.txt') }}
+      - name: Cache tox env
+        uses: actions/cache@v3
+        with:
+          path: .tox
+          key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-osx
+      - name: Install and activate miniconda  # use this job to test using Python from a conda environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: ''
+      - name: Install tox
+        run: pip install tox
+      - name: run tests
+        run: tox -e first_startup
+        working-directory: 'galaxy root'

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         id: pip-cache

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -23,33 +23,33 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-    - uses: actions/checkout@v3
-      with:
-        path: 'galaxy root'
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Get full Python version
-      id: full-python-version
-      shell: bash
-      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-    - name: Cache pip dir
-      uses: actions/cache@v3
-      id: pip-cache
-      with:
-        path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
-    - name: Cache galaxy venv
-      uses: actions/cache@v3
-      with:
-        path: 'galaxy root/.venv'
-        key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-reports-startup
-    - uses: mvdbeek/gha-yarn-cache@master
-      with:
-        yarn-lock-file: 'galaxy root/client/yarn.lock'
-    - name: Install tox
-      run: pip install tox
-    - name: Run tests
-      run: tox -e reports_startup
-      working-directory: 'galaxy root'
+      - uses: actions/checkout@v3
+        with:
+          path: 'galaxy root'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash
+        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+      - name: Cache pip dir
+        uses: actions/cache@v3
+        id: pip-cache
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - name: Cache galaxy venv
+        uses: actions/cache@v3
+        with:
+          path: 'galaxy root/.venv'
+          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-reports-startup
+      - uses: mvdbeek/gha-yarn-cache@master
+        with:
+          yarn-lock-file: 'galaxy root/client/yarn.lock'
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests
+        run: tox -e reports_startup
+        working-directory: 'galaxy root'

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -27,7 +27,7 @@ jobs:
       with:
         path: 'galaxy root'
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get full Python version

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -70,7 +70,7 @@ jobs:
       - name: Run tests
         run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           flags: selenium
           working-directory: 'galaxy root'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test_galaxy_packages.yaml
+++ b/.github/workflows/test_galaxy_packages.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Cache pip dir

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         id: pip-cache

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version

--- a/.github/workflows/unit-postgres.yaml
+++ b/.github/workflows/unit-postgres.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Get full Python version
         id: full-python-version
         shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
         with:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -47,7 +47,7 @@ jobs:
       - name: Run tests
         run: ./run_tests.sh --coverage -u
         working-directory: 'galaxy root'
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           flags: py-unit
           working-directory: 'galaxy root'


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Also:
- Update GitHub action versions
- Use indentation for YAML nested sequences for consistency
- Add missing `python-version` to matrix expansion and simplify some steps in `.github/workflows/db_indexes.yaml`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
