### PR TITLE
Fix loading subworkflows from editor interface

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -362,6 +362,11 @@ export default {
         },
     },
     watch: {
+        id(newId, oldId) {
+            if (oldId) {
+                this._loadCurrent(newId);
+            }
+        },
         annotation(newAnnotation, oldAnnotation) {
             if (newAnnotation != oldAnnotation) {
                 this.hasChanges = true;
@@ -490,7 +495,7 @@ export default {
             this.showInPanel = "attributes";
         },
         onEditSubworkflow(contentId) {
-            const editUrl = `/workflows/edit?id=${contentId}`;
+            const editUrl = `/workflows/edit?workflow_id=${contentId}`;
             this.onNavigate(editUrl);
         },
         async onClone(node) {
@@ -563,7 +568,7 @@ export default {
                 .then((response) => {
                     this.onWorkflowMessage("Workflow saved as", "success");
                     this.hideModal();
-                    this.onNavigate(`${getAppRoot()}workflow/editor?id=${response.data}`, true);
+                    this.onNavigate(`${getAppRoot()}workflows/edit?id=${response.data}`, true);
                 })
                 .catch((response) => {
                     this.onWorkflowError("Saving workflow failed, please contact an administrator.");

--- a/client/src/entry/analysis/modules/WorkflowEditor.vue
+++ b/client/src/entry/analysis/modules/WorkflowEditor.vue
@@ -1,8 +1,8 @@
 <template>
     <Editor
         v-if="editorConfig"
-        :id="workflowId"
-        :data-managers="editorConfig.workflows"
+        :id="editorConfig.id"
+        :data-managers="editorConfig.dataManagers"
         :initial-version="editorConfig.initialVersion"
         :module-sections="editorConfig.moduleSections"
         :tags="editorConfig.tags"
@@ -19,16 +19,30 @@ export default {
     },
     data() {
         return {
-            workflowId: Query.get("id"),
+            storedWorkflowId: null,
+            workflowId: null,
             editorConfig: null,
         };
     },
-    created() {
-        this.getState();
+    watch: {
+        "$route.params": {
+            handler() {
+                this.getEditorConfig();
+            },
+            immediate: true,
+        },
     },
     methods: {
-        async getState() {
-            this.editorConfig = await urlData({ url: `/workflow/editor?id=${this.workflowId}` });
+        async getEditorConfig() {
+            const storedWorkflowId = Query.get("id");
+            const workflowId = Query.get("workflow_id");
+            const params = {};
+            if (workflowId) {
+                params.workflow_id = workflowId;
+            } else if (storedWorkflowId) {
+                params.id = storedWorkflowId;
+            }
+            this.editorConfig = await urlData({ url: "/workflow/editor", params });
         },
     },
 };

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -556,6 +556,7 @@ workflow_editor:
       selector: '//a[contains(., "${workflow_title}")]'
     connect_icon: 'div.ui-form-element[id="form-element-${name}"] .ui-form-connected-icon'
     collapse_icon: 'div.ui-form-element[id="form-element-${name}"] .ui-form-collapsible-icon'
+    edit_subworkflow: 'button[title="Edit this Subworkflow. You will need to upgrade this Workflow Step afterwards."]'
     node_title:
       type: xpath
       selector: '//span[@class="node-title" and text()="${title}"]'

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -30,10 +30,7 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.sanitize_html import sanitize_html
-from galaxy.web import (
-    error,
-    url_for,
-)
+from galaxy.web import url_for
 from galaxy.web.framework.helpers import (
     grids,
     time_ago,
@@ -527,9 +524,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             if workflow_id:
                 stored_workflow = self.app.workflow_manager.get_stored_workflow(trans, workflow_id, by_stored_id=False)
                 self.security_check(trans, stored_workflow, True, False)
-                stored_workflow_id = trans.security.encode_id(stored_workflow.id)
-                return trans.response.send_redirect(f'{url_for("/")}workflows/edit?id={stored_workflow_id}')
-            error("Invalid workflow id")
+                id = trans.security.encode_id(stored_workflow.id)
         stored = self.get_stored_workflow(trans, id)
         # The following query loads all user-owned workflows,
         # So that they can be copied or inserted in the workflow editor.

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -619,6 +619,29 @@ steps:
         self.assert_connected("nested_workflow#workflow_output", "metadata_bam#input_bam")
 
     @selenium_test
+    def test_edit_subworkflow(self):
+        self.open_in_workflow_editor(
+            """
+class: GalaxyWorkflow
+inputs: []
+steps:
+  nested_workflow:
+    run:
+        class: GalaxyWorkflow
+        inputs: []
+        steps:
+          - tool_id: create_2
+            label: create_2
+"""
+        )
+        editor = self.components.workflow_editor
+        node = editor.node._(label="nested_workflow")
+        node.wait_for_and_click()
+        editor.edit_subworkflow.wait_for_and_click()
+        node = editor.node._(label="create_2")
+        node.wait_for_and_click()
+
+    @selenium_test
     def test_editor_duplicate_node(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
         self.workflow_index_open()


### PR DESCRIPTION
This probably broke in
https://github.com/galaxyproject/galaxy/pull/13984. There were 3 issues here: Subworkflows are referenced by Workflow.id, not StoredWorkflow.id, so we'd build the wrong url. The other issue is that if we push the new url into the router nothing happens as we re-use the component. Instead we need to listen to route changes and reload the editor config. The third problem is that the main editor component loads the workflow data only in the created hook.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
