### PR TITLE
Implement default locations for data and collection parameters.

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1121,7 +1121,7 @@ class WorkflowContentsManager(UsesAnnotations):
             else:
                 module = step.module
                 step_dict["label"] = module.name
-                step_dict["inputs"] = do_inputs(module.get_runtime_inputs(), step.state.inputs, "", step)
+                step_dict["inputs"] = do_inputs(module.get_runtime_inputs(step), step.state.inputs, "", step)
             step_dicts.append(step_dict)
         return {
             "name": workflow.name,

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -969,7 +969,7 @@ class WorkflowContentsManager(UsesAnnotations):
                     for pja in step.post_job_actions
                 ]
             else:
-                inputs = step.module.get_runtime_inputs(connections=step.output_connections)
+                inputs = step.module.get_runtime_inputs(step, connections=step.output_connections)
                 step_model = {"inputs": [input.to_dict(trans) for input in inputs.values()]}
             step_model["when"] = step.when_expression
             step_model["replacement_parameters"] = step.module.get_informal_replacement_parameters(step)
@@ -1770,6 +1770,11 @@ class WorkflowContentsManager(UsesAnnotations):
 
         if "in" in step_dict:
             for input_name, input_dict in step_dict["in"].items():
+                # This is just a bug in gxformat? I think the input
+                # defaults should be called input to match the input modules's
+                # input parameter name.
+                if input_name == "default":
+                    input_name = "input"
                 step_input = step.get_or_add_input(input_name)
                 NO_DEFAULT_DEFINED = object()
                 default = input_dict.get("default", NO_DEFAULT_DEFINED)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7625,10 +7625,20 @@ class WorkflowStep(Base, RepresentById):
 
     @property
     def input_default_value(self):
-        tool_state = self.tool_inputs
-        default_value = tool_state.get("default")
-        if default_value:
-            default_value = json.loads(default_value)["value"]
+        self.get_input_default_value(None)
+
+    def get_input_default_value(self, default_default):
+        # parameter_input and the data parameters handle this slightly differently
+        # unfortunately.
+        if self.type == "parameter_input":
+            tool_state = self.tool_inputs
+            default_value = tool_state.get("default", default_default)
+        else:
+            default_value = default_default
+            for step_input in self.inputs:
+                if step_input.name == "input" and step_input.default_value_set:
+                    default_value = step_input.default_value
+                    break
         return default_value
 
     @property

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -425,6 +425,9 @@ class InputSource(metaclass=ABCMeta):
     def parse_when_input_sources(self):
         raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
 
+    def parse_default(self) -> Optional[Dict[str, Any]]:
+        return None
+
 
 class PageSource(metaclass=ABCMeta):
     def parse_display(self):

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -5,7 +5,9 @@ import os
 import re
 import uuid
 from typing import (
+    Any,
     cast,
+    Dict,
     Iterable,
     List,
     Optional,
@@ -1273,6 +1275,56 @@ class XmlInputSource(InputSource):
             case_page_source = XmlPageSource(case_elem)
             sources.append((value, case_page_source))
         return sources
+
+    def parse_default(self) -> Optional[Dict[str, Any]]:
+        def file_default_from_elem(elem):
+            # TODO: hashes, created_from_basename, etc...
+            return {"class": "File", "location": elem.get("location")}
+
+        def read_elements(collection_elem):
+            element_dicts = []
+            elements = collection_elem.findall("element")
+            for element in elements:
+                identifier = element.get("name")
+                subcollection_elem = element.find("collection")
+                if subcollection_elem:
+                    collection_type = subcollection_elem.get("collection_type")
+                    element_dicts.append(
+                        {
+                            "class": "Collection",
+                            "identifier": identifier,
+                            "collection_type": collection_type,
+                            "elements": read_elements(subcollection_elem),
+                        }
+                    )
+                else:
+                    element_dict = file_default_from_elem(element)
+                    element_dict["identifier"] = identifier
+                    element_dicts.append(element_dict)
+            return element_dicts
+
+        elem = self.input_elem
+        element_type = self.input_elem.get("type")
+        if element_type == "data":
+            default_elem = elem.find("default")
+            if default_elem is not None:
+                return file_default_from_elem(default_elem)
+            else:
+                return None
+        else:
+            default_elem = elem.find("default")
+            if default_elem is not None:
+                default_elem = elem.find("default")
+                collection_type = default_elem.get("collection_type")
+                name = default_elem.get("name", elem.get("name"))
+                return {
+                    "class": "Collection",
+                    "name": name,
+                    "collection_type": collection_type,
+                    "elements": read_elements(default_elem),
+                }
+            else:
+                return None
 
 
 class ParallelismInfo:

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -1,7 +1,9 @@
 import json
 from typing import (
+    Any,
     Dict,
     List,
+    Optional,
 )
 
 import packaging.version
@@ -357,6 +359,11 @@ class YamlInputSource(InputSource):
             selected = option.get("selected", False)
             static_options.append((label, value, selected))
         return static_options
+
+    def parse_default(self) -> Optional[Dict[str, Any]]:
+        input_dict = self.input_dict
+        default_def = input_dict.get("default", None)
+        return default_def
 
 
 def _ensure_has(dict, defaults):

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3731,6 +3731,7 @@ allow access to Python code to generate options for a select list. See
       <xs:element name="options" type="ParamOptions"/>
       <xs:element name="validator" type="Validator" />
       <xs:element name="sanitizer" type="Sanitizer"/>
+      <xs:element name="default" type="ParamDefault" />
       <xs:element name="help" type="xs:string">
         <xs:annotation>
           <xs:documentation xml:lang="en">Documentation for help</xs:documentation>
@@ -4114,6 +4115,41 @@ dataset for the contained input of the type specified using the ``type`` tag.
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
+
+  <xs:complexType name="ParamDefault">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[
+]]>
+</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:group ref="ParamDefaultCollectionElement" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="collection_type" type="CollectionType" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en"><![CDATA[
+Collection type for default collection (if param type is data_collection). Simple collection types are
+either ``list`` or ``paired``, nested collections are specified as colon separated list of simple
+collection types (the most common types are ``list``, ``paired``,
+``list:paired``, or ``list:list``).
+        ]]></xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="location" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en"><![CDATA[
+Galaxy-aware URI for the default file.
+        ]]></xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+  </xs:complexType>
+
+  <xs:group name="ParamDefaultCollectionElement">
+    <xs:choice>
+      <xs:element name="element" type="OutputData" />
+    </xs:choice>
+  </xs:group>
 
   <xs:complexType name="ParamOptions">
     <xs:annotation>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4123,7 +4123,8 @@ dataset for the contained input of the type specified using the ``type`` tag.
 </xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:group ref="ParamDefaultCollectionElement" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- can have zero or one collection elements -->
+      <xs:element name="element" type="ParamDefaultElement" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
     <xs:attribute name="collection_type" type="CollectionType" use="optional">
       <xs:annotation>
@@ -4135,21 +4136,52 @@ collection types (the most common types are ``list``, ``paired``,
         ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="location" type="xs:string" use="optional">
+
+    <xs:attribute name="location" type="xs:anyURI" gxdocs:added="23.2" use="optional">
       <xs:annotation>
         <xs:documentation xml:lang="en"><![CDATA[
-Galaxy-aware URI for the default file.
+Galaxy-aware URI for the default file. This should only be used with parameters of type "data".
         ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
 
   </xs:complexType>
 
-  <xs:group name="ParamDefaultCollectionElement">
-    <xs:choice>
-      <xs:element name="element" type="OutputData" />
-    </xs:choice>
-  </xs:group>
+  <xs:complexType name="ParamDefaultCollection">
+    <xs:sequence>
+      <xs:element name="element" type="ParamDefaultElement" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+
+    <xs:attribute name="collection_type" type="CollectionType" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en"><![CDATA[
+Collection type for default collection (if param type is data_collection). Simple collection types are
+either ``list`` or ``paired``, nested collections are specified as colon separated list of simple
+collection types (the most common types are ``list``, ``paired``,
+``list:paired``, or ``list:list``).
+        ]]></xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+
+  </xs:complexType>
+
+  <xs:complexType name="ParamDefaultElement">
+    <xs:sequence>
+      <xs:element name="collection" type="ParamDefaultCollection" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Name (and element identifier) for this element</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="location" type="xs:anyURI" gxdocs:added="23.2" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en"><![CDATA[
+Galaxy-aware URI for the default file for collection element.
+        ]]></xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
 
   <xs:complexType name="ParamOptions">
     <xs:annotation>

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -26,12 +26,16 @@ from galaxy.managers.dbkeys import read_dbnames
 from galaxy.model import (
     cached_id,
     Dataset,
+    DatasetCollection,
     DatasetCollectionElement,
+    DatasetHash,
     DatasetInstance,
+    DatasetSource,
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
     LibraryDatasetDatasetAssociation,
 )
+from galaxy.model.dataset_collections import builder
 from galaxy.schema.fetch_data import FilesPayload
 from galaxy.tool_util.parser import get_input_source as ensure_input_source
 from galaxy.util import (
@@ -43,6 +47,7 @@ from galaxy.util import (
 )
 from galaxy.util.dictifiable import Dictifiable
 from galaxy.util.expressions import ExpressionContext
+from galaxy.util.hash_util import HASH_NAMES
 from galaxy.util.rules_dsl import RuleSet
 from . import (
     dynamic_options,
@@ -2094,6 +2099,11 @@ class DataToolParameter(BaseDataToolParameter):
         self._parse_options(input_source)
         # Load conversions required for the dataset input
         self.conversions = []
+        self.default_object = input_source.parse_default()
+        if self.optional and self.default_object is not None:
+            raise ParameterValueError(
+                "Cannot specify a Galaxy tool data parameter to be both optional and have a default value.", self.name
+            )
         for name, conv_extension in input_source.parse_conversion_tuples():
             assert None not in [
                 name,
@@ -2114,9 +2124,11 @@ class DataToolParameter(BaseDataToolParameter):
         other_values = other_values or {}
         if trans.workflow_building_mode is workflow_building_modes.ENABLED or is_runtime_value(value):
             return None
-        if not value and not self.optional:
+        if not value and not self.optional and not self.default_object:
             raise ParameterValueError("specify a dataset of the required format / build for parameter", self.name)
         if value in [None, "None", ""]:
+            if self.default_object:
+                return raw_to_galaxy(trans, self.default_object)
             return None
         if isinstance(value, dict) and "values" in value:
             value = self.to_python(value, trans.app)
@@ -2411,6 +2423,11 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         self.multiple = False  # Accessed on DataToolParameter a lot, may want in future
         self.is_dynamic = True
         self._parse_options(input_source)  # TODO: Review and test.
+        self.default_object = input_source.parse_default()
+        if self.optional and self.default_object is not None:
+            raise ParameterValueError(
+                "Cannot specify a Galaxy tool data parameter to be both optional and have a default value.", self.name
+            )
 
     @property
     def collection_types(self):
@@ -2447,9 +2464,11 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         rval: Optional[Union[DatasetCollectionElement, HistoryDatasetCollectionAssociation]] = None
         if trans.workflow_building_mode is workflow_building_modes.ENABLED:
             return None
-        if not value and not self.optional:
+        if not value and not self.optional and not self.default_object:
             raise ParameterValueError("specify a dataset collection of the correct type", self.name)
         if value in [None, "None"]:
+            if self.default_object:
+                return raw_to_galaxy(trans, self.default_object)
             return None
         if isinstance(value, dict) and "values" in value:
             value = self.to_python(value, trans.app)
@@ -2662,6 +2681,90 @@ class RulesListToolParameter(BaseJsonToolParameter):
             return rule_set.display
         else:
             return ""
+
+
+# Code from CWL branch to massage in order to be shared across tools and workflows,
+# and for CWL artifacts as well as Galaxy ones.
+def raw_to_galaxy(trans, as_dict_value):
+    app = trans.app
+    history = trans.history
+
+    object_class = as_dict_value["class"]
+    if object_class == "File":
+        relative_to = "/"  # TODO
+        from galaxy.tool_util.cwl.util import abs_path
+
+        path = abs_path(as_dict_value.get("location"), relative_to)
+
+        name = os.path.basename(path)
+        extension = as_dict_value.get("format") or "data"
+        dataset = Dataset()
+        source = DatasetSource()
+        source.source_uri = path
+        # TODO: validate this...
+        source.transform = as_dict_value.get("transform")
+        dataset.sources.append(source)
+
+        for hash_name in HASH_NAMES:
+            # TODO: Convert md5 -> MD5 during tool parsing.
+            if hash_name in as_dict_value:
+                hash_object = DatasetHash()
+                hash_object.hash_function = hash_name
+                hash_object.hash_value = as_dict_value[hash_name]
+                dataset.hashes.append(hash_object)
+
+        if "created_from_basename" in as_dict_value:
+            dataset.created_from_basename = as_dict_value["created_from_basename"]
+
+        dataset.state = Dataset.states.DEFERRED
+        primary_data = HistoryDatasetAssociation(
+            name=name,
+            extension=extension,
+            metadata_deferred=True,
+            designation=None,
+            visible=True,
+            dbkey="?",
+            dataset=dataset,
+            flush=False,
+            sa_session=trans.sa_session,
+        )
+        primary_data.state = Dataset.states.DEFERRED
+        permissions = app.security_agent.history_get_default_permissions(history)
+        app.security_agent.set_all_dataset_permissions(primary_data.dataset, permissions, new=True, flush=False)
+        trans.sa_session.add(primary_data)
+        history.stage_addition(primary_data)
+        history.add_pending_items()
+        trans.sa_session.flush()
+        return primary_data
+    else:
+        name = as_dict_value.get("name")
+        collection_type = as_dict_value.get("collection_type")
+        collection = DatasetCollection(
+            collection_type=collection_type,
+        )
+        hdca = HistoryDatasetCollectionAssociation(
+            name=name,
+            collection=collection,
+        )
+
+        def write_elements_to_collection(has_elements, collection_builder):
+            element_dicts = has_elements.get("elements")
+            for element_dict in element_dicts:
+                element_class = element_dict["class"]
+                identifier = element_dict["identifier"]
+                if element_class == "File":
+                    hda = raw_to_galaxy(trans, element_dict)
+                    collection_builder.add_dataset(identifier, hda)
+                else:
+                    subcollection_builder = collection_builder.get_level(identifier)
+                    write_elements_to_collection(element_dict, subcollection_builder)
+
+        collection_builder = builder.BoundCollectionBuilder(collection)
+        write_elements_to_collection(as_dict_value, collection_builder)
+        collection_builder.populate()
+        trans.sa_session.add(hdca)
+        trans.sa_session.flush()
+        return hdca
 
 
 parameter_types = dict(

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -8,6 +8,7 @@ import logging
 import os
 import os.path
 import re
+import urllib.parse
 from typing import (
     Any,
     Dict,
@@ -2691,16 +2692,17 @@ def raw_to_galaxy(trans, as_dict_value):
 
     object_class = as_dict_value["class"]
     if object_class == "File":
-        relative_to = "/"  # TODO
-        from galaxy.tool_util.cwl.util import abs_path
-
-        path = abs_path(as_dict_value.get("location"), relative_to)
-
-        name = os.path.basename(path)
+        # TODO: relative_to = "/"
+        location = as_dict_value.get("location")
+        name = (
+            as_dict_value.get("identifier")
+            or as_dict_value.get("basename")
+            or os.path.basename(urllib.parse.urlparse(location).path)
+        )
         extension = as_dict_value.get("format") or "data"
         dataset = Dataset()
         source = DatasetSource()
-        source.source_uri = path
+        source.source_uri = location
         # TODO: validate this...
         source.transform = as_dict_value.get("transform")
         dataset.sources.append(source)

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -99,6 +99,8 @@ from galaxy.util.tool_shed.common_util import get_tool_shed_url_from_tool_shed_r
 
 if TYPE_CHECKING:
     from galaxy.schema.invocation import InvocationMessageUnion
+    from galaxy.workflow.run import WorkflowProgress
+
 
 log = logging.getLogger(__name__)
 
@@ -176,7 +178,7 @@ def to_cwl(value, hda_references, step):
         return value
 
 
-def from_cwl(value, hda_references, progress):
+def from_cwl(value, hda_references, progress: "WorkflowProgress"):
     # TODO: turn actual files into HDAs here ... somehow I suppose. Things with
     # file:// locations for instance.
     if isinstance(value, dict) and "class" in value and "location" in value:

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2227,7 +2227,7 @@ class ToolModule(WorkflowModule):
                             if iteration_elements and step_input_name in iteration_elements:  # noqa: B023
                                 value = iteration_elements[step_input_name]  # noqa: B023
                             else:
-                                value = progress.replacement_for_input(step, all_inputs_by_name[step_input_name])
+                                value = progress.replacement_for_input(trans, step, all_inputs_by_name[step_input_name])
                             # TODO: only do this for values... is everything with a default
                             # this way a field parameter? I guess not?
                             extra_step_state[step_input_name] = value

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -328,6 +328,8 @@ STEP_OUTPUT_DELAYED = object()
 
 
 class ModuleInjector(Protocol):
+    trans: "WorkRequestContext"
+
     def inject(self, step, step_args=None, steps=None, **kwargs):
         pass
 
@@ -698,6 +700,9 @@ class WorkflowProgress:
             subworkflow_collection_info=subworkflow_collection_info,
             when_values=when_values,
         )
+
+    def raw_to_galaxy(self, value: dict):
+        return raw_to_galaxy(self.module_injector.trans, value)
 
     def _recover_mapping(self, step_invocation: WorkflowInvocationStep) -> None:
         try:

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -31,6 +31,7 @@ from galaxy.schema.invocation import (
     InvocationWarningWorkflowOutputNotFound,
     WarningReason,
 )
+from galaxy.tools.parameters.basic import raw_to_galaxy
 from galaxy.util import ExecutionTimer
 from galaxy.workflow import modules
 from galaxy.workflow.run_request import (
@@ -399,7 +400,7 @@ class WorkflowProgress:
                 raise MessageException(public_message)
             runtime_state = step_states[step_id].value
             assert step.module
-            step.state = step.module.decode_runtime_state(runtime_state)
+            step.state = step.module.decode_runtime_state(step, runtime_state)
 
             invocation_step = step_invocations_by_id.get(step_id, None)
             if invocation_step and invocation_step.state == "scheduled":
@@ -408,7 +409,7 @@ class WorkflowProgress:
                 remaining_steps.append((step, invocation_step))
         return remaining_steps
 
-    def replacement_for_input(self, step: "WorkflowStep", input_dict: Dict[str, Any]) -> Any:
+    def replacement_for_input(self, trans, step: "WorkflowStep", input_dict: Dict[str, Any]) -> Any:
         replacement: Union[
             modules.NoReplacement,
             model.DatasetCollectionInstance,
@@ -416,6 +417,7 @@ class WorkflowProgress:
         ] = modules.NO_REPLACEMENT
         prefixed_name = input_dict["name"]
         multiple = input_dict["multiple"]
+        is_data = input_dict["input_type"] in ["dataset", "dataset_collection"]
         if prefixed_name in step.input_connections_by_name:
             connection = step.input_connections_by_name[prefixed_name]
             if input_dict["input_type"] == "dataset" and multiple:
@@ -431,9 +433,12 @@ class WorkflowProgress:
                 else:
                     replacement = temp
             else:
-                is_data = input_dict["input_type"] in ["dataset", "dataset_collection"]
                 replacement = self.replacement_for_connection(connection[0], is_data=is_data)
-
+        else:
+            for step_input in step.inputs:
+                if step_input.name == prefixed_name and step_input.default_value_set:
+                    if is_data:
+                        replacement = raw_to_galaxy(trans, step_input.default_value)
         return replacement
 
     def replacement_for_connection(self, connection: "WorkflowStepConnection", is_data: bool = True) -> Any:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -57,11 +57,13 @@ from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_WITH_BAD_COLUMN_PARAMETER_GOOD_TEST_DATA,
     WORKFLOW_WITH_CUSTOM_REPORT_1,
     WORKFLOW_WITH_CUSTOM_REPORT_1_TEST_DATA,
+    WORKFLOW_WITH_DEFAULT_FILE_DATASET_INPUT,
     WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION,
     WORKFLOW_WITH_MAPPED_OUTPUT_COLLECTION,
     WORKFLOW_WITH_OUTPUT_COLLECTION,
     WORKFLOW_WITH_OUTPUT_COLLECTION_MAPPING,
     WORKFLOW_WITH_RULES_1,
+    WORKFLOW_WITH_STEP_DEFAULT_FILE_DATASET_INPUT,
 )
 from ._framework import ApiTestCase
 from .sharable import SharingApiTests
@@ -4693,6 +4695,57 @@ data_input:
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             content = self.dataset_populator.get_history_dataset_content(history_id)
             assert len(content.splitlines()) == 3, content
+
+    def test_run_with_default_file_dataset_input(self):
+        with self.dataset_populator.test_history() as history_id:
+            run_response = self._run_workflow(
+                WORKFLOW_WITH_DEFAULT_FILE_DATASET_INPUT,
+                history_id=history_id,
+                wait=True,
+                assert_ok=True,
+            )
+            invocation_details = self.workflow_populator.get_invocation(run_response.invocation_id, step_details=True)
+            assert invocation_details["steps"][0]["outputs"]["output"]["src"] == "hda"
+            dataset_details = self.dataset_populator.get_history_dataset_details(
+                history_id, dataset_id=invocation_details["steps"][1]["outputs"]["out_file1"]["id"]
+            )
+            assert dataset_details["file_ext"] == "txt"
+            assert "chr1" in dataset_details["peek"]
+
+    def test_run_with_default_file_dataset_input_and_explicit_input(self):
+        with self.dataset_populator.test_history() as history_id:
+            run_response = self._run_workflow(
+                WORKFLOW_WITH_DEFAULT_FILE_DATASET_INPUT,
+                test_data="""
+default_file_input:
+  value: 1.fasta
+  type: File
+""",
+                history_id=history_id,
+                wait=True,
+                assert_ok=True,
+            )
+            invocation_details = self.workflow_populator.get_invocation(run_response.invocation_id, step_details=True)
+            assert invocation_details["steps"][0]["outputs"]["output"]["src"] == "hda"
+            dataset_details = self.dataset_populator.get_history_dataset_details(
+                history_id, dataset_id=invocation_details["steps"][1]["outputs"]["out_file1"]["id"]
+            )
+            assert dataset_details["file_ext"] == "txt"
+            assert (
+                "gtttgccatcttttgctgctctagggaatccagcagctgtcaccatgtaaacaagcccaggctagaccaGTTACCCTCATCATCTTAGCTGATAGCCAGCCAGCCACCACAGGCA"
+                in dataset_details["peek"]
+            )
+
+    def test_run_with_default_file_in_step_inline(self):
+        with self.dataset_populator.test_history() as history_id:
+            self._run_workflow(
+                WORKFLOW_WITH_STEP_DEFAULT_FILE_DATASET_INPUT,
+                history_id=history_id,
+                wait=True,
+                assert_ok=True,
+            )
+            content = self.dataset_populator.get_history_dataset_content(history_id)
+            assert "chr1" in content
 
     def test_run_with_validated_parameter_connection_invalid(self):
         with self.dataset_populator.test_history() as history_id:

--- a/lib/galaxy_test/base/workflow_fixtures.py
+++ b/lib/galaxy_test/base/workflow_fixtures.py
@@ -1147,3 +1147,33 @@ outputs:
   outer_output_2:
     outputSource: subworkflow/inner_output_2
 """
+
+WORKFLOW_WITH_DEFAULT_FILE_DATASET_INPUT = """
+class: GalaxyWorkflow
+inputs:
+  default_file_input:
+    default:
+      class: File
+      basename: a file
+      format: txt
+      location: https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed
+steps:
+  cat1:
+    tool_id: cat1
+    in:
+      input1: default_file_input
+"""
+
+WORKFLOW_WITH_STEP_DEFAULT_FILE_DATASET_INPUT = """
+class: GalaxyWorkflow
+steps:
+  cat1:
+    tool_id: cat1
+    in:
+      input1:
+        default:
+          class: File
+          basename: a file
+          format: txt
+          location: https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed
+"""

--- a/test/functional/tools/collection_nested_default.xml
+++ b/test/functional/tools/collection_nested_default.xml
@@ -1,0 +1,50 @@
+<tool id="collection_nested_default" name="collection_nested_default" version="0.1.0">
+  <command>
+    echo #for $f in $f1# ${f.is_collection} #end for# >> $out1;
+    cat #for $f in $f1# #if $f.is_collection# #for $inner in $f# ${inner} #end for# #else# $f # #end if# #end for# >> $out2
+  </command>
+  <inputs>
+    <param name="f1" type="data_collection">
+        <default collection_type="list:paired">
+          <element name="i1">
+            <collection collection_type="paired">
+              <element name="forward" location="https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed" />
+              <element name="reverse" location="https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.fasta" />
+            </collection>
+          </element>
+        </default>
+    </param>
+  </inputs>
+  <outputs>
+    <data format="txt" name="out1" />
+    <data format="txt" name="out2" />
+  </outputs>
+  <tests>
+    <test>
+      <output name="out1">
+        <assert_contents>
+          <has_line line="True" />
+        </assert_contents>
+      </output>
+      <output name="out2">
+        <assert_contents>
+          <has_text text="CCDS989.1_cds_0_0_chr1_147962193_r" />
+          <has_text text=">hg17" />
+        </assert_contents>
+      </output>
+    </test>
+    <test>
+      <param name="f1">
+        <collection type="paired">
+          <element name="forward" value="simple_line.txt" />
+          <element name="reverse" value="simple_line_alternative.txt" />
+        </collection>
+      </param>
+      <output name="out1">
+        <assert_contents>
+          <has_line line="False False" />
+        </assert_contents>
+      </output>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/collection_paired_default.xml
+++ b/test/functional/tools/collection_paired_default.xml
@@ -1,0 +1,40 @@
+<tool id="collection_paired_default" name="collection_paired_default" version="0.1.0">
+  <command>
+    cat $f1.forward $f1['reverse'] >> $out1;
+  </command>
+  <inputs>
+    <param name="f1" type="data_collection" collection_type="paired" label="Input pair">
+      <default collection_type="paired">
+          <element name="forward" location="https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed" />
+          <element name="reverse" location="https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.fasta" />
+      </default>
+    </param>
+  </inputs>
+  <outputs>
+    <data format="txt" name="out1" />
+  </outputs>
+  <tests>
+    <test>
+      <param name="f1">
+        <collection type="paired">
+          <element name="forward" value="simple_line.txt" />
+          <element name="reverse" value="simple_line_alternative.txt" />
+        </collection>
+      </param>
+      <output name="out1">
+        <assert_contents>
+          <has_line line="This is a line of text." />
+          <has_line line="This is a different line of text." />
+        </assert_contents>
+      </output>
+    </test>
+    <test>
+      <output name="out1">
+        <assert_contents>
+          <has_text text="CCDS989.1_cds_0_0_chr1_147962193_r" />
+          <has_text text=">hg17" />
+        </assert_contents>
+      </output>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/for_workflows/cat_default.xml
+++ b/test/functional/tools/for_workflows/cat_default.xml
@@ -1,0 +1,21 @@
+<tool id="cat_default" name="cat_default" version="1.0.0">
+    <description></description>
+    <command><![CDATA[
+cat '$input1' > '$out_file1'
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" label="Concatenate Dataset">
+            <default location="https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed" />
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="input" metadata_source="input1"/>
+    </outputs>
+    <tests>
+        <test>
+            <output name="out_file1" file="1.bed" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -176,9 +176,11 @@
   <tool file="output_action_change_format.xml" />
   <tool file="output_action_change_format_paired.xml" />
   <tool file="collection_paired_test.xml" />
+  <tool file="collection_paired_default.xml" />
   <tool file="collection_paired_structured_like.xml" />
   <tool file="collection_paired_conditional_structured_like.xml" />
   <tool file="collection_nested_test.xml" />
+  <tool file="collection_nested_default.xml" />
   <tool file="collection_mixed_param.xml" />
   <tool file="collection_two_paired.xml" />
   <tool file="collection_creates_pair.xml" />
@@ -236,6 +238,7 @@
        parameter, and multiple datasets from a collection. -->
   <tool file="for_workflows/cat.xml" />
   <tool file="for_workflows/cat_list.xml" />
+  <tool file="for_workflows/cat_default.xml" />
   <tool file="for_workflows/cat_collection.xml" />
   <tool file="for_workflows/head.xml" />
   <tool file="for_workflows/cat_interleave.xml" />

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -693,6 +693,79 @@ class TestExpressionTestToolLoader(BaseLoaderTestCase):
         assert output0["attributes"]["object"] is None
 
 
+class TestDefaultDataTestToolLoader(BaseLoaderTestCase):
+    source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/for_workflows/cat_default.xml")
+    source_contents = None
+
+    def test_input_parsing(self):
+        input_pages = self._tool_source.parse_input_pages()
+        assert input_pages.inputs_defined
+        page_sources = input_pages.page_sources
+        assert len(page_sources) == 1
+        page_source = page_sources[0]
+        input_sources = page_source.parse_input_sources()
+        assert len(input_sources) == 1
+        data_input = input_sources[0]
+        default_dict = data_input.parse_default()
+        assert default_dict
+        assert default_dict["location"] == "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed"
+
+
+class TestDefaultCollectionDataTestToolLoader(BaseLoaderTestCase):
+    source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/collection_paired_default.xml")
+    source_contents = None
+
+    def test_input_parsing(self):
+        input_pages = self._tool_source.parse_input_pages()
+        assert input_pages.inputs_defined
+        page_sources = input_pages.page_sources
+        assert len(page_sources) == 1
+        page_source = page_sources[0]
+        input_sources = page_source.parse_input_sources()
+        assert len(input_sources) == 1
+        data_input = input_sources[0]
+        default_dict = data_input.parse_default()
+        assert default_dict
+        assert default_dict["collection_type"] == "paired"
+        elements = default_dict["elements"]
+        assert len(elements) == 2
+        element0 = elements[0]
+        assert element0["identifier"] == "forward"
+        assert element0["location"] == "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bed"
+        element1 = elements[1]
+        assert element1["identifier"] == "reverse"
+        assert element1["location"] == "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.fasta"
+
+
+class TestDefaultNestedCollectionDataTestToolLoader(BaseLoaderTestCase):
+    source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/collection_nested_default.xml")
+    source_contents = None
+
+    def test_input_parsing(self):
+        input_pages = self._tool_source.parse_input_pages()
+        assert input_pages.inputs_defined
+        page_sources = input_pages.page_sources
+        assert len(page_sources) == 1
+        page_source = page_sources[0]
+        input_sources = page_source.parse_input_sources()
+        assert len(input_sources) == 1
+        data_input = input_sources[0]
+        default_dict = data_input.parse_default()
+        assert default_dict
+        assert default_dict["collection_type"] == "list:paired"
+        elements = default_dict["elements"]
+        assert len(elements) == 1
+        element0 = elements[0]
+        assert element0["identifier"] == "i1"
+
+        elements0 = element0["elements"]
+        assert len(elements0) == 2
+        elements00 = elements0[0]
+        assert elements00["identifier"] == "forward"
+        elements01 = elements0[1]
+        assert elements01["identifier"] == "reverse"
+
+
 class TestExpressionOutputDataToolLoader(BaseLoaderTestCase):
     source_file_name = os.path.join(galaxy_directory(), "test/functional/tools/expression_pick_larger_file.xml")
     source_contents = None

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -427,7 +427,10 @@ def __new_subworkflow_module(workflow=TEST_WORKFLOW_YAML):
 
 
 def __assert_has_runtime_input(module, label=None, collection_type=None):
-    inputs = module.get_runtime_inputs()
+    test_step = getattr(module, "test_step", None)
+    if test_step is None:
+        test_step = mock.MagicMock()
+    inputs = module.get_runtime_inputs(test_step)
     assert len(inputs) == 1
     assert "input" in inputs
     input_param = inputs["input"]

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -132,7 +132,7 @@ class TestWorkflowProgress(TestCase):
             "input_type": "dataset",
             "multiple": False,
         }
-        replacement = progress.replacement_for_input(self._step(2), step_dict)
+        replacement = progress.replacement_for_input(None, self._step(2), step_dict)
         assert replacement is hda
 
     def test_connect_tool_output(self):
@@ -169,7 +169,7 @@ class TestWorkflowProgress(TestCase):
             "input_type": "dataset",
             "multiple": False,
         }
-        replacement = progress.replacement_for_input(self._step(4), step_dict)
+        replacement = progress.replacement_for_input(None, self._step(4), step_dict)
         assert replacement is hda3
 
     # TODO: Replace multiple true HDA with HDCA
@@ -216,6 +216,7 @@ class TestWorkflowProgress(TestCase):
             "multiple": False,
         }
         assert hda is subworkflow_progress.replacement_for_input(
+            None,
             subworkflow_cat_step,
             step_dict,
         )
@@ -242,7 +243,7 @@ class MockModule:
     def __init__(self, progress):
         self.progress = progress
 
-    def decode_runtime_state(self, runtime_state):
+    def decode_runtime_state(self, step, runtime_state):
         return True
 
     def recover_mapping(self, invocation_step, progress):

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -1,9 +1,15 @@
+from typing import cast
+
 from galaxy import model
 from galaxy.model.base import transaction
 from galaxy.util.unittest import TestCase
-from galaxy.workflow.run import WorkflowProgress
+from galaxy.workflow.run import (
+    ModuleInjector,
+    WorkflowProgress,
+)
 from .workflow_support import (
     MockApp,
+    MockTrans,
     yaml_to_model,
 )
 
@@ -76,7 +82,8 @@ class TestWorkflowProgress(TestCase):
         self.invocation.workflow = workflow
 
     def _new_workflow_progress(self):
-        return WorkflowProgress(self.invocation, self.inputs_by_step_id, MockModuleInjector(self.progress), {})
+        mock_injector: ModuleInjector = cast(ModuleInjector, MockModuleInjector(self.progress))
+        return WorkflowProgress(self.invocation, self.inputs_by_step_id, mock_injector, {})
 
     def _set_previous_progress(self, outputs):
         for i, (step_id, step_value) in enumerate(outputs):
@@ -242,6 +249,7 @@ class MockModuleInjector:
 class MockModule:
     def __init__(self, progress):
         self.progress = progress
+        self.trans = MockTrans()
 
     def decode_runtime_state(self, step, runtime_state):
         return True


### PR DESCRIPTION
Works for both files and collections. Workflow defaults override tool defaults.

This is not strictly better or worse than #14938 / #13110, but to my eyes this is both cleaner than that approach and brings in more CWL (the ``raw_to_galaxy`` here is a cleanup and generalization of a CWL-branch-ism). Both approaches commit Galaxy to doing some long term, difficult things - I think by not adding a new tool form type, not adding new models, not adding new ways users can have data associated with their account, etc... this approach is a bit more conservative. Both approaches do some things with workflow state that make me uncomfortable and this approach adds some tool features -  but I feel good about the tool features (they are useful, tested, and feel both cohesive and 'galaxy').

TODO:

- [ ] Fix up the UI
- [ ] Unit test case to ensure this only works for non-default, non-multi data parameters.
- [x] Implement XSD once syntax is finalized.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
