### PR TITLE
Downgrade exception to warning when job properties files could not be found

### DIFF
--- a/lib/galaxy/job_metrics/__init__.py
+++ b/lib/galaxy/job_metrics/__init__.py
@@ -211,8 +211,10 @@ class JobInstrumenter(JobInstrumenterI):
                 properties = plugin.job_properties(job_id, job_directory)
                 if properties:
                     per_plugin_properties[plugin.plugin_type] = properties
+            except FileNotFoundError as e:
+                log.warning("Failed to collect job properties for plugin %s: %s", plugin, e)
             except Exception:
-                log.warning("Failed to collect job properties for plugin %s", plugin)
+                log.exception("Failed to collect job properties for plugin %s", plugin)
         return per_plugin_properties
 
     def __plugins_from_source(self, plugins_source):

--- a/lib/galaxy/job_metrics/__init__.py
+++ b/lib/galaxy/job_metrics/__init__.py
@@ -212,7 +212,7 @@ class JobInstrumenter(JobInstrumenterI):
                 if properties:
                     per_plugin_properties[plugin.plugin_type] = properties
             except Exception:
-                log.exception("Failed to collect job properties for plugin %s", plugin)
+                log.warning("Failed to collect job properties for plugin %s", plugin)
         return per_plugin_properties
 
     def __plugins_from_source(self, plugins_source):


### PR DESCRIPTION
I get several tracebacks like the following in logs after running a job:

```nov 10 13:59:35 g-1 uwsgi[805468]: Traceback (most recent call last):
nov 10 13:59:35 g-1 uwsgi[805468]:   File "/srv/galaxy/server/lib/galaxy/job_metrics/__init__.py", line 120, in collect_properties
nov 10 13:59:35 g-1 uwsgi[805468]:     properties = plugin.job_properties(job_id, job_directory)
nov 10 13:59:35 g-1 uwsgi[805468]:   File "/srv/galaxy/server/lib/galaxy/job_metrics/instrumenters/cpuinfo.py", line 39, in job_properties
nov 10 13:59:35 g-1 uwsgi[805468]:     with open(self.__instrument_cpuinfo_path(job_directory)) as f:
nov 10 13:59:35 g-1 uwsgi[805468]: FileNotFoundError: [Errno 2] No such file or directory: '/srv/galaxy/jobs/000/527/__instrument_cpuinfo_cpuinfo'
```
Maybe I'm missing something here but I don't understand why it makes sense to attempt collecting job metrics if `job_metrics_directory` is not passed to `finish()` (and thus set to `None`). If on the other hand the metrics should be collected under all circumstances, `job_metrics_directory` should be a compulsory argument of `finish()`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
