### PR TITLE
Undelete workflows

### DIFF
--- a/client/src/components/Common/Tags.vue
+++ b/client/src/components/Common/Tags.vue
@@ -1,5 +1,5 @@
 <template>
-    <StatelessTags :value="tags" @input="onInput" @tag-click="onTagClick" />
+    <StatelessTags :value="tags" :disabled="disabled" @input="onInput" @tag-click="onTagClick" />
 </template>
 <script>
 import StatelessTags from "components/Tags/StatelessTags";
@@ -13,6 +13,10 @@ export default {
         },
         tags: {
             type: Array,
+        },
+        disabled: {
+            type: Boolean,
+            default: false,
         },
     },
     methods: {

--- a/client/src/components/Workflow/WorkflowDropdown.test.js
+++ b/client/src/components/Workflow/WorkflowDropdown.test.js
@@ -112,7 +112,7 @@ describe("WorkflowDropdown.vue", () => {
             confirmRequest = true;
             global.confirm = jest.fn(() => confirmRequest);
             axiosMock.onDelete("/api/workflows/workflowid123").reply(202, "deleted...");
-            axiosMock.onRestore("/api/workflows/workfrlowid123".reply(204, "restored..."));
+            axiosMock.onPost("/api/workflows/workflowid123/undelete").reply(204, "restored...");
         });
 
         afterEach(() => {
@@ -145,8 +145,9 @@ describe("WorkflowDropdown.vue", () => {
             expect(emitted["onRemove"][0][0]).toEqual("workflowid123");
             expect(emitted["onSuccess"][0][0]).toEqual("deleted...");
             await wrapper.vm.onRestore();
-            expect(emitted["onRestore"][0][0].toEqual("workflowid123"));
-            expect(emitted)["onRestore"].toEqual("restored...");
+            await flushPromises();
+            expect(emitted["onRestore"][0][0]).toEqual("workflowid123");
+            expect(emitted["onSuccess"][1][0]).toEqual("restored...");
         });
     });
 });

--- a/client/src/components/Workflow/WorkflowDropdown.test.js
+++ b/client/src/components/Workflow/WorkflowDropdown.test.js
@@ -93,7 +93,6 @@ describe("WorkflowDropdown.vue", () => {
 
     describe("workflow clicking workflow deletion", () => {
         let axiosMock;
-        let confirmRequest;
 
         async function mountAndDelete() {
             const workflow = {
@@ -109,8 +108,6 @@ describe("WorkflowDropdown.vue", () => {
 
         beforeEach(async () => {
             axiosMock = new MockAdapter(axios);
-            confirmRequest = true;
-            global.confirm = jest.fn(() => confirmRequest);
             axiosMock.onDelete("/api/workflows/workflowid123").reply(202, "deleted...");
             axiosMock.onPost("/api/workflows/workflowid123/undelete").reply(204, "restored...");
         });
@@ -119,24 +116,11 @@ describe("WorkflowDropdown.vue", () => {
             axiosMock.restore();
         });
 
-        it("should confirm with localized deletion message", async () => {
-            await mountAndDelete();
-            expect(global.confirm).toHaveBeenCalledWith(expect.toBeLocalized());
-        });
-
-        it("should fire deletion API request upon confirmation", async () => {
+        it("should fire deletion API request upon remove action", async () => {
             await mountAndDelete();
             const emitted = wrapper.emitted();
             expect(emitted["onRemove"][0][0]).toEqual("workflowid123");
             expect(emitted["onSuccess"][0][0]).toEqual("deleted...");
-        });
-
-        it("should not fire deletion API request if not confirmed", async () => {
-            confirmRequest = false;
-            await mountAndDelete();
-            const emitted = wrapper.emitted();
-            expect(emitted["onRemove"]).toBeFalsy();
-            expect(emitted["onSuccess"]).toBeFalsy();
         });
 
         it("should restore previously deleted workflows", async () => {

--- a/client/src/components/Workflow/WorkflowDropdown.test.js
+++ b/client/src/components/Workflow/WorkflowDropdown.test.js
@@ -112,6 +112,7 @@ describe("WorkflowDropdown.vue", () => {
             confirmRequest = true;
             global.confirm = jest.fn(() => confirmRequest);
             axiosMock.onDelete("/api/workflows/workflowid123").reply(202, "deleted...");
+            axiosMock.onRestore("/api/workflows/workfrlowid123".reply(204, "restored..."));
         });
 
         afterEach(() => {
@@ -136,6 +137,16 @@ describe("WorkflowDropdown.vue", () => {
             const emitted = wrapper.emitted();
             expect(emitted["onRemove"]).toBeFalsy();
             expect(emitted["onSuccess"]).toBeFalsy();
+        });
+
+        it("should restore previously deleted workflows", async () => {
+            await mountAndDelete();
+            const emitted = wrapper.emitted();
+            expect(emitted["onRemove"][0][0]).toEqual("workflowid123");
+            expect(emitted["onSuccess"][0][0]).toEqual("deleted...");
+            await wrapper.vm.onRestore();
+            expect(emitted["onRestore"][0][0].toEqual("workflowid123"));
+            expect(emitted)["onRestore"].toEqual("restored...");
         });
     });
 });

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -215,18 +215,15 @@ export default {
         },
         onRestore: function () {
             const id = this.workflow.id;
-            const name = this.workflow.name;
-
-            console.log(name + " is restored!");
-            // this.services
-            //     .undeleteWorkflow(id) //what is function called on backend?
-            //     .then((message) => {
-            //         this.$emit("onRestore", id);
-            //         this.$emit("onSuccess", message);
-            //     })
-            //     .catch((error) => {
-            //         this.$emit("onError", error);
-            //     });
+            this.services
+                .undeleteWorkflow(id)
+                .then((message) => {
+                    this.$emit("onRestore", id);
+                    this.$emit("onSuccess", message);
+                })
+                .catch((error) => {
+                    this.$emit("onError", error);
+                });
         },
     },
 };

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -23,56 +23,60 @@
         <p v-if="workflow.description" class="workflow-dropdown-description">{{ workflow.description }}</p>
         <div class="dropdown-menu" aria-labelledby="workflow-dropdown">
             <a
-                v-if="!readOnly"
+                v-if="!readOnly && !isDeleted"
                 class="dropdown-item"
                 @keypress="$router.push(urlEdit)"
                 @click.prevent="$router.push(urlEdit)">
                 <span class="fa fa-edit fa-fw mr-1" />
                 <span v-localize>Edit</span>
             </a>
-            <a class="dropdown-item" href="#" @click.prevent="onCopy">
+            <a v-if="!isDeleted" class="dropdown-item" href="#" @click.prevent="onCopy">
                 <span class="fa fa-copy fa-fw mr-1" />
                 <span v-localize>Copy</span>
             </a>
             <a
-                v-if="!readOnly"
+                v-if="!readOnly && !isDeleted"
                 class="dropdown-item"
                 @keypress="$router.push(urlInvocations)"
                 @click.prevent="$router.push(urlInvocations)">
                 <span class="fa fa-list fa-fw mr-1" />
                 <span v-localize>Invocations</span>
             </a>
-            <a class="dropdown-item" :href="urlDownload">
+            <a v-if="!isDeleted" class="dropdown-item" :href="urlDownload">
                 <span class="fa fa-download fa-fw mr-1" />
                 <span v-localize>Download</span>
             </a>
-            <a v-if="!readOnly" class="dropdown-item" href="#" @click.prevent="onRename">
+            <a v-if="!readOnly && !isDeleted" class="dropdown-item" href="#" @click.prevent="onRename">
                 <span class="fa fa-signature fa-fw mr-1" />
                 <span v-localize>Rename</span>
             </a>
             <a
-                v-if="!readOnly"
+                v-if="!readOnly && !isDeleted"
                 class="dropdown-item"
                 @keypress="$router.push(urlShare)"
                 @click.prevent="$router.push(urlShare)">
                 <span class="fa fa-share-alt fa-fw mr-1" />
                 <span v-localize>Share</span>
             </a>
-            <a v-if="!readOnly" class="dropdown-item" :href="urlExport">
+            <a v-if="!readOnly && !isDeleted" class="dropdown-item" :href="urlExport">
                 <span class="fa fa-file-export fa-fw mr-1" />
                 <span v-localize>Export</span>
             </a>
-            <a class="dropdown-item" :href="urlView">
+            <a v-if="!isDeleted" class="dropdown-item" :href="urlView">
                 <span class="fa fa-eye fa-fw mr-1" />
                 <span v-localize>View</span>
             </a>
-            <a v-if="sourceLabel" class="dropdown-item" :href="sourceUrl">
+            <a v-if="sourceLabel && !isDeleted" class="dropdown-item" :href="sourceUrl">
                 <span class="fa fa-globe fa-fw mr-1" />
                 <span v-localize>{{ sourceLabel }}</span>
             </a>
-            <a v-if="!readOnly" class="dropdown-item" href="#" @click.prevent="onDelete">
+            <a v-if="!readOnly && !isDeleted" class="dropdown-item" href="#" @click.prevent="onDelete">
                 <span class="fa fa-trash fa-fw mr-1" />
                 <span v-localize>Delete</span>
+            </a>
+            <a v-if="isDeleted" class="dropdown-item" href="#" @click.prevent="onRestore">
+                <span class="fa fa-trash fa-fw mr-1" />
+                <span v-localize>Restore</span>
             </a>
         </div>
     </div>
@@ -120,6 +124,9 @@ export default {
         },
         readOnly() {
             return !!this.workflow.shared;
+        },
+        isDeleted(){
+            return this.workflow.deleted;
         },
         sourceUrl() {
             if (this.workflow.source_metadata?.url) {
@@ -204,6 +211,23 @@ export default {
                     .catch((error) => {
                         this.$emit("onError", error);
                     });
+            }
+        },
+        onRestore: function () {
+            const id = this.workflow.id;
+            const name = this.workflow.name;
+            const confirmationMessage = this.l(`Are you sure you want to restore workflow '${name}'?`);
+            if (window.confirm(confirmationMessage)) {
+                console.log (name + " is restored!")
+                // this.services
+                //     .undeleteWorkflow(id) //what is function called on backend?
+                //     .then((message) => {
+                //         this.$emit("onRestore", id);
+                //         this.$emit("onSuccess", message);
+                //     })
+                //     .catch((error) => {
+                //         this.$emit("onError", error);
+                //     });
             }
         },
     },

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -182,19 +182,15 @@ export default {
         },
         onDelete: function () {
             const id = this.workflow.id;
-            const name = this.workflow.name;
-            const confirmationMessage = this.l(`Are you sure you want to delete workflow '${name}'?`);
-            if (window.confirm(confirmationMessage)) {
-                this.services
-                    .deleteWorkflow(id)
-                    .then((message) => {
-                        this.$emit("onRemove", id);
-                        this.$emit("onSuccess", message);
-                    })
-                    .catch((error) => {
-                        this.$emit("onError", error);
-                    });
-            }
+            this.services
+                .deleteWorkflow(id)
+                .then((message) => {
+                    this.$emit("onRemove", id);
+                    this.$emit("onSuccess", message);
+                })
+                .catch((error) => {
+                    this.$emit("onError", error);
+                });
         },
         onRename: function () {
             const id = this.workflow.id;

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -125,7 +125,7 @@ export default {
         readOnly() {
             return !!this.workflow.shared;
         },
-        isDeleted(){
+        isDeleted() {
             return this.workflow.deleted;
         },
         sourceUrl() {
@@ -216,19 +216,17 @@ export default {
         onRestore: function () {
             const id = this.workflow.id;
             const name = this.workflow.name;
-            const confirmationMessage = this.l(`Are you sure you want to restore workflow '${name}'?`);
-            if (window.confirm(confirmationMessage)) {
-                console.log (name + " is restored!")
-                // this.services
-                //     .undeleteWorkflow(id) //what is function called on backend?
-                //     .then((message) => {
-                //         this.$emit("onRestore", id);
-                //         this.$emit("onSuccess", message);
-                //     })
-                //     .catch((error) => {
-                //         this.$emit("onError", error);
-                //     });
-            }
+
+            console.log(name + " is restored!");
+            // this.services
+            //     .undeleteWorkflow(id) //what is function called on backend?
+            //     .then((message) => {
+            //         this.$emit("onRestore", id);
+            //         this.$emit("onSuccess", message);
+            //     })
+            //     .catch((error) => {
+            //         this.$emit("onError", error);
+            //     });
         },
     },
 };

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -40,9 +40,9 @@
                 <Tags
                     :index="row.index"
                     :tags="row.item.tags"
+                    :disabled="row.item.deleted"
                     @input="onTags"
-                    @tag-click="onTagClick"
-                    :disabled="row.item.deleted" />
+                    @tag-click="onTagClick" />
             </template>
             <template v-slot:cell(published)="row">
                 <SharingIndicators
@@ -91,32 +91,49 @@ import WorkflowRunButton from "./WorkflowRunButton.vue";
 import SharingIndicators from "components/Indices/SharingIndicators";
 
 const helpHtml = `<div>
-<p>This textbox box can be used to filter the workflows displayed.
+    <p>This input can be used to filter the workflows displayed.</p>
 
-<p>Text entered here will be searched against workflow names and workflow tags. Additionally, advanced
-filtering tags can be used to refine the search more precisely. Filtering tags are of the form
-<code>&lt;tag_name&gt;:&lt;tag_value&gt;</code> or <code>&lt;tag_name&gt;:'&lt;tag_value&gt;'</code>.
-For instance to search just for RNAseq in the workflow name, <code>name:rnsseq</code> can be used.
-Notice by default the search is not case-sensitive.
+    <p>
+        Text entered here will be searched against workflow names and workflow
+        tags. Additionally, advanced filtering tags can be used to refine the
+        search more precisely. Filtering tags are of the form
+        <code>&lt;tag_name&gt;:&lt;tag_value&gt;</code> or
+        <code>&lt;tag_name&gt;:'&lt;tag_value&gt;'</code>. For instance to
+        search just for RNAseq in the workflow name,
+        <code>name:rnsseq</code> can be used. Notice by default the search is
+        not case-sensitive. If the quoted version of tag is used, the search is
+        case sensitive and only full matches will be returned. So
+        <code>name:'RNAseq'</code> would show only workflows named exactly
+        <code>RNAseq</code>.
+    </p>
 
-If the quoted version of tag is used, the search is case sensitive and only full matches will be
-returned. So <code>name:'RNAseq'</code> would show only workflows named exactly <code>RNAseq</code>.
-
-<p>The available filtering tags are:
-<dl>
-    <dt><code>name</code></dt>
-    <dd>Shows workflows with given sequence of characters in their names.</dd>
-    <dt><code>tag</code></dt>
-    <dd>Shows workflows with the given workflow tag. You may also just click on a tag in your list of workflows to filter on that tag directly.</dd>
-    <dt><code>is:published</code></dt>
-    <dd>Shows published workflows. You may also just click on the "published" icon of a workflow in your list to filter on this directly.</dd>
-    <dt><code>is:shared</code></dt>
-    <dd>Shows workflows shared by another user directly with you. You may also just click on the "shared with me" icon of a workflow in your list to filter on this directly.</dd>
-    <dt><code>is:deleted</code></dt>
-    <dd>Shows deleted workflows.</dd>
-</dl>
-</div>
-`;
+    <p>The available filtering tags are:</p>
+    <dl>
+        <dt><code>name</code></dt>
+        <dd>
+            Shows workflows with given sequence of characters in their names.
+        </dd>
+        <dt><code>tag</code></dt>
+        <dd>
+            Shows workflows with the given workflow tag. You may also just click
+            on a tag in your list of workflows to filter on that tag directly.
+        </dd>
+        <dt><code>is:published</code></dt>
+        <dd>
+            Shows published workflows. You may also just click on the
+            "published" icon of a workflow in your list to filter on this
+            directly.
+        </dd>
+        <dt><code>is:shared</code></dt>
+        <dd>
+            Shows workflows shared by another user directly with you. You may
+            also just click on the "shared with me" icon of a workflow in your
+            list to filter on this directly.
+        </dd>
+        <dt><code>is:deleted</code></dt>
+        <dd>Shows deleted workflows.</dd>
+    </dl>
+</div>`;
 
 export default {
     components: {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -93,25 +93,27 @@ import SharingIndicators from "components/Indices/SharingIndicators";
 const helpHtml = `<div>
 <p>This textbox box can be used to filter the workflows displayed.
 
-<p>Text entered here will be searched against workflow names and tags. Additionally, advanced
-filtering tags can be used to refine the search more precisely. Tags are of the form
+<p>Text entered here will be searched against workflow names and workflow tags. Additionally, advanced
+filtering tags can be used to refine the search more precisely. Filtering tags are of the form
 <code>&lt;tag_name&gt;:&lt;tag_value&gt;</code> or <code>&lt;tag_name&gt;:'&lt;tag_value&gt;'</code>.
 For instance to search just for RNAseq in the workflow name, <code>name:rnsseq</code> can be used.
 Notice by default the search is not case-sensitive.
 
-If the quoted version of tag is used, the search is not case sensitive and only full matches will be
+If the quoted version of tag is used, the search is case sensitive and only full matches will be
 returned. So <code>name:'RNAseq'</code> would show only workflows named exactly <code>RNAseq</code>.
 
-<p>The available tags are:
+<p>The available filtering tags are:
 <dl>
     <dt><code>name</code></dt>
-    <dd>This filters only against the workflow name.</dd>
+    <dd>Shows workflows with given sequence of characters in their names.</dd>
     <dt><code>tag</code></dt>
-    <dd>This filters only against the workflow tag. You may also just click on a tag in your list of workflows to filter on that tag using this directly.</dd>
+    <dd>Shows workflows with the given workflow tag. You may also just click on a tag in your list of workflows to filter on that tag directly.</dd>
     <dt><code>is:published</code></dt>
-    <dd>This filters the workflows such that only published workflows are shown. You may also just click on the "published" icon of a workflow in your list to filter on this directly.</dd>
+    <dd>Shows published workflows. You may also just click on the "published" icon of a workflow in your list to filter on this directly.</dd>
     <dt><code>is:shared</code></dt>
-    <dd>This filters the workflows such that only workflows shared from another user directly with you are are shown. You may also just click on the "shared with me" icon of a workflow in your list to filter on this directly.</dd>
+    <dd>Shows workflows shared by another user directly with you. You may also just click on the "shared with me" icon of a workflow in your list to filter on this directly.</dd>
+    <dt><code>is:deleted</code></dt>
+    <dd>Shows deleted workflows.</dd>
 </dl>
 </div>
 `;

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -33,24 +33,37 @@
                     @onRemove="onRemove"
                     @onUpdate="onUpdate"
                     @onSuccess="onSuccess"
-                    @onError="onError" />
+                    @onError="onError"
+                    @onRestore="onRestore" />
             </template>
             <template v-slot:cell(tags)="row">
-                <Tags :index="row.index" :tags="row.item.tags" @input="onTags" @tag-click="onTagClick" />
+                <Tags
+                    :index="row.index"
+                    :tags="row.item.tags"
+                    @input="onTags"
+                    @tag-click="onTagClick"
+                    :disabled="row.item.deleted" />
             </template>
             <template v-slot:cell(published)="row">
-                <SharingIndicators :object="row.item" @filter="(filter) => appendFilter(filter)" />
+                <SharingIndicators
+                    v-if="!row.item.deleted"
+                    :object="row.item"
+                    @filter="(filter) => appendFilter(filter)" />
+                <div v-else>&#8212;</div>
             </template>
             <template v-slot:cell(show_in_tool_panel)="row">
                 <WorkflowBookmark
+                    v-if="!row.item.deleted"
                     :checked="row.item.show_in_tool_panel"
                     @bookmark="(checked) => bookmarkWorkflow(row.item.id, checked)" />
+                <div v-else>&#8212;</div>
             </template>
             <template v-slot:cell(update_time)="data">
                 <UtcDate :date="data.value" mode="elapsed" />
             </template>
             <template v-slot:cell(execute)="row">
-                <WorkflowRunButton :id="row.item.id" :root="root" />
+                <WorkflowRunButton v-if="!row.item.deleted" :id="row.item.id" :root="root" />
+                <div v-else>&#8212;</div>
             </template>
         </b-table>
         <b-pagination
@@ -232,6 +245,9 @@ export default {
             this.refresh();
         },
         onUpdate: function (id, data) {
+            this.refresh();
+        },
+        onRestore: function (id) {
             this.refresh();
         },
     },

--- a/client/src/components/Workflow/services.js
+++ b/client/src/components/Workflow/services.js
@@ -37,6 +37,16 @@ export class Services {
         }
     }
 
+    async undeleteWorkflow(id) {
+        const url = safePath(`/api/workflows/${id}/undelete`);
+        try {
+            const response = await axios.post(url);
+            return response.data;
+        } catch (e) {
+            rethrowSimple(e);
+        }
+    }
+
     async updateWorkflow(id, data) {
         const url = safePath(`/api/workflows/${id}`);
         try {

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -166,7 +166,6 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
         query = query.options(latest_workflow_load)
         query = query.filter(or_(*filters))
         query = query.filter(model.StoredWorkflow.table.c.hidden == (true() if show_hidden else false()))
-        query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
         if payload.search:
             search_query = payload.search
             parsed_search = parse_filters_structured(search_query, INDEX_SEARCH_FILTERS)
@@ -194,6 +193,9 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
                     elif key == "is":
                         if q == "published":
                             query = query.filter(model.StoredWorkflow.published == true())
+                        elif q == "deleted":
+                            query = query.filter(model.StoredWorkflow.deleted == true())
+                            show_deleted = true
                         elif q == "shared_with_me":
                             if not show_shared:
                                 message = "Can only use tag is:shared_with_me if show_shared parameter also true."
@@ -213,6 +215,7 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
                             term,
                         )
                     )
+        query = query.filter(model.StoredWorkflow.table.c.deleted == (true() if show_deleted else false()))
         if include_total_count:
             total_matches = query.count()
         else:

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -158,7 +158,6 @@ class TestWorkflowManagement(SeleniumTestCase, TestsGalaxyPagers, UsesWorkflowAs
         self.workflow_index_rename("fordelete")
         self._assert_showing_n_workflows(1)
         self.workflow_index_click_option("Delete")
-        self.accept_alert()
         self._assert_showing_n_workflows(0)
 
         self.workflow_index_open()


### PR DESCRIPTION
Fix for #6493
To be implemented with #14794; still needs to be rebased off this PR
Not currently functional, but UI pieces are in place. 



https://user-images.githubusercontent.com/26912553/197619052-cd80fee2-d1db-4081-9374-e2f7f313cb2f.mp4





## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. From Workflows List, delete a workflow
  2. In filters type "is:deleted" to view deleted workflows
  3. Note the change in available things you can do to a deleted WF (only dropdown choice is Restore, cannot edit Tags, cannot run, publish, bookmark, etc.)
  4. Select Restore from dropdown options.
  5. Note that the WF is now restored and cannot be viewed using "is:deleted" filter

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
