### PR TITLE
Job-based chart UX improvements.

### DIFF
--- a/client/src/mvc/visualization/chart/chart-client.js
+++ b/client/src/mvc/visualization/chart/chart-client.js
@@ -10,6 +10,11 @@ import Editor from "mvc/visualization/chart/views/editor";
 import Viewer from "mvc/visualization/chart/views/viewer";
 import Menu from "mvc/visualization/chart/views/menu";
 
+/** Get boolean as string */
+function asBoolean(value) {
+    return String(value).toLowerCase() == "true";
+}
+
 export default Backbone.View.extend({
     initialize: function (options) {
         const Galaxy = getGalaxyInstance();
@@ -26,6 +31,7 @@ export default Backbone.View.extend({
         this.$buttons = this.$(".charts-buttons");
         this.chart = new Chart({}, options);
         this.chart.plugin = options.visualization_plugin;
+        this.chart.requiresConfirmation = asBoolean(this.chart.plugin.specs.confirm);
         this.chart.plugin.specs = this.chart.plugin.specs || {};
         this.chart_load = options.chart_load;
         this.message = new Ui.Message();

--- a/client/src/mvc/visualization/chart/views/menu.js
+++ b/client/src/mvc/visualization/chart/views/menu.js
@@ -5,7 +5,7 @@ import Ui from "mvc/ui/ui-misc";
 export default Backbone.View.extend({
     initialize: function (app) {
         this.app = app;
-        this.model = new Backbone.Model({ visible: false });
+        this.model = new Backbone.Model({ visible: true });
         this.execute_button = new Ui.Button({
             icon: "fa-check-square",
             tooltip: "Confirm",

--- a/client/src/mvc/visualization/chart/views/menu.js
+++ b/client/src/mvc/visualization/chart/views/menu.js
@@ -5,7 +5,7 @@ import Ui from "mvc/ui/ui-misc";
 export default Backbone.View.extend({
     initialize: function (app) {
         this.app = app;
-        this.model = new Backbone.Model({ visible: true });
+        this.model = new Backbone.Model({ visible: app.chart.requiresConfirmation });
         this.execute_button = new Ui.Button({
             icon: "fa-check-square",
             tooltip: "Confirm",

--- a/client/src/mvc/visualization/chart/views/viewer.js
+++ b/client/src/mvc/visualization/chart/views/viewer.js
@@ -36,7 +36,10 @@ export default Backbone.View.extend({
                     self._draw(process, self.chart);
                 });
             } else {
-                self.chart.state("info", "Please confirm the settings before rendering the results.");
+                self.chart.state(
+                    "info",
+                    "Please review the chart settings in the menu to the right and select 'Confirm' to render the visualization."
+                );
             }
         });
         this.chart.on("set:state", function () {

--- a/client/src/mvc/visualization/chart/views/viewer.js
+++ b/client/src/mvc/visualization/chart/views/viewer.js
@@ -30,7 +30,7 @@ export default Backbone.View.extend({
         this.$text = this.$(".text");
         this._fullscreen(this.$el, 20);
         this.chart.on("redraw", function (confirmed) {
-            if (!self.chart.get("modified") || !self._asBoolean(self.chart.plugin.specs.confirm) || confirmed) {
+            if (!self.chart.get("modified") || !self.chart.requiresConfirmation || confirmed) {
                 self.app.deferred.execute(function (process) {
                     console.debug("viewer:redraw() - Redrawing...");
                     self._draw(process, self.chart);
@@ -69,11 +69,6 @@ export default Backbone.View.extend({
                     $container.show();
             }
         });
-    },
-
-    /** Get boolean as string */
-    _asBoolean: function (value) {
-        return String(value).toLowerCase() == "true";
     },
 
     /** Force resize to fullscreen */


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/issues/15011

Clarifies info message when chart configuration needs confirm prior to running, and has the settings window for charts open by default when using a charts plugin that requires confirmation.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
