### PR TITLE
Allow specifying safe paths for ``find_required_files``

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3051,6 +3051,20 @@
 :Type: bool
 
 
+~~~~~~~~~~~~~~~~~~~~~~~
+``tool_path_allowlist``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    List of paths that are valid targets of symbolic links outside of
+    the current tool directory. Currently only used when staging files
+    to a remote location using a pulsar job runner. This option should
+    only be useful during local development and in continuous
+    integration environments.
+:Default: ``[]``
+:Type: seq
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``disable_library_comptypes``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1583,6 +1583,13 @@ galaxy:
   # access to.
   #allow_path_paste: false
 
+  # List of paths that are valid targets of symbolic links outside of
+  # the current tool directory. Currently only used when staging files
+  # to a remote location using a pulsar job runner. This option should
+  # only be useful during local development and in continuous
+  # integration environments.
+  #tool_path_allowlist: []
+
   # Users may choose to download multiple files from a library in an
   # archive.  By default, Galaxy allows users to select from a few
   # different archive formats if testing shows that Galaxy is able to

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2212,6 +2212,16 @@ mapping:
           implication that this will give Galaxy Admins access to anything your Galaxy
           user has access to.
 
+      tool_path_allowlist:
+        type: seq
+        sequence:
+          - type: str
+        required: false
+        desc: |
+          List of paths that are valid targets of symbolic links outside of the current tool directory.
+          Currently only used when staging files to a remote location using a pulsar job runner.
+          This option should only be useful during local development and in continuous integration environments.
+
       disable_library_comptypes:
         type: str
         required: false

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -3,7 +3,10 @@ import logging
 import math
 import re
 import uuid
-from typing import Optional
+from typing import (
+    List,
+    Optional,
+)
 
 import packaging.version
 
@@ -262,7 +265,7 @@ class XmlToolSource(ToolSource):
             elem = self.root
         return string_as_bool(elem.get(attribute, default))
 
-    def parse_required_files(self) -> Optional[RequiredFiles]:
+    def parse_required_files(self, tool_path_allowlist: Optional[List[str]] = None) -> Optional[RequiredFiles]:
         required_files = self.root.find("required_files")
         if required_files is None:
             return None
@@ -282,6 +285,7 @@ class XmlToolSource(ToolSource):
         )
         as_dict["includes"] = parse_include_exclude_list("include")
         as_dict["excludes"] = parse_include_exclude_list("exclude")
+        as_dict["tool_path_allowlist"] = tool_path_allowlist
         return RequiredFiles.from_dict(as_dict)
 
     def parse_requirements_and_containers(self):


### PR DESCRIPTION
This for instance allows setting up a planemo instance with embedded pulsar. The input staging then allows testing tools whose scripts are symlinks to shared locations (this is only needed during CI, the scripts are properly tar-ed up when uploaded to the tool shed).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
