### PR TITLE
fix container_resolvers API index and show

### DIFF
--- a/lib/galaxy/tool_util/deps/views.py
+++ b/lib/galaxy/tool_util/deps/views.py
@@ -403,7 +403,7 @@ class ContainerResolutionView:
 
     @property
     def _container_resolvers(self):
-        return self._app.container_finder.container_resolvers
+        return self._app.container_finder.default_container_registry.container_resolvers
 
     def _container_resolver(self, index):
         index = int(index)

--- a/lib/galaxy/webapps/galaxy/api/container_resolution.py
+++ b/lib/galaxy/webapps/galaxy/api/container_resolution.py
@@ -31,11 +31,11 @@ class ContainerResolutionAPIController(BaseGalaxyAPIController):
 
     @expose_api
     @require_admin
-    def show(self, trans, id):
+    def show(self, trans, index):
         """
         GET /api/container_resolvers/<id>
         """
-        return self._view.show(id)
+        return self._view.show(index)
 
     @expose_api
     @require_admin

--- a/lib/galaxy_test/api/test_container_resolution.py
+++ b/lib/galaxy_test/api/test_container_resolution.py
@@ -1,8 +1,7 @@
 from ._framework import ApiTestCase
 
 
-class ContainerResolversApiTestCase(ApiTestCase):
-
+class ContainerResolutionApiTestCase(ApiTestCase):
     def test_index(self):
         response = self._get("container_resolvers", admin=True)
         assert response.status_code == 200

--- a/lib/galaxy_test/api/test_container_resolvers.py
+++ b/lib/galaxy_test/api/test_container_resolvers.py
@@ -1,5 +1,6 @@
 from ._framework import ApiTestCase
 
+
 class ContainerResolversApiTestCase(ApiTestCase):
 
     def test_index(self):
@@ -8,6 +9,6 @@ class ContainerResolversApiTestCase(ApiTestCase):
         assert isinstance(response.json(), list)
 
     def test_show(self):
-        response = self._get("container_resolvers/0",  admin=True)
+        response = self._get("container_resolvers/0", admin=True)
         assert response.status_code == 200
         assert isinstance(response.json(), dict)

--- a/lib/galaxy_test/api/test_container_resolvers.py
+++ b/lib/galaxy_test/api/test_container_resolvers.py
@@ -1,0 +1,13 @@
+from ._framework import ApiTestCase
+
+class ContainerResolversApiTestCase(ApiTestCase):
+
+    def test_index(self):
+        response = self._get("container_resolvers", admin=True)
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+
+    def test_show(self):
+        response = self._get("container_resolvers/0",  admin=True)
+        assert response.status_code == 200
+        assert isinstance(response.json(), dict)


### PR DESCRIPTION
Add a couple of tests for `/api/container_resolvers` and `/api/container_resolvers/<id>` that are failing with the error `{"err_msg": "Uncaught exception in exposed API method:", "err_code": 0}`


## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
