### PR TITLE
[22.05] Add HEAD route for ``/api/datasets/{history_content_id}/display``

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -11,7 +11,11 @@ import urllib.parse
 import zipfile
 from json import dumps
 from logging import getLogger
-from typing import Optional
+from typing import (
+    Any,
+    Dict,
+    Optional
+)
 
 import requests
 from packaging.version import parse as parse_version
@@ -809,6 +813,15 @@ class GalaxyInteractorApi:
             kwargs["cookies"] = self.cookies
         # no data for GET
         return requests.get(url, params=data, headers=headers, timeout=util.DEFAULT_SOCKET_TIMEOUT, **kwargs)
+
+    def _head(self, path, data=None, key=None, headers=None, admin=False, anon=False):
+        headers = self.api_key_header(key=key, admin=admin, anon=anon, headers=headers)
+        url = self.get_api_url(path)
+        kwargs: Dict[str, Any] = {}
+        if self.cookies:
+            kwargs["cookies"] = self.cookies
+        # no data for HEAD
+        return requests.head(url, params=data, headers=headers, timeout=util.DEFAULT_SOCKET_TIMEOUT, **kwargs)
 
     def get_api_url(self, path: str) -> str:
         if path.startswith("http"):

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -14,7 +14,7 @@ from logging import getLogger
 from typing import (
     Any,
     Dict,
-    Optional
+    Optional,
 )
 
 import requests

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -275,6 +275,7 @@ class BaseGalaxyAPIController(BaseAPIController):
 
 class RestVerb(str, Enum):
     get = "GET"
+    head = "HEAD"
     post = "POST"
     put = "PUT"
     patch = "PATCH"
@@ -356,6 +357,9 @@ class Router(InferringRouter):
 
     def options(self, *args, **kwd):
         return self.wrap_with_alias(RestVerb.options, *args, **kwd)
+
+    def head(self, *args, **kwd):
+        return self.wrap_with_alias(RestVerb.head, *args, **kwd)
 
     def _handle_galaxy_kwd(self, kwd):
         require_admin = kwd.pop("require_admin", False)

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -211,6 +211,16 @@ class FastAPIDatasets:
         tags=["histories"],
         response_class=StreamingResponse,
     )
+    @router.head(
+        "/api/datasets/{history_content_id}/display",
+        summary="Check if dataset content can be previewed or downloaded.",
+    )
+    @router.head(
+        "/api/histories/{history_id}/contents/{history_content_id}/display",
+        name="history_contents_display",
+        summary="Check if dataset content can be previewed or downloaded.",
+        tags=["histories"],
+    )
     def display(
         self,
         request: Request,

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -121,11 +121,12 @@ def add_galaxy_middleware(app: FastAPI, gx_app):
             if not isinstance(response, FileResponse):
                 return response
             response = cast(FileResponse, response)
-            if nginx_x_accel_redirect_base:
-                full_path = Path(nginx_x_accel_redirect_base) / response.path
-                response.headers["X-Accel-Redirect"] = str(full_path)
-            if apache_xsendfile:
-                response.headers["X-Sendfile"] = str(response.path)
+            if not response.send_header_only:
+                if nginx_x_accel_redirect_base:
+                    full_path = Path(nginx_x_accel_redirect_base) / response.path
+                    response.headers["X-Accel-Redirect"] = str(full_path)
+                if apache_xsendfile:
+                    response.headers["X-Sendfile"] = str(response.path)
             return response
 
     if gx_app.config.get("allowed_origin_hostnames", None):

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -316,6 +316,18 @@ class DatasetsApiTestCase(ApiTestCase):
         self._assert_status_code_is(display_response, 200)
         assert display_response.text == contents
 
+    def test_head(self):
+        history_id = self.history_id
+        hda1 = self.dataset_populator.new_dataset(history_id)
+        self.dataset_populator.wait_for_history(history_id)
+        display_response = self._head(f"histories/{history_id}/contents/{hda1['id']}/display", {"raw": "True"})
+        self._assert_status_code_is(display_response, 200)
+        assert display_response.text == ""
+        display_response = self._head(
+            f"histories/{history_id}/contents/{hda1['id']}{hda1['id']}/display", {"raw": "True"}
+        )
+        self._assert_status_code_is(display_response, 400)
+
     def test_tag_change(self):
         hda_id = self.dataset_populator.new_dataset(self.history_id)["id"]
         payload = {

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -150,6 +150,9 @@ class UsesApiTestCaseMixin:
     def _get(self, *args, **kwds):
         return self.galaxy_interactor.get(*args, **kwds)
 
+    def _head(self, *args, **kwds):
+        return self.galaxy_interactor.head(*args, **kwds)
+
     def _post(self, *args, **kwds):
         return self.galaxy_interactor.post(*args, **kwds)
 
@@ -200,6 +203,9 @@ class ApiTestInteractor(BaseInteractor):
     # testing.
     def get(self, *args, **kwds):
         return self._get(*args, **kwds)
+
+    def head(self, *args, **kwds):
+        return self._head(*args, **kwds)
 
     def post(self, *args, **kwds):
         return self._post(*args, **kwds)


### PR DESCRIPTION
and ``/api/histories/{history_id}/contents/{history_content_id}/display``

paste/webob would allow HEAD requests everywhere, so this just worked previously.

Partially fixes https://github.com/galaxyproject/galaxy/issues/14982, for dev we could use https://baize.aber.sh/asgi#fileresponse as a drop-in for our fileresponse, it's supposed to be able to handle byte-range requests.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
