### PR TITLE
Test upgrade to bootstrap-vue 2.23.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,7 @@
     "babel-runtime": "^6.26.0",
     "backbone": "1.4.1",
     "bootstrap": "4.6",
-    "bootstrap-vue": "^2.21.2",
+    "bootstrap-vue": "^2.23.0",
     "citation-js": "^0.6.4",
     "core-js": "^3.21.0",
     "csv-parse": "^5.3.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2808,10 +2808,10 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap-vue@^2.21.2:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/bootstrap-vue/-/bootstrap-vue-2.22.0.tgz#2b3d7926d24af0bd289ddce7ba76b07000aab3e5"
-  integrity sha512-denjR/ae0K7Jrcqud3TrZWw0p/crtyigeGUNunWQ4t+KFi+7rzJ6j6lx1W5/gpUtSSUgNbWrXcHH4lIWXzXOOQ==
+bootstrap-vue@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-vue/-/bootstrap-vue-2.23.0.tgz#b1013392146852172e8076330169ea6aace2a130"
+  integrity sha512-cue/PixZ9p3SF7+x0necSE5jkwHWcBeDtUn8/MIWvqh0p5uxWjW3qIMep4cro6wte6ASJ7jGWhTaqHDtdMgHow==
   dependencies:
     "@nuxt/opencollective" "^0.3.2"
     bootstrap "^4.6.1"


### PR DESCRIPTION
Smoke testing the new version; this release is supposed to provide preliminary/bridge support for vue3 using `@vue/compat` prior to a new release targeting 3 from the ground up.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
