### PR TITLE
add basic wheels and functionality for ITs in history

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -33,7 +33,7 @@
                     <span class="fa fa-info-circle" />
                 </b-button>
                 <b-button
-                    v-if="writable && showRerun"
+                    v-if="writable && showRerun && !isRunningInteractive"
                     class="rerun-btn px-1"
                     title="Run Job Again"
                     size="sm"
@@ -53,7 +53,7 @@
                     <span class="fa fa-bar-chart-o" />
                 </b-button>
                 <b-button
-                    v-if="showHighlight"
+                    v-if="showHighlight && !isRunningInteractive"
                     class="px-1"
                     title="Show Inputs for this item"
                     size="sm"
@@ -61,18 +61,18 @@
                     @click.stop="onHighlight">
                     <span class="fa fa-sitemap" />
                 </b-button>
-                <b-button v-if="showRerun" class="px-1" title="Help" size="sm" variant="link" @click.stop="onRerun">
+                <b-button v-if="showRerun && !isRunningInteractive" class="px-1" title="Help" size="sm" variant="link" @click.stop="onRerun">
                     <span class="fa fa-question" />
                 </b-button>
                 <b-button
-                    v-if="isInteractive && isRunning"
+                    v-if="isRunningInteractive"
                     v-b-tooltip
                     class="px-1"
                     title="Open Interactive Tool"
                     size="sm"
                     variant="link"
                     @click.stop="onInteractive">
-                    <span class="fa fa-external-link-alt" />
+                    interact <span class="fa fa-external-link-alt" />
                 </b-button>
             </div>
         </div>
@@ -136,6 +136,9 @@ export default {
         },
         isInteractive() {
             return this.item.tool_type == "interactive";
+        },
+        isRunningInteractive(){
+            return this.isInteractive && this.isRunning;
         },
     },
     methods: {

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -64,6 +64,16 @@
                 <b-button v-if="showRerun" class="px-1" title="Help" size="sm" variant="link" @click.stop="onRerun">
                     <span class="fa fa-question" />
                 </b-button>
+                <b-button
+                    v-if="isInteractive && isRunning"
+                    v-b-tooltip
+                    class="px-1"
+                    title="Open Interactive Tool"
+                    size="sm"
+                    variant="link"
+                    @click.stop="onInteractive">
+                    <span class="fa fa-external-link-alt" />
+                </b-button>
             </div>
         </div>
     </div>
@@ -74,6 +84,7 @@ import { copy as sendToClipboard } from "utils/clipboard";
 import { absPath, prependPath } from "utils/redirect.js";
 import { downloadUrlMixin } from "./mixins.js";
 import DatasetDownload from "./DatasetDownload";
+import { getEntryPoint } from "./InteractiveToolEntry.js";
 
 export default {
     components: {
@@ -92,6 +103,9 @@ export default {
         },
         showError() {
             return this.item.state == "error";
+        },
+        isRunning(){
+            return this.item.state == "running";
         },
         showInfo() {
             return this.item.state != "noPermission";
@@ -120,6 +134,9 @@ export default {
         visualizeUrl() {
             return prependPath(this.itemUrls.visualize);
         },
+        isInteractive() {
+            return this.item.tool_type == "interactive";
+        },
     },
     methods: {
         onCopyLink() {
@@ -144,6 +161,9 @@ export default {
         },
         onHighlight() {
             this.$emit("toggleHighlights");
+        },
+        onInteractive(){
+            getEntryPoint(this.item.creating_job).then((data) => { window.open(data.data[0].target)})
         },
     },
 };

--- a/client/src/components/History/Content/Dataset/InteractiveToolEntry.js
+++ b/client/src/components/History/Content/Dataset/InteractiveToolEntry.js
@@ -1,0 +1,14 @@
+import { getAppRoot } from "onload/loadConfig";
+import axios from "axios";
+import { rethrowSimple } from "utils/simple-error";
+
+export async function getEntryPoint(creating_job) {
+    const params = { job_id: creating_job };
+    const url = `${getAppRoot()}api/entry_points`;
+    try {
+        const response = await axios.get(url, { params: params });
+        return response;
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -220,6 +220,7 @@ class DatasetSerializer(base.ModelSerializer[DatasetManager], deletable.Purgable
                 "file_size",
                 "total_size",
                 "uuid",
+                "tool_type",
             ],
         )
         # could do visualizations and/or display_apps
@@ -584,6 +585,7 @@ class _UnflattenedMetadataDatasetAssociationSerializer(base.ModelSerializer[T], 
             # derived (not mapped) attributes
             "data_type": lambda item, key, **context: f"{item.datatype.__class__.__module__}.{item.datatype.__class__.__name__}",
             "converted": self.serialize_converted_datasets,
+            "tool_type": self.serialize_tool_type,
             # TODO: metadata/extra files
         }
         self.serializers.update(serializers)
@@ -689,6 +691,13 @@ class _UnflattenedMetadataDatasetAssociationSerializer(base.ModelSerializer[T], 
             if not converted.deleted and converted.dataset:
                 id_map[converted.type] = self.serialize_id(converted.dataset, "id")
         return id_map
+
+    def serialize_tool_type(self, dataset, key, user=None, **context):
+        if dataset.creating_job:
+            tool = self.app.toolbox.get_tool(dataset.creating_job.tool_id, dataset.creating_job.tool_version)
+            if tool:
+                return tool.tool_type
+        return None
 
 
 class DatasetAssociationSerializer(_UnflattenedMetadataDatasetAssociationSerializer[T]):

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -347,6 +347,7 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                 "url",
                 "create_time",
                 "update_time",
+                "tool_type",
             ],
         )
         self.add_view(
@@ -387,6 +388,7 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                 "created_from_basename",
                 "hashes",
                 "sources",
+                "tool_type",
             ],
             include_keys_from="summary",
         )


### PR DESCRIPTION
This aims to be a lighter alternative to https://github.com/galaxyproject/galaxy/pull/12369

Very much WIP, just wanted to get the basics checked. The idea is to make couple more small changes to the history dataset that is attached to the running IT to make it more prominent and useful. 

- Ideally the 'eye' previews the actual ipynb.
- I'd probably drop the tag and edit buttons from the top menu, same with rerun, hierarchy, and help from the bottom. (done)



![Galaxy___martenson](https://user-images.githubusercontent.com/1814954/201748032-1821a640-670b-4ae3-bece-c74ecc44229e.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
