### PR TITLE
[22.05] Use create_time instead of dropped update_time JobStateHistory attribute

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -738,7 +738,7 @@ class JobHandlerQueue(Monitors):
                 # History is job.state_history
                 started = None
                 finished = None
-                for history in sorted(job.state_history, key=lambda h: h.update_time):
+                for history in sorted(job.state_history, key=lambda h: h.create_time):
                     if history.state == "running":
                         started = history.create_time
                     elif history.state == "ok":


### PR DESCRIPTION
Use `create_time` instead of `update_time` (attr was dropped in #13997)

Thanks to Mahendra Paipuri for reporting the bug!

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
