### PR TITLE
[22.01] Fix setting ``LC_CTYPE`` variable in clean environment on macOS

### DIFF
--- a/lib/galaxy/util/commands.py
+++ b/lib/galaxy/util/commands.py
@@ -164,7 +164,7 @@ def new_clean_env():
     Returns a minimal environment to use when invoking a subprocess
     """
     env = {}
-    for k in ("HOME", "PATH", "TMPDIR"):
+    for k in ("HOME", "LC_CTYPE", "PATH", "TMPDIR"):
         if k in os.environ:
             env[k] = os.environ[k]
     if "TMPDIR" not in env:
@@ -173,7 +173,8 @@ def new_clean_env():
     # This is needed e.g. for Python < 3.7 where
     # `locale.getpreferredencoding()` (also used by open() to determine the
     # default file encoding) would return `ANSI_X3.4-1968` without this.
-    env["LC_CTYPE"] = "C.UTF-8"
+    if not env.get("LC_CTYPE", "").endswith("UTF-8"):
+        env["LC_CTYPE"] = "C.UTF-8"
     return env
 
 

--- a/test/unit/util/test_commands.py
+++ b/test/unit/util/test_commands.py
@@ -1,0 +1,20 @@
+import os
+
+from galaxy.util.commands import new_clean_env
+
+
+def test_new_clean_env() -> None:
+    saved_environ = os.environ.copy()
+    os.environ["FOO"] = "foo"
+    os.environ.pop("TMPDIR", None)
+    try:
+        clean_env = new_clean_env()
+    finally:
+        os.environ.clear()
+        os.environ.update(saved_environ)
+    assert "FOO" not in clean_env
+    for k in ("HOME", "PATH"):
+        if k in saved_environ:
+            assert clean_env[k] == saved_environ[k]
+    assert clean_env["LC_CTYPE"].endswith("UTF-8")
+    assert clean_env["TMPDIR"]


### PR DESCRIPTION
Fix some older tools (not using `profile` or `stdio`) failing because of the following warning printed on stderr when run locally on macOS:

```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
LC_ALL = (unset),
LC_CTYPE = "C.UTF-8",
LANG = (unset)
are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
```

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
