### PR TITLE
reintroduce decoding for PUT /dataset/set_edit calls

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -459,7 +459,8 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             payload_permissions = {}
             for key, value in {"DATASET_MANAGE_PERMISSIONS": "manage_ids", "DATASET_ACCESS": "access_ids"}.items():
                 role_ids = util.listify(payload.get(key))
-                payload_permissions[f"{value}[]"] = role_ids
+                decoded_role_ids = list(map(self.decode_id, role_ids))
+                payload_permissions[f"{value}[]"] = decoded_role_ids
 
             self.hda_manager.update_permissions(
                 trans,


### PR DESCRIPTION
closes https://github.com/galaxyproject/galaxy/issues/14883

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. try changing a dataset permission

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
