### PR TITLE
Order steps relation of workflow_invocation by order_index

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
@@ -30,7 +30,6 @@
                     v-for="step in Object.values(workflow.steps)"
                     :key="step.id"
                     :invocation="invocation"
-                    :ordered-steps="orderedSteps"
                     :workflow="workflow"
                     :workflow-step="step" />
             </b-tab>
@@ -59,9 +58,6 @@ export default {
     },
     computed: {
         ...mapGetters(["getWorkflowByInstanceId"]),
-        orderedSteps() {
-            return [...this.invocation.steps].sort((a, b) => a.order_index - b.order_index);
-        },
         workflow() {
             return this.getWorkflowByInstanceId(this.invocation.workflow_id);
         },
@@ -72,7 +68,7 @@ export default {
     methods: {
         ...mapCacheActions(["fetchWorkflowForInstanceId"]),
         dataInputStepLabel(key, input) {
-            const invocationStep = this.orderedSteps[key];
+            const invocationStep = this.invocation.steps[key];
             let label = invocationStep && invocationStep.workflow_step_label;
             if (!label) {
                 if (input.src === "hda" || input.src === "ldda") {

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -104,7 +104,6 @@ export default {
     },
     props: {
         invocation: Object,
-        orderedSteps: Array,
         workflowStep: Object,
         workflow: Object,
     },
@@ -117,10 +116,7 @@ export default {
     computed: {
         ...mapGetters(["getToolForId", "getToolNameById", "getWorkflowByInstanceId", "getInvocationStepById"]),
         isReady() {
-            return this.invocationSteps.length > 0;
-        },
-        invocationSteps() {
-            return this.orderedSteps;
+            return this.invocation.steps.length > 0;
         },
         invocationStepId() {
             return this.step?.id;
@@ -129,7 +125,7 @@ export default {
             return this.workflowStep.type;
         },
         step() {
-            return this.invocationSteps[this.workflowStep.id];
+            return this.invocation.steps[this.workflowStep.id];
         },
         isDataStep() {
             return ["data_input", "data_collection_input"].includes(this.workflowStepType);
@@ -162,7 +158,7 @@ export default {
             this.expanded = !this.expanded;
         },
         labelForWorkflowStep(stepIndex) {
-            const invocationStep = this.invocationSteps[stepIndex];
+            const invocationStep = this.invocation.steps[stepIndex];
             const workflowStep = this.workflow.steps[stepIndex];
             const oneBasedStepIndex = stepIndex + 1;
             if (invocationStep && invocationStep.workflow_step_label) {

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7431,7 +7431,11 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializabl
         back_populates="parent_workflow_invocation",
         uselist=True,
     )
-    steps = relationship("WorkflowInvocationStep", back_populates="workflow_invocation")
+    steps = relationship(
+        "WorkflowInvocationStep",
+        back_populates="workflow_invocation",
+        order_by=lambda: WorkflowInvocationStep.order_index,
+    )
     workflow: Workflow = relationship("Workflow")
     output_dataset_collections = relationship(
         "WorkflowInvocationOutputDatasetCollectionAssociation", back_populates="workflow_invocation"
@@ -7908,6 +7912,9 @@ class WorkflowInvocationStep(Base, Dictifiable, Serializable):
         ),
         back_populates="workflow_invocation_step",
         viewonly=True,
+    )
+    order_index = column_property(
+        select([WorkflowStep.order_index]).where(WorkflowStep.id == workflow_step_id).scalar_subquery()
     )
 
     subworkflow_invocation_id: column_property

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1579,8 +1579,6 @@ test_data:
                 wait=True,
             )
             invocation = self.workflow_populator.get_invocation(job_summary.invocation_id, step_details=True)
-            # TODO: return steps sorted by order_index ? Why don't we do that ??
-            invocation["steps"].sort(key=lambda step: step["order_index"])
             failed_step = invocation["steps"][1]
             assert failed_step["jobs"][0]["state"] == "error"
             failed_hdca_id = failed_step["output_collections"]["list_output"]["id"]
@@ -1914,12 +1912,8 @@ outer_input:
                 step["subworkflow_invocation_id"] for step in steps if step["subworkflow_invocation_id"]
             ][0]
             subworkflow_invocation = self.workflow_populator.get_invocation(subworkflow_invocation_id)
-            assert [step for step in subworkflow_invocation["steps"] if step["order_index"] == 0][0][
-                "workflow_step_label"
-            ] == "inner_input"
-            assert [step for step in subworkflow_invocation["steps"] if step["order_index"] == 1][0][
-                "workflow_step_label"
-            ] == "random_lines"
+            assert subworkflow_invocation["steps"][0]["workflow_step_label"] == "inner_input"
+            assert subworkflow_invocation["steps"][1]["workflow_step_label"] == "random_lines"
 
     @skip_without_tool("random_lines1")
     def test_run_subworkflow_runtime_parameters(self):
@@ -5388,24 +5382,15 @@ steps: []
         self._assert_has_keys(usage_details, "inputs", "steps", "workflow_id")
 
         invocation_steps = usage_details["steps"]
-        invocation_input_step, invocation_tool_step = None, None
-        for invocation_step in invocation_steps:
+        for step_index, invocation_step in enumerate(invocation_steps):
             self._assert_has_keys(invocation_step, "workflow_step_id", "order_index", "id")
-            order_index = invocation_step["order_index"]
-            assert order_index in [0, 1]
-            if invocation_step["order_index"] == 0:
-                assert invocation_input_step is None
-                invocation_input_step = invocation_step
-            else:
-                assert invocation_tool_step is None
-                invocation_tool_step = invocation_step
-
-        assert invocation_input_step
-        assert invocation_tool_step
+            assert step_index == invocation_step["order_index"]
+        invocation_input_step = invocation_steps[0]
+        invocation_tool_step = invocation_steps[1]
 
         # Tool steps have non-null job_ids (deprecated though they may be)
-        assert invocation_input_step.get("job_id", None) is None
-        assert invocation_tool_step.get("job_id", None) is None
+        assert invocation_input_step.get("job_id") is None
+        assert invocation_tool_step.get("job_id") is None
         assert invocation_tool_step["state"] == "scheduled"
 
         usage_details = self._invocation_details(workflow_id, invocation_id, legacy_job_state="true")
@@ -5417,13 +5402,8 @@ steps: []
         invocation_tool_steps = []
         for invocation_step in invocation_steps:
             self._assert_has_keys(invocation_step, "workflow_step_id", "order_index", "id")
-            order_index = invocation_step["order_index"]
-            assert order_index in [0, 1]
-            if invocation_step["order_index"] == 0:
-                assert invocation_input_step is None
-                invocation_input_step = invocation_step
-            else:
-                invocation_tool_steps.append(invocation_step)
+        invocation_input_step = invocation_steps[0]
+        invocation_tool_steps.extend(invocation_steps[1:])
 
         assert len(invocation_tool_steps) == 2
         assert invocation_tool_steps[0]["state"] == "ok"

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5398,15 +5398,11 @@ steps: []
         self._assert_has_keys(usage_details, "inputs", "steps", "workflow_id")
 
         invocation_steps = usage_details["steps"]
-        invocation_input_step = None
-        invocation_tool_steps = []
+        assert len(invocation_steps) == 3
         for invocation_step in invocation_steps:
             self._assert_has_keys(invocation_step, "workflow_step_id", "order_index", "id")
-        invocation_input_step = invocation_steps[0]
-        invocation_tool_steps.extend(invocation_steps[1:])
 
-        assert len(invocation_tool_steps) == 2
-        assert invocation_tool_steps[0]["state"] == "ok"
+        assert invocation_steps[1]["state"] == "ok"
 
     def _run_mapping_workflow(self):
         history_id = self.dataset_populator.new_history()


### PR DESCRIPTION
Cool work from @mvdbeek to order workflow steps at the ORM layer so we don't need client side and API hacks.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
