### PR TITLE
Fix Tool form header overlaps with window manager

### DIFF
--- a/client/src/layout/window-manager.js
+++ b/client/src/layout/window-manager.js
@@ -32,6 +32,7 @@ export class WindowManager {
         WinBox.new({
             title: options.title || "Window",
             url: boxUrl,
+            index: 850,
             onclose: () => {
                 this.counter--;
             },


### PR DESCRIPTION
Fixes #14805 by setting the window managers default z-index.
Also fixes an issue on Firefox where the center panel scroll-bar would render above the window manager.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open window in window manager
  2. See it render above the tool form header

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
