### PR TITLE
add a test for metadata of interval

### DIFF
--- a/test/functional/tools/metadata_interval.xml
+++ b/test/functional/tools/metadata_interval.xml
@@ -8,15 +8,15 @@
   </outputs>
   <tests>
     <test>
-      <param name="input" value="test.txt" ftype="interval" >
-        <metadata name="chromCol" value="2"/>
-        <metadata name="startCol" value="3"/>
-        <metadata name="endCol" value="4"/>
+      <param name="input" value="droPer1.gff" ftype="interval" >
+        <metadata name="chromCol" value="1"/>
+        <metadata name="startCol" value="4"/>
+        <metadata name="endCol" value="5"/>
       </param>
       <!-- This ouptut tests setting input metadata above -->
       <output name="output_of_input_metadata" ftype="txt">
         <assert_contents>
-          <has_line line="2 3 4" />
+          <has_line line="1 4 5" />
         </assert_contents>
       </output>
     </test>

--- a/test/functional/tools/metadata_interval.xml
+++ b/test/functional/tools/metadata_interval.xml
@@ -1,0 +1,24 @@
+<tool id="metadata_interval" name="metadata_interval" version="1.0.0">
+  <command>echo "$input.metadata.chromCol $input.metadata.startCol $input.metadata.endCol" > $output_of_input_metadata</command>
+  <inputs>
+    <param name="input" type="data" format="interval" label="Interval"/>
+  </inputs>
+  <outputs>
+    <data format="txt" name="output_of_input_metadata" />
+  </outputs>
+  <tests>
+    <test>
+      <param name="input" value="test.txt" ftype="interval" >
+        <metadata name="chromCol" value="2"/>
+        <metadata name="startCol" value="3"/>
+        <metadata name="endCol" value="4"/>
+      </param>
+      <!-- This ouptut tests setting input metadata above -->
+      <output name="output_of_input_metadata" ftype="txt">
+        <assert_contents>
+          <has_line line="2 3 4" />
+        </assert_contents>
+      </output>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -61,6 +61,7 @@
   <tool file="unicode_stream.xml" />
   <tool file="vcf_bgzip.xml" />
   <tool file="metadata.xml" />
+  <tool file="metadata_interval.xml" />
   <tool file="metadata_bam.xml" />
   <tool file="metadata_bcf.xml" />
   <tool file="metadata_biom1.xml" />


### PR DESCRIPTION
Hi,
I am not solving an issue but raising an issue... I think this test is missing and it seems that it is failing locally.
I tested it with planemo with the following test.txt:
```
read1	chr1	0	2
```
I did not understand where the functional tests were supposed to find their inputs...

I hope it is still helpful...

For info, when I run it with planemo the json for upload is:
```
[{"file_type": "interval", "ext": "interval", "name": "test.txt", "dataset_id": 1, "dbkey": "?", "type": "file", "is_binary": false, "link_data_only": "copy_files", "uuid": null, "to_posix_lines": true, "auto_decompress": true, "purge_source": true, "space_to_tab": false, "run_as_real_user": false, "check_content": false, "path": "/tmp/upload_file_data_v24yjg05"}]
```
No metadata.

On the contrary if I use planemo to test the `metadata.xml` I get:
```
[{"file_type": "velvet", "dataset_id": 1, "dbkey": "?", "type": "composite", "metadata": {"base_name": "Example Metadata", "paired_end_reads": "False", "long_reads": "False", "short2_reads": "False"}, "primary_file": "/tmp/upload_auto_primary_file3_c7l7m7", "composite_file_paths": {"Sequences": {"type": "file", "path": "/tmp/upload_file_data_ezc902zl", "name": "files_0|file_data", "purge_source": true, "to_posix_lines": true, "auto_decompress": true, "space_to_tab": false, "uuid": null, "file_type": "", "dbkey": ""}, "Roadmaps": {"type": "file", "path": "/tmp/upload_file_data_t15pez7e", "name": "files_1|file_data", "purge_source": true, "to_posix_lines": true, "auto_decompress": true, "space_to_tab": false, "uuid": null, "file_type": "", "dbkey": ""}, "Log": {"type": "file", "path": "/tmp/upload_file_data_48oof00e", "name": "files_2|file_data", "purge_source": true, "to_posix_lines": true, "auto_decompress": true, "space_to_tab": false, "uuid": null, "file_type": "", "dbkey": ""}}, "composite_files": {"Sequences": {"name": "Sequences", "optional": false, "mimetype": "text/html", "description": "Sequences", "substitute_name_with_metadata": null, "is_binary": false, "to_posix_lines": true, "space_to_tab": false}, "Roadmaps": {"name": "Roadmaps", "optional": false, "mimetype": "text/html", "description": "Roadmaps", "substitute_name_with_metadata": null, "is_binary": false, "to_posix_lines": true, "space_to_tab": false}, "Log": {"name": "Log", "optional": "True", "mimetype": "text/html", "description": "Log", "substitute_name_with_metadata": null, "is_binary": false, "to_posix_lines": true, "space_to_tab": false}}}]
```
The metadata are set.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
