### PR TITLE
[22.05] Fix response encoding when getting tool citations via API

### DIFF
--- a/lib/galaxy/managers/citations.py
+++ b/lib/galaxy/managers/citations.py
@@ -47,9 +47,14 @@ class DoiCache:
     def _raw_get_bibtex(self, doi):
         doi_url = f"https://doi.org/{doi}"
         headers = {"Accept": "application/x-bibtex"}
-        req = requests.get(doi_url, headers=headers, timeout=DEFAULT_SOCKET_TIMEOUT)
-        req.encoding = req.apparent_encoding
-        return req.text
+        res = requests.get(doi_url, headers=headers, timeout=DEFAULT_SOCKET_TIMEOUT)
+        # To decode the response content, res.text tries to determine the
+        # content encoding from the Content-Type header (res.encoding), and if
+        # that fails, falls back to guessing from the content itself (res.apparent_encoding).
+        # The guessed encoding is sometimes wrong, better to default to utf-8.
+        if res.encoding is None:
+            res.encoding = "utf-8"
+        return res.text
 
     def get_bibtex(self, doi):
         createfunc = functools.partial(self._raw_get_bibtex, doi)

--- a/test/unit/app/managers/test_CitationsManager.py
+++ b/test/unit/app/managers/test_CitationsManager.py
@@ -1,0 +1,16 @@
+import os.path
+import tempfile
+
+from galaxy.managers.citations import DoiCache
+from galaxy.util.bunch import Bunch
+
+
+def test_DoiCache():
+    with tempfile.TemporaryDirectory() as tmp_database_dir:
+        config = Bunch(
+            citation_cache_data_dir=os.path.join(tmp_database_dir, "data"),
+            citation_cache_lock_dir=os.path.join(tmp_database_dir, "locks"),
+        )
+        doi_cache = DoiCache(config)
+        assert "Jörg" in doi_cache.get_bibtex("10.1093/bioinformatics/bts252")
+        assert "Özkurt" in doi_cache.get_bibtex("10.1101/2021.12.24.474111")


### PR DESCRIPTION
Fix the first author surname in:

https://usegalaxy.eu/api/tools/lotus2/citations

without regressing on https://github.com/galaxyproject/galaxy/issues/9369 .

When decoding the response content, it is better to default to utf-8 than trust the encoding guessed from the content itself.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
