### PR TITLE
Refactored set() for readability. Renamed optArray() as formattedOpti…

### DIFF
--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -1,0 +1,250 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import FormSelect from "./FormSelect";
+import Multiselect from "vue-multiselect";
+import flushPromises from "flush-promises";
+
+const localVue = getLocalVue();
+
+describe("FormSelect", () => {
+    // Single select, no radio
+    it("Sets default currentValue as first option when not told otherwise", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "",
+                defaultValue: "",
+                display: null,
+                multiple: false,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
+    });
+    it("Sets no value if optional", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "",
+                defaultValue: "",
+                display: null,
+                multiple: false,
+                optional: true,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual({ default: false, label: "Nothing selected", value: null });
+    });
+    it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "",
+                defaultValue: "",
+                display: null,
+                multiple: false,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", true],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: true });
+    });
+    it("Sets default from defaultValue", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "2",
+                defaultValue: "2",
+                display: null,
+                multiple: false,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: false });
+    });
+    it("Changes value after new selection is made", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "T",
+                defaultValue: "T",
+                display: null,
+                multiple: false,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
+            },
+            localVue,
+        });
+
+        const multiselect = wrapper.findComponent(Multiselect);
+        // Manually trigger selection of the second item in formattedOptions in the multiselect
+        multiselect.vm.select(wrapper.vm.formattedOptions[1]);
+        expect(wrapper.emitted().input).toEqual([["2"]]);
+    });
+});
+
+describe("FormSelect", () => {
+    // Single select, with radio
+    const mountFormSelect = async (props) =>
+        await mount(FormSelect, {
+            propsData: props,
+            localVue,
+        });
+
+    it("Sets default currentValue as first option when not told otherwise", async () => {
+        const wrapper = await mountFormSelect({
+            value: "",
+            defaultValue: "",
+            display: "radio",
+            multiple: false,
+            options: [
+                ["test1", "T", false],
+                ["test2", "2", false],
+            ],
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
+    });
+    it("Changes values when selected, and sets from proper default", async () => {
+        const wrapper = await mountFormSelect({
+            value: "",
+            defaultValue: "",
+            display: "radio",
+            multiple: false,
+            options: [
+                ["test1", "T", false],
+                ["test2", "2", true],
+            ],
+        });
+        const radio = wrapper.find("input[type='radio']");
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: true });
+        radio.trigger("click");
+        radio.trigger("change");
+        await flushPromises();
+        expect(wrapper.emitted().input).toEqual([["T"]]);
+    });
+    it("Changes values to a selected value", async () => {
+        const wrapper = await mountFormSelect({
+            value: "",
+            defaultValue: "",
+            display: "radio",
+            multiple: false,
+            options: [
+                ["test1", "T", true],
+                ["test2", "2", false],
+                ["test3", "3", false],
+            ],
+        });
+        const radio = wrapper.find("input[value='3']");
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: true });
+        radio.trigger("click");
+        radio.trigger("change");
+        await flushPromises();
+        expect(wrapper.emitted().input).toEqual([["3"]]);
+    });
+});
+
+describe("FormSelect", () => {
+    // Multiple select, no radio
+    it("Nothing selected if no defaults, adds values individaully if selected", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: null,
+                defaultValue: null,
+                display: null,
+                multiple: true,
+                optional: true,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                    ["test3", "3", false],
+                ],
+            },
+            localVue,
+        });
+
+        expect(wrapper.vm.currentValue).toStrictEqual(undefined);
+        const multiselect = wrapper.findComponent(Multiselect);
+        multiselect.vm.select(wrapper.vm.formattedOptions[1]);
+        expect(wrapper.emitted().input).toEqual([[["2"]]]);
+        multiselect.vm.select(wrapper.vm.formattedOptions[2]);
+        expect(wrapper.emitted().input).toEqual([[["2"]], [["3"]]]);
+    });
+    it("Changes value after new selection is made", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: ["T", "2"],
+                defaultValue: ["T", "2"],
+                display: null,
+                multiple: true,
+                options: [
+                    ["test1", "T", true],
+                    ["test2", "2", true],
+                    ["test3", "3", false],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual([
+            { label: "test1", value: "T", default: true },
+            { label: "test2", value: "2", default: true },
+        ]);
+    });
+});
+
+describe("FormSelect", () => {
+    // Multiple select, with checkboxes
+    const mountFormSelect = async (props) =>
+        await mount(FormSelect, {
+            propsData: props,
+            localVue,
+        });
+
+    it("Changes values to a selected value, and can contain multiple values", async () => {
+        const wrapper = await mountFormSelect({
+            value: ["T"],
+            defaultValue: ["T"],
+            display: "checkboxes",
+            multiple: true,
+            options: [
+                ["test1", "T", true],
+                ["test2", "2", false],
+                ["test3", "3", false],
+            ],
+        });
+        const checkboxes_3 = wrapper.find("input[value='3']");
+        const checkboxes_2 = wrapper.find("input[value='2']");
+        expect(wrapper.vm.currentValue).toStrictEqual(["T"]);
+        checkboxes_2.trigger("click");
+        checkboxes_3.trigger("click");
+        checkboxes_2.trigger("change");
+        checkboxes_3.trigger("change");
+        await flushPromises();
+        expect(wrapper.emitted().input).toEqual([[["T", "2", "3"]]]);
+    });
+    it("Has no calue if nothing is selected", async () => {
+        const wrapper = await mountFormSelect({
+            value: null,
+            defaultValue: null,
+            display: "checkboxes",
+            multiple: true,
+            options: [
+                ["test1", "T", true],
+                ["test2", "2", false],
+                ["test3", "3", false],
+            ],
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual(undefined);
+    });
+});

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -113,9 +113,9 @@ export default {
                 if (this.value == null) {
                     return;
                 } else if (this.value !== "") {
-                    if (this.multiple) {
+                    if (this.multiple && this.display != "checkboxes") {
                         return this.selectValueMultiple(this.value);
-                    } else if (this.display == "checkboxes") {
+                    } else if (this.multiple && this.display == "checkboxes") {
                         return this.selectValueCheckboxes(this.value);
                     } else if (this.display == "radio") {
                         return this.selectValueSingle(this.value);
@@ -167,7 +167,9 @@ export default {
         },
         selectDefaultLabelValue() {
             // Try to find a value labeled default in the options
-            return this.formattedOptions.filter((option) => option.default);
+            let formattedOption = [this.formattedOptions.find(option => option.default)];
+            let selectedOption = (formattedOption[0]) ?? this.formattedOptions[0];
+            return selectedOption;
         },
         selectFirstValue() {
             return this.formattedOptions[0];
@@ -179,6 +181,9 @@ export default {
             // A string is returned if single, but an array if zero or multiple
             return !Array.isArray(val) ? [val] : val;
         },
+        hasArrayData(data) {
+            return Array.isArray(data) && data.length > 0;
+        }
     },
 };
 </script>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -1,0 +1,184 @@
+<template>
+    <div>
+        <b-row align-v="center">
+            <b-col v-if="display == 'radio' || display == 'radiobutton'">
+                <b-form-group>
+                    <!-- Select single from radio -->
+                    <b-form-radio-group v-model="currentValue" :options="formattedOptions" text-field="label" stacked>
+                    </b-form-radio-group>
+                </b-form-group>
+            </b-col>
+            <b-col v-else-if="display == 'checkboxes'">
+                <!-- Select multiple from checkboxes -->
+                <b-form-group>
+                    <b-form-checkbox-group
+                        v-model="currentValue"
+                        :options="formattedOptions"
+                        value-field="value"
+                        text-field="label"
+                        stacked>
+                    </b-form-checkbox-group>
+                </b-form-group>
+            </b-col>
+            <b-col v-else>
+                <!-- Multiple select from drop down -->
+                <multiselect
+                    v-if="multiple"
+                    v-model="currentValue"
+                    :options="formattedOptions"
+                    :multiple="true"
+                    placeholder="Select value"
+                    deselect-label=""
+                    select-label=""
+                    track-by="value"
+                    label="label">
+                </multiselect>
+                <!-- Single select from drop down -->
+                <multiselect
+                    v-else
+                    v-model="currentValue"
+                    :options="formattedOptions"
+                    deselect-label=""
+                    select-label=""
+                    label="label"
+                    track-by="value">
+                    {{ currentValue }}
+                </multiselect>
+            </b-col>
+        </b-row>
+    </div>
+</template>
+
+<script>
+import Multiselect from "vue-multiselect";
+
+export default {
+    components: {
+        Multiselect,
+    },
+    props: {
+        value: {
+            default: null,
+        },
+        defaultValue: {
+            type: [String, Array],
+            required: true,
+        },
+        options: {
+            type: Array,
+            required: true,
+            default: undefined,
+        },
+        multiple: {
+            type: Boolean,
+            required: true,
+            default: false,
+        },
+        display: {
+            type: String,
+            required: false,
+            default: null,
+        },
+        optional: {
+            type: Boolean,
+            required: false,
+            default: null,
+        },
+    },
+    computed: {
+        formattedOptions() {
+            const formattedOptions = [];
+            this.options.map((option, i) => {
+                formattedOptions[i] = {
+                    label: option[0],
+                    value: option[1],
+                    default: option[2],
+                };
+            });
+            if (!this.multiple && this.optional) {
+                formattedOptions.unshift({
+                    label: "Nothing selected",
+                    value: null,
+                    default: false,
+                });
+            }
+            return formattedOptions;
+        },
+        currentValue: {
+            get() {
+                // My understanding of this is that if we start with a value prop, use it.
+                // If there's a defaultValue set, find it in the array and use that.
+                // If there's no default value set, use the first item in the array with 'default' set to true.
+                // Lastly, just default to the first element in the array.
+                if (this.value == null) {
+                    return;
+                } else if (this.value !== "") {
+                    if (this.multiple) {
+                        return this.selectValueMultiple(this.value);
+                    } else if (this.display == "checkboxes") {
+                        return this.selectValueCheckboxes(this.value);
+                    } else if (this.display == "radio") {
+                        return this.selectValueSingle(this.value);
+                    } else {
+                        return this.selectValue(this.value);
+                    }
+                } else if (this.defaultValue !== "") {
+                    if (this.multiple || this.display == "checkboxes") {
+                        return this.selectValueMultiple(this.defaultValue);
+                    } else {
+                        return this.selectValue(this.defaultValue);
+                    }
+                } else {
+                    return this.selectDefaultLabelValue();
+                }
+            },
+            set(val) {
+                // Checkbox is mutliple, but not automatically set. If it IS set, this prevents the multiple from overriding the checkbox
+                if (val == null) {
+                    // This case can occur when single-select dropdown is re-selected
+                    return;
+                } else if (this.multiple && this.display != "checkboxes") {
+                    const values = this.getValuesFromFormattedOptions(val);
+                    this.$emit("input", values);
+                } else if (this.display == "radio" || this.display == "checkboxes") {
+                    this.$emit("input", val);
+                } else {
+                    this.$emit("input", val.value);
+                }
+            },
+        },
+    },
+    methods: {
+        selectValueMultiple(val) {
+            const selectedValues = this.normalizeSelectedValues(val);
+            return this.formattedOptions.filter((option) => selectedValues.indexOf(option.value) > -1);
+        },
+        selectValueCheckboxes(val) {
+            const selectedValues = this.normalizeSelectedValues(val);
+            return this.formattedOptions
+                .filter((option) => selectedValues.indexOf(option.value) > -1)
+                .map((option) => option.value);
+        },
+        selectValueSingle(val) {
+            return this.formattedOptions.find((option) => option.value === val).value;
+        },
+        selectValue(val) {
+            return this.formattedOptions.find((option) => option.value === val);
+        },
+        selectDefaultLabelValue() {
+            // Try to find a value labeled default in the options
+            return this.formattedOptions.filter((option) => option.default);
+        },
+        selectFirstValue() {
+            return this.formattedOptions[0];
+        },
+        getValuesFromFormattedOptions(options) {
+            return Array.isArray(options) ? options.map((option) => option.value) : options;
+        },
+        normalizeSelectedValues(val) {
+            // A string is returned if single, but an array if zero or multiple
+            return !Array.isArray(val) ? [val] : val;
+        },
+    },
+};
+</script>


### PR DESCRIPTION
…ons() for consistency. Refactor get() for to organizationally match AlexO's comment and improve readability. AlexO original logic left in place, however very like could still use further code consolidation. Test script variable rename to correspond with main script. Removal of error message at child-component level in favor of parent-component error message. Added radio-input type variation.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
