### PR TITLE
Change Custos url in oidc_backends_config

### DIFF
--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -88,7 +88,7 @@ Please mind `http` and `https`.
     </provider>
 
     <provider name="Custos">
-        <url>https://custos.scigap.org/apiserver/identity-management/v1.0.0/</url>
+        <url>https://dev.custos.usecustos.org/apiserver/identity-management/v1.0.0/</url>
         <client_id> ... </client_id>
         <client_secret> ... </client_secret>
         <redirect_uri>http://localhost:8080/authnz/custos/callback</redirect_uri>


### PR DESCRIPTION
Custos changed their routes recently due to js2 migrations etc. Therefore, the `<url>` in `oidc_backends_config.xml.sample` had to be changed.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
