### PR TITLE
accept tool execution exception if expect_failure

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1290,7 +1290,7 @@ def verify_tool(
             if job_output_exceptions:
                 job_data["output_problems"] = [util.unicodify(_) for _ in job_output_exceptions]
                 status = "failure"
-            if tool_execution_exception:
+            if tool_execution_exception and not expected_failure_occurred:
                 job_data["execution_problem"] = util.unicodify(tool_execution_exception)
                 dynamic_param_error = getattr(tool_execution_exception, "dynamic_param_error", False)
                 job_data["dynamic_param_error"] = dynamic_param_error

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -135,6 +135,7 @@
   <tool file="section.xml" />
   <tool file="sam_to_unsorted_bam.xml" />
   <tool file="top_level_data.xml" />
+  <tool file="validation_regex.xml" />
   <tool file="validation_hdf5.xml" />
   <tool file="validation_zip.xml" />
   <tool file="validation_tar.xml" />

--- a/test/functional/tools/validation_regex.xml
+++ b/test/functional/tools/validation_regex.xml
@@ -1,0 +1,28 @@
+<tool id="validation_regex" name="validation_regex" profile="19.05" version="0.1">
+    <command><![CDATA[
+echo 'Hello World' > out1
+    ]]></command>
+    <inputs>
+        <param name="text_in" type="text" label="text">
+            <validator type="regex">^valid$</validator>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" from_work_dir="out1"/>
+    </outputs>
+    <tests>
+        <test expect_failure="true">
+            <param name="text_in" value="invalid"/>
+        </test>
+        <test expect_failure="false">
+            <param name="text_in" value="valid"/>
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="Hello World" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>


### PR DESCRIPTION
some CI tool tests at IUC which had `expect_failure="true"` were failing "suddenly". I guess this coincides with the introducion of planemo 0.75.x. But I'm not sure if this is due to a change in planemo (gravity), the testing functions in `tool-util`, or changes to the paramater validators.

I guess its one of the latter two, but I'm not sure why we did not see this earlier. Also I'm not sure if this is the correct fix (but it solves the problems in the IUC tests).

xref https://github.com/galaxyproject/tools-iuc/pull/4910

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
