### PR TITLE
Vueified Multiple Selection Form Fields (checkboxes, radios, single/multi select dropdowns)

### DIFF
--- a/client/src/components/Form/Elements/FormNumber.test.js
+++ b/client/src/components/Form/Elements/FormNumber.test.js
@@ -20,8 +20,6 @@ describe("FormInput", () => {
         const wrapper = await mountFormNumber({ value: 1, type: "float" });
         await flushPromises();
         const input = await getInput(wrapper);
-        // console.log(wrapper);
-        console.log(input);
         expect(input.exists()).toBe(true);
     });
 

--- a/client/src/components/Form/Elements/FormNumber.test.js
+++ b/client/src/components/Form/Elements/FormNumber.test.js
@@ -20,6 +20,8 @@ describe("FormInput", () => {
         const wrapper = await mountFormNumber({ value: 1, type: "float" });
         await flushPromises();
         const input = await getInput(wrapper);
+        // console.log(wrapper);
+        console.log(input);
         expect(input.exists()).toBe(true);
     });
 

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -2,36 +2,12 @@ import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import FormSelect from "./FormSelect";
 import Multiselect from "vue-multiselect";
-import flushPromises from "flush-promises";
 
 const localVue = getLocalVue();
 
-// describe("FormSelect", () => {
-//     const mountFormSelect = async (props) =>
-//         await mount(FormSelect, {
-//             propsData: props,
-//             localVue,
-//         });
-// const getInput = async (wrapper) => await wrapper.find("input[type='select']");
-
-//     it("input should be rendered with select type", async () => {
-//         const wrapper = await mountFormSelect({
-//             value: "T",
-//             defaultValue: "T",
-//             options: [["test1", "T", true], ["test2", "2", false]]
-//         });
-//         await flushPromises();
-//         const input = await getInput(wrapper);
-//         console.log(wrapper);
-//         console.log(input);
-//         expect(input.exists()).toBe(true);
-//     });
-// });
-
 describe("FormSelect", () => {
     it("Sets default currentValue as first option when not told otherwise", async () => {
-        let wrapper;
-        wrapper = mount(FormSelect, {
+        const wrapper = mount(FormSelect, {
             propsData: {
                 value: "",
                 defaultValue: "",
@@ -42,12 +18,10 @@ describe("FormSelect", () => {
             },
             localVue,
         });
-        const input = wrapper.find("input");
         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
     });
     it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
-        let wrapper;
-        wrapper = mount(FormSelect, {
+        const wrapper = mount(FormSelect, {
             propsData: {
                 value: "",
                 defaultValue: "",
@@ -58,12 +32,10 @@ describe("FormSelect", () => {
             },
             localVue,
         });
-        const input = wrapper.find("input");
         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: true });
     });
     it("Sets default from defaultValue", async () => {
-        let wrapper;
-        wrapper = mount(FormSelect, {
+        const wrapper = mount(FormSelect, {
             propsData: {
                 value: "2",
                 defaultValue: "2",
@@ -74,7 +46,6 @@ describe("FormSelect", () => {
             },
             localVue,
         });
-        const input = wrapper.find("input");
         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: false });
     });
     it("Changes value after new selection is made", async () => {

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -2,68 +2,132 @@ import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import FormSelect from "./FormSelect";
 import Multiselect from "vue-multiselect";
+import { BFormRadioGroup } from 'bootstrap-vue';
+import Vue from "vue";
 
 const localVue = getLocalVue();
 
+// describe("FormSelect", () => {
+//     // Single dataset, no radio
+//     it("Sets default currentValue as first option when not told otherwise", async () => {
+//         const wrapper = mount(FormSelect, {
+//             propsData: {
+//                 value: "",
+//                 defaultValue: "",
+//                 display: null,
+//                 multiple: null,
+//                 options: [
+//                     ["test1", "T", false],
+//                     ["test2", "2", false],
+//                 ],
+//             },
+//             localVue,
+//         });
+//         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
+//     });
+//     it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
+//         const wrapper = mount(FormSelect, {
+//             propsData: {
+//                 value: "",
+//                 defaultValue: "",
+//                 display: null,
+//                 multiple: null,
+//                 options: [
+//                     ["test1", "T", false],
+//                     ["test2", "2", true],
+//                 ],
+//             },
+//             localVue,
+//         });
+//         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: true });
+//     });
+//     it("Sets default from defaultValue", async () => {
+//         const wrapper = mount(FormSelect, {
+//             propsData: {
+//                 value: "2",
+//                 defaultValue: "2",
+//                 display: null,
+//                 multiple: null,
+//                 options: [
+//                     ["test1", "T", false],
+//                     ["test2", "2", false],
+//                 ],
+//             },
+//             localVue,
+//         });
+//         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: false });
+//     });
+//     it("Changes value after new selection is made", async () => {
+//         const wrapper = mount(FormSelect, {
+//             propsData: {
+//                 value: "T",
+//                 defaultValue: "T",
+//                 display: null,
+//                 multiple: null,
+//                 options: [
+//                     ["test1", "T", false],
+//                     ["test2", "2", false],
+//                 ],
+//             },
+//             localVue,
+//         });
+
+//         const multiselect = wrapper.findComponent(Multiselect);
+//         // Manually trigger selection of the second item in optarray in the multiselect
+//         multiselect.vm.select(wrapper.vm.optArray[1]);
+//         expect(wrapper.emitted().input).toEqual([["2"]]);
+//     });
+// });
+
 describe("FormSelect", () => {
+    // Single dataset, with radio
+    const mountFormSelect = async (props) =>
+        await mount(FormSelect, {
+            propsData: props,
+            localVue,
+        });
+        
+
+    const getInput = async (wrapper) => await wrapper.find("input[type='radio']");
+    // const getOptions = async (wrapper) => await wrapper.find('radio').findAll('option');
+
     it("Sets default currentValue as first option when not told otherwise", async () => {
-        const wrapper = mount(FormSelect, {
-            propsData: {
+        const wrapper = await mountFormSelect({
                 value: "",
                 defaultValue: "",
+                display: "radio",
+                multiple: false,
                 options: [
                     ["test1", "T", false],
                     ["test2", "2", false],
                 ],
-            },
-            localVue,
         });
         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
     });
-    it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
-        const wrapper = mount(FormSelect, {
-            propsData: {
-                value: "",
-                defaultValue: "",
-                options: [
-                    ["test1", "T", false],
-                    ["test2", "2", true],
-                ],
-            },
-            localVue,
+    it("Changes values when selected, and sets from proper default", async () => {
+        const wrapper = await mountFormSelect({
+            value: "",
+            defaultValue: "",
+            display: "radio",
+            multiple: false,
+            options: [
+                ["test1", "T", false],
+                ["test2", "2", true],
+            ],
         });
-        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: true });
-    });
-    it("Sets default from defaultValue", async () => {
-        const wrapper = mount(FormSelect, {
-            propsData: {
-                value: "2",
-                defaultValue: "2",
-                options: [
-                    ["test1", "T", false],
-                    ["test2", "2", false],
-                ],
-            },
-            localVue,
-        });
-        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: false });
-    });
-    it("Changes value after new selection is made", async () => {
-        const wrapper = mount(FormSelect, {
-            propsData: {
-                value: "T",
-                defaultValue: "T",
-                options: [
-                    ["test1", "T", false],
-                    ["test2", "2", false],
-                ],
-            },
-            localVue,
-        });
-
-        const multiselect = wrapper.findComponent(Multiselect);
-        // Manually trigger selection of the second item in optarray in the multiselect
-        multiselect.vm.select(wrapper.vm.optArray[1]);
+        const radio = wrapper.findComponent(BFormRadioGroup)
+        expect(wrapper.vm.currentValue).toStrictEqual({label: "test2", value: "2", default: true});
+        await radio.trigger('click');
+        const input = radio.find('input');
+        console.log(radio.vm.emitted());
         expect(wrapper.emitted().input).toEqual([["2"]]);
     });
 });
+
+// describe("FormSelect", () => {
+//     // Multiple datasets, no radio
+// });
+
+// describe("FormSelect", () => {
+//     // Multiple datasets, with radio
+// });

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -1,0 +1,82 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import FormSelect from "./FormSelect";
+import flushPromises from "flush-promises";
+
+const localVue = getLocalVue();
+
+// describe("FormSelect", () => {
+//     const mountFormSelect = async (props) =>
+//         await mount(FormSelect, {
+//             propsData: props,
+//             localVue,
+//         });
+    // const getInput = async (wrapper) => await wrapper.find("input[type='select']");
+
+//     it("input should be rendered with select type", async () => {
+//         const wrapper = await mountFormSelect({
+//             value: "T",
+//             defaultValue: "T",
+//             options: [["test1", "T", true], ["test2", "2", false]]
+//         });
+//         await flushPromises();
+//         const input = await getInput(wrapper);
+//         console.log(wrapper);
+//         console.log(input);
+//         expect(input.exists()).toBe(true);
+//     });
+// });
+
+describe("FormSelect", () => {
+    it("Sets default currentValue as first option when not told otherwise", async () => {
+        let wrapper;
+        wrapper = mount(FormSelect, {
+            propsData: {
+                value: "",
+                defaultValue: "",
+                options: [["test1", "T", false], ["test2", "2", false]],
+            },
+            localVue,
+        });
+        const input = wrapper.find("input");
+        expect(wrapper.vm.currentValue).toStrictEqual({"label": "test1", "value": "T", "default": false});
+    })
+    it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
+        let wrapper;
+        wrapper = mount(FormSelect, {
+            propsData: {
+                value: "",
+                defaultValue: "",
+                options: [["test1", "T", false], ["test2", "2", true]],
+            },
+            localVue,
+        });
+        const input = wrapper.find("input");
+        expect(wrapper.vm.currentValue).toStrictEqual({"label": "test2", "value": "2", "default": true});
+    })
+    it("Sets default from defaultValue", async () => {
+        let wrapper;
+        wrapper = mount(FormSelect, {
+            propsData: {
+                value: "2",
+                defaultValue: "2",
+                options: [["test1", "T", false], ["test2", "2", false]],
+            },
+            localVue,
+        });
+        const input = wrapper.find("input");
+        expect(wrapper.vm.currentValue).toStrictEqual({"label": "test1", "value": "T", "default": false});
+    })
+    it("Returns a new value after being switched over", async() => {
+        let wrapper;
+        wrapper = mount(FormSelect, {
+            propsData: {
+                value: "",
+                defaultValue: "",
+                options: [["test1", "T", false], ["test2", "2", false]],
+            },
+            localVue,
+        });
+        wrapper.setValue()
+    }
+});

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -4,92 +4,91 @@ import FormSelect from "./FormSelect";
 import Multiselect from "vue-multiselect";
 import { BFormRadioGroup } from 'bootstrap-vue';
 import Vue from "vue";
+import flushPromises from "flush-promises";
+
+
 
 const localVue = getLocalVue();
 
-// describe("FormSelect", () => {
-//     // Single dataset, no radio
-//     it("Sets default currentValue as first option when not told otherwise", async () => {
-//         const wrapper = mount(FormSelect, {
-//             propsData: {
-//                 value: "",
-//                 defaultValue: "",
-//                 display: null,
-//                 multiple: null,
-//                 options: [
-//                     ["test1", "T", false],
-//                     ["test2", "2", false],
-//                 ],
-//             },
-//             localVue,
-//         });
-//         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
-//     });
-//     it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
-//         const wrapper = mount(FormSelect, {
-//             propsData: {
-//                 value: "",
-//                 defaultValue: "",
-//                 display: null,
-//                 multiple: null,
-//                 options: [
-//                     ["test1", "T", false],
-//                     ["test2", "2", true],
-//                 ],
-//             },
-//             localVue,
-//         });
-//         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: true });
-//     });
-//     it("Sets default from defaultValue", async () => {
-//         const wrapper = mount(FormSelect, {
-//             propsData: {
-//                 value: "2",
-//                 defaultValue: "2",
-//                 display: null,
-//                 multiple: null,
-//                 options: [
-//                     ["test1", "T", false],
-//                     ["test2", "2", false],
-//                 ],
-//             },
-//             localVue,
-//         });
-//         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: false });
-//     });
-//     it("Changes value after new selection is made", async () => {
-//         const wrapper = mount(FormSelect, {
-//             propsData: {
-//                 value: "T",
-//                 defaultValue: "T",
-//                 display: null,
-//                 multiple: null,
-//                 options: [
-//                     ["test1", "T", false],
-//                     ["test2", "2", false],
-//                 ],
-//             },
-//             localVue,
-//         });
+describe("FormSelect", () => {
+    // Single select, no radio
+    it("Sets default currentValue as first option when not told otherwise", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "",
+                defaultValue: "",
+                display: null,
+                multiple: false,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
+    });
+    it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "",
+                defaultValue: "",
+                display: null,
+                multiple: false,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", true],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: true });
+    });
+    it("Sets default from defaultValue", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "2",
+                defaultValue: "2",
+                display: null,
+                multiple: false,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: false });
+    });
+    it("Changes value after new selection is made", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "T",
+                defaultValue: "T",
+                display: null,
+                multiple: false,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
+            },
+            localVue,
+        });
 
-//         const multiselect = wrapper.findComponent(Multiselect);
-//         // Manually trigger selection of the second item in optarray in the multiselect
-//         multiselect.vm.select(wrapper.vm.optArray[1]);
-//         expect(wrapper.emitted().input).toEqual([["2"]]);
-//     });
-// });
+        const multiselect = wrapper.findComponent(Multiselect);
+        // Manually trigger selection of the second item in optarray in the multiselect
+        multiselect.vm.select(wrapper.vm.optArray[1]);
+        expect(wrapper.emitted().input).toEqual([["2"]]);
+    });
+});
 
 describe("FormSelect", () => {
-    // Single dataset, with radio
+    // Single select, with radio
     const mountFormSelect = async (props) =>
         await mount(FormSelect, {
             propsData: props,
             localVue,
         });
-        
-
-    const getInput = async (wrapper) => await wrapper.find("input[type='radio']");
-    // const getOptions = async (wrapper) => await wrapper.find('radio').findAll('option');
 
     it("Sets default currentValue as first option when not told otherwise", async () => {
         const wrapper = await mountFormSelect({
@@ -115,19 +114,38 @@ describe("FormSelect", () => {
                 ["test2", "2", true],
             ],
         });
-        const radio = wrapper.findComponent(BFormRadioGroup)
+        const radio = wrapper.find("input[type='radio']");
         expect(wrapper.vm.currentValue).toStrictEqual({label: "test2", value: "2", default: true});
-        await radio.trigger('click');
-        const input = radio.find('input');
-        console.log(radio.vm.emitted());
-        expect(wrapper.emitted().input).toEqual([["2"]]);
+        radio.trigger('click')
+        radio.trigger('change')
+        await flushPromises();
+        expect(wrapper.emitted().input).toEqual([["T"]]);
+    });
+    it("Changes values to a selected value", async () => {
+        const wrapper = await mountFormSelect({
+            value: "",
+            defaultValue: "",
+            display: "radio",
+            multiple: false,
+            options: [
+                ["test1", "T", true],
+                ["test2", "2", false],
+                ["test3", "3", false],
+            ],
+        });
+        const radio = wrapper.find("input[value='3']");
+        expect(wrapper.vm.currentValue).toStrictEqual({label: "test1", value: "T", default: true});
+        radio.trigger('click')
+        radio.trigger('change')
+        await flushPromises();
+        expect(wrapper.emitted().input).toEqual([["3"]]);
     });
 });
 
-// describe("FormSelect", () => {
-//     // Multiple datasets, no radio
-// });
+describe("FormSelect", () => {
+    // Multiple select, no radio
+});
 
 // describe("FormSelect", () => {
-//     // Multiple datasets, with radio
+//     // Multiple select, with checkboxes
 // });

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -2,12 +2,10 @@ import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import FormSelect from "./FormSelect";
 import Multiselect from "vue-multiselect";
-import { BFormRadioGroup } from 'bootstrap-vue';
+import { BFormRadioGroup } from "bootstrap-vue";
 import Vue from "vue";
 import flushPromises from "flush-promises";
 import { min } from "underscore";
-
-
 
 const localVue = getLocalVue();
 
@@ -44,7 +42,7 @@ describe("FormSelect", () => {
             },
             localVue,
         });
-        expect(wrapper.vm.currentValue).toStrictEqual({"default": false, "label": "Nothing selected", "value": null});
+        expect(wrapper.vm.currentValue).toStrictEqual({ default: false, label: "Nothing selected", value: null });
     });
     it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
         const wrapper = mount(FormSelect, {
@@ -110,14 +108,14 @@ describe("FormSelect", () => {
 
     it("Sets default currentValue as first option when not told otherwise", async () => {
         const wrapper = await mountFormSelect({
-                value: "",
-                defaultValue: "",
-                display: "radio",
-                multiple: false,
-                options: [
-                    ["test1", "T", false],
-                    ["test2", "2", false],
-                ],
+            value: "",
+            defaultValue: "",
+            display: "radio",
+            multiple: false,
+            options: [
+                ["test1", "T", false],
+                ["test2", "2", false],
+            ],
         });
         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
     });
@@ -133,9 +131,9 @@ describe("FormSelect", () => {
             ],
         });
         const radio = wrapper.find("input[type='radio']");
-        expect(wrapper.vm.currentValue).toStrictEqual({label: "test2", value: "2", default: true});
-        radio.trigger('click')
-        radio.trigger('change')
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: true });
+        radio.trigger("click");
+        radio.trigger("change");
         await flushPromises();
         expect(wrapper.emitted().input).toEqual([["T"]]);
     });
@@ -152,9 +150,9 @@ describe("FormSelect", () => {
             ],
         });
         const radio = wrapper.find("input[value='3']");
-        expect(wrapper.vm.currentValue).toStrictEqual({label: "test1", value: "T", default: true});
-        radio.trigger('click')
-        radio.trigger('change')
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: true });
+        radio.trigger("click");
+        radio.trigger("change");
         await flushPromises();
         expect(wrapper.emitted().input).toEqual([["3"]]);
     });
@@ -184,7 +182,7 @@ describe("FormSelect", () => {
         multiselect.vm.select(wrapper.vm.optArray[1]);
         expect(wrapper.emitted().input).toEqual([[["2"]]]);
         multiselect.vm.select(wrapper.vm.optArray[2]);
-        expect(wrapper.emitted().input).toEqual([[["2"]],[["3"]]]);
+        expect(wrapper.emitted().input).toEqual([[["2"]], [["3"]]]);
     });
     it("Changes value after new selection is made", async () => {
         const wrapper = mount(FormSelect, {
@@ -201,17 +199,20 @@ describe("FormSelect", () => {
             },
             localVue,
         });
-        expect(wrapper.vm.currentValue).toStrictEqual([{ label: "test1", value: "T", default: true }, { label: "test2", value: "2", default: true }]);
+        expect(wrapper.vm.currentValue).toStrictEqual([
+            { label: "test1", value: "T", default: true },
+            { label: "test2", value: "2", default: true },
+        ]);
     });
 });
 
 describe("FormSelect", () => {
     // Multiple select, with checkboxes
     const mountFormSelect = async (props) =>
-    await mount(FormSelect, {
-        propsData: props,
-        localVue,
-    });
+        await mount(FormSelect, {
+            propsData: props,
+            localVue,
+        });
 
     it("Changes values to a selected value, and can contain multiple values", async () => {
         const wrapper = await mountFormSelect({
@@ -228,10 +229,10 @@ describe("FormSelect", () => {
         const checkboxes_3 = wrapper.find("input[value='3']");
         const checkboxes_2 = wrapper.find("input[value='2']");
         expect(wrapper.vm.currentValue).toStrictEqual(["T"]);
-        checkboxes_2.trigger('click')
-        checkboxes_3.trigger('click')
-        checkboxes_2.trigger('change')
-        checkboxes_3.trigger('change')
+        checkboxes_2.trigger("click");
+        checkboxes_3.trigger("click");
+        checkboxes_2.trigger("change");
+        checkboxes_3.trigger("change");
         await flushPromises();
         expect(wrapper.emitted().input).toEqual([[["T", "2", "3"]]]);
     });

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -92,7 +92,9 @@ describe("FormSelect", () => {
 
         const multiselect = wrapper.findComponent(Multiselect);
         multiselect.vm.select(wrapper.vm.options[1]);
-        expect(multiselect.emitted().input).toEqual([[["test2", "2", false], null]]);
-        expect(multiselect.emitted().select).toEqual([[["test2", "2", false], null]]);
+        console.log(wrapper.vm.options);
+        console.log(wrapper.vm.options[1]);
+        expect(wrapper.emitted().input).toEqual([[["test2", "2", false], null]]);
+        expect(wrapper.emitted().select).toEqual([[["test2", "2", false], null]]);
     });
 });

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -91,10 +91,8 @@ describe("FormSelect", () => {
         });
 
         const multiselect = wrapper.findComponent(Multiselect);
-        multiselect.vm.select(wrapper.vm.options[1]);
-        console.log(wrapper.vm.options);
-        console.log(wrapper.vm.options[1]);
-        expect(wrapper.emitted().input).toEqual([[["test2", "2", false], null]]);
-        expect(wrapper.emitted().select).toEqual([[["test2", "2", false], null]]);
+        // Manually trigger selection of the second item in optarray in the multiselect
+        multiselect.vm.select(wrapper.vm.optArray[1]);
+        expect(wrapper.emitted().input).toEqual([["2"]]);
     });
 });

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -5,6 +5,7 @@ import Multiselect from "vue-multiselect";
 import { BFormRadioGroup } from 'bootstrap-vue';
 import Vue from "vue";
 import flushPromises from "flush-promises";
+import { min } from "underscore";
 
 
 
@@ -27,6 +28,23 @@ describe("FormSelect", () => {
             localVue,
         });
         expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
+    });
+    it("Sets no value if optional", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: "",
+                defaultValue: "",
+                display: null,
+                multiple: false,
+                optional: true,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual({"default": false, "label": "Nothing selected", "value": null});
     });
     it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
         const wrapper = mount(FormSelect, {
@@ -144,8 +162,91 @@ describe("FormSelect", () => {
 
 describe("FormSelect", () => {
     // Multiple select, no radio
+    it("Nothing selected if no defaults, adds values individaully if selected", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: null,
+                defaultValue: null,
+                display: null,
+                multiple: true,
+                optional: true,
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                    ["test3", "3", false],
+                ],
+            },
+            localVue,
+        });
+
+        expect(wrapper.vm.currentValue).toStrictEqual(undefined);
+        const multiselect = wrapper.findComponent(Multiselect);
+        multiselect.vm.select(wrapper.vm.optArray[1]);
+        expect(wrapper.emitted().input).toEqual([[["2"]]]);
+        multiselect.vm.select(wrapper.vm.optArray[2]);
+        expect(wrapper.emitted().input).toEqual([[["2"]],[["3"]]]);
+    });
+    it("Changes value after new selection is made", async () => {
+        const wrapper = mount(FormSelect, {
+            propsData: {
+                value: ["T", "2"],
+                defaultValue: ["T", "2"],
+                display: null,
+                multiple: true,
+                options: [
+                    ["test1", "T", true],
+                    ["test2", "2", true],
+                    ["test3", "3", false],
+                ],
+            },
+            localVue,
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual([{ label: "test1", value: "T", default: true }, { label: "test2", value: "2", default: true }]);
+    });
 });
 
-// describe("FormSelect", () => {
-//     // Multiple select, with checkboxes
-// });
+describe("FormSelect", () => {
+    // Multiple select, with checkboxes
+    const mountFormSelect = async (props) =>
+    await mount(FormSelect, {
+        propsData: props,
+        localVue,
+    });
+
+    it("Changes values to a selected value, and can contain multiple values", async () => {
+        const wrapper = await mountFormSelect({
+            value: ["T"],
+            defaultValue: ["T"],
+            display: "checkboxes",
+            multiple: true,
+            options: [
+                ["test1", "T", true],
+                ["test2", "2", false],
+                ["test3", "3", false],
+            ],
+        });
+        const checkboxes_3 = wrapper.find("input[value='3']");
+        const checkboxes_2 = wrapper.find("input[value='2']");
+        expect(wrapper.vm.currentValue).toStrictEqual(["T"]);
+        checkboxes_2.trigger('click')
+        checkboxes_3.trigger('click')
+        checkboxes_2.trigger('change')
+        checkboxes_3.trigger('change')
+        await flushPromises();
+        expect(wrapper.emitted().input).toEqual([[["T", "2", "3"]]]);
+    });
+    it("Has no calue if nothing is selected", async () => {
+        const wrapper = await mountFormSelect({
+            value: null,
+            defaultValue: null,
+            display: "checkboxes",
+            multiple: true,
+            options: [
+                ["test1", "T", true],
+                ["test2", "2", false],
+                ["test3", "3", false],
+            ],
+        });
+        expect(wrapper.vm.currentValue).toStrictEqual(undefined);
+    });
+});

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -12,7 +12,7 @@ const localVue = getLocalVue();
 //             propsData: props,
 //             localVue,
 //         });
-    // const getInput = async (wrapper) => await wrapper.find("input[type='select']");
+// const getInput = async (wrapper) => await wrapper.find("input[type='select']");
 
 //     it("input should be rendered with select type", async () => {
 //         const wrapper = await mountFormSelect({
@@ -35,52 +35,64 @@ describe("FormSelect", () => {
             propsData: {
                 value: "",
                 defaultValue: "",
-                options: [["test1", "T", false], ["test2", "2", false]],
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
             },
             localVue,
         });
         const input = wrapper.find("input");
-        expect(wrapper.vm.currentValue).toStrictEqual({"label": "test1", "value": "T", "default": false});
-    })
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test1", value: "T", default: false });
+    });
     it("Sets default currentValue to object with 'default: true' when default not provided from defaultValue", async () => {
         let wrapper;
         wrapper = mount(FormSelect, {
             propsData: {
                 value: "",
                 defaultValue: "",
-                options: [["test1", "T", false], ["test2", "2", true]],
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", true],
+                ],
             },
             localVue,
         });
         const input = wrapper.find("input");
-        expect(wrapper.vm.currentValue).toStrictEqual({"label": "test2", "value": "2", "default": true});
-    })
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: true });
+    });
     it("Sets default from defaultValue", async () => {
         let wrapper;
         wrapper = mount(FormSelect, {
             propsData: {
                 value: "2",
                 defaultValue: "2",
-                options: [["test1", "T", false], ["test2", "2", false]],
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
             },
             localVue,
         });
         const input = wrapper.find("input");
-        expect(wrapper.vm.currentValue).toStrictEqual({"label": "test2", "value": "2", "default": false});
-    })
-    it("Changes value after new selection is made", async() => {
+        expect(wrapper.vm.currentValue).toStrictEqual({ label: "test2", value: "2", default: false });
+    });
+    it("Changes value after new selection is made", async () => {
         const wrapper = mount(FormSelect, {
             propsData: {
                 value: "T",
                 defaultValue: "T",
-                options: [["test1", "T", false], ["test2", "2", false]],
+                options: [
+                    ["test1", "T", false],
+                    ["test2", "2", false],
+                ],
             },
             localVue,
         });
-    
-        const multiselect = wrapper.findComponent( Multiselect );
+
+        const multiselect = wrapper.findComponent(Multiselect);
         multiselect.vm.select(wrapper.vm.options[1]);
         expect(multiselect.emitted().input).toEqual([[["test2", "2", false], null]]);
         expect(multiselect.emitted().select).toEqual([[["test2", "2", false], null]]);
-    })
+    });
 });

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -2,10 +2,7 @@ import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import FormSelect from "./FormSelect";
 import Multiselect from "vue-multiselect";
-import { BFormRadioGroup } from "bootstrap-vue";
-import Vue from "vue";
 import flushPromises from "flush-promises";
-import { min } from "underscore";
 
 const localVue = getLocalVue();
 

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -1,6 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import FormSelect from "./FormSelect";
+import Multiselect from "vue-multiselect";
 import flushPromises from "flush-promises";
 
 const localVue = getLocalVue();
@@ -65,18 +66,21 @@ describe("FormSelect", () => {
             localVue,
         });
         const input = wrapper.find("input");
-        expect(wrapper.vm.currentValue).toStrictEqual({"label": "test1", "value": "T", "default": false});
+        expect(wrapper.vm.currentValue).toStrictEqual({"label": "test2", "value": "2", "default": false});
     })
-    it("Returns a new value after being switched over", async() => {
-        let wrapper;
-        wrapper = mount(FormSelect, {
+    it("Changes value after new selection is made", async() => {
+        const wrapper = mount(FormSelect, {
             propsData: {
-                value: "",
-                defaultValue: "",
+                value: "T",
+                defaultValue: "T",
                 options: [["test1", "T", false], ["test2", "2", false]],
             },
             localVue,
         });
-        wrapper.setValue()
-    }
+    
+        const multiselect = wrapper.findComponent( Multiselect );
+        multiselect.vm.select(wrapper.vm.options[1]);
+        expect(multiselect.emitted().input).toEqual([[["test2", "2", false], null]]);
+        expect(multiselect.emitted().select).toEqual([[["test2", "2", false], null]]);
+    })
 });

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -89,8 +89,8 @@ describe("FormSelect", () => {
         });
 
         const multiselect = wrapper.findComponent(Multiselect);
-        // Manually trigger selection of the second item in optarray in the multiselect
-        multiselect.vm.select(wrapper.vm.optArray[1]);
+        // Manually trigger selection of the second item in formattedOptions in the multiselect
+        multiselect.vm.select(wrapper.vm.formattedOptions[1]);
         expect(wrapper.emitted().input).toEqual([["2"]]);
     });
 });
@@ -176,9 +176,9 @@ describe("FormSelect", () => {
 
         expect(wrapper.vm.currentValue).toStrictEqual(undefined);
         const multiselect = wrapper.findComponent(Multiselect);
-        multiselect.vm.select(wrapper.vm.optArray[1]);
+        multiselect.vm.select(wrapper.vm.formattedOptions[1]);
         expect(wrapper.emitted().input).toEqual([[["2"]]]);
-        multiselect.vm.select(wrapper.vm.optArray[2]);
+        multiselect.vm.select(wrapper.vm.formattedOptions[2]);
         expect(wrapper.emitted().input).toEqual([[["2"]], [["3"]]]);
     });
     it("Changes value after new selection is made", async () => {

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -126,37 +126,37 @@ export default {
                 // If there's no default value set, use the first item in the array with 'default' set to true.
                 // Lastly, just default to the first element in the array.
                 if (this.multiple || this.display == "checkboxes") {
-                    this.multiple = true;
                     if (this.value !== "") {
-                        let selected = [];
+                        const selected = [];
                         if (this.value == null) {
                             return;
                         }
+                        let array_val = this.value;
                         // A string is returned if single, but an array if zero or multiple
                         if (!Array.isArray(this.value)) {
-                            this.value = [this.value];
+                            array_val = [this.value];
                         }
-                        for (var i = 0; i < this.value.length; i++) {
+                        for (var i = 0; i < array_val.length; i++) {
                             if (this.display == "checkboxes") {
-                                selected.push(this.optArray.find((element) => element.value == this.value[i]).value);
+                                selected.push(this.optArray.find((element) => element.value == array_val[i]).value);
                             } else {
-                                selected.push(this.optArray.find((element) => element.value == this.value[i]));
+                                selected.push(this.optArray.find((element) => element.value == array_val[i]));
                             }
                         }
                         return selected;
                     } else if (this.defaultValue !== "") {
-                        let selected = [];
+                        const selected = [];
                         // Create list from default selected values
-                        for (var i = 0; i < this.defaultValue.length; i++) {
-                            selected.push(this.optArray.find((element) => element.value === this.defaultValue[i]));
+                        for (var n = 0; n < this.defaultValue.length; n++) {
+                            selected.push(this.optArray.find((element) => element.value === this.defaultValue[n]));
                         }
                         return selected;
                         // Return null if value is optional
                     } else {
                         // Try to find a value labeled default in the options
-                        for (let i = 0, len = this.optArray.length; i < len; i++) {
-                            if (this.optArray[i].default) {
-                                return this.optArray[i];
+                        for (let x = 0, len = this.optArray.length; x < len; x++) {
+                            if (this.optArray[x].default) {
+                                return this.optArray[x];
                             }
                         }
                         // Else return first value
@@ -193,7 +193,7 @@ export default {
             set(val) {
                 // Checkbox is mutliple, but not automatically set. If it IS set, this prevents the multiple from overriding the checkbox
                 if (this.multiple && this.display != "checkboxes") {
-                    let values = [];
+                    const values = [];
                     for (var i = 0; i < val.length; i++) {
                         values.push(val[i].value);
                     }

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -84,8 +84,6 @@ export default {
                 }
             },
             set(val) {
-                console.log(val);
-                console.log(val.value);
                 this.$emit("input", val.value);
             },
         },

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -1,0 +1,84 @@
+<template>
+    <div>
+        <b-alert
+            class="mt-2"
+            v-if="errorMessage"
+            :show="dismissCountDown"
+            variant="info"
+            @dismissed="dismissCountDown = 0"
+        >
+            {{ errorMessage }}
+        </b-alert>
+        <b-row align-v="center">
+            <b-col>
+                <multiselect v-model="currentValue" 
+                    :options="optArray"
+                    label="label"
+                    track-by="value" 
+                    />
+                    {{ currentValue }}
+            </b-col>
+        </b-row>
+    </div>
+</template>
+
+<script>
+
+import Multiselect from 'vue-multiselect'
+
+export default {
+    components: {
+        Multiselect
+    },
+    props: {
+        value: {
+            required: true,
+        },
+        default_value: {
+            type: String,
+            required: true,
+        },
+        options: {
+            type: Array,
+            required: true,
+            default: undefined,
+        },
+    },
+    data() {
+        return {
+            errorMessage: "",
+        };
+    },
+    computed: {
+        optArray() {
+            const formattedOptions = []
+            for (let i = 0, len = this.options.length; i < len; i++){
+                formattedOptions[i] = {"label": this.options[i][0], "value": this.options[i][1], "default": this.options[i][2]}
+            }
+            return formattedOptions
+        },
+        currentValue: {
+            get() {
+                return this.value
+            },
+            set(val) {
+                this.$emit("input", val.value);
+            },
+        },
+    },
+    // methods: {
+    //     onInputChange(value) {
+    //         // hide error message after value has changed
+    //         this.currentValue = value
+    //         console.log('helloworld"')
+    //         this.$emit("input", this.currentValue.value);
+    //     },
+    //     onSelectItem(currentValue) {
+    //         this.$emit("update:currentValue", currentValue);
+    //     },
+    // },
+    created() {
+        this.currentValue = this.optArray.find(element => element.value == this.default_value) || this.optArray[0];
+    },
+};
+</script>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -9,19 +9,15 @@
             {{ errorMessage }}
         </b-alert>
         <b-row align-v="center">
-            <b-col v-if=" display == 'radio'">
-                <b-form-group>                    
+            <b-col v-if="display == 'radio'">
+                <b-form-group>
                     <!-- Select single from radio -->
-                    <b-form-radio-group
-                        v-model="currentValue"
-                        :options="optArray"
-                        text-field="label"
-                        stacked>
+                    <b-form-radio-group v-model="currentValue" :options="optArray" text-field="label" stacked>
                     </b-form-radio-group>
                 </b-form-group>
             </b-col>
             <b-col v-else-if="display == 'checkboxes'">
-             <!-- Select multiple from checkboxes -->
+                <!-- Select multiple from checkboxes -->
                 <b-form-group>
                     <b-form-checkbox-group
                         v-model="currentValue"
@@ -43,8 +39,7 @@
                     deselect-label=""
                     select-label=""
                     track-by="value"
-                    label="label"
-                    > 
+                    label="label">
                 </multiselect>
                 <!-- Single select from drop down -->
                 <multiselect
@@ -54,9 +49,8 @@
                     deselect-label=""
                     select-label=""
                     label="label"
-                    track-by="value"
-                    > 
-                    {{ currentValue }} 
+                    track-by="value">
+                    {{ currentValue }}
                 </multiselect>
             </b-col>
         </b-row>
@@ -98,7 +92,7 @@ export default {
             type: Boolean,
             required: false,
             default: null,
-        }
+        },
     },
     data() {
         return {
@@ -121,7 +115,7 @@ export default {
                     label: "Nothing selected",
                     value: null,
                     default: false,
-                })
+                });
             }
             return formattedOptions;
         },
@@ -131,33 +125,33 @@ export default {
                 // If there's a defaultValue set, find it in the array and use that.
                 // If there's no default value set, use the first item in the array with 'default' set to true.
                 // Lastly, just default to the first element in the array.
-                if(this.multiple || this.display == "checkboxes") { 
-                    this.multiple = true
+                if (this.multiple || this.display == "checkboxes") {
+                    this.multiple = true;
                     if (this.value !== "") {
                         let selected = [];
                         if (this.value == null) {
-                            return
+                            return;
                         }
                         // A string is returned if single, but an array if zero or multiple
-                        if (! Array.isArray(this.value)) {
-                            this.value = [this.value]
+                        if (!Array.isArray(this.value)) {
+                            this.value = [this.value];
                         }
-                        for(var i = 0; i < this.value.length; i++){
+                        for (var i = 0; i < this.value.length; i++) {
                             if (this.display == "checkboxes") {
                                 selected.push(this.optArray.find((element) => element.value == this.value[i]).value);
                             } else {
                                 selected.push(this.optArray.find((element) => element.value == this.value[i]));
                             }
                         }
-                        return selected
+                        return selected;
                     } else if (this.defaultValue !== "") {
                         let selected = [];
                         // Create list from default selected values
-                        for(var i = 0; i < this.defaultValue.length; i++){
+                        for (var i = 0; i < this.defaultValue.length; i++) {
                             selected.push(this.optArray.find((element) => element.value === this.defaultValue[i]));
                         }
                         return selected;
-                    // Return null if value is optional
+                        // Return null if value is optional
                     } else {
                         // Try to find a value labeled default in the options
                         for (let i = 0, len = this.optArray.length; i < len; i++) {
@@ -169,22 +163,22 @@ export default {
                         return this.optArray[0];
                     }
 
-                // If single select
+                    // If single select
                 } else {
                     // If value provided, use value
                     if (this.value !== "") {
                         if (this.value == null) {
-                            return
+                            return;
                         }
-                        if (this.display == 'radio') { 
+                        if (this.display == "radio") {
                             return this.optArray.find((element) => element.value === this.value).value;
                         } else {
                             return this.optArray.find((element) => element.value === this.value);
                         }
-                    // if no value provided, use default value
+                        // if no value provided, use default value
                     } else if (this.defaultValue !== "") {
                         return this.optArray.find((element) => element.default === this.defaultValue);
-                    // If no default value provided and optional is selected, return null
+                        // If no default value provided and optional is selected, return null
                     } else {
                         for (let i = 0, len = this.optArray.length; i < len; i++) {
                             if (this.optArray[i].default) {
@@ -198,15 +192,14 @@ export default {
             },
             set(val) {
                 // Checkbox is mutliple, but not automatically set. If it IS set, this prevents the multiple from overriding the checkbox
-                if (this.multiple && this.display != "checkboxes"){
+                if (this.multiple && this.display != "checkboxes") {
                     let values = [];
-                    for(var i = 0; i < val.length; i++){
+                    for (var i = 0; i < val.length; i++) {
                         values.push(val[i].value);
                     }
                     this.$emit("input", values);
-                }
-                else {
-                    if (this.display == "radio" || this.display == "checkboxes"){
+                } else {
+                    if (this.display == "radio" || this.display == "checkboxes") {
                         this.$emit("input", val);
                     } else {
                         this.$emit("input", val.value);

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -13,7 +13,7 @@
                 <b-form-group>                    
                     <!-- Select multiple from checkboxes -->
                     <b-form-checkbox-group
-                        v-if="multiple == true"
+                        v-if="multiple"
                         v-model="currentValue"
                         :options="optArray"
                         value-field="value"
@@ -33,7 +33,7 @@
             <b-col v-else>
                 <!-- Multiple select from drop down -->
                 <multiselect
-                    v-if=" multiple == true"
+                    v-if="multiple"
                     v-model="currentValue"
                     :options="optArray"
                     :multiple="true"
@@ -71,9 +71,6 @@ export default {
     },
     props: {
         value: {
-            required: true,
-            type: [String, Array],
-            nullable: true,
             default: null,
         },
         defaultValue: {
@@ -153,7 +150,7 @@ export default {
                     } else {
                         // Try to find a value labeled default in the options
                         for (let i = 0, len = this.optArray.length; i < len; i++) {
-                            if (this.optArray[i].default === true) {
+                            if (this.optArray[i].default) {
                                 return this.optArray[i];
                             }
                         }
@@ -179,7 +176,7 @@ export default {
                     // If no default value provided and optional is selected, return null
                     } else {
                         for (let i = 0, len = this.optArray.length; i < len; i++) {
-                            if (this.optArray[i].default === true) {
+                            if (this.optArray[i].default) {
                                 return this.optArray[i];
                             }
                         }
@@ -212,15 +209,3 @@ export default {
     },
 };
 </script>
-<style>
-.multiselect__option--selected.multiselect__option--highlight {
-    color: #2c3143 !important;
-    background: #dee2e6 !important;
-}
-.multiselect__tag,
-.multiselect__tag-icon::after { 
-    background: #25537b !important;
-    border-color: #25537b !important;
-    color: white !important;
-}
-</style>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -19,7 +19,10 @@
                     deselect-label=""
                     select-label=""
                     label="label"
-                    track-by="value"> {{ currentValue }} </multiselect>
+                    track-by="value"
+                    > 
+                    {{ currentValue }} 
+                </multiselect>
                 <!-- Multiple select from drop down -->
                 <multiselect
                     v-else-if=" multiple == true"
@@ -29,9 +32,9 @@
                     placeholder="Select value"
                     deselect-label=""
                     select-label="Selected"
-                    label="label"
                     track-by="value"
-                    >
+                    label="label"
+                    > 
                 </multiselect>
             </b-col>
             <b-col v-else-if=" display == 'radio'">
@@ -71,7 +74,7 @@ export default {
     props: {
         value: {
             required: true,
-            type: [String, Array],
+            type: [String, Array, null],
         },
         defaultValue: {
             type: [String, Array],
@@ -90,6 +93,11 @@ export default {
         },
         display: {
             type: String,
+            required: false,
+            default: null,
+        },
+        optional: {
+            type: Boolean,
             required: false,
             default: null,
         }
@@ -122,48 +130,77 @@ export default {
                     if (this.value !== "") {
                         let selected = [];
                         for(var i = 0; i < this.value.length; i++){
-                            if(selected.includes(this.value[i])){
-                                selected = selected.filter((element) => element === this.value[i].value)
-                            } else {
+                            // checkboxes expects a value, multiselect expects an object
+                            if (this.display == "radio") {
                                 selected.push(this.optArray.find((element) => element.value === this.value[i]).value);
+                            } else {
+                                selected.push(this.optArray.find((element) => element.value === this.value[i]));
                             }
                         }
-                        return selected;
+                        return selected
+                    // If 'value' is not provided from the wrapper, move to default value
                     } else if (this.defaultValue !== "") {
                         let selected = [];
+                        // Create list from default selected values
                         for(var i = 0; i < this.defaultValue.length; i++){
                             selected.push(this.optArray.find((element) => element.value === this.defaultValue[i]));
                         }
                         return selected;
+                    // Return null if value is optional
+                    } else if (optional == "true") {
+                        return null
                     } else {
+                        // Try to find a value labeled default in the options
                         for (let i = 0, len = this.optArray.length; i < len; i++) {
                             if (this.optArray[i].default === true) {
                                 return this.optArray[i];
                             }
                         }
+                        // Else return first value
                         return this.optArray[0];
                     }
+
+                // If single select
                 } else {
+                    // If value provided, use value
                     if (this.value !== "") {
                         return this.optArray.find((element) => element.value === this.value);
+                    // if no value provided, use default value
                     } else if (this.defaultValue !== "") {
                         return this.optArray.find((element) => element.default === this.defaultValue);
-                    } else {
+                    // If no default value provided and optional is selected, return null
+                    } else if (optional == "true") {
+                        return null
+                    // Try to find a value labeled default in the options
+                    }else {
                         for (let i = 0, len = this.optArray.length; i < len; i++) {
                             if (this.optArray[i].default === true) {
                                 return this.optArray[i];
                             }
                         }
+                        // Else return first value
                         return this.optArray[0];
                     }
                 }
             },
             set(val) {
                 if (this.multiple){
-                    this.$emit("input", val);
+                    if (this.display == "radio"){
+                        this.$emit("input", val.value);
+                    } else {
+                        let values = [];
+                        for(var i = 0; i < val.length; i++){
+                            values.push(val[i].value);
+                        }
+                        this.$emit("input", values);
+                    }
                 }
                 else {
-                    this.$emit("input", val.value);
+                    if (this.display == "radio"){
+                        this.$emit("input", val);
+                    } else {
+                        this.$emit("input", val.value);
+                    }
                 }
             },
         },

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -11,23 +11,25 @@
         <b-row align-v="center">
             <b-col v-if=" display == 'radio'">
                 <b-form-group>                    
-                    <!-- Select multiple from checkboxes -->
+                    <!-- Select single from radio -->
+                    <b-form-radio-group
+                        v-model="currentValue"
+                        :options="optArray"
+                        text-field="label"
+                        stacked>
+                    </b-form-radio-group>
+                </b-form-group>
+            </b-col>
+            <b-col v-else-if="display == 'checkboxes'">
+             <!-- Select multiple from checkboxes -->
+                <b-form-group>
                     <b-form-checkbox-group
-                        v-if="multiple"
                         v-model="currentValue"
                         :options="optArray"
                         value-field="value"
                         text-field="label"
                         stacked>
                     </b-form-checkbox-group>
-                    <!-- Select single from radio -->
-                    <b-form-radio-group
-                        v-else
-                        v-model="currentValue"
-                        :options="optArray"
-                        text-field="label"
-                        stacked>
-                    </b-form-radio-group>
                 </b-form-group>
             </b-col>
             <b-col v-else>
@@ -123,21 +125,36 @@ export default {
                 // If there's a defaultValue set, find it in the array and use that.
                 // If there's no default value set, use the first item in the array with 'default' set to true.
                 // Lastly, just default to the first element in the array.
-                if(this.multiple) { 
+                if(this.multiple || this.display == "checkboxes") { 
+                    this.multiple = true
+                    console.log(this.value)
                     if (this.value !== "") {
                         let selected = [];
                         if (this.value == null) {
                             return
                         }
+                        // A string is returned if single, but an array if zero or multiple
+                        console.log(this.value)
+                        if (! Array.isArray(this.value)) {
+                            this.value = [this.value]
+                        }
                         for(var i = 0; i < this.value.length; i++){
-                            // checkboxes expects a value, multiselect expects an object
-                            if (this.display == "radio") {
+                            if (this.display == "checkboxes") {
                                 selected.push(this.optArray.find((element) => element.value == this.value[i]).value);
                             } else {
                                 selected.push(this.optArray.find((element) => element.value == this.value[i]));
                             }
                         }
                         return selected
+                        // else {
+                        //     // checkboxes expects a value, multiselect expects an object
+                        //     if (this.display == "checkboxes") {
+                        //         selected.push(this.optArray.find((element) => element.value == this.value).value);
+                        //     } else {
+                        //         selected.push(this.optArray.find((element) => element.value == this.value[i]));
+                        //     }
+                        // }
+                        // return selected
                     // If 'value' is not provided from the wrapper, move to default value
                     } else if (this.defaultValue !== "") {
                         let selected = [];
@@ -186,19 +203,16 @@ export default {
                 }
             },
             set(val) {
-                if (this.multiple){
-                    if (this.display == "radio"){
-                        this.$emit("input", val);
-                    } else {
-                        let values = [];
-                        for(var i = 0; i < val.length; i++){
-                            values.push(val[i].value);
-                        }
-                        this.$emit("input", values);
+                // Checkbox is mutliple, but not automatically set. If it IS set, this prevents the multiple from overriding the checkbox
+                if (this.multiple && this.display != "checkboxes"){
+                    let values = [];
+                    for(var i = 0; i < val.length; i++){
+                        values.push(val[i].value);
                     }
+                    this.$emit("input", values);
                 }
                 else {
-                    if (this.display == "radio"){
+                    if (this.display == "radio" || this.display == "checkboxes"){
                         this.$emit("input", val);
                     } else {
                         this.$emit("input", val.value);

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -10,7 +10,7 @@
         </b-alert>
         <b-row align-v="center">
             <b-col>
-                <multiselect v-model="currentValue" :options="optArray" label="label" track-by="value" />
+                <multiselect v-model="currentValue" :options="optArray" :allow-empty="false" deselect-label="" select-label="" label="label" track-by="value" />
             </b-col>
         </b-row>
     </div>
@@ -77,9 +77,21 @@ export default {
                 }
             },
             set(val) {
+                console.log(val);
+                console.log(val.value);
                 this.$emit("input", val.value);
             },
         },
     },
 };
 </script>
+<style>
+    /* .multiselect__option {
+    background: #dee2e6;
+    } */
+/* 
+    .multiselect__option--selected
+    .multiselect__option--highlight {
+    background: #dee2e6;
+    } */
+</style>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -51,7 +51,6 @@
                     v-else
                     v-model="currentValue"
                     :options="optArray"
-                    :allow-empty="true"
                     deselect-label=""
                     select-label=""
                     label="label"
@@ -117,6 +116,13 @@ export default {
                     default: this.options[i][2],
                 };
             }
+            if (this.multiple == false && this.optional == true) {
+                formattedOptions.unshift({
+                    label: "Nothing selected",
+                    value: null,
+                    default: false,
+                })
+            }
             return formattedOptions;
         },
         currentValue: {
@@ -127,14 +133,12 @@ export default {
                 // Lastly, just default to the first element in the array.
                 if(this.multiple || this.display == "checkboxes") { 
                     this.multiple = true
-                    console.log(this.value)
                     if (this.value !== "") {
                         let selected = [];
                         if (this.value == null) {
                             return
                         }
                         // A string is returned if single, but an array if zero or multiple
-                        console.log(this.value)
                         if (! Array.isArray(this.value)) {
                             this.value = [this.value]
                         }
@@ -146,16 +150,6 @@ export default {
                             }
                         }
                         return selected
-                        // else {
-                        //     // checkboxes expects a value, multiselect expects an object
-                        //     if (this.display == "checkboxes") {
-                        //         selected.push(this.optArray.find((element) => element.value == this.value).value);
-                        //     } else {
-                        //         selected.push(this.optArray.find((element) => element.value == this.value[i]));
-                        //     }
-                        // }
-                        // return selected
-                    // If 'value' is not provided from the wrapper, move to default value
                     } else if (this.defaultValue !== "") {
                         let selected = [];
                         // Create list from default selected values

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -9,46 +9,8 @@
             {{ errorMessage }}
         </b-alert>
         <b-row align-v="center">
-            <b-col v-if=" display == null">
-                <!-- Single select from drop down -->
-                <multiselect
-                    v-if=" multiple == false"
-                    v-model="currentValue"
-                    :options="optArray"
-                    :allow-empty="false"
-                    deselect-label=""
-                    select-label=""
-                    label="label"
-                    track-by="value"
-                    > 
-                    {{ currentValue }} 
-                </multiselect>
-                <!-- Multiple select from drop down -->
-                <multiselect
-                    v-else-if=" multiple == true"
-                    v-model="currentValue"
-                    :options="optArray"
-                    :multiple="true"
-                    placeholder="Select value"
-                    deselect-label=""
-                    select-label="Selected"
-                    track-by="value"
-                    label="label"
-                    > 
-                </multiselect>
-            </b-col>
-            <b-col v-else-if=" display == 'radio'">
-                <b-form-group>
-                    <!-- Select single from checkboxes -->
-                    <b-form-radio-group
-                        v-if="multiple == false"
-                        v-model="currentValue"
-                        :options="optArray"
-                        text-field="label"
-                        value-field="value"
-                        stacked>
-                    </b-form-radio-group>
-
+            <b-col v-if=" display == 'radio'">
+                <b-form-group>                    
                     <!-- Select multiple from checkboxes -->
                     <b-form-checkbox-group
                         v-if="multiple == true"
@@ -58,7 +20,43 @@
                         text-field="label"
                         stacked>
                     </b-form-checkbox-group>
+                    <!-- Select single from radio -->
+                    <b-form-radio-group
+                        v-else
+                        v-model="currentValue"
+                        :options="optArray"
+                        text-field="label"
+                        stacked>
+                    </b-form-radio-group>
                 </b-form-group>
+            </b-col>
+            <b-col v-else>
+                <!-- Multiple select from drop down -->
+                <multiselect
+                    v-if=" multiple == true"
+                    v-model="currentValue"
+                    :options="optArray"
+                    :multiple="true"
+                    placeholder="Select value"
+                    deselect-label=""
+                    select-label=""
+                    track-by="value"
+                    label="label"
+                    > 
+                </multiselect>
+                <!-- Single select from drop down -->
+                <multiselect
+                    v-else
+                    v-model="currentValue"
+                    :options="optArray"
+                    :allow-empty="true"
+                    deselect-label=""
+                    select-label=""
+                    label="label"
+                    track-by="value"
+                    > 
+                    {{ currentValue }} 
+                </multiselect>
             </b-col>
         </b-row>
     </div>
@@ -74,12 +72,14 @@ export default {
     props: {
         value: {
             required: true,
-            type: [String, Array, null],
+            type: [String, Array],
+            nullable: true,
+            default: null,
         },
         defaultValue: {
             type: [String, Array],
             required: false,
-            default: "",
+            default: null,
         },
         options: {
             type: Array,
@@ -129,12 +129,15 @@ export default {
                 if(this.multiple) { 
                     if (this.value !== "") {
                         let selected = [];
+                        if (this.value == null) {
+                            return
+                        }
                         for(var i = 0; i < this.value.length; i++){
                             // checkboxes expects a value, multiselect expects an object
                             if (this.display == "radio") {
-                                selected.push(this.optArray.find((element) => element.value === this.value[i]).value);
+                                selected.push(this.optArray.find((element) => element.value == this.value[i]).value);
                             } else {
-                                selected.push(this.optArray.find((element) => element.value === this.value[i]));
+                                selected.push(this.optArray.find((element) => element.value == this.value[i]));
                             }
                         }
                         return selected
@@ -147,8 +150,6 @@ export default {
                         }
                         return selected;
                     // Return null if value is optional
-                    } else if (optional == "true") {
-                        return null
                     } else {
                         // Try to find a value labeled default in the options
                         for (let i = 0, len = this.optArray.length; i < len; i++) {
@@ -164,15 +165,19 @@ export default {
                 } else {
                     // If value provided, use value
                     if (this.value !== "") {
-                        return this.optArray.find((element) => element.value === this.value);
+                        if (this.value == null) {
+                            return
+                        }
+                        if (this.display == 'radio') { 
+                            return this.optArray.find((element) => element.value === this.value).value;
+                        } else {
+                            return this.optArray.find((element) => element.value === this.value);
+                        }
                     // if no value provided, use default value
                     } else if (this.defaultValue !== "") {
                         return this.optArray.find((element) => element.default === this.defaultValue);
                     // If no default value provided and optional is selected, return null
-                    } else if (optional == "true") {
-                        return null
-                    // Try to find a value labeled default in the options
-                    }else {
+                    } else {
                         for (let i = 0, len = this.optArray.length; i < len; i++) {
                             if (this.optArray[i].default === true) {
                                 return this.optArray[i];
@@ -186,7 +191,7 @@ export default {
             set(val) {
                 if (this.multiple){
                     if (this.display == "radio"){
-                        this.$emit("input", val.value);
+                        this.$emit("input", val);
                     } else {
                         let values = [];
                         for(var i = 0; i < val.length; i++){
@@ -211,5 +216,11 @@ export default {
 .multiselect__option--selected.multiselect__option--highlight {
     color: #2c3143 !important;
     background: #dee2e6 !important;
+}
+.multiselect__tag,
+.multiselect__tag-icon::after { 
+    background: #25537b !important;
+    border-color: #25537b !important;
+    color: white !important;
 }
 </style>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -5,38 +5,33 @@
             v-if="errorMessage"
             :show="dismissCountDown"
             variant="info"
-            @dismissed="dismissCountDown = 0"
-        >
+            @dismissed="dismissCountDown = 0">
             {{ errorMessage }}
         </b-alert>
         <b-row align-v="center">
             <b-col>
-                <multiselect v-model="currentValue" 
-                    :options="optArray"
-                    label="label"
-                    track-by="value" 
-                    />
-                    {{ currentValue }}
+                <multiselect v-model="currentValue" :options="optArray" label="label" track-by="value" />
             </b-col>
         </b-row>
     </div>
 </template>
 
 <script>
-
-import Multiselect from 'vue-multiselect'
+import Multiselect from "vue-multiselect";
 
 export default {
     components: {
-        Multiselect
+        Multiselect,
     },
     props: {
         value: {
             required: true,
-        },
-        default_value: {
             type: String,
-            required: true,
+        },
+        defaultValue: {
+            type: String,
+            required: false,
+            default: "",
         },
         options: {
             type: Array,
@@ -46,39 +41,45 @@ export default {
     },
     data() {
         return {
+            // Currently never set?
             errorMessage: "",
         };
     },
     computed: {
         optArray() {
-            const formattedOptions = []
-            for (let i = 0, len = this.options.length; i < len; i++){
-                formattedOptions[i] = {"label": this.options[i][0], "value": this.options[i][1], "default": this.options[i][2]}
+            const formattedOptions = [];
+            for (let i = 0, len = this.options.length; i < len; i++) {
+                formattedOptions[i] = {
+                    label: this.options[i][0],
+                    value: this.options[i][1],
+                    default: this.options[i][2],
+                };
             }
-            return formattedOptions
+            return formattedOptions;
         },
         currentValue: {
             get() {
-                return this.value
+                // My understanding of this is that if we start with a value prop, use it.
+                // If there's a defaultValue set, find it in the array and use that.
+                // If there's no default value set, use the first item in the array with 'default' set to true.
+                // Lastly, just default to the first element in the array.
+                if (this.value !== "") {
+                    return this.optArray.find((element) => element.value === this.value);
+                } else if (this.defaultValue !== "") {
+                    return this.optArray.find((element) => element.default === this.defaultValue);
+                } else {
+                    for (let i = 0, len = this.optArray.length; i < len; i++) {
+                        if (this.optArray[i].default === true) {
+                            return this.optArray[i];
+                        }
+                    }
+                    return this.optArray[0];
+                }
             },
             set(val) {
                 this.$emit("input", val.value);
             },
         },
-    },
-    // methods: {
-    //     onInputChange(value) {
-    //         // hide error message after value has changed
-    //         this.currentValue = value
-    //         console.log('helloworld"')
-    //         this.$emit("input", this.currentValue.value);
-    //     },
-    //     onSelectItem(currentValue) {
-    //         this.$emit("update:currentValue", currentValue);
-    //     },
-    // },
-    created() {
-        this.currentValue = this.optArray.find(element => element.value == this.default_value) || this.optArray[0];
     },
 };
 </script>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -10,7 +10,14 @@
         </b-alert>
         <b-row align-v="center">
             <b-col>
-                <multiselect v-model="currentValue" :options="optArray" :allow-empty="false" deselect-label="" select-label="" label="label" track-by="value" />
+                <multiselect
+                    v-model="currentValue"
+                    :options="optArray"
+                    :allow-empty="false"
+                    deselect-label=""
+                    select-label=""
+                    label="label"
+                    track-by="value" />
             </b-col>
         </b-row>
     </div>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -93,12 +93,8 @@ export default {
 };
 </script>
 <style>
-    /* .multiselect__option {
-    background: #dee2e6;
-    } */
-/* 
-    .multiselect__option--selected
-    .multiselect__option--highlight {
-    background: #dee2e6;
-    } */
+.multiselect__option--selected.multiselect__option--highlight {
+    color: #2c3143 !important;
+    background: #dee2e6 !important;
+}
 </style>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -9,15 +9,53 @@
             {{ errorMessage }}
         </b-alert>
         <b-row align-v="center">
-            <b-col>
+            <b-col v-if=" display == null">
+                <!-- Single select from drop down -->
                 <multiselect
+                    v-if=" multiple == false"
                     v-model="currentValue"
                     :options="optArray"
                     :allow-empty="false"
                     deselect-label=""
                     select-label=""
                     label="label"
-                    track-by="value" />
+                    track-by="value"> {{ currentValue }} </multiselect>
+                <!-- Multiple select from drop down -->
+                <multiselect
+                    v-else-if=" multiple == true"
+                    v-model="currentValue"
+                    :options="optArray"
+                    :multiple="true"
+                    placeholder="Select value"
+                    deselect-label=""
+                    select-label="Selected"
+                    label="label"
+                    track-by="value"
+                    >
+                </multiselect>
+            </b-col>
+            <b-col v-else-if=" display == 'radio'">
+                <b-form-group>
+                    <!-- Select single from checkboxes -->
+                    <b-form-radio-group
+                        v-if="multiple == false"
+                        v-model="currentValue"
+                        :options="optArray"
+                        text-field="label"
+                        value-field="value"
+                        stacked>
+                    </b-form-radio-group>
+
+                    <!-- Select multiple from checkboxes -->
+                    <b-form-checkbox-group
+                        v-if="multiple == true"
+                        v-model="currentValue"
+                        :options="optArray"
+                        value-field="value"
+                        text-field="label"
+                        stacked>
+                    </b-form-checkbox-group>
+                </b-form-group>
             </b-col>
         </b-row>
     </div>
@@ -33,10 +71,10 @@ export default {
     props: {
         value: {
             required: true,
-            type: String,
+            type: [String, Array],
         },
         defaultValue: {
-            type: String,
+            type: [String, Array],
             required: false,
             default: "",
         },
@@ -45,6 +83,16 @@ export default {
             required: true,
             default: undefined,
         },
+        multiple: {
+            type: Boolean,
+            required: true,
+            default: false,
+        },
+        display: {
+            type: String,
+            required: false,
+            default: null,
+        }
     },
     data() {
         return {
@@ -70,21 +118,53 @@ export default {
                 // If there's a defaultValue set, find it in the array and use that.
                 // If there's no default value set, use the first item in the array with 'default' set to true.
                 // Lastly, just default to the first element in the array.
-                if (this.value !== "") {
-                    return this.optArray.find((element) => element.value === this.value);
-                } else if (this.defaultValue !== "") {
-                    return this.optArray.find((element) => element.default === this.defaultValue);
-                } else {
-                    for (let i = 0, len = this.optArray.length; i < len; i++) {
-                        if (this.optArray[i].default === true) {
-                            return this.optArray[i];
+                if(this.multiple) { 
+                    if (this.value !== "") {
+                        let selected = [];
+                        for(var i = 0; i < this.value.length; i++){
+                            if(selected.includes(this.value[i])){
+                                selected = selected.filter((element) => element === this.value[i].value)
+                            } else {
+                                selected.push(this.optArray.find((element) => element.value === this.value[i]).value);
+                            }
                         }
+                        return selected;
+                    } else if (this.defaultValue !== "") {
+                        let selected = [];
+                        for(var i = 0; i < this.defaultValue.length; i++){
+                            selected.push(this.optArray.find((element) => element.value === this.defaultValue[i]));
+                        }
+                        return selected;
+                    } else {
+                        for (let i = 0, len = this.optArray.length; i < len; i++) {
+                            if (this.optArray[i].default === true) {
+                                return this.optArray[i];
+                            }
+                        }
+                        return this.optArray[0];
                     }
-                    return this.optArray[0];
+                } else {
+                    if (this.value !== "") {
+                        return this.optArray.find((element) => element.value === this.value);
+                    } else if (this.defaultValue !== "") {
+                        return this.optArray.find((element) => element.default === this.defaultValue);
+                    } else {
+                        for (let i = 0, len = this.optArray.length; i < len; i++) {
+                            if (this.optArray[i].default === true) {
+                                return this.optArray[i];
+                            }
+                        }
+                        return this.optArray[0];
+                    }
                 }
             },
             set(val) {
-                this.$emit("input", val.value);
+                if (this.multiple){
+                    this.$emit("input", val);
+                }
+                else {
+                    this.$emit("input", val.value);
+                }
             },
         },
     },

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -67,7 +67,6 @@ export default {
         options: {
             type: Array,
             required: true,
-            default: undefined,
         },
         multiple: {
             type: Boolean,

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -63,6 +63,7 @@ export default {
         defaultValue: {
             type: [String, Array],
             required: true,
+            default: '',
         },
         options: {
             type: Array,

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -113,7 +113,7 @@ export default {
                 if (this.value == null) {
                     return;
                 } else if (this.value !== "") {
-                    if (this.multiple && this.display != "checkboxes") {
+                    if (this.multiple && this.display !== "checkboxes") {
                         return this.selectValueMultiple(this.formattedOptions, this.value);
                     } else if (this.multiple && this.display == "checkboxes") {
                         return this.selectValueCheckboxes(this.formattedOptions, this.value);
@@ -137,7 +137,7 @@ export default {
                 if (val == null) {
                     // This case can occur when single-select dropdown is re-selected
                     return;
-                } else if (this.multiple && this.display != "checkboxes") {
+                } else if (this.multiple && this.display !== "checkboxes") {
                     const values = this.buildValuesFromFormattedOptions(val);
                     this.$emit("input", values);
                 } else if (this.display == "radio" || this.display == "checkboxes") {

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -114,22 +114,22 @@ export default {
                     return;
                 } else if (this.value !== "") {
                     if (this.multiple && this.display != "checkboxes") {
-                        return this.selectValueMultiple(this.value);
+                        return this.selectValueMultiple(this.formattedOptions, this.value);
                     } else if (this.multiple && this.display == "checkboxes") {
-                        return this.selectValueCheckboxes(this.value);
+                        return this.selectValueCheckboxes(this.formattedOptions, this.value);
                     } else if (this.display == "radio") {
-                        return this.selectValueSingle(this.value);
+                        return this.selectValueSingle(this.formattedOptions, this.value);
                     } else {
-                        return this.selectValue(this.value);
+                        return this.selectValue(this.formattedOptions, this.value);
                     }
                 } else if (this.defaultValue !== "") {
                     if (this.multiple || this.display == "checkboxes") {
-                        return this.selectValueMultiple(this.defaultValue);
+                        return this.selectValueMultiple(this.formattedOptions, this.defaultValue);
                     } else {
-                        return this.selectValue(this.defaultValue);
+                        return this.selectValue(this.formattedOptions, this.defaultValue);
                     }
                 } else {
-                    return this.selectDefaultLabelValue();
+                    return this.selectDefaultLabelValue(this.formattedOptions);
                 }
             },
             set(val) {
@@ -138,7 +138,7 @@ export default {
                     // This case can occur when single-select dropdown is re-selected
                     return;
                 } else if (this.multiple && this.display != "checkboxes") {
-                    const values = this.getValuesFromFormattedOptions(val);
+                    const values = this.buildValuesFromFormattedOptions(val);
                     this.$emit("input", values);
                 } else if (this.display == "radio" || this.display == "checkboxes") {
                     this.$emit("input", val);
@@ -149,32 +149,32 @@ export default {
         },
     },
     methods: {
-        selectValueMultiple(val) {
+        selectValueMultiple(formattedOptions, val) {
             const selectedValues = this.normalizeSelectedValues(val);
-            return this.formattedOptions.filter((option) => selectedValues.indexOf(option.value) > -1);
+            return formattedOptions.filter((option) => selectedValues.indexOf(option.value) > -1);
         },
-        selectValueCheckboxes(val) {
+        selectValueCheckboxes(formattedOptions, val) {
             const selectedValues = this.normalizeSelectedValues(val);
-            return this.formattedOptions
+            return formattedOptions
                 .filter((option) => selectedValues.indexOf(option.value) > -1)
                 .map((option) => option.value);
         },
-        selectValueSingle(val) {
-            return this.formattedOptions.find((option) => option.value === val).value;
+        selectValueSingle(formattedOptions, val) {
+            return formattedOptions.find((option) => option.value === val).value;
         },
-        selectValue(val) {
-            return this.formattedOptions.find((option) => option.value === val);
+        selectValue(formattedOptions, val) {
+            return formattedOptions.find((option) => option.value === val);
         },
-        selectDefaultLabelValue() {
+        selectDefaultLabelValue(formattedOptions) {
             // Try to find a value labeled default in the options
-            const formattedOption = [this.formattedOptions.find((option) => option.default)];
-            const selectedOption = formattedOption[0] ?? this.formattedOptions[0];
+            const formattedOption = [formattedOptions.find((option) => option.default)];
+            const selectedOption = formattedOption[0] ?? formattedOptions[0];
             return selectedOption;
         },
-        selectFirstValue() {
-            return this.formattedOptions[0];
+        selectFirstValue(formattedOptions) {
+            return formattedOptions[0];
         },
-        getValuesFromFormattedOptions(options) {
+        buildValuesFromFormattedOptions(options) {
             return Array.isArray(options) ? options.map((option) => option.value) : options;
         },
         normalizeSelectedValues(val) {

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -1,18 +1,10 @@
 <template>
     <div>
-        <b-alert
-            class="mt-2"
-            v-if="errorMessage"
-            :show="dismissCountDown"
-            variant="info"
-            @dismissed="dismissCountDown = 0">
-            {{ errorMessage }}
-        </b-alert>
         <b-row align-v="center">
-            <b-col v-if="display == 'radio'">
+            <b-col v-if="display == 'radio' || display == 'radiobutton'">
                 <b-form-group>
                     <!-- Select single from radio -->
-                    <b-form-radio-group v-model="currentValue" :options="optArray" text-field="label" stacked>
+                    <b-form-radio-group v-model="currentValue" :options="formattedOptions" text-field="label" stacked>
                     </b-form-radio-group>
                 </b-form-group>
             </b-col>
@@ -21,7 +13,7 @@
                 <b-form-group>
                     <b-form-checkbox-group
                         v-model="currentValue"
-                        :options="optArray"
+                        :options="formattedOptions"
                         value-field="value"
                         text-field="label"
                         stacked>
@@ -33,7 +25,7 @@
                 <multiselect
                     v-if="multiple"
                     v-model="currentValue"
-                    :options="optArray"
+                    :options="formattedOptions"
                     :multiple="true"
                     placeholder="Select value"
                     deselect-label=""
@@ -45,7 +37,7 @@
                 <multiselect
                     v-else
                     v-model="currentValue"
-                    :options="optArray"
+                    :options="formattedOptions"
                     deselect-label=""
                     select-label=""
                     label="label"
@@ -70,8 +62,7 @@ export default {
         },
         defaultValue: {
             type: [String, Array],
-            required: false,
-            default: null,
+            required: true,
         },
         options: {
             type: Array,
@@ -94,23 +85,17 @@ export default {
             default: null,
         },
     },
-    data() {
-        return {
-            // Currently never set?
-            errorMessage: "",
-        };
-    },
     computed: {
-        optArray() {
+        formattedOptions() {
             const formattedOptions = [];
-            for (let i = 0, len = this.options.length; i < len; i++) {
+            this.options.map((option, i) => {
                 formattedOptions[i] = {
-                    label: this.options[i][0],
-                    value: this.options[i][1],
-                    default: this.options[i][2],
+                    label: option[0],
+                    value: option[1],
+                    default: option[2],
                 };
-            }
-            if (this.multiple == false && this.optional == true) {
+            });
+            if (!this.multiple && this.optional) {
                 formattedOptions.unshift({
                     label: "Nothing selected",
                     value: null,
@@ -125,87 +110,79 @@ export default {
                 // If there's a defaultValue set, find it in the array and use that.
                 // If there's no default value set, use the first item in the array with 'default' set to true.
                 // Lastly, just default to the first element in the array.
-                if (this.multiple || this.display == "checkboxes") {
-                    if (this.value !== "") {
-                        const selected = [];
-                        if (this.value == null) {
-                            return;
-                        }
-                        let array_val = this.value;
-                        // A string is returned if single, but an array if zero or multiple
-                        if (!Array.isArray(this.value)) {
-                            array_val = [this.value];
-                        }
-                        for (var i = 0; i < array_val.length; i++) {
-                            if (this.display == "checkboxes") {
-                                selected.push(this.optArray.find((element) => element.value == array_val[i]).value);
-                            } else {
-                                selected.push(this.optArray.find((element) => element.value == array_val[i]));
-                            }
-                        }
-                        return selected;
-                    } else if (this.defaultValue !== "") {
-                        const selected = [];
-                        // Create list from default selected values
-                        for (var n = 0; n < this.defaultValue.length; n++) {
-                            selected.push(this.optArray.find((element) => element.value === this.defaultValue[n]));
-                        }
-                        return selected;
-                        // Return null if value is optional
+                if (this.value == null) {
+                    return;
+                } else if (this.value !== "") {
+                    if (this.multiple && this.display != "checkboxes") {
+                        return this.selectValueMultiple(this.value);
+                    } else if (this.multiple && this.display == "checkboxes") {
+                        return this.selectValueCheckboxes(this.value);
+                    } else if (this.display == "radio") {
+                        return this.selectValueSingle(this.value);
                     } else {
-                        // Try to find a value labeled default in the options
-                        for (let x = 0, len = this.optArray.length; x < len; x++) {
-                            if (this.optArray[x].default) {
-                                return this.optArray[x];
-                            }
-                        }
-                        // Else return first value
-                        return this.optArray[0];
+                        return this.selectValue(this.value);
                     }
-
-                    // If single select
+                } else if (this.defaultValue !== "") {
+                    if (this.multiple || this.display == "checkboxes") {
+                        return this.selectValueMultiple(this.defaultValue);
+                    } else {
+                        return this.selectValue(this.defaultValue);
+                    }
                 } else {
-                    // If value provided, use value
-                    if (this.value !== "") {
-                        if (this.value == null) {
-                            return;
-                        }
-                        if (this.display == "radio") {
-                            return this.optArray.find((element) => element.value === this.value).value;
-                        } else {
-                            return this.optArray.find((element) => element.value === this.value);
-                        }
-                        // if no value provided, use default value
-                    } else if (this.defaultValue !== "") {
-                        return this.optArray.find((element) => element.default === this.defaultValue);
-                        // If no default value provided and optional is selected, return null
-                    } else {
-                        for (let i = 0, len = this.optArray.length; i < len; i++) {
-                            if (this.optArray[i].default) {
-                                return this.optArray[i];
-                            }
-                        }
-                        // Else return first value
-                        return this.optArray[0];
-                    }
+                    return this.selectDefaultLabelValue();
                 }
             },
             set(val) {
                 // Checkbox is mutliple, but not automatically set. If it IS set, this prevents the multiple from overriding the checkbox
-                if (this.multiple && this.display != "checkboxes") {
-                    const values = [];
-                    for (var i = 0; i < val.length; i++) {
-                        values.push(val[i].value);
-                    }
+                if (val == null) {
+                    // This case can occur when single-select dropdown is re-selected
+                    return;
+                } else if (this.multiple && this.display != "checkboxes") {
+                    const values = this.getValuesFromFormattedOptions(val);
                     this.$emit("input", values);
+                } else if (this.display == "radio" || this.display == "checkboxes") {
+                    this.$emit("input", val);
                 } else {
-                    if (this.display == "radio" || this.display == "checkboxes") {
-                        this.$emit("input", val);
-                    } else {
-                        this.$emit("input", val.value);
-                    }
+                    this.$emit("input", val.value);
                 }
             },
+        },
+    },
+    methods: {
+        selectValueMultiple(val) {
+            const selectedValues = this.normalizeSelectedValues(val);
+            return this.formattedOptions.filter((option) => selectedValues.indexOf(option.value) > -1);
+        },
+        selectValueCheckboxes(val) {
+            const selectedValues = this.normalizeSelectedValues(val);
+            return this.formattedOptions
+                .filter((option) => selectedValues.indexOf(option.value) > -1)
+                .map((option) => option.value);
+        },
+        selectValueSingle(val) {
+            return this.formattedOptions.find((option) => option.value === val).value;
+        },
+        selectValue(val) {
+            return this.formattedOptions.find((option) => option.value === val);
+        },
+        selectDefaultLabelValue() {
+            // Try to find a value labeled default in the options
+            const formattedOption = [this.formattedOptions.find((option) => option.default)];
+            const selectedOption = formattedOption[0] ?? this.formattedOptions[0];
+            return selectedOption;
+        },
+        selectFirstValue() {
+            return this.formattedOptions[0];
+        },
+        getValuesFromFormattedOptions(options) {
+            return Array.isArray(options) ? options.map((option) => option.value) : options;
+        },
+        normalizeSelectedValues(val) {
+            // A string is returned if single, but an array if zero or multiple
+            return !Array.isArray(val) ? [val] : val;
+        },
+        hasArrayData(data) {
+            return Array.isArray(data) && data.length > 0;
         },
     },
 };

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -6,6 +6,7 @@ import FormParameter from "./Elements/FormParameter";
 import FormColor from "./Elements/FormColor";
 import FormDirectory from "./Elements/FormDirectory";
 import FormNumber from "./Elements/FormNumber";
+import FormSelect from "./Elements/FormSelect";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { ref, computed, useAttrs } from "vue";
 
@@ -255,6 +256,15 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 :min="attrs.min"
                 :type="type"
                 :workflow-building-mode="workflowBuildingMode" />
+            <FormSelect
+                v-else-if="type == 'select'"
+                v-model="currentValue"
+                :id="id"
+                :options="attrs.options"
+                :default-value="attrs.default_value"
+                :multiple="attrs.multiple"
+                :display="attrs.display"
+                :optional="attrs.optional" />
             <FormColor v-else-if="props.type === 'color'" :id="props.id" v-model="currentValue" />
             <FormDirectory v-else-if="props.type === 'directory_uri'" v-model="currentValue" />
             <FormParameter

--- a/client/src/style/scss/multiselect.scss
+++ b/client/src/style/scss/multiselect.scss
@@ -5,14 +5,17 @@
     background: #dee2e6;
     color: #2c3143;
 }
-.multiselect__tag {
-    background: #dee2e6;
-    color: #2c3143;
-}
-.multiselect__tag-icon:after {
-    color: white;
-}
-.multiselect__tag-icon:focus,
-.multiselect__tag-icon:hover {
+.multiselect__tag-icon:focus {
     background: #132c40;
+}
+.multiselect__option--selected.multiselect__option--highlight {
+    color: #2c3143 !important;
+    background: #dee2e6 !important;
+}
+.multiselect__tag,
+.multiselect__tag-icon::after,
+.multiselect__tag-icon:hover {
+    background: $brand-primary !important;
+    border-color: $brand-primary !important;
+    color: white !important;
 }


### PR DESCRIPTION
![screenshot_MultiSelect_Global](https://user-images.githubusercontent.com/3672779/202542591-48ca282e-664c-4988-9b8b-a56c16c1afca.gif)

### What this PR Does: 
- This PR addresses github issue #11944 
- This PR refactors a branch from the original logic by @astrovsky01 - the original logic (should) still be in place ([from this PR](https://github.com/galaxyproject/galaxy/pull/13222))
- This PR moves the CSS styling into a separate SCSS file to fulfill the Interface Segregation Principle (see: SOLID)
- This PR includes obvious fixes from the @astrovsky01 original branch while still passing the original corresponding `*.test.js` file created by @astrovsky01

### What this PR Does _Not_ Do:
- This PR does not handle functionality that should be handled in the parent component logic
- This PR does not include error messaging which (should) ideally be handled in the parent-components (like `FormElement.vue`)

#### List of Related PRs that are incorporated in this PR:
1. #13222
2. #14787
3. (all other PRs/branches prefixed as `select_vueify_v*` can be deleted)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
