### PR TITLE
[22.05] Fix displaying named tags

### DIFF
--- a/templates/tagging_common.mako
+++ b/templates/tagging_common.mako
@@ -77,7 +77,7 @@ from markupsafe import escape
 
         item_tag_names = []
         for ta in item_tags:
-            item_tag_names.append(escape(ta.tag.name))
+            item_tag_names.append(escape(f"#{ta.value}" if ta.value else ta.tag.name))
     %>
 
     <div id="tags-${tagged_item_id}"></div>


### PR DESCRIPTION
Related #14893 

Both pages use mako files and grid, and in 8e0f91460962aa6b9fe4b421999325b2888771c4 commit, the `histories/list` problem was fixed only. To fix `histories/list_published` there is not enough data returned from the query and it needs to be updated.
Community tags are returned in https://github.com/itisAliRH/galaxy/blob/fix_grid_tags_display/lib/galaxy/model/tags.py#L88 and it only uses the `tags` table but the named tags are stored in `history_tag_association`.

I'm not sure if it's worth(?) fixing it or just migrating everything to vue and fast API.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. open `histories/list`
  2. tags starting with `#` should be rendered properly

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
