### PR TITLE
fix tooltip rendering on icons

### DIFF
--- a/client/src/components/DatasetInformation/DatasetSource.vue
+++ b/client/src/components/DatasetInformation/DatasetSource.vue
@@ -1,13 +1,15 @@
 <template>
     <li class="dataset-source">
-        <a v-if="browserCompatUri" :href="sourceUri" target="_blank">
+        <a v-if="browserCompatUri" v-b-tooltip.hover title="Dataset Source URL" :href="sourceUri" target="_blank">
             {{ source.source_uri }}
-            <font-awesome-icon v-b-tooltip.hover title="Dataset Source URL" icon="external-link-alt" />
+            <font-awesome-icon icon="external-link-alt" />
         </a>
         <span v-else>
             {{ source.source_uri }}
         </span>
-        <font-awesome-icon v-b-tooltip.hover title="Copy URI" icon="copy" style="cursor: pointer" @click="copyLink" />
+        <span v-b-tooltip.hover title="Copy URI"
+            ><font-awesome-icon icon="copy" style="cursor: pointer" @click="copyLink"
+        /></span>
         <br />
         <DatasetSourceTransform :transform="source.transform" />
     </li>

--- a/client/src/components/HistoryExport/ExportLink.vue
+++ b/client/src/components/HistoryExport/ExportLink.vue
@@ -3,13 +3,9 @@
         <b
             ><a class="generated-export-link" :href="link">{{ link }}</a></b
         >
-        <font-awesome-icon
-            v-b-tooltip.hover
-            title="Copy export URL to your clipboard"
-            class="copy-export-link"
-            icon="link"
-            style="cursor: pointer"
-            @click="copyUrl" />
+        <span v-b-tooltip.hover title="Copy export URL to your clipboard">
+            <font-awesome-icon class="copy-export-link" icon="link" style="cursor: pointer" @click="copyUrl" />
+        </span>
         <i
             title="Information about when the history export was generated is included in the job details. Additionally, if there are issues with export, the job details may help figure out the underlying problem or communicate issues to your Galaxy administrator.">
             (<b-link class="show-job-link" href="#" @click="showDetails">view job details</b-link>)

--- a/client/src/components/Indices/SharingIndicators.vue
+++ b/client/src/components/Indices/SharingIndicators.vue
@@ -1,19 +1,17 @@
 <template>
     <span>
-        <font-awesome-icon
-            v-if="object.published"
-            v-b-tooltip.hover
-            :title="'Published' | localize"
-            icon="globe"
-            class="sharing-indicator-published"
-            @click="$emit('filter', 'is:published')" />
-        <font-awesome-icon
-            v-if="object.shared"
-            v-b-tooltip.hover
-            :title="'Shared' | localize"
-            icon="share-alt"
-            class="sharing-indicator-shared"
-            @click="$emit('filter', 'is:shared_with_me')" />
+        <span v-if="object.published" v-b-tooltip.hover :title="'Published' | localize">
+            <font-awesome-icon
+                icon="globe"
+                class="sharing-indicator-published"
+                @click="$emit('filter', 'is:published')" />
+        </span>
+        <span v-if="object.shared" v-b-tooltip.hover :title="'Shared' | localize">
+            <font-awesome-icon
+                icon="share-alt"
+                class="sharing-indicator-shared"
+                @click="$emit('filter', 'is:shared_with_me')" />
+        </span>
     </span>
 </template>
 

--- a/client/src/components/License/LicenseSelector.vue
+++ b/client/src/components/License/LicenseSelector.vue
@@ -4,8 +4,10 @@
         <b-form-select v-else v-model="license" :options="licenseOptions"></b-form-select>
         <License v-if="currentLicenseInfo" :license-id="license" :input-license-info="currentLicenseInfo">
             <template v-slot:buttons>
-                <font-awesome-icon v-b-tooltip.hover title="Save License" icon="save" @click="onSave" />
-                <font-awesome-icon v-b-tooltip.hover title="Cancel Edit" icon="times" @click="disableEdit" />
+                <span v-b-tooltip.hover title="Save License"><font-awesome-icon icon="save" @click="onSave" /></span>
+                <span v-b-tooltip.hover title="Cancel Edit"
+                    ><font-awesome-icon icon="times" @click="disableEdit"
+                /></span>
             </template>
         </License>
         <div v-else>
@@ -16,7 +18,9 @@
     <div v-else-if="license">
         <License :license-id="license">
             <template v-slot:buttons>
-                <font-awesome-icon v-b-tooltip.hover title="Edit License" icon="edit" @click="editLicense = true" />
+                <span v-b-tooltip.hover title="Edit License"
+                    ><font-awesome-icon icon="edit" @click="editLicense = true"
+                /></span>
             </template>
         </License>
     </div>

--- a/client/src/components/SchemaOrg/CreatorEditor.vue
+++ b/client/src/components/SchemaOrg/CreatorEditor.vue
@@ -10,12 +10,12 @@
             <div v-for="(creator, index) in creatorsCurrent" :key="index">
                 <CreatorViewer :creator="creator">
                     <template v-slot:buttons>
-                        <font-awesome-icon v-b-tooltip.hover title="Edit Creator" icon="edit" @click="onEdit(index)" />
-                        <font-awesome-icon
-                            v-b-tooltip.hover
-                            title="Remove Creator"
-                            icon="times"
-                            @click="onRemove(index)" />
+                        <span v-b-tooltip.hover title="Edit Creator"
+                            ><font-awesome-icon icon="edit" @click="onEdit(index)"
+                        /></span>
+                        <span v-b-tooltip.hover title="Remove Creator">
+                            <font-awesome-icon icon="times" @click="onRemove(index)" />
+                        </span>
                     </template>
                 </CreatorViewer>
             </div>

--- a/client/src/components/SchemaOrg/OrganizationForm.vue
+++ b/client/src/components/SchemaOrg/OrganizationForm.vue
@@ -3,11 +3,9 @@
     <b-form @submit="onSave" @reset="onReset">
         <div v-for="attribute in displayedAttributes" :key="attribute.key" role="group" class="form-group">
             <label :for="attribute.key">{{ attribute.label }}</label>
-            <font-awesome-icon
-                v-b-tooltip.hover
-                title="Hide Attribute"
-                icon="eye-slash"
-                @click="onHide(attribute.key)" />
+            <span v-b-tooltip.hover title="Hide Attribute"
+                ><font-awesome-icon icon="eye-slash" @click="onHide(attribute.key)"
+            /></span>
             <b-form-input
                 :id="attribute.key"
                 v-model="currentValues[attribute.key]"

--- a/client/src/components/SchemaOrg/OrganizationViewer.vue
+++ b/client/src/components/SchemaOrg/OrganizationViewer.vue
@@ -18,9 +18,9 @@
         <span v-else-if="email" itemprop="email" :content="organization.email">
             {{ email }}
         </span>
-        <a v-if="url" :href="url" target="_blank">
+        <a v-if="url" v-b-tooltip.hover title="Organization URL" :href="url" target="_blank">
             <link itemprop="url" :href="url" />
-            <font-awesome-icon v-b-tooltip.hover title="Organization URL" icon="external-link-alt" />
+            <font-awesome-icon icon="external-link-alt" />
         </a>
         <meta
             v-for="attribute in explicitMetaAttributes"

--- a/client/src/components/SchemaOrg/PersonForm.vue
+++ b/client/src/components/SchemaOrg/PersonForm.vue
@@ -3,11 +3,9 @@
     <b-form @submit="onSave" @reset="onReset">
         <div v-for="attribute in displayedAttributes" :key="attribute.key" role="group" class="form-group">
             <label :for="attribute.key">{{ attribute.label }}</label>
-            <font-awesome-icon
-                v-b-tooltip.hover
-                title="Hide Attribute"
-                icon="eye-slash"
-                @click="onHide(attribute.key)" />
+            <span v-b-tooltip.hover title="Hide Attribute"
+                ><font-awesome-icon icon="eye-slash" @click="onHide(attribute.key)"
+            /></span>
             <b-form-input
                 :id="attribute.key"
                 v-model="currentValues[attribute.key]"

--- a/client/src/components/SchemaOrg/PersonViewer.vue
+++ b/client/src/components/SchemaOrg/PersonViewer.vue
@@ -21,13 +21,13 @@
         <span v-else itemprop="email" :content="person.email">
             {{ email }}
         </span>
-        <a v-if="orcidLink" :href="orcidLink" target="_blank">
+        <a v-if="orcidLink" v-b-tooltip.hover title="View orcid.org profile" :href="orcidLink" target="_blank">
             <link itemprop="identifier" :href="orcidLink" />
-            <font-awesome-icon v-b-tooltip.hover title="View orcid.org profile" :icon="['fab', 'orcid']" />
+            <font-awesome-icon :icon="['fab', 'orcid']" />
         </a>
-        <a v-if="url" :href="url" target="_blank">
+        <a v-if="url" v-b-tooltip.hover title="URL" :href="url" target="_blank">
             <link itemprop="url" :href="url" />
-            <font-awesome-icon v-b-tooltip.hover title="URL" icon="external-link-alt" />
+            <font-awesome-icon icon="external-link-alt" />
         </a>
         <meta
             v-for="attribute in explicitMetaAttributes"


### PR DESCRIPTION
move v-b-tooltip to a parent element (or create one) to fix rendering

related to https://github.com/galaxyproject/galaxy/pull/14857

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. find a fontawesome icon with tooltip in UI
  2. the tooltip should trigger on `hover`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
