### PR TITLE
Add documentation statement to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 - [ ] This is a refactoring of components with existing test coverage.
 - [ ] Instructions for manual testing are as follows:
   1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
+- [ ] New or changed functionality is sufficiently documented
 
 ## License
 - [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Galaxy is in many parts well documented. But it could be improved. 

For instance admin stuff:

- https://github.com/galaxyproject/galaxy/issues/12272
- https://github.com/galaxyproject/galaxy/issues/14068

Also doc strings of functions and classes. To me coding in Galaxy too often feels like guessing around and detective work. 
This is because it is mostly not documented what a function/class is supposed to do, what the parameters/return values are and how they influence the function. Tests and type hints (if available) often help a bit but should not replace docs.  Also digging out commit messages and reading discussions of PRs should not be necessary.

My suggestion would be add a checkbox analogous to the test question to the PR template in order to nudge contributors to add at least rudimentary documentation. 

We probably should also add something like https://github.com/galaxyproject/galaxy/issues/10348 here?





## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
