### PR TITLE
Fix interpolation in ``NicerConfigParser`` on Python 3.11

### DIFF
--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -8,7 +8,7 @@ import sys
 from configparser import (
     BasicInterpolation,
     ConfigParser,
-    Error,
+    InterpolationError,
 )
 from functools import partial
 from itertools import (
@@ -159,18 +159,12 @@ def nice_config_parser(path):
     return parser
 
 
-class _InterpolateWrapper:
-    def __init__(self, original: Optional[BasicInterpolation] = None):
-        self._original = original or BasicInterpolation()
-
-    def __getattr__(self, name):
-        return getattr(self._original, name)
-
+class _InterpolateWrapper(BasicInterpolation):
     def before_get(self, parser, section, option, value, defaults):
         try:
-            return self._original.before_get(parser, section, option, value, defaults)
-        except Error:
-            e = cast(Error, sys.exc_info()[1])
+            return super().before_get(parser, section, option, value, defaults)
+        except InterpolationError:
+            e = cast(InterpolationError, sys.exc_info()[1])
             args = list(e.args)
             args[0] = f"Error in file {parser.filename}: {e}"
             e.args = tuple(args)


### PR DESCRIPTION
``_InterpolateWrapper`` needs to inherit from ``BasicInterpolation`` .

Fix:

```
___________________________ test_nice_config_parser ____________________________

tmp_path = PosixPath('/tmp/pytest-of-runner/pytest-0/test_nice_config_parser0')

    def test_nice_config_parser(tmp_path):
        conf_path = tmp_path / "config.ini"
        conf_path.write_text(
            """
    [main]
    foo_path = %(here)s/cow
    FOO_PATH123 = hackedtonotchangecase
    config_file = %(__file__)s
    """
        )
>       config_parser = nice_config_parser(conf_path)

tests/util/test_properties.py:150:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
galaxy/util/properties.py:156: in nice_config_parser
    parser = NicerConfigParser(path, defaults=__default_properties(path))
galaxy/util/properties.py:184: in __init__
    ConfigParser.__init__(self, *args, **kw)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <galaxy.util.properties.NicerConfigParser object at 0x7fb0fac5dd10>
defaults = {'__file__': '/tmp/pytest-of-runner/pytest-0/test_nice_config_parser0/config.ini', 'here': '/tmp/pytest-of-runner/pytest-0/test_nice_config_parser0'}
dict_type = <class 'dict'>, allow_no_value = False

    def __init__(self, defaults=None, dict_type=_default_dict,
                 allow_no_value=False, *, delimiters=('=', ':'),
                 comment_prefixes=('#', ';'), inline_comment_prefixes=None,
                 strict=True, empty_lines_in_values=True,
                 default_section=DEFAULTSECT,
                 interpolation=_UNSET, converters=_UNSET):

        self._dict = dict_type
        self._sections = self._dict()
        self._defaults = self._dict()
        self._converters = ConverterMapping(self)
        self._proxies = self._dict()
        self._proxies[default_section] = SectionProxy(self, default_section)
        self._delimiters = tuple(delimiters)
        if delimiters == ('=', ':'):
            self._optcre = self.OPTCRE_NV if allow_no_value else self.OPTCRE
        else:
            d = "|".join(re.escape(d) for d in delimiters)
            if allow_no_value:
                self._optcre = re.compile(self._OPT_NV_TMPL.format(delim=d),
                                          re.VERBOSE)
            else:
                self._optcre = re.compile(self._OPT_TMPL.format(delim=d),
                                          re.VERBOSE)
        self._comment_prefixes = tuple(comment_prefixes or ())
        self._inline_comment_prefixes = tuple(inline_comment_prefixes or ())
        self._strict = strict
        self._allow_no_value = allow_no_value
        self._empty_lines_in_values = empty_lines_in_values
        self.default_section=default_section
        self._interpolation = interpolation
        if self._interpolation is _UNSET:
            self._interpolation = self._DEFAULT_INTERPOLATION
        if self._interpolation is None:
            self._interpolation = Interpolation()
        if not isinstance(self._interpolation, Interpolation):
>           raise TypeError(
                f"interpolation= must be None or an instance of Interpolation;"
                f" got an object of type {type(self._interpolation)}"
            )
E           TypeError: interpolation= must be None or an instance of Interpolation; got an object of type <class 'galaxy.util.properties._InterpolateWrapper'>

/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/configparser.py:646: TypeError
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
