### PR TITLE
Fix tool help headings and sizes

### DIFF
--- a/client/src/components/Tool/ToolHelp.test.js
+++ b/client/src/components/Tool/ToolHelp.test.js
@@ -1,0 +1,39 @@
+import { getLocalVue } from "jest/helpers";
+import ToolHelp from "./ToolHelp";
+import { mount } from "@vue/test-utils";
+
+const localVue = getLocalVue();
+
+const inputHelpText = `
+<h1>Tool Help</h1>
+<p>Hello World</p>
+<h2><b>Heading h2</b></h2>
+<span>Text</span>
+<h2 class="red">Heading</h2>
+<h3>h3 Heading</h3>
+<h4>h4 Heading</h4>
+<a>empty link</a>`;
+
+const expectedHelpText = `
+<h3>Tool Help</h3>
+<p>Hello World</p>
+<h4><b>Heading h2</b></h4>
+<span>Text</span>
+<h4 class="red">Heading</h4>
+<h5>h3 Heading</h5>
+<h6>h4 Heading</h6>
+<a target="_blank">empty link</a>`;
+
+describe("ToolHelp", () => {
+    it("modifies help text", () => {
+        const wrapper = mount(ToolHelp, {
+            propsData: {
+                content: inputHelpText,
+            },
+            localVue,
+        });
+
+        const help = wrapper.find(".form-help");
+        expect(help.element).toContainHTML(expectedHelpText.trim());
+    });
+});


### PR DESCRIPTION
Followup for #14549
Fixes #14799

![image](https://user-images.githubusercontent.com/44241786/196958553-482b3d50-c026-42d3-bf4e-6b9161181b17.png)

ToolHelp now adjusts the heading levels of tool descriptions, and adds heading styles more in-line with the rest of the tool form.
This PR also refactors the ToolHelp component removing jquery, and adds an unit test for the component.

Also relevant for #14622

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
