### PR TITLE
Move ToolShedRepositoryCache into galaxy.tool_shed.

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -91,6 +91,7 @@ from galaxy.security.vault import (
     Vault,
     VaultFactory,
 )
+from galaxy.tool_shed.cache import ToolShedRepositoryCache
 from galaxy.tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
 from galaxy.tool_shed.galaxy_install.update_repository_manager import UpdateRepositoryManager
 from galaxy.tool_util.deps import containers
@@ -98,10 +99,7 @@ from galaxy.tool_util.deps.dependencies import AppInfo
 from galaxy.tool_util.deps.views import DependencyResolversView
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy.tools.biotools import get_galaxy_biotools_metadata_source
-from galaxy.tools.cache import (
-    ToolCache,
-    ToolShedRepositoryCache,
-)
+from galaxy.tools.cache import ToolCache
 from galaxy.tools.data import ToolDataTableManager
 from galaxy.tools.data_manager.manager import DataManagers
 from galaxy.tools.error_reports import ErrorReports

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -30,6 +30,7 @@ from galaxy.objectstore import (
 from galaxy.quota import QuotaAgent
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.security.vault import Vault
+from galaxy.tool_shed.cache import ToolShedRepositoryCache
 from galaxy.tool_util.deps.views import DependencyResolversView
 from galaxy.tool_util.verify import test_data
 from galaxy.util.dbkeys import GenomeBuilds
@@ -46,7 +47,7 @@ if TYPE_CHECKING:
     from galaxy.managers.histories import HistoryManager
     from galaxy.managers.workflows import WorkflowsManager
     from galaxy.tools import ToolBox
-    from galaxy.tools.cache import ToolShedRepositoryCache
+    from galaxy.tools.cache import ToolCache
     from galaxy.tools.data import ToolDataTableManager
     from galaxy.tools.error_reports import ErrorReports
     from galaxy.visualization.genomes import Genomes
@@ -142,9 +143,9 @@ class StructuredApp(MinimalManagerApp):
     queue_worker: Any  # 'galaxy.queue_worker.GalaxyQueueWorker'
     data_provider_registry: Any  # 'galaxy.visualization.data_providers.registry.DataProviderRegistry'
     tool_data_tables: "ToolDataTableManager"
-    tool_cache: Any  # 'galaxy.tools.cache.ToolCache'
+    tool_cache: "ToolCache"
     tool_shed_registry: ToolShedRegistry
-    tool_shed_repository_cache: Optional["ToolShedRepositoryCache"]
+    tool_shed_repository_cache: Optional[ToolShedRepositoryCache]
     watchers: "ConfigWatchers"
     workflow_scheduling_manager: Any  # 'galaxy.workflow.scheduling_manager.WorkflowSchedulingManager'
     interactivetool_manager: Any

--- a/lib/galaxy/tool_shed/cache.py
+++ b/lib/galaxy/tool_shed/cache.py
@@ -1,0 +1,70 @@
+import logging
+from collections import defaultdict
+from typing import (
+    Dict,
+    List,
+    Tuple,
+)
+
+from sqlalchemy.orm import defer
+
+from galaxy.model.scoped_session import install_model_scoped_session
+from galaxy.model.tool_shed_install import ToolShedRepository
+from galaxy.tool_util.toolbox.base import ToolConfRepository
+
+log = logging.getLogger(__name__)
+
+
+class ToolShedRepositoryCache:
+    """
+    Cache installed ToolShedRepository objects.
+    """
+
+    local_repositories: List[ToolConfRepository]
+    repositories: List[ToolShedRepository]
+    repos_by_tuple: Dict[Tuple[str, str, str], List[ToolConfRepository]]
+
+    def __init__(self, session: install_model_scoped_session):
+        self.session = session()
+        # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
+        self.local_repositories = []
+        # Repositories loaded from database
+        self.repositories = []
+        self.repos_by_tuple = defaultdict(list)
+        self._build()
+        self.session.close()
+
+    def add_local_repository(self, repository):
+        self.local_repositories.append(repository)
+        self.repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
+
+    def _build(self):
+        self.repositories = self.session.query(ToolShedRepository).options(defer(ToolShedRepository.metadata_)).all()
+        repos_by_tuple = defaultdict(list)
+        for repository in self.repositories + self.local_repositories:
+            repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
+        self.repos_by_tuple = repos_by_tuple
+
+    def get_installed_repository(
+        self,
+        tool_shed=None,
+        name=None,
+        owner=None,
+        installed_changeset_revision=None,
+        changeset_revision=None,
+        repository_id=None,
+    ):
+        if repository_id:
+            repos = [repo for repo in self.repositories if repo.id == repository_id]
+            if repos:
+                return repos[0]
+            else:
+                return None
+        repos = self.repos_by_tuple[(tool_shed, owner, name)]
+        for repo in repos:
+            if installed_changeset_revision and repo.installed_changeset_revision != installed_changeset_revision:
+                continue
+            if changeset_revision and repo.changeset_revision != changeset_revision:
+                continue
+            return repo
+        return None

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -5,20 +5,10 @@ import shutil
 import sqlite3
 import tempfile
 import zlib
-from collections import defaultdict
 from threading import Lock
-from typing import (
-    Dict,
-    List,
-    Tuple,
-)
 
-from sqlalchemy.orm import defer
 from sqlitedict import SqliteDict
 
-from galaxy.model.scoped_session import install_model_scoped_session
-from galaxy.model.tool_shed_install import ToolShedRepository
-from galaxy.tool_util.toolbox.base import ToolConfRepository
 from galaxy.util import unicodify
 from galaxy.util.hash_util import md5_hash_file
 
@@ -278,58 +268,3 @@ class ToolHash:
         if self._tool_hash is None:
             self._tool_hash = md5_hash_file(self.path)
         return self._tool_hash
-
-
-class ToolShedRepositoryCache:
-    """
-    Cache installed ToolShedRepository objects.
-    """
-
-    local_repositories: List[ToolConfRepository]
-    repositories: List[ToolShedRepository]
-    repos_by_tuple: Dict[Tuple[str, str, str], List[ToolConfRepository]]
-
-    def __init__(self, session: install_model_scoped_session):
-        self.session = session()
-        # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
-        self.local_repositories = []
-        # Repositories loaded from database
-        self.repositories = []
-        self.repos_by_tuple = defaultdict(list)
-        self._build()
-        self.session.close()
-
-    def add_local_repository(self, repository):
-        self.local_repositories.append(repository)
-        self.repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
-
-    def _build(self):
-        self.repositories = self.session.query(ToolShedRepository).options(defer(ToolShedRepository.metadata_)).all()
-        repos_by_tuple = defaultdict(list)
-        for repository in self.repositories + self.local_repositories:
-            repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
-        self.repos_by_tuple = repos_by_tuple
-
-    def get_installed_repository(
-        self,
-        tool_shed=None,
-        name=None,
-        owner=None,
-        installed_changeset_revision=None,
-        changeset_revision=None,
-        repository_id=None,
-    ):
-        if repository_id:
-            repos = [repo for repo in self.repositories if repo.id == repository_id]
-            if repos:
-                return repos[0]
-            else:
-                return None
-        repos = self.repos_by_tuple[(tool_shed, owner, name)]
-        for repo in repos:
-            if installed_changeset_revision and repo.installed_changeset_revision != installed_changeset_revision:
-                continue
-            if changeset_revision and repo.changeset_revision != changeset_revision:
-                continue
-            return repo
-        return None

--- a/mypy.ini
+++ b/mypy.ini
@@ -454,6 +454,8 @@ check_untyped_defs = False
 check_untyped_defs = False
 [mypy-galaxy.tools.cache]
 check_untyped_defs = False
+[mypy-galaxy.tool_shed.cache]
+check_untyped_defs = False
 [mypy-galaxy.tool_util.deps.containers]
 check_untyped_defs = False
 [mypy-galaxy.managers.users]

--- a/test/unit/app/tools/conftest.py
+++ b/test/unit/app/tools/conftest.py
@@ -5,8 +5,8 @@ import pytest
 
 from galaxy.model import tool_shed_install
 from galaxy.model.tool_shed_install import mapping
+from galaxy.tool_shed.cache import ToolShedRepositoryCache
 from galaxy.tool_util.toolbox.base import ToolConfRepository
-from galaxy.tools.cache import ToolShedRepositoryCache
 
 
 @pytest.fixture


### PR DESCRIPTION
Things required to perform tool shed installs should be galaxy.tool_shed - this module doesn't require anything in galaxy-app - galaxy-data is sufficient.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
