### PR TITLE
Visible marker to distinguish required/optional tool params

### DIFF
--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -57,11 +57,11 @@ export default {
         },
         collapsedEnableIcon: {
             type: String,
-            default: "fa fa-caret-square-o-down",
+            default: "far fa-caret-square-down",
         },
         collapsedDisableIcon: {
             type: String,
-            default: "fa fa-caret-square-o-up",
+            default: "far fa-caret-square-up",
         },
         validationScrollTo: {
             type: Array,

--- a/client/src/components/Form/FormElement.test.js
+++ b/client/src/components/Form/FormElement.test.js
@@ -34,7 +34,7 @@ describe("FormElement", () => {
         expect(no_error.length).toBe(0);
 
         const title = wrapper.find(".ui-form-title");
-        expect(title.text()).toBe("title_text");
+        expect(title.text()).toContain("title_text");
     });
 
     it("check collapsibles and other features", async () => {
@@ -76,5 +76,23 @@ describe("FormElement", () => {
         await wrapper.setProps({ attributes: { titleonly: true } });
         expect(wrapper.findComponent(FormHidden).exists()).toBe(true);
         expect(wrapper.findComponent(FormInput).exists()).toBe(false);
+    });
+
+    it("marks required values", async () => {
+        await wrapper.setProps({ type: "text", attributes: { optional: false } });
+        expect(wrapper.find(".ui-form-title-star").exists()).toBe(true);
+        expect(wrapper.find(".ui-form-title-message").exists()).toBe(false);
+    });
+
+    it("marks optional values", async () => {
+        await wrapper.setProps({ type: "text", attributes: { optional: true } });
+        expect(wrapper.find(".ui-form-title-star").exists()).toBe(false);
+        expect(wrapper.find(".ui-form-title-message").text()).toContain("optional");
+    });
+
+    it("warns about empty required values", async () => {
+        await wrapper.setProps({ type: "text", value: "", attributes: { optional: false } });
+        expect(wrapper.find(".ui-form-title-star").exists()).toBe(true);
+        expect(wrapper.find(".ui-form-title-message").text()).toContain("required");
     });
 });

--- a/client/src/components/Form/FormElement.test.js
+++ b/client/src/components/Form/FormElement.test.js
@@ -44,7 +44,9 @@ describe("FormElement", () => {
         await wrapper.setProps({ disabled: false });
         expect(wrapper.findAll(".ui-form-field").length).toEqual(1);
 
-        await wrapper.setProps({ default_value: "default_value", collapsible_value: "collapsible_value" });
+        await wrapper.setProps({
+            attributes: { default_value: "default_value", collapsible_value: "collapsible_value" },
+        });
         expect(wrapper.find(".ui-form-title-text").text()).toEqual("title_text");
         expect(wrapper.findAll("button[title='Disable']").length).toEqual(1);
         expect(wrapper.emitted().input[0][0]).toEqual("initial_value");

--- a/client/src/components/Form/FormElement.test.js
+++ b/client/src/components/Form/FormElement.test.js
@@ -1,6 +1,8 @@
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import FormElement from "./FormElement";
+import FormHidden from "./Elements/FormHidden";
+import FormInput from "./Elements/FormInput";
 
 const localVue = getLocalVue();
 
@@ -17,21 +19,20 @@ describe("FormElement", () => {
                 title: "title_text",
             },
             localVue,
-            stubs: {
-                FormInput: { template: "<div>form-input</div>" },
-                FormHidden: { template: "<div>form-hidden</div>" },
-            },
         });
     });
 
     it("check props", async () => {
         const help = wrapper.find(".ui-form-info");
         expect(help.text()).toBe("help_text");
+
         const error = wrapper.find(".ui-form-error-text");
         expect(error.text()).toBe("error_text");
+
         await wrapper.setProps({ error: "" });
         const no_error = wrapper.findAll(".ui-form-error");
         expect(no_error.length).toBe(0);
+
         const title = wrapper.find(".ui-form-title");
         expect(title.text()).toBe("title_text");
     });
@@ -39,31 +40,39 @@ describe("FormElement", () => {
     it("check collapsibles and other features", async () => {
         await wrapper.setProps({ disabled: true });
         expect(wrapper.findAll(".ui-form-field").length).toEqual(0);
+
         await wrapper.setProps({ disabled: false });
         expect(wrapper.findAll(".ui-form-field").length).toEqual(1);
+
         await wrapper.setProps({ default_value: "default_value", collapsible_value: "collapsible_value" });
         expect(wrapper.find(".ui-form-title-text").text()).toEqual("title_text");
-        expect(wrapper.findAll("span[title='Disable']").length).toEqual(1);
+        expect(wrapper.findAll("button[title='Disable']").length).toEqual(1);
         expect(wrapper.emitted().input[0][0]).toEqual("initial_value");
+
         await wrapper.find(".ui-form-collapsible-icon").trigger("click");
         expect(wrapper.emitted().input[1][0]).toEqual("collapsible_value");
         expect(wrapper.emitted().input[1][1]).toEqual("input");
+
         await wrapper.setProps({
             collapsedEnableText: "Enable Collapsible",
             collapsedDisableText: "Disable Collapsible",
         });
-        expect(wrapper.findAll("span[title='Enable Collapsible']").length).toEqual(1);
-        expect(wrapper.findAll("span[title='Disable Collapsible']").length).toEqual(0);
+        expect(wrapper.findAll("button[title='Enable Collapsible']").length).toEqual(1);
+        expect(wrapper.findAll("button[title='Disable Collapsible']").length).toEqual(0);
+
         await wrapper.find(".ui-form-collapsible-icon").trigger("click");
         expect(wrapper.emitted().input[2][0]).toEqual("default_value");
-        expect(wrapper.findAll("span[title='Disable Collapsible']").length).toEqual(1);
-        expect(wrapper.findAll("span[title='Enable Collapsible']").length).toEqual(0);
+        expect(wrapper.findAll("button[title='Disable Collapsible']").length).toEqual(1);
+        expect(wrapper.findAll("button[title='Enable Collapsible']").length).toEqual(0);
     });
 
     it("check type matching", async () => {
         await wrapper.setProps({ type: "text" });
-        expect(wrapper.find("div[id='input'").text()).toEqual("form-input");
+        expect(wrapper.findComponent(FormInput).exists()).toBe(true);
+        expect(wrapper.findComponent(FormHidden).exists()).toBe(false);
+
         await wrapper.setProps({ attributes: { titleonly: true } });
-        expect(wrapper.find("div[id='input'").text()).toEqual("form-hidden");
+        expect(wrapper.findComponent(FormHidden).exists()).toBe(true);
+        expect(wrapper.findComponent(FormInput).exists()).toBe(false);
     });
 });

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -276,10 +276,6 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
     .ui-form-title {
         word-wrap: break-word;
         font-weight: bold;
-        .icon {
-            cursor: pointer;
-            font-size: 1.2em;
-        }
 
         .ui-form-title-message {
             font-size: $font-size-base * 0.7;

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -210,7 +210,7 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
             <span class="ui-form-error-text" v-html="props.error" />
         </div>
 
-        <div v-if="props.title" class="ui-form-title">
+        <div class="ui-form-title">
             <span v-if="collapsible || connectable">
                 <b-button
                     v-if="collapsible && !connected"
@@ -226,14 +226,14 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                     <FontAwesomeIcon v-else :icon="props.connectedDisableIcon" />
                 </b-button>
 
-                <span class="ui-form-title-text ml-1">
+                <span v-if="props.title" class="ui-form-title-text ml-1">
                     {{ props.title }}
                 </span>
             </span>
-            <span v-else class="ui-form-title-text">{{ props.title }}</span>
+            <span v-else-if="props.title" class="ui-form-title-text">{{ props.title }}</span>
 
             <span
-                v-if="isRequired && isRequiredType"
+                v-if="isRequired && isRequiredType && props.title"
                 v-b-tooltip.hover
                 class="ui-form-title-star"
                 title="required"
@@ -241,7 +241,7 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 *
                 <span v-if="isEmpty" class="ui-form-title-message warning"> required </span>
             </span>
-            <span v-else-if="isRequiredType" class="ui-form-title-message"> - optional </span>
+            <span v-else-if="isRequiredType && props.title" class="ui-form-title-message"> - optional </span>
         </div>
 
         <div v-if="showField" class="ui-form-field" :data-label="props.title">

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -180,7 +180,7 @@ const isEmpty = computed(() => {
         return true;
     }
 
-    if (["text", "integer", "float"].includes(props.type) && currentValue.value === "") {
+    if (["text", "integer", "float", "password"].includes(props.type) && currentValue.value === "") {
         return true;
     }
 

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -175,9 +175,18 @@ const isHiddenType = computed(
 const collapseText = computed(() => (collapsed.value ? props.collapsedEnableText : props.collapsedDisableText));
 const connectText = computed(() => (connected.value ? props.connectedEnableText : props.connectedDisableText));
 
-const isEmpty = computed(
-    () => currentValue.value === null || currentValue.value === undefined || currentValue.value === ""
-);
+const isEmpty = computed(() => {
+    if (currentValue.value === null || currentValue.value === undefined) {
+        return true;
+    }
+
+    if (["text", "integer", "float"].includes(props.type) && currentValue.value === "") {
+        return true;
+    }
+
+    return false;
+});
+
 const isRequired = computed(() => attrs.value["optional"] === false);
 const isRequiredType = computed(() => props.type !== "boolean");
 </script>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -174,6 +174,12 @@ const isHiddenType = computed(
 
 const collapseText = computed(() => (collapsed.value ? props.collapsedEnableText : props.collapsedDisableText));
 const connectText = computed(() => (connected.value ? props.connectedEnableText : props.connectedDisableText));
+
+const isEmpty = computed(
+    () => currentValue.value === null || currentValue.value === undefined || currentValue.value === ""
+);
+const isRequired = computed(() => attrs.value["optional"] === false);
+const isRequiredType = computed(() => props.type !== "boolean");
 </script>
 
 <script>
@@ -216,6 +222,17 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 </span>
             </div>
             <span v-else class="ui-form-title-text">{{ props.title }}</span>
+
+            <span
+                v-if="isRequired && isRequiredType"
+                v-b-tooltip.hover
+                class="ui-form-title-star"
+                title="required"
+                :class="{ warning: isEmpty }">
+                *
+                <span v-if="isEmpty" class="ui-form-title-message warning"> required </span>
+            </span>
+            <span v-else-if="isRequiredType" class="ui-form-title-message"> - optional </span>
         </div>
 
         <div v-if="showField" class="ui-form-field" :data-label="props.title">
@@ -262,6 +279,24 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
         .icon {
             cursor: pointer;
             font-size: 1.2em;
+        }
+
+        .ui-form-title-message {
+            font-size: $font-size-base * 0.7;
+            font-weight: 300;
+            vertical-align: text-top;
+            color: $text-light;
+            cursor: default;
+        }
+
+        .ui-form-title-star {
+            color: $text-light;
+            font-weight: 300;
+            cursor: default;
+        }
+
+        .warning {
+            color: $brand-danger;
         }
     }
 

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -202,7 +202,7 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
         </div>
 
         <div v-if="props.title" class="ui-form-title">
-            <div v-if="collapsible || connectable">
+            <span v-if="collapsible || connectable">
                 <b-button
                     v-if="collapsible && !connected"
                     class="ui-form-collapsible-icon"
@@ -220,7 +220,7 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 <span class="ui-form-title-text ml-1">
                     {{ props.title }}
                 </span>
-            </div>
+            </span>
             <span v-else class="ui-form-title-text">{{ props.title }}</span>
 
             <span

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -89,6 +89,11 @@ const props = defineProps({
 
 const emit = defineEmits(["input", "change"]);
 
+/** TODO: remove attrs computed.
+ useAttrs is *not* reactive, and does not play nice with type safety.
+ It is present for compatibility with the legacy "FormParameter" component,
+ but should be removed as soon as that component is removed.
+ */
 const attrs = computed(() => props.attributes || useAttrs());
 const collapsibleValue = computed(() => attrs.value["collapsible_value"]);
 const defaultValue = computed(() => attrs.value["default_value"]);

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -1,5 +1,4 @@
 <script setup>
-import _ from "underscore";
 import FormBoolean from "./Elements/FormBoolean";
 import FormHidden from "./Elements/FormHidden";
 import FormInput from "./Elements/FormInput";
@@ -144,7 +143,7 @@ const elementId = computed(() => `form-element-${props.id}`);
 const hasError = computed(() => Boolean(props.error));
 const showPreview = computed(() => (collapsed.value && attrs.value["collapsible_preview"]) || props.disabled);
 
-const previewText = computed(() => _.escape(this.textValue).replace(/\n/g, "<br>"));
+const previewText = computed(() => attrs.value["text_value"]);
 const helpText = computed(() => {
     const helpArgument = attrs.value["argument"];
     if (helpArgument && !props.help.includes(`(${helpArgument})`)) {
@@ -236,15 +235,59 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
             <FormInput v-else :id="props.id" v-model="currentValue" :area="attrs['area']" />
         </div>
 
-        <div v-if="showPreview" class="ui-form-preview" v-html="previewText" />
+        <div v-if="showPreview" class="ui-form-preview pt-1 pl-2 mt-1">{{ previewText }}</div>
         <span v-if="Boolean(helpText)" class="ui-form-info form-text text-muted" v-html="helpText" />
     </div>
 </template>
 
 <style lang="scss" scoped>
 @import "theme/blue.scss";
+@import "~@fortawesome/fontawesome-free/scss/_variables";
 
 .ui-form-element {
+    margin-top: $margin-v * 0.25;
+    margin-bottom: $margin-v * 0.25;
+    overflow: visible;
+    clear: both;
+
+    .ui-form-title {
+        word-wrap: break-word;
+        font-weight: bold;
+        .icon {
+            cursor: pointer;
+            font-size: 1.2em;
+        }
+    }
+
+    .ui-form-field {
+        position: relative;
+        margin-top: $margin-v * 0.25;
+        .ui-form-wp-source {
+            border-left-width: 10px;
+        }
+
+        .ui-form-wp-target {
+            box-shadow: none;
+            border-top: none;
+            border-bottom: none;
+            border-right: none;
+            border-left-width: 5px;
+            font-style: italic;
+        }
+
+        .ui-form-backdrop {
+            z-index: 10;
+            position: absolute;
+            top: 0px;
+            width: 100%;
+            height: 100%;
+            background: $white;
+            display: block;
+            opacity: 0;
+            cursor: default;
+        }
+    }
+
     &:deep(.ui-form-collapsible-icon),
     &:deep(.ui-form-connected-icon) {
         border: none;

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -303,30 +303,6 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
     .ui-form-field {
         position: relative;
         margin-top: $margin-v * 0.25;
-        .ui-form-wp-source {
-            border-left-width: 10px;
-        }
-
-        .ui-form-wp-target {
-            box-shadow: none;
-            border-top: none;
-            border-bottom: none;
-            border-right: none;
-            border-left-width: 5px;
-            font-style: italic;
-        }
-
-        .ui-form-backdrop {
-            z-index: 10;
-            position: absolute;
-            top: 0px;
-            width: 100%;
-            height: 100%;
-            background: $white;
-            display: block;
-            opacity: 0;
-            cursor: default;
-        }
     }
 
     &:deep(.ui-form-collapsible-icon),

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -142,6 +142,7 @@ const isHidden = computed(() => attrs.value["hidden"]);
 const elementId = computed(() => `form-element-${props.id}`);
 const hasError = computed(() => Boolean(props.error));
 const showPreview = computed(() => (collapsed.value && attrs.value["collapsible_preview"]) || props.disabled);
+const showField = computed(() => !collapsed.value && !props.disabled.value);
 
 const previewText = computed(() => attrs.value["text_value"]);
 const helpText = computed(() => {
@@ -212,7 +213,7 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
             <span v-else class="ui-form-title-text">{{ props.title }}</span>
         </div>
 
-        <div v-if="!collapsed && !disabled" class="ui-form-field" :data-label="props.title">
+        <div v-if="showField" class="ui-form-field" :data-label="props.title">
             <FormBoolean v-if="props.type === 'boolean'" :id="props.id" v-model="currentValue" />
             <FormHidden v-else-if="isHiddenType" :id="props.id" v-model="currentValue" :info="attrs['info']" />
             <FormNumber

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -1,54 +1,4 @@
-<template>
-    <div v-show="!isHidden" :id="elementId" :class="['ui-form-element section-row', cls]">
-        <div v-if="hasError" class="ui-form-error">
-            <span class="fa fa-exclamation mr-1" />
-            <span class="ui-form-error-text" v-html="error" />
-        </div>
-        <div class="ui-form-title">
-            <div v-if="collapsible || connectable">
-                <span v-if="collapsible && !connected" class="ui-form-collapsible-icon icon" @click="onCollapse">
-                    <span v-if="collapsed" :class="collapsedEnableIcon" :title="collapsedEnableText" />
-                    <span v-else :class="collapsedDisableIcon" :title="collapsedDisableText" />
-                </span>
-                <span v-if="connectable" class="ui-form-connected-icon icon" @click="onConnect">
-                    <span v-if="connected" :class="connectedEnableIcon" :title="connectedEnableText" />
-                    <span v-else :class="connectedDisableIcon" :title="connectedDisableText" />
-                </span>
-                <span v-if="title" class="ui-form-title-text ml-1">
-                    {{ title }}
-                </span>
-            </div>
-            <span v-else-if="title" class="ui-form-title-text">{{ title }}</span>
-        </div>
-        <div v-if="showField" class="ui-form-field" :data-label="title">
-            <FormBoolean v-if="type == 'boolean'" :id="id" v-model="currentValue" />
-            <FormHidden v-else-if="isHiddenType" :id="id" v-model="currentValue" :info="attrs['info']" />
-            <FormNumber
-                v-else-if="type == 'integer' || type == 'float'"
-                :id="id"
-                v-model="currentValue"
-                :max="attrs.max"
-                :min="attrs.min"
-                :type="type"
-                :workflow-building-mode="workflowBuildingMode" />
-            <FormColor v-else-if="type == 'color'" :id="id" v-model="currentValue" />
-            <FormDirectory v-else-if="type == 'directory_uri'" v-model="currentValue" />
-            <FormParameter
-                v-else-if="backbonejs"
-                :id="id"
-                ref="params"
-                v-model="currentValue"
-                :data-label="title"
-                :type="type"
-                :attributes="attrs" />
-            <FormInput v-else :id="id" v-model="currentValue" :area="attrs['area']" />
-        </div>
-        <div v-if="showPreview" class="ui-form-preview" v-html="previewText" />
-        <span v-if="!!helpText" class="ui-form-info form-text text-muted" v-html="helpText" />
-    </div>
-</template>
-
-<script>
+<script setup>
 import _ from "underscore";
 import FormBoolean from "./Elements/FormBoolean";
 import FormHidden from "./Elements/FormHidden";
@@ -57,214 +7,263 @@ import FormParameter from "./Elements/FormParameter";
 import FormColor from "./Elements/FormColor";
 import FormDirectory from "./Elements/FormDirectory";
 import FormNumber from "./Elements/FormNumber";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { ref, computed, useAttrs } from "vue";
 
-export default {
-    components: {
-        FormBoolean,
-        FormHidden,
-        FormInput,
-        FormNumber,
-        FormColor,
-        FormParameter,
-        FormDirectory,
+const props = defineProps({
+    id: {
+        type: String,
+        default: "identifier",
     },
-    props: {
-        id: {
-            type: String,
-            default: "identifer",
-        },
-        type: {
-            type: String,
-            default: "",
-        },
-        value: {
-            default: null,
-        },
-        title: {
-            type: String,
-            default: null,
-        },
-        refreshOnChange: {
-            type: Boolean,
-            default: false,
-        },
-        help: {
-            type: String,
-            default: null,
-        },
-        error: {
-            type: String,
-            default: null,
-        },
-        backbonejs: {
-            type: Boolean,
-            default: false,
-        },
-        disabled: {
-            type: Boolean,
-            default: false,
-        },
-        attributes: {
-            type: Object,
-            default: null,
-        },
-        collapsedEnableText: {
-            type: String,
-            default: "Enable",
-        },
-        collapsedDisableText: {
-            type: String,
-            default: "Disable",
-        },
-        collapsedEnableIcon: {
-            type: String,
-            default: "fa fa-caret-square-o-down",
-        },
-        collapsedDisableIcon: {
-            type: String,
-            default: "fa fa-caret-square-o-up",
-        },
-        connectedEnableText: {
-            type: String,
-            default: "Remove connection from module.",
-        },
-        connectedDisableText: {
-            type: String,
-            default: "Add connection to module.",
-        },
-        connectedEnableIcon: {
-            type: String,
-            default: "fa fa fa-times",
-        },
-        connectedDisableIcon: {
-            type: String,
-            default: "fa fa-arrows-h",
-        },
-        workflowBuildingMode: {
-            type: Boolean,
-            default: false,
-        },
+    type: {
+        type: String,
+        default: null,
     },
-    data() {
-        return {
-            collapsed: false,
-            connected: false,
-            connectedValue: { __class__: "ConnectedValue" },
-        };
+    value: {
+        default: null,
     },
-    computed: {
-        elementId() {
-            return `form-element-${this.id}`;
-        },
-        argument() {
-            return this.attrs["argument"];
-        },
-        attrs() {
-            return this.attributes || this.$attrs;
-        },
-        cls() {
-            return this.hasError && "alert alert-info";
-        },
-        collapsible() {
-            return !this.disabled && this.collapsibleValue !== undefined;
-        },
-        collapsibleValue() {
-            return this.attrs["collapsible_value"];
-        },
-        collapsiblePreview() {
-            return this.attrs["collapsible_preview"];
-        },
-        connectable() {
-            return this.collapsible && this.attrs["connectable"];
-        },
-        currentValue: {
-            get() {
-                return this.value;
-            },
-            set(val) {
-                this.setValue(val);
-            },
-        },
-        defaultValue() {
-            return this.attrs["default_value"];
-        },
-        hasError() {
-            return !!this.error;
-        },
-        helpText() {
-            const help = this.help;
-            const helpArgument = this.argument;
-            if (helpArgument && help.indexOf(`(${helpArgument})`) == -1) {
-                return `${help} (${helpArgument})`;
-            }
-            return help;
-        },
-        isHidden() {
-            return this.attrs["hidden"];
-        },
-        isHiddenType() {
-            return (
-                ["hidden", "hidden_data", "baseurl"].includes(this.type) ||
-                (this.attributes && this.attributes.titleonly)
-            );
-        },
-        previewText() {
-            return _.escape(this.textValue).replace(/\n/g, "<br>");
-        },
-        showField() {
-            return !this.collapsed && !this.disabled;
-        },
-        showPreview() {
-            return (this.collapsed && this.collapsiblePreview) || this.disabled;
-        },
-        textValue() {
-            return this.attrs["text_value"];
-        },
+    title: {
+        type: String,
+        default: null,
     },
-    created() {
-        this.initialState();
+    refreshOnChange: {
+        type: Boolean,
+        default: false,
     },
-    methods: {
-        /** Submits a changed value. */
-        setValue(value) {
-            this.$emit("input", value, this.id);
-            this.$emit("change", this.refreshOnChange);
-        },
-        /**
-         * Determines to wether expand or collapse the input.
-         */
-        initialState() {
-            this.setValue(this.value);
-            const collapsibleValue = this.collapsibleValue;
-            const value = JSON.stringify(this.value);
-            this.connected = value == JSON.stringify(this.connectedValue);
-            this.collapsed =
-                this.connected || (collapsibleValue !== undefined && value == JSON.stringify(collapsibleValue));
-        },
-        /**
-         * Handles collapsible toggle.
-         */
-        onCollapse() {
-            this.collapsed = !this.collapsed;
-            this.connected = false;
-            if (this.collapsed) {
-                this.setValue(this.collapsibleValue);
-            } else {
-                this.setValue(this.defaultValue);
-            }
-        },
-        /**
-         * Handles connected state.
-         */
-        onConnect() {
-            this.connected = !this.connected;
-            this.collapsed = this.connected;
-            if (this.connected) {
-                this.setValue(this.connectedValue);
-            } else {
-                this.setValue(this.defaultValue);
-            }
-        },
+    help: {
+        type: String,
+        default: null,
     },
-};
+    error: {
+        type: String,
+        default: null,
+    },
+    backbonejs: {
+        type: Boolean,
+        default: false,
+    },
+    disabled: {
+        type: Boolean,
+        default: false,
+    },
+    attributes: {
+        type: Object,
+        default: null,
+    },
+    collapsedEnableText: {
+        type: String,
+        default: "Enable",
+    },
+    collapsedDisableText: {
+        type: String,
+        default: "Disable",
+    },
+    collapsedEnableIcon: {
+        type: String,
+        default: "far fa-caret-square-down",
+    },
+    collapsedDisableIcon: {
+        type: String,
+        default: "far fa-caret-square-up",
+    },
+    connectedEnableText: {
+        type: String,
+        default: "Remove connection from module.",
+    },
+    connectedDisableText: {
+        type: String,
+        default: "Add connection to module.",
+    },
+    connectedEnableIcon: {
+        type: String,
+        default: "fa fa-times",
+    },
+    connectedDisableIcon: {
+        type: String,
+        default: "fa fa-arrows-alt-h",
+    },
+    workflowBuildingMode: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const emit = defineEmits(["input", "change"]);
+
+const attrs = computed(() => props.attributes || useAttrs());
+const collapsibleValue = computed(() => attrs.value["collapsible_value"]);
+const defaultValue = computed(() => attrs.value["default_value"]);
+const connectedValue = { __class__: "ConnectedValue" };
+
+const connected = ref(false);
+const collapsed = ref(false);
+
+const collapsible = computed(() => !props.disabled && collapsibleValue.value !== undefined);
+const connectable = computed(() => collapsible.value && attrs.value["connectable"]);
+
+// Determines to wether expand or collapse the input
+{
+    setValue(props.value);
+    const valueJson = JSON.stringify(props.value);
+    connected.value = valueJson === JSON.stringify(connectedValue);
+    collapsed.value =
+        connected.value ||
+        (collapsibleValue.value !== undefined && valueJson === JSON.stringify(collapsibleValue.value));
+}
+
+/** Submits a changed value. */
+function setValue(value) {
+    emit("input", value, props.id);
+    emit("change", props.refreshOnChange);
+}
+
+/** Handles collapsible toggle. */
+function onCollapse() {
+    collapsed.value = !collapsed.value;
+    connected.value = false;
+    if (collapsed.value) {
+        setValue(collapsibleValue.value);
+    } else {
+        setValue(defaultValue.value);
+    }
+}
+
+/** Handles connected state. */
+function onConnect() {
+    connected.value = !connected.value;
+    collapsed.value = connected.value;
+    if (connected.value) {
+        setValue(connectedValue);
+    } else {
+        setValue(defaultValue.value);
+    }
+}
+
+const isHidden = computed(() => attrs.value["hidden"]);
+const elementId = computed(() => `form-element-${props.id}`);
+const hasError = computed(() => Boolean(props.error));
+const showPreview = computed(() => (collapsed.value && attrs.value["collapsible_preview"]) || props.disabled);
+
+const previewText = computed(() => _.escape(this.textValue).replace(/\n/g, "<br>"));
+const helpText = computed(() => {
+    const helpArgument = attrs.value["argument"];
+    if (helpArgument && !props.help.includes(`(${helpArgument})`)) {
+        return `${props.help} (${helpArgument})`;
+    } else {
+        return props.help;
+    }
+});
+
+const currentValue = computed({
+    get() {
+        return props.value;
+    },
+    set(val) {
+        setValue(val);
+    },
+});
+
+const isHiddenType = computed(
+    () => ["hidden", "hidden_data", "baseurl"].includes(props.type) || (props.attributes && props.attributes.titleonly)
+);
+
+const collapseText = computed(() => (collapsed.value ? props.collapsedEnableText : props.collapsedDisableText));
+const connectText = computed(() => (connected.value ? props.connectedEnableText : props.connectedDisableText));
 </script>
+
+<script>
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faExclamation, faTimes, faArrowsAltH } from "@fortawesome/free-solid-svg-icons";
+import { faCaretSquareDown, faCaretSquareUp } from "@fortawesome/free-regular-svg-icons";
+
+library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSquareUp);
+</script>
+
+<template>
+    <div
+        v-show="!isHidden"
+        :id="elementId"
+        class="ui-form-element section-row"
+        :class="{ alert: hasError, 'alert-info': hasError }">
+        <div v-if="hasError" class="ui-form-error">
+            <FontAwesomeIcon class="mr-1" icon="fa-exclamation" />
+            <span class="ui-form-error-text" v-html="props.error" />
+        </div>
+
+        <div v-if="props.title" class="ui-form-title">
+            <div v-if="collapsible || connectable">
+                <b-button
+                    v-if="collapsible && !connected"
+                    class="ui-form-collapsible-icon"
+                    :title="collapseText"
+                    @click="onCollapse">
+                    <FontAwesomeIcon v-if="collapsed" :icon="props.collapsedEnableIcon" />
+                    <FontAwesomeIcon v-else :icon="props.collapsedDisableIcon" />
+                </b-button>
+
+                <b-button v-if="connectable" class="ui-form-connected-icon" :title="connectText" @click="onConnect">
+                    <FontAwesomeIcon v-if="connected" :icon="props.connectedEnableIcon" />
+                    <FontAwesomeIcon v-else :icon="props.connectedDisableIcon" />
+                </b-button>
+
+                <span class="ui-form-title-text ml-1">
+                    {{ props.title }}
+                </span>
+            </div>
+            <span v-else class="ui-form-title-text">{{ props.title }}</span>
+        </div>
+
+        <div v-if="!collapsed && !disabled" class="ui-form-field" :data-label="props.title">
+            <FormBoolean v-if="props.type === 'boolean'" :id="props.id" v-model="currentValue" />
+            <FormHidden v-else-if="isHiddenType" :id="props.id" v-model="currentValue" :info="attrs['info']" />
+            <FormNumber
+                v-else-if="props.type === 'integer' || props.type === 'float'"
+                :id="props.id"
+                v-model="currentValue"
+                :max="attrs.max"
+                :min="attrs.min"
+                :type="type"
+                :workflow-building-mode="workflowBuildingMode" />
+            <FormColor v-else-if="props.type === 'color'" :id="props.id" v-model="currentValue" />
+            <FormDirectory v-else-if="props.type === 'directory_uri'" v-model="currentValue" />
+            <FormParameter
+                v-else-if="backbonejs"
+                :id="props.id"
+                v-model="currentValue"
+                :data-label="props.title"
+                :type="props.type"
+                :attributes="attrs" />
+            <FormInput v-else :id="props.id" v-model="currentValue" :area="attrs['area']" />
+        </div>
+
+        <div v-if="showPreview" class="ui-form-preview" v-html="previewText" />
+        <span v-if="Boolean(helpText)" class="ui-form-info form-text text-muted" v-html="helpText" />
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@import "theme/blue.scss";
+
+.ui-form-element {
+    &:deep(.ui-form-collapsible-icon),
+    &:deep(.ui-form-connected-icon) {
+        border: none;
+        background: none;
+        padding: 0;
+        line-height: 1;
+        font-size: 1.2em;
+
+        &:hover {
+            color: $brand-info;
+        }
+
+        &:focus {
+            color: $brand-primary;
+        }
+
+        &:active {
+            background: none;
+        }
+    }
+}
+</style>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -147,7 +147,7 @@ const isHidden = computed(() => attrs.value["hidden"]);
 const elementId = computed(() => `form-element-${props.id}`);
 const hasError = computed(() => Boolean(props.error));
 const showPreview = computed(() => (collapsed.value && attrs.value["collapsible_preview"]) || props.disabled);
-const showField = computed(() => !collapsed.value && !props.disabled.value);
+const showField = computed(() => !collapsed.value && !props.disabled);
 
 const previewText = computed(() => attrs.value["text_value"]);
 const helpText = computed(() => {

--- a/client/src/components/Workflow/Editor/Forms/FormOutput.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutput.vue
@@ -12,7 +12,7 @@
             <FormElement
                 :id="actionNames.ChangeDatatypeAction__newtype"
                 :value="formData[actionNames.ChangeDatatypeAction__newtype]"
-                :options="datatypeExtensions"
+                :attributes="{ options: datatypeExtensions }"
                 title="Change datatype"
                 type="select"
                 backbonejs

--- a/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
@@ -27,6 +27,10 @@ import FormMessage from "components/Form/FormMessage";
 import FormCard from "components/Form/FormCard";
 import { visitInputs } from "components/Form/utilities";
 import { getTool } from "./services";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faEdit, faUndo } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faEdit, faUndo);
 
 export default {
     components: {

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -142,62 +142,6 @@ $ui-margin-horizontal-large: $margin-v * 2;
     }
 }
 
-// table form elements
-.ui-form-element {
-    margin-top: $ui-margin-vertical;
-    margin-bottom: $ui-margin-vertical;
-    overflow: visible;
-    clear: both;
-    .ui-form-title {
-        word-wrap: break-word;
-        font-weight: bold;
-        .icon {
-            cursor: pointer;
-            font-size: 1.2em;
-        }
-    }
-    .ui-form-field {
-        position: relative;
-        margin-top: $ui-margin-vertical;
-        .ui-form-wp-source {
-            border-left-width: 10px;
-        }
-        .ui-form-wp-target {
-            box-shadow: none;
-            border-top: none;
-            border-bottom: none;
-            border-right: none;
-            border-left-width: 5px;
-            font-style: italic;
-        }
-        .ui-form-backdrop {
-            z-index: 10;
-            position: absolute;
-            top: 0px;
-            width: 100%;
-            height: 100%;
-            background: $white;
-            display: block;
-            opacity: 0;
-            cursor: default;
-        }
-    }
-    .ui-form-preview {
-        @extend .ui-input;
-        margin-top: $ui-margin-vertical;
-        border-color: transparent !important;
-        box-shadow: none !important;
-        height: auto !important;
-    }
-}
-
-.ui-form-element-disabled {
-    @extend .ui-form-element;
-    .ui-form-title {
-        font-weight: normal;
-    }
-}
-
 .ui-form-composite {
     height: 100%;
     flex-direction: column;


### PR DESCRIPTION
Fixes #14627

# Param Hints

Adds hints for required, optional and empty but required form elements.

The following screenshot shows one required and empty, one optional parameter, and one boolean parameter. Since boolean parameters can not be empty, the required / optional hint is not shown.

![image](https://user-images.githubusercontent.com/44241786/198040187-a090c433-28de-42ab-9cfc-5637cfe76198.png)

The next screenshot shows a required but empty param, next to two required params containing values.

![image](https://user-images.githubusercontent.com/44241786/198040552-dbd2f0b1-c210-438f-b995-a35fa0ebc4c1.png)

## Refactor

This PR also refactors the FormElement component, bringing several fixes and some changes.

 - The collapse and connect buttons are now keyboard navigatable
 - The default icons for these buttons have been updated to the current font awesome version used in galaxy, and are now font-awesome icon components. This change now requires calling `library.add(...)` in any place a custom icon is to be used. These changes have been applied accordingly.
 - The components css has been moved to the component, and made scoped.
 - Dynamic props (props mapped to attributes, when no attributes object is provided) have been deprecated for the FormElement component. Reasons for this are (in no particular order):
   * It is prone to breaking. Adding an attributes prop will disable dynamic props, which is not clear and might lead to unforeseen behavior.
   * It is very hard to type-check, which will become relevant once we introduce typescript.
   * They are no longer reactive in the composition api (though this might be a bug)
   
  Existing uses of this feature have been rewritten accordingly. Attributes are still mapped dynamically to not break the legacy FormParameter components.

## Tests

New test cases have been added to account for the new features and changes.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
