### PR TITLE
fix textarea height to make it resizeable

### DIFF
--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -245,7 +245,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
 
 .ui-textarea {
     @extend .ui-input;
-    height: 100px !important;
+    min-height: 100px !important;
 }
 
 .ui-switch {


### PR DESCRIPTION
HTML tag <textarea> is used e.g. in editing the markdown of workflow reports. The field in which the markdown can be edited is restricted to a 100px size so it's almost impossible to properly work in a longer report.
Changing the `.ui-textarea` class in the UI style sheet allows the user to enlarge the textarea field, but ensures a minimum height of 100px.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Navigate to User > Workflow Invocations
  2. Expand any of the workflow invocations
  3. Click on View Report
  4. In case the report is not erroneous, click the "Edit Markdown" icon at the top right
  5. The content field in the bottom displays the actual markdown and is now resizeable to more than 100px for a better overview.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
