### PR TITLE
Allow LSF Cli submission to detect walltime reached

### DIFF
--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -95,6 +95,8 @@ class LSF(BaseJobExec):
         for line in reason.splitlines():
             if "TERM_MEMLIMIT" in line:
                 return runner_states.MEMORY_LIMIT_REACHED
+            if "TERM_RUNLIMIT" in line:
+                return runner_states.WALLTIME_REACHED
         return None
 
     def _get_job_state(self, state):


### PR DESCRIPTION
When LSF hits the walltime limit, the term "TERM_RUNLIMIT" appears in the output. This catches that term and will subsequently allow Galaxy to handle this correctly.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Setup Galaxy to submit to LSF using the Cli system
  2. Set up a job so that it reaches the walltime limit.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
