### PR TITLE
Fix history_id fixture naming error

### DIFF
--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -189,7 +189,7 @@ class IntegrationInstance(UsesApiTestCaseMixin, UsesCeleryTasks):
         return os.path.realpath(os.path.join(cls._test_driver.galaxy_test_tmp_dir, name))
 
     @pytest.fixture
-    def history_id(self) -> Iterator[str]:
+    def history_id_(self) -> Iterator[str]:
         assert self.dataset_populator
         with self.dataset_populator.test_history() as history_id:
             yield history_id

--- a/test/integration/test_apache_nginx_sendfile.py
+++ b/test/integration/test_apache_nginx_sendfile.py
@@ -15,7 +15,8 @@ class TestNginxAccelHeader(IntegrationTestCase):
     def handle_galaxy_config_kwds(cls, config):
         config["nginx_x_accel_redirect_base"] = "/redirect"
 
-    def test_dataset_download(self, history_id):
+    def test_dataset_download(self, history_id_):
+        history_id = history_id_
         hda = self.dataset_populator.new_dataset(history_id=history_id, wait=True)
         head_response = self._head(f"histories/{history_id}/contents/{hda['id']}/display", {"raw": "True"})
         self._assert_status_code_is(head_response, 200)
@@ -37,7 +38,8 @@ class TestApacheSendFileHeader(IntegrationTestCase):
     def handle_galaxy_config_kwds(cls, config):
         config["apache_xsendfile"] = True
 
-    def test_dataset_download(self, history_id):
+    def test_dataset_download(self, history_id_):
+        history_id = history_id_
         hda = self.dataset_populator.new_dataset(history_id=history_id, wait=True)
         head_response = self._head(f"histories/{history_id}/contents/{hda['id']}/display", {"raw": "True"})
         self._assert_status_code_is(head_response, 200)

--- a/test/integration/test_async_downloads.py
+++ b/test/integration/test_async_downloads.py
@@ -19,7 +19,8 @@ class TestAsyncDownloadsIntegration(IntegrationTestCase):
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
     @pytest.mark.require_new_history
-    def test_async_collection_download(self, history_id):
+    def test_async_collection_download(self, history_id_):
+        history_id = history_id_
         fetch_response = self.dataset_collection_populator.create_list_in_history(history_id, direct_upload=True).json()
         dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
         returned_dce = dataset_collection["elements"]

--- a/test/integration/test_extended_metadata_mapping.py
+++ b/test/integration/test_extended_metadata_mapping.py
@@ -23,7 +23,8 @@ class TestExtendedMetadataMappingIntegration(integration_util.IntegrationTestCas
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
-    def test_map_over_collection(self, history_id):
+    def test_map_over_collection(self, history_id_):
+        history_id = history_id_
         hdca_id = self._build_pair(history_id, ["123", "456"])
         inputs = {
             "input1": {"batch": True, "values": [{"src": "hdca", "id": hdca_id}]},

--- a/test/integration/test_materialize_dataset_instance_tasks.py
+++ b/test/integration/test_materialize_dataset_instance_tasks.py
@@ -38,7 +38,8 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
     @pytest.mark.require_new_history
-    def test_materialize_history_dataset(self, history_id: str):
+    def test_materialize_history_dataset(self, history_id_: str):
+        history_id = history_id_
         as_list = self.dataset_populator.create_contents_from_store(
             history_id,
             store_dict=deferred_hda_model_store_dict(),
@@ -58,7 +59,8 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         assert not new_hda_details["deleted"]
 
     @pytest.mark.require_new_history
-    def test_materialize_gxfiles_uri(self, history_id: str):
+    def test_materialize_gxfiles_uri(self, history_id_: str):
+        history_id = history_id_
         as_list = self.dataset_populator.create_contents_from_store(
             history_id,
             store_dict=deferred_hda_model_store_dict(source_uri="gxfiles://testdatafiles/2.bed"),
@@ -79,7 +81,8 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         assert not new_hda_details["deleted"]
 
     @pytest.mark.require_new_history
-    def test_materialize_history_dataset_bam(self, history_id: str):
+    def test_materialize_history_dataset_bam(self, history_id_: str):
+        history_id = history_id_
         as_list = self.dataset_populator.create_contents_from_store(
             history_id,
             store_dict=deferred_hda_model_store_dict_bam(),
@@ -111,7 +114,8 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         assert "metadata_bam_index" in new_hda_details
 
     @pytest.mark.require_new_history
-    def test_materialize_library_dataset(self, history_id: str):
+    def test_materialize_library_dataset(self, history_id_: str):
+        history_id = history_id_
         response = self.library_populator.create_from_store(store_dict=one_ld_library_deferred_model_store_dict())
         assert isinstance(response, list)
         assert len(response) == 1
@@ -130,7 +134,8 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         assert not new_hda_details["deleted"]
 
     @pytest.mark.require_new_history
-    def test_upload_vs_materialize_simplest_upload(self, history_id: str):
+    def test_upload_vs_materialize_simplest_upload(self, history_id_: str):
+        history_id = history_id_
         item = {"src": "url", "url": "gxfiles://testdatafiles//simple_line_no_newline.txt", "ext": "txt"}
         output = self.dataset_populator.fetch_hda(history_id, item)
         uploaded_details = self.dataset_populator.get_history_dataset_details(
@@ -145,7 +150,8 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         assert content == "This is a line of text."
 
     @pytest.mark.require_new_history
-    def test_upload_vs_materialize_to_posix_lines(self, history_id: str):
+    def test_upload_vs_materialize_to_posix_lines(self, history_id_: str):
+        history_id = history_id_
         item = {
             "src": "url",
             "url": "gxfiles://testdatafiles//simple_line_no_newline.txt",
@@ -171,7 +177,8 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         assert content == "This is a line of text.\n"
 
     @pytest.mark.require_new_history
-    def test_upload_vs_materialize_space_to_tab(self, history_id: str):
+    def test_upload_vs_materialize_space_to_tab(self, history_id_: str):
+        history_id = history_id_
         item = {
             "src": "url",
             "url": "gxfiles://testdatafiles//simple_line_no_newline.txt",
@@ -197,7 +204,8 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         assert content == "This\tis\ta\tline\tof\ttext."
 
     @pytest.mark.require_new_history
-    def test_upload_vs_materialize_to_posix_and_space_to_tab(self, history_id: str):
+    def test_upload_vs_materialize_to_posix_and_space_to_tab(self, history_id_: str):
+        history_id = history_id_
         item = {
             "src": "url",
             "url": "gxfiles://testdatafiles//simple_line_no_newline.txt",
@@ -224,7 +232,8 @@ class TestMaterializeDatasetInstanceTasaksIntegration(IntegrationTestCase, UsesC
         assert content == "This\tis\ta\tline\tof\ttext.\n"
 
     @pytest.mark.require_new_history
-    def test_upload_vs_materialize_grooming(self, history_id: str):
+    def test_upload_vs_materialize_grooming(self, history_id_: str):
+        history_id = history_id_
         item = {
             "src": "url",
             "url": "gxfiles://testdatafiles/qname_sorted.bam",


### PR DESCRIPTION
This fixes 91 mypy errors caused by a bug introduced in #14679. (discovered while working on #15004; similar set of errors can be triggered by running `mypy lib test` from the galaxy venv).

The new `history_id` pytest fixture ([see `integration_utils.py`](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy_test/driver/integration_util.py#L192)) conflicts with `history_id` instance variables [like this one](https://github.com/galaxyproject/galaxy/blob/dev/test/integration/test_upload_configuration_options.py#L57).

The proposed solution renames the fixture as `history_id_`.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
