### PR TITLE
Add automated tests for presenting unavailable options to logged-out users

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.test.js
@@ -1,0 +1,110 @@
+import { mockModule, getLocalVue } from "jest/helpers";
+import { userStore } from "store/userStore";
+import Vuex from "vuex";
+import HistoryNavigation from "./HistoryNavigation";
+import { shallowMount } from "@vue/test-utils";
+
+const localVue = getLocalVue();
+
+const createStore = (currentUser) => {
+    return new Vuex.Store({
+        modules: {
+            user: mockModule(userStore, { currentUser }),
+        },
+    });
+};
+
+// all options
+const expectedOptions = [
+    "Show Histories Side-by-Side",
+    "Resume Paused Jobs",
+    "Copy this History",
+    "Delete this History",
+    "Export Tool Citations",
+    "Export History to File",
+    "Extract Workflow",
+    "Share or Publish",
+    "Set Permissions",
+    "Make Private",
+];
+
+// options enabled for logged-out users
+const anonymousOptions = [
+    "Resume Paused Jobs",
+    "Delete this History",
+    "Export Tool Citations",
+    "Export History to File",
+];
+
+// options disabled for logged-out users
+const anonymousDisabledOptions = expectedOptions.filter((option) => !anonymousOptions.includes(option));
+
+describe("History Navigation", () => {
+    it("presents all options to logged-in users", () => {
+        const store = createStore({
+            id: "user.id",
+            email: "user.email",
+        });
+
+        const wrapper = shallowMount(HistoryNavigation, {
+            propsData: {
+                history: { id: "current_history_id" },
+                histories: [],
+            },
+            localVue,
+            store,
+            provide: { store },
+        });
+
+        const dropDown = wrapper.find("*[data-description='history options']");
+        const optionElements = dropDown.findAll("b-dropdown-item-stub");
+        const optionTexts = optionElements.wrappers.map((el) => el.text());
+
+        expect(optionTexts).toStrictEqual(expectedOptions);
+    });
+
+    it("disables options for anonymous users", () => {
+        const store = createStore({});
+
+        const wrapper = shallowMount(HistoryNavigation, {
+            propsData: {
+                history: { id: "current_history_id" },
+                histories: [],
+            },
+            localVue,
+            store,
+            provide: { store },
+        });
+
+        const dropDown = wrapper.find("*[data-description='history options']");
+
+        const enabledOptionElements = dropDown.findAll("b-dropdown-item-stub:not([disabled])");
+        const enabledOptionTexts = enabledOptionElements.wrappers.map((el) => el.text());
+        expect(enabledOptionTexts).toStrictEqual(anonymousOptions);
+
+        const disabledOptionElements = dropDown.findAll("b-dropdown-item-stub[disabled]");
+        const disabledOptionTexts = disabledOptionElements.wrappers.map((el) => el.text());
+        expect(disabledOptionTexts).toStrictEqual(anonymousDisabledOptions);
+    });
+
+    it("prompts anonymous users to log in", () => {
+        const store = createStore({});
+
+        const wrapper = shallowMount(HistoryNavigation, {
+            propsData: {
+                history: { id: "current_history_id" },
+                histories: [],
+            },
+            localVue,
+            store,
+            provide: { store },
+        });
+
+        const dropDown = wrapper.find("*[data-description='history options']");
+        const disabledOptionElements = dropDown.findAll("b-dropdown-item-stub[disabled]");
+
+        disabledOptionElements.wrappers.forEach((option) => {
+            expect(option.attributes("title").toLowerCase()).toContain("log in");
+        });
+    });
+});

--- a/client/src/components/History/Layout/DetailsLayout.test.js
+++ b/client/src/components/History/Layout/DetailsLayout.test.js
@@ -1,0 +1,44 @@
+import { mockModule, getLocalVue } from "jest/helpers";
+import { userStore } from "store/userStore";
+import Vuex from "vuex";
+import DetailsLayout from "./DetailsLayout";
+import { mount } from "@vue/test-utils";
+
+const localVue = getLocalVue();
+
+const createStore = (currentUser) => {
+    return new Vuex.Store({
+        modules: {
+            user: mockModule(userStore, { currentUser }),
+        },
+    });
+};
+
+describe("DetailsLayout", () => {
+    it("allows logged-in users to edit details", () => {
+        const store = createStore({
+            id: "user.id",
+            email: "user.email",
+        });
+
+        const wrapper = mount(DetailsLayout, {
+            localVue,
+            store,
+            provide: { store },
+        });
+
+        expect(wrapper.find(".edit-button").attributes("title")).toBe("Edit");
+    });
+
+    it("prompts anonymous users to log in", () => {
+        const store = createStore({});
+
+        const wrapper = mount(DetailsLayout, {
+            localVue,
+            store,
+            provide: { store },
+        });
+
+        expect(wrapper.find(".edit-button").attributes("title")).toContain("Log in");
+    });
+});

--- a/client/src/components/Panels/Buttons/FavoritesButton.test.js
+++ b/client/src/components/Panels/Buttons/FavoritesButton.test.js
@@ -1,0 +1,46 @@
+import { mockModule, getLocalVue } from "jest/helpers";
+import { userStore } from "store/userStore";
+import Vuex from "vuex";
+import FavoritesButton from "./FavoritesButton";
+import { shallowMount } from "@vue/test-utils";
+
+const localVue = getLocalVue();
+
+const createStore = (currentUser) => {
+    return new Vuex.Store({
+        modules: {
+            user: mockModule(userStore, { currentUser }),
+        },
+    });
+};
+
+describe("Favorites Button", () => {
+    it("describes it's function to logged-in users", () => {
+        const store = createStore({
+            id: "user.id",
+            email: "user.email",
+        });
+
+        const wrapper = shallowMount(FavoritesButton, {
+            localVue,
+            store,
+            provide: { store },
+        });
+
+        expect(wrapper.attributes("disabled")).toBeFalsy();
+        expect(wrapper.attributes("title")).toBe("Show favorites");
+    });
+
+    it("prompts anonymous users to log in", () => {
+        const store = createStore({});
+
+        const wrapper = shallowMount(FavoritesButton, {
+            localVue,
+            store,
+            provide: { store },
+        });
+
+        expect(wrapper.attributes("disabled")).toBeTruthy();
+        expect(wrapper.attributes("title").toLowerCase()).toContain("log in");
+    });
+});


### PR DESCRIPTION
Follow-up for #14419 adding test coverage to the PRs changes.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
