### PR TITLE
For output filters the value of a select with `multiple="true" is rendered as string if only one option is selected

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1012,11 +1012,11 @@ class SelectToolParameter(ToolParameter):
             if is_runtime_value(value):
                 return None
             if value in legal_values:
-                return value
+                rval = value
             elif value in fallback_values:
-                return fallback_values[value]
+                rval = fallback_values[value]
             elif not require_legal_value:
-                return value
+                rval = value
             else:
                 raise ParameterValueError(
                     f"an invalid option ({value!r}) was selected (valid options: {','.join(legal_values)})",
@@ -1024,6 +1024,10 @@ class SelectToolParameter(ToolParameter):
                     value,
                     is_dynamic=self.is_dynamic,
                 )
+            if self.multiple:
+                return [rval]
+            else:
+                return rval
 
     def to_param_dict_string(self, value, other_values=None):
         if value in (None, []):

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1082,7 +1082,7 @@ class SelectToolParameter(ToolParameter):
                 value2 = options[0][1]
             else:
                 value2 = None
-        elif len(value) == 1 or not self.multiple:
+        elif len(value) == 1 and not self.multiple:
             value2 = value[0]
         else:
             value2 = value

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -880,6 +880,19 @@ class SelectToolParameter(ToolParameter):
     [('argument', None), ('display', None), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'SelectToolParameter'), ('multiple', True), ('name', '_name'), ('optional', True), ('options', [('x_label', 'x', False), ('y_label', 'y', True), ('z_label', 'z', True)]), ('refresh_on_change', False), ('textable', False), ('type', 'select'), ('value', ['y', 'z'])]
     >>> print(p.to_param_dict_string(["y", "z"]))
     y,z
+    >>> p = SelectToolParameter(None, XML(
+    ... '''
+    ... <param name="_name" type="select" multiple="true">
+    ...     <option value="x">x_label</option>
+    ...     <option value="y" selected="true">y_label</option>
+    ... </param>
+    ... '''))
+    >>> print(p.name)
+    _name
+    >>> sorted(p.to_dict(trans).items())
+    [('argument', None), ('display', None), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'SelectToolParameter'), ('multiple', True), ('name', '_name'), ('optional', True), ('options', [('x_label', 'x', False), ('y_label', 'y', True)]), ('refresh_on_change', False), ('textable', False), ('type', 'select'), ('value', ['y'])]
+    >>> print(p.to_param_dict_string(["y"]))
+    y
     """
 
     value_label: str

--- a/test/functional/tools/output_filter_select.xml
+++ b/test/functional/tools/output_filter_select.xml
@@ -1,0 +1,66 @@
+<tool id="output_filter_select" name="output_filter_select" version="1.0.0">
+    <description>test for output filtering with selects</description>
+    <command><![CDATA[
+#if "A" in str($sel).split(",")
+    echo 'test' > A &&
+#end if
+#if "AA" in str($sel).split(",")
+    echo 'test' > AA &&
+#end if
+echo $sel 
+    ]]></command>
+    <inputs>
+        <param name="sel" type="select" multiple="true">
+            <option value="A">A</option>
+            <option value="AA">AA</option>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="A" format="txt" from_work_dir="A">
+            <filter>"A" in sel</filter>
+        </data>
+        <data name="AA" format="txt" from_work_dir="AA">
+            <filter>"AA" in sel</filter>
+        </data>
+    </outputs>
+    <tests>
+        <test expect_num_outputs="1">
+            <param name="sel" value="A" />
+            <output name="A">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <assert_stdout>
+                <has_line line="A"/>
+            </assert_stdout>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="sel" value="AA" />
+            <output name="AA">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <assert_stdout>
+                <has_line line="AA"/>
+            </assert_stdout>
+        </test>
+        <test expect_num_outputs="2">
+            <param name="sel" value="A,AA" />
+            <output name="A">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="AA">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <assert_stdout>
+                <has_line line="A,AA"/>
+            </assert_stdout>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/output_filter_select.xml
+++ b/test/functional/tools/output_filter_select.xml
@@ -1,53 +1,84 @@
 <tool id="output_filter_select" name="output_filter_select" version="1.0.0">
+    <!-- this tests output filtering based on a select parameter.
+
+         for multiple="false" 
+
+         for `mutiple="true"` the select is accessed as a list (containing the
+         selected options). if the options would be a comma separated string
+         then selecting a value that contains another value as substring
+         (eg AA contains A) would produce an error.
+         for optional selects it should be `None` if nothing is selected.
+         -->
     <description>test for output filtering with selects</description>
     <command><![CDATA[
-#if "A" in str($sel).split(",")
+#if "A" in str($sel_mult).split(",")
     echo 'test' > A &&
 #end if
-#if "AA" in str($sel).split(",")
+#if "AA" in str($sel_mult).split(",")
     echo 'test' > AA &&
 #end if
-echo $sel 
+echo sel_mult $sel_mult &&
+echo sel_mult_opt $sel_mult_opt
     ]]></command>
     <inputs>
-        <param name="sel" type="select" multiple="true">
+        <param name="sel_mult" type="select" multiple="true">
             <option value="A">A</option>
             <option value="AA">AA</option>
+        </param>
+        <param name="sel_mult_opt" type="select" multiple="true" optional="true">
+            <option value="B">B</option>
+            <option value="BB">BB</option>
         </param>
     </inputs>
     <outputs>
         <data name="A" format="txt" from_work_dir="A">
-            <filter>"A" in sel</filter>
+            <filter>"A" in sel_mult</filter>
         </data>
         <data name="AA" format="txt" from_work_dir="AA">
-            <filter>"AA" in sel</filter>
+            <filter>"AA" in sel_mult</filter>
+        </data>
+        <data name="B" format="txt" from_work_dir="A">
+            <filter>"B" in sel_mult_opt</filter>
+        </data>
+        <data name="BB" format="txt" from_work_dir="AA">
+            <filter>"BB" in sel_mult_opt</filter>
         </data>
     </outputs>
     <tests>
         <test expect_num_outputs="1">
-            <param name="sel" value="A" />
+            <param name="sel_mult" value="A" />
+            <param name="sel_mult_opt" value="" />
             <output name="A">
                 <assert_contents>
                     <has_line line="test" />
                 </assert_contents>
             </output>
             <assert_stdout>
-                <has_line line="A"/>
-            </assert_stdout>
-        </test>
-        <test expect_num_outputs="1">
-            <param name="sel" value="AA" />
-            <output name="AA">
-                <assert_contents>
-                    <has_line line="test" />
-                </assert_contents>
-            </output>
-            <assert_stdout>
-                <has_line line="AA"/>
+                <has_line line="sel_mult A"/>
+                <has_line line="sel_mult_opt "/>
             </assert_stdout>
         </test>
         <test expect_num_outputs="2">
-            <param name="sel" value="A,AA" />
+            <param name="sel_mult" value="AA" />
+            <param name="sel_mult_opt" value="BB" />
+            <output name="AA">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="BB">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <assert_stdout>
+                <has_line line="sel_mult AA"/>
+                <has_line line="sel_mult_opt BB"/>
+            </assert_stdout>
+        </test>
+        <test expect_num_outputs="2">
+            <param name="sel_mult" value="A,AA" />
+            <param name="sel_mult_opt" value="B,BB" />
             <output name="A">
                 <assert_contents>
                     <has_line line="test" />
@@ -58,8 +89,19 @@ echo $sel
                     <has_line line="test" />
                 </assert_contents>
             </output>
+            <output name="B">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="BB">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
             <assert_stdout>
-                <has_line line="A,AA"/>
+                <has_line line="sel_mult A,AA"/>
+                <has_line line="sel_mult_opt B,BB"/>
             </assert_stdout>
         </test>
     </tests>

--- a/test/functional/tools/output_filter_select.xml
+++ b/test/functional/tools/output_filter_select.xml
@@ -1,13 +1,17 @@
 <tool id="output_filter_select" name="output_filter_select" version="1.0.0">
-    <!-- this tests output filtering based on a select parameter.
+    <!-- this tests output filtering based on a select parameter, ie the focus
+         is on the output filter and the test outputs. the command is just used
+         to examplify how to use selects.
 
-         for multiple="false" 
-
+         the main motivation for the test is to ensure that
          for `mutiple="true"` the select is accessed as a list (containing the
-         selected options). if the options would be a comma separated string
+         selected options). if the option(s) would be a comma separated string
          then selecting a value that contains another value as substring
          (eg AA contains A) would produce an error.
-         for optional selects it should be `None` if nothing is selected.
+         
+         In addition also other cases are tested: 
+         - for optional selects it should be `None` if nothing is selected.
+         - for completeness also multiple="false" is tested
          -->
     <description>test for output filtering with selects</description>
     <command><![CDATA[
@@ -17,8 +21,29 @@
 #if "AA" in str($sel_mult).split(",")
     echo 'test' > AA &&
 #end if
+#if $sel_mult_opt and "B" in str($sel_mult_opt).split(",")
+    echo 'test' > B &&
+#end if
+#if $sel_mult_opt and "BB" in str($sel_mult_opt).split(",")
+    echo 'test' > BB &&
+#end if
+#if $sel == "C"
+    echo 'test' > C &&
+#end if
+#if $sel == "CC"
+    echo 'test' > CC &&
+#end if
+#if $sel_opt == "D"
+    echo 'test' > D &&
+#end if
+#if $sel_opt == "DD"
+    echo 'test' > DD &&
+#end if
+
 echo sel_mult $sel_mult &&
-echo sel_mult_opt $sel_mult_opt
+echo sel_mult_opt $sel_mult_opt &&
+echo sel $sel &&
+echo sel_opt $sel_opt
     ]]></command>
     <inputs>
         <param name="sel_mult" type="select" multiple="true">
@@ -29,38 +54,78 @@ echo sel_mult_opt $sel_mult_opt
             <option value="B">B</option>
             <option value="BB">BB</option>
         </param>
-    </inputs>
+        <param name="sel" type="select">
+            <option value="C">C</option>
+            <option value="CC">CC</option>
+        </param>
+        <param name="sel_opt" type="select" optional="true">
+            <option value="D">D</option>
+            <option value="DD">DD</option>
+        </param> </inputs>
     <outputs>
+        <!-- filtering with mandatory, multiple selects use `in` 
+             to check if the option is in the list -->
         <data name="A" format="txt" from_work_dir="A">
             <filter>"A" in sel_mult</filter>
         </data>
         <data name="AA" format="txt" from_work_dir="AA">
             <filter>"AA" in sel_mult</filter>
         </data>
-        <data name="B" format="txt" from_work_dir="A">
-            <filter>"B" in sel_mult_opt</filter>
+        <!-- filtering with optional, multiple selects 
+             need to check for `None` in addition -->
+        <data name="B" format="txt" from_work_dir="B">
+            <filter>sel_mult_opt and "B" in sel_mult_opt</filter>
         </data>
-        <data name="BB" format="txt" from_work_dir="AA">
-            <filter>"BB" in sel_mult_opt</filter>
+        <data name="BB" format="txt" from_work_dir="BB">
+            <filter>sel_mult_opt and "BB" in sel_mult_opt</filter>
+        </data>
+        <!-- filtering with selects allowing a single option
+             can simply check with `==`, no check for `None`
+             is necessary -->
+        <data name="C" format="txt" from_work_dir="C">
+            <filter>sel == "C"</filter>
+        </data>
+        <data name="CC" format="txt" from_work_dir="CC">
+            <filter>sel == "CC"</filter>
+        </data>
+        <data name="D" format="txt" from_work_dir="D">
+            <filter>sel_opt == "D"</filter>
+        </data>
+        <data name="DD" format="txt" from_work_dir="DD">
+            <filter>sel_opt == "DD"</filter>
         </data>
     </outputs>
     <tests>
-        <test expect_num_outputs="1">
+        <!-- A and C are selected (by default)
+             which implies outputs A and C -->
+        <test expect_num_outputs="2">
             <param name="sel_mult" value="A" />
-            <param name="sel_mult_opt" value="" />
+            <param name="sel" value="C" />
             <output name="A">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="C">
                 <assert_contents>
                     <has_line line="test" />
                 </assert_contents>
             </output>
             <assert_stdout>
                 <has_line line="sel_mult A"/>
-                <has_line line="sel_mult_opt "/>
+                <has_line line="sel_mult_opt None"/>
+                <has_line line="sel C"/>
+                <has_line line="sel_opt None"/>
             </assert_stdout>
         </test>
-        <test expect_num_outputs="2">
+        <!-- make sure that selecting AA, ... does not imply that A, ...
+             are is in the output as well which happens if the select
+             would be a (comma separated) string in the output filter -->
+        <test expect_num_outputs="4">
             <param name="sel_mult" value="AA" />
             <param name="sel_mult_opt" value="BB" />
+            <param name="sel" value="CC" />
+            <param name="sel_opt" value="DD" />
             <output name="AA">
                 <assert_contents>
                     <has_line line="test" />
@@ -71,12 +136,24 @@ echo sel_mult_opt $sel_mult_opt
                     <has_line line="test" />
                 </assert_contents>
             </output>
+            <output name="CC">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="DD">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
             <assert_stdout>
                 <has_line line="sel_mult AA"/>
                 <has_line line="sel_mult_opt BB"/>
+                <has_line line="sel CC"/>
+                <has_line line="sel_opt DD"/>
             </assert_stdout>
         </test>
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="5">
             <param name="sel_mult" value="A,AA" />
             <param name="sel_mult_opt" value="B,BB" />
             <output name="A">
@@ -99,9 +176,16 @@ echo sel_mult_opt $sel_mult_opt
                     <has_line line="test" />
                 </assert_contents>
             </output>
+            <output name="C">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
             <assert_stdout>
                 <has_line line="sel_mult A,AA"/>
                 <has_line line="sel_mult_opt B,BB"/>
+                <has_line line="sel C"/>
+                <has_line line="sel_opt None"/>
             </assert_stdout>
         </test>
     </tests>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -107,6 +107,7 @@
   <tool file="output_format_deprecated_when.xml" />
   <tool file="output_format_collection.xml" />
   <tool file="output_filter.xml" />
+  <tool file="output_filter_select.xml" />
   <tool file="output_empty_work_dir.xml" />
   <tool file="output_filter_with_input.xml" />
   <tool file="output_filter_with_input_optional.xml" />


### PR DESCRIPTION
It should always be a list. 

Currently this only adds a functional tool test that shows the bug: 

For the filter the content of `sel` is either

- a string (if one option is selected)
- a list (if multiple options are selected)

it should always be a list. The test only shows the former, but I verified the later by adding some debug statements.

this leads to the bug that multiple datasets are selected if a single option is selected if other options are a substring.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
