### PR TITLE
make solo fontawesome elements render attached tooltips properly

### DIFF
--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -8,18 +8,15 @@
             <font-awesome-icon icon="caret-down" />
             <span class="workflow-dropdown-name">{{ workflow.name }}</span>
         </b-link>
-        <font-awesome-icon
+        <span
             v-if="sourceType.includes('trs')"
             v-b-tooltip.hover
-            :title="`Imported from TRS ID (version ${workflow.source_metadata.trs_version_id})`"
-            icon="check"
-            class="workflow-trs-icon" />
-        <font-awesome-icon
-            v-if="sourceType == 'url'"
-            v-b-tooltip.hover
-            :title="`Imported from ${workflow.source_metadata.url}`"
-            class="workflow-external-link"
-            icon="link" />
+            :title="`Imported from TRS ID (version ${workflow.source_metadata.trs_version_id})`">
+            <font-awesome-icon icon="check" class="workflow-trs-icon" />
+        </span>
+        <span v-if="sourceType == 'url'" v-b-tooltip.hover :title="`Imported from ${workflow.source_metadata.url}`">
+            <font-awesome-icon class="workflow-external-link" icon="link" />
+        </span>
         <p v-if="workflow.description" class="workflow-dropdown-description">{{ workflow.description }}</p>
         <div class="dropdown-menu" aria-labelledby="workflow-dropdown">
             <a


### PR DESCRIPTION
It seems that if the tooltip element is added directly to the `<font-awesome-icon>` element it is never rendered properly. Wrapping it in a different element and moving the tooltip there is a possible workaround. Is there a better solution? 

closes https://github.com/galaxyproject/galaxy/issues/14855

There are more places in the codebase where this does not work, I am happy to fix these once we agree on an approach.

before
![Galaxy](https://user-images.githubusercontent.com/1814954/197885257-db9681e2-ad84-4e30-9069-3aae420a3f72.png)

after
![Galaxy___martenson](https://user-images.githubusercontent.com/1814954/197885349-e1bec176-8f16-4f16-a059-ac5e86c2a32d.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. import a workflow from TRS
  2. check that the tooltip renders on hover

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
