### PR TITLE
Fix deprecation of ``ProcessPool.schedule()`` since pebble 5.0

### DIFF
--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -47,6 +47,8 @@ serialization.register(
 
 
 class GalaxyCelery(Celery):
+    fork_pool: pebble.ProcessPool
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Fix:

```
DeprecationWarning: schedule is deprecated; use submit instead
```

Also:
- Add some type annotations

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
