### PR TITLE
[22.05] Make workflow cycle test side-effect free

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -89,7 +89,10 @@ from galaxy.workflow.refactor.schema import (
 )
 from galaxy.workflow.reports import generate_report
 from galaxy.workflow.resources import get_resource_mapper_function
-from galaxy.workflow.steps import attach_ordered_steps
+from galaxy.workflow.steps import (
+    attach_ordered_steps,
+    has_cycles,
+)
 from .base import decode_id
 from .executables import artifact_class
 
@@ -854,7 +857,7 @@ class WorkflowContentsManager(UsesAnnotations):
         """
         if len(workflow.steps) == 0:
             raise exceptions.MessageException("Workflow cannot be run because it does not have any steps.")
-        if attach_ordered_steps(workflow):
+        if has_cycles(workflow):
             raise exceptions.MessageException("Workflow cannot be run because it contains cycles.")
         trans.workflow_building_mode = workflow_building_modes.USE_HISTORY
         module_injector = WorkflowModuleInjector(trans)
@@ -946,7 +949,7 @@ class WorkflowContentsManager(UsesAnnotations):
         """
         if len(workflow.steps) == 0:
             raise exceptions.MessageException("Workflow cannot be run because it does not have any steps.")
-        if attach_ordered_steps(workflow):
+        if has_cycles(workflow):
             raise exceptions.MessageException("Workflow cannot be run because it contains cycles.")
 
         # Ensure that the user has a history

--- a/lib/galaxy/workflow/steps.py
+++ b/lib/galaxy/workflow/steps.py
@@ -56,6 +56,14 @@ def order_workflow_steps(steps):
         return None
 
 
+def has_cycles(workflow):
+    try:
+        topsort(sorted(edgelist_for_workflow_steps(workflow.steps)))
+        return False
+    except CycleError:
+        return True
+
+
 def edgelist_for_workflow_steps(steps):
     """
     Create a list of tuples representing edges between ``WorkflowStep`` s based


### PR DESCRIPTION
`attach_ordered_steps` had always potentially had side effects (I guess it was in the name too ...), but with https://github.com/galaxyproject/galaxy/pull/13641 the workflow run form would receive reordered inputs if any of the steps were going to be reordered according to the new sorting rules, while the invocation endpoint would use the original, correct input order. That would lead to mixed up inputs.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
