### PR TITLE
lint for coexisting expect_num_outputs and expect_failure

### DIFF
--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -5,6 +5,7 @@ from inspect import (
     signature,
 )
 
+from galaxy.util import asbool
 from ._util import is_datasource
 from ..verify import asserts
 
@@ -117,9 +118,16 @@ def lint_tests(tool_xml, lint_ctx):
                                 node=output,
                             )
 
-        if "expect_failure" in test.attrib and found_output_test:
-            lint_ctx.error(f"Test {test_idx}: Cannot specify outputs in a test expecting failure.", node=test)
-            continue
+        if "expect_failure" in test.attrib and asbool(test.attrib["expect_failure"]):
+            if found_output_test:
+                lint_ctx.error(f"Test {test_idx}: Cannot specify outputs in a test expecting failure.", node=test)
+                continue
+            if "expect_num_outputs" in test.attrib:
+                lint_ctx.error(
+                    f"Test {test_idx}: Cannot make assumptions on the number of outputs in a test expecting failure.",
+                    node=test,
+                )
+                continue
 
         has_test = has_test or found_output_test
         if not has_test:

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -636,6 +636,7 @@ TESTS_EXPECT_FAILURE_OUTPUT = """
         <test expect_failure="true">
             <output name="test"/>
         </test>
+        <test expect_num_outputs="1" expect_failure="true"/>
     </tests>
 </tool>
 """
@@ -1495,10 +1496,14 @@ def test_tests_expect_failure_output(lint_ctx):
     run_lint(lint_ctx, tests.lint_tests, tool_source)
     assert "No valid test(s) found." in lint_ctx.warn_messages
     assert "Test 1: Cannot specify outputs in a test expecting failure." in lint_ctx.error_messages
+    assert (
+        "Test 2: Cannot make assumptions on the number of outputs in a test expecting failure."
+        in lint_ctx.error_messages
+    )
     assert not lint_ctx.info_messages
     assert not lint_ctx.valid_messages
     assert len(lint_ctx.warn_messages) == 1
-    assert len(lint_ctx.error_messages) == 1
+    assert len(lint_ctx.error_messages) == 2
 
 
 def test_tests_without_expectations(lint_ctx):


### PR DESCRIPTION
which IMO makes no sense since output assumption are not checked if an error occurs

xref https://github.com/galaxyproject/tools-iuc/pull/4910#issuecomment-1307786066 (but this obviously does not solve this problem)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
