### PR TITLE
Small change to job runner docs to state more explicitly what `check_watched_item()` should return

### DIFF
--- a/doc/source/dev/build_a_job_runner.rst
+++ b/doc/source/dev/build_a_job_runner.rst
@@ -276,7 +276,9 @@ Note:
 
 -  ``get_task_from_external_runner`` and ``create_log_files`` are user-defined methods.
 
--  Return value is ``job_state`` for running, pending jobs and None for any remaining states of a job.
+-  The method should return ``job_state`` if the job should remain in the job runner's list of watched
+   jobs (i.e. if it is running or pending). If it no longer needs to be watched (e.g. it has terminated
+   either successfully or with an error) it should return None.
 
 ``create_log_files()`` are nothing but copying the files (``error_file``,
 ``output_file``, ``exit_code_file``) from the external runner's directory to


### PR DESCRIPTION
## How to test the changes?
Not applicable
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
