### PR TITLE
[19.05] Backport fixes from #14882

### DIFF
--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -121,9 +121,9 @@ class CondaContext(installable.InstallableContext):
         self._conda_version = packaging.version.parse(info["conda_version"])
         self._conda_build_available = False
         conda_build_version = info.get("conda_build_version")
-        if conda_build_version != "not installed":
+        if conda_build_version and conda_build_version != "not installed":
             try:
-                self._conda_version = packaging.version.parse(conda_build_version)
+                packaging.version.parse(conda_build_version)
                 self._conda_build_available = True
             except Exception:
                 pass

--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -100,9 +100,12 @@ class CondaContext(installable.InstallableContext):
         else:
             ensure_channels = None
         self.ensure_channels = ensure_channels
+        self.use_local = use_local
+        self._reset_conda_properties()
+
+    def _reset_conda_properties(self):
         self._conda_version = None
         self._conda_build_available = None
-        self.use_local = use_local
 
     @property
     def conda_version(self):
@@ -272,6 +275,8 @@ class CondaContext(installable.InstallableContext):
             ret = self.exec_command("install", install_args, stdout_path=stdout_path)
             if ret == 0:
                 break
+        if ret == 0:
+            self._reset_conda_properties()
         return ret
 
     def exec_clean(self, args=[], quiet=False):

--- a/lib/galaxy/tools/deps/conda_util.py
+++ b/lib/galaxy/tools/deps/conda_util.py
@@ -224,14 +224,21 @@ class CondaContext(installable.InstallableContext):
         """
         Return the process exit code (i.e. 0 in case of success).
         """
-        create_args = ["-y", "--quiet"]
-        if self.conda_version >= packaging.version.parse("4.7.5"):
-            create_args.append("--strict-channel-priority")
-        if allow_local and self.use_local:
-            create_args.extend(["--use-local"])
-        create_args.extend(self._override_channels_args)
-        create_args.extend(args)
-        return self.exec_command("create", create_args, stdout_path=stdout_path)
+        for try_strict in [True, False]:
+            create_args = ["-y", "--quiet"]
+            if try_strict:
+                if self.conda_version >= packaging.version.parse("4.7.5"):
+                    create_args.append("--strict-channel-priority")
+                else:
+                    continue
+            if allow_local and self.use_local:
+                create_args.append("--use-local")
+            create_args.extend(self._override_channels_args)
+            create_args.extend(args)
+            ret = self.exec_command("create", create_args, stdout_path=stdout_path)
+            if ret == 0:
+                break
+        return ret
 
     def exec_remove(self, args):
         """
@@ -251,14 +258,21 @@ class CondaContext(installable.InstallableContext):
         """
         Return the process exit code (i.e. 0 in case of success).
         """
-        install_args = ["-y"]
-        if self.conda_version >= packaging.version.parse("4.7.5"):
-            install_args.append("--strict-channel-priority")
-        if allow_local and self.use_local:
-            install_args.append("--use-local")
-        install_args.extend(self._override_channels_args)
-        install_args.extend(args)
-        return self.exec_command("install", install_args, stdout_path=stdout_path)
+        for try_strict in [True, False]:
+            install_args = ["-y"]
+            if try_strict:
+                if self.conda_version >= packaging.version.parse("4.7.5"):
+                    install_args.append("--strict-channel-priority")
+                else:
+                    continue
+            if allow_local and self.use_local:
+                install_args.append("--use-local")
+            install_args.extend(self._override_channels_args)
+            install_args.extend(args)
+            ret = self.exec_command("install", install_args, stdout_path=stdout_path)
+            if ret == 0:
+                break
+        return ret
 
     def exec_clean(self, args=[], quiet=False):
         """


### PR DESCRIPTION
Fix 2 issues introduced in https://github.com/galaxyproject/galaxy/pull/14856 .

Also:
- Force recomputation of conda properties after `conda install`, since conda version and conda-build availability may change after an `install` in the root environment.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
