### PR TITLE
[22.05] Backport #14643: Enable simplified workflow with optional disconnected data inputs

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRun.test.js
+++ b/client/src/components/Workflow/Run/WorkflowRun.test.js
@@ -49,6 +49,7 @@ describe("WorkflowRun.vue", () => {
 
         expect(wrapper.vm.error).toBeNull();
         expect(wrapper.vm.loading).toBe(false);
+        expect(wrapper.vm.simpleForm).toBe(false);
         const model = wrapper.vm.model;
         expect(model).not.toBeNull();
         expect(model.workflowId).toBe(run1WorkflowId);

--- a/client/src/components/Workflow/Run/model.js
+++ b/client/src/components/Workflow/Run/model.js
@@ -153,8 +153,9 @@ export class WorkflowRunModel {
                             (data_ref.step_linked && !isDataStep(data_ref.step_linked)) || input.wp_linked;
                     }
                     if (
-                        is_data_input ||
-                        (input.value && input.value.__class__ == "RuntimeValue" && !input.step_linked)
+                        !input.optional &&
+                        (is_data_input ||
+                            (input.value && input.value.__class__ == "RuntimeValue" && !input.step_linked))
                     ) {
                         step.expanded = true;
                         hasOpenToolSteps = true;

--- a/client/src/components/Workflow/Run/model.test.js
+++ b/client/src/components/Workflow/Run/model.test.js
@@ -1,4 +1,5 @@
-import { getReplacements } from "./model";
+import { getReplacements, WorkflowRunModel } from "./model";
+import sampleRunData1 from "./testdata/run1.json";
 
 describe("test basic parameter replacement", () => {
     it("should replace", async () => {
@@ -13,5 +14,50 @@ describe("test basic parameter replacement", () => {
         const result = getReplacements(step_1.inputs, stepData, wpData);
         expect(result.input_1).toEqual("input_new_wp");
         expect(result.input_2.values[0]).toEqual("input_new_data");
+    });
+});
+
+describe("WorkflowRunModel status", () => {
+    it("expands tool steps with disconnected data inputs", async () => {
+        const runModel = new WorkflowRunModel(sampleRunData1);
+        expect(runModel.hasOpenToolSteps).toBe(true);
+    });
+    it("collapses tool steps with optional disconnected data inputs", async () => {
+        const optionalDataSteps = {
+            ...sampleRunData1,
+            steps: [
+                {
+                    id: "cat",
+                    inputs: [
+                        {
+                            label: "Concatenate Dataset",
+                            model_class: "DataToolParameter",
+                            multiple: false,
+                            name: "input1",
+                            optional: true,
+                            options: {
+                                hda: [],
+                                hdca: [],
+                            },
+                            text_value: "Not available.",
+                            type: "data",
+                            value: {
+                                __class__: "RuntimeValue",
+                            },
+                        },
+                    ],
+                    model_class: "Tool",
+                    name: "Concatenate datasets (for test workflows)",
+                    replacement_parameters: [],
+                    step_index: 0,
+                    step_label: "",
+                    step_name: "Concatenate datasets (for test workflows)",
+                    step_type: "tool",
+                    step_version: "1.0.0",
+                },
+            ],
+        };
+        const runModel = new WorkflowRunModel(optionalDataSteps);
+        expect(runModel.hasOpenToolSteps).toBe(false);
     });
 });


### PR DESCRIPTION
Backport of https://github.com/galaxyproject/galaxy/pull/14643, we've been running this on main for weeks without issues.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
