### PR TITLE
Make form repeat blocks reordarable

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,8 @@
   ],
   "browserslist": [
     "defaults",
-    "not op_mini all"
+    "not op_mini all",
+    "not ios_saf <= 15.0"
   ],
   "resolutions": {
     "chokidar": "3.5.3",

--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -165,7 +165,6 @@ export default {
             });
         },
         onChangeForm() {
-            this.formInputs = JSON.parse(JSON.stringify(this.formInputs));
             this.onChange(true);
         },
         onCloneInputs() {

--- a/client/src/components/Form/FormInputs.vue
+++ b/client/src/components/Form/FormInputs.vue
@@ -27,14 +27,13 @@
             </div>
             <div v-else-if="input.type == 'repeat'">
                 <FormRepeat
-                    v-model="input.cache"
                     :input="input"
                     :sustain-repeats="sustainRepeats"
                     :passthrough-props="$props"
                     :prefix="prefix"
                     @insert="() => repeatInsert(input)"
                     @delete="(id) => repeatDelete(input, id)"
-                    @change="onChangeForm" />
+                    @swap="(a, b) => repeatSwap(input, a, b)" />
             </div>
             <div v-else-if="input.type == 'section'">
                 <FormCard :title="input.title || input.name" :expanded.sync="input.expanded" :collapsible="true">
@@ -148,6 +147,10 @@ export default {
         },
         repeatDelete(input, cacheId) {
             input.cache.splice(cacheId, 1);
+            this.onChangeForm();
+        },
+        repeatSwap(input, a, b) {
+            [input.cache[a], input.cache[b]] = [input.cache[b], input.cache[a]];
             this.onChangeForm();
         },
     },

--- a/client/src/components/Form/FormInputs.vue
+++ b/client/src/components/Form/FormInputs.vue
@@ -140,7 +140,7 @@ export default {
             return matchCase(input, input.test_param.value) == caseId;
         },
         repeatInsert(input) {
-            const newInputs = JSON.parse(JSON.stringify(input.inputs));
+            const newInputs = structuredClone(input.inputs);
             input.cache = input.cache || [];
             input.cache.push(newInputs);
             this.onChangeForm();
@@ -150,7 +150,12 @@ export default {
             this.onChangeForm();
         },
         repeatSwap(input, a, b) {
-            [input.cache[a], input.cache[b]] = [input.cache[b], input.cache[a]];
+            const tmpA = input.cache[a];
+            const tmpB = input.cache[b];
+
+            input.cache.splice(a, 1, tmpB);
+            input.cache.splice(b, 1, tmpA);
+
             this.onChangeForm();
         },
     },

--- a/client/src/components/Form/FormInputs.vue
+++ b/client/src/components/Form/FormInputs.vue
@@ -66,11 +66,13 @@
 </template>
 
 <script>
-import FormCard from "components/Form/FormCard";
-import FormElement from "components/Form/FormElement";
-import { matchCase } from "components/Form/utilities";
+import { set } from "vue";
 
+import { matchCase } from "@/components/Form/utilities";
+
+import FormCard from "./FormCard.vue";
 import FormRepeat from "./FormRepeat.vue";
+import FormElement from "@/components/Form/FormElement.vue";
 
 export default {
     name: "FormNode",
@@ -141,8 +143,10 @@ export default {
         },
         repeatInsert(input) {
             const newInputs = structuredClone(input.inputs);
-            input.cache = input.cache || [];
+
+            set(input, "cache", input.cache ?? []);
             input.cache.push(newInputs);
+
             this.onChangeForm();
         },
         repeatDelete(input, cacheId) {

--- a/client/src/components/Form/FormInputs.vue
+++ b/client/src/components/Form/FormInputs.vue
@@ -26,35 +26,15 @@
                 </div>
             </div>
             <div v-else-if="input.type == 'repeat'">
-                <div v-if="!sustainRepeats || (input.cache && input.cache.length > 0)">
-                    <div class="font-weight-bold mb-2">{{ input.title }}</div>
-                    <div v-if="input.help" class="mb-2" data-description="repeat help">{{ input.help }}</div>
-                </div>
-                <FormCard
-                    v-for="(cache, cacheId) in input.cache"
-                    :key="cacheId"
-                    data-description="repeat block"
-                    :title="repeatTitle(cacheId, input.title)">
-                    <template v-slot:operations>
-                        <b-button
-                            v-if="!sustainRepeats"
-                            v-b-tooltip.hover.bottom
-                            role="button"
-                            variant="link"
-                            size="sm"
-                            class="float-right"
-                            @click="repeatDelete(input, cacheId)">
-                            <FontAwesomeIcon icon="trash-alt" />
-                        </b-button>
-                    </template>
-                    <template v-slot:body>
-                        <FormNode v-bind="$props" :inputs="cache" :prefix="getPrefix(input.name, cacheId)" />
-                    </template>
-                </FormCard>
-                <b-button v-if="!sustainRepeats" @click="repeatInsert(input)">
-                    <FontAwesomeIcon icon="plus" class="mr-1" />
-                    <span data-description="repeat insert">Insert {{ input.title || "Repeat" }}</span>
-                </b-button>
+                <FormRepeat
+                    v-model="input.cache"
+                    :input="input"
+                    :sustain-repeats="sustainRepeats"
+                    :passthrough-props="$props"
+                    :prefix="prefix"
+                    @insert="() => repeatInsert(input)"
+                    @delete="(id) => repeatDelete(input, id)"
+                    @change="onChangeForm" />
             </div>
             <div v-else-if="input.type == 'section'">
                 <FormCard :title="input.title || input.name" :expanded.sync="input.expanded" :collapsible="true">
@@ -87,21 +67,18 @@
 </template>
 
 <script>
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faPlus, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import FormCard from "components/Form/FormCard";
 import FormElement from "components/Form/FormElement";
 import { matchCase } from "components/Form/utilities";
 
-library.add(faPlus, faTrashAlt);
+import FormRepeat from "./FormRepeat.vue";
 
 export default {
     name: "FormNode",
     components: {
-        FontAwesomeIcon,
         FormCard,
         FormElement,
+        FormRepeat,
     },
     props: {
         inputs: {
@@ -151,9 +128,6 @@ export default {
     },
     methods: {
         getPrefix(name, index) {
-            if (index !== undefined) {
-                name = `${name}_${index}`;
-            }
             if (this.prefix) {
                 return `${this.prefix}|${name}`;
             } else {
@@ -165,9 +139,6 @@ export default {
         },
         conditionalMatch(input, caseId) {
             return matchCase(input, input.test_param.value) == caseId;
-        },
-        repeatTitle(index, title) {
-            return `${parseInt(index) + 1}: ${title}`;
         },
         repeatInsert(input) {
             const newInputs = JSON.parse(JSON.stringify(input.inputs));

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -1,8 +1,7 @@
 <script setup>
-import Draggable from "vuedraggable";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import FormCard from "./FormCard";
-import { defineAsyncComponent, computed, ref } from "vue";
+import { defineAsyncComponent } from "vue";
 
 const FormNode = defineAsyncComponent(() => import("./FormInputs.vue"));
 
@@ -25,26 +24,7 @@ const props = defineProps({
     },
 });
 
-const emit = defineEmits("insert", "delete", "changed");
-const uidCounter = ref(0);
-
-const cache = computed({
-    get() {
-        const items = props.input.cache;
-
-        items.forEach((item) => {
-            if (!item.uid) {
-                item.uid = uidCounter.value;
-                uidCounter.value += 1;
-            }
-        });
-
-        return items;
-    },
-    set(val) {
-        emit("changed");
-    },
-});
+const emit = defineEmits("insert", "delete", "swap");
 
 function onInsert() {
     emit("insert");
@@ -67,48 +47,90 @@ function getPrefix(index) {
 function getTitle(index) {
     return `${parseInt(index) + 1}: ${props.input.title}`;
 }
+
+/** swap blocks if possible */
+function swap(index, swapWith, up) {
+    if (swapWith >= 0 && swapWith < props.input.cache?.length) {
+        emit("swap", index, swapWith);
+
+        const buttonId = getButtonId(swapWith, up);
+        document.getElementById(buttonId).focus();
+    }
+}
+
+/** get a uid for the up/down button */
+function getButtonId(index, up) {
+    const prefix = getPrefix(index);
+    return `${prefix}_${up ? "up" : "down"}`;
+}
 </script>
 
 <script>
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faPlus, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faTrashAlt, faCaretUp, faCaretDown } from "@fortawesome/free-solid-svg-icons";
 
-library.add(faPlus, faTrashAlt);
+library.add(faPlus, faTrashAlt, faCaretUp, faCaretDown);
 </script>
 
 <template>
     <div>
-        <div v-if="!props.sustainRepeats || (cache && cache.length > 0)">
+        <div v-if="!props.sustainRepeats || props.input.cache?.length > 0">
             <div class="font-weight-bold mb-2">{{ props.input.title }}</div>
             <div v-if="props.input.help" class="mb-2" data-description="repeat help">{{ props.input.help }}</div>
         </div>
-        <Draggable v-model="cache" :options="{ handle: '.portlet-header' }">
-            <FormCard
-                v-for="(cache, cacheId) in cache"
-                :key="cache.uid"
-                data-description="repeat block"
-                class="card"
-                :title="getTitle(cacheId)">
-                <template v-slot:operations>
+
+        <FormCard
+            v-for="(cache, cacheId) in props.input.cache"
+            :key="cacheId"
+            data-description="repeat block"
+            class="card"
+            :title="getTitle(cacheId)">
+            <template v-slot:operations>
+                <span v-if="!props.sustainRepeats" class="float-right">
+                    <b-button-group>
+                        <b-button
+                            v-b-tooltip.hover.bottom
+                            title="move up"
+                            role="button"
+                            variant="link"
+                            size="sm"
+                            class="ml-0"
+                            :id="getButtonId(cacheId, true)"
+                            @click="() => swap(cacheId, cacheId - 1, true)">
+                            <FontAwesomeIcon icon="caret-up" />
+                        </b-button>
+                        <b-button
+                            v-b-tooltip.hover.bottom
+                            title="move down"
+                            role="button"
+                            variant="link"
+                            size="sm"
+                            class="ml-0"
+                            :id="getButtonId(cacheId, false)"
+                            @click="() => swap(cacheId, cacheId + 1, false)">
+                            <FontAwesomeIcon icon="caret-down" />
+                        </b-button>
+                    </b-button-group>
+
                     <b-button
-                        v-if="!props.sustainRepeats"
                         v-b-tooltip.hover.bottom
+                        title="delete"
                         role="button"
                         variant="link"
                         size="sm"
-                        class="float-right"
-                        @click="onDelete(cacheId)">
+                        class="ml-0"
+                        @click="() => onDelete(cacheId)">
                         <FontAwesomeIcon icon="trash-alt" />
                     </b-button>
-                </template>
+                </span>
+            </template>
 
-                <template v-slot:body>
-                    <FormNode v-bind="props.passthroughProps" :inputs="cache" :prefix="getPrefix(cacheId)" />
-                </template>
-            </FormCard>
-        </Draggable>
+            <template v-slot:body>
+                <FormNode v-bind="props.passthroughProps" :inputs="cache" :prefix="getPrefix(cacheId)" />
+            </template>
+        </FormCard>
 
-        <b-button v-if="!props.sustainRepeats" @click="onInsert()">
+        <b-button v-if="!props.sustainRepeats" @click="onInsert">
             <font-awesome-icon icon="plus" class="mr-1" />
             <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
         </b-button>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -2,7 +2,7 @@
 import Draggable from "vuedraggable";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import FormCard from "./FormCard";
-import { defineAsyncComponent, computed } from "vue";
+import { defineAsyncComponent, computed, ref } from "vue";
 
 const FormNode = defineAsyncComponent(() => import("./FormInputs.vue"));
 
@@ -26,10 +26,20 @@ const props = defineProps({
 });
 
 const emit = defineEmits("insert", "delete", "changed");
+const uidCounter = ref(0);
 
 const cache = computed({
     get() {
-        return props.input.cache;
+        const items = props.input.cache;
+
+        items.forEach((item) => {
+            if (!item.uid) {
+                item.uid = uidCounter.value;
+                uidCounter.value += 1;
+            }
+        });
+
+        return items;
     },
     set(val) {
         emit("changed");
@@ -72,10 +82,10 @@ library.add(faPlus, faTrashAlt);
             <div class="font-weight-bold mb-2">{{ props.input.title }}</div>
             <div v-if="props.input.help" class="mb-2" data-description="repeat help">{{ props.input.help }}</div>
         </div>
-        <Draggable v-model="cache" draggable="card">
+        <Draggable v-model="cache" :options="{ handle: '.portlet-header' }">
             <FormCard
                 v-for="(cache, cacheId) in cache"
-                :key="cacheId"
+                :key="cache.uid"
                 data-description="repeat block"
                 class="card"
                 :title="getTitle(cacheId)">
@@ -96,11 +106,11 @@ library.add(faPlus, faTrashAlt);
                     <FormNode v-bind="props.passthroughProps" :inputs="cache" :prefix="getPrefix(cacheId)" />
                 </template>
             </FormCard>
-
-            <b-button v-if="!props.sustainRepeats" slot="footer" @click="onInsert()">
-                <font-awesome-icon icon="plus" class="mr-1" />
-                <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
-            </b-button>
         </Draggable>
+
+        <b-button v-if="!props.sustainRepeats" @click="onInsert()">
+            <font-awesome-icon icon="plus" class="mr-1" />
+            <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
+        </b-button>
     </div>
 </template>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -1,7 +1,9 @@
-<script setup>
+<script setup lang="ts">
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import FormCard from "./FormCard";
+import FormCard from "./FormCard.vue";
 import { defineAsyncComponent } from "vue";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faPlus, faTrashAlt, faCaretUp, faCaretDown } from "@fortawesome/free-solid-svg-icons";
 
 const FormNode = defineAsyncComponent(() => import("./FormInputs.vue"));
 
@@ -24,17 +26,24 @@ const props = defineProps({
     },
 });
 
-const emit = defineEmits("insert", "delete", "swap");
+const emit = defineEmits<{
+    (e: "insert"): void;
+    (e: "delete", index: number): void;
+    (e: "swap", a: number, b: number): void;
+}>();
+
+// @ts-ignore: bad library types
+library.add(faPlus, faTrashAlt, faCaretUp, faCaretDown);
 
 function onInsert() {
     emit("insert");
 }
 
-function onDelete(index) {
+function onDelete(index: number) {
     emit("delete", index);
 }
 
-function getPrefix(index) {
+function getPrefix(index: number) {
     const name = `${props.input.name}_${index}`;
 
     if (props.prefix) {
@@ -44,32 +53,25 @@ function getPrefix(index) {
     }
 }
 
-function getTitle(index) {
-    return `${parseInt(index) + 1}: ${props.input.title}`;
+function getTitle(index: number) {
+    return `${index + 1}: ${props.input.title}`;
 }
 
 /** swap blocks if possible */
-function swap(index, swapWith, up) {
+function swap(index: number, swapWith: number, direction: "up" | "down") {
     if (swapWith >= 0 && swapWith < props.input.cache?.length) {
         emit("swap", index, swapWith);
 
-        const buttonId = getButtonId(swapWith, up);
-        document.getElementById(buttonId).focus();
+        const buttonId = getButtonId(swapWith, direction);
+        document.getElementById(buttonId)?.focus();
     }
 }
 
 /** get a uid for the up/down button */
-function getButtonId(index, up) {
+function getButtonId(index: number, direction: "up" | "down") {
     const prefix = getPrefix(index);
-    return `${prefix}_${up ? "up" : "down"}`;
+    return `${prefix}_${direction}`;
 }
-</script>
-
-<script>
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faPlus, faTrashAlt, faCaretUp, faCaretDown } from "@fortawesome/free-solid-svg-icons";
-
-library.add(faPlus, faTrashAlt, faCaretUp, faCaretDown);
 </script>
 
 <template>
@@ -89,25 +91,25 @@ library.add(faPlus, faTrashAlt, faCaretUp, faCaretDown);
                 <span v-if="!props.sustainRepeats" class="float-right">
                     <b-button-group>
                         <b-button
+                            :id="getButtonId(cacheId, 'up')"
                             v-b-tooltip.hover.bottom
                             title="move up"
                             role="button"
                             variant="link"
                             size="sm"
                             class="ml-0"
-                            :id="getButtonId(cacheId, true)"
-                            @click="() => swap(cacheId, cacheId - 1, true)">
+                            @click="() => swap(cacheId, cacheId - 1, 'up')">
                             <FontAwesomeIcon icon="caret-up" />
                         </b-button>
                         <b-button
+                            :id="getButtonId(cacheId, 'down')"
                             v-b-tooltip.hover.bottom
                             title="move down"
                             role="button"
                             variant="link"
                             size="sm"
                             class="ml-0"
-                            :id="getButtonId(cacheId, false)"
-                            @click="() => swap(cacheId, cacheId + 1, false)">
+                            @click="() => swap(cacheId, cacheId + 1, 'down')">
                             <FontAwesomeIcon icon="caret-down" />
                         </b-button>
                     </b-button-group>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -159,7 +159,7 @@ function getOrSetKey(object: Object) {
         </FormCard>
 
         <b-button v-if="!props.sustainRepeats" @click="onInsert">
-            <font-awesome-icon icon="plus" class="mr-1" />
+            <FontAwesomeIcon icon="plus" class="mr-1" />
             <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
         </b-button>
     </div>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import FormCard from "./FormCard.vue";
-import { defineAsyncComponent, unref, type PropType, nextTick } from "vue";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faPlus, faTrashAlt, faCaretUp, faCaretDown } from "@fortawesome/free-solid-svg-icons";
+import { faCaretDown, faCaretUp, faPlus, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { defineAsyncComponent, nextTick, type PropType, unref } from "vue";
+
 import { useUid } from "@/composables/utils/uid";
+
+import FormCard from "./FormCard.vue";
 
 const FormNode = defineAsyncComponent(() => import("./FormInputs.vue"));
 

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -1,0 +1,106 @@
+<script setup>
+import Draggable from "vuedraggable";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import FormCard from "./FormCard";
+import { defineAsyncComponent, computed } from "vue";
+
+const FormNode = defineAsyncComponent(() => import("./FormInputs.vue"));
+
+const props = defineProps({
+    input: {
+        type: Object,
+        required: true,
+    },
+    sustainRepeats: {
+        type: Boolean,
+        default: false,
+    },
+    passthroughProps: {
+        type: Object,
+        required: true,
+    },
+    prefix: {
+        type: String,
+        default: null,
+    },
+});
+
+const emit = defineEmits("insert", "delete", "changed");
+
+const cache = computed({
+    get() {
+        return props.input.cache;
+    },
+    set(val) {
+        emit("changed");
+    },
+});
+
+function onInsert() {
+    emit("insert");
+}
+
+function onDelete(index) {
+    emit("delete", index);
+}
+
+function getPrefix(index) {
+    const name = `${props.input.name}_${index}`;
+
+    if (props.prefix) {
+        return `${props.prefix}|${name}`;
+    } else {
+        return name;
+    }
+}
+
+function getTitle(index) {
+    return `${parseInt(index) + 1}: ${props.input.title}`;
+}
+</script>
+
+<script>
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faPlus, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faPlus, faTrashAlt);
+</script>
+
+<template>
+    <div>
+        <div v-if="!props.sustainRepeats || (cache && cache.length > 0)">
+            <div class="font-weight-bold mb-2">{{ props.input.title }}</div>
+            <div v-if="props.input.help" class="mb-2" data-description="repeat help">{{ props.input.help }}</div>
+        </div>
+        <Draggable v-model="cache" draggable="card">
+            <FormCard
+                v-for="(cache, cacheId) in cache"
+                :key="cacheId"
+                data-description="repeat block"
+                class="card"
+                :title="getTitle(cacheId)">
+                <template v-slot:operations>
+                    <b-button
+                        v-if="!props.sustainRepeats"
+                        v-b-tooltip.hover.bottom
+                        role="button"
+                        variant="link"
+                        size="sm"
+                        class="float-right"
+                        @click="onDelete(cacheId)">
+                        <FontAwesomeIcon icon="trash-alt" />
+                    </b-button>
+                </template>
+
+                <template v-slot:body>
+                    <FormNode v-bind="props.passthroughProps" :inputs="cache" :prefix="getPrefix(cacheId)" />
+                </template>
+            </FormCard>
+
+            <b-button v-if="!props.sustainRepeats" slot="footer" @click="onInsert()">
+                <font-awesome-icon icon="plus" class="mr-1" />
+                <span data-description="repeat insert">Insert {{ props.input.title || "Repeat" }}</span>
+            </b-button>
+        </Draggable>
+    </div>
+</template>

--- a/client/src/components/Form/FormRepeat.vue
+++ b/client/src/components/Form/FormRepeat.vue
@@ -2,9 +2,9 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretDown, faCaretUp, faPlus, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { defineAsyncComponent, nextTick, type PropType, unref } from "vue";
+import { defineAsyncComponent, nextTick, type PropType } from "vue";
 
-import { useUid } from "@/composables/utils/uid";
+import { useKeyedObjects } from "@/composables/keyedObjects";
 
 import FormCard from "./FormCard.vue";
 
@@ -85,19 +85,7 @@ function getButtonId(index: number, direction: "up" | "down") {
     return `${prefix}_${direction}`;
 }
 
-const keyCache = new WeakMap<object, string>();
-
-function getOrSetKey(object: Object) {
-    const cachedKey = keyCache.get(object);
-
-    if (cachedKey) {
-        return cachedKey;
-    } else {
-        const key = unref(useUid("repeat-"));
-        keyCache.set(object, key);
-        return key;
-    }
-}
+const { keyObject } = useKeyedObjects();
 </script>
 
 <template>
@@ -109,7 +97,7 @@ function getOrSetKey(object: Object) {
 
         <FormCard
             v-for="(cache, cacheId) in props.input.cache"
-            :key="getOrSetKey(cache)"
+            :key="keyObject(cache)"
             data-description="repeat block"
             class="card"
             :title="getTitle(cacheId)">

--- a/client/src/composables/keyedObjects.test.ts
+++ b/client/src/composables/keyedObjects.test.ts
@@ -1,0 +1,50 @@
+import { useKeyedObjects } from "./keyedObjects";
+
+describe("useKeyedObjects", () => {
+    it("returns the same id for the same object", () => {
+        const { keyObject } = useKeyedObjects();
+
+        const obj = {
+            a: 1,
+            b: 2,
+        } as {
+            a: number;
+            b: number;
+            c?: number;
+        };
+
+        const keyA = keyObject(obj);
+        expect(keyObject(obj)).toBe(keyA);
+
+        obj.a += 5;
+        obj["c"] = 6;
+
+        expect(keyObject(obj)).toBe(keyA);
+    });
+
+    it("returns different ids for different objects", () => {
+        const { keyObject } = useKeyedObjects();
+
+        const objA = {
+            a: 1,
+        };
+
+        const objB = {
+            b: 2,
+        };
+
+        const keyA = keyObject(objA);
+        const keyB = keyObject(objB);
+        expect(keyA).not.toBe(keyB);
+
+        const objD = {
+            d: 3,
+        };
+        const objE = structuredClone(objD);
+        const keyD = keyObject(objD);
+        const keyE = keyObject(objE);
+        expect(keyD).not.toBe(keyE);
+
+        expect(keyObject({})).not.toBe(keyObject({}));
+    });
+});

--- a/client/src/composables/keyedObjects.ts
+++ b/client/src/composables/keyedObjects.ts
@@ -1,0 +1,34 @@
+import { unref } from "vue";
+
+import { useUid } from "./utils/uid";
+
+/**
+ * Allows for keying objects by their internal ids.
+ * Returns a function which takes an object and returns a string uid.
+ * Passing the same object to this function twice, will return the same id.
+ *
+ * Passing the same object to a function created by another
+ * `useKeyedObjects` composable will not produce the same ids.
+ *
+ * A cloned object will not have the same id as the object it was cloned from.
+ * Modifying an objects properties will not affect its id.
+ *
+ * @returns A function which allows for keying objects
+ */
+export function useKeyedObjects() {
+    const keyCache = new WeakMap<object, string>();
+
+    function keyObject(object: object) {
+        const cachedKey = keyCache.get(object);
+
+        if (cachedKey) {
+            return cachedKey;
+        } else {
+            const key = unref(useUid("object-"));
+            keyCache.set(object, key);
+            return key;
+        }
+    }
+
+    return { keyObject };
+}

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -125,6 +125,7 @@ $panel_footer_height: 25px;
 
 // Portlets
 $portlet-bg-color: $gray-200;
+$portlet-focus-color: $brand-info;
 
 // Borders
 $border-radius-base: 0.1875rem;

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -138,8 +138,9 @@ $ui-margin-horizontal-large: $margin-v * 2;
         }
         .portlet-operations {
             button {
-                @extend .ml-1;
-                @extend .py-0;
+                margin-left: 0.25rem;
+                padding-top: 0;
+                padding-bottom: 0;
             }
         }
     }
@@ -171,7 +172,11 @@ $ui-margin-horizontal-large: $margin-v * 2;
     @extend .mb-2;
     border: none;
     border-left: solid 3px $portlet-bg-color;
-    border-radius: $border-radius-large;
+    border-radius: $border-radius-large $border-radius-large $border-radius-large 0;
+    &:focus-within {
+        border-left: solid 3px $portlet-focus-color;
+    }
+
     .portlet-header:first-child {
         @extend .rounded-0;
         @extend .p-2;

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -564,13 +564,14 @@ tool_form:
     data_option_value: option[value="${item_id}"]
 
     repeat_insert: '[data-description="repeat insert"]'
+    repeat_move_up: '#${parameter}_up'
+    repeat_move_down: '#${parameter}_down'
     reference: '.formatted-reference'
     about: '.tool-footer'
     storage_options: '.tool-storage'
     drilldown_select_all: 'div.ui-form-element[id="form-element-${parameter}"] div.select-all-checkbox'
     drilldown_option: '.drilldown-option'
     drilldown_expand: '.fa-plus-square'
-
 
   labels:
     generate_tour: 'Generate Tour'

--- a/client/tests/jest/jest-environment.js
+++ b/client/tests/jest/jest-environment.js
@@ -1,10 +1,14 @@
-import JSDOMEnvironment from "jest-environment-jsdom";
 import "jsdom-worker";
+
+import JSDOMEnvironment from "jest-environment-jsdom";
 
 export default class CustomJSDOMEnvironment extends JSDOMEnvironment {
     constructor(...args) {
         super(...args);
 
         this.global.Worker = Worker;
+
+        // FIXME https://github.com/jsdom/jsdom/issues/3363
+        this.global.structuredClone = structuredClone;
     }
 }

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -2,11 +2,11 @@ import json
 from typing import (
     Any,
     Dict,
+    List,
 )
 
 import pytest
 from selenium.webdriver.common.by import By
-from typing import List
 
 from galaxy.model.unittest_utils.store_fixtures import one_hda_model_store_dict
 from galaxy.selenium.navigates_galaxy import retry_call_during_transitions

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -218,6 +218,7 @@
   <tool file="python_environment_problem.xml" />
   <tool file="config_vars.xml" />
   <tool file="expect_num_outputs.xml" />
+  <tool file="text_repeat.xml" />
 
   <tool file="multiple_versions_v01.xml" />
   <tool file="multiple_versions_v01galaxy6.xml" />

--- a/test/functional/tools/text_repeat.xml
+++ b/test/functional/tools/text_repeat.xml
@@ -1,0 +1,15 @@
+<tool id="text_repeat" name="text_repeat" version="1.0.0">
+    <command><![CDATA[
+#for $repeat_instance in $the_repeat#
+    echo '$repeat_instance.texttest' >> 'out_file1';
+#end for#
+    ]]></command>
+    <inputs>
+        <repeat name="the_repeat" title="Repeat Inputs">
+            <param name="texttest" type="text" />
+        </repeat>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+</tool>


### PR DESCRIPTION
Closes #1311

Adds "move up" / "move down" buttons to repeat blocks. Also adds focus highlighting to portlets, so the active repeat block can be followed visually, when it is moved. ~~This still breaks for some legacy form parameters within the repeat block. I will wait for #11076 before attempting a fix, as I suspect the problem may solve itself when vueifying all form components.~~ Update: Keying using a WeakMap fixed this issue.

Existing drag and drop solutions were not possible to implement, due to incompatibilities in the way the form data is handled. While a custom drag and drop solution may be an option, I opted to go for the button approach for now. Buttons would be necessary either way, to make this functionality accessible.

![image](https://user-images.githubusercontent.com/44241786/199001422-c29a7141-620b-45f0-85b9-c6df501c6bf9.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
