### PR TITLE
Fix download urls in embedded workflow component

### DIFF
--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.test.js
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.test.js
@@ -1,0 +1,43 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import MountTarget from "./WorkflowDisplay";
+
+const localVue = getLocalVue(true);
+
+describe("WorkflowDisplay", () => {
+    let wrapper;
+    let axiosMock;
+
+    beforeEach(() => {
+        axiosMock = new MockAdapter(axios);
+        const data = {};
+        axiosMock.onGet(`/api/workflows/workflow_id/download?style=preview`).reply(200, data);
+        wrapper = mount(MountTarget, {
+            propsData: {
+                args: {
+                    workflow_id: "workflow_id",
+                },
+                embedded: false,
+                expanded: false,
+            },
+            localVue,
+        });
+    });
+
+    afterEach(() => {
+        axiosMock.reset();
+    });
+
+    it("basics", async () => {
+        const cardHeader = wrapper.find(".card-header");
+        expect(cardHeader.text()).toBe("Workflow:");
+        const downloadUrl = wrapper.find("[data-description='workflow download']");
+        expect(downloadUrl.attributes("href")).toBe("/api/workflows/workflow_id/download?format=json-download");
+        const importUrl = wrapper.find("[data-description='workflow import']");
+        expect(importUrl.attributes("href")).toBe("/workflow/imp?id=workflow_id");
+        const dataRequest = axiosMock.history.get[0].url;
+        expect(dataRequest).toBe("/api/workflows/workflow_id/download?style=preview");
+    });
+});

--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
@@ -78,10 +78,10 @@ export default {
             return this.itemContent ? this.itemContent.name : "...";
         },
         downloadUrl() {
-            return safePath("/api/workflows/${this.args.workflow_id}/download?format=json-download");
+            return safePath(`/api/workflows/${this.args.workflow_id}/download?format=json-download`);
         },
         importUrl() {
-            return safePath("/workflow/imp?id=${this.args.workflow_id}");
+            return safePath(`/workflow/imp?id=${this.args.workflow_id}`);
         },
         itemUrl() {
             return `/api/workflows/${this.args.workflow_id}/download?style=preview`;

--- a/lib/galaxy_test/selenium/test_anon_history.py
+++ b/lib/galaxy_test/selenium/test_anon_history.py
@@ -9,7 +9,7 @@ class TestAnonymousHistories(SeleniumTestCase):
     def test_anon_history_landing(self):
         self.home()
         self.assert_initial_history_panel_state_correct()
-        self.history_element("editor toggle").assert_absent()
+        self.history_element("editor toggle").wait_for_present()
         self.history_element("name display").wait_for_present()
 
     @selenium_test


### PR DESCRIPTION
Follow-up for #14803. Fixes download and import urls in embedded workflow markdown elements. Also fixes a currently failing selenium test.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
