### PR TITLE
Fix conda-build version not compatible

### DIFF
--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -18,6 +18,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.7']
     steps:
@@ -33,7 +34,6 @@ jobs:
         run: echo "version=$(python -c 'import sys; print("-".join(str(v) for v in sys.version_info))')" >> $GITHUB_OUTPUT
       - name: Cache pip dir
         uses: actions/cache@v3
-        id: pip-cache
         with:
           path: ~/.cache/pip
           key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
@@ -44,7 +44,7 @@ jobs:
           key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-mulled
       - name: Install tox
         run: pip install tox
-      - name: run tests
+      - name: Run tests
         run: tox -e mulled
         working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -42,6 +42,8 @@ jobs:
         with:
           path: .tox
           key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-mulled
+      - name: Install Apptainer's singularity
+        uses: eWaterCycle/setup-apptainer@v2
       - name: Install tox
         run: pip install tox
       - name: Run tests

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -37,15 +37,17 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
-      - name: Cache galaxy venv
+      - name: Cache tox env
         uses: actions/cache@v3
         with:
-          path: 'galaxy root/.venv'
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-unit
+          path: .tox
+          key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-unit
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get -y install ffmpeg
+      - name: Install tox
+        run: pip install tox
       - name: Run tests
-        run: ./run_tests.sh --coverage -u
+        run: tox -e unit-coverage
         working-directory: 'galaxy root'
       - uses: codecov/codecov-action@v3
         with:

--- a/doc/source/dev/run_tests_help.txt
+++ b/doc/source/dev/run_tests_help.txt
@@ -142,8 +142,8 @@ Extra options:
  --no_cleanup          Do not delete temp files for Python functional tests
                        (-toolshed, -framework, etc...)
  --coverage            Generate a test coverage report. This option currently
-                       works with every python test, but the
-                       results may not be reliable with selenium or other
+                       works with every Python test, but the
+                       results may not be reliable with Selenium or other
                        frameworks that primarily test the client.
  --debug               On python test error or failure invoke a pdb shell for
                        interactive debugging of the test
@@ -169,6 +169,11 @@ can be used to control the Galaxy functional testing processing. Command-line
 options above like (--external_url) will set environment variables - in such
 cases the command line argument takes precedent over environment variables set
 at the time of running this script.
+
+General Test Environment Variables
+
+GALAXY_TEST_COVERAGE            If set, it is equivalent to passing the
+                                --coverage option.
 
 Functional Test Environment Variables
 
@@ -239,9 +244,4 @@ TOOL_SHED_TEST_TMP_DIR          Defaults to random /tmp directory - place for
 TOOL_SHED_TEST_OMIT_GALAXY      Do not launch a Galaxy server for tool shed
                                 testing.
 GALAXY_TEST_DISABLE_ACCESS_LOG  Do not log access messages
-
-Unit Test Environment Variables
-
-GALAXY_TEST_INCLUDE_SLOW - Used in unit tests to trigger slower tests that
-                           aren't included by default with --unit/-u.
 

--- a/doc/source/dev/writing_tests.md
+++ b/doc/source/dev/writing_tests.md
@@ -151,8 +151,8 @@ that do not require a full Galaxy server. While these aren't really
 "unit" tests in a traditional sense, they are unit tests from a Galaxy
 perspective because they do not depend on a Galaxy server.
 
-These tests should be marked as requiring the environment variable
-``GALAXY_TEST_INCLUDE_SLOW`` to run.
+These tests should be marked with the `@external_dependency_management`
+decorator, and can then be tested with `tox -e mulled`.
 
 ### Continuous Integration
 

--- a/lib/galaxy/tool_util/unittest_utils/__init__.py
+++ b/lib/galaxy/tool_util/unittest_utils/__init__.py
@@ -52,3 +52,6 @@ def skip_if_site_down(url: str) -> Callable:
         return wrapped_method
 
     return method_wrapper
+
+
+skip_if_github_down = skip_if_site_down("https://github.com/")

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -2,11 +2,11 @@ import zipfile
 from io import BytesIO
 from typing import List
 
+from galaxy.tool_util.unittest_utils import skip_if_github_down
 from galaxy_test.base.api_asserts import assert_object_id_error
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
-    skip_if_github_down,
 )
 from ._framework import ApiTestCase
 

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -11,11 +11,11 @@ from galaxy.model.unittest_utils.store_fixtures import (
     one_hda_model_store_dict,
     TEST_SOURCE_URI,
 )
+from galaxy.tool_util.unittest_utils import skip_if_github_down
 from galaxy_test.base.api_asserts import assert_has_keys
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
-    skip_if_github_down,
     skip_without_datatype,
     skip_without_tool,
 )

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -4,13 +4,13 @@ from galaxy.model.unittest_utils.store_fixtures import (
     one_ld_library_model_store_dict,
     TEST_LIBRARY_NAME,
 )
+from galaxy.tool_util.unittest_utils import skip_if_github_down
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
     FILE_URL,
     LibraryPopulator,
-    skip_if_github_down,
     skip_without_asgi,
 )
 from ._framework import ApiTestCase

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -11,6 +11,7 @@ from requests import (
     put,
 )
 
+from galaxy.tool_util.unittest_utils import skip_if_github_down
 from galaxy.util import galaxy_root_path
 from galaxy_test.base import rules_test_data
 from galaxy_test.base.api_asserts import (
@@ -22,7 +23,6 @@ from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
     LibraryPopulator,
-    skip_if_github_down,
     skip_without_tool,
     stage_rules_example,
     uses_test_history,

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -5,7 +5,10 @@ import urllib.parse
 import pytest
 from tusclient import client
 
-from galaxy.tool_util.unittest_utils import skip_if_site_down
+from galaxy.tool_util.unittest_utils import (
+    skip_if_github_down,
+    skip_if_site_down,
+)
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy_test.base.constants import (
     ONE_TO_SIX_ON_WINDOWS,
@@ -16,7 +19,6 @@ from galaxy_test.base.constants import (
 )
 from galaxy_test.base.populators import (
     DatasetPopulator,
-    skip_if_github_down,
     skip_without_datatype,
     stage_inputs,
     uses_test_history,

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -195,7 +195,6 @@ def skip_without_datatype(extension):
 
 
 skip_if_toolshed_down = skip_if_site_down("https://toolshed.g2.bx.psu.edu")
-skip_if_github_down = skip_if_site_down("https://github.com/")
 
 
 def summarize_instance_history_on_error(method):

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -31,6 +31,7 @@ from galaxy.selenium.navigates_galaxy import (
     NavigatesGalaxy,
     retry_during_transitions,
 )
+from galaxy.tool_util.unittest_utils import skip_if_github_down
 from galaxy.tool_util.verify.interactor import prepare_request_params
 from galaxy.util import (
     asbool,
@@ -49,7 +50,6 @@ from galaxy_test.base.env import (
 )
 from galaxy_test.base.populators import (
     load_data_dict,
-    skip_if_github_down,
     YamlContentT,
 )
 from galaxy_test.base.testcase import FunctionalTestCase

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -5,10 +5,10 @@ from selenium.webdriver.common.by import By
 
 from galaxy.model.unittest_utils.store_fixtures import one_hda_model_store_dict
 from galaxy.selenium.navigates_galaxy import retry_call_during_transitions
+from galaxy.tool_util.unittest_utils import skip_if_github_down
 from galaxy_test.base import rules_test_data
 from galaxy_test.base.populators import (
     flakey,
-    skip_if_github_down,
     stage_rules_example,
 )
 from .framework import (

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -60,7 +60,7 @@ for ((i=0; i<${#PACKAGE_DIRS[@]}; i++)); do
     # Also ignore functional tests (galaxy_test/ and tool_shed/test/).
     unit_extra='--doctest-modules --ignore=galaxy/model/migrations/alembic/ --ignore=galaxy_test/ --ignore=tool_shed/test/'
     # Ignore exit code 5 (no tests ran)
-    pytest $unit_extra . || test $? -eq 5
+    pytest $unit_extra -m 'not external_dependency_management' . || test $? -eq 5
     make mypy
     cd ..
 done

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ log_level = DEBUG
 pythonpath = lib
 markers =
   data_manager: marks test as a data_manager test
+  external_dependency_management: slow tests which resolves dependencies with e.g. conda
   tool: marks test as a tool test
   gtn_screenshot: marks test as a screenshot producer for galaxy training network
   local: mark indicates, that it is sufficient to run test locally to get relevant artifacts (e.g. screenshots)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -148,8 +148,8 @@ Extra options:
  --no_cleanup          Do not delete temp files for Python functional tests
                        (-toolshed, -framework, etc...)
  --coverage            Generate a test coverage report. This option currently
-                       works with every python test, but the
-                       results may not be reliable with selenium or other
+                       works with every Python test, but the
+                       results may not be reliable with Selenium or other
                        frameworks that primarily test the client.
  --debug               On python test error or failure invoke a pdb shell for
                        interactive debugging of the test
@@ -175,6 +175,11 @@ can be used to control the Galaxy functional testing processing. Command-line
 options above like (--external_url) will set environment variables - in such
 cases the command line argument takes precedent over environment variables set
 at the time of running this script.
+
+General Test Environment Variables
+
+GALAXY_TEST_COVERAGE            If set, it is equivalent to passing the
+                                --coverage option.
 
 Functional Test Environment Variables
 
@@ -246,11 +251,6 @@ TOOL_SHED_TEST_OMIT_GALAXY      Do not launch a Galaxy server for tool shed
                                 testing.
 GALAXY_TEST_DISABLE_ACCESS_LOG  Do not log access messages
 
-Unit Test Environment Variables
-
-GALAXY_TEST_INCLUDE_SLOW - Used in unit tests to trigger slower tests that
-                           aren't included by default with --unit/-u.
-
 EOF
 }
 
@@ -268,21 +268,23 @@ exists() {
 debug=""
 test_script="pytest"
 report_file="run_functional_tests.html"
-coverage_arg=""
+if [ -n "$GALAXY_TEST_COVERAGE" ]; then
+    coverage_arg="--with-coverage"
+else
+    coverage_arg=""
+fi
 xunit_report_file=""
 structured_data_report_file=""
 structured_data_html=0
 SKIP_CLIENT_BUILD=${GALAXY_SKIP_CLIENT_BUILD:-1}
-if [ "$SKIP_CLIENT_BUILD" = "1" ];
-then
+if [ "$SKIP_CLIENT_BUILD" = "1" ]; then
     skip_client_build="--skip-client-build"
 else
     skip_client_build=""
 fi
 
 # If in Jenkins environment, create xunit-${BUILD_NUMBER}.xml by default.
-if [ -n "$BUILD_NUMBER" ];
-then
+if [ -n "$BUILD_NUMBER" ]; then
     xunit_report_file="xunit-${BUILD_NUMBER}.xml"
 fi
 

--- a/test/unit/app/tools/test_data_fetch.py
+++ b/test/unit/app/tools/test_data_fetch.py
@@ -2,17 +2,11 @@ import json
 import os
 import tempfile
 from contextlib import contextmanager
-from os import environ
 from shutil import rmtree
 from tempfile import mkdtemp
 
-import pytest
-
+from galaxy.tool_util.unittest_utils import skip_if_github_down
 from galaxy.tools.data_fetch import main
-
-github_fetch = pytest.mark.skipif(
-    not environ.get("GALAXY_TEST_INCLUDE_SLOW"), reason="GALAXY_TEST_INCLUDE_SLOW not set"
-)
 
 
 def test_simple_path_get():
@@ -36,6 +30,7 @@ def test_simple_path_get():
         assert output
 
 
+@skip_if_github_down
 def test_simple_uri_get():
     with _execute_context() as execute_context:
         request = {
@@ -60,6 +55,7 @@ def test_simple_uri_get():
         assert hda_result["ext"] == "bed"
 
 
+@skip_if_github_down
 def test_deferred_uri_get():
     with _execute_context() as execute_context:
         request = {
@@ -109,7 +105,7 @@ def test_simple_list_path_get():
         assert destination["object_id"] == 76
 
 
-@github_fetch
+@skip_if_github_down
 def test_hdas_single_url_error():
     with _execute_context() as execute_context:
         job_directory = execute_context.job_directory
@@ -145,7 +141,7 @@ def test_hdas_single_url_error():
         )
 
 
-@github_fetch
+@skip_if_github_down
 def test_hdca_collection_element_failed():
     with _execute_context() as execute_context:
         job_directory = execute_context.job_directory
@@ -177,7 +173,7 @@ def test_hdca_collection_element_failed():
         )
 
 
-@github_fetch
+@skip_if_github_down
 def test_hdca_allow_failed_collections():
     with _execute_context() as execute_context:
         job_directory = execute_context.job_directory

--- a/test/unit/files/test_s3.py
+++ b/test/unit/files/test_s3.py
@@ -4,15 +4,12 @@ import pytest
 
 from ._util import assert_simple_file_realize
 
+pytest.importorskip("s3fs")
+
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 FILE_SOURCES_CONF = os.path.join(SCRIPT_DIRECTORY, "s3_file_sources_conf.yml")
 
-skip_if_not_slow = pytest.mark.skipif(
-    not os.environ.get("GALAXY_TEST_INCLUDE_SLOW"), reason="GALAXY_TEST_INCLUDE_SLOW not set"
-)
 
-
-@skip_if_not_slow
 def test_file_source():
     assert_simple_file_realize(
         FILE_SOURCES_CONF,

--- a/test/unit/tool_util/mulled/test_mulled_update_singularity_containers.py
+++ b/test/unit/tool_util/mulled/test_mulled_update_singularity_containers.py
@@ -1,6 +1,8 @@
 import os
-import shutil
-import tempfile
+from typing import (
+    Any,
+    Dict,
+)
 
 import pytest
 
@@ -13,59 +15,49 @@ from galaxy.util import which
 from ..util import external_dependency_management
 
 
-def test_get_list_from_file():
-    test_dir = tempfile.mkdtemp()
-    try:
-        list_file = os.path.join(test_dir, "list_file.txt")
-        with open(list_file, "w") as f:
-            f.write("bbmap:36.84--0\nbiobambam:2.0.42--0\nconnor:0.5.1--py35_0\ndiamond:0.8.26--0\nedd:1.1.18--py27_0")
-        assert get_list_from_file(list_file) == [
-            "bbmap:36.84--0",
-            "biobambam:2.0.42--0",
-            "connor:0.5.1--py35_0",
-            "diamond:0.8.26--0",
-            "edd:1.1.18--py27_0",
-        ]
-    finally:
-        shutil.rmtree(test_dir)
+def test_get_list_from_file(tmp_path) -> None:
+    list_file = os.path.join(tmp_path, "list_file.txt")
+    with open(list_file, "w") as f:
+        f.write("bbmap:36.84--0\nbiobambam:2.0.42--0\nconnor:0.5.1--py35_0\ndiamond:0.8.26--0\nedd:1.1.18--py27_0")
+    assert get_list_from_file(list_file) == [
+        "bbmap:36.84--0",
+        "biobambam:2.0.42--0",
+        "connor:0.5.1--py35_0",
+        "diamond:0.8.26--0",
+        "edd:1.1.18--py27_0",
+    ]
 
 
 @external_dependency_management
 @pytest.mark.skipif(not which("singularity"), reason="requires singularity but singularity not on PATH")
-def test_docker_to_singularity(tmp_path):
-    tmp_dir = str(tmp_path)
-    docker_to_singularity("abundancebin:1.0.1--0", "singularity", tmp_dir, no_sudo=True)
+def test_docker_to_singularity(tmp_path) -> None:
+    docker_to_singularity("abundancebin:1.0.1--0", "singularity", tmp_path, no_sudo=True)
     assert tmp_path.joinpath("abundancebin:1.0.1--0").exists()
 
 
 @external_dependency_management
 @pytest.mark.skipif(not which("singularity"), reason="requires singularity but singularity not on PATH")
-def test_singularity_container_test(tmp_path):
-    test_dir = tempfile.mkdtemp()
-    try:
-        for n in ["pybigwig:0.1.11--py36_0", "samtools:1.0--1", "yasm:1.3.0--0"]:
-            docker_to_singularity(n, "singularity", test_dir, no_sudo=True)
-        results = singularity_container_test(
-            {
-                "pybigwig:0.1.11--py36_0": {
-                    "imports": ["pyBigWig"],
-                    "commands": [
-                        'python -c "import pyBigWig; assert(pyBigWig.numpy == 1); assert(pyBigWig.remote == 1)"'
-                    ],
-                    "import_lang": "python -c",
-                },
-                "samtools:1.0--1": {
-                    "commands": ["samtools --help"],
-                    "import_lang": "python -c",
-                    "container": "samtools:1.0--1",
-                },
-                "yasm:1.3.0--0": {},
-            },
-            "singularity",
-            test_dir,
-        )
-        assert "samtools:1.0--1" in results["passed"]
-        assert results["failed"][0]["imports"] == ["pyBigWig"]
-        assert "yasm:1.3.0--0" in results["notest"]
-    finally:
-        shutil.rmtree(test_dir)
+def test_singularity_container_test(tmp_path) -> None:
+    tests: Dict[str, Dict[str, Any]] = {
+        "pybigwig:0.1.11--py36_0": {
+            "imports": ["pyBigWig"],
+            "commands": ['python -c "import pyBigWig; assert(pyBigWig.numpy == 1); assert(pyBigWig.remote == 1)"'],
+            "import_lang": "python -c",
+        },
+        "samtools:1.0--1": {
+            "commands": ["samtools --help"],
+            "import_lang": "python -c",
+            "container": "samtools:1.0--1",
+        },
+        "yasm:1.3.0--0": {},
+    }
+    for n in tests.keys():
+        docker_to_singularity(n, "singularity", tmp_path, no_sudo=True)
+    results = singularity_container_test(
+        tests,
+        "singularity",
+        tmp_path,
+    )
+    assert "samtools:1.0--1" in results["passed"]
+    assert results["failed"][0]["imports"] == ["pyBigWig"]
+    assert "yasm:1.3.0--0" in results["notest"]

--- a/test/unit/tool_util/test_conda_resolution.py
+++ b/test/unit/tool_util/test_conda_resolution.py
@@ -1,47 +1,55 @@
-import os
-import shutil
-from tempfile import mkdtemp
+import os.path
+import tempfile
 
-from galaxy.tool_util.deps import (
-    conda_util,
-    DependencyManager,
+from galaxy.tool_util.deps import DependencyManager
+from galaxy.tool_util.deps.conda_util import (
+    CondaContext,
+    install_conda,
+    installed_conda_targets,
 )
 from galaxy.tool_util.deps.requirements import ToolRequirement
-from galaxy.tool_util.deps.resolvers.conda import CondaDependencyResolver
+from galaxy.tool_util.deps.resolvers.conda import (
+    CondaDependencyResolver,
+    DEFAULT_ENSURE_CHANNELS,
+)
 from .util import external_dependency_management
 
 
 @external_dependency_management
-def test_conda_resolution():
-    base_path = mkdtemp()
-    try:
-        job_dir = os.path.join(base_path, "000")
-        dependency_manager = DependencyManager(base_path)
-        resolver = CondaDependencyResolver(
-            dependency_manager,
-            auto_init=True,
-            auto_install=True,
-            use_path_exec=False,  # For the test ensure this is always a clean install
-        )
-        resolver.read_only = True
-        req = ToolRequirement(name="samtools", version=None, type="package")
-        dependency = resolver.resolve(req, job_directory=job_dir)
-        assert dependency.shell_commands() is None
-
-        resolver.read_only = False
-        req = ToolRequirement(name="samtools", version=None, type="package")
-        dependency = resolver.resolve(req, job_directory=job_dir)
-        assert dependency.shell_commands() is not None
-    finally:
-        shutil.rmtree(base_path)
+def test_install_conda_build(tmp_path) -> None:
+    conda_prefix = os.path.join(tmp_path, "miniconda3")
+    cc = CondaContext(conda_prefix=conda_prefix, ensure_channels=DEFAULT_ENSURE_CHANNELS)
+    assert not cc.is_conda_installed()
+    assert install_conda(cc, force_conda_build=True) == 0
+    assert cc.is_conda_installed()
+    assert cc.conda_build_available
 
 
 @external_dependency_management
-def test_against_conda_prefix_regression():
-    """Test that would fail if https://github.com/rtfd/readthedocs.org/issues/1902 regressed."""
+def test_conda_resolution(tmp_path) -> None:
+    job_dir = os.path.join(tmp_path, "000")
+    dependency_manager = DependencyManager(tmp_path)
+    resolver = CondaDependencyResolver(
+        dependency_manager,
+        auto_init=True,
+        auto_install=True,
+        use_path_exec=False,  # For the test ensure this is always a clean install
+    )
+    resolver.read_only = True
+    req = ToolRequirement(name="samtools", version=None, type="package")
+    dependency = resolver.resolve(req, job_directory=job_dir)
+    assert dependency.shell_commands() is None
 
-    base_path = mkdtemp(prefix="x" * 80)  # a ridiculously long prefix
-    try:
+    resolver.read_only = False
+    req = ToolRequirement(name="samtools", version=None, type="package")
+    dependency = resolver.resolve(req, job_directory=job_dir)
+    assert dependency.shell_commands() is not None
+
+
+@external_dependency_management
+def test_against_conda_prefix_regression() -> None:
+    """Test that would fail if https://github.com/rtfd/readthedocs.org/issues/1902 regressed."""
+    with tempfile.TemporaryDirectory(prefix="x" * 80) as base_path:  # a ridiculously long prefix
         job_dir = os.path.join(base_path, "000")
         dependency_manager = DependencyManager(base_path)
         resolver = CondaDependencyResolver(
@@ -51,11 +59,9 @@ def test_against_conda_prefix_regression():
             use_path_exec=False,  # For the test ensure this is always a clean install
         )
         conda_context = resolver.conda_context
-        assert len(list(conda_util.installed_conda_targets(conda_context))) == 0
+        assert len(list(installed_conda_targets(conda_context))) == 0
         req = ToolRequirement(name="samtools", version="0.1.16", type="package")
         dependency = resolver.resolve(req, job_directory=job_dir)
         assert dependency.shell_commands() is not None  # install should not fail anymore
-        installed_targets = list(conda_util.installed_conda_targets(conda_context))
+        installed_targets = list(installed_conda_targets(conda_context))
         assert len(installed_targets) > 0
-    finally:
-        shutil.rmtree(base_path)

--- a/test/unit/tool_util/util.py
+++ b/test/unit/tool_util/util.py
@@ -3,9 +3,7 @@ from os import environ
 
 import pytest
 
-external_dependency_management = pytest.mark.skipif(
-    not environ.get("GALAXY_TEST_INCLUDE_SLOW"), reason="GALAXY_TEST_INCLUDE_SLOW not set"
-)
+external_dependency_management = pytest.mark.external_dependency_management
 
 
 @contextmanager

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     lint_docstring: bash .ci/flake8_wrapper_docstrings.sh --exclude
     lint_docstring_include_list: bash .ci/flake8_wrapper_docstrings.sh --include
     reports_startup: bash .ci/first_startup.sh reports
-    unit: bash run_tests.sh -u
+    mulled,unit: bash run_tests.sh -u
     # start with test here but obviously someday all of it...
     mypy: mypy test lib
     test_galaxy_packages: make generate-cwl-conformance-tests
@@ -25,20 +25,20 @@ passenv =
     APP_WEBSERVER
     TERM
 setenv =
+    coverage: GALAXY_TEST_COVERAGE=1
     first_startup: GALAXY_PYTHON=python
     first_startup: GALAXY_CONFIG_DATABASE_AUTO_MIGRATE=true
     py{36,37,38}-first_startup: GALAXY_VIRTUAL_ENV=.venv3
-    unit: GALAXY_VIRTUAL_ENV={envdir}
+    mulled: marker=external_dependency_management
+    mulled,unit: GALAXY_VIRTUAL_ENV={envdir}
     unit: GALAXY_ENABLE_BETA_COMPRESSED_GENBANK_SNIFFING=1
-    mulled: GALAXY_TEST_INCLUDE_SLOW=1
+    unit: marker=not external_dependency_management
     check_indexes: GALAXY_SKIP_CLIENT_BUILD=1
 deps =
+    coverage: coverage
     lint,lint_docstring,lint_docstring_include_list,mypy: -rlib/galaxy/dependencies/pinned-lint-requirements.txt
     test_galaxy_packages: pyyaml
     unit: mock-ssh-server
-
-[testenv:mulled]
-commands =  bash run_tests.sh --skip-venv -u test/unit/tool_util/mulled
 
 [testenv:check_py3_compatibility]
 commands = bash .ci/check_py3_compatibility.sh


### PR DESCRIPTION
with the new miniconda Python version introduced in commit 06832df48fd4f71c3ca59ba99a01655d3c7f9d0d .

Also, a few changes required for unit testing this (and bugfixes), see individual commits for details.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
