### PR TITLE
Visually show which parameters belong to a conditional

### DIFF
--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -14,11 +14,11 @@
                     <span v-if="connected" :class="connectedEnableIcon" :title="connectedEnableText" />
                     <span v-else :class="connectedDisableIcon" :title="connectedDisableText" />
                 </span>
-                <span class="ui-form-title-text ml-1">
+                <span v-if="title" class="ui-form-title-text ml-1">
                     {{ title }}
                 </span>
             </div>
-            <span v-else class="ui-form-title-text">{{ title }}</span>
+            <span v-else-if="title" class="ui-form-title-text">{{ title }}</span>
         </div>
         <div v-if="showField" class="ui-form-field" :data-label="title">
             <FormBoolean v-if="type == 'boolean'" :id="id" v-model="currentValue" />

--- a/client/src/components/Form/FormInputs.vue
+++ b/client/src/components/Form/FormInputs.vue
@@ -1,24 +1,28 @@
 <template>
     <div>
         <div v-for="(input, index) in inputs" :key="index">
-            <div v-if="input.type == 'conditional'">
-                <FormElement
-                    :id="conditionalPrefix(input, input.test_param.name)"
-                    v-model="input.test_param.value"
-                    :title="input.test_param.label"
-                    :type="input.test_param.type"
-                    :help="input.test_param.help"
-                    :refresh-on-change="false"
-                    :disabled="sustainConditionals"
-                    :attributes="input.test_param"
-                    :backbonejs="true"
-                    @change="onChange" />
-                <div v-for="(caseDetails, caseId) in input.cases" :key="caseId">
-                    <FormNode
-                        v-if="conditionalMatch(input, caseId)"
-                        v-bind="$props"
-                        :inputs="caseDetails.inputs"
-                        :prefix="getPrefix(input.name)" />
+            <div v-if="input.type == 'conditional'" class="ui-portlet-section mt-3">
+                <div class="portlet-header">
+                    <b>{{ input.test_param.label }}</b>
+                </div>
+                <div class="portlet-content">
+                    <FormElement
+                        :id="conditionalPrefix(input, input.test_param.name)"
+                        v-model="input.test_param.value"
+                        :type="input.test_param.type"
+                        :help="input.test_param.help"
+                        :refresh-on-change="false"
+                        :disabled="sustainConditionals"
+                        :attributes="input.test_param"
+                        :backbonejs="true"
+                        @change="onChange" />
+                    <div v-for="(caseDetails, caseId) in input.cases" :key="caseId">
+                        <FormNode
+                            v-if="conditionalMatch(input, caseId)"
+                            v-bind="$props"
+                            :inputs="caseDetails.inputs"
+                            :prefix="getPrefix(input.name)" />
+                    </div>
                 </div>
             </div>
             <div v-else-if="input.type == 'repeat'">


### PR DESCRIPTION
Fixes #14702 by adding the same visuals sections use to conditionals

![image](https://user-images.githubusercontent.com/44241786/198268376-fe94c0c0-23af-4dbe-b0e7-9fdddf71dbcc.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
