### PR TITLE
Fix indentation level on SnpSiftDbNSFP.set_peek()

### DIFF
--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -879,13 +879,13 @@ class SnpSiftDbNSFP(Text):
                 unicodify(e),
             )
 
-        def set_peek(self, dataset):
-            if not dataset.dataset.purged:
-                dataset.peek = f"{dataset.metadata.reference_name} :  {','.join(dataset.metadata.annotation)}"
-                dataset.blurb = f"{dataset.metadata.reference_name}"
-            else:
-                dataset.peek = "file does not exist"
-                dataset.blurb = "file purged from disc"
+    def set_peek(self, dataset):
+        if not dataset.dataset.purged:
+            dataset.peek = f"{dataset.metadata.reference_name} :  {','.join(dataset.metadata.annotation)}"
+            dataset.blurb = f"{dataset.metadata.reference_name}"
+        else:
+            dataset.peek = "file does not exist"
+            dataset.blurb = "file purged from disc"
 
 
 @build_sniff_from_prefix


### PR DESCRIPTION
Fixes a bug introduced in #1280.

This is old. Not sure if it makes sense to backport this to a previous release instead?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
