### PR TITLE
[22.01] Revert "Use _run_jobs instead of _run_workflows"

### DIFF
--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1279,7 +1279,7 @@ steps:
         # In this case the newline may have been added by the workflow editor
         # text field that is used for data_column parameters
         with self.dataset_populator.test_history() as history_id:
-            job_summary = self._run_jobs(
+            job_summary = self._run_workflow(
                 """class: GalaxyWorkflow
 steps:
   empty_output:


### PR DESCRIPTION
This reverts commit a01c8c5a88debc7f9e0c7e2865a33acb9633acab.

_run_workflow has the right type annotations, but 21.09 didn't have this. Sorry about that @martenson , I should have mentioned it in https://github.com/galaxyproject/galaxy/pull/14908

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
