### PR TITLE
[22.01] Add missing ``unittest_utils`` package to galaxy-tool-util

### DIFF
--- a/packages/tool_util/setup.py
+++ b/packages/tool_util/setup.py
@@ -45,6 +45,7 @@ PACKAGES = [
     'galaxy.tool_util.toolbox.filters',
     'galaxy.tool_util.toolbox.lineages',
     'galaxy.tool_util.toolbox.views',
+    "galaxy.tool_util.unittest_utils",
     'galaxy.tool_util.verify',
     'galaxy.tool_util.verify.asserts',
 ]


### PR DESCRIPTION
Fix:

```
ModuleNotFoundError: No module named 'galaxy.tool_util.unittest_utils'
```

in https://github.com/conda-forge/galaxy-tool-util-feedstock/pull/4 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
