### PR TITLE
Vueify Toast

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -144,7 +144,7 @@
 
 <script>
 import Vue from "vue";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { mapActions } from "vuex";
 import { HistoryItemsProvider } from "components/providers/storeProviders";
 import LoadingSpan from "components/LoadingSpan";

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -189,7 +189,7 @@ import { getAppRoot } from "onload/loadConfig";
 import BootstrapVue from "bootstrap-vue";
 import { Services } from "./services";
 import { fields } from "./table-fields";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { initLibrariesIcons } from "components/Libraries/icons";
 import { MAX_DESCRIPTION_LENGTH, DEFAULT_PER_PAGE, onError } from "components/Libraries/library-utils";
 import LibraryEditField from "components/Libraries/LibraryEditField";

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -276,7 +276,7 @@ import { Services } from "./services";
 import Utils from "utils/utils";
 import linkifyHtml from "linkify-html";
 import { fields } from "./table-fields";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import FolderTopBar from "./TopToolbar/FolderTopBar";
 import { initFolderTableIcons } from "components/Libraries/icons";
 import { MAX_DESCRIPTION_LENGTH, DEFAULT_PER_PAGE } from "components/Libraries/library-utils";

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
@@ -139,7 +139,7 @@ import { Services } from "components/Libraries/LibraryFolder/services";
 import LibraryBreadcrumb from "components/Libraries/LibraryFolder/LibraryBreadcrumb";
 import download from "components/Libraries/LibraryFolder/TopToolbar/download";
 import CopyToClipboard from "components/CopyToClipboard";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { fieldTitles } from "components/Libraries/LibraryFolder/LibraryFolderDataset/constants";
 import { DbKeyProvider, DatatypesProvider } from "components/providers";
 import SingleItemSelector from "components/SingleItemSelector";

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
@@ -78,7 +78,7 @@ import Vue from "vue";
 import { getAppRoot } from "onload/loadConfig";
 import BootstrapVue from "bootstrap-vue";
 import { Services } from "components/Libraries/LibraryPermissions/services";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { getGalaxyInstance } from "app";
 import PermissionsHeader from "components/Libraries/LibraryPermissions/PermissionsHeader";

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
@@ -44,7 +44,7 @@ import Vue from "vue";
 import { getAppRoot } from "onload/loadConfig";
 import BootstrapVue from "bootstrap-vue";
 import { Services } from "components/Libraries/LibraryPermissions/services";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import PermissionsInputField from "components/Libraries/LibraryPermissions/PermissionsInputField";
 import PermissionsHeader from "components/Libraries/LibraryPermissions/PermissionsHeader";

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -125,7 +125,7 @@ import { initTopBarIcons } from "components/Libraries/icons";
 import mod_import_dataset from "./import-to-history/import-dataset";
 import mod_import_collection from "./import-to-history/import-collection";
 import mod_add_datasets from "./add-datasets";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import download from "./download";
 import mod_utils from "utils/utils";
 import { getAppRoot } from "onload/loadConfig";

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/add-datasets.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/add-datasets.js
@@ -1,5 +1,5 @@
 import { getGalaxyInstance } from "app";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import _l from "utils/localization";
 import mod_library_model from "./library-model";
 import _ from "underscore";

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/delete-selected.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/delete-selected.js
@@ -1,5 +1,5 @@
 import { getGalaxyInstance } from "app";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import _l from "utils/localization";
 import mod_library_model from "./library-model";
 import _ from "underscore";

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/download.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/download.js
@@ -1,5 +1,5 @@
 import $ from "jquery";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { getAppRoot } from "onload";
 
 function processDownload(url, data, method) {

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/import-to-history/import-collection.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/import-to-history/import-collection.js
@@ -1,6 +1,6 @@
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload/loadConfig";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import mod_library_model from "../library-model";
 import _ from "underscore";
 import Backbone from "backbone";

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/import-to-history/import-dataset.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/import-to-history/import-dataset.js
@@ -1,5 +1,5 @@
 import { getGalaxyInstance } from "app";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import _l from "utils/localization";
 import mod_library_model from "../library-model";
 import _ from "underscore";

--- a/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
+++ b/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
@@ -43,7 +43,7 @@ import Vue from "vue";
 import { getAppRoot } from "onload/loadConfig";
 import BootstrapVue from "bootstrap-vue";
 import { Services } from "components/Libraries/LibraryPermissions/services";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import PermissionsHeader from "components/Libraries/LibraryPermissions/PermissionsHeader";
 import { extractRoles } from "components/Libraries/library-utils";

--- a/client/src/components/Libraries/library-utils.js
+++ b/client/src/components/Libraries/library-utils.js
@@ -1,4 +1,4 @@
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 
 export const MAX_DESCRIPTION_LENGTH = 40;
 export const DEFAULT_PER_PAGE = 10;

--- a/client/src/components/PageEditor/PageEditor.vue
+++ b/client/src/components/PageEditor/PageEditor.vue
@@ -11,7 +11,7 @@
 
 <script>
 import axios from "axios";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { getAppRoot } from "onload/loadConfig";
 import { rethrowSimple } from "utils/simple-error";
 import LoadingSpan from "components/LoadingSpan";

--- a/client/src/components/PageEditor/PageEditorMarkdown.vue
+++ b/client/src/components/PageEditor/PageEditorMarkdown.vue
@@ -36,7 +36,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEye, faSave } from "@fortawesome/free-solid-svg-icons";
 import MarkdownEditor from "components/Markdown/MarkdownEditor";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { save } from "./util";
 
 Vue.use(BootstrapVue);

--- a/client/src/components/StsDownloadButton.vue
+++ b/client/src/components/StsDownloadButton.vue
@@ -25,7 +25,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faDownload, faSpinner } from "@fortawesome/free-solid-svg-icons";
 library.add(faDownload, faSpinner);
 import ConfigProvider from "components/providers/ConfigProvider";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import axios from "axios";
 import { safePath } from "utils/redirect";
 export default {

--- a/client/src/components/Toast.js
+++ b/client/src/components/Toast.js
@@ -1,0 +1,16 @@
+export default {
+    methods: {
+        showToast(message, title, variant) {
+            this.$bvToast.toast(message, {
+                variant,
+                title,
+                toaster: "b-toaster-bottom-right",
+                append: true,
+                solid: true,
+            });
+        },
+    },
+    render() {
+        return {};
+    },
+};

--- a/client/src/components/Workflow/Editor/modules/connector.js
+++ b/client/src/components/Workflow/Editor/modules/connector.js
@@ -1,5 +1,5 @@
 import * as d3 from "d3";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 
 // Rendering parameters
 const zIndex = 1000;

--- a/client/src/components/Workflow/Import/TrsImport.vue
+++ b/client/src/components/Workflow/Import/TrsImport.vue
@@ -1,6 +1,6 @@
 <script setup>
 import TrsTool from "./TrsTool";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { Services } from "../services";
 import { getGalaxyInstance } from "app";
 import { safePath } from "utils/redirect";

--- a/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.vue
+++ b/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.vue
@@ -7,7 +7,7 @@ import StsDownloadButton from "components/StsDownloadButton.vue";
 import ExportToRemoteButton from "components/Workflow/Invocation/Export/ExportToRemoteButton.vue";
 import ExportToRemoteModal from "components/Workflow/Invocation/Export/ExportToRemoteModal.vue";
 import { useMarkdown } from "composables/useMarkdown";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import axios from "axios";
 
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });

--- a/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/SendForm.vue
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/SendForm.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, inject } from "vue";
 import { BModal } from "bootstrap-vue";
 import axios from "axios";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import { safePath } from "utils/redirect";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import ExternalLink from "components/ExternalLink";

--- a/client/src/components/Workflow/InvocationReport.vue
+++ b/client/src/components/Workflow/InvocationReport.vue
@@ -12,7 +12,7 @@
 <script>
 import { safePath } from "utils/redirect";
 import { urlData } from "utils/url";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import ConfigProvider from "components/providers/ConfigProvider";
 import Markdown from "components/Markdown/Markdown";
 import Vue from "vue";

--- a/client/src/composables/toast.js
+++ b/client/src/composables/toast.js
@@ -1,0 +1,33 @@
+import { ref } from "vue";
+
+let toastRef = ref(null);
+
+export const setToastComponentRef = (newRef) => {
+    toastRef = newRef;
+};
+
+/**
+ * Direct export to simplify usage in Options Api component.
+ * Use 'useToast' for the Composition Api instead.
+ */
+export const Toast = {
+    success(message, title = "Success") {
+        toastRef.value.showToast(message, title, "success");
+    },
+
+    info(message, title = "Info") {
+        toastRef.value.showToast(message, title, "info");
+    },
+
+    warning(message, title = "Warning") {
+        toastRef.value.showToast(message, title, "warning");
+    },
+
+    error(message, title = "Error") {
+        toastRef.value.showToast(message, title, "error");
+    },
+};
+
+export function useToast() {
+    return { ...Toast };
+}

--- a/client/src/entry/analysis/App.vue
+++ b/client/src/entry/analysis/App.vue
@@ -35,6 +35,7 @@
             <router-view @update:confirmation="confirmation = $event" />
         </div>
         <div id="dd-helper" />
+        <Toast ref="toastRef" />
     </div>
 </template>
 <script>
@@ -46,10 +47,14 @@ import { HistoryPanelProxy } from "components/History/adapters/HistoryPanelProxy
 import { fetchMenu } from "entry/analysis/menu";
 import { WindowManager } from "layout/window-manager";
 import { safePath } from "utils/redirect";
+import Toast from "components/Toast";
+import { setToastComponentRef } from "composables/toast";
+import { ref } from "vue";
 
 export default {
     components: {
         Masthead,
+        Toast,
     },
     data() {
         return {
@@ -58,6 +63,12 @@ export default {
             resendUrl: `${getAppRoot()}user/resend_verification`,
             windowManager: new WindowManager(),
         };
+    },
+    setup() {
+        const toastRef = ref(null);
+        setToastComponentRef(toastRef);
+
+        return { toastRef };
     },
     computed: {
         tabs() {

--- a/client/src/toolshed/groups/group-detail-view.js
+++ b/client/src/toolshed/groups/group-detail-view.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 import _ from "underscore";
 import Backbone from "backbone";
-import { Toast } from "composables/toast";
+import { Toast } from "ui/toast";
 import mod_group_model from "toolshed/groups/group-model";
 
 // toolshed group detail view

--- a/client/src/toolshed/groups/group-detail-view.js
+++ b/client/src/toolshed/groups/group-detail-view.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 import _ from "underscore";
 import Backbone from "backbone";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import mod_group_model from "toolshed/groups/group-model";
 
 // toolshed group detail view

--- a/client/src/toolshed/groups/group-list-view.js
+++ b/client/src/toolshed/groups/group-list-view.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 import _ from "underscore";
 import Backbone from "backbone";
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 import mod_group_model from "toolshed/groups/group-model";
 import mod_group_row from "toolshed/groups/group-listrow-view";
 const GroupListView = Backbone.View.extend({

--- a/client/src/toolshed/groups/group-list-view.js
+++ b/client/src/toolshed/groups/group-list-view.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 import _ from "underscore";
 import Backbone from "backbone";
-import { Toast } from "composables/toast";
+import { Toast } from "ui/toast";
 import mod_group_model from "toolshed/groups/group-model";
 import mod_group_row from "toolshed/groups/group-listrow-view";
 const GroupListView = Backbone.View.extend({

--- a/client/src/utils/clipboard.js
+++ b/client/src/utils/clipboard.js
@@ -1,5 +1,5 @@
 // abstraction for copying text to the clipboard (or prompting if that isn't available)
-import { Toast } from "ui/toast";
+import { Toast } from "composables/toast";
 
 export function copy(text, notificationText) {
     if (navigator.clipboard) {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -798,8 +798,8 @@ libraries:
       input_folder_description: '.input_folder_description'
       download_button: '#download-btn'
       delete_btn: '.toolbtn-bulk-delete'
-      toast_msg: '.toast-message'
-      toast_warning: '.toast-warning'
+      toast_msg: '.b-toast'
+      toast_warning: '.b-toast-warning'
       select_import_dir_item: 'li[full_path="${name}"] .jstree-anchor'
       import_dir_btn:
         type: xpath


### PR DESCRIPTION
Adds a bootstrap vue based toast component, with a downwards compatible interface for existing uses of Toast.
Webhooks and toolshed still use Toastr.

![image](https://user-images.githubusercontent.com/44241786/200323168-23a2254c-fd4d-4282-a02e-a82576b807a9.png)
A new success message.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
