### PR TITLE
Add slack error reporting plugin

### DIFF
--- a/lib/galaxy/config/sample/error_report.yml.sample
+++ b/lib/galaxy/config/sample/error_report.yml.sample
@@ -88,3 +88,11 @@
 #   gitlab_labels:
 #     - Label1
 #     - Label2
+
+# Slack error reporting backend. You'll need to create an "app" which is added
+# to your workspace, and configure it for a Webhook URL with a specific channel.
+# Then upon activation it will send a new message for each error report to your slack.
+# - type: slack
+#   verbose: false
+#   user_submission: true
+#   webhook_url: "https://hooks.slack.com/services/..."

--- a/lib/galaxy/config/sample/error_report.yml.sample
+++ b/lib/galaxy/config/sample/error_report.yml.sample
@@ -92,6 +92,7 @@
 # Slack error reporting backend. You'll need to create an "app" which is added
 # to your workspace, and configure it for a Webhook URL with a specific channel.
 # Then upon activation it will send a new message for each error report to your slack.
+# See https://api.slack.com/messaging/webhooks for more information.
 # - type: slack
 #   verbose: false
 #   user_submission: true

--- a/lib/galaxy/tools/error_reports/plugins/slack.py
+++ b/lib/galaxy/tools/error_reports/plugins/slack.py
@@ -1,6 +1,10 @@
 """The module describes the ``slack`` error plugin plugin."""
 import logging
 import uuid
+from typing import (
+    Any,
+    Dict,
+)
 
 import requests
 
@@ -38,7 +42,7 @@ class SlackPlugin(BaseGitPlugin):
         error_report_id = str(uuid.uuid4())[0:13]
         title = self._generate_error_title(job)
 
-        blocks = {
+        blocks: Dict[str, Any] = {
             "blocks": [
                 {
                     "type": "section",

--- a/lib/galaxy/tools/error_reports/plugins/slack.py
+++ b/lib/galaxy/tools/error_reports/plugins/slack.py
@@ -1,0 +1,105 @@
+"""The module describes the ``slack`` error plugin plugin."""
+import logging
+import uuid
+
+import requests
+
+from galaxy import web
+from galaxy.util import string_as_bool
+from .base_git import BaseGitPlugin
+
+log = logging.getLogger(__name__)
+
+
+class SlackPlugin(BaseGitPlugin):
+    """Send error report to Sentry."""
+
+    plugin_type = "slack"
+
+    def __init__(self, **kwargs):
+        self.app = kwargs["app"]
+        self.redact_user_details_in_bugreport = self.app.config.redact_user_details_in_bugreport
+        self.verbose = string_as_bool(kwargs.get("verbose", False))
+        self.user_submission = string_as_bool(kwargs.get("user_submission", False))
+        self.webhook_url = kwargs.get("webhook_url", "https://localhost/")
+
+    def _append_issue(self, *args, **kwargs):
+        pass
+
+    def _create_issue(self, *args, **kwargs):
+        pass
+
+    def _fill_issue_cache(self, *args, **kwargs):
+        pass
+
+    def submit_report(self, dataset, job, tool, **kwargs):
+        history_id_encoded = self.app.security.encode_id(dataset.history_id)
+        history_view_link = web.url_for("/histories/view", id=history_id_encoded, qualified=True)
+        error_report_id = str(uuid.uuid4())[0:13]
+        title = self._generate_error_title(job)
+
+        blocks = {
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"You have a new Galaxy bug report:\n*<{history_view_link}|{title}>*",
+                    },
+                },
+            ]
+        }
+
+        if "message" in kwargs and kwargs["message"] is not None:
+            message = kwargs["message"].strip().replace("\n", "\n> ")
+            blocks["blocks"].extend(
+                [{"type": "section", "text": {"type": "mrkdwn", "text": f"*Message*\n> {message}```"}}]
+            )
+
+        blocks["blocks"].extend(
+            [
+                {
+                    "type": "section",
+                    "fields": [
+                        {"type": "mrkdwn", "text": f"*Error Report ID:*\n`{error_report_id}`"},
+                        {"type": "mrkdwn", "text": f"*ID:*\n{job.id}"},
+                        {"type": "mrkdwn", "text": f"*Destination ID:*\n{job.destination_id}"},
+                        {"type": "mrkdwn", "text": f"*Exit Code:*\n{job.exit_code}"},
+                        {"type": "mrkdwn", "text": f"*Handler:*\n{job.handler}"},
+                        {"type": "mrkdwn", "text": f"*Tool Version:*\n{job.tool_version}"},
+                        {"type": "mrkdwn", "text": f"*User:*\n{job.get_user().id}"},
+                    ],
+                },
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": f"*Command Line:*\n```\n{job.command_line[0:2800]}\n```"},
+                },
+            ]
+        )
+
+        if job.stdout:
+            blocks["blocks"].extend(
+                [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": f"*Stdout*\n```\n{job.stdout.strip()[0:2800]}\n```"},
+                    }
+                ]
+            )
+
+        if job.stderr:
+            blocks["blocks"].extend(
+                [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": f"*Stderr*\n```\n{job.stderr.strip()[0:2800]}\n```"},
+                    }
+                ]
+            )
+
+        requests.post(self.webhook_url, json=blocks)
+        return (f"Sent report to Slack with ID: {error_report_id}", "success")
+
+
+__all__ = ("SlackPlugin",)


### PR DESCRIPTION
Fixes #15022. Adds a new slack-based error reporter, similar to the github/gitlab/etc.

![screenshot of the message in a slack channel reporting all relevant fields](https://user-images.githubusercontent.com/458683/202739177-1c3ff545-aaa2-426b-a1cb-4a14bf981d3b.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Setup a webhook URL in a slack workspace
  2. configure the plugin


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
