### PR TITLE
Drop broken output.parent logic

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -10,6 +10,7 @@ from typing import (
     Dict,
     List,
     Set,
+    TYPE_CHECKING,
     Union,
 )
 
@@ -31,6 +32,9 @@ from galaxy.tools.parameters.basic import (
 from galaxy.tools.parameters.wrapped import WrappedParameters
 from galaxy.util import ExecutionTimer
 from galaxy.util.template import fill_template
+
+if TYPE_CHECKING:
+    from galaxy.model import DatasetInstance
 
 log = logging.getLogger(__name__)
 
@@ -428,7 +432,7 @@ class DefaultToolAction(ToolAction):
         # wrapped params are used by change_format action and by output.label; only perform this wrapping once, as needed
         wrapped_params = self._wrapped_params(trans, tool, incoming, inp_data)
 
-        out_data = {}
+        out_data: Dict[str, "DatasetInstance"] = {}
         input_collections = {k: v[0][0] for k, v in inp_dataset_collections.items()}
         output_collections = OutputCollections(
             trans,
@@ -445,16 +449,9 @@ class DefaultToolAction(ToolAction):
             hdca_tags=preserved_hdca_tags,
         )
 
-        # Keep track of parent / child relationships, we'll create all the
-        # datasets first, then create the associations
-        parent_to_child_pairs = []
-        child_dataset_names = set()
         async_tool = tool.tool_type == "data_source_async"
 
         def handle_output(name, output, hidden=None):
-            if output.parent:
-                parent_to_child_pairs.append((output.parent, name))
-                child_dataset_names.add(name)
             if async_tool and name in incoming:
                 # HACK: output data has already been created as a result of the async controller
                 dataid = incoming[name]
@@ -543,6 +540,8 @@ class DefaultToolAction(ToolAction):
             # Flush all datasets at once.
             return data
 
+        child_dataset_names = set()
+
         for name, output in tool.outputs.items():
             if not filter_output(tool, output, incoming):
                 handle_output_timer = ExecutionTimer()
@@ -591,13 +590,13 @@ class DefaultToolAction(ToolAction):
                             )
 
                         effective_output_name = output_part_def.effective_output_name
+                        child_dataset_names.add(effective_output_name)
                         element = handle_output(effective_output_name, output_part_def.output_def, hidden=True)
                         history.stage_addition(element)
                         # TODO: this shouldn't exist in the top-level of the history at all
                         # but for now we are still working around that by hiding the contents
                         # there.
                         # Following hack causes dataset to no be added to history...
-                        child_dataset_names.add(effective_output_name)
                         trans.sa_session.add(element)
                         current_element_identifiers.append(
                             {
@@ -625,17 +624,10 @@ class DefaultToolAction(ToolAction):
         )
         # Add all the top-level (non-child) datasets to the history unless otherwise specified
         for name, data in out_data.items():
-            if (
-                name not in child_dataset_names and name not in incoming
-            ):  # don't add children; or already existing datasets, i.e. async created
+            if name not in incoming and name not in child_dataset_names:
+                # don't add already existing datasets, i.e. async created
                 history.stage_addition(data)
         history.add_pending_items(set_output_hid=set_output_hid)
-
-        # Add all the children to their parents
-        for parent_name, child_name in parent_to_child_pairs:
-            parent_dataset = out_data[parent_name]
-            child_dataset = out_data[child_name]
-            parent_dataset.children.append(child_dataset)
 
         log.info(add_datasets_timer)
         job_setup_timer = ExecutionTimer()

--- a/test/unit/app/tools/test_data_parameters.py
+++ b/test/unit/app/tools/test_data_parameters.py
@@ -202,7 +202,6 @@ class MockHistoryDatasetAssociation:
         self.name = name
         self.hid = id
         self.id = id
-        self.children = []
         self.tags = []
         self.metadata = None
 


### PR DESCRIPTION
⚠ I don't know what this was used for, but none of the dataset-like models have a children list (was probably a relationship at one point). We have no coverage at this point:
https://app.codecov.io/github/galaxyproject/galaxy/blob/dev/lib/galaxy/tools/actions/__init__.py and if you add type hints to `out_data` this breaks because there's no children attribute on DatasetInstance.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
