### PR TITLE
Upgrade vue-router to latest 3x series for composition api usage

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -89,7 +89,7 @@
     "vue-multiselect": "^2.1.6",
     "vue-observe-visibility": "^1.0.0",
     "vue-prismjs": "^1.2.0",
-    "vue-router": "^3.5.3",
+    "vue-router": "^3.6.5",
     "vue-rx": "^6.2.0",
     "vue-virtual-scroll-list": "^2.3.3",
     "vuedraggable": "2.24.3",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9993,10 +9993,10 @@ vue-prismjs@^1.2.0:
   dependencies:
     prismjs "^1.6.0"
 
-vue-router@^3.5.3:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.5.4.tgz#c453c0b36bc75554de066fefc3f2a9c3212aca70"
-  integrity sha512-x+/DLAJZv2mcQ7glH2oV9ze8uPwcI+H+GgTgTmb5I55bCgY3+vXWIsqbYUzbBSZnwFHEJku4eoaH/x98veyymQ==
+vue-router@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.6.5.tgz#95847d52b9a7e3f1361cb605c8e6441f202afad8"
+  integrity sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ==
 
 vue-rx@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
In composition API components you can use the router like so:

```
<script setup>
import { useRouter } from "vue-router/composables";

const router = useRouter();

function goToHome() {
    router.push({ name: "root" });
}

...
</script>
```

(and then call `goToHome()` wherever in your component you need, like usual)
```
<b-button variant="primary" @click="goToHome">Return to Home</b-button>
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
