### PR TITLE
[22.05] Fix bug in api test introduced in 14918

### DIFF
--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5022,8 +5022,9 @@ steps:
         return run_workflow_response, history_id
 
     def test_subworkflow_import_order_maintained(self):
-        summary = self._run_workflow(
-            """
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow(
+                """
 class: GalaxyWorkflow
 inputs:
   outer_input_1:
@@ -5068,9 +5069,10 @@ outputs:
   - label: out_2
     outputSource: nested_workflow/nested_out_2
 """,
-            assert_ok=False,
-            wait=False,
-        )
+                history_id=history_id,
+                assert_ok=False,
+                wait=False,
+            )
         self.workflow_populator.wait_for_invocation(summary.workflow_id, summary.invocation_id)
         self.workflow_populator.wait_for_history_workflows(
             summary.history_id, assert_ok=False, expected_invocation_count=2


### PR DESCRIPTION
Missing `history_id` argument
Ref #14918

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
