### PR TITLE
[22.05] Fix VCF handling for IGV Viewer

### DIFF
--- a/lib/galaxy/datatypes/display_applications/configs/igv/vcf.xml
+++ b/lib/galaxy/datatypes/display_applications/configs/igv/vcf.xml
@@ -13,7 +13,7 @@
         <!-- We define url and params as normal, but values defined in dynamic_param are available by specified name -->
         <url>${redirect_url}</url>
         <param type="data" name="bgzip_file" url="galaxy_${DATASET_HASH}.vcf.gz" format="vcf_bgzip" allow_cors="true" mimetype="application/octet-stream"/>
-        <param type="data" name="tabix_file" metadata="tabix_index" url="galaxy_${DATASET_HASH}.vcf.gz.tbi" allow_cors="true" mimetype="application/octet-stream"/>
+        <param type="data" name="tabix_file" dataset="bgzip_file" metadata="tabix_index" url="galaxy_${DATASET_HASH}.vcf.gz.tbi" allow_cors="true" mimetype="application/octet-stream"/>
         <param type="template" name="site_organism" strip="True" >
             #if ($dataset.dbkey in $site_dbkeys)
                 $site_organisms[ $site_dbkeys.index( $bgzip_file.dbkey ) ]

--- a/lib/galaxy/datatypes/display_applications/configs/igv/vcf.xml
+++ b/lib/galaxy/datatypes/display_applications/configs/igv/vcf.xml
@@ -13,7 +13,7 @@
         <!-- We define url and params as normal, but values defined in dynamic_param are available by specified name -->
         <url>${redirect_url}</url>
         <param type="data" name="bgzip_file" url="galaxy_${DATASET_HASH}.vcf.gz" format="vcf_bgzip" allow_cors="true" mimetype="application/octet-stream"/>
-        <param type="data" name="tabix_file" dataset="bgzip_file" metadata="tabix_index" url="galaxy_${DATASET_HASH}.vcf.gz.tbi" allow_cors="true" mimetype="application/octet-stream"/>
+        <param type="data" name="tabix_file" metadata="tabix_index" url="galaxy_${DATASET_HASH}.vcf.gz.tbi" allow_cors="true" mimetype="application/octet-stream" />
         <param type="template" name="site_organism" strip="True" >
             #if ($dataset.dbkey in $site_dbkeys)
                 $site_organisms[ $site_dbkeys.index( $bgzip_file.dbkey ) ]
@@ -95,7 +95,7 @@
         <!-- We define url and params as normal, but values defined in dynamic_param are available by specified name -->
         <url>http://www.broadinstitute.org/igv/projects/current/igv.php?sessionURL=${bgzip_file.qp}&amp;genome=${qp($bgzip_file.dbkey)}&amp;merge=true&amp;name=${qp( ( $bgzip_file.name or $DATASET_HASH ).replace( ',', ';' ) )}</url>
         <param type="data" name="bgzip_file" url="galaxy_${DATASET_HASH}.vcf.gz" format="vcf_bgzip" mimetype="application/octet-stream"/>
-        <param type="data" name="tabix_file" metadata="tabix_index" url="galaxy_${DATASET_HASH}.vcf.gz.tbi" format="vcf_bgzip" mimetype="application/octet-stream"/>
+        <param type="data" name="tabix_file" metadata="tabix_index" url="galaxy_${DATASET_HASH}.vcf.gz.tbi" mimetype="application/octet-stream" />
     </dynamic_links>
 </display>
 <!-- Dan Blankenberg -->

--- a/lib/galaxy/datatypes/display_applications/parameters.py
+++ b/lib/galaxy/datatypes/display_applications/parameters.py
@@ -100,6 +100,8 @@ class DisplayApplicationDataParameter(DisplayApplicationParameter):
         assert data, "Base dataset could not be found in values provided to DisplayApplicationDataParameter"
         if isinstance(data, DisplayDataValueWrapper):
             data = data.value
+        if data.state != data.states.OK:
+            return None
         if self.metadata:
             rval = getattr(data.metadata, self.metadata, None)
             assert rval, f'Unknown metadata name "{self.metadata}" provided for dataset type "{data.ext}".'
@@ -109,8 +111,7 @@ class DisplayApplicationDataParameter(DisplayApplicationParameter):
                 rval = data.get_converted_files_by_type(ext)
                 if rval:
                     return rval
-
-            direct_match, target_ext, converted_dataset = data.find_conversion_destination(self.formats)
+            direct_match, target_ext, _ = data.find_conversion_destination(self.formats)
             assert direct_match or target_ext is not None, f"No conversion path found for data param: {self.name}"
             return None
         return data

--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -530,20 +530,41 @@ def send_file(start_response, trans, body):
         body = [b""]
     # Fall back on sending the file in chunks
     else:
-        body = iterate_file(body)
+        trans.response.headers["accept-ranges"] = "bytes"
+        start = None
+        end = None
+        if trans.request.range:
+            start = trans.request.range.start
+            end = trans.request.range.end
+            file_size = trans.response.headers["content-length"]
+            trans.response.headers["content-length"] = str(end - start)
+            trans.response.headers["content-range"] = f"bytes {start}-{end - 1}/{file_size}"
+            trans.response.status = 206
+        body = iterate_file(body, start, end)
     start_response(trans.response.wsgi_status(), trans.response.wsgi_headeritems())
     return body
 
 
-def iterate_file(fh):
+def iterate_file(fh, start=None, stop=None):
     """
     Progressively return chunks from `file`.
     """
+    length = None
+    if start:
+        fh.seek(start)
+    if stop:
+        length = stop - start
     while 1:
-        chunk = fh.read(CHUNK_SIZE)
+        read_size = CHUNK_SIZE
+        if length:
+            read_size = min(CHUNK_SIZE, length)
+            length -= read_size
+        chunk = fh.read(read_size)
         if not chunk:
             break
         yield chunk
+        if length is not None and length == 0:
+            break
 
 
 def flatten(seq):

--- a/test/unit/webapps/test_send_file.py
+++ b/test/unit/webapps/test_send_file.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from galaxy.util.bunch import Bunch
 from galaxy.web.framework.base import (
+    Request,
     Response,
     send_file,
 )
@@ -18,6 +19,7 @@ def setup_fastAPI(fh, nginx_x_accel_redirect_base=None, apache_xsendfile=None):
     def wsgi_application(env, start_response):
         trans = Bunch(
             response=Response(),
+            request=Request(env),
             app=Bunch(
                 config=Bunch(nginx_x_accel_redirect_base=nginx_x_accel_redirect_base, apache_xsendfile=apache_xsendfile)
             ),


### PR DESCRIPTION
Fixes #14951. Will follow-up with the removal of the `display_application mako`, potentially moving the data retrieval to the API.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
