### PR TITLE
[22.05] Cherry pick #14807 and add test for /api/container_resolvers/resolve

### DIFF
--- a/lib/galaxy/tool_util/deps/views.py
+++ b/lib/galaxy/tool_util/deps/views.py
@@ -403,7 +403,7 @@ class ContainerResolutionView:
 
     @property
     def _container_resolvers(self):
-        return self._app.container_finder.container_resolvers
+        return self._app.container_finder.default_container_registry.container_resolvers
 
     def _container_resolver(self, index):
         index = int(index)

--- a/lib/galaxy/tool_util/deps/views.py
+++ b/lib/galaxy/tool_util/deps/views.py
@@ -340,7 +340,7 @@ class ContainerResolutionView:
     def show(self, index):
         return self._container_resolver(index).to_dict()
 
-    def resolve(self, **kwds):
+    def resolve(self, index=None, **kwds):
         find_best_kwds = {
             "install": False,
             "enabled_container_types": ["docker", "singularity"],
@@ -348,8 +348,8 @@ class ContainerResolutionView:
             "session": kwds.get("session"),
         }
 
-        if "index" in kwds:
-            find_best_kwds["index"] = int(kwds["index"])
+        if index is not None:
+            find_best_kwds["index"] = int(index)
         if "container_type" in kwds:
             find_best_kwds["enabled_container_types"] = [kwds["container_type"]]
         if "resolver_type" in kwds:

--- a/lib/galaxy/webapps/galaxy/api/container_resolution.py
+++ b/lib/galaxy/webapps/galaxy/api/container_resolution.py
@@ -31,11 +31,11 @@ class ContainerResolutionAPIController(BaseGalaxyAPIController):
 
     @expose_api
     @require_admin
-    def show(self, trans, id):
+    def show(self, trans, index):
         """
         GET /api/container_resolvers/<id>
         """
-        return self._view.show(id)
+        return self._view.show(index)
 
     @expose_api
     @require_admin

--- a/lib/galaxy_test/api/test_container_resolution.py
+++ b/lib/galaxy_test/api/test_container_resolution.py
@@ -1,3 +1,4 @@
+from galaxy_test.base.populators import skip_without_tool
 from ._framework import ApiTestCase
 
 
@@ -11,3 +12,15 @@ class ContainerResolutionApiTestCase(ApiTestCase):
         response = self._get("container_resolvers/0", admin=True)
         assert response.status_code == 200
         assert isinstance(response.json(), dict)
+
+    @skip_without_tool("cat1")
+    def test_resolve(self):
+        tool_id = "cat1"
+
+        # no index
+        response = self._get(f"container_resolvers/resolve?tool_id={tool_id}", admin=True)
+        assert response.status_code == 200
+
+        # with index
+        response = self._get(f"container_resolvers/0/resolve?tool_id={tool_id}", admin=True)
+        assert response.status_code == 200

--- a/lib/galaxy_test/api/test_container_resolution.py
+++ b/lib/galaxy_test/api/test_container_resolution.py
@@ -1,8 +1,7 @@
 from ._framework import ApiTestCase
 
 
-class ContainerResolversApiTestCase(ApiTestCase):
-
+class ContainerResolutionApiTestCase(ApiTestCase):
     def test_index(self):
         response = self._get("container_resolvers", admin=True)
         assert response.status_code == 200

--- a/lib/galaxy_test/api/test_container_resolvers.py
+++ b/lib/galaxy_test/api/test_container_resolvers.py
@@ -1,5 +1,6 @@
 from ._framework import ApiTestCase
 
+
 class ContainerResolversApiTestCase(ApiTestCase):
 
     def test_index(self):
@@ -8,6 +9,6 @@ class ContainerResolversApiTestCase(ApiTestCase):
         assert isinstance(response.json(), list)
 
     def test_show(self):
-        response = self._get("container_resolvers/0",  admin=True)
+        response = self._get("container_resolvers/0", admin=True)
         assert response.status_code == 200
         assert isinstance(response.json(), dict)

--- a/lib/galaxy_test/api/test_container_resolvers.py
+++ b/lib/galaxy_test/api/test_container_resolvers.py
@@ -1,0 +1,13 @@
+from ._framework import ApiTestCase
+
+class ContainerResolversApiTestCase(ApiTestCase):
+
+    def test_index(self):
+        response = self._get("container_resolvers", admin=True)
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+
+    def test_show(self):
+        response = self._get("container_resolvers/0",  admin=True)
+        assert response.status_code == 200
+        assert isinstance(response.json(), dict)


### PR DESCRIPTION
Cherry pick commits from #14807 for 22.05.  Add a commit to fix /api/container_resolvers/resolve which has an error, and a test for this endpoint.
/api/container_resolvers/resolve currently has an error but /api/container_resolvers/{index}/resolve is OK.

Adding broken test followed by change that should fix it.

## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
