### PR TITLE
[PROCEDURES] add GH private reporting option to security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,9 @@ The Galaxy project is strongly committed to security and responsible disclosure.
 
 ## Reporting Security Issues
 
-If you believe you have discovered a security issue, please email [galaxy-committers@lists.galaxyproject.org](galaxy-committers@lists.galaxyproject.org). Please use `[SECURITY]` in the email title. Someone on that list will acknowledge your email within 2 US business days. We ask that you not disclose the issues on the public issue tracker. We will provide you credit for the discovery when publicly disclosing the issue.
+If you believe you have discovered a security issue, please email [galaxy-committers@lists.galaxyproject.org](galaxy-committers@lists.galaxyproject.org). Please use `[SECURITY]` in the email title. Alternatively you can report a security vulnerability using GitHub [private reporting](https://github.com/galaxyproject/galaxy/security/advisories/new). In either case one of the maintainers will acknowledge your report within 2 US business days.
+
+We ask that you not disclose the issues publicly. We will provide you credit for the discovery when publicly disclosing the issue.
 
 Security issues which *only* affect a pre-release version of Galaxy (i.e. the `dev` branch in GitHub) do not need to go through this process, so you may open issues and pull requests publicly.
 


### PR DESCRIPTION
details: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability

ping @galaxyproject/core 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
