### PR TITLE
Implement library/standalone tool shed install functionality. 

### DIFF
--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -21,6 +21,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7']
+        test-install-client: ['standalone', 'galaxy_api']
     services:
       postgres:
         image: postgres:13
@@ -54,9 +55,11 @@ jobs:
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-toolshed
       - name: Run tests
         run: './run_tests.sh -toolshed'
+        env:
+          TOOL_SHED_TEST_INSTALL_CLIENT: ${{ matrix.test-install-client }}
         working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: Toolshed test results (${{ matrix.python-version }})
+          name: Toolshed test results (${{ matrix.python-version }}, ${{ matrix.test-install-client }})
           path: 'galaxy root/run_toolshed_tests.html'

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -93,7 +93,7 @@ class MockApp(di.Container, GalaxyDataTestApp):
     config: "MockAppConfig"
     amqp_type: str
     job_search: Optional[JobSearch] = None
-    toolbox: ToolBox
+    _toolbox: ToolBox
     tool_cache: ToolCache
     install_model: ModelMapping
     watchers: ConfigWatchers
@@ -108,6 +108,7 @@ class MockApp(di.Container, GalaxyDataTestApp):
         super().__init__()
         config = config or MockAppConfig(**kwargs)
         GalaxyDataTestApp.__init__(self, config=config, **kwargs)
+        self.install_model = self.model
         self[BasicSharedApp] = cast(BasicSharedApp, self)
         self[MinimalManagerApp] = cast(MinimalManagerApp, self)
         self[StructuredApp] = cast(StructuredApp, self)
@@ -150,6 +151,10 @@ class MockApp(di.Container, GalaxyDataTestApp):
             return "/mock/url"
 
         self.url_for = url_for
+
+    @property
+    def toolbox(self) -> ToolBox:
+        return self._toolbox
 
     def wait_for_toolbox_reload(self, toolbox):
         # TODO: If the tpm test case passes, does the operation really

--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -50,8 +50,13 @@ else:
 
 
 class HasToolBox(common_util.HasToolShedRegistry):
-    tool_dependency_dir: Optional[str]
-    toolbox: AbstractToolBox
+    @property
+    def tool_dependency_dir(self) -> Optional[str]:
+        ...
+
+    @property
+    def toolbox(self) -> AbstractToolBox:
+        ...
 
 
 class Base(metaclass=DeclarativeMeta):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -184,7 +184,7 @@ def _get_new_toolbox(app, save_integrated_tool_panel=True):
     app.datatypes_registry.load_external_metadata_tool(new_toolbox)
     load_lib_tools(new_toolbox)
     [new_toolbox.register_tool(tool) for tool in new_toolbox.data_manager_tools.values()]
-    app.toolbox = new_toolbox
+    app._toolbox = new_toolbox
     app.toolbox.persist_cache()
 
 
@@ -194,9 +194,8 @@ def reload_data_managers(app, **kwargs):
     log.debug("Executing data managers reload on '%s'", app.config.server_name)
     app._configure_tool_data_tables(from_shed_config=False)
     reload_tool_data_tables(app)
-    reload_count = app.data_managers._reload_count
     app.data_managers = DataManagers(app)
-    app.data_managers._reload_count = reload_count + 1
+    app.data_managers.increment_reload_count()
     if hasattr(app, "tool_cache"):
         app.tool_cache.reset_status()
     if hasattr(app, "watchers"):

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -31,6 +31,7 @@ from galaxy.quota import QuotaAgent
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.security.vault import Vault
 from galaxy.tool_shed.cache import ToolShedRepositoryCache
+from galaxy.tool_util.data import ToolDataTableManager
 from galaxy.tool_util.deps.views import DependencyResolversView
 from galaxy.tool_util.verify import test_data
 from galaxy.util.dbkeys import GenomeBuilds
@@ -48,7 +49,6 @@ if TYPE_CHECKING:
     from galaxy.managers.workflows import WorkflowsManager
     from galaxy.tools import ToolBox
     from galaxy.tools.cache import ToolCache
-    from galaxy.tools.data import ToolDataTableManager
     from galaxy.tools.error_reports import ErrorReports
     from galaxy.visualization.genomes import Genomes
 
@@ -67,9 +67,12 @@ class BasicSharedApp(Container):
     model: SharedModelMapping
     security: IdEncodingHelper
     auth_manager: AuthManager
-    toolbox: "ToolBox"
     security_agent: Any
     quota_agent: QuotaAgent
+
+    @property
+    def toolbox(self) -> "ToolBox":
+        ...
 
 
 class MinimalToolApp(Protocol):
@@ -77,7 +80,7 @@ class MinimalToolApp(Protocol):
     config: Any  # 'galaxy.config.BaseAppConfiguration'
     datatypes_registry: Registry
     object_store: ObjectStore
-    tool_data_tables: "ToolDataTableManager"
+    tool_data_tables: ToolDataTableManager
     file_sources: ConfiguredFileSources
     security: IdEncodingHelper
 
@@ -142,7 +145,7 @@ class StructuredApp(MinimalManagerApp):
     webhooks_registry: WebhooksRegistry
     queue_worker: Any  # 'galaxy.queue_worker.GalaxyQueueWorker'
     data_provider_registry: Any  # 'galaxy.visualization.data_providers.registry.DataProviderRegistry'
-    tool_data_tables: "ToolDataTableManager"
+    tool_data_tables: ToolDataTableManager
     tool_cache: "ToolCache"
     tool_shed_registry: ToolShedRegistry
     tool_shed_repository_cache: Optional[ToolShedRepositoryCache]

--- a/lib/galaxy/tool_shed/galaxy_install/client.py
+++ b/lib/galaxy/tool_shed/galaxy_install/client.py
@@ -1,0 +1,66 @@
+import threading
+from typing import (
+    Any,
+    Generic,
+    List,
+    Optional,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
+
+from typing_extensions import Protocol
+
+from galaxy.model.base import ModelMapping
+from galaxy.model.tool_shed_install import HasToolBox
+from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.tool_shed.cache import ToolShedRepositoryCache
+from galaxy.tool_util.data import ToolDataTableManager
+from galaxy.tool_util.toolbox.base import AbstractToolBox
+
+if TYPE_CHECKING:
+    import galaxy.tool_shed.metadata.installed_repository_manger
+
+
+class DataManagerInterface(Protocol):
+    GUID_TYPE: str = "data_manager"
+    DEFAULT_VERSION: str = "0.0.1"
+
+    def process_result(self, out_data):
+        ...
+
+
+class DataManagersInterface(Protocol):
+    @property
+    def _reload_count(self) -> int:
+        ...
+
+    def load_manager_from_elem(
+        self, data_manager_elem, tool_path=None, add_manager=True
+    ) -> Optional[DataManagerInterface]:
+        ...
+
+    def get_manager(self, data_manager_id: str) -> Optional[DataManagerInterface]:
+        ...
+
+    def remove_manager(self, manager_ids: Union[str, List[str]]) -> None:
+        ...
+
+
+ToolBoxType = TypeVar("ToolBoxType", bound="AbstractToolBox")
+
+
+class InstallationTarget(HasToolBox, Generic[ToolBoxType]):
+    data_managers: DataManagersInterface
+    install_model: ModelMapping
+    model: ModelMapping
+    security: IdEncodingHelper
+    config: Any
+    installed_repository_manager: "galaxy.tool_shed.metadata.installed_repository_manger.InstalledRepositoryManager"
+    watchers: Any  # TODO: interface...
+    _toolbox_lock: threading.RLock
+    tool_shed_repository_cache: Optional[ToolShedRepositoryCache]
+    tool_data_tables: ToolDataTableManager
+
+    def wait_for_toolbox_reload(self, old_toolbox: ToolBoxType) -> None:
+        ...

--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -15,7 +15,7 @@ from galaxy import (
     exceptions,
     util,
 )
-from galaxy.structured_app import StructuredApp
+from galaxy.tool_shed.galaxy_install.client import InstallationTarget
 from galaxy.tool_shed.galaxy_install.metadata.installed_repository_metadata_manager import (
     InstalledRepositoryMetadataManager,
 )
@@ -41,10 +41,10 @@ log = logging.getLogger(__name__)
 
 
 class InstallRepositoryManager:
-    app: StructuredApp
+    app: InstallationTarget
     tpm: tool_panel_manager.ToolPanelManager
 
-    def __init__(self, app: StructuredApp, tpm: Optional[tool_panel_manager.ToolPanelManager] = None):
+    def __init__(self, app: InstallationTarget, tpm: Optional[tool_panel_manager.ToolPanelManager] = None):
         self.app = app
         self.install_model = self.app.install_model
         self._view = views.DependencyResolversView(app)

--- a/lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py
@@ -19,7 +19,7 @@ from galaxy.model.tool_shed_install import (
     ToolDependency,
     ToolShedRepository,
 )
-from galaxy.structured_app import MinimalManagerApp
+from galaxy.tool_shed.galaxy_install.client import InstallationTarget
 from galaxy.tool_shed.galaxy_install.metadata.installed_repository_metadata_manager import (
     InstalledRepositoryMetadataManager,
 )
@@ -43,14 +43,14 @@ RepositoryTupleT = Tuple[str, str, str, str]
 
 
 class InstalledRepositoryManager:
-    app: MinimalManagerApp
+    app: InstallationTarget
     _tool_paths: List[str]
     installed_repository_dicts: List[Dict[str, Any]]
     repository_dependencies_of_installed_repositories: Dict[RepositoryTupleT, List[RepositoryTupleT]]
     installed_repository_dependencies_of_installed_repositories: Dict[RepositoryTupleT, List[RepositoryTupleT]]
     installed_dependent_repositories_of_installed_repositories: Dict[RepositoryTupleT, List[RepositoryTupleT]]
 
-    def __init__(self, app: MinimalManagerApp):
+    def __init__(self, app: InstallationTarget):
         """
         Among other things, keep in in-memory sets of tuples defining installed repositories and tool dependencies along with
         the relationships between each of them.  This will allow for quick discovery of those repositories or components that

--- a/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
@@ -124,6 +124,7 @@ class InstalledRepositoryMetadataManager(GalaxyMetadataGenerator):
     def reset_all_metadata_on_installed_repository(self):
         """Reset all metadata on a single tool shed repository installed into a Galaxy instance."""
         if self.relative_install_dir:
+            assert self.repository
             original_metadata_dict = self.repository.metadata_
             self.generate_metadata_for_changeset_revision()
             if self.metadata_dict != original_metadata_dict:
@@ -135,7 +136,9 @@ class InstalledRepositoryMetadataManager(GalaxyMetadataGenerator):
             else:
                 log.debug(f"Metadata did not need to be reset on repository {self.repository.name}.")
         else:
-            log.debug(f"Error locating installation directory for repository {self.repository.name}.")
+            log.debug(
+                f"Error locating installation directory for repository {self.repository and self.repository.name}."
+            )
 
     def reset_metadata_on_selected_repositories(self, user, **kwd):
         """
@@ -202,6 +205,7 @@ class InstalledRepositoryMetadataManager(GalaxyMetadataGenerator):
         A tool shed repository is being updated so change the shed_tool_conf file.  Parse the config
         file to generate the entire list of config_elems instead of using the in-memory list.
         """
+        assert self.repository
         shed_conf_dict = self.shed_config_dict or self.repository.get_shed_config_dict(self.app)
         shed_tool_conf = shed_conf_dict["config_filename"]
         tool_path = shed_conf_dict["tool_path"]

--- a/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
@@ -12,7 +12,7 @@ from galaxy import util
 from galaxy.model.tool_shed_install import ToolShedRepository
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.tool_shed.galaxy_install.tools import tool_panel_manager
-from galaxy.tool_shed.metadata.metadata_generator import MetadataGenerator
+from galaxy.tool_shed.metadata.metadata_generator import GalaxyMetadataGenerator
 from galaxy.tool_shed.util.repository_util import (
     get_installed_tool_shed_repository,
     get_repository_owner,
@@ -28,7 +28,7 @@ from galaxy.web.form_builder import SelectField
 log = logging.getLogger(__name__)
 
 
-class InstalledRepositoryMetadataManager(MetadataGenerator):
+class InstalledRepositoryMetadataManager(GalaxyMetadataGenerator):
     def __init__(
         self,
         app: MinimalManagerApp,

--- a/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
@@ -1,10 +1,15 @@
 import logging
 import os
-from typing import Optional
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
 
 from sqlalchemy import false
 
 from galaxy import util
+from galaxy.model.tool_shed_install import ToolShedRepository
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.tool_shed.galaxy_install.tools import tool_panel_manager
 from galaxy.tool_shed.metadata.metadata_generator import MetadataGenerator
@@ -28,16 +33,16 @@ class InstalledRepositoryMetadataManager(MetadataGenerator):
         self,
         app: MinimalManagerApp,
         tpm: Optional[tool_panel_manager.ToolPanelManager] = None,
-        repository=None,
-        changeset_revision=None,
-        repository_clone_url=None,
-        shed_config_dict=None,
-        relative_install_dir=None,
-        repository_files_dir=None,
-        resetting_all_metadata_on_repository=False,
-        updating_installed_repository=False,
-        persist=False,
-        metadata_dict=None,
+        repository: Optional[ToolShedRepository] = None,
+        changeset_revision: Optional[str] = None,
+        repository_clone_url: Optional[str] = None,
+        shed_config_dict: Optional[Dict[str, Any]] = None,
+        relative_install_dir: Optional[str] = None,
+        repository_files_dir: Optional[str] = None,
+        resetting_all_metadata_on_repository: bool = False,
+        updating_installed_repository: bool = False,
+        persist: bool = False,
+        metadata_dict: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(
             app,
@@ -181,9 +186,11 @@ class InstalledRepositoryMetadataManager(MetadataGenerator):
         super().set_repository(repository)
         self.repository_clone_url = common_util.generate_clone_url_for_installed_repository(self.app, repository)
 
-    def tool_shed_from_repository_clone_url(self):
+    def tool_shed_from_repository_clone_url(self) -> str:
         """Given a repository clone URL, return the tool shed that contains the repository."""
-        cleaned_repository_clone_url = common_util.remove_protocol_and_user_from_clone_url(self.repository_clone_url)
+        repository_clone_url = self.repository_clone_url
+        assert repository_clone_url
+        cleaned_repository_clone_url = common_util.remove_protocol_and_user_from_clone_url(repository_clone_url)
         return (
             common_util.remove_protocol_and_user_from_clone_url(cleaned_repository_clone_url)
             .split("/repos/")[0]

--- a/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
@@ -10,7 +10,7 @@ from sqlalchemy import false
 
 from galaxy import util
 from galaxy.model.tool_shed_install import ToolShedRepository
-from galaxy.structured_app import MinimalManagerApp
+from galaxy.tool_shed.galaxy_install.client import InstallationTarget
 from galaxy.tool_shed.galaxy_install.tools import tool_panel_manager
 from galaxy.tool_shed.metadata.metadata_generator import GalaxyMetadataGenerator
 from galaxy.tool_shed.util.repository_util import (
@@ -29,9 +29,11 @@ log = logging.getLogger(__name__)
 
 
 class InstalledRepositoryMetadataManager(GalaxyMetadataGenerator):
+    app: InstallationTarget
+
     def __init__(
         self,
-        app: MinimalManagerApp,
+        app: InstallationTarget,
         tpm: Optional[tool_panel_manager.ToolPanelManager] = None,
         repository: Optional[ToolShedRepository] = None,
         changeset_revision: Optional[str] = None,

--- a/lib/galaxy/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
@@ -15,6 +15,7 @@ from urllib.request import (
     urlopen,
 )
 
+from galaxy.tool_shed.galaxy_install import installed_repository_manager
 from galaxy.tool_shed.galaxy_install.tools import tool_panel_manager
 from galaxy.tool_shed.util import repository_util
 from galaxy.tool_shed.util.container_util import get_components_from_key
@@ -263,7 +264,8 @@ class RepositoryDependencyInstallManager:
                                 log.info(
                                     f"Reactivating deactivated tool_shed_repository '{str(repository_db_record.name)}'."
                                 )
-                                self.app.installed_repository_manager.activate_repository(repository_db_record)
+                                irm = installed_repository_manager.InstalledRepositoryManager(self.app)
+                                irm.activate_repository(repository_db_record)
                                 # No additional updates to the database record are necessary.
                                 can_update_db_record = False
                             elif repository_db_record.status not in [

--- a/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
@@ -7,9 +7,12 @@ from typing import (
     Dict,
     List,
     Optional,
-    TYPE_CHECKING,
 )
 
+from galaxy.tool_shed.galaxy_install.client import (
+    DataManagerInterface,
+    InstallationTarget,
+)
 from galaxy.util import (
     Element,
     etree,
@@ -21,9 +24,6 @@ from galaxy.util.renamed_temporary_file import RenamedTemporaryFile
 from galaxy.util.tool_shed.xml_util import parse_xml
 from . import tool_panel_manager
 
-if TYPE_CHECKING:
-    from galaxy.tools.data_manager.manager import DataManager
-
 log = logging.getLogger(__name__)
 
 SHED_DATA_MANAGER_CONF_XML = """<?xml version="1.0"?>
@@ -33,9 +33,10 @@ SHED_DATA_MANAGER_CONF_XML = """<?xml version="1.0"?>
 
 
 class DataManagerHandler:
+    app: InstallationTarget
     root: Optional[Element] = None
 
-    def __init__(self, app):
+    def __init__(self, app: InstallationTarget):
         self.app = app
 
     @property
@@ -74,7 +75,7 @@ class DataManagerHandler:
         repository,
         repository_tools_tups,
     ):
-        rval: List["DataManager"] = []
+        rval: List["DataManagerInterface"] = []
         if "data_manager" in metadata_dict:
             tpm = tool_panel_manager.ToolPanelManager(self.app)
             repository_tools_by_guid = {}

--- a/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -7,7 +7,7 @@ from typing import (
 )
 
 from galaxy.exceptions import RequestParameterInvalidException
-from galaxy.structured_app import MinimalManagerApp
+from galaxy.tool_shed.galaxy_install.client import InstallationTarget
 from galaxy.tool_shed.util.basic_util import strip_path
 from galaxy.tool_shed.util.repository_util import get_repository_owner
 from galaxy.tool_shed.util.shed_util_common import get_tool_panel_config_tool_path_install_dir
@@ -24,9 +24,9 @@ log = logging.getLogger(__name__)
 
 
 class ToolPanelManager:
-    app: MinimalManagerApp
+    app: InstallationTarget
 
-    def __init__(self, app: MinimalManagerApp):
+    def __init__(self, app: InstallationTarget):
         self.app = app
 
     def add_to_shed_tool_config(self, shed_tool_conf_dict: Dict[str, Any], elem_list: list) -> None:
@@ -134,7 +134,7 @@ class ToolPanelManager:
             self.app.toolbox.update_shed_config(shed_tool_conf_dict)
             self.add_to_shed_tool_config(shed_tool_conf_dict, elem_list)
 
-    def config_elems_to_xml_file(self, config_elems, config_filename, tool_path, tool_cache_data_dir=None):
+    def config_elems_to_xml_file(self, config_elems, config_filename, tool_path, tool_cache_data_dir=None) -> None:
         """
         Persist the current in-memory list of config_elems to a file named by the
         value of config_filename.

--- a/lib/galaxy/tool_shed/metadata/metadata_generator.py
+++ b/lib/galaxy/tool_shed/metadata/metadata_generator.py
@@ -898,7 +898,6 @@ class GalaxyMetadataGenerator(BaseMetadataGenerator):
         self.updating_installed_repository = updating_installed_repository
         self.persist = persist
         self.invalid_file_tups = []
-        self.sa_session = app.model.session
 
     def initial_metadata_dict(self) -> Dict[str, Any]:
         # Shed related tool panel configs are only relevant to Galaxy.

--- a/lib/galaxy/tool_shed/metadata/metadata_generator.py
+++ b/lib/galaxy/tool_shed/metadata/metadata_generator.py
@@ -67,6 +67,9 @@ class BaseMetadataGenerator:
     repository_files_dir: Optional[str]
     persist: bool
 
+    def initial_metadata_dict(self) -> Dict[str, Any]:
+        ...
+
     def _generate_data_manager_metadata(
         self, repo_dir, data_manager_config_filename, metadata_dict: Dict[str, Any], shed_config_dict=None
     ) -> Dict[str, Any]:
@@ -195,14 +198,6 @@ class BaseMetadataGenerator:
         assert self.repository_clone_url
         tmp_url = remove_protocol_and_user_from_clone_url(self.repository_clone_url)
         return f"{tmp_url}/{guid_type}/{obj_id}/{version}"
-
-    def initial_metadata_dict(self) -> Dict[str, Any]:
-        if self.app.name == "galaxy":
-            # Shed related tool panel configs are only relevant to Galaxy.
-            metadata_dict = {"shed_config_filename": self.shed_config_dict.get("config_filename")}
-        else:
-            metadata_dict = {}
-        return metadata_dict
 
     def generate_metadata_for_changeset_revision(self):
         """
@@ -1092,6 +1087,11 @@ class GalaxyMetadataGenerator(BaseMetadataGenerator):
         self.invalid_file_tups = []
         self.sa_session = app.model.session
 
+    def initial_metadata_dict(self) -> Dict[str, Any]:
+        # Shed related tool panel configs are only relevant to Galaxy.
+        metadata_dict = {"shed_config_filename": self.shed_config_dict.get("config_filename")}
+        return metadata_dict
+
 
 class ToolShedMetadataGenerator(BaseMetadataGenerator):
     """A MetadataGenerator building on ToolShed's app and repository constructs."""
@@ -1141,6 +1141,9 @@ class ToolShedMetadataGenerator(BaseMetadataGenerator):
         self.persist = persist
         self.invalid_file_tups = []
         self.sa_session = app.model.session
+
+    def initial_metadata_dict(self) -> Dict[str, Any]:
+        return {}
 
 
 def _get_readme_file_names(repository_name: str) -> List[str]:

--- a/lib/galaxy/tool_shed/metadata/metadata_generator.py
+++ b/lib/galaxy/tool_shed/metadata/metadata_generator.py
@@ -48,6 +48,13 @@ log = logging.getLogger(__name__)
 InvalidFileT = Tuple[str, str]
 HandleResultT = Tuple[List, bool, str]
 
+NOT_TOOL_CONFIGS = [
+    suc.DATATYPES_CONFIG_FILENAME,
+    REPOSITORY_DEPENDENCY_DEFINITION_FILENAME,
+    TOOL_DEPENDENCY_DEFINITION_FILENAME,
+    suc.REPOSITORY_DATA_MANAGER_CONFIG_FILENAME,
+]
+
 
 class BaseMetadataGenerator:
     app: MinimalManagerApp
@@ -133,12 +140,6 @@ class BaseMetadataGenerator:
         self.persist = persist
         self.invalid_file_tups = []
         self.sa_session = app.model.session
-        self.NOT_TOOL_CONFIGS = [
-            suc.DATATYPES_CONFIG_FILENAME,
-            REPOSITORY_DEPENDENCY_DEFINITION_FILENAME,
-            TOOL_DEPENDENCY_DEFINITION_FILENAME,
-            suc.REPOSITORY_DATA_MANAGER_CONFIG_FILENAME,
-        ]
 
     def _generate_data_manager_metadata(
         self, repo_dir, data_manager_config_filename, metadata_dict: Dict[str, Any], shed_config_dict=None
@@ -377,7 +378,7 @@ class BaseMetadataGenerator:
                             )
                             readme_files.append(relative_path_to_readme)
                         # See if we have a tool config.
-                        elif looks_like_a_tool(os.path.join(root, name), invalid_names=self.NOT_TOOL_CONFIGS):
+                        elif looks_like_a_tool(os.path.join(root, name), invalid_names=NOT_TOOL_CONFIGS):
                             full_path = str(os.path.abspath(os.path.join(root, name)))  # why the str, seems very odd
                             element_tree, error_message = parse_xml(full_path)
                             if element_tree is None:

--- a/lib/galaxy/tool_shed/metadata/metadata_generator.py
+++ b/lib/galaxy/tool_shed/metadata/metadata_generator.py
@@ -968,29 +968,6 @@ class BaseMetadataGenerator:
     def set_relative_install_dir(self, relative_install_dir: Optional[str]):
         self.relative_install_dir = relative_install_dir
 
-    def set_repository(
-        self, repository, relative_install_dir: Optional[str] = None, changeset_revision: Optional[str] = None
-    ):
-        self.repository = repository
-        # Shed related tool panel configs are only relevant to Galaxy.
-        if self.app.name == "galaxy":
-            if relative_install_dir is None and self.repository is not None:
-                tool_path, relative_install_dir = self.repository.get_tool_relative_path(self.app)
-            if changeset_revision is None and self.repository is not None:
-                self.set_changeset_revision(self.repository.changeset_revision)
-            else:
-                self.set_changeset_revision(changeset_revision)
-            self.shed_config_dict = repository.get_shed_config_dict(self.app)
-        else:
-            if relative_install_dir is None and self.repository is not None:
-                relative_install_dir = repository.repo_path(self.app)
-            if changeset_revision is None and self.repository is not None:
-                self.set_changeset_revision(self.repository.tip())
-            else:
-                self.set_changeset_revision(changeset_revision)
-            self.shed_config_dict = {}
-        self._reset_attributes_after_repository_update(relative_install_dir)
-
     def _reset_attributes_after_repository_update(self, relative_install_dir: Optional[str]):
         self.metadata_dict = self.initial_metadata_dict()
         self.set_relative_install_dir(relative_install_dir)
@@ -1092,6 +1069,19 @@ class GalaxyMetadataGenerator(BaseMetadataGenerator):
         metadata_dict = {"shed_config_filename": self.shed_config_dict.get("config_filename")}
         return metadata_dict
 
+    def set_repository(
+        self, repository, relative_install_dir: Optional[str] = None, changeset_revision: Optional[str] = None
+    ):
+        self.repository = repository
+        if relative_install_dir is None and self.repository is not None:
+            tool_path, relative_install_dir = self.repository.get_tool_relative_path(self.app)
+        if changeset_revision is None and self.repository is not None:
+            self.set_changeset_revision(self.repository.changeset_revision)
+        else:
+            self.set_changeset_revision(changeset_revision)
+        self.shed_config_dict = repository.get_shed_config_dict(self.app)
+        self._reset_attributes_after_repository_update(relative_install_dir)
+
 
 class ToolShedMetadataGenerator(BaseMetadataGenerator):
     """A MetadataGenerator building on ToolShed's app and repository constructs."""
@@ -1144,6 +1134,19 @@ class ToolShedMetadataGenerator(BaseMetadataGenerator):
 
     def initial_metadata_dict(self) -> Dict[str, Any]:
         return {}
+
+    def set_repository(
+        self, repository, relative_install_dir: Optional[str] = None, changeset_revision: Optional[str] = None
+    ):
+        self.repository = repository
+        if relative_install_dir is None and self.repository is not None:
+            relative_install_dir = repository.repo_path(self.app)
+        if changeset_revision is None and self.repository is not None:
+            self.set_changeset_revision(self.repository.tip())
+        else:
+            self.set_changeset_revision(changeset_revision)
+        self.shed_config_dict = {}
+        self._reset_attributes_after_repository_update(relative_install_dir)
 
 
 def _get_readme_file_names(repository_name: str) -> List[str]:

--- a/lib/galaxy/tool_shed/metadata/metadata_generator.py
+++ b/lib/galaxy/tool_shed/metadata/metadata_generator.py
@@ -67,80 +67,6 @@ class BaseMetadataGenerator:
     repository_files_dir: Optional[str]
     persist: bool
 
-    def __init__(
-        self,
-        app: MinimalManagerApp,
-        repository=None,
-        changeset_revision: Optional[str] = None,
-        repository_clone_url: Optional[str] = None,
-        shed_config_dict: Optional[Dict[str, Any]] = None,
-        relative_install_dir=None,
-        repository_files_dir=None,
-        resetting_all_metadata_on_repository=False,
-        updating_installed_repository=False,
-        persist=False,
-        metadata_dict=None,
-        user=None,
-    ):
-        self.app = app
-        self.user = user
-        self.repository = repository
-        if self.app.name == "galaxy":
-            if changeset_revision is None and self.repository is not None:
-                self.changeset_revision = self.repository.changeset_revision
-            else:
-                self.changeset_revision = changeset_revision
-
-            if repository_clone_url is None and self.repository is not None:
-                self.repository_clone_url = generate_clone_url_for_installed_repository(self.app, self.repository)
-            else:
-                self.repository_clone_url = repository_clone_url
-            if shed_config_dict is None:
-                if self.repository is not None:
-                    self.shed_config_dict = self.repository.get_shed_config_dict(self.app)
-                else:
-                    self.shed_config_dict = {}
-            else:
-                self.shed_config_dict = shed_config_dict
-            if relative_install_dir is None and self.repository is not None:
-                tool_path, relative_install_dir = self.repository.get_tool_relative_path(self.app)
-            if repository_files_dir is None and self.repository is not None:
-                repository_files_dir = self.repository.repo_files_directory(self.app)
-            if metadata_dict is None:
-                # Shed related tool panel configs are only relevant to Galaxy.
-                self.metadata_dict = {"shed_config_filename": self.shed_config_dict.get("config_filename", None)}
-            else:
-                self.metadata_dict = metadata_dict
-        else:
-            # We're in the Tool Shed.
-            if changeset_revision is None and self.repository is not None:
-                self.changeset_revision = self.repository.tip()
-            else:
-                self.changeset_revision = changeset_revision
-            if repository_clone_url is None and self.repository is not None:
-                self.repository_clone_url = generate_clone_url_for_repository_in_tool_shed(self.user, self.repository)
-            else:
-                self.repository_clone_url = repository_clone_url
-            if shed_config_dict is None:
-                self.shed_config_dict = {}
-            else:
-                self.shed_config_dict = shed_config_dict
-            if relative_install_dir is None and self.repository is not None:
-                relative_install_dir = self.repository.repo_path(self.app)
-            if repository_files_dir is None and self.repository is not None:
-                repository_files_dir = self.repository.repo_path(self.app)
-            if metadata_dict is None:
-                self.metadata_dict = {}
-            else:
-                self.metadata_dict = metadata_dict
-        self.relative_install_dir = relative_install_dir
-        self.repository_files_dir = repository_files_dir
-        self.resetting_all_metadata_on_repository = resetting_all_metadata_on_repository
-        self.updating_installed_repository = updating_installed_repository
-        self.persist = persist
-        self.invalid_file_tups = []
-        self.sa_session = app.model.session
-
     def _generate_data_manager_metadata(
         self, repo_dir, data_manager_config_filename, metadata_dict: Dict[str, Any], shed_config_dict=None
     ) -> Dict[str, Any]:
@@ -1115,9 +1041,106 @@ class BaseMetadataGenerator:
 class GalaxyMetadataGenerator(BaseMetadataGenerator):
     """A MetadataGenerator building on Galaxy's app and repository constructs."""
 
+    def __init__(
+        self,
+        app: MinimalManagerApp,
+        repository=None,
+        changeset_revision: Optional[str] = None,
+        repository_clone_url: Optional[str] = None,
+        shed_config_dict: Optional[Dict[str, Any]] = None,
+        relative_install_dir=None,
+        repository_files_dir=None,
+        resetting_all_metadata_on_repository=False,
+        updating_installed_repository=False,
+        persist=False,
+        metadata_dict=None,
+        user=None,
+    ):
+        self.app = app
+        self.user = user
+        self.repository = repository
+        if changeset_revision is None and self.repository is not None:
+            self.changeset_revision = self.repository.changeset_revision
+        else:
+            self.changeset_revision = changeset_revision
+
+        if repository_clone_url is None and self.repository is not None:
+            self.repository_clone_url = generate_clone_url_for_installed_repository(self.app, self.repository)
+        else:
+            self.repository_clone_url = repository_clone_url
+        if shed_config_dict is None:
+            if self.repository is not None:
+                self.shed_config_dict = self.repository.get_shed_config_dict(self.app)
+            else:
+                self.shed_config_dict = {}
+        else:
+            self.shed_config_dict = shed_config_dict
+        if relative_install_dir is None and self.repository is not None:
+            tool_path, relative_install_dir = self.repository.get_tool_relative_path(self.app)
+        if repository_files_dir is None and self.repository is not None:
+            repository_files_dir = self.repository.repo_files_directory(self.app)
+        if metadata_dict is None:
+            # Shed related tool panel configs are only relevant to Galaxy.
+            self.metadata_dict = {"shed_config_filename": self.shed_config_dict.get("config_filename", None)}
+        else:
+            self.metadata_dict = metadata_dict
+        self.relative_install_dir = relative_install_dir
+        self.repository_files_dir = repository_files_dir
+        self.resetting_all_metadata_on_repository = resetting_all_metadata_on_repository
+        self.updating_installed_repository = updating_installed_repository
+        self.persist = persist
+        self.invalid_file_tups = []
+        self.sa_session = app.model.session
+
 
 class ToolShedMetadataGenerator(BaseMetadataGenerator):
     """A MetadataGenerator building on ToolShed's app and repository constructs."""
+
+    def __init__(
+        self,
+        app: MinimalManagerApp,
+        repository=None,
+        changeset_revision: Optional[str] = None,
+        repository_clone_url: Optional[str] = None,
+        shed_config_dict: Optional[Dict[str, Any]] = None,
+        relative_install_dir=None,
+        repository_files_dir=None,
+        resetting_all_metadata_on_repository=False,
+        updating_installed_repository=False,
+        persist=False,
+        metadata_dict=None,
+        user=None,
+    ):
+        self.app = app
+        self.user = user
+        self.repository = repository
+        if changeset_revision is None and self.repository is not None:
+            self.changeset_revision = self.repository.tip()
+        else:
+            self.changeset_revision = changeset_revision
+        if repository_clone_url is None and self.repository is not None:
+            self.repository_clone_url = generate_clone_url_for_repository_in_tool_shed(self.user, self.repository)
+        else:
+            self.repository_clone_url = repository_clone_url
+        if shed_config_dict is None:
+            self.shed_config_dict = {}
+        else:
+            self.shed_config_dict = shed_config_dict
+        if relative_install_dir is None and self.repository is not None:
+            relative_install_dir = self.repository.repo_path(self.app)
+        if repository_files_dir is None and self.repository is not None:
+            repository_files_dir = self.repository.repo_path(self.app)
+        if metadata_dict is None:
+            self.metadata_dict = {}
+        else:
+            self.metadata_dict = metadata_dict
+        self.relative_install_dir = relative_install_dir
+        self.repository_files_dir = repository_files_dir
+        self.resetting_all_metadata_on_repository = resetting_all_metadata_on_repository
+        self.updating_installed_repository = updating_installed_repository
+        self.persist = persist
+        self.invalid_file_tups = []
+        self.sa_session = app.model.session
 
 
 def _get_readme_file_names(repository_name: str) -> List[str]:

--- a/lib/galaxy/tool_shed/metadata/metadata_generator.py
+++ b/lib/galaxy/tool_shed/metadata/metadata_generator.py
@@ -49,7 +49,7 @@ InvalidFileT = Tuple[str, str]
 HandleResultT = Tuple[List, bool, str]
 
 
-class MetadataGenerator:
+class BaseMetadataGenerator:
     app: MinimalManagerApp
     invalid_file_tups: List[InvalidFileT]
     changeset_revision: Optional[str]
@@ -1109,6 +1109,14 @@ class MetadataGenerator:
             else:
                 metadata["invalid_repository_dependencies"] = repository_dependencies_dict
         return metadata
+
+
+class GalaxyMetadataGenerator(BaseMetadataGenerator):
+    """A MetadataGenerator building on Galaxy's app and repository constructs."""
+
+
+class ToolShedMetadataGenerator(BaseMetadataGenerator):
+    """A MetadataGenerator building on ToolShed's app and repository constructs."""
 
 
 def _get_readme_file_names(repository_name: str) -> List[str]:

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -1,9 +1,13 @@
 import logging
 import os
 import shutil
-from typing import List
+from typing import (
+    List,
+    Union,
+)
 
-from galaxy.structured_app import StructuredApp
+from galaxy.structured_app import BasicSharedApp
+from galaxy.tool_shed.galaxy_install.client import InstallationTarget
 from galaxy.tool_shed.util import hg_util
 from galaxy.util import etree
 from galaxy.util.tool_shed import xml_util
@@ -12,7 +16,9 @@ log = logging.getLogger(__name__)
 
 
 class ShedToolDataTableManager:
-    def __init__(self, app: StructuredApp):
+    app: Union[BasicSharedApp, InstallationTarget]
+
+    def __init__(self, app: Union[BasicSharedApp, InstallationTarget]):
         self.app = app
 
     def generate_repository_info_elem(

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -14,11 +14,13 @@ from galaxy.util.tool_shed import xml_util
 
 log = logging.getLogger(__name__)
 
+RequiredAppT = Union[BasicSharedApp, InstallationTarget]
+
 
 class ShedToolDataTableManager:
-    app: Union[BasicSharedApp, InstallationTarget]
+    app: RequiredAppT
 
-    def __init__(self, app: Union[BasicSharedApp, InstallationTarget]):
+    def __init__(self, app: RequiredAppT):
         self.app = app
 
     def generate_repository_info_elem(

--- a/lib/galaxy/tool_shed/tools/tool_validator.py
+++ b/lib/galaxy/tool_shed/tools/tool_validator.py
@@ -1,6 +1,9 @@
 import logging
 
-from galaxy.tool_shed.tools.data_table_manager import ShedToolDataTableManager
+from galaxy.tool_shed.tools.data_table_manager import (
+    RequiredAppT,
+    ShedToolDataTableManager,
+)
 from galaxy.tool_shed.util import (
     basic_util,
     hg_util,
@@ -17,7 +20,7 @@ log = logging.getLogger(__name__)
 
 
 class ToolValidator:
-    def __init__(self, app):
+    def __init__(self, app: RequiredAppT):
         self.app = app
         self.stdtm = ShedToolDataTableManager(self.app)
 

--- a/lib/galaxy/tool_shed/unittest_utils/__init__.py
+++ b/lib/galaxy/tool_shed/unittest_utils/__init__.py
@@ -1,0 +1,212 @@
+import threading
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Union,
+)
+
+from galaxy.model.migrations import (
+    DatabaseStateVerifier,
+    TSI,
+)
+from galaxy.model.orm.engine_factory import build_engine
+from galaxy.model.tool_shed_install import mapping as install_mapping
+from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.tool_shed.cache import ToolShedRepositoryCache
+from galaxy.tool_shed.galaxy_install.client import (
+    DataManagerInterface,
+    DataManagersInterface,
+    InstallationTarget,
+)
+from galaxy.tool_shed.util.repository_util import get_installed_repository
+from galaxy.tool_util.data import ToolDataTableManager
+from galaxy.tool_util.toolbox.base import AbstractToolBox
+from galaxy.tool_util.toolbox.watcher import (
+    get_tool_conf_watcher,
+    get_tool_watcher,
+)
+from galaxy.util.tool_shed.tool_shed_registry import Registry
+
+
+class ToolShedTarget(NamedTuple):
+    url: str
+    name: str
+
+    @property
+    def as_str(self) -> str:
+        return f"""<?xml version="1.0"?>
+<tool_sheds>
+    <tool_shed name="{self.name}" url="{self.url}"/>
+</tool_sheds>
+"""
+
+
+EMPTY_TOOL_DATA_TABLE_CONFIG = """<?xml version="1.0"?>
+<tables>
+</tables>
+"""
+
+
+class Config:
+    tool_data_path: str
+    install_database_connection: str
+    install_database_engine_options: Dict[str, Any] = {}
+    update_integrated_tool_panel: bool = True
+    integrated_tool_panel_config: str
+    shed_tool_config_file: str
+    shed_tool_data_path: str
+    migrated_tools_config: Optional[str] = None
+    shed_tools_dir: str
+    edam_panel_views: list = []
+    tool_configs: list = []
+    shed_tool_data_table_config: str
+    shed_data_manager_config_file: str
+
+
+class TestTool:
+    _macro_paths: List[str] = []
+    params_with_missing_data_table_entry: list = []
+    params_with_missing_index_file: list = []
+
+    def __init__(self, config_file, tool_shed_repository, guid):
+        self.config_file = config_file
+        self.tool_shed_repository = tool_shed_repository
+        self.guid = guid
+        self.id = guid
+        self.version = "1.0.0"
+        self.hidden = False
+        self._lineage = None
+        self.name = "test_tool"
+
+    @property
+    def lineage(self):
+        return self._lineage
+
+
+class TestToolBox(AbstractToolBox):
+    def create_tool(self, config_file, tool_cache_data_dir=None, **kwds):
+        tool = TestTool(config_file, kwds["tool_shed_repository"], kwds["guid"])
+        tool._lineage = self._lineage_map.register(tool)  # cleanup?
+        return tool
+
+    def _get_tool_shed_repository(self, tool_shed, name, owner, installed_changeset_revision):
+        return get_installed_repository(
+            self.app,
+            tool_shed=tool_shed,
+            name=name,
+            owner=owner,
+            installed_changeset_revision=installed_changeset_revision,
+            from_cache=True,
+        )
+
+
+class Watchers:
+    def __init__(self, app):
+        self.app = app
+        self.tool_config_watcher = get_tool_conf_watcher(
+            reload_callback=self.app.reload_toolbox,
+            tool_cache=None,
+        )
+        self.tool_watcher = get_tool_watcher(self, app.config)
+
+
+class DummyDataManager(DataManagerInterface):
+    GUID_TYPE: str = "data_manager"
+    DEFAULT_VERSION: str = "0.0.1"
+
+    def process_result(self, out_data):
+        return None
+
+
+class StandaloneDataManagers(DataManagersInterface):
+    __reload_count = 0
+
+    def load_manager_from_elem(
+        self, data_manager_elem, tool_path=None, add_manager=True
+    ) -> Optional[DataManagerInterface]:
+        return DummyDataManager()
+
+    def get_manager(self, data_manager_id: str) -> Optional[DataManagerInterface]:
+        return None
+
+    def remove_manager(self, manager_ids: Union[str, List[str]]) -> None:
+        return None
+
+    @property
+    def _reload_count(self) -> int:
+        self.__reload_count += 1
+        return self.__reload_count
+
+
+class StandaloneInstallationTarget(InstallationTarget):
+    name: str = "galaxy"
+    tool_shed_registry: Registry
+    security: IdEncodingHelper
+    _toolbox: TestToolBox
+    _toolbox_lock: threading.RLock = threading.RLock()
+    tool_shed_repository_cache: Optional[ToolShedRepositoryCache] = None
+    data_managers = StandaloneDataManagers()
+
+    def __init__(
+        self,
+        target_directory: Path,
+        tool_shed_target: Optional[ToolShedTarget] = None,
+    ):
+        tool_root_dir = target_directory / "tools"
+        config: Config = Config()
+        install_db_path = str(target_directory / "install.sqlite")
+        config.tool_data_path = str(target_directory / "tool_data")
+        config.shed_tool_data_path = config.tool_data_path
+        config.install_database_connection = f"sqlite:///{install_db_path}?isolation_level=IMMEDIATE"
+        config.integrated_tool_panel_config = str(target_directory / "integrated.xml")
+        config.shed_tool_data_table_config = str(target_directory / "shed_tool_data_table_conf.xml")
+        shed_conf = target_directory / "shed_conf.xml"
+        shed_data_manager_config_file = target_directory / "shed_data_manager_conf.xml"
+        config.shed_data_manager_config_file = str(shed_data_manager_config_file)
+        config.shed_tool_config_file = str(shed_conf)
+        shed_conf.write_text(f'<?xml version="1.0"?>\n<toolbox tool_path="{tool_root_dir}"></toolbox>')
+        (target_directory / "shed_tool_data_table_conf.xml").write_text(EMPTY_TOOL_DATA_TABLE_CONFIG)
+        self.config = config
+        install_engine = build_engine(config.install_database_connection, config.install_database_engine_options)
+        self.security = IdEncodingHelper(id_secret="notasecretfortests")
+        DatabaseStateVerifier(
+            install_engine,
+            TSI,
+            None,
+            None,
+            True,
+            False,
+        ).run()
+        self.install_model = install_mapping.configure_model_mapping(install_engine)
+        registry_config: Optional[Path] = None
+        if tool_shed_target:
+            registry_config = target_directory / "tool_sheds_conf.xml"
+            with registry_config.open("w") as f:
+                f.write(tool_shed_target.as_str)
+
+        self.tool_shed_registry = Registry(registry_config)
+        self.tool_root_dir = tool_root_dir
+        self.tool_root_dir.mkdir()
+        config.shed_tools_dir = str(tool_root_dir)
+        self.watchers = Watchers(self)
+        self.reload_toolbox()
+        self.tool_data_tables = ToolDataTableManager(
+            tool_data_path=self.config.tool_data_path,
+            config_filename=self.config.shed_tool_data_table_config,
+            other_config_dict=self.config,
+        )
+
+    def reload_toolbox(self):
+        self._toolbox = TestToolBox(
+            config_filenames=[self.config.shed_tool_config_file],
+            tool_root_dir=self.tool_root_dir,
+            app=self,
+        )
+
+    @property
+    def toolbox(self) -> TestToolBox:
+        return self._toolbox

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3044,7 +3044,7 @@ class DataManagerTool(OutputParameterJSONTool):
         super().exec_after_process(app, inp_data, out_data, param_dict, job=job, **kwds)
         # process results of tool
         data_manager_id = job.data_manager_association.data_manager_id
-        data_manager = self.app.data_managers.get_manager(data_manager_id, None)
+        data_manager = self.app.data_managers.get_manager(data_manager_id)
         assert (
             data_manager is not None
         ), f"Invalid data manager ({data_manager_id}) requested. It may have been removed before the job completed."

--- a/lib/galaxy/tools/repositories.py
+++ b/lib/galaxy/tools/repositories.py
@@ -3,20 +3,33 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
+from typing import Optional
 
 from galaxy.tools.data import ToolDataTableManager
 from galaxy.util.bunch import Bunch
 from galaxy.util.dbkeys import GenomeBuilds
 
 
+class ValidationContextConfig:
+    tool_data_path: Optional[str]
+    shed_tool_data_path: Optional[str]
+    tool_data_table_config: str
+    shed_tool_data_table_config: str
+    interactivetools_enable: bool
+    len_file_path: str
+    builds_file_path: Optional[str]
+
+
 class ValidationContext:
     """Minimal App object for tool validation."""
 
+    config: ValidationContextConfig
+
     def __init__(
         self,
-        app_name,
-        security,
+        app_name: str,
         model,
+        security,
         tool_data_path,
         shed_tool_data_path,
         tool_data_tables=None,
@@ -25,9 +38,9 @@ class ValidationContext:
         biotools_metadata_source=None,
     ):
         self.name = app_name
-        self.security = security
         self.model = model
-        self.config = Bunch()
+        self.security = security
+        self.config = ValidationContextConfig()
         self.config.tool_data_path = tool_data_path
         self.config.shed_tool_data_path = shed_tool_data_path
         self.temporary_path = tempfile.mkdtemp(prefix="tool_validation_")
@@ -65,11 +78,11 @@ class ValidationContext:
             with ValidationContext(
                 app_name=app.name,
                 security=app.security,
-                model=app.model,
+                model=getattr(app, "model", None),
                 tool_data_path=work_dir,
                 shed_tool_data_path=work_dir,
                 tool_data_tables=tool_data_tables,
-                registry=app.datatypes_registry,
+                registry=getattr(app, "datatypes_registry", None),
                 hgweb_config_manager=getattr(app, "hgweb_config_manager", None),
                 biotools_metadata_source=getattr(app, "biotools_metadata_source", None),
             ) as app:

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -153,17 +153,4 @@ class AdminToolshed(AdminGalaxy):
                 trans.install_model.context.add(repository)
                 trans.install_model.context.flush()
             message = "The repository information has been updated."
-        dd = dependency_display.DependencyDisplayer(trans.app)
-        containers_dict = dd.populate_containers_dict_from_repository_metadata(
-            repository=repository,
-        )
-        management_dict = {
-            "status": status,
-        }
-        missing_repo_dependencies = containers_dict.get("missing_repository_dependencies", None)
-        if missing_repo_dependencies:
-            management_dict["missing_repository_dependencies"] = missing_repo_dependencies.to_dict()
-        repository_dependencies = containers_dict.get("repository_dependencies", None)
-        if repository_dependencies:
-            management_dict["repository_dependencies"] = repository_dependencies.to_dict()
-        return management_dict
+        return dependency_display.build_manage_repository_dict(trans.app, status, repository)

--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -1,3 +1,0 @@
-from galaxy.tool_shed.metadata.metadata_generator import MetadataGenerator
-
-__all__ = ("MetadataGenerator",)

--- a/lib/tool_shed/metadata/repository_metadata_manager.py
+++ b/lib/tool_shed/metadata/repository_metadata_manager.py
@@ -1055,6 +1055,7 @@ class RepositoryMetadataManager(ToolShedMetadataGenerator):
             work_dir = tempfile.mkdtemp(prefix="tmp-toolshed-ramorits")
             ctx = repo[changeset]
             log.debug("Cloning repository changeset revision: %s", str(ctx.rev()))
+            assert self.repository_clone_url
             cloned_ok, error_message = hg_util.clone_repository(self.repository_clone_url, work_dir, str(ctx.rev()))
             if cloned_ok:
                 log.debug("Generating metadata for changeset revision: %s", str(ctx.rev()))

--- a/lib/tool_shed/metadata/repository_metadata_manager.py
+++ b/lib/tool_shed/metadata/repository_metadata_manager.py
@@ -14,7 +14,6 @@ from sqlalchemy import (
 )
 
 from galaxy import util
-from galaxy.structured_app import MinimalManagerApp
 from galaxy.tool_shed.metadata.metadata_generator import (
     BaseMetadataGenerator,
     HandleResultT,
@@ -43,6 +42,7 @@ log = logging.getLogger(__name__)
 class ToolShedMetadataGenerator(BaseMetadataGenerator):
     """A MetadataGenerator building on ToolShed's app and repository constructs."""
 
+    app: ToolShedApp
     repository: Optional[Repository]
 
     # why is mypy making me re-annotate these things from the base class, it didn't
@@ -52,7 +52,7 @@ class ToolShedMetadataGenerator(BaseMetadataGenerator):
 
     def __init__(
         self,
-        app: MinimalManagerApp,
+        app: ToolShedApp,
         repository: Optional[Repository] = None,
         changeset_revision: Optional[str] = None,
         repository_clone_url: Optional[str] = None,

--- a/lib/tool_shed/metadata/repository_metadata_manager.py
+++ b/lib/tool_shed/metadata/repository_metadata_manager.py
@@ -261,6 +261,7 @@ class RepositoryMetadataManager(ToolShedMetadataGenerator):
             metadata_dict=metadata_dict,
             user=user,
         )
+        self.sa_session = app.model.context
         self.app = app
         self.user = user
         # Repository metadata comparisons for changeset revisions.

--- a/lib/tool_shed/metadata/repository_metadata_manager.py
+++ b/lib/tool_shed/metadata/repository_metadata_manager.py
@@ -1,5 +1,9 @@
 import logging
 import tempfile
+from typing import (
+    List,
+    Optional,
+)
 
 from sqlalchemy import (
     false,
@@ -835,7 +839,7 @@ class RepositoryMetadataManager(metadata_generator.MetadataGenerator):
         # The list of changeset_revisions refers to repository_metadata records that have been created
         # or updated.  When the following loop completes, we'll delete all repository_metadata records
         # for this repository that do not have a changeset_revision value in this list.
-        changeset_revisions = []
+        changeset_revisions: List[Optional[str]] = []
         # When a new repository_metadata record is created, it always uses the values of
         # metadata_changeset_revision and metadata_dict.
         metadata_changeset_revision = None

--- a/lib/tool_shed/metadata/repository_metadata_manager.py
+++ b/lib/tool_shed/metadata/repository_metadata_manager.py
@@ -13,7 +13,7 @@ from sqlalchemy import (
 from galaxy import util
 from galaxy.util import inflector
 from galaxy.web.form_builder import SelectField
-from tool_shed.metadata import metadata_generator
+from galaxy.tool_shed.galaxy_install.metadata_generator import ToolShedMetadataGenerator
 from tool_shed.repository_types import util as rt_util
 from tool_shed.repository_types.metadata import TipOnly
 from tool_shed.structured_app import ToolShedApp
@@ -30,7 +30,7 @@ from tool_shed.util import (
 log = logging.getLogger(__name__)
 
 
-class RepositoryMetadataManager(metadata_generator.MetadataGenerator):
+class RepositoryMetadataManager(ToolShedMetadataGenerator):
     def __init__(
         self,
         app: ToolShedApp,

--- a/lib/tool_shed/test/base/test_db_util.py
+++ b/lib/tool_shed/test/base/test_db_util.py
@@ -1,11 +1,15 @@
 import logging
-from typing import Optional
+from typing import (
+    List,
+    Optional,
+)
 
 from sqlalchemy import (
     and_,
     false,
     true,
 )
+from uvloop import install
 
 import galaxy.model
 import galaxy.model.tool_shed_install
@@ -46,23 +50,21 @@ def get_all_repositories():
     return sa_session().query(model.Repository).all()
 
 
-def get_all_installed_repositories(actually_installed=False):
-    if actually_installed:
-        return (
-            install_session()
-            .query(galaxy.model.tool_shed_install.ToolShedRepository)
-            .filter(
-                and_(
-                    galaxy.model.tool_shed_install.ToolShedRepository.table.c.deleted == false(),
-                    galaxy.model.tool_shed_install.ToolShedRepository.table.c.uninstalled == false(),
-                    galaxy.model.tool_shed_install.ToolShedRepository.table.c.status
-                    == galaxy.model.tool_shed_install.ToolShedRepository.installation_status.INSTALLED,
-                )
+def get_all_installed_repositories(session=None) -> List[galaxy.model.tool_shed_install.ToolShedRepository]:
+    if session is None:
+        session = install_session()
+    return list(
+        session.query(galaxy.model.tool_shed_install.ToolShedRepository)
+        .filter(
+            and_(
+                galaxy.model.tool_shed_install.ToolShedRepository.table.c.deleted == false(),
+                galaxy.model.tool_shed_install.ToolShedRepository.table.c.uninstalled == false(),
+                galaxy.model.tool_shed_install.ToolShedRepository.table.c.status
+                == galaxy.model.tool_shed_install.ToolShedRepository.installation_status.INSTALLED,
             )
-            .all()
         )
-    else:
-        return install_session().query(galaxy.model.tool_shed_install.ToolShedRepository).all()
+        .all()
+    )
 
 
 def get_galaxy_repository_by_name_owner_changeset_revision(repository_name, owner, changeset_revision):
@@ -89,15 +91,13 @@ def get_installed_repository_by_id(repository_id):
     )
 
 
-def get_installed_repository_by_name_owner(repository_name, owner, return_multiple=False):
-    query = (
-        install_session()
-        .query(galaxy.model.tool_shed_install.ToolShedRepository)
-        .filter(
-            and_(
-                galaxy.model.tool_shed_install.ToolShedRepository.table.c.name == repository_name,
-                galaxy.model.tool_shed_install.ToolShedRepository.table.c.owner == owner,
-            )
+def get_installed_repository_by_name_owner(repository_name, owner, return_multiple=False, session=None):
+    if session is None:
+        session = install_session()
+    query = session.query(galaxy.model.tool_shed_install.ToolShedRepository).filter(
+        and_(
+            galaxy.model.tool_shed_install.ToolShedRepository.table.c.name == repository_name,
+            galaxy.model.tool_shed_install.ToolShedRepository.table.c.owner == owner,
         )
     )
     if return_multiple:

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -1301,7 +1301,7 @@ class ShedTwillTestCase(ShedApiTestCase):
         strings_not_displayed: List[str] = []
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
-    def uninstall_repository(self, installed_repository, strings_displayed=None, strings_not_displayed=None):
+    def uninstall_repository(self, installed_repository: galaxy_model.ToolShedRepository) -> None:
         encoded_id = self.security.encode_id(installed_repository.id)
         api_key = get_admin_api_key()
         response = requests.delete(

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -1330,14 +1330,6 @@ class ShedTwillTestCase(ShedApiTestCase):
             assert "The status has not changed in the tool shed for repository" in message, str(response_dict)
         return response_dict
 
-    def update_tool_shed_status(self):
-        api_key = get_admin_api_key()
-        response = requests.get(
-            f"{self.galaxy_url}/api/tool_shed_repositories/check_for_updates?key={api_key}",
-            timeout=DEFAULT_SOCKET_TIMEOUT,
-        )
-        assert response.status_code != 403, response.content
-
     def upload_file(
         self,
         repository: Repository,

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -800,13 +800,6 @@ class ShedTwillTestCase(ShedApiTestCase):
             os.makedirs(temp_path)
         return temp_path
 
-    def get_datatypes_count(self):
-        params = {"upload_only": False}
-        self.visit_galaxy_url("/api/datatypes", params=params)
-        html = self.last_page()
-        datatypes = loads(html)
-        return len(datatypes)
-
     def get_filename(self, filename, filepath=None):
         if filepath is not None:
             return os.path.abspath(os.path.join(filepath, filename))

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -559,7 +559,7 @@ class ShedTwillTestCase(ShedApiTestCase):
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def display_installed_jobs_list_page(
-        self, installed_repository, data_manager_names=None, strings_displayed=None, strings_not_displayed=None
+        self, installed_repository, data_manager_names=None, strings_displayed=None
     ):
         data_managers = installed_repository.metadata_.get("data_manager", {}).get("data_managers", {})
         if data_manager_names:
@@ -574,7 +574,7 @@ class ShedTwillTestCase(ShedApiTestCase):
         for data_manager_name in data_manager_names:
             params = {"id": data_managers[data_manager_name]["guid"]}
             self.visit_galaxy_url("/data_manager/jobs_list", params=params)
-            self.check_for_strings(strings_displayed, strings_not_displayed)
+            self.check_for_strings(strings_displayed)
 
     def display_installed_repository_manage_json(self, installed_repository):
         params = {"id": self.security.encode_id(installed_repository.id)}

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -59,6 +59,8 @@ tc.options["equiv_refresh_interval"] = 0
 class ShedTwillTestCase(ShedApiTestCase):
     """Class of FunctionalTestCase geared toward HTML interactions using the Twill library."""
 
+    requires_galaxy: bool = False
+
     def setUp(self):
         super().setUp()
         # Security helper
@@ -73,6 +75,8 @@ class ShedTwillTestCase(ShedApiTestCase):
         self.tool_data_path = os.environ.get("GALAXY_TEST_TOOL_DATA_PATH")
         self.shed_tool_conf = os.environ.get("GALAXY_TEST_SHED_TOOL_CONF")
         self.test_db_util = test_db_util
+        if self.requires_galaxy:
+            self._galaxy_login(email=common.admin_email, username=common.admin_username)
 
     def check_for_strings(self, strings_displayed=None, strings_not_displayed=None):
         strings_displayed = strings_displayed or []
@@ -717,7 +721,7 @@ class ShedTwillTestCase(ShedApiTestCase):
         token = html[(token_quote_start_index + 1) : token_quote_end_index]
         return token
 
-    def galaxy_login(
+    def _galaxy_login(
         self, email="test@bx.psu.edu", password="testuser", username="admin-user", redirect="", logout_first=True
     ):
         if logout_first:

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -299,20 +299,6 @@ class ShedTwillTestCase(ShedApiTestCase):
         self.check_repository_changelog(repository)
         self.check_string_count_in_page("Repository metadata is associated with this change set.", metadata_count)
 
-    def check_exported_repository_dependency(self, dependency_filename, repository_name, repository_owner):
-        root, error_message = xml_util.parse_xml(dependency_filename)
-        for elem in root.findall("repository"):
-            if "changeset_revision" in elem:
-                raise AssertionError(
-                    "Exported repository %s with owner %s has a dependency with a defined changeset revision."
-                    % (repository_name, repository_owner)
-                )
-            if "toolshed" in elem:
-                raise AssertionError(
-                    "Exported repository %s with owner %s has a dependency with a defined tool shed."
-                    % (repository_name, repository_owner)
-                )
-
     def check_for_valid_tools(self, repository, strings_displayed=None, strings_not_displayed=None):
         if strings_displayed is None:
             strings_displayed = ["Valid tools"]

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -4,6 +4,7 @@ import string
 import tempfile
 import time
 from json import loads
+from pathlib import Path
 from typing import (
     Any,
     Dict,
@@ -23,9 +24,25 @@ from mercurial import (
     hg,
     ui,
 )
+from sqlalchemy import (
+    and_,
+    false,
+)
 
 import galaxy.model.tool_shed_install as galaxy_model
+from galaxy.schema.schema import CheckForUpdatesResponse
 from galaxy.security import idencoding
+from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
+from galaxy.tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
+from galaxy.tool_shed.galaxy_install.metadata.installed_repository_metadata_manager import (
+    InstalledRepositoryMetadataManager,
+)
+from galaxy.tool_shed.unittest_utils import (
+    StandaloneInstallationTarget,
+    ToolShedTarget,
+)
+from galaxy.tool_shed.util.dependency_display import build_manage_repository_dict
+from galaxy.tool_shed.util.repository_util import check_for_updates
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
     smart_str,
@@ -94,7 +111,7 @@ class ToolShedInstallationClient:
     def reactivate_repository(self, installed_repository: galaxy_model.ToolShedRepository) -> None:
         ...
 
-    def reset_metadata_on_selected_installed_repositories(self, repository_ids: List[str]) -> None:
+    def reset_metadata_on_installed_repositories(self, repositories: List[galaxy_model.ToolShedRepository]) -> None:
         ...
 
     def reset_installed_repository_metadata(self, repository: galaxy_model.ToolShedRepository) -> None:
@@ -106,6 +123,14 @@ class ToolShedInstallationClient:
     def update_installed_repository(
         self, installed_repository: galaxy_model.ToolShedRepository, verify_no_updates: bool = False
     ) -> Dict[str, Any]:
+        ...
+
+    @property
+    def tool_data_path(self) -> str:
+        ...
+
+    @property
+    def shed_tool_data_table_conf(self) -> str:
         ...
 
     def get_tool_names(self) -> List[str]:
@@ -124,6 +149,12 @@ class ToolShedInstallationClient:
     def get_installed_repository_for(
         self, owner: Optional[str] = None, name: Optional[str] = None, changeset: Optional[str] = None
     ) -> Optional[Dict[str, Any]]:
+        ...
+
+    def get_all_installed_repositories(self) -> List[galaxy_model.ToolShedRepository]:
+        ...
+
+    def refresh_tool_shed_repository(self, repo: galaxy_model.ToolShedRepository) -> None:
         ...
 
 
@@ -148,7 +179,7 @@ class GalaxyInteractorToolShedInstallationClient(ToolShedInstallationClient):
             galaxy_model.ToolShedRepository.installation_status.UNINSTALLED,
             galaxy_model.ToolShedRepository.installation_status.DEACTIVATED,
         ]:
-            tool_panel_section = self._get_tool_panel_section_from_repository_metadata(metadata)
+            tool_panel_section = _get_tool_panel_section_from_repository_metadata(metadata)
         else:
             tool_panel_section = self._get_tool_panel_section_from_api(metadata)
         assert (
@@ -229,7 +260,10 @@ class GalaxyInteractorToolShedInstallationClient(ToolShedInstallationClient):
         url = "/admin_toolshed/restore_repository"
         self._visit_galaxy_url(url, params=params)
 
-    def reset_metadata_on_selected_installed_repositories(self, repository_ids: List[str]) -> None:
+    def reset_metadata_on_installed_repositories(self, repositories: List[galaxy_model.ToolShedRepository]) -> None:
+        repository_ids = []
+        for repository in repositories:
+            repository_ids.append(self.testcase.security.encode_id(repository.id))
         api_key = get_admin_api_key()
         response = requests.post(
             f"{self.testcase.galaxy_url}/api/tool_shed_repositories/reset_metadata_on_selected_installed_repositories",
@@ -279,6 +313,14 @@ class GalaxyInteractorToolShedInstallationClient(ToolShedInstallationClient):
         )
         assert response.status_code != 403, response.content
 
+    @property
+    def tool_data_path(self):
+        return os.environ.get("GALAXY_TEST_TOOL_DATA_PATH")
+
+    @property
+    def shed_tool_data_table_conf(self):
+        return os.environ.get("TOOL_SHED_TEST_TOOL_DATA_TABLE_CONF")
+
     def get_tool_names(self) -> List[str]:
         response = self.testcase.galaxy_interactor._get("tools?in_panel=false")
         response.raise_for_status()
@@ -301,6 +343,15 @@ class GalaxyInteractorToolShedInstallationClient(ToolShedInstallationClient):
         self, owner: Optional[str] = None, name: Optional[str] = None, changeset: Optional[str] = None
     ) -> Optional[Dict[str, Any]]:
         return self.testcase.get_installed_repository_for(owner=owner, name=name, changeset=changeset)
+
+    def get_all_installed_repositories(self) -> List[galaxy_model.ToolShedRepository]:
+        repositories = test_db_util.get_all_installed_repositories()
+        for repository in repositories:
+            test_db_util.ga_refresh(repository)
+        return repositories
+
+    def refresh_tool_shed_repository(self, repo: galaxy_model.ToolShedRepository) -> None:
+        test_db_util.ga_refresh(repo)
 
     def _galaxy_login(self, email="test@bx.psu.edu", password="testuser", username="admin-user"):
         self._galaxy_logout()
@@ -340,24 +391,7 @@ class GalaxyInteractorToolShedInstallationClient(ToolShedInstallationClient):
         tool_panel_section = tool_dict["panel_section_name"]
         return tool_panel_section
 
-    def _get_tool_panel_section_from_repository_metadata(self, metadata):
-        tool_metadata = metadata["tools"]
-        tool_guid = tool_metadata[0]["guid"]
-        assert "tool_panel_section" in metadata, f"Tool panel section not found in metadata: {metadata}"
-        tool_panel_section_metadata = metadata["tool_panel_section"]
-        # tool_section_dict = dict( tool_config=guids_and_configs[ guid ],
-        #                           id=section_id,
-        #                           name=section_name,
-        #                           version=section_version )
-        # This dict is appended to tool_panel_section_metadata[ tool_guid ]
-        tool_panel_section = tool_panel_section_metadata[tool_guid][0]["name"]
-        return tool_panel_section
-
     def _wait_for_repository_installation(self, repository_ids):
-        final_states = [
-            galaxy_model.ToolShedRepository.installation_status.ERROR,
-            galaxy_model.ToolShedRepository.installation_status.INSTALLED,
-        ]
         # Wait until all repositories are in a final state before returning. This ensures that subsequent tests
         # are running against an installed repository, and not one that is still in the process of installing.
         if repository_ids:
@@ -365,18 +399,7 @@ class GalaxyInteractorToolShedInstallationClient(ToolShedInstallationClient):
                 galaxy_repository = test_db_util.get_installed_repository_by_id(
                     self.testcase.security.decode_id(repository_id)
                 )
-                timeout_counter = 0
-                while galaxy_repository.status not in final_states:
-                    test_db_util.ga_refresh(galaxy_repository)
-                    timeout_counter = timeout_counter + 1
-                    # This timeout currently defaults to 10 minutes.
-                    if timeout_counter > repository_installation_timeout:
-                        raise AssertionError(
-                            "Repository installation timed out, %d seconds elapsed, repository state is %s."
-                            % (timeout_counter, galaxy_repository.status)
-                        )
-                        break
-                    time.sleep(1)
+                _wait_for_installation(galaxy_repository, test_db_util.ga_refresh)
 
     def _visit_galaxy_url(self, url, params=None, doseq=False, allowed_codes=None):
         if allowed_codes is None:
@@ -385,10 +408,186 @@ class GalaxyInteractorToolShedInstallationClient(ToolShedInstallationClient):
         self.testcase.visit_url(url, params=params, doseq=doseq, allowed_codes=allowed_codes)
 
 
+class StandaloneToolShedInstallationClient(ToolShedInstallationClient):
+    def __init__(self, testcase):
+        self.testcase = testcase
+        self.temp_directory = Path(tempfile.mkdtemp(prefix="toolshedtestinstalltarget"))
+        tool_shed_target = ToolShedTarget(
+            self.testcase.url,
+            "Tool Shed for Testing",
+        )
+        self._installation_target = StandaloneInstallationTarget(self.temp_directory, tool_shed_target=tool_shed_target)
+
+    def setup(self) -> None:
+        pass
+
+    def check_galaxy_repository_tool_panel_section(
+        self, repository: galaxy_model.ToolShedRepository, expected_tool_panel_section: str
+    ) -> None:
+        metadata = repository.metadata_
+        assert "tools" in metadata, f"Tools not found in repository metadata: {metadata}"
+        # TODO: check actual toolbox if tool is already installed...
+        tool_panel_section = _get_tool_panel_section_from_repository_metadata(metadata)
+        assert (
+            tool_panel_section == expected_tool_panel_section
+        ), f"Expected to find tool panel section *{expected_tool_panel_section}*, but instead found *{tool_panel_section}*\nMetadata: {metadata}\n"
+
+    def deactivate_repository(self, installed_repository: galaxy_model.ToolShedRepository) -> None:
+        irm = InstalledRepositoryManager(app=self._installation_target)
+        errors = irm.uninstall_repository(repository=installed_repository, remove_from_disk=False)
+        if errors:
+            raise Exception(
+                f"Attempting to uninstall tool dependencies for repository named {installed_repository.name} resulted in errors: {errors}"
+            )
+
+    def display_installed_jobs_list_page(
+        self, installed_repository: galaxy_model.ToolShedRepository, data_manager_names=None, strings_displayed=None
+    ) -> None:
+        raise NotImplementedError()
+
+    def installed_repository_extended_info(
+        self, installed_repository: galaxy_model.ToolShedRepository
+    ) -> Dict[str, Any]:
+        self._installation_target.install_model.context.refresh(installed_repository)
+        return build_manage_repository_dict(self._installation_target, "ok", installed_repository)
+
+    def install_repository(
+        self,
+        name: str,
+        owner: str,
+        changeset_revision: str,
+        install_tool_dependencies: bool,
+        install_repository_dependencies: bool,
+        new_tool_panel_section_label: Optional[str],
+    ):
+        tool_shed_url = self.testcase.url
+        payload = {
+            "tool_shed_url": tool_shed_url,
+            "name": name,
+            "owner": owner,
+            "changeset_revision": changeset_revision,
+            "install_tool_dependencies": install_tool_dependencies,
+            "install_repository_dependencies": install_repository_dependencies,
+            "install_resolver_dependencies": False,
+        }
+        if new_tool_panel_section_label:
+            payload["new_tool_panel_section_label"] = new_tool_panel_section_label
+        irm = InstallRepositoryManager(app=self._installation_target)
+        installed_tool_shed_repositories = irm.install(str(tool_shed_url), name, owner, changeset_revision, payload)
+        for installed_tool_shed_repository in installed_tool_shed_repositories or []:
+            _wait_for_installation(
+                installed_tool_shed_repository, self._installation_target.install_model.context.refresh
+            )
+
+    def reactivate_repository(self, installed_repository: galaxy_model.ToolShedRepository) -> None:
+        irm = InstalledRepositoryManager(app=self._installation_target)
+        irm.activate_repository(installed_repository)
+
+    def reset_metadata_on_installed_repositories(self, repositories: List[galaxy_model.ToolShedRepository]) -> None:
+        for repository in repositories:
+            irmm = InstalledRepositoryMetadataManager(self._installation_target)
+            irmm.set_repository(repository)
+            irmm.reset_all_metadata_on_installed_repository()
+
+    def reset_installed_repository_metadata(self, repository: galaxy_model.ToolShedRepository) -> None:
+        irmm = InstalledRepositoryMetadataManager(self._installation_target)
+        irmm.set_repository(repository)
+        irmm.reset_all_metadata_on_installed_repository()
+
+    def uninstall_repository(self, installed_repository: galaxy_model.ToolShedRepository) -> None:
+        irm = InstalledRepositoryManager(app=self._installation_target)
+        errors = irm.uninstall_repository(repository=installed_repository, remove_from_disk=True)
+        if errors:
+            raise Exception(
+                f"Attempting to uninstall tool dependencies for repository named {installed_repository.name} resulted in errors: {errors}"
+            )
+
+    def update_installed_repository(
+        self, installed_repository: galaxy_model.ToolShedRepository, verify_no_updates: bool = False
+    ) -> Dict[str, Any]:
+        message, status = check_for_updates(
+            self._installation_target.tool_shed_registry,
+            self._installation_target.install_model.context,
+            installed_repository.id,
+        )
+        response = CheckForUpdatesResponse(message=message, status=status)
+        response_dict = response.dict()
+        if verify_no_updates:
+            assert "message" in response_dict
+            message = response_dict["message"]
+            assert "The status has not changed in the tool shed for repository" in message, str(response_dict)
+        return response_dict
+
+    def get_installed_repository_by_name_owner(
+        self, repository_name: str, repository_owner: str
+    ) -> galaxy_model.ToolShedRepository:
+        return test_db_util.get_installed_repository_by_name_owner(
+            repository_name, repository_owner, session=self._installation_target.install_model.context
+        )
+
+    def get_installed_repositories_by_name_owner(
+        self, repository_name: str, repository_owner: str
+    ) -> List[galaxy_model.ToolShedRepository]:
+        return test_db_util.get_installed_repository_by_name_owner(
+            repository_name,
+            repository_owner,
+            return_multiple=True,
+            session=self._installation_target.install_model.context,
+        )
+
+    def get_installed_repository_for(
+        self, owner: Optional[str] = None, name: Optional[str] = None, changeset: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        clause_list = []
+        if name is not None:
+            clause_list.append(galaxy_model.ToolShedRepository.table.c.name == name)
+        if owner is not None:
+            clause_list.append(galaxy_model.ToolShedRepository.table.c.owner == owner)
+        if changeset is not None:
+            clause_list.append(galaxy_model.ToolShedRepository.table.c.changeset_revision == changeset)
+        clause_list.append(galaxy_model.ToolShedRepository.table.c.deleted == false())
+        clause_list.append(galaxy_model.ToolShedRepository.table.c.uninstalled == false())
+
+        query = self._installation_target.install_model.context.query(galaxy_model.ToolShedRepository)
+        if len(clause_list) > 0:
+            query = query.filter(and_(*clause_list))
+        repository = query.one_or_none()
+        if repository:
+            return repository.to_dict()
+        else:
+            return None
+
+    def get_all_installed_repositories(self) -> List[galaxy_model.ToolShedRepository]:
+        repositories = test_db_util.get_all_installed_repositories(
+            session=self._installation_target.install_model.context
+        )
+        for repository in repositories:
+            self._installation_target.install_model.context.refresh(repository)
+        return repositories
+
+    def refresh_tool_shed_repository(self, repo: galaxy_model.ToolShedRepository) -> None:
+        self._installation_target.install_model.context.refresh(repo)
+
+    @property
+    def shed_tool_data_table_conf(self):
+        return self._installation_target.config.shed_tool_data_table_config
+
+    @property
+    def tool_data_path(self):
+        return self._installation_target.config.tool_data_path
+
+    def get_tool_names(self) -> List[str]:
+        tool_names = []
+        for _, tool in self._installation_target.toolbox.tools():
+            tool_names.append(tool.name)
+        return tool_names
+
+
 class ShedTwillTestCase(ShedApiTestCase):
     """Class of FunctionalTestCase geared toward HTML interactions using the Twill library."""
 
     requires_galaxy: bool = False
+    _installation_client = None
 
     def setUp(self):
         super().setUp()
@@ -399,14 +598,22 @@ class ShedTwillTestCase(ShedApiTestCase):
         self.hgweb_config_manager = hgweb_config.hgweb_config_manager
         self.hgweb_config_manager.hgweb_config_dir = self.hgweb_config_dir
         self.tool_shed_test_tmp_dir = os.environ.get("TOOL_SHED_TEST_TMP_DIR", None)
-        self.shed_tool_data_table_conf = os.environ.get("TOOL_SHED_TEST_TOOL_DATA_TABLE_CONF")
         self.file_dir = os.environ.get("TOOL_SHED_TEST_FILE_DIR", None)
-        self.tool_data_path = os.environ.get("GALAXY_TEST_TOOL_DATA_PATH")
         self.shed_tool_conf = os.environ.get("GALAXY_TEST_SHED_TOOL_CONF")
         self.test_db_util = test_db_util
-        self._installation_client = GalaxyInteractorToolShedInstallationClient(self)
-        if self.requires_galaxy:
-            self._installation_client.setup()
+        if os.environ.get("TOOL_SHED_TEST_INSTALL_CLIENT") == "standalone":
+            # TODO: once nose is out of the way - try to get away without
+            # instantiating the unused Galaxy server here.
+            installation_client_class = StandaloneToolShedInstallationClient
+            full_stack_galaxy = False
+        else:
+            installation_client_class = GalaxyInteractorToolShedInstallationClient
+            full_stack_galaxy = True
+        self.full_stack_galaxy = full_stack_galaxy
+        if self.requires_galaxy and (self.__class__._installation_client is None):
+            self.__class__._installation_client = installation_client_class(self)
+            self.__class__._installation_client.setup()
+        self._installation_client = self.__class__._installation_client
 
     def check_for_strings(self, strings_displayed=None, strings_not_displayed=None):
         strings_displayed = strings_displayed or []
@@ -638,6 +845,7 @@ class ShedTwillTestCase(ShedApiTestCase):
 
     def check_galaxy_repository_db_status(self, repository_name, owner, expected_status):
         installed_repository = self._get_installed_repository_by_name_owner(repository_name, owner)
+        self._refresh_tool_shed_repository(installed_repository)
         assert (
             installed_repository.status == expected_status
         ), f"Status in database is {installed_repository.status}, expected {expected_status}"
@@ -747,6 +955,7 @@ class ShedTwillTestCase(ShedApiTestCase):
     def check_galaxy_repository_tool_panel_section(
         self, repository: galaxy_model.ToolShedRepository, expected_tool_panel_section: str
     ) -> None:
+        assert self._installation_client
         self._installation_client.check_galaxy_repository_tool_panel_section(repository, expected_tool_panel_section)
 
     def clone_repository(self, repository: Repository, destination_path: str) -> None:
@@ -828,6 +1037,7 @@ class ShedTwillTestCase(ShedApiTestCase):
         )
 
     def deactivate_repository(self, installed_repository: galaxy_model.ToolShedRepository) -> None:
+        assert self._installation_client
         self._installation_client.deactivate_repository(installed_repository)
 
     def delete_files_from_repository(
@@ -858,11 +1068,13 @@ class ShedTwillTestCase(ShedApiTestCase):
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def display_installed_jobs_list_page(self, installed_repository, data_manager_names=None, strings_displayed=None):
+        assert self._installation_client
         self._installation_client.display_installed_jobs_list_page(
             installed_repository, data_manager_names, strings_displayed
         )
 
     def display_installed_repository_manage_json(self, installed_repository):
+        assert self._installation_client
         return self._installation_client.installed_repository_extended_info(installed_repository)
 
     def display_manage_repository_page(
@@ -1049,6 +1261,10 @@ class ShedTwillTestCase(ShedApiTestCase):
         if not os.path.exists(temp_path):
             os.makedirs(temp_path)
         return temp_path
+
+    def get_all_installed_repositories(self) -> List[galaxy_model.ToolShedRepository]:
+        assert self._installation_client
+        return self._installation_client.get_all_installed_repositories()
 
     def get_filename(self, filename, filepath=None):
         if filepath is not None:
@@ -1259,6 +1475,7 @@ class ShedTwillTestCase(ShedApiTestCase):
         # repository_id = repository.id
         if changeset_revision is None:
             changeset_revision = self.get_repository_tip(repository)
+        assert self._installation_client
         self._installation_client.install_repository(
             name,
             owner,
@@ -1398,8 +1615,9 @@ class ShedTwillTestCase(ShedApiTestCase):
         kwd = dict(repository_ids=repository_ids)
         self.submit_form(button="reset_metadata_on_selected_repositories_button", **kwd)
 
-    def reset_metadata_on_selected_installed_repositories(self, repository_ids):
-        self._installation_client.reset_metadata_on_selected_installed_repositories(repository_ids)
+    def reset_metadata_on_installed_repositories(self, repositories):
+        assert self._installation_client
+        self._installation_client.reset_metadata_on_installed_repositories(repositories)
 
     def reset_repository_metadata(self, repository):
         params = {"id": repository.id}
@@ -1490,11 +1708,13 @@ class ShedTwillTestCase(ShedApiTestCase):
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def _uninstall_repository(self, installed_repository: galaxy_model.ToolShedRepository) -> None:
+        assert self._installation_client
         self._installation_client.uninstall_repository(installed_repository)
 
     def update_installed_repository(
         self, installed_repository: galaxy_model.ToolShedRepository, verify_no_updates: bool = False
     ) -> Dict[str, Any]:
+        assert self._installation_client
         return self._installation_client.update_installed_repository(installed_repository, verify_no_updates=False)
 
     def upload_file(
@@ -1600,7 +1820,9 @@ class ShedTwillTestCase(ShedApiTestCase):
 
     def verify_installed_repository_metadata_unchanged(self, name, owner):
         installed_repository = self._get_installed_repository_by_name_owner(name, owner)
+        assert installed_repository
         metadata = installed_repository.metadata_
+        assert self._installation_client
         self._installation_client.reset_installed_repository_metadata(installed_repository)
         new_metadata = installed_repository.metadata_
         assert metadata == new_metadata, f"Metadata for installed repository {name} differs after metadata reset."
@@ -1610,9 +1832,27 @@ class ShedTwillTestCase(ShedApiTestCase):
         metadata = repository.metadata_
         assert "tool_panel_section" not in metadata, f"Tool panel section incorrectly found in metadata: {metadata}"
 
+    @property
+    def shed_tool_data_table_conf(self):
+        return self._installation_client.shed_tool_data_table_conf
+
+    @property
+    def tool_data_path(self):
+        return self._installation_client.tool_data_path
+
+    def _refresh_tool_shed_repository(self, repo: galaxy_model.ToolShedRepository) -> None:
+        assert self._installation_client
+        self._installation_client.refresh_tool_shed_repository(repo)
+
     def verify_installed_repository_data_table_entries(self, required_data_table_entries):
         # The value of the received required_data_table_entries will be something like: [ 'sam_fa_indexes' ]
-        data_tables, error_message = xml_util.parse_xml(self.shed_tool_data_table_conf)
+        shed_tool_data_table_conf = self.shed_tool_data_table_conf
+        data_tables, error_message = xml_util.parse_xml(shed_tool_data_table_conf)
+        with open(shed_tool_data_table_conf) as f:
+            shed_tool_data_table_conf_contents = f.read()
+        assert (
+            not error_message
+        ), f"Failed to parse {shed_tool_data_table_conf} properly. File contents [{shed_tool_data_table_conf_contents}]"
         found = False
         # With the tool shed, the "path" attribute that is hard-coded into the tool_data_tble_conf.xml
         # file is ignored.  This is because the tool shed requires the directory location to which this
@@ -1668,21 +1908,32 @@ class ShedTwillTestCase(ShedApiTestCase):
                 break
         # We better have an entry like: <table comment_char="#" name="sam_fa_indexes"> in our parsed data_tables
         # or we know that the repository was not correctly installed!
-        assert found, f"No entry for {required_data_table_entry} in {self.shed_tool_data_table_conf}."
+        if not found:
+            if required_data_table_entry is None:
+                raise AssertionError(
+                    f"No tables found in {shed_tool_data_table_conf}. File contents {shed_tool_data_table_conf_contents}"
+                )
+            else:
+                raise AssertionError(
+                    f"No entry for {required_data_table_entry} in {shed_tool_data_table_conf}. File contents {shed_tool_data_table_conf_contents}"
+                )
 
     def _get_installed_repository_by_name_owner(
         self, repository_name: str, repository_owner: str
     ) -> galaxy_model.ToolShedRepository:
+        assert self._installation_client
         return self._installation_client.get_installed_repository_by_name_owner(repository_name, repository_owner)
 
     def _get_installed_repositories_by_name_owner(
         self, repository_name: str, repository_owner: str
     ) -> List[galaxy_model.ToolShedRepository]:
+        assert self._installation_client
         return self._installation_client.get_installed_repositories_by_name_owner(repository_name, repository_owner)
 
     def _get_installed_repository_for(
         self, owner: Optional[str] = None, name: Optional[str] = None, changeset: Optional[str] = None
     ):
+        assert self._installation_client
         return self._installation_client.get_installed_repository_for(owner=owner, name=name, changeset=changeset)
 
     def _assert_has_installed_repos_with_names(self, *names):
@@ -1721,8 +1972,9 @@ class ShedTwillTestCase(ShedApiTestCase):
         changeset: Optional[str] = None,
     ) -> None:
         json = self.display_installed_repository_manage_json(installed_repository)
-        assert "repository_dependencies" in json, (
-            "No repository dependencies were defined in %s." % installed_repository.name
+        assert "repository_dependencies" in json, "No repository dependencies were defined in %s. manage json is %s" % (
+            installed_repository.name,
+            json,
         )
         repository_dependencies = json["repository_dependencies"]
         found = False
@@ -1755,6 +2007,7 @@ class ShedTwillTestCase(ShedApiTestCase):
 
     def _assert_has_valid_tool_with_name(self, tool_name: str) -> None:
         def assert_has():
+            assert self._installation_client
             tool_names = self._installation_client.get_tool_names()
             assert tool_name in tool_names
 
@@ -1798,3 +2051,33 @@ class ShedTwillTestCase(ShedApiTestCase):
         # Python's dict comparison recursively compares sorted key => value pairs and returns true if any key or value differs,
         # or if the number of keys differs.
         assert old_metadata == new_metadata, f"Metadata changed after reset on repository {repository.name}."
+
+
+def _wait_for_installation(repository: galaxy_model.ToolShedRepository, refresh):
+    final_states = [
+        galaxy_model.ToolShedRepository.installation_status.ERROR,
+        galaxy_model.ToolShedRepository.installation_status.INSTALLED,
+    ]
+    # Wait until all repositories are in a final state before returning. This ensures that subsequent tests
+    # are running against an installed repository, and not one that is still in the process of installing.
+    timeout_counter = 0
+    while repository.status not in final_states:
+        refresh(repository)
+        timeout_counter = timeout_counter + 1
+        # This timeout currently defaults to 10 minutes.
+        if timeout_counter > repository_installation_timeout:
+            raise AssertionError(
+                "Repository installation timed out, %d seconds elapsed, repository state is %s."
+                % (timeout_counter, repository.status)
+            )
+            break
+        time.sleep(1)
+
+
+def _get_tool_panel_section_from_repository_metadata(metadata):
+    tool_metadata = metadata["tools"]
+    tool_guid = tool_metadata[0]["guid"]
+    assert "tool_panel_section" in metadata, f"Tool panel section not found in metadata: {metadata}"
+    tool_panel_section_metadata = metadata["tool_panel_section"]
+    tool_panel_section = tool_panel_section_metadata[tool_guid][0]["name"]
+    return tool_panel_section

--- a/lib/tool_shed/test/functional/test_1000_install_basic_repository.py
+++ b/lib/tool_shed/test/functional/test_1000_install_basic_repository.py
@@ -10,11 +10,12 @@ repo_description = "Galaxy's filtering tool"
 class TestBasicToolShedFeatures(ShedTwillTestCase):
     """Test installing a basic repository."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
 
     def test_0005_ensure_repositories_and_categories_exist(self):
         """Create the 0000 category and upload the filtering repository to it, if necessary."""
@@ -83,7 +84,6 @@ class TestBasicToolShedFeatures(ShedTwillTestCase):
 
     def test_0010_browse_tool_sheds(self):
         """Browse the available tool sheds in this Galaxy instance."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.browse_tool_shed(
             url=self.url,
             strings_displayed=["Test 0000 Basic Repository Features 1", "Test 0000 Basic Repository Features 2"],

--- a/lib/tool_shed/test/functional/test_1000_install_basic_repository.py
+++ b/lib/tool_shed/test/functional/test_1000_install_basic_repository.py
@@ -107,19 +107,15 @@ class TestBasicToolShedFeatures(ShedTwillTestCase):
             "Test 0000 Basic Repository Features 1",
             new_tool_panel_section_label="test_1000",
         )
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repo_name, common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner(repo_name, common.test_user_1_name)
         changeset = str(installed_repository.installed_changeset_revision)
-        assert self.get_installed_repository_for(common.test_user_1, repo_name, changeset)
+        assert self._get_installed_repository_for(common.test_user_1, repo_name, changeset)
         self._assert_has_valid_tool_with_name("Filter1")
         self._assert_repo_has_tool_with_id(installed_repository, "Filter1")
 
     def test_0030_install_filtering_repository_again(self):
         """Attempt to install the already installed filtering repository."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repo_name, common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner(repo_name, common.test_user_1_name)
         # Just make sure the repo is still installed, used to monitoring tests but we've
         # removed that page.
         self._install_repository(
@@ -128,7 +124,7 @@ class TestBasicToolShedFeatures(ShedTwillTestCase):
             "Test 0000 Basic Repository Features 1",
         )
         changeset = str(installed_repository.installed_changeset_revision)
-        assert self.get_installed_repository_for(common.test_user_1, repo_name, changeset)
+        assert self._get_installed_repository_for(common.test_user_1, repo_name, changeset)
 
     def test_0035_verify_installed_repository_metadata(self):
         """Verify that resetting the metadata on an installed repository does not change the metadata."""

--- a/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
@@ -16,9 +16,10 @@ log = logging.getLogger(__name__)
 class TestToolWithToolDependencies(ShedTwillTestCase):
     """Test installing a repository with tool dependencies."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
 
@@ -111,7 +112,6 @@ class TestToolWithToolDependencies(ShedTwillTestCase):
 
     def test_0010_browse_tool_shed(self):
         """Browse the available tool sheds in this Galaxy instance and preview the freebayes tool."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.browse_tool_shed(url=self.url, strings_displayed=[category_name])
         category = self.populator.get_category_with_name(category_name)
         self.browse_category(category, strings_displayed=[repository_name])

--- a/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1010_install_repository_with_tool_dependencies.py
@@ -129,10 +129,8 @@ class TestToolWithToolDependencies(ShedTwillTestCase):
             install_tool_dependencies=False,
             new_tool_panel_section_label="test_1010",
         )
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repository_name, common.test_user_1_name
-        )
-        assert self.get_installed_repository_for(
+        installed_repository = self._get_installed_repository_by_name_owner(repository_name, common.test_user_1_name)
+        assert self._get_installed_repository_for(
             common.test_user_1, repository_name, installed_repository.installed_changeset_revision
         )
         self._assert_has_valid_tool_with_name("FreeBayes")

--- a/lib/tool_shed/test/functional/test_1020_install_repository_with_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1020_install_repository_with_repository_dependencies.py
@@ -98,10 +98,10 @@ class TestToolWithRepositoryDependencies(ShedTwillTestCase):
             install_tool_dependencies=False,
             new_tool_panel_section_label="test_1020",
         )
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_repository = self._get_installed_repository_by_name_owner(
             emboss_repository_name, common.test_user_1_name
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, emboss_repository_name, installed_repository.installed_changeset_revision
         )
         self._assert_has_valid_tool_with_name("antigenic")
@@ -113,14 +113,14 @@ class TestToolWithRepositoryDependencies(ShedTwillTestCase):
 
     def test_0025_deactivate_datatypes_repository(self):
         """Deactivate the emboss_datatypes repository without removing it from disk."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_repository = self._get_installed_repository_by_name_owner(
             column_maker_repository_name, common.test_user_1_name
         )
         self.deactivate_repository(installed_repository)
 
     def test_0030_reactivate_datatypes_repository(self):
         """Reactivate the datatypes repository and verify that the datatypes are again present."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_repository = self._get_installed_repository_by_name_owner(
             column_maker_repository_name, common.test_user_1_name
         )
         self.reactivate_repository(installed_repository)

--- a/lib/tool_shed/test/functional/test_1020_install_repository_with_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1020_install_repository_with_repository_dependencies.py
@@ -15,11 +15,12 @@ emboss_repository_long_description = "Galaxy wrappers for Emboss version 5.0.0 t
 class TestToolWithRepositoryDependencies(ShedTwillTestCase):
     """Test installing a repository with repository dependencies."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
 
     def test_0005_ensure_repositories_and_categories_exist(self):
         """Create the 0020 category and any missing repositories."""
@@ -81,7 +82,6 @@ class TestToolWithRepositoryDependencies(ShedTwillTestCase):
 
     def test_0010_browse_tool_shed(self):
         """Browse the available tool sheds in this Galaxy instance and preview the emboss tool."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.browse_tool_shed(url=self.url, strings_displayed=["Test 0020 Basic Repository Dependencies"])
         category = self.populator.get_category_with_name("Test 0020 Basic Repository Dependencies")
         self.browse_category(category, strings_displayed=[emboss_repository_name])

--- a/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
@@ -178,10 +178,10 @@ class TestRepositoryWithDependencyRevisions(ShedTwillTestCase):
             install_tool_dependencies=False,
             new_tool_panel_section_label="test_1030",
         )
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_repository = self._get_installed_repository_by_name_owner(
             emboss_repository_name, common.test_user_1_name
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, emboss_repository_name, installed_repository.installed_changeset_revision
         )
         self._assert_repo_has_tool_with_id(installed_repository, "EMBOSS: antigenic1")

--- a/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
@@ -186,7 +186,7 @@ class TestRepositoryWithDependencyRevisions(ShedTwillTestCase):
         )
         self._assert_repo_has_tool_with_id(installed_repository, "EMBOSS: antigenic1")
         self._assert_has_valid_tool_with_name("antigenic")
-        self.update_installed_repository_api(installed_repository, verify_no_updates=True)
+        self.update_installed_repository(installed_repository, verify_no_updates=True)
 
     def test_0025_verify_installed_repository_metadata(self):
         """Verify that resetting the metadata on an installed repository does not change the metadata."""

--- a/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1030_install_repository_with_dependency_revisions.py
@@ -19,11 +19,12 @@ running_standalone = False
 class TestRepositoryWithDependencyRevisions(ShedTwillTestCase):
     """Test installing a repository with dependency revisions."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
 
     def test_0005_ensure_repositories_and_categories_exist(self):
         """Create the 0030 category and add repositories to it, if necessary."""
@@ -160,7 +161,6 @@ class TestRepositoryWithDependencyRevisions(ShedTwillTestCase):
 
     def test_0010_browse_tool_shed(self):
         """Browse the available tool sheds in this Galaxy instance and preview the emboss tool."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.browse_tool_shed(url=self.url, strings_displayed=["Test 0030 Repository Dependency Revisions"])
         category = self.populator.get_category_with_name("Test 0030 Repository Dependency Revisions")
         self.browse_category(category, strings_displayed=[emboss_repository_name])

--- a/lib/tool_shed/test/functional/test_1040_install_repository_basic_circular_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1040_install_repository_basic_circular_dependencies.py
@@ -19,6 +19,8 @@ running_standalone = False
 class TestInstallingCircularDependencies(ShedTwillTestCase):
     """Verify that the code correctly handles installing repositories with circular dependencies."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
@@ -122,7 +124,6 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
 
     def test_0025_install_freebayes_repository(self):
         """Install freebayes with blank tool panel section, without tool dependencies but with repository dependencies."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             freebayes_repository_name,
             common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1040_install_repository_basic_circular_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1040_install_repository_basic_circular_dependencies.py
@@ -147,7 +147,7 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
             common.test_user_1, filtering_repository_name, installed_filtering_repository.installed_changeset_revision
         )
         self.deactivate_repository(installed_filtering_repository)
-        self.test_db_util.ga_refresh(installed_filtering_repository)
+        self._refresh_tool_shed_repository(installed_filtering_repository)
         self._assert_has_missing_dependency(installed_freebayes_repository, filtering_repository_name)
         self.check_galaxy_repository_db_status(filtering_repository_name, common.test_user_1_name, "Deactivated")
 
@@ -185,7 +185,7 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
         assert not self._get_installed_repository_for(
             common.test_user_1, freebayes_repository_name, installed_freebayes_repository.installed_changeset_revision
         )
-        self.test_db_util.ga_refresh(installed_freebayes_repository)
+        self._refresh_tool_shed_repository(installed_filtering_repository)
         self._assert_has_missing_dependency(installed_filtering_repository, freebayes_repository_name)
         self.check_galaxy_repository_db_status("freebayes_0040", "user1", "Deactivated")
 
@@ -207,6 +207,6 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
         assert not self._get_installed_repository_for(
             common.test_user_1, filtering_repository_name, installed_filtering_repository.installed_changeset_revision
         )
-        self.test_db_util.ga_refresh(installed_filtering_repository)
+        self._refresh_tool_shed_repository(installed_freebayes_repository)
         self._assert_has_missing_dependency(installed_freebayes_repository, filtering_repository_name)
         self.check_galaxy_repository_db_status(filtering_repository_name, common.test_user_1_name, "Deactivated")

--- a/lib/tool_shed/test/functional/test_1040_install_repository_basic_circular_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1040_install_repository_basic_circular_dependencies.py
@@ -134,16 +134,16 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
 
     def test_0030_uninstall_filtering_repository(self):
         """Deactivate filtering, verify tool panel section and missing repository dependency."""
-        installed_freebayes_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_freebayes_repository = self._get_installed_repository_by_name_owner(
             freebayes_repository_name, common.test_user_1_name
         )
-        installed_filtering_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_filtering_repository = self._get_installed_repository_by_name_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, freebayes_repository_name, installed_freebayes_repository.installed_changeset_revision
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, filtering_repository_name, installed_filtering_repository.installed_changeset_revision
         )
         self.deactivate_repository(installed_filtering_repository)
@@ -153,7 +153,7 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
 
     def test_0035_reactivate_filtering_repository(self):
         """Reinstall filtering into 'filtering' tool panel section."""
-        installed_filtering_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_filtering_repository = self._get_installed_repository_by_name_owner(
             freebayes_repository_name, common.test_user_1_name
         )
         self.reinstall_repository_api(
@@ -162,27 +162,27 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
             install_repository_dependencies=True,
             new_tool_panel_section_label="filtering",
         )
-        installed_freebayes_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_freebayes_repository = self._get_installed_repository_by_name_owner(
             freebayes_repository_name, common.test_user_1_name
         )
         self._assert_is_not_missing_dependency(installed_freebayes_repository, filtering_repository_name)
 
     def test_0040_uninstall_freebayes_repository(self):
         """Deactivate freebayes, verify tool panel section and missing repository dependency."""
-        installed_freebayes_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_freebayes_repository = self._get_installed_repository_by_name_owner(
             freebayes_repository_name, common.test_user_1_name
         )
-        installed_filtering_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_filtering_repository = self._get_installed_repository_by_name_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, freebayes_repository_name, installed_freebayes_repository.installed_changeset_revision
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, filtering_repository_name, installed_filtering_repository.installed_changeset_revision
         )
         self.deactivate_repository(installed_freebayes_repository)
-        assert not self.get_installed_repository_for(
+        assert not self._get_installed_repository_for(
             common.test_user_1, freebayes_repository_name, installed_freebayes_repository.installed_changeset_revision
         )
         self.test_db_util.ga_refresh(installed_freebayes_repository)
@@ -191,20 +191,20 @@ class TestInstallingCircularDependencies(ShedTwillTestCase):
 
     def test_0045_deactivate_filtering_repository(self):
         """Deactivate filtering, verify tool panel section."""
-        installed_filtering_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_filtering_repository = self._get_installed_repository_by_name_owner(
             filtering_repository_name, common.test_user_1_name
         )
-        installed_freebayes_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_freebayes_repository = self._get_installed_repository_by_name_owner(
             freebayes_repository_name, common.test_user_1_name
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, filtering_repository_name, installed_filtering_repository.installed_changeset_revision
         )
         self.deactivate_repository(installed_filtering_repository)
-        assert not self.get_installed_repository_for(
+        assert not self._get_installed_repository_for(
             common.test_user_1, freebayes_repository_name, installed_freebayes_repository.installed_changeset_revision
         )
-        assert not self.get_installed_repository_for(
+        assert not self._get_installed_repository_for(
             common.test_user_1, filtering_repository_name, installed_filtering_repository.installed_changeset_revision
         )
         self.test_db_util.ga_refresh(installed_filtering_repository)

--- a/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
+++ b/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
@@ -382,9 +382,7 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0065_deactivate_bismark_repository(self):
         """Deactivate bismark and verify things are okay."""
-        repository = self.test_db_util.get_installed_repository_by_name_owner(
-            bismark_repository_name, common.test_user_1_name
-        )
+        repository = self._get_installed_repository_by_name_owner(bismark_repository_name, common.test_user_1_name)
         self.deactivate_repository(repository)
         # Now we have emboss, bismark, column_maker, and convert_chars installed, filtering and freebayes never installed.
         installed_repositories = [
@@ -401,9 +399,7 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0070_uninstall_emboss_repository(self):
         """Uninstall the emboss_5 repository."""
-        repository = self.test_db_util.get_installed_repository_by_name_owner(
-            emboss_repository_name, common.test_user_1_name
-        )
+        repository = self._get_installed_repository_by_name_owner(emboss_repository_name, common.test_user_1_name)
         self._uninstall_repository(repository)
         self._assert_has_no_installed_repos_with_names(repository.name)
         self.test_db_util.ga_refresh(repository)

--- a/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
+++ b/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
@@ -36,6 +36,8 @@ running_standalone = False
 class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
     """Verify that the code correctly handles circular dependencies down to n levels."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
@@ -325,7 +327,6 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
 
     def test_0055_install_column_repository(self):
         """Install column_maker with repository dependencies."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             column_repository_name,
             common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
+++ b/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
@@ -404,7 +404,7 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
         repository = self.test_db_util.get_installed_repository_by_name_owner(
             emboss_repository_name, common.test_user_1_name
         )
-        self.uninstall_repository(repository)
+        self._uninstall_repository(repository)
         self._assert_has_no_installed_repos_with_names(repository.name)
         self.test_db_util.ga_refresh(repository)
         self.check_galaxy_repository_tool_panel_section(repository, "emboss_5_0050")

--- a/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
+++ b/lib/tool_shed/test/functional/test_1050_circular_dependencies_4_levels.py
@@ -389,7 +389,6 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
             (column_repository_name, common.test_user_1_name),
             (emboss_repository_name, common.test_user_1_name),
             (convert_repository_name, common.test_user_1_name),
-            (bismark_repository_name, common.test_user_1_name),
         ]
         strings_displayed = ["emboss_0050", "column_maker_0050", "convert_chars_0050"]
         strings_not_displayed = ["bismark", "filtering_0050", "freebayes_0050"]
@@ -402,7 +401,7 @@ class TestInstallRepositoryCircularDependencies(ShedTwillTestCase):
         repository = self._get_installed_repository_by_name_owner(emboss_repository_name, common.test_user_1_name)
         self._uninstall_repository(repository)
         self._assert_has_no_installed_repos_with_names(repository.name)
-        self.test_db_util.ga_refresh(repository)
+        self._refresh_tool_shed_repository(repository)
         self.check_galaxy_repository_tool_panel_section(repository, "emboss_5_0050")
         # Now we have bismark, column_maker, and convert_chars installed, filtering and freebayes never installed,
         # and emboss uninstalled.

--- a/lib/tool_shed/test/functional/test_1070_invalid_tool.py
+++ b/lib/tool_shed/test/functional/test_1070_invalid_tool.py
@@ -13,9 +13,10 @@ category_description = "Test 1070 for a repository with an invalid tool."
 class TestFreebayesRepository(ShedTwillTestCase):
     """Test repository with multiple revisions with invalid tools."""
 
+    requires_galaxy = True
+
     def test_0000_create_or_login_admin_user(self):
         """Create necessary user accounts and login as an admin user."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
 
@@ -58,7 +59,6 @@ class TestFreebayesRepository(ShedTwillTestCase):
 
     def test_0010_browse_tool_shed(self):
         """Browse the available tool sheds in this Galaxy instance and preview the bismark repository."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.browse_tool_shed(url=self.url, strings_displayed=[category_name])
         category = self.populator.get_category_with_name(category_name)
         self.browse_category(category, strings_displayed=[repository_name])

--- a/lib/tool_shed/test/functional/test_1070_invalid_tool.py
+++ b/lib/tool_shed/test/functional/test_1070_invalid_tool.py
@@ -75,10 +75,8 @@ class TestFreebayesRepository(ShedTwillTestCase):
             install_tool_dependencies=False,
             new_tool_panel_section_label="test_1070",
         )
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repository_name, common.test_user_1_name
-        )
-        assert self.get_installed_repository_for(
+        installed_repository = self._get_installed_repository_by_name_owner(repository_name, common.test_user_1_name)
+        assert self._get_installed_repository_for(
             common.test_user_1, repository_name, installed_repository.installed_changeset_revision
         )
         self.update_installed_repository(installed_repository, verify_no_updates=True)

--- a/lib/tool_shed/test/functional/test_1070_invalid_tool.py
+++ b/lib/tool_shed/test/functional/test_1070_invalid_tool.py
@@ -81,5 +81,5 @@ class TestFreebayesRepository(ShedTwillTestCase):
         assert self.get_installed_repository_for(
             common.test_user_1, repository_name, installed_repository.installed_changeset_revision
         )
-        self.update_installed_repository_api(installed_repository, verify_no_updates=True)
+        self.update_installed_repository(installed_repository, verify_no_updates=True)
         self._assert_repo_has_invalid_tool_in_file(installed_repository, "bismark_bowtie_wrapper.xml")

--- a/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
+++ b/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
@@ -242,7 +242,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
         installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        self.uninstall_repository(installed_column_repository)
+        self._uninstall_repository(installed_column_repository)
         self._assert_has_missing_dependency(installed_convert_repository, "column_maker_0080")
 
     def test_0065_reinstall_column_repository(self):

--- a/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
+++ b/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
@@ -128,13 +128,13 @@ class TestRepositoryDependencies(ShedTwillTestCase):
             install_repository_dependencies=False,
             new_tool_panel_section_label="convert_chars",
         )
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, "convert_chars_0080", installed_convert_repository.installed_changeset_revision
         )
         self._assert_has_installed_repository_dependency(
@@ -154,16 +154,16 @@ class TestRepositoryDependencies(ShedTwillTestCase):
             install_repository_dependencies=True,
             new_tool_panel_section_label="column_maker",
         )
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, "convert_chars_0080", installed_convert_repository.installed_changeset_revision
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, "column_maker_0080", installed_column_repository.installed_changeset_revision
         )
         self._assert_has_installed_repository_dependency(
@@ -172,10 +172,10 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0030_deactivate_convert_repository(self):
         """Deactivate convert_chars, verify that column_maker is installed and missing repository dependencies."""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.deactivate_repository(installed_convert_repository)
@@ -183,10 +183,10 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0035_reactivate_convert_repository(self):
         """Reactivate convert_chars, both convert_chars and column_maker should now show as installed."""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.reactivate_repository(installed_convert_repository)
@@ -196,10 +196,10 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0040_deactivate_column_repository(self):
         """Deactivate column_maker, verify that convert_chars is installed and missing repository dependencies."""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.deactivate_repository(installed_column_repository)
@@ -207,7 +207,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0045_deactivate_convert_repository(self):
         """Deactivate convert_chars, verify that both convert_chars and column_maker are deactivated."""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
         self.deactivate_repository(installed_convert_repository)
@@ -215,7 +215,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0050_reactivate_column_repository(self):
         """Reactivate column_maker. This should not automatically reactivate convert_chars, so column_maker should be displayed as installed but missing repository dependencies."""
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.reactivate_repository(installed_column_repository)
@@ -223,10 +223,10 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0055_reactivate_convert_repository(self):
         """Activate convert_chars. Both convert_chars and column_maker should now show as installed."""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.reactivate_repository(installed_convert_repository)
@@ -236,10 +236,10 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0060_uninstall_column_repository(self):
         """Uninstall column_maker. Verify that convert_chars is installed and missing repository dependencies."""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self._uninstall_repository(installed_column_repository)
@@ -247,10 +247,10 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0065_reinstall_column_repository(self):
         """Reinstall column_maker without repository dependencies, verify both convert_chars and column_maker are installed."""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.reinstall_repository_api(installed_column_repository, install_repository_dependencies=False)
@@ -260,10 +260,10 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0070_uninstall_convert_repository(self):
         """Uninstall convert_chars, verify column_maker installed but missing repository dependencies."""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.deactivate_repository(installed_convert_repository)
@@ -271,7 +271,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0075_uninstall_column_repository(self):
         """Uninstall column_maker, verify that both convert_chars and column_maker are uninstalled."""
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.deactivate_repository(installed_column_repository)
@@ -279,10 +279,10 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0080_reinstall_convert_repository(self):
         """Reinstall convert_chars with repository dependencies, verify that this installs both convert_chars and column_maker."""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.reinstall_repository_api(installed_convert_repository, install_repository_dependencies=True)

--- a/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
+++ b/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
@@ -24,9 +24,10 @@ running_standalone = False
 class TestRepositoryDependencies(ShedTwillTestCase):
     """Testing uninstalling and reinstalling repository dependencies, and setting tool panel sections."""
 
+    requires_galaxy = True
+
     def test_0000_create_or_login_admin_user(self):
         """Create necessary user accounts and login as an admin user."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
 
@@ -119,7 +120,6 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0020_install_convert_repository(self):
         """Install convert_chars without repository dependencies into convert_chars tool panel section."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             convert_repository_name,
             common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
+++ b/lib/tool_shed/test/functional/test_1080_advanced_circular_dependency_installation.py
@@ -135,15 +135,18 @@ class TestRepositoryDependencies(ShedTwillTestCase):
             column_repository_name, common.test_user_1_name
         )
         assert self._get_installed_repository_for(
-            common.test_user_1, "convert_chars_0080", installed_convert_repository.installed_changeset_revision
+            common.test_user_1, convert_repository_name, installed_convert_repository.installed_changeset_revision
         )
-        self._assert_has_installed_repository_dependency(
-            installed_convert_repository, "column_maker_0080", installed_column_repository.installed_changeset_revision
-        )
-        # installed_convert_repository has required_repositories and the following string
-        # is included when not installing via the API. This distrubs me but we've not installed
-        # not from the API for a long time so I'm just dropping the check. -John
-        # "Missing repository dependencies",
+        if self.full_stack_galaxy:
+            # This branch has been broken since we switched from mako to API for installing...
+            self._assert_has_installed_repository_dependency(
+                installed_convert_repository,
+                column_repository_name,
+                installed_column_repository.installed_changeset_revision,
+            )
+        else:
+            # Previous mako had some string checks and such equivalent to this.
+            self._assert_has_missing_dependency(installed_convert_repository, column_repository_name)
 
     def test_0025_install_column_repository(self):
         """Install column maker with repository dependencies into column_maker tool panel section."""

--- a/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
+++ b/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
@@ -22,9 +22,10 @@ log = logging.getLogger(__name__)
 class TestRepositoryDependencies(ShedTwillTestCase):
     """Testing the behavior of repository dependencies with tool panel sections."""
 
+    requires_galaxy = True
+
     def test_0000_create_or_login_admin_user(self):
         """Create necessary user accounts and login as an admin user."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
 
@@ -103,7 +104,6 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0020_install_repositories(self):
         """Install column_maker into column_maker tool panel section and install repository dependencies."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             column_repository_name,
             common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
+++ b/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
@@ -115,6 +115,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
         installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
+        self._refresh_tool_shed_repository(installed_convert_repository)
         self._assert_has_installed_repos_with_names("convert_chars_1085", "column_maker_1085")
         self._assert_is_not_missing_dependency(installed_convert_repository, "column_maker_1085")
 
@@ -124,7 +125,6 @@ class TestRepositoryDependencies(ShedTwillTestCase):
             column_repository_name, common.test_user_1_name
         )
         self._uninstall_repository(installed_column_repository)
-        self.test_db_util.ga_refresh(installed_column_repository)
         self.check_galaxy_repository_tool_panel_section(installed_column_repository, "column_maker")
 
     def test_0030_uninstall_convert_repository(self):
@@ -132,7 +132,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
             convert_repository_name, common.test_user_1_name
         )
         self._uninstall_repository(installed_convert_repository)
-        self.test_db_util.ga_refresh(installed_convert_repository)
+        self._refresh_tool_shed_repository(installed_convert_repository)
         self.check_galaxy_repository_tool_panel_section(installed_convert_repository, "column_maker")
 
     def test_0035_reinstall_column_repository(self):

--- a/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
+++ b/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
@@ -112,7 +112,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
             install_repository_dependencies=True,
             new_tool_panel_section_label="column_maker",
         )
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
         self._assert_has_installed_repos_with_names("convert_chars_1085", "column_maker_1085")
@@ -120,7 +120,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0025_uninstall_column_repository(self):
         """uninstall column_maker, verify same section"""
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self._uninstall_repository(installed_column_repository)
@@ -128,7 +128,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
         self.check_galaxy_repository_tool_panel_section(installed_column_repository, "column_maker")
 
     def test_0030_uninstall_convert_repository(self):
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
         self._uninstall_repository(installed_convert_repository)
@@ -137,7 +137,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0035_reinstall_column_repository(self):
         """reinstall column_maker into new section 'new_column_maker' (no_changes = false), no dependencies"""
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self.reinstall_repository_api(
@@ -150,7 +150,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0040_reinstall_convert_repository(self):
         """reinstall convert_chars into new section 'new_convert_chars' (no_changes = false), no dependencies"""
-        installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
         self.reinstall_repository_api(
@@ -166,9 +166,9 @@ class TestRepositoryDependencies(ShedTwillTestCase):
     # https://jenkins.galaxyproject.org/job/docker-toolshed/5198/
     # def test_0045_uninstall_and_verify_tool_panel_sections( self ):
     #    '''uninstall both and verify tool panel sections'''
-    #    installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner( convert_repository_name,
+    #    installed_convert_repository = self._get_installed_repository_by_name_owner( convert_repository_name,
     #                                                                                        common.test_user_1_name )
-    #    installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner( column_repository_name,
+    #    installed_column_repository = self._get_installed_repository_by_name_owner( column_repository_name,
     #                                                                                        common.test_user_1_name )
     #    self._uninstall_repository( installed_convert_repository )
     #    self._uninstall_repository( installed_column_repository )

--- a/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
+++ b/lib/tool_shed/test/functional/test_1090_repository_dependency_handling.py
@@ -123,7 +123,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
         installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        self.uninstall_repository(installed_column_repository)
+        self._uninstall_repository(installed_column_repository)
         self.test_db_util.ga_refresh(installed_column_repository)
         self.check_galaxy_repository_tool_panel_section(installed_column_repository, "column_maker")
 
@@ -131,7 +131,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
         installed_convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
-        self.uninstall_repository(installed_convert_repository)
+        self._uninstall_repository(installed_convert_repository)
         self.test_db_util.ga_refresh(installed_convert_repository)
         self.check_galaxy_repository_tool_panel_section(installed_convert_repository, "column_maker")
 
@@ -170,8 +170,8 @@ class TestRepositoryDependencies(ShedTwillTestCase):
     #                                                                                        common.test_user_1_name )
     #    installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner( column_repository_name,
     #                                                                                        common.test_user_1_name )
-    #    self.uninstall_repository( installed_convert_repository )
-    #    self.uninstall_repository( installed_column_repository )
+    #    self._uninstall_repository( installed_convert_repository )
+    #    self._uninstall_repository( installed_column_repository )
     #    self.test_db_util.ga_refresh( installed_convert_repository )
     #    self.test_db_util.ga_refresh( installed_column_repository )
     #    self.check_galaxy_repository_tool_panel_section( installed_column_repository, 'new_column_maker' )

--- a/lib/tool_shed/test/functional/test_1100_install_updated_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1100_install_updated_repository_dependencies.py
@@ -18,9 +18,10 @@ category_description = "Test circular dependency features"
 class TestRepositoryDependencies(ShedTwillTestCase):
     """Test installing a repository, then updating it to include repository dependencies."""
 
+    requires_galaxy = True
+
     def test_0000_create_or_login_admin_user(self):
         """Create necessary user accounts and login as an admin user."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
 
@@ -77,7 +78,6 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0015_install_and_uninstall_column_repository(self):
         """Install and uninstall the column_maker repository."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             column_repository_name,
             common.test_user_1_name,
@@ -115,7 +115,6 @@ class TestRepositoryDependencies(ShedTwillTestCase):
 
     def test_0030_reinstall_column_repository(self):
         """Reinstall column_maker and verify it installs repository dependencies."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         strings_not_displayed = ["column_maker_1087"]
         self._assert_has_no_installed_repos_with_names(*strings_not_displayed)
         self._install_repository(

--- a/lib/tool_shed/test/functional/test_1100_install_updated_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1100_install_updated_repository_dependencies.py
@@ -86,7 +86,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
             install_repository_dependencies=True,
             new_tool_panel_section_label="column_maker",
         )
-        installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
         self._uninstall_repository(installed_column_repository)

--- a/lib/tool_shed/test/functional/test_1100_install_updated_repository_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1100_install_updated_repository_dependencies.py
@@ -89,7 +89,7 @@ class TestRepositoryDependencies(ShedTwillTestCase):
         installed_column_repository = self.test_db_util.get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        self.uninstall_repository(installed_column_repository)
+        self._uninstall_repository(installed_column_repository)
 
     def test_0020_upload_dependency_xml(self):
         """Upload a repository_dependencies.xml file to column_maker that specifies convert_chars."""

--- a/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
@@ -269,16 +269,16 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
 
     def test_0050_verify_installed_repositories(self):
         """Verify that the installed repositories are displayed properly."""
-        base_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        base_repository = self._get_installed_repository_by_name_owner(
             bwa_base_repository_name, common.test_user_1_name
         )
-        tool_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        tool_repository = self._get_installed_repository_by_name_owner(
             bwa_package_repository_name, common.test_user_1_name
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, "bwa_base_repository_0100", base_repository.installed_changeset_revision
         )
-        assert self.get_installed_repository_for(
+        assert self._get_installed_repository_for(
             common.test_user_1, "package_bwa_0_5_9_0100", tool_repository.installed_changeset_revision
         )
         self._assert_has_installed_repository_dependency(base_repository, "package_bwa_0_5_9_0100")

--- a/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
@@ -25,6 +25,8 @@ running_standalone = False
 class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
     """Test features related to installing repositories with complex repository dependencies."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
@@ -255,7 +257,6 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
 
     def test_0045_install_base_repository(self):
         """Verify installation of the repository with complex repository dependencies."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         tool_repository = self._get_repository_by_name_and_owner(bwa_package_repository_name, common.test_user_1_name)
         preview_strings_displayed = [tool_repository.name, self.get_repository_tip(tool_repository)]
         self._install_repository(

--- a/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
@@ -263,7 +263,6 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
             bwa_base_repository_name,
             common.test_user_1_name,
             category_name,
-            install_tool_dependencies=True,
             preview_strings_displayed=preview_strings_displayed,
         )
 

--- a/lib/tool_shed/test/functional/test_1130_install_repository_with_invalid_repository_dependency.py
+++ b/lib/tool_shed/test/functional/test_1130_install_repository_with_invalid_repository_dependency.py
@@ -184,7 +184,7 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
             install_repository_dependencies=True,
             preview_strings_displayed=preview_strings_displayed,
         )
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_repository = self._get_installed_repository_by_name_owner(
             emboss_repository_name, common.test_user_1_name
         )
         json = self.display_installed_repository_manage_json(installed_repository)

--- a/lib/tool_shed/test/functional/test_1130_install_repository_with_invalid_repository_dependency.py
+++ b/lib/tool_shed/test/functional/test_1130_install_repository_with_invalid_repository_dependency.py
@@ -19,6 +19,8 @@ running_standalone = False
 class TestBasicRepositoryDependencies(ShedTwillTestCase):
     """Testing emboss 5 with repository dependencies."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts and login as an admin user."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
@@ -168,7 +170,6 @@ class TestBasicRepositoryDependencies(ShedTwillTestCase):
 
     def test_0045_install_repository_with_invalid_repository_dependency(self):
         """Install the repository and verify that galaxy detects invalid repository dependencies."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         repository = self._get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)
         preview_strings_displayed = [
             "emboss_0110",

--- a/lib/tool_shed/test/functional/test_1140_simple_repository_dependency_multiple_owners.py
+++ b/lib/tool_shed/test/functional/test_1140_simple_repository_dependency_multiple_owners.py
@@ -30,6 +30,8 @@ running_standalone = False
 
 
 class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts and login as an admin user.
 
@@ -174,7 +176,6 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         We are at step 1, Galaxy side.
         Install blastxml_to_top_descr_0120 to Galaxy, with repository dependencies, so that the datatypes repository is also installed.
         """
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             name="blastxml_to_top_descr_0120",
             owner=common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1140_simple_repository_dependency_multiple_owners.py
+++ b/lib/tool_shed/test/functional/test_1140_simple_repository_dependency_multiple_owners.py
@@ -192,8 +192,6 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         are now new datatypes in the registry matching the ones defined in blast_datatypes_0120. Also check that
         blast_datatypes_0120 is labeled as an installed repository dependency of blastxml_to_top_descr_0120.
         """
-        tool_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            tool_repository_name, common.test_user_1_name
-        )
+        tool_repository = self._get_installed_repository_by_name_owner(tool_repository_name, common.test_user_1_name)
         self._assert_has_valid_tool_with_name("BLAST top hit")
         self._assert_repo_has_tool_with_id(tool_repository, "blastxml_to_top_descr")

--- a/lib/tool_shed/test/functional/test_1160_tool_help_images.py
+++ b/lib/tool_shed/test/functional/test_1160_tool_help_images.py
@@ -23,6 +23,8 @@ category_description = "Test 0140 Tool Help Images"
 class TestToolHelpImages(ShedTwillTestCase):
     """Test features related to tool help images."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)

--- a/lib/tool_shed/test/functional/test_1170_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1170_prior_installation_required.py
@@ -38,9 +38,10 @@ running_standalone = False
 class TestSimplePriorInstallation(ShedTwillTestCase):
     """Test features related to datatype converters."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
 
@@ -133,7 +134,6 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0025_install_column_repository(self):
         """Install column_maker_0150."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         column_repository = self._get_repository_by_name_and_owner(column_repository_name, common.test_user_1_name)
         preview_strings_displayed = ["column_maker_0150", self.get_repository_tip(column_repository)]
         self._install_repository(

--- a/lib/tool_shed/test/functional/test_1170_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1170_prior_installation_required.py
@@ -147,10 +147,10 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0030_verify_installation_order(self):
         """Verify that convert_chars_0150 was installed before column_maker_0150."""
-        column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
         # Column maker was selected for installation, so convert chars should have been installed first, as reflected by the update_time field.

--- a/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
@@ -51,9 +51,10 @@ running_standalone = False
 class TestSimplePriorInstallation(ShedTwillTestCase):
     """Test features related to datatype converters."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
 
@@ -214,7 +215,6 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0030_install_filtering_repository(self):
         """Install the filtering_0160 repository."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         filter_repository = self._get_repository_by_name_and_owner(filter_repository_name, common.test_user_1_name)
         preview_strings_displayed = ["filtering_0160", self.get_repository_tip(filter_repository)]
         self._install_repository(

--- a/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
@@ -283,8 +283,9 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
             convert_repository_name, common.test_user_1_name
         )
         # Filtering was selected for reinstallation, so convert chars and column maker should have been installed first.
-        for repo in [convert_repository, column_repository, filter_repository]:
-            self.test_db_util.install_session().refresh(repo)
+        if self.full_stack_galaxy:
+            for repo in [convert_repository, column_repository, filter_repository]:
+                self.test_db_util.install_session().refresh(repo)
         assert (
             filter_repository.update_time > convert_repository.update_time
         ), "Prior installed convert_chars_0160 shows a later update time than filtering_0160"

--- a/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
@@ -228,13 +228,13 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0035_verify_installation_order(self):
         """Verify that convert_chars_0160 and column_maker_0160 were installed before filtering_0160."""
-        filter_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        filter_repository = self._get_installed_repository_by_name_owner(
             filter_repository_name, common.test_user_1_name
         )
-        column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
         # Filtering was selected for installation, so convert chars and column maker should have been installed first.
@@ -247,13 +247,13 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0040_deactivate_all_repositories(self):
         """Uninstall convert_chars_0160, column_maker_0160, and filtering_0160."""
-        filter_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        filter_repository = self._get_installed_repository_by_name_owner(
             filter_repository_name, common.test_user_1_name
         )
-        column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
         self.deactivate_repository(filter_repository)
@@ -262,7 +262,7 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
 
     def test_0045_reactivate_filter_repository(self):
         """Reinstall the filtering_0160 repository."""
-        filter_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        filter_repository = self._get_installed_repository_by_name_owner(
             filter_repository_name, common.test_user_1_name
         )
         self.reactivate_repository(filter_repository)
@@ -273,13 +273,13 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
     def test_0050_verify_reinstallation_order(self):
         """Verify that convert_chars_0160 and column_maker_0160 were reinstalled before filtering_0160."""
         # Fixme: this test is not covering any important behavior since repositories were only deactivated and not uninstalled.
-        filter_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        filter_repository = self._get_installed_repository_by_name_owner(
             filter_repository_name, common.test_user_1_name
         )
-        column_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        column_repository = self._get_installed_repository_by_name_owner(
             column_repository_name, common.test_user_1_name
         )
-        convert_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        convert_repository = self._get_installed_repository_by_name_owner(
             convert_repository_name, common.test_user_1_name
         )
         # Filtering was selected for reinstallation, so convert chars and column maker should have been installed first.

--- a/lib/tool_shed/test/functional/test_1190_complex_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1190_complex_prior_installation_required.py
@@ -36,6 +36,8 @@ running_standalone = False
 class TestComplexPriorInstallation(ShedTwillTestCase):
     """Test features related to datatype converters."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
@@ -170,7 +172,6 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
 
         This is step 4 - Install package_matplotlib_1_2_0170 with repository dependencies.
         """
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         matplotlib_repository = self._get_repository_by_name_and_owner(
             matplotlib_repository_name, common.test_user_1_name
         )

--- a/lib/tool_shed/test/functional/test_1190_complex_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1190_complex_prior_installation_required.py
@@ -193,12 +193,10 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         prior_installation_required attribute set. Confirm that this resulted in package_numpy_1_7_0170 being installed before
         package_matplotlib_1_2_0170.
         """
-        matplotlib_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        matplotlib_repository = self._get_installed_repository_by_name_owner(
             matplotlib_repository_name, common.test_user_1_name
         )
-        numpy_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            numpy_repository_name, common.test_user_1_name
-        )
+        numpy_repository = self._get_installed_repository_by_name_owner(numpy_repository_name, common.test_user_1_name)
         assert (
             matplotlib_repository.update_time > numpy_repository.update_time
         ), "Error: package_numpy_1_7_0170 shows a later update time than package_matplotlib_1_2_0170"

--- a/lib/tool_shed/test/functional/test_1200_uninstall_and_reinstall_basic_repository.py
+++ b/lib/tool_shed/test/functional/test_1200_uninstall_and_reinstall_basic_repository.py
@@ -91,7 +91,7 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
             "filtering_0000", common.test_user_1_name
         )
-        self.uninstall_repository(installed_repository)
+        self._uninstall_repository(installed_repository)
         self._assert_has_no_installed_repos_with_names("filtering_0000")
 
     def test_0020_reinstall_filtering_repository(self):

--- a/lib/tool_shed/test/functional/test_1200_uninstall_and_reinstall_basic_repository.py
+++ b/lib/tool_shed/test/functional/test_1200_uninstall_and_reinstall_basic_repository.py
@@ -88,17 +88,13 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0015_uninstall_filtering_repository(self):
         """Uninstall the filtering repository."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            "filtering_0000", common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner("filtering_0000", common.test_user_1_name)
         self._uninstall_repository(installed_repository)
         self._assert_has_no_installed_repos_with_names("filtering_0000")
 
     def test_0020_reinstall_filtering_repository(self):
         """Reinstall the filtering repository."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            "filtering_0000", common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner("filtering_0000", common.test_user_1_name)
         self.reinstall_repository_api(installed_repository)
         self._assert_has_installed_repos_with_names("filtering_0000")
         self._assert_has_valid_tool_with_name("Filter1")
@@ -106,17 +102,13 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0025_deactivate_filtering_repository(self):
         """Deactivate the filtering repository without removing it from disk."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            "filtering_0000", common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner("filtering_0000", common.test_user_1_name)
         self.deactivate_repository(installed_repository)
         self._assert_has_no_installed_repos_with_names("filtering_0000")
 
     def test_0030_reactivate_filtering_repository(self):
         """Reactivate the filtering repository and verify that it now shows up in the list of installed repositories."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            "filtering_0000", common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner("filtering_0000", common.test_user_1_name)
         self.reactivate_repository(installed_repository)
         self._assert_has_installed_repos_with_names("filtering_0000")
         self._assert_has_valid_tool_with_name("Filter1")

--- a/lib/tool_shed/test/functional/test_1200_uninstall_and_reinstall_basic_repository.py
+++ b/lib/tool_shed/test/functional/test_1200_uninstall_and_reinstall_basic_repository.py
@@ -7,11 +7,12 @@ from ..base.twilltestcase import (
 class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
     """Test uninstalling and reinstalling a basic repository."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
 
     def test_0005_ensure_repositories_and_categories_exist(self):
         """Create the 0000 category and upload the filtering repository to the tool shed, if necessary."""
@@ -77,7 +78,6 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0010_install_filtering_repository(self):
         """Install the filtering repository into the Galaxy instance."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             "filtering_0000",
             common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
@@ -116,17 +116,13 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0015_uninstall_freebayes_repository(self):
         """Uninstall the freebayes repository."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            "freebayes_0010", common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner("freebayes_0010", common.test_user_1_name)
         self._uninstall_repository(installed_repository)
         self._assert_has_no_installed_repos_with_names("freebayes_0010")
 
     def test_0020_reinstall_freebayes_repository(self):
         """Reinstall the freebayes repository."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            "freebayes_0010", common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner("freebayes_0010", common.test_user_1_name)
         self.reinstall_repository_api(installed_repository)
         self._assert_has_installed_repos_with_names("freebayes_0010")
         self._assert_has_valid_tool_with_name("FreeBayes")
@@ -134,17 +130,13 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0025_deactivate_freebayes_repository(self):
         """Deactivate the freebayes repository without removing it from disk."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            "freebayes_0010", common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner("freebayes_0010", common.test_user_1_name)
         self.deactivate_repository(installed_repository)
         self._assert_has_no_installed_repos_with_names("freebayes_0010")
 
     def test_0030_reactivate_freebayes_repository(self):
         """Reactivate the freebayes repository and verify that it now shows up in the list of installed repositories."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            "freebayes_0010", common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner("freebayes_0010", common.test_user_1_name)
         self.reactivate_repository(installed_repository)
         self._assert_has_installed_repos_with_names("freebayes_0010")
         self._assert_has_valid_tool_with_name("FreeBayes")

--- a/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
@@ -119,7 +119,7 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
             "freebayes_0010", common.test_user_1_name
         )
-        self.uninstall_repository(installed_repository)
+        self._uninstall_repository(installed_repository)
         self._assert_has_no_installed_repos_with_names("freebayes_0010")
 
     def test_0020_reinstall_freebayes_repository(self):

--- a/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1210_uninstall_reinstall_repository_with_tool_dependencies.py
@@ -9,9 +9,10 @@ from ..base.twilltestcase import (
 class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
     """Test uninstalling and reinstalling a repository with tool dependencies."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
 
@@ -105,7 +106,6 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0010_install_freebayes_repository(self):
         """Install the freebayes repository into the Galaxy instance."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             "freebayes_0010",
             common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
@@ -165,7 +165,7 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
             emboss_repository_name, common.test_user_1_name
         )
-        self.uninstall_repository(installed_repository)
+        self._uninstall_repository(installed_repository)
         self._assert_has_no_installed_repos_with_names(emboss_repository_name)
 
     def test_0020_reinstall_emboss_repository(self):

--- a/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
@@ -162,7 +162,7 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0015_uninstall_emboss_repository(self):
         """Uninstall the emboss repository."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_repository = self._get_installed_repository_by_name_owner(
             emboss_repository_name, common.test_user_1_name
         )
         self._uninstall_repository(installed_repository)
@@ -170,7 +170,7 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0020_reinstall_emboss_repository(self):
         """Reinstall the emboss repository."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_repository = self._get_installed_repository_by_name_owner(
             emboss_repository_name, common.test_user_1_name
         )
         self.reinstall_repository_api(installed_repository)
@@ -179,7 +179,7 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0025_deactivate_emboss_repository(self):
         """Deactivate the emboss repository without removing it from disk."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_repository = self._get_installed_repository_by_name_owner(
             emboss_repository_name, common.test_user_1_name
         )
         self.deactivate_repository(installed_repository)
@@ -187,7 +187,7 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
 
     def test_0030_reactivate_emboss_repository(self):
         """Reactivate the emboss repository and verify that it now shows up in the list of installed repositories."""
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
+        installed_repository = self._get_installed_repository_by_name_owner(
             emboss_repository_name, common.test_user_1_name
         )
         self.reactivate_repository(installed_repository)

--- a/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
+++ b/lib/tool_shed/test/functional/test_1230_uninstall_reinstall_repository_with_dependency_revisions.py
@@ -19,9 +19,10 @@ running_standalone = False
 class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
     """Test uninstalling and reinstalling a repository with repository dependency revisions."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
 
@@ -151,7 +152,6 @@ class TestUninstallingAndReinstallingRepositories(ShedTwillTestCase):
     def test_0010_install_emboss_repository(self):
         """Install the emboss repository into the Galaxy instance."""
         global running_standalone
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             emboss_repository_name,
             common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1300_reset_all_metadata.py
+++ b/lib/tool_shed/test/functional/test_1300_reset_all_metadata.py
@@ -526,14 +526,13 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
 
     def test_9905_reset_metadata_on_all_repositories(self):
         """Reset metadata on all repositories, then verify that it has not changed."""
-        repository_metadata = dict()
-        repositories = self.test_db_util.get_all_installed_repositories(actually_installed=True)
+        repositories = self.get_all_installed_repositories()
+        repository_metadata = {}
         for repository in repositories:
-            repository_metadata[self.security.encode_id(repository.id)] = repository.metadata_
-        self.reset_metadata_on_selected_installed_repositories(list(repository_metadata.keys()))
-        for repository in repositories:
-            self.test_db_util.ga_refresh(repository)
-            old_metadata = repository_metadata[self.security.encode_id(repository.id)]
+            repository_metadata[repository.id] = repository.metadata_
+        self.reset_metadata_on_installed_repositories(repositories)
+        for repository in self.get_all_installed_repositories():
+            old_metadata = repository_metadata[repository.id]
             # When a repository with tools to be displayed in a tool panel section is deactivated and reinstalled,
             # the tool panel section remains in the repository metadata. However, when the repository's metadata
             # is subsequently reset, the tool panel section is removed from the repository metadata. While this

--- a/lib/tool_shed/test/functional/test_1300_reset_all_metadata.py
+++ b/lib/tool_shed/test/functional/test_1300_reset_all_metadata.py
@@ -44,6 +44,8 @@ running_standalone = False
 class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
     """Verify that the "Reset selected metadata" feature works."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
@@ -516,7 +518,6 @@ class TestResetInstalledRepositoryMetadata(ShedTwillTestCase):
 
     def test_9900_install_all_missing_repositories(self):
         """Call the install_repository method to ensure that all required repositories are installed."""
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository("filtering_0000", common.test_user_1_name, category_0000_name)
         self._install_repository("freebayes_0010", common.test_user_1_name, category_0010_name)
         self._install_repository("emboss_0020", common.test_user_1_name, category_0020_name)

--- a/lib/tool_shed/test/functional/test_1410_update_manager.py
+++ b/lib/tool_shed/test/functional/test_1410_update_manager.py
@@ -74,9 +74,7 @@ class TestUpdateManager(ShedTwillTestCase):
         self._install_repository(
             repository_name, common.test_user_1_name, category_name, new_tool_panel_section_label="test_1410"
         )
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repository_name, common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner(repository_name, common.test_user_1_name)
         self._assert_has_installed_repos_with_names(repository_name)
         self._assert_has_valid_tool_with_name("Filter")
         self._assert_repo_has_tool_with_id(installed_repository, "Filter1")
@@ -111,9 +109,7 @@ class TestUpdateManager(ShedTwillTestCase):
         """
         # Wait 3 seconds, just to be sure we're past hours_between_check.
         time.sleep(3)
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repository_name, common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner(repository_name, common.test_user_1_name)
         response = self.update_installed_repository(installed_repository)
         assert response["status"] == "ok"
         assert "has been updated" in response["message"]

--- a/lib/tool_shed/test/functional/test_1410_update_manager.py
+++ b/lib/tool_shed/test/functional/test_1410_update_manager.py
@@ -114,6 +114,6 @@ class TestUpdateManager(ShedTwillTestCase):
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
             repository_name, common.test_user_1_name
         )
-        response = self.update_installed_repository_api(installed_repository)
+        response = self.update_installed_repository(installed_repository)
         assert response["status"] == "ok"
         assert "has been updated" in response["message"]

--- a/lib/tool_shed/test/functional/test_1410_update_manager.py
+++ b/lib/tool_shed/test/functional/test_1410_update_manager.py
@@ -26,6 +26,8 @@ category_description = "Functional test suite to test the update manager."
 class TestUpdateManager(ShedTwillTestCase):
     """Test the Galaxy update manager."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts and login as an admin user.
 
@@ -34,7 +36,6 @@ class TestUpdateManager(ShedTwillTestCase):
         """
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         self.login(email=common.admin_email, username=common.admin_username)
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
 
     def test_0005_create_filtering_repository(self):
         """Create and populate the filtering_1410 repository.
@@ -70,7 +71,6 @@ class TestUpdateManager(ShedTwillTestCase):
         We are at step 2 - Install filtering_1410 to Galaxy.
         Install the filtering repository to Galaxy.
         """
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             repository_name, common.test_user_1_name, category_name, new_tool_panel_section_label="test_1410"
         )
@@ -111,7 +111,6 @@ class TestUpdateManager(ShedTwillTestCase):
         """
         # Wait 3 seconds, just to be sure we're past hours_between_check.
         time.sleep(3)
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
             repository_name, common.test_user_1_name
         )

--- a/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
+++ b/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
@@ -142,5 +142,5 @@ class TestRepairRepository(ShedTwillTestCase):
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
             "filter_1430", common.test_user_1_name
         )
-        self.uninstall_repository(installed_repository)
+        self._uninstall_repository(installed_repository)
         self._assert_has_no_installed_repos_with_names("filter_1430")

--- a/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
+++ b/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
@@ -37,6 +37,8 @@ In Galaxy:
 class TestRepairRepository(ShedTwillTestCase):
     """Test repairing an installed repository."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users_and_category(self):
         """Create necessary user accounts and login as an admin user."""
         self.login(email=common.admin_email, username=common.admin_username)
@@ -123,7 +125,6 @@ class TestRepairRepository(ShedTwillTestCase):
         handle repository dependencies so that the filter_1430 repository is also installed. Make sure to install
         the repositories in a specified section of the tool panel.
         """
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             "column_1430",
             common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
+++ b/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
@@ -139,8 +139,6 @@ class TestRepairRepository(ShedTwillTestCase):
 
         This is step 2 - Uninstall the filter_1430 repository.
         """
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            "filter_1430", common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner("filter_1430", common.test_user_1_name)
         self._uninstall_repository(installed_repository)
         self._assert_has_no_installed_repos_with_names("filter_1430")

--- a/lib/tool_shed/test/functional/test_1460_data_managers.py
+++ b/lib/tool_shed/test/functional/test_1460_data_managers.py
@@ -77,16 +77,17 @@ class TestDataManagers(ShedTwillTestCase):
             data_manager_repository_name,
             common.test_user_1_name,
             category_name,
-            install_tool_dependencies=True,
+            install_tool_dependencies=False,
         )
 
     def test_0030_verify_data_manager_tool(self):
         """Verify that the data_manager_1460 repository is installed and Data Manager tool appears in list in Galaxy."""
         repository = self._get_installed_repository_by_name_owner(data_manager_repository_name, common.test_user_1_name)
-        strings_displayed = ["status", "jobs", data_manager_name]
-        self.display_installed_jobs_list_page(
-            repository, data_manager_names=data_manager_name, strings_displayed=strings_displayed
-        )
+        if self.full_stack_galaxy:
+            strings_displayed = ["status", "jobs", data_manager_name]
+            self.display_installed_jobs_list_page(
+                repository, data_manager_names=data_manager_name, strings_displayed=strings_displayed
+            )
 
     def test_0040_verify_data_manager_data_table(self):
         """Verify that the installed repository populated shed_tool_data_table.xml and the sample files."""

--- a/lib/tool_shed/test/functional/test_1460_data_managers.py
+++ b/lib/tool_shed/test/functional/test_1460_data_managers.py
@@ -30,6 +30,8 @@ data_manager_tar_file = "1460_files/data_manager_files/test_data_manager.tar"
 class TestDataManagers(ShedTwillTestCase):
     """Test installing a repository containing a Data Manager."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users_and_category(self):
         """Create necessary user accounts and login as an admin user."""
         self.login(email=common.admin_email, username=common.admin_username)
@@ -71,7 +73,6 @@ class TestDataManagers(ShedTwillTestCase):
 
         This is step 3 - Attempt to install the repository into a galaxy instance, verify that it is installed.
         """
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             data_manager_repository_name,
             common.test_user_1_name,

--- a/lib/tool_shed/test/functional/test_1460_data_managers.py
+++ b/lib/tool_shed/test/functional/test_1460_data_managers.py
@@ -82,9 +82,7 @@ class TestDataManagers(ShedTwillTestCase):
 
     def test_0030_verify_data_manager_tool(self):
         """Verify that the data_manager_1460 repository is installed and Data Manager tool appears in list in Galaxy."""
-        repository = self.test_db_util.get_installed_repository_by_name_owner(
-            data_manager_repository_name, common.test_user_1_name
-        )
+        repository = self._get_installed_repository_by_name_owner(data_manager_repository_name, common.test_user_1_name)
         strings_displayed = ["status", "jobs", data_manager_name]
         self.display_installed_jobs_list_page(
             repository, data_manager_names=data_manager_name, strings_displayed=strings_displayed

--- a/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
+++ b/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
@@ -105,7 +105,7 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
             repository_name, common.test_user_1_name
         )
-        self.update_installed_repository_api(installed_repository)
+        self.update_installed_repository(installed_repository)
 
     def test_0025_uninstall_repository(self):
         """Uninstall the filtering_1470 repository.
@@ -115,7 +115,7 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
             repository_name, common.test_user_1_name
         )
-        self.uninstall_repository(installed_repository)
+        self._uninstall_repository(installed_repository)
 
     def test_0030_reinstall_repository(self):
         """Reinstall the filtering_1470 repository.

--- a/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
+++ b/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
@@ -102,9 +102,7 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
 
         This is step 3 - In Galaxy, get updates to the repository.
         """
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repository_name, common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner(repository_name, common.test_user_1_name)
         self.update_installed_repository(installed_repository)
 
     def test_0025_uninstall_repository(self):
@@ -112,9 +110,7 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
 
         This is step 4 - In Galaxy, uninstall the repository.
         """
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repository_name, common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner(repository_name, common.test_user_1_name)
         self._uninstall_repository(installed_repository)
 
     def test_0030_reinstall_repository(self):
@@ -122,9 +118,7 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
 
         This is step 5 - In Galaxy, reinstall the repository.
         """
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repository_name, common.test_user_1_name
-        )
+        installed_repository = self._get_installed_repository_by_name_owner(repository_name, common.test_user_1_name)
         self.reinstall_repository_api(installed_repository)
 
     def test_0035_verify_absence_of_ghosts(self):
@@ -132,9 +126,7 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
 
         This is step 6 - Make sure step 5 created no white ghosts.
         """
-        installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
-            repository_name, common.test_user_1_name, return_multiple=True
-        )
+        installed_repository = self._get_installed_repositories_by_name_owner(repository_name, common.test_user_1_name)
         assert (
             len(installed_repository) == 1
         ), 'Multiple filtering repositories found in the Galaxy database, possibly indicating a "white ghost" scenario.'

--- a/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
+++ b/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
@@ -29,6 +29,8 @@ category_description = (
 class TestUpdateInstalledRepository(ShedTwillTestCase):
     """Verify that the code correctly handles updating an installed repository, then uninstalling and reinstalling."""
 
+    requires_galaxy = True
+
     def test_0000_initiate_users(self):
         """Create necessary user accounts."""
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
@@ -63,7 +65,6 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
 
         This is step 1 - Install a repository into Galaxy.
         """
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         self._install_repository(
             repository_name,
             common.test_user_1_name,
@@ -101,7 +102,6 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
 
         This is step 3 - In Galaxy, get updates to the repository.
         """
-        self.galaxy_login(email=common.admin_email, username=common.admin_username)
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(
             repository_name, common.test_user_1_name
         )

--- a/mypy.ini
+++ b/mypy.ini
@@ -488,8 +488,6 @@ check_untyped_defs = False
 check_untyped_defs = False
 [mypy-galaxy.jobs]
 check_untyped_defs = False
-[mypy-galaxy.tool_shed.metadata.metadata_generator]
-check_untyped_defs = False
 [mypy-galaxy.jobs.handler]
 check_untyped_defs = False
 [mypy-galaxy.workflow.scheduling_manager]

--- a/test/unit/app/jobs/test_job_wrapper.py
+++ b/test/unit/app/jobs/test_job_wrapper.py
@@ -50,7 +50,7 @@ class AbstractTestCases:
             self.model_objects: Dict[Type[Base], Dict[int, Base]] = {Job: {345: job}}
             self.app.model.session = MockContext(self.model_objects)
 
-            self.app.toolbox = cast(ToolBox, MockToolbox(MockTool(self)))
+            self.app._toolbox = cast(ToolBox, MockToolbox(MockTool(self)))
             self.working_directory = os.path.join(self.test_directory, "working")
             self.app.object_store = cast(BaseObjectStore, MockObjectStore(self.working_directory))
 

--- a/test/unit/app/test_galaxy_install.py
+++ b/test/unit/app/test_galaxy_install.py
@@ -1,0 +1,60 @@
+"""Test installation using galaxy.tool_shed package.
+
+It should be able to quickly test installing things from the real tool shed
+and from bootstrapped tool sheds.
+"""
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+)
+
+from galaxy.model.tool_shed_install import ToolShedRepository
+from galaxy.tool_shed.galaxy_install.client import InstallationTarget
+from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
+from galaxy.tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
+from galaxy.tool_shed.unittest_utils import StandaloneInstallationTarget
+from galaxy.tool_shed.util.repository_util import check_for_updates
+from galaxy.util.tool_shed.tool_shed_registry import DEFAULT_TOOL_SHED_URL
+
+
+def test_against_production_shed(tmp_path: Path):
+    repo_owner = "iuc"
+    repo_name = "collection_column_join"
+    repo_revision = "dfde09461b1e"
+
+    install_target: InstallationTarget = StandaloneInstallationTarget(tmp_path)
+    install_manager = InstallRepositoryManager(install_target)
+    install_options: Dict[str, Any] = {}
+    install_manager.install(
+        DEFAULT_TOOL_SHED_URL,
+        repo_name,
+        repo_owner,
+        repo_revision,  # revision 2, a known installable revision
+        install_options,
+    )
+    with open(tmp_path / "shed_conf.xml", "r") as f:
+        assert "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.2" in f.read()
+    repo_path = tmp_path / "tools" / "toolshed.g2.bx.psu.edu" / "repos" / repo_owner / repo_name / repo_revision
+    assert repo_path.exists()
+
+    install_model_context = install_target.install_model.context
+    query = install_model_context.query(ToolShedRepository).where(ToolShedRepository.name == repo_name)
+    tsr = query.first()
+    assert tsr
+    message, status = check_for_updates(
+        install_target.tool_shed_registry,
+        install_model_context,
+        tsr.id,
+    )
+    assert status
+
+    irm = InstalledRepositoryManager(install_target)
+    errors = irm.uninstall_repository(repository=tsr, remove_from_disk=True)
+    assert not errors
+
+    with open(tmp_path / "shed_conf.xml", "r") as f:
+        assert "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.2" not in f.read()
+
+    repo_path = tmp_path / "tools" / "toolshed.g2.bx.psu.edu" / "repos" / repo_owner / repo_name / repo_revision
+    assert not repo_path.exists()

--- a/test/unit/app/tools/test_toolbox.py
+++ b/test/unit/app/tools/test_toolbox.py
@@ -81,7 +81,7 @@ class BaseToolBoxTestCase(TestCase, UsesTools):
     @property
     def toolbox(self):
         if self._toolbox is None:
-            self.app.toolbox = self._toolbox = SimplifiedToolBox(self)
+            self.app._toolbox = self._toolbox = SimplifiedToolBox(self)
         return self._toolbox
 
     def setUp(self):

--- a/test/unit/shed_unit/test_installed_repository_manager.py
+++ b/test/unit/shed_unit/test_installed_repository_manager.py
@@ -25,7 +25,7 @@ class ToolShedRepoBaseTestCase(BaseToolBoxTestCase):
         self._init_dynamic_tool_conf()
         self.app.config.tool_configs = self.config_files
         self.app.config.manage_dependency_relationships = False
-        self.app.toolbox = self.toolbox
+        self.app._toolbox = self.toolbox
 
     def _setup_repository(self):
         return self._repo_install(changeset="1", config_filename=self.config_files[0])

--- a/test/unit/workflows/workflow_support.py
+++ b/test/unit/workflows/workflow_support.py
@@ -33,7 +33,7 @@ class MockTrans:
 class MockApp(galaxy_mock.MockApp):
     def __init__(self):
         super().__init__()
-        self.toolbox = MockToolbox()
+        self._toolbox = MockToolbox()
         self.workflow_manager = WorkflowsManager(self)
 
 


### PR DESCRIPTION
- Introduce a MyPy Protocol that describes what part of "app" is consumed by essentially all the tool shed install and management code - called ``InstallationTarget``.
- Implement a standalone class (``StandaloneInstallationTarget`` ) that doesn't depend on anything in ``galaxy-app`` and can be used to install tools, repositories, data managers, etc... into a directory, manage a simplified toolbox, manage tool data, etc...
- Introduce an abstraction for the client interaction in the tool shed tests and move all existing implementation details into a "Galaxy API" version. 
- Introduce a second test client interaction implementation that uses a ``StandaloneInstallationTarget`` - update CI to run tool shed tests against both in a matrix strategy - so we are testing the Galaxy API as well as the new client install library functionality.

Builds on:
- [x] #14824 
- [x] #14822 
- [x] #14811
- [x] Dozens of already merged PRs obviously.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
