### PR TITLE
Remove incorrect references to datasets instead of dataset instances in run_request.py

### DIFF
--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -11,7 +11,6 @@ from typing import (
 
 from galaxy import exceptions
 from galaxy.model import (
-    Dataset,
     History,
     HistoryDatasetAssociation,
     LibraryDataset,
@@ -383,16 +382,6 @@ def build_workflow_run_configs(
                     assert trans.user_is_admin or trans.app.security_agent.can_access_dataset(
                         trans.get_current_user_roles(), content.dataset
                     )
-                elif input_source == "uuid":
-                    dataset = trans.sa_session.query(Dataset).filter(Dataset.uuid == input_id).first()
-                    if dataset is None:
-                        # this will need to be changed later. If federation code is avalible, then a missing UUID
-                        # could be found amoung fereration partners
-                        raise exceptions.RequestParameterInvalidException(f"Input cannot find UUID: {input_id}.")
-                    assert trans.user_is_admin or trans.app.security_agent.can_access_dataset(
-                        trans.get_current_user_roles(), dataset
-                    )
-                    content = history.add_dataset(dataset)
                 elif input_source == "hdca":
                     content = app.dataset_collection_manager.get_dataset_collection_instance(trans, "history", input_id)
                 else:


### PR DESCRIPTION
See Marius' notes on https://github.com/galaxyproject/galaxy/pull/14938/files.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Well if no tests fail, I think we can assume it was unused. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
