### PR TITLE
Convert radio button to vue

### DIFF
--- a/client/src/components/Form/Elements/FormRadio.test.js
+++ b/client/src/components/Form/Elements/FormRadio.test.js
@@ -1,0 +1,39 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import MountTarget from "./FormRadio";
+
+const localVue = getLocalVue(true);
+
+describe("FormRadio", () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = mount(MountTarget, {
+            propsData: {
+                value: false,
+                options: [],
+            },
+            localVue,
+        });
+    });
+
+    it("basics", async () => {
+        const noInput = wrapper.find("[type='radio']");
+        expect(noInput.exists()).toBe(false);
+        const n = 3;
+        const options = [];
+        for (let i = 0; i < n; i++) {
+            options.push([`label_${i}`, `value_${i}`]);
+        }
+        await wrapper.setProps({ options });
+        const inputs = wrapper.findAll("[type='radio']");
+        const labels = wrapper.findAll(".custom-control-label");
+        expect(inputs.length).toBe(n);
+        for (let i = 0; i < n; i++) {
+            await inputs.at(i).setChecked();
+            expect(labels.at(i).text()).toBe(`label_${i}`);
+            expect(inputs.at(i).attributes("value")).toBe(`value_${i}`);
+            expect(wrapper.emitted()["input"][i][0]).toBe(`value_${i}`);
+        }
+    });
+});

--- a/client/src/components/Form/Elements/FormRadio.vue
+++ b/client/src/components/Form/Elements/FormRadio.vue
@@ -1,0 +1,32 @@
+<script setup>
+import Multiselect from "vue-multiselect";
+import { computed, defineProps, defineEmits } from "vue";
+
+const $emit = defineEmits(["input"]);
+const props = defineProps({
+    value: {
+        default: null,
+    },
+    options: {
+        type: Array,
+        required: true,
+    },
+});
+
+const currentValue = computed({
+    get: () => {
+        return props.value;
+    },
+    set: (val) => {
+        $emit("input", val);
+    },
+});
+</script>
+
+<template>
+    <b-form-radio-group v-model="currentValue" stacked>
+        <b-form-radio v-for="(option, index) in options" :key="index" :value="option[1]">
+            {{ option[0] }}
+        </b-form-radio>
+    </b-form-radio-group>
+</template>

--- a/client/src/components/Form/Elements/FormRadio.vue
+++ b/client/src/components/Form/Elements/FormRadio.vue
@@ -1,5 +1,4 @@
 <script setup>
-import Multiselect from "vue-multiselect";
 import { computed, defineProps, defineEmits } from "vue";
 
 const $emit = defineEmits(["input"]);

--- a/client/src/components/Form/Elements/FormSelection.vue
+++ b/client/src/components/Form/Elements/FormSelection.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { computed, defineProps, defineEmits } from "vue";
+import FormRadio from "./FormRadio";
+
+const $emit = defineEmits(["input"]);
+const props = defineProps({
+    value: {
+        default: null,
+    },
+    data: {
+        type: Array,
+        default: null,
+    },
+    display: {
+        type: String,
+        default: null,
+    },
+    options: {
+        type: Array,
+        default: null,
+    },
+    multiple: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const currentValue = computed({
+    get: () => {
+        return props.value;
+    },
+    set: (val) => {
+        $emit("input", val);
+    },
+});
+
+/** Provides formatted select options. */
+const currentOptions = computed(() => {
+    const data = props.data;
+    const options = props.options;
+    if (options && options.length > 0) {
+        return options;
+    } else if (data && data.length > 0) {
+        return data.map((option) => {
+            return [option.label, option.value];
+        });
+    }
+    return [];
+});
+</script>
+
+<template>
+    <form-radio v-if="display == 'radio'" v-model="currentValue" :options="currentOptions" />
+</template>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -144,6 +144,18 @@ function onConnect() {
     }
 }
 
+/** Format select options. */
+function formatOptions(options, data) {
+    if (options && options.length > 0) {
+        return options;
+    } else if (data && data.length > 0) {
+        return data.map((option) => {
+            return [option.label, option.value];
+        });
+    }
+    return [];
+}
+
 const isHidden = computed(() => attrs.value["hidden"]);
 const elementId = computed(() => `form-element-${props.id}`);
 const hasError = computed(() => Boolean(props.error));
@@ -260,7 +272,7 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 v-else-if="props.type == 'select' && attrs.display == 'radio'"
                 v-model="currentValue"
                 :id="id"
-                :options="attrs.options" />
+                :options="formatOptions(attrs.options, attrs.data)" />
             <FormColor v-else-if="props.type === 'color'" :id="props.id" v-model="currentValue" />
             <FormDirectory v-else-if="props.type === 'directory_uri'" v-model="currentValue" />
             <FormParameter

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -144,18 +144,6 @@ function onConnect() {
     }
 }
 
-/** Format select options. */
-function formatOptions(options, data) {
-    if (options && options.length > 0) {
-        return options;
-    } else if (data && data.length > 0) {
-        return data.map((option) => {
-            return [option.label, option.value];
-        });
-    }
-    return [];
-}
-
 const isHidden = computed(() => attrs.value["hidden"]);
 const elementId = computed(() => `form-element-${props.id}`);
 const hasError = computed(() => Boolean(props.error));
@@ -179,6 +167,20 @@ const currentValue = computed({
     set(val) {
         setValue(val);
     },
+});
+
+/** Provides formatted select options. */
+const currentOptions = computed(() => {
+    const data = attrs.value["data"];
+    const options = attrs.value["options"];
+    if (options && options.length > 0) {
+        return options;
+    } else if (data && data.length > 0) {
+        return data.map((option) => {
+            return [option.label, option.value];
+        });
+    }
+    return [];
 });
 
 const isHiddenType = computed(
@@ -272,7 +274,7 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 v-else-if="props.type == 'select' && attrs.display == 'radio'"
                 v-model="currentValue"
                 :id="id"
-                :options="formatOptions(attrs.options, attrs.data)" />
+                :options="currentOptions" />
             <FormColor v-else-if="props.type === 'color'" :id="props.id" v-model="currentValue" />
             <FormDirectory v-else-if="props.type === 'directory_uri'" v-model="currentValue" />
             <FormParameter

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -3,6 +3,7 @@ import FormBoolean from "./Elements/FormBoolean";
 import FormHidden from "./Elements/FormHidden";
 import FormInput from "./Elements/FormInput";
 import FormParameter from "./Elements/FormParameter";
+import FormRadio from "./Elements/FormRadio";
 import FormColor from "./Elements/FormColor";
 import FormDirectory from "./Elements/FormDirectory";
 import FormNumber from "./Elements/FormNumber";
@@ -255,6 +256,11 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 :min="attrs.min"
                 :type="type"
                 :workflow-building-mode="workflowBuildingMode" />
+            <FormRadio
+                v-else-if="props.type == 'select' && attrs.display == 'radio'"
+                v-model="currentValue"
+                :id="id"
+                :options="attrs.options" />
             <FormColor v-else-if="props.type === 'color'" :id="props.id" v-model="currentValue" />
             <FormDirectory v-else-if="props.type === 'directory_uri'" v-model="currentValue" />
             <FormParameter

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -3,7 +3,7 @@ import FormBoolean from "./Elements/FormBoolean";
 import FormHidden from "./Elements/FormHidden";
 import FormInput from "./Elements/FormInput";
 import FormParameter from "./Elements/FormParameter";
-import FormRadio from "./Elements/FormRadio";
+import FormSelection from "./Elements/FormSelection";
 import FormColor from "./Elements/FormColor";
 import FormDirectory from "./Elements/FormDirectory";
 import FormNumber from "./Elements/FormNumber";
@@ -169,20 +169,6 @@ const currentValue = computed({
     },
 });
 
-/** Provides formatted select options. */
-const currentOptions = computed(() => {
-    const data = attrs.value["data"];
-    const options = attrs.value["options"];
-    if (options && options.length > 0) {
-        return options;
-    } else if (data && data.length > 0) {
-        return data.map((option) => {
-            return [option.label, option.value];
-        });
-    }
-    return [];
-});
-
 const isHiddenType = computed(
     () => ["hidden", "hidden_data", "baseurl"].includes(props.type) || (props.attributes && props.attributes.titleonly)
 );
@@ -270,11 +256,15 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 :min="attrs.min"
                 :type="type"
                 :workflow-building-mode="workflowBuildingMode" />
-            <FormRadio
+            <FormSelection
                 v-else-if="props.type == 'select' && attrs.display == 'radio'"
                 v-model="currentValue"
                 :id="id"
-                :options="currentOptions" />
+                :data="attrs.data"
+                :display="attrs.display"
+                :options="attrs.options"
+                :optional="attrs.optional"
+                :multiple="attrs.multiple" />
             <FormColor v-else-if="props.type === 'color'" :id="props.id" v-model="currentValue" />
             <FormDirectory v-else-if="props.type === 'directory_uri'" v-model="currentValue" />
             <FormParameter


### PR DESCRIPTION
Exploring options to separate out individual select field variations to simplify the migration process. Suggesting to create individual independent components for radio buttons as demonstrated here, with the goal to follow-up on creating another component for checkboxes and then actual dropdown-selects.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
