### PR TITLE
Add composable confirmation dialog

### DIFF
--- a/client/src/components/ConfirmDialog.js
+++ b/client/src/components/ConfirmDialog.js
@@ -1,0 +1,15 @@
+export default {
+    methods: {
+        async confirm(message, options = {}) {
+            return this.$bvModal.msgBoxConfirm(message, {
+                title: "Please Confirm",
+                titleClass: "h-md",
+                hideHeaderClose: false,
+                ...options,
+            });
+        },
+    },
+    render() {
+        return {};
+    },
+};

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -229,6 +229,7 @@ import WorkflowAttributes from "./Attributes";
 import ZoomControl from "./ZoomControl";
 import WorkflowNode from "./Node";
 import Vue from "vue";
+import { ConfirmDialog } from "composables/confirmDialog";
 
 export default {
     components: {
@@ -541,7 +542,7 @@ export default {
             if (stepCount < 10) {
                 this.copyIntoWorkflow(workflowId);
             } else {
-                const confirmed = await this.$bvModal.msgBoxConfirm(
+                const confirmed = await ConfirmDialog.confirm(
                     `Warning this will add ${stepCount} new steps into your current workflow.  You may want to consider using a subworkflow instead.`
                 );
                 if (confirmed) {

--- a/client/src/composables/confirmDialog.js
+++ b/client/src/composables/confirmDialog.js
@@ -1,0 +1,28 @@
+import { ref } from "vue";
+
+let confirmDialogRef = ref(null);
+
+export const setConfirmDialogComponentRef = (newRef) => {
+    confirmDialogRef = newRef;
+};
+
+/**
+ * Direct export to simplify usage in Options API component.
+ * Use 'useConfirmDialog' for the Composition API instead.
+ */
+export const ConfirmDialog = {
+    /**
+     * Displays a simple confirmation message to the user.
+     * For additional options see https://bootstrap-vue.org/docs/components/modal#modal-message-boxes.
+     * @param {String} message The message to display to the user.
+     * @param {Object} options Additional display options to customize the dialog.
+     * @returns A promise with `true` if the user confirms the message.
+     */
+    async confirm(message, options = {}) {
+        return confirmDialogRef.value.confirm(message, options);
+    },
+};
+
+export function useConfirmDialog() {
+    return { ...ConfirmDialog };
+}

--- a/client/src/entry/analysis/App.vue
+++ b/client/src/entry/analysis/App.vue
@@ -36,6 +36,7 @@
         </div>
         <div id="dd-helper" />
         <Toast ref="toastRef" />
+        <ConfirmDialog ref="confirmDialogRef" />
     </div>
 </template>
 <script>
@@ -48,13 +49,24 @@ import { fetchMenu } from "entry/analysis/menu";
 import { WindowManager } from "layout/window-manager";
 import { safePath } from "utils/redirect";
 import Toast from "components/Toast";
+import ConfirmDialog from "components/ConfirmDialog";
 import { setToastComponentRef } from "composables/toast";
+import { setConfirmDialogComponentRef } from "composables/confirmDialog";
 import { ref } from "vue";
 
 export default {
     components: {
         Masthead,
         Toast,
+        ConfirmDialog,
+    },
+    setup() {
+        const toastRef = ref(null);
+        setToastComponentRef(toastRef);
+        const confirmDialogRef = ref(null);
+        setConfirmDialogComponentRef(confirmDialogRef);
+
+        return { toastRef, confirmDialogRef };
     },
     data() {
         return {
@@ -63,12 +75,6 @@ export default {
             resendUrl: `${getAppRoot()}user/resend_verification`,
             windowManager: new WindowManager(),
         };
-    },
-    setup() {
-        const toastRef = ref(null);
-        setToastComponentRef(toastRef);
-
-        return { toastRef };
     },
     computed: {
         tabs() {


### PR DESCRIPTION
Similar to  #14935, this adds a wrapper for the Bootstrap modal confirmation message box (`$bvModal.msgBoxConfirm`) that can be used in composition API.

Usage example:
```vue
<script setup>
import { useConfirmDialog } from "composables/confirmDialog";

const { confirm } = useConfirmDialog();

async function doThingOnConfirm() {
  const confirmed = await confirm(`Are you 120% sure?`, { okVariant: "danger" });
  if (confirmed) {
    // Do the thing
  }
}
</script>

```

![image](https://user-images.githubusercontent.com/46503462/202470625-928e4f57-36b0-4926-b08a-2fffc9811dbc.png)


Required for #14839

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
