### PR TITLE
[21.09] Backport 14518: Always call strip() on data_column column values

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1259,6 +1259,11 @@ class ColumnListParameter(SelectToolParameter):
         self.is_dynamic = True
         self.usecolnames = input_source.get_bool("use_header_names", False)
 
+    def to_json(self, value, app, use_security):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
     def from_json(self, value, trans, other_values=None):
         """
         Label convention prepends column number with a 'c', but tool uses the integer. This
@@ -1292,8 +1297,9 @@ class ColumnListParameter(SelectToolParameter):
     @staticmethod
     def _strip_c(column):
         if isinstance(column, str):
-            if column.startswith('c') and len(column) > 1 and all(c.isdigit() for c in column[1:]):
-                column = column.strip().lower()[1:]
+            column = column.strip()
+            if column.startswith("c") and len(column) > 1 and all(c.isdigit() for c in column[1:]):
+                column = column.lower()[1:]
         return column
 
     def get_column_list(self, trans, other_values):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1325,7 +1325,7 @@ steps:
         # In this case the newline may have been added by the workflow editor
         # text field that is used for data_column parameters
         with self.dataset_populator.test_history() as history_id:
-            job_summary = self._run_workflow(
+            job_summary = self._run_jobs(
                 """class: GalaxyWorkflow
 steps:
   empty_output:


### PR DESCRIPTION
Not just when they start with `c`. Should fix running workflows that were created by manually writing columns in the text area field and then hitting enter.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
