### PR TITLE
Fix merge forward of #14918

### DIFF
--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5059,7 +5059,7 @@ steps:
         run_workflow_response = self.workflow_populator.invoke_workflow_raw(uploaded_workflow_id, workflow_request)
         return run_workflow_response, history_id
 
-    def test_subworkflow_import_order_maintained(self):
+    def test_subworkflow_import_order_maintained(self, history_id):
         summary = self._run_workflow(
             """
 class: GalaxyWorkflow
@@ -5106,6 +5106,7 @@ outputs:
   - label: out_2
     outputSource: nested_workflow/nested_out_2
 """,
+            history_id=history_id,
             assert_ok=False,
             wait=False,
         )

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ pythonpath = lib
 markers =
   data_manager: marks test as a data_manager test
   external_dependency_management: slow tests which resolves dependencies with e.g. conda
+  require_new_history: test that needs to be given a new history
   tool: marks test as a tool test
   gtn_screenshot: marks test as a screenshot producer for galaxy training network
   local: mark indicates, that it is sufficient to run test locally to get relevant artifacts (e.g. screenshots)


### PR DESCRIPTION
The new test needs to use the `history_id` fixture and pass it to `self._run_workflow()` .

Also:
- Add `require_new_history` marker to `pytest.ini` (missed in commit 3a8997ccf28f9757ac08ccd6fa7915140cd1c187 ).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
