### PR TITLE
Fix tool linting with comments

### DIFF
--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -1,5 +1,8 @@
 """This module contains a linting functions for tool outputs."""
-from galaxy.util import string_as_bool
+from galaxy.util import (
+    etree,
+    string_as_bool,
+)
 from ._util import is_valid_cheetah_placeholder
 from ..parser.output_collection_def import NAMED_PATTERNS
 
@@ -20,6 +23,8 @@ def lint_output(tool_xml, lint_ctx):
     labels = set()
     names = set()
     for output in list(outputs[0]):
+        if output.tag is etree.Comment:
+            continue
         if output.tag not in ["data", "collection"]:
             lint_ctx.warn(f"Unknown element found in outputs [{output.tag}]", node=output)
             continue

--- a/lib/galaxy/tool_util/linters/stdio.py
+++ b/lib/galaxy/tool_util/linters/stdio.py
@@ -1,6 +1,7 @@
 """This module contains a linting functions for tool error detection."""
 import re
 
+from galaxy.util import etree
 from .command import get_command
 
 
@@ -37,6 +38,8 @@ def lint_stdio(tool_source, lint_ctx):
 
     stdio = stdios[0]
     for child in list(stdio):
+        if child.tag is etree.Comment:
+            continue
         if child.tag == "regex":
             _lint_regex(tool_xml, child, lint_ctx)
         elif child.tag == "exit_code":


### PR DESCRIPTION
Fixes #14836

Galaxy and the tests for tool linting strip all comments from the XML source by default so the tests couldn't catch this.

Keeping the XML source intact is important for the tools language server so the document location information is accurate and matches the actual XML document we are editing.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
