### PR TITLE
[22.01] Set test status to success on expected failure

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1145,10 +1145,10 @@ def verify_tool(tool_id,
                 dynamic_param_error = getattr(tool_execution_exception, "dynamic_param_error", False)
                 job_data["dynamic_param_error"] = dynamic_param_error
                 if not expected_failure_occurred:
-                    if not skip_on_dynamic_param_errors or not dynamic_param_error:
-                        status = "error"
-                    else:
+                    if skip_on_dynamic_param_errors and dynamic_param_error:
                         status = "skip"
+                    else:
+                        status = "error"
             if input_staging_exception:
                 job_data["execution_problem"] = f"Input staging problem: {util.unicodify(input_staging_exception)}"
                 status = "error"

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1144,7 +1144,11 @@ def verify_tool(tool_id,
                 job_data["execution_problem"] = util.unicodify(tool_execution_exception)
                 dynamic_param_error = getattr(tool_execution_exception, "dynamic_param_error", False)
                 job_data["dynamic_param_error"] = dynamic_param_error
-                status = "error" if not skip_on_dynamic_param_errors or not dynamic_param_error else "skip"
+                if not expected_failure_occurred:
+                    if not skip_on_dynamic_param_errors or not dynamic_param_error:
+                        status = "error"
+                    else:
+                        status = "skip"
             if input_staging_exception:
                 job_data["execution_problem"] = f"Input staging problem: {util.unicodify(input_staging_exception)}"
                 status = "error"


### PR DESCRIPTION
Alternative to https://github.com/galaxyproject/galaxy/pull/14958.

We keep `execution_problem` and `dynamic_param_error`. This may or may not be useful for further checks.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
