### PR TITLE
Mark optional form parameters followup

### DIFF
--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -189,6 +189,7 @@ const isEmpty = computed(() => {
 
 const isRequired = computed(() => attrs.value["optional"] === false);
 const isRequiredType = computed(() => props.type !== "boolean");
+const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !== undefined);
 </script>
 
 <script>
@@ -241,7 +242,9 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 *
                 <span v-if="isEmpty" class="ui-form-title-message warning"> required </span>
             </span>
-            <span v-else-if="isRequiredType && props.title" class="ui-form-title-message"> - optional </span>
+            <span v-else-if="isOptional && isRequiredType && props.title" class="ui-form-title-message">
+                - optional
+            </span>
         </div>
 
         <div v-if="showField" class="ui-form-field" :data-label="props.title">


### PR DESCRIPTION
Followup for #14861

Hides the optional hint, if no optional attribute is provided.

![image](https://user-images.githubusercontent.com/44241786/199710486-b7b4a7c4-f1ab-482d-ae98-29edb56d497c.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
