### PR TITLE
[22.05] Fix collection download link

### DIFF
--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -7,6 +7,7 @@
                     class="rounded-0 text-decoration-none"
                     size="sm"
                     variant="link"
+                    :href="downloadUrl"
                     @click="onDownload">
                     <Icon class="mr-1" icon="download" />
                     <span>Download</span>


### PR DESCRIPTION
Adds href to collection download link so users have the ability to copy it for sharing, use w/ curl, etc.

The same sharing rules apply as usual datasets -- has to be accessible, etc.  This fixes #14896 


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
