### PR TITLE
Fix discarded datasets when importing history from file sources using tasks

### DIFF
--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -168,7 +168,6 @@ class ModelStoreManager:
 
     def import_model_store(self, request: ImportModelStoreTaskRequest):
         import_options = ImportOptions(
-            discarded_data=ImportDiscardedDataType.FORCE,
             allow_library_creation=request.for_library,
         )
         history_id = request.history_id

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -186,6 +186,7 @@ class ModelStoreManager:
             self._app,
             galaxy_user,
             import_options,
+            model_store_format=request.model_store_format,
         )
         new_history = history is None and not request.for_library
         if new_history:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -632,8 +632,11 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                             )
                         else:
                             # Try to set metadata directly. TODO: check efficiency of this?
-                            if dataset_instance.has_metadata_files:
-                                dataset_instance.datatype.set_meta(dataset_instance)
+                            try:
+                                if dataset_instance.has_metadata_files:
+                                    dataset_instance.datatype.set_meta(dataset_instance)
+                            except Exception:
+                                dataset_instance.dataset.state = dataset_instance.dataset.states.FAILED_METADATA
 
                 if model_class == "HistoryDatasetAssociation":
                     if object_key in dataset_attrs:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -54,6 +54,7 @@ from galaxy.model.orm.util import (
     add_object_to_session,
     get_object_session,
 )
+from galaxy.model.tags import GalaxyTagHandler
 from galaxy.objectstore import ObjectStore
 from galaxy.schema.bco import (
     BioComputeObjectCore,
@@ -134,6 +135,7 @@ class StoreAppProtocol(Protocol):
     datatypes_registry: Registry
     object_store: ObjectStore
     security: IdEncodingHelper
+    tag_handler: GalaxyTagHandler
     model: GalaxyModelMapping
     file_sources: ConfiguredFileSources
     workflow_contents_manager: "WorkflowContentsManager"
@@ -2662,6 +2664,7 @@ def source_to_import_store(
     else:
         source_uri: str = str(source)
         delete = False
+        tag_handler = app.tag_handler.create_tag_handler_session()
         if source_uri.startswith("file://"):
             source_uri = source_uri[len("file://") :]
         if "://" in source_uri:
@@ -2680,7 +2683,7 @@ def source_to_import_store(
             )
         elif os.path.isdir(target_path):
             model_import_store = get_import_model_store_for_directory(
-                target_path, import_options=import_options, app=app, user=galaxy_user
+                target_path, import_options=import_options, app=app, user=galaxy_user, tag_handler=tag_handler
             )
         else:
             model_store_format = model_store_format or "tgz"
@@ -2692,7 +2695,7 @@ def source_to_import_store(
                     if delete:
                         os.remove(target_path)
                 model_import_store = get_import_model_store_for_directory(
-                    target_dir, import_options=import_options, app=app, user=galaxy_user
+                    target_dir, import_options=import_options, app=app, user=galaxy_user, tag_handler=tag_handler
                 )
             elif model_store_format in ["bag.gz", "bag.tar", "bag.zip"]:
                 model_import_store = BagArchiveImportModelStore(

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -79,6 +79,7 @@ from galaxy.schema.bco.util import (
     get_contributors,
     write_to_file,
 )
+from galaxy.schema.schema import ModelStoreFormat
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import (
     FILENAME_VALID_CHARS,
@@ -2648,7 +2649,7 @@ def source_to_import_store(
     app: StoreAppProtocol,
     galaxy_user: Optional[model.User],
     import_options: Optional[ImportOptions],
-    model_store_format: Optional[str] = None,
+    model_store_format: Optional[ModelStoreFormat] = None,
 ) -> ModelImportStore:
     if isinstance(source, dict):
         if model_store_format is not None:
@@ -2686,8 +2687,8 @@ def source_to_import_store(
                 target_path, import_options=import_options, app=app, user=galaxy_user, tag_handler=tag_handler
             )
         else:
-            model_store_format = model_store_format or "tgz"
-            if model_store_format in ["tar.gz", "tgz", "tar"]:
+            model_store_format = model_store_format or ModelStoreFormat.TGZ
+            if ModelStoreFormat.is_compressed(model_store_format):
                 try:
                     temp_dir = mkdtemp()
                     target_dir = CompressedFile(target_path).extract(temp_dir)
@@ -2697,7 +2698,7 @@ def source_to_import_store(
                 model_import_store = get_import_model_store_for_directory(
                     target_dir, import_options=import_options, app=app, user=galaxy_user, tag_handler=tag_handler
                 )
-            elif model_store_format in ["bag.gz", "bag.tar", "bag.zip"]:
+            elif ModelStoreFormat.is_bag(model_store_format):
                 model_import_store = BagArchiveImportModelStore(
                     target_path, import_options=import_options, app=app, user=galaxy_user
                 )

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -626,9 +626,14 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         else:
                             # Need a user to run library jobs to generate metadata...
                             pass
-                        self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(
-                            dataset_instance, history, **regenerate_kwds
-                        )
+                        if self.app.datatypes_registry.set_external_metadata_tool:
+                            self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(
+                                dataset_instance, history, **regenerate_kwds
+                            )
+                        else:
+                            # Try to set metadata directly. TODO: check efficiency of this?
+                            if dataset_instance.has_metadata_files:
+                                dataset_instance.datatype.set_meta(dataset_instance)
 
                 if model_class == "HistoryDatasetAssociation":
                     if object_key in dataset_attrs:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1,6 +1,7 @@
 import abc
 import contextlib
 import datetime
+import logging
 import os
 import shutil
 import tarfile
@@ -103,6 +104,7 @@ from ... import model
 if TYPE_CHECKING:
     from galaxy.managers.workflows import WorkflowContentsManager
 
+log = logging.getLogger(__name__)
 
 ObjectKeyType = Union[str, int]
 
@@ -631,11 +633,12 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                                 dataset_instance, history, **regenerate_kwds
                             )
                         else:
-                            # Try to set metadata directly. TODO: check efficiency of this?
+                            # Try to set metadata directly. @mvdbeek thinks we should only record the datasets
                             try:
                                 if dataset_instance.has_metadata_files:
                                     dataset_instance.datatype.set_meta(dataset_instance)
                             except Exception:
+                                log.debug(f"Metadata setting failed on {dataset_instance}", exc_info=True)
                                 dataset_instance.dataset.state = dataset_instance.dataset.states.FAILED_METADATA
 
                 if model_class == "HistoryDatasetAssociation":

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1305,6 +1305,14 @@ class ModelStoreFormat(str, Enum):
     ROCRATE_ZIP = "rocrate.zip"
     BCO_JSON = "bco.json"
 
+    @classmethod
+    def is_compressed(cls, value: "ModelStoreFormat"):
+        return value in [cls.TAR_DOT_GZ, cls.TGZ, cls.TAR, cls.ROCRATE_ZIP]
+
+    @classmethod
+    def is_bag(cls, value: "ModelStoreFormat"):
+        return value in [cls.BAG_DOT_TAR, cls.BAG_DOT_TGZ, cls.BAG_DOT_ZIP]
+
 
 class StoreContentSource(Model):
     store_content_uri: Optional[str]

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -10,6 +10,7 @@ from .schema import (
     BcoGenerationParametersMixin,
     DatasetSourceType,
     HistoryContentType,
+    ModelStoreFormat,
     StoreExportPayload,
     WriteStoreToPayload,
 )
@@ -88,6 +89,7 @@ class ImportModelStoreTaskRequest(BaseModel):
     history_id: Optional[int]
     source_uri: str
     for_library: bool
+    model_store_format: Optional[ModelStoreFormat]
 
 
 class MaterializeDatasetInstanceTaskRequest(BaseModel):

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -281,6 +281,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             user=trans.async_request_user,
             source_uri=source_uri,
             for_library=False,
+            model_store_format=payload.model_store_format,
         )
         result = import_model_store.delay(request=request)
         return async_task_summary(result)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -477,17 +477,23 @@ class BaseDatasetPopulator(BasePopulator):
         return create_response
 
     def create_from_store(
-        self, store_dict: Optional[Dict[str, Any]] = None, store_path: Optional[str] = None
+        self,
+        store_dict: Optional[Dict[str, Any]] = None,
+        store_path: Optional[str] = None,
+        model_store_format: Optional[str] = None,
     ) -> Dict[str, Any]:
-        payload = _store_payload(store_dict=store_dict, store_path=store_path)
+        payload = _store_payload(store_dict=store_dict, store_path=store_path, model_store_format=model_store_format)
         create_response = self.create_from_store_raw(payload)
         api_asserts.assert_status_code_is_ok(create_response)
         return create_response.json()
 
     def create_from_store_async(
-        self, store_dict: Optional[Dict[str, Any]] = None, store_path: Optional[str] = None
+        self,
+        store_dict: Optional[Dict[str, Any]] = None,
+        store_path: Optional[str] = None,
+        model_store_format: Optional[str] = None,
     ) -> Dict[str, Any]:
-        payload = _store_payload(store_dict=store_dict, store_path=store_path)
+        payload = _store_payload(store_dict=store_dict, store_path=store_path, model_store_format=model_store_format)
         create_response = self.create_from_store_raw_async(payload)
         create_response.raise_for_status()
         return create_response.json()
@@ -1223,7 +1229,9 @@ class BaseDatasetPopulator(BasePopulator):
 
     def wait_on_task(self, async_task_response: Response):
         task_id = async_task_response.json()["id"]
+        return self.wait_on_task_id(task_id)
 
+    def wait_on_task_id(self, task_id: str):
         def state():
             state_response = self._get(f"tasks/{task_id}/state")
             state_response.raise_for_status()
@@ -1323,6 +1331,27 @@ class BaseDatasetPopulator(BasePopulator):
             content_format=content_format,
         )
         return request
+
+    def export_history_to_uri_async(
+        self, history_id: str, target_uri: str, model_store_format: str = "tgz", include_files: bool = True
+    ):
+        url = f"histories/{history_id}/write_store"
+        download_response = self._post(
+            url,
+            dict(target_uri=target_uri, include_files=include_files, model_store_format=model_store_format),
+            json=True,
+        )
+        api_asserts.assert_status_code_is_ok(download_response)
+        task_ok = self.wait_on_task(download_response)
+        assert task_ok, f"Task: Writing history to {target_uri} task failed"
+
+    def import_history_from_uri_async(self, target_uri: str, model_store_format: str):
+        import_async_response = self.create_from_store_async(
+            store_path=target_uri, model_store_format=model_store_format
+        )
+        task_id = import_async_response["id"]
+        task_ok = self.wait_on_task_id(task_id)
+        assert task_ok, f"Task: Import history from {target_uri} failed"
 
 
 class GalaxyInteractorHttpMixin:

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -74,8 +74,12 @@ class TestImportExportHistoryViaTasksIntegration(
         assert imported_history["name"] == history_name
         history_contents = self.dataset_populator.get_history_contents(imported_history_id)
         assert len(history_contents) == 2
+        # Only deleted datasets should appear as "discarded"
         for dataset in history_contents:
-            assert dataset["state"] == "ok"
+            if dataset["deleted"] is True:
+                assert dataset["state"] == "discarded"
+            else:
+                assert dataset["state"] == "ok"
 
 
 class TestImportExportHistoryContentsViaTasksIntegration(IntegrationTestCase, UsesCeleryTasks):


### PR DESCRIPTION
Required for #14839

When importing a history archive from a file source using the tasks system with `/api/histories/from_store_async` all datasets appear as `discarded` in the new history regardless of their real state.

This adds test coverage to expose the bug. Currently investigating the fix... :mag: 

## Update
This PR tries to fix some issues found in this context:
- The `tag_handler` instance was missing during import so it failed when items had tags.
- The `model_store_format` was not passed to the import model store and was always the default `tgz`.
- The default value for `discarded_data` in the `ImportOptions` was always `FORCE` which apparently treated every dataset as discarded independently of their real `state`.
- We don't have `set_external_metadata_tool` in the context of tasks so, for now, we try to set the metadata directly withing the task... See [3404db4](https://github.com/galaxyproject/galaxy/pull/14989/commits/3404db4149134d7f072126805088811763369a60).

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
