### PR TITLE
Infrastructure for indicating Galaxy features being used by tests.

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -367,11 +367,13 @@ class GalaxyInteractorApi:
             return None
 
     @contextlib.contextmanager
-    def test_history(self, require_new: bool = True, cleanup_callback: Optional[Callable[[str], None]] = None) -> Generator[str, None, None]:
+    def test_history(
+        self, require_new: bool = True, cleanup_callback: Optional[Callable[[str], None]] = None
+    ) -> Generator[str, None, None]:
+        history_id = None
         if not require_new:
             history_id = DEFAULT_TARGET_HISTORY
 
-        history_id = history_id or self.new_history()
         cleanup = CLEANUP_TEST_HISTORIES
         history_id = history_id or self.new_history()
         try:

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1,3 +1,4 @@
+import contextlib
 import io
 import json
 import os
@@ -15,6 +16,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Generator,
     List,
     NamedTuple,
     Optional,
@@ -48,6 +50,8 @@ VERBOSE_ERRORS = util.asbool(os.environ.get("GALAXY_TEST_VERBOSE_ERRORS", False)
 UPLOAD_ASYNC = util.asbool(os.environ.get("GALAXY_TEST_UPLOAD_ASYNC", True))
 ERROR_MESSAGE_DATASET_SEP = "--------------------------------------"
 DEFAULT_TOOL_TEST_WAIT = int(os.environ.get("GALAXY_TEST_DEFAULT_WAIT", 86400))
+CLEANUP_TEST_HISTORIES = "GALAXY_TEST_NO_CLEANUP" not in os.environ
+DEFAULT_TARGET_HISTORY = os.environ.get("GALAXY_TEST_HISTORY_ID", None)
 
 DEFAULT_FTYPE = "auto"
 # This following default dbkey was traditionally hg17 before Galaxy 18.05,
@@ -362,12 +366,29 @@ class GalaxyInteractorApi:
         except IndexError:
             return None
 
+    @contextlib.contextmanager
+    def test_history(self, require_new: bool = True, cleanup_callback: Optional[Callable[[str], None]] = None) -> Generator[str, None, None]:
+        if not require_new:
+            history_id = DEFAULT_TARGET_HISTORY
+
+        history_id = history_id or self.new_history()
+        cleanup = CLEANUP_TEST_HISTORIES
+        history_id = history_id or self.new_history()
+        try:
+            yield history_id
+        except Exception:
+            self._summarize_history(history_id)
+            raise
+        finally:
+            if cleanup and cleanup_callback is not None:
+                cleanup_callback(history_id)
+
     def new_history(self, history_name="test_history", publish_history=False):
         create_response = self._post("histories", {"name": history_name})
         try:
             create_response.raise_for_status()
         except Exception as e:
-            raise Exception(f"Error occured while creating history with name '{history_name}': {e}")
+            raise Exception(f"Error occurred while creating history with name '{history_name}': {e}")
         history_id = create_response.json()["id"]
         if publish_history:
             self.publish_history(history_id)
@@ -633,7 +654,7 @@ class GalaxyInteractorApi:
                 self._summarize_history(history_id)
             raise
 
-    def _summarize_history(self, history_id):
+    def _summarize_history(self, history_id: str):
         if history_id is None:
             raise ValueError("_summarize_history passed empty history_id")
         print(f"Problem in history with id {history_id} - summary of history's datasets and jobs below.")

--- a/lib/galaxy_test/api/_framework.py
+++ b/lib/galaxy_test/api/_framework.py
@@ -10,7 +10,6 @@ from galaxy_test.base.api import (
     UsesApiTestCaseMixin,
     UsesCeleryTasks,
 )
-from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.base.testcase import FunctionalTestCase
 
 try:
@@ -24,7 +23,6 @@ except ImportError:
 class ApiTestCase(FunctionalTestCase, UsesApiTestCaseMixin, UsesCeleryTasks):
     galaxy_driver_class = GalaxyTestDriver
     _test_driver: Optional[GalaxyTestDriver]
-    dataset_populator: Optional[DatasetPopulator]
 
     def setUp(self):
         super().setUp()
@@ -37,8 +35,7 @@ class ApiTestCase(FunctionalTestCase, UsesApiTestCaseMixin, UsesCeleryTasks):
 
     @pytest.fixture
     def history_id(self) -> Iterator[str]:
-        assert self.dataset_populator
-        with self.dataset_populator.test_history() as history_id:
+        with self.galaxy_interactor.test_history() as history_id:
             yield history_id
 
 

--- a/lib/galaxy_test/api/test_authenticate.py
+++ b/lib/galaxy_test/api/test_authenticate.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 from requests import get
 
 from galaxy_test.base.api_util import baseauth_headers
+from galaxy_test.base.decorators import requires_new_user
 from ._framework import ApiTestCase
 
 TEST_USER_EMAIL = "auth_user_test@bx.psu.edu"
@@ -10,6 +11,7 @@ TEST_USER_PASSWORD = "testpassword1"
 
 
 class TestAuthenticateApi(ApiTestCase):
+    @requires_new_user
     def test_auth(self):
         self._setup_user(TEST_USER_EMAIL, TEST_USER_PASSWORD)
         baseauth_url = self._api_url("authenticate/baseauth", use_key=False)

--- a/lib/galaxy_test/api/test_configuration.py
+++ b/lib/galaxy_test/api/test_configuration.py
@@ -3,6 +3,7 @@ from galaxy_test.base.api_asserts import (
     assert_not_has_keys,
 )
 from galaxy_test.base.api_util import TEST_USER
+from galaxy_test.base.decorators import requires_admin
 from ._framework import ApiTestCase
 
 TEST_KEYS_FOR_ALL_USERS = [
@@ -33,6 +34,7 @@ class TestConfigurationApi(ApiTestCase):
         assert_has_keys(config, *TEST_KEYS_FOR_ALL_USERS)
         assert_not_has_keys(config, *TEST_KEYS_FOR_ADMIN_ONLY)
 
+    @requires_admin
     def test_admin_user_configuration(self):
         config = self._get_configuration(admin=True)
         assert_has_keys(config, *TEST_KEYS_FOR_ALL_USERS)

--- a/lib/galaxy_test/api/test_container_resolution.py
+++ b/lib/galaxy_test/api/test_container_resolution.py
@@ -1,19 +1,23 @@
+from galaxy_test.base.decorators import requires_admin
 from galaxy_test.base.populators import skip_without_tool
 from ._framework import ApiTestCase
 
 
 class TestContainerResolutionApi(ApiTestCase):
+    @requires_admin
     def test_index(self):
         response = self._get("container_resolvers", admin=True)
         assert response.status_code == 200
         assert isinstance(response.json(), list)
 
+    @requires_admin
     def test_show(self):
         response = self._get("container_resolvers/0", admin=True)
         assert response.status_code == 200
         assert isinstance(response.json(), dict)
 
     @skip_without_tool("cat1")
+    @requires_admin
     def test_resolve(self):
         tool_id = "cat1"
 

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -100,7 +100,9 @@ class TestDatasetCollectionsApi(ApiTestCase):
 
     def test_list_download(self):
         with self.dataset_populator.test_history(require_new=False) as history_id:
-            fetch_response = self.dataset_collection_populator.create_list_in_history(history_id, direct_upload=True).json()
+            fetch_response = self.dataset_collection_populator.create_list_in_history(
+                history_id, direct_upload=True
+            ).json()
             dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
             returned_dce = dataset_collection["elements"]
             assert len(returned_dce) == 3, dataset_collection
@@ -115,7 +117,9 @@ class TestDatasetCollectionsApi(ApiTestCase):
 
     def test_pair_download(self):
         with self.dataset_populator.test_history(require_new=False) as history_id:
-            fetch_response = self.dataset_collection_populator.create_pair_in_history(history_id, direct_upload=True).json()
+            fetch_response = self.dataset_collection_populator.create_pair_in_history(
+                history_id, direct_upload=True
+            ).json()
             dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
             returned_dce = dataset_collection["elements"]
             assert len(returned_dce) == 2, dataset_collection

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -19,315 +19,331 @@ class TestDatasetCollectionsApi(ApiTestCase):
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
-    def test_create_pair_from_history(self, history_id):
-        payload = self.dataset_collection_populator.create_pair_payload(
-            history_id,
-            instance_type="history",
-        )
-        create_response = self.dataset_populator.fetch(payload, wait=True)
-        dataset_collection = self._check_create_response(create_response)
-        returned_datasets = dataset_collection["elements"]
-        assert len(returned_datasets) == 2, dataset_collection
-
-    def test_create_list_from_history(self, history_id):
-        element_identifiers = self.dataset_collection_populator.list_identifiers(history_id)
-
-        payload = dict(
-            instance_type="history",
-            history_id=history_id,
-            element_identifiers=element_identifiers,
-            collection_type="list",
-        )
-
-        create_response = self._post("dataset_collections", payload, json=True)
-        dataset_collection = self._check_create_response(create_response)
-        returned_datasets = dataset_collection["elements"]
-        assert len(returned_datasets) == 3, dataset_collection
-
-    def test_create_list_of_existing_pairs(self, history_id):
-        pair_payload = self.dataset_collection_populator.create_pair_payload(
-            history_id,
-            instance_type="history",
-        )
-        pair_create_response = self._post("tools/fetch", pair_payload, json=True)
-        dataset_collection = self._check_create_response(pair_create_response)
-        hdca_id = dataset_collection["id"]
-
-        element_identifiers = [dict(name="test1", src="hdca", id=hdca_id)]
-
-        payload = dict(
-            instance_type="history",
-            history_id=history_id,
-            element_identifiers=element_identifiers,
-            collection_type="list",
-        )
-        create_response = self._post("dataset_collections", payload, json=True)
-        dataset_collection = self._check_create_response(create_response)
-        returned_collections = dataset_collection["elements"]
-        assert len(returned_collections) == 1, dataset_collection
-
-    def test_create_list_of_new_pairs(self, history_id):
-        identifiers = self.dataset_collection_populator.nested_collection_identifiers(history_id, "list:paired")
-        payload = dict(
-            collection_type="list:paired",
-            instance_type="history",
-            history_id=history_id,
-            name="a nested collection",
-            element_identifiers=identifiers,
-        )
-        create_response = self._post("dataset_collections", payload, json=True)
-        dataset_collection = self._check_create_response(create_response)
-        assert dataset_collection["collection_type"] == "list:paired"
-        assert dataset_collection["name"] == "a nested collection"
-        returned_collections = dataset_collection["elements"]
-        assert len(returned_collections) == 1, dataset_collection
-        pair_1_element = returned_collections[0]
-        self._assert_has_keys(pair_1_element, "element_identifier", "element_index", "object")
-        assert pair_1_element["element_identifier"] == "test_level_1", pair_1_element
-        assert pair_1_element["element_index"] == 0, pair_1_element
-        pair_1_object = pair_1_element["object"]
-        self._assert_has_keys(pair_1_object, "collection_type", "elements", "element_count")
-        assert pair_1_object["collection_type"] == "paired"
-        assert pair_1_object["populated"] is True
-        pair_elements = pair_1_object["elements"]
-        assert len(pair_elements) == 2
-        pair_1_element_1 = pair_elements[0]
-        assert pair_1_element_1["element_index"] == 0
-
-    def test_list_download(self, history_id):
-        fetch_response = self.dataset_collection_populator.create_list_in_history(history_id, direct_upload=True).json()
-        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
-        returned_dce = dataset_collection["elements"]
-        assert len(returned_dce) == 3, dataset_collection
-        create_response = self._download_dataset_collection(history_id=history_id, hdca_id=dataset_collection["id"])
-        self._assert_status_code_is(create_response, 200)
-        archive = zipfile.ZipFile(BytesIO(create_response.content))
-        namelist = archive.namelist()
-        assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
-        collection_name = dataset_collection["name"]
-        for element, zip_path in zip(returned_dce, namelist):
-            assert f"{collection_name}/{element['element_identifier']}.{element['object']['file_ext']}" == zip_path
-
-    def test_pair_download(self, history_id):
-        fetch_response = self.dataset_collection_populator.create_pair_in_history(history_id, direct_upload=True).json()
-        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
-        returned_dce = dataset_collection["elements"]
-        assert len(returned_dce) == 2, dataset_collection
-        hdca_id = dataset_collection["id"]
-        create_response = self._download_dataset_collection(history_id=history_id, hdca_id=hdca_id)
-        self._assert_status_code_is(create_response, 200)
-        archive = zipfile.ZipFile(BytesIO(create_response.content))
-        namelist = archive.namelist()
-        assert len(namelist) == 2, f"Expected 2 elements in [{namelist}]"
-        collection_name = dataset_collection["name"]
-        for element, zip_path in zip(returned_dce, namelist):
-            assert f"{collection_name}/{element['element_identifier']}.{element['object']['file_ext']}" == zip_path
-
-    def test_list_pair_download(self, history_id):
-        fetch_response = self.dataset_collection_populator.create_list_of_pairs_in_history(history_id).json()
-        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
-        returned_dce = dataset_collection["elements"]
-        assert len(returned_dce) == 1, dataset_collection
-        list_collection_name = dataset_collection["name"]
-        pair = returned_dce[0]
-        create_response = self._download_dataset_collection(history_id=history_id, hdca_id=dataset_collection["id"])
-        self._assert_status_code_is(create_response, 200)
-        archive = zipfile.ZipFile(BytesIO(create_response.content))
-        namelist = archive.namelist()
-        assert len(namelist) == 2, f"Expected 2 elements in [{namelist}]"
-        pair_collection_name = pair["element_identifier"]
-        for element, zip_path in zip(pair["object"]["elements"], namelist):
-            assert (
-                f"{list_collection_name}/{pair_collection_name}/{element['element_identifier']}.{element['object']['file_ext']}"
-                == zip_path
+    def test_create_pair_from_history(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            payload = self.dataset_collection_populator.create_pair_payload(
+                history_id,
+                instance_type="history",
             )
+            create_response = self.dataset_populator.fetch(payload, wait=True)
+            dataset_collection = self._check_create_response(create_response)
+            returned_datasets = dataset_collection["elements"]
+            assert len(returned_datasets) == 2, dataset_collection
 
-    def test_list_list_download(self, history_id):
-        dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(
-            history_id, wait=True
-        ).json()
-        returned_dce = dataset_collection["elements"]
-        assert len(returned_dce) == 1, dataset_collection
-        create_response = self._download_dataset_collection(history_id=history_id, hdca_id=dataset_collection["id"])
-        self._assert_status_code_is(create_response, 200)
-        archive = zipfile.ZipFile(BytesIO(create_response.content))
-        namelist = archive.namelist()
-        assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
+    def test_create_list_from_history(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            element_identifiers = self.dataset_collection_populator.list_identifiers(history_id)
 
-    def test_list_list_list_download(self, history_id):
-        dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(
-            history_id,
-            collection_type="list:list:list",
-            wait=True,
-        ).json()
-        returned_dce = dataset_collection["elements"]
-        assert len(returned_dce) == 1, dataset_collection
-        create_response = self._download_dataset_collection(history_id=history_id, hdca_id=dataset_collection["id"])
-        self._assert_status_code_is(create_response, 200)
-        archive = zipfile.ZipFile(BytesIO(create_response.content))
-        namelist = archive.namelist()
-        assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
-
-    def test_hda_security(self, history_id):
-        element_identifiers = self.dataset_collection_populator.pair_identifiers(history_id)
-        self.dataset_populator.make_private(history_id, element_identifiers[0]["id"])
-        with self._different_user():
-            history_id = self.dataset_populator.new_history()
             payload = dict(
                 instance_type="history",
                 history_id=history_id,
                 element_identifiers=element_identifiers,
-                collection_type="paired",
+                collection_type="list",
+            )
+
+            create_response = self._post("dataset_collections", payload, json=True)
+            dataset_collection = self._check_create_response(create_response)
+            returned_datasets = dataset_collection["elements"]
+            assert len(returned_datasets) == 3, dataset_collection
+
+    def test_create_list_of_existing_pairs(self, history_id):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            pair_payload = self.dataset_collection_populator.create_pair_payload(
+                history_id,
+                instance_type="history",
+            )
+            pair_create_response = self._post("tools/fetch", pair_payload, json=True)
+            dataset_collection = self._check_create_response(pair_create_response)
+            hdca_id = dataset_collection["id"]
+
+            element_identifiers = [dict(name="test1", src="hdca", id=hdca_id)]
+
+            payload = dict(
+                instance_type="history",
+                history_id=history_id,
+                element_identifiers=element_identifiers,
+                collection_type="list",
             )
             create_response = self._post("dataset_collections", payload, json=True)
-            self._assert_status_code_is(create_response, 403)
+            dataset_collection = self._check_create_response(create_response)
+            returned_collections = dataset_collection["elements"]
+            assert len(returned_collections) == 1, dataset_collection
 
-    def test_enforces_unique_names(self, history_id):
-        element_identifiers = self.dataset_collection_populator.list_identifiers(history_id)
-        element_identifiers[2]["name"] = element_identifiers[0]["name"]
-        payload = dict(
-            instance_type="history",
-            history_id=history_id,
-            element_identifiers=element_identifiers,
-            collection_type="list",
-        )
+    def test_create_list_of_new_pairs(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            identifiers = self.dataset_collection_populator.nested_collection_identifiers(history_id, "list:paired")
+            payload = dict(
+                collection_type="list:paired",
+                instance_type="history",
+                history_id=history_id,
+                name="a nested collection",
+                element_identifiers=identifiers,
+            )
+            create_response = self._post("dataset_collections", payload, json=True)
+            dataset_collection = self._check_create_response(create_response)
+            assert dataset_collection["collection_type"] == "list:paired"
+            assert dataset_collection["name"] == "a nested collection"
+            returned_collections = dataset_collection["elements"]
+            assert len(returned_collections) == 1, dataset_collection
+            pair_1_element = returned_collections[0]
+            self._assert_has_keys(pair_1_element, "element_identifier", "element_index", "object")
+            assert pair_1_element["element_identifier"] == "test_level_1", pair_1_element
+            assert pair_1_element["element_index"] == 0, pair_1_element
+            pair_1_object = pair_1_element["object"]
+            self._assert_has_keys(pair_1_object, "collection_type", "elements", "element_count")
+            assert pair_1_object["collection_type"] == "paired"
+            assert pair_1_object["populated"] is True
+            pair_elements = pair_1_object["elements"]
+            assert len(pair_elements) == 2
+            pair_1_element_1 = pair_elements[0]
+            assert pair_1_element_1["element_index"] == 0
 
-        create_response = self._post("dataset_collections", payload, json=True)
-        self._assert_status_code_is(create_response, 400)
+    def test_list_download(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            fetch_response = self.dataset_collection_populator.create_list_in_history(history_id, direct_upload=True).json()
+            dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
+            returned_dce = dataset_collection["elements"]
+            assert len(returned_dce) == 3, dataset_collection
+            create_response = self._download_dataset_collection(history_id=history_id, hdca_id=dataset_collection["id"])
+            self._assert_status_code_is(create_response, 200)
+            archive = zipfile.ZipFile(BytesIO(create_response.content))
+            namelist = archive.namelist()
+            assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
+            collection_name = dataset_collection["name"]
+            for element, zip_path in zip(returned_dce, namelist):
+                assert f"{collection_name}/{element['element_identifier']}.{element['object']['file_ext']}" == zip_path
+
+    def test_pair_download(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            fetch_response = self.dataset_collection_populator.create_pair_in_history(history_id, direct_upload=True).json()
+            dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
+            returned_dce = dataset_collection["elements"]
+            assert len(returned_dce) == 2, dataset_collection
+            hdca_id = dataset_collection["id"]
+            create_response = self._download_dataset_collection(history_id=history_id, hdca_id=hdca_id)
+            self._assert_status_code_is(create_response, 200)
+            archive = zipfile.ZipFile(BytesIO(create_response.content))
+            namelist = archive.namelist()
+            assert len(namelist) == 2, f"Expected 2 elements in [{namelist}]"
+            collection_name = dataset_collection["name"]
+            for element, zip_path in zip(returned_dce, namelist):
+                assert f"{collection_name}/{element['element_identifier']}.{element['object']['file_ext']}" == zip_path
+
+    def test_list_pair_download(self, history_id):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            fetch_response = self.dataset_collection_populator.create_list_of_pairs_in_history(history_id).json()
+            dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
+            returned_dce = dataset_collection["elements"]
+            assert len(returned_dce) == 1, dataset_collection
+            list_collection_name = dataset_collection["name"]
+            pair = returned_dce[0]
+            create_response = self._download_dataset_collection(history_id=history_id, hdca_id=dataset_collection["id"])
+            self._assert_status_code_is(create_response, 200)
+            archive = zipfile.ZipFile(BytesIO(create_response.content))
+            namelist = archive.namelist()
+            assert len(namelist) == 2, f"Expected 2 elements in [{namelist}]"
+            pair_collection_name = pair["element_identifier"]
+            for element, zip_path in zip(pair["object"]["elements"], namelist):
+                assert (
+                    f"{list_collection_name}/{pair_collection_name}/{element['element_identifier']}.{element['object']['file_ext']}"
+                    == zip_path
+                )
+
+    def test_list_list_download(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(
+                history_id, wait=True
+            ).json()
+            returned_dce = dataset_collection["elements"]
+            assert len(returned_dce) == 1, dataset_collection
+            create_response = self._download_dataset_collection(history_id=history_id, hdca_id=dataset_collection["id"])
+            self._assert_status_code_is(create_response, 200)
+            archive = zipfile.ZipFile(BytesIO(create_response.content))
+            namelist = archive.namelist()
+            assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
+
+    def test_list_list_list_download(self, history_id):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            dataset_collection = self.dataset_collection_populator.create_list_of_list_in_history(
+                history_id,
+                collection_type="list:list:list",
+                wait=True,
+            ).json()
+            returned_dce = dataset_collection["elements"]
+            assert len(returned_dce) == 1, dataset_collection
+            create_response = self._download_dataset_collection(history_id=history_id, hdca_id=dataset_collection["id"])
+            self._assert_status_code_is(create_response, 200)
+            archive = zipfile.ZipFile(BytesIO(create_response.content))
+            namelist = archive.namelist()
+            assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
+
+    def test_hda_security(self, history_id):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            element_identifiers = self.dataset_collection_populator.pair_identifiers(history_id)
+            self.dataset_populator.make_private(history_id, element_identifiers[0]["id"])
+            with self._different_user():
+                history_id = self.dataset_populator.new_history()
+                payload = dict(
+                    instance_type="history",
+                    history_id=history_id,
+                    element_identifiers=element_identifiers,
+                    collection_type="paired",
+                )
+                create_response = self._post("dataset_collections", payload, json=True)
+                self._assert_status_code_is(create_response, 403)
+
+    def test_enforces_unique_names(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            element_identifiers = self.dataset_collection_populator.list_identifiers(history_id)
+            element_identifiers[2]["name"] = element_identifiers[0]["name"]
+            payload = dict(
+                instance_type="history",
+                history_id=history_id,
+                element_identifiers=element_identifiers,
+                collection_type="list",
+            )
+
+            create_response = self._post("dataset_collections", payload, json=True)
+            self._assert_status_code_is(create_response, 400)
 
     def test_upload_collection(self, history_id):
-        elements = [
-            {
-                "src": "files",
-                "dbkey": "hg19",
-                "info": "my cool bed",
-                "tags": ["name:data1", "group:condition:treated", "machine:illumina"],
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            elements = [
+                {
+                    "src": "files",
+                    "dbkey": "hg19",
+                    "info": "my cool bed",
+                    "tags": ["name:data1", "group:condition:treated", "machine:illumina"],
+                }
+            ]
+            targets = [
+                {
+                    "destination": {"type": "hdca"},
+                    "elements": elements,
+                    "collection_type": "list",
+                    "name": "Test upload",
+                    "tags": ["name:collection1"],
+                }
+            ]
+            payload = {
+                "history_id": history_id,
+                "targets": targets,
+                "__files": {"files_0|file_data": open(self.test_data_resolver.get_filename("4.bed"))},
             }
-        ]
-        targets = [
-            {
-                "destination": {"type": "hdca"},
-                "elements": elements,
-                "collection_type": "list",
-                "name": "Test upload",
-                "tags": ["name:collection1"],
-            }
-        ]
-        payload = {
-            "history_id": history_id,
-            "targets": targets,
-            "__files": {"files_0|file_data": open(self.test_data_resolver.get_filename("4.bed"))},
-        }
-        self.dataset_populator.fetch(payload)
-        hdca = self._assert_one_collection_created_in_history(history_id)
-        assert hdca["name"] == "Test upload"
-        hdca_tags = hdca["tags"]
-        assert len(hdca_tags) == 1
-        assert "name:collection1" in hdca_tags
-        assert len(hdca["elements"]) == 1, hdca
-        element0 = hdca["elements"][0]
-        assert element0["element_identifier"] == "4.bed"
-        dataset0 = element0["object"]
-        assert dataset0["file_size"] == 61
-        dataset_tags = dataset0["tags"]
-        assert len(dataset_tags) == 3, dataset0
+            self.dataset_populator.fetch(payload)
+            hdca = self._assert_one_collection_created_in_history(history_id)
+            assert hdca["name"] == "Test upload"
+            hdca_tags = hdca["tags"]
+            assert len(hdca_tags) == 1
+            assert "name:collection1" in hdca_tags
+            assert len(hdca["elements"]) == 1, hdca
+            element0 = hdca["elements"][0]
+            assert element0["element_identifier"] == "4.bed"
+            dataset0 = element0["object"]
+            assert dataset0["file_size"] == 61
+            dataset_tags = dataset0["tags"]
+            assert len(dataset_tags) == 3, dataset0
 
     def test_upload_nested(self, history_id):
-        elements = [{"name": "samp1", "elements": [{"src": "files", "dbkey": "hg19", "info": "my cool bed"}]}]
-        targets = [
-            {
-                "destination": {"type": "hdca"},
-                "elements": elements,
-                "collection_type": "list:list",
-                "name": "Test upload",
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            elements = [{"name": "samp1", "elements": [{"src": "files", "dbkey": "hg19", "info": "my cool bed"}]}]
+            targets = [
+                {
+                    "destination": {"type": "hdca"},
+                    "elements": elements,
+                    "collection_type": "list:list",
+                    "name": "Test upload",
+                }
+            ]
+            payload = {
+                "history_id": history_id,
+                "targets": targets,
+                "__files": {"files_0|file_data": open(self.test_data_resolver.get_filename("4.bed"))},
             }
-        ]
-        payload = {
-            "history_id": history_id,
-            "targets": targets,
-            "__files": {"files_0|file_data": open(self.test_data_resolver.get_filename("4.bed"))},
-        }
-        self.dataset_populator.fetch(payload)
-        hdca = self._assert_one_collection_created_in_history(history_id)
-        assert hdca["name"] == "Test upload"
-        assert len(hdca["elements"]) == 1, hdca
-        element0 = hdca["elements"][0]
-        assert element0["element_identifier"] == "samp1"
+            self.dataset_populator.fetch(payload)
+            hdca = self._assert_one_collection_created_in_history(history_id)
+            assert hdca["name"] == "Test upload"
+            assert len(hdca["elements"]) == 1, hdca
+            element0 = hdca["elements"][0]
+            assert element0["element_identifier"] == "samp1"
 
     @skip_if_github_down
-    def test_upload_collection_from_url(self, history_id):
-        elements = [
-            {
-                "src": "url",
-                "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed",
-                "info": "my cool bed",
+    def test_upload_collection_from_url(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            elements = [
+                {
+                    "src": "url",
+                    "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed",
+                    "info": "my cool bed",
+                }
+            ]
+            targets = [
+                {
+                    "destination": {"type": "hdca"},
+                    "elements": elements,
+                    "collection_type": "list",
+                }
+            ]
+            payload = {
+                "history_id": history_id,
+                "targets": targets,
             }
-        ]
-        targets = [
-            {
-                "destination": {"type": "hdca"},
-                "elements": elements,
-                "collection_type": "list",
-            }
-        ]
-        payload = {
-            "history_id": history_id,
-            "targets": targets,
-        }
-        self.dataset_populator.fetch(payload)
-        hdca = self._assert_one_collection_created_in_history(history_id)
-        assert len(hdca["elements"]) == 1, hdca
-        element0 = hdca["elements"][0]
-        assert element0["element_identifier"] == "4.bed"
-        assert element0["object"]["file_size"] == 61
+            self.dataset_populator.fetch(payload)
+            hdca = self._assert_one_collection_created_in_history(history_id)
+            assert len(hdca["elements"]) == 1, hdca
+            element0 = hdca["elements"][0]
+            assert element0["element_identifier"] == "4.bed"
+            assert element0["object"]["file_size"] == 61
 
-    def test_upload_collection_deferred(self, history_id):
-        elements = [
-            {
-                "src": "url",
-                "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed",
-                "info": "my cool bed",
-                "deferred": True,
+    def test_upload_collection_deferred(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            elements = [
+                {
+                    "src": "url",
+                    "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed",
+                    "info": "my cool bed",
+                    "deferred": True,
+                }
+            ]
+            targets = [
+                {
+                    "destination": {"type": "hdca"},
+                    "elements": elements,
+                    "collection_type": "list",
+                }
+            ]
+            payload = {
+                "history_id": history_id,
+                "targets": targets,
             }
-        ]
-        targets = [
-            {
-                "destination": {"type": "hdca"},
-                "elements": elements,
-                "collection_type": "list",
-            }
-        ]
-        payload = {
-            "history_id": history_id,
-            "targets": targets,
-        }
-        self.dataset_populator.fetch(payload)
-        hdca = self._assert_one_collection_created_in_history(history_id)
-        assert len(hdca["elements"]) == 1, hdca
-        element0 = hdca["elements"][0]
-        assert element0["element_identifier"] == "4.bed"
-        object0 = element0["object"]
-        assert object0["state"] == "deferred"
+            self.dataset_populator.fetch(payload)
+            hdca = self._assert_one_collection_created_in_history(history_id)
+            assert len(hdca["elements"]) == 1, hdca
+            element0 = hdca["elements"][0]
+            assert element0["element_identifier"] == "4.bed"
+            object0 = element0["object"]
+            assert object0["state"] == "deferred"
 
     @skip_if_github_down
-    def test_upload_collection_failed_expansion_url(self, history_id):
-        targets = [
-            {
-                "destination": {"type": "hdca"},
-                "elements_from": "bagit",
-                "collection_type": "list",
-                "src": "url",
-                "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed",
+    def test_upload_collection_failed_expansion_url(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            targets = [
+                {
+                    "destination": {"type": "hdca"},
+                    "elements_from": "bagit",
+                    "collection_type": "list",
+                    "src": "url",
+                    "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed",
+                }
+            ]
+            payload = {
+                "history_id": history_id,
+                "targets": targets,
             }
-        ]
-        payload = {
-            "history_id": history_id,
-            "targets": targets,
-        }
-        self.dataset_populator.fetch(payload, assert_ok=False, wait=True)
-        hdca = self._assert_one_collection_created_in_history(history_id)
-        assert hdca["populated"] is False
-        assert "bagit.txt" in hdca["populated_state_message"], hdca
+            self.dataset_populator.fetch(payload, assert_ok=False, wait=True)
+            hdca = self._assert_one_collection_created_in_history(history_id)
+            assert hdca["populated"] is False
+            assert "bagit.txt" in hdca["populated_state_message"], hdca
 
     def _assert_one_collection_created_in_history(self, history_id: str):
         contents_response = self._get(f"histories/{history_id}/contents/dataset_collections")

--- a/lib/galaxy_test/api/test_datatypes.py
+++ b/lib/galaxy_test/api/test_datatypes.py
@@ -2,6 +2,7 @@ import time
 
 from requests import put
 
+from galaxy_test.base.decorators import requires_admin
 from ._framework import ApiTestCase
 
 HIDDEN_DURING_UPLOAD_DATATYPE = "fli"
@@ -70,6 +71,7 @@ class TestDatatypesApi(ApiTestCase):
 
         assert found_fasta_to_tabular
 
+    @requires_admin
     def test_converter_present_after_toolbox_reload(self):
         response = self._get("tools", data={"tool_id": "CONVERTER_fasta_to_tabular"})
         self._assert_status_code_is(response, 200)

--- a/lib/galaxy_test/api/test_display_applications.py
+++ b/lib/galaxy_test/api/test_display_applications.py
@@ -1,6 +1,7 @@
 import random
 from typing import List
 
+from galaxy_test.base.decorators import requires_admin
 from ._framework import ApiTestCase
 
 
@@ -14,10 +15,12 @@ class TestDisplayApplicationsApi(ApiTestCase):
         for display_app in as_list:
             self._assert_has_keys(display_app, "id", "name", "version", "filename_", "links")
 
+    @requires_admin
     def test_reload_as_admin(self):
         response = self._post("display_applications/reload", admin=True)
         self._assert_status_code_is(response, 200)
 
+    @requires_admin
     def test_reload_with_some_ids(self):
         response = self._get("display_applications")
         self._assert_status_code_is(response, 200)
@@ -31,7 +34,8 @@ class TestDisplayApplicationsApi(ApiTestCase):
         assert len(reloaded) == len(input_ids)
         assert all(elem in reloaded for elem in input_ids)
 
-    def test_reload_unknow_returns_as_failed(self):
+    @requires_admin
+    def test_reload_unknown_returns_as_failed(self):
         unknown_id = "unknown"
         payload = {"ids": [unknown_id]}
         response = self._post("display_applications/reload", payload, admin=True)

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -5,6 +5,7 @@ from typing import (
     Tuple,
 )
 
+from galaxy_test.base.decorators import requires_new_library
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
@@ -25,6 +26,7 @@ class TestFolderContentsApi(ApiTestCase):
         self.library = self.library_populator.new_private_library("FolderContentsTestsLibrary")
         self.root_folder_id = self._create_folder_in_library("Test Folder Contents")
 
+    @requires_new_library
     def test_create_hda_with_ldda_message(self, history_id):
         hda_id = self._create_hda(history_id)
         ldda_message = "Test message"
@@ -35,6 +37,8 @@ class TestFolderContentsApi(ApiTestCase):
         ldda = self._create_content_in_folder_with_payload(self.root_folder_id, data)
         self._assert_has_keys(ldda, "name", "id")
 
+
+    @requires_new_library
     def test_create_hdca_with_ldda_message(self, history_id):
         contents = ["dataset01", "dataset02"]
         hdca_id = self._create_hdca_with_contents(history_id, contents)
@@ -46,6 +50,7 @@ class TestFolderContentsApi(ApiTestCase):
         lddas = self._create_content_in_folder_with_payload(self.root_folder_id, data)
         assert len(contents) == len(lddas)
 
+    @requires_new_library
     def test_index(self, history_id):
         folder_id = self._create_folder_in_library("Test Folder Contents Index")
 
@@ -55,6 +60,7 @@ class TestFolderContentsApi(ApiTestCase):
         response = self._get(f"folders/{folder_id}/contents")
         self._assert_index_count_is_correct(response, expected_contents_count=2)
 
+    @requires_new_library
     def test_index_include_deleted(self, history_id):
         folder_name = "Test Folder Contents Index include deleted"
         folder_id = self._create_folder_in_library(folder_name)
@@ -73,6 +79,7 @@ class TestFolderContentsApi(ApiTestCase):
         for content in index_response["folder_contents"]:
             assert content["deleted"] is True
 
+    @requires_new_library
     def test_index_pagination(self, history_id):
         folder_name = "Test Folder Contents Pagination"
         folder_id = self._create_folder_in_library(folder_name)
@@ -136,6 +143,7 @@ class TestFolderContentsApi(ApiTestCase):
         for index in range(actual_limit):
             assert contents[index]["id"] == expected_query_result[index]["id"]
 
+    @requires_new_library
     def test_index_search_text(self, history_id):
         folder_name = "Test Folder Contents Index search text"
         folder_id = self._create_folder_in_library(folder_name)
@@ -159,6 +167,7 @@ class TestFolderContentsApi(ApiTestCase):
             for content in contents:
                 assert search_text.casefold() in content["name"].casefold()
 
+    @requires_new_library
     def test_index_permissions(self, history_id):
         folder_name = "Test Folder Contents Index permissions"
         folder_id = self._create_folder_in_library(folder_name)
@@ -193,6 +202,7 @@ class TestFolderContentsApi(ApiTestCase):
             response = self._get(f"folders/{folder_id}/contents")
             self._assert_index_count_is_correct(response, expected_contents_count=1)
 
+    @requires_new_library
     def test_index_permissions_include_deleted(self, history_id):
         folder_name = "Test Folder Contents Index permissions include deleted"
         folder_id = self._create_folder_in_library(folder_name)
@@ -247,6 +257,7 @@ class TestFolderContentsApi(ApiTestCase):
             response = self._get(f"folders/{folder_id}/contents?include_deleted={include_deleted}")
             self._assert_index_count_is_correct(response, expected_contents_count=num_non_deleted)
 
+    @requires_new_library
     def test_index_order_by(self, history_id):
         folder_name = "Test Folder Contents Index Order By"
         folder_id = self._create_folder_in_library(folder_name)

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -37,7 +37,6 @@ class TestFolderContentsApi(ApiTestCase):
         ldda = self._create_content_in_folder_with_payload(self.root_folder_id, data)
         self._assert_has_keys(ldda, "name", "id")
 
-
     @requires_new_library
     def test_create_hdca_with_ldda_message(self, history_id):
         contents = ["dataset01", "dataset02"]

--- a/lib/galaxy_test/api/test_folders.py
+++ b/lib/galaxy_test/api/test_folders.py
@@ -1,3 +1,4 @@
+from galaxy_test.base.decorators import requires_new_library
 from galaxy_test.base.populators import (
     DatasetPopulator,
     LibraryPopulator,
@@ -14,10 +15,12 @@ class TestFoldersApi(ApiTestCase):
         self.library_populator = LibraryPopulator(self.galaxy_interactor)
         self.library = self.library_populator.new_library("FolderTestsLibrary")
 
+    @requires_new_library
     def test_create(self):
         folder = self._create_folder("Test Create Folder")
         self._assert_valid_folder(folder)
 
+    @requires_new_library
     def test_create_without_name_raises_400(self):
         root_folder_id = self.library["root_folder_id"]
         data = {
@@ -26,6 +29,7 @@ class TestFoldersApi(ApiTestCase):
         create_response = self._post(f"folders/{root_folder_id}", data=data, admin=True)
         self._assert_status_code_is(create_response, 400)
 
+    @requires_new_library
     def test_permissions(self):
         folder = self._create_folder("Test Permissions Folder")
         folder_id = folder["id"]
@@ -48,6 +52,7 @@ class TestFoldersApi(ApiTestCase):
         assert permissions == new_permissions
         self._assert_permissions_contains_role(permissions, role_id)
 
+    @requires_new_library
     def test_update(self):
         folder = self._create_folder("Test Update Folder")
         folder_id = folder["id"]
@@ -64,6 +69,7 @@ class TestFoldersApi(ApiTestCase):
         assert updated_folder["name"] == updated_name
         assert updated_folder["description"] == updated_desc
 
+    @requires_new_library
     def test_delete(self):
         folder = self._create_folder("Test Delete Folder")
         folder_id = folder["id"]
@@ -71,6 +77,7 @@ class TestFoldersApi(ApiTestCase):
         deleted_folder = self._delete_folder(folder_id)
         assert deleted_folder["deleted"] is True
 
+    @requires_new_library
     def test_undelete(self):
         folder = self._create_folder("Test Undelete Folder")
         folder_id = folder["id"]
@@ -84,6 +91,7 @@ class TestFoldersApi(ApiTestCase):
         undeleted_folder = undelete_response.json()
         assert undeleted_folder["deleted"] is False
 
+    @requires_new_library
     def test_import_folder_to_history(self):
         library, response = self.library_populator.fetch_single_url_to_folder()
         dataset = self.library_populator.get_library_contents_with_path(library["id"], "/4.bed")
@@ -95,6 +103,7 @@ class TestFoldersApi(ApiTestCase):
             assert len(datasets) == 1
             assert datasets[0]["name"] == "4.bed"
 
+    @requires_new_library
     def test_update_deleted_raise_403(self):
         folder = self._create_folder("Test Update Deleted Folder")
         folder_id = folder["id"]

--- a/lib/galaxy_test/api/test_framework.py
+++ b/lib/galaxy_test/api/test_framework.py
@@ -1,5 +1,6 @@
 # This file doesn't test any API in particular but is meant to functionally
 # test the API framework itself.
+from galaxy_test.base.decorators import requires_admin
 from ._framework import ApiTestCase
 
 
@@ -20,6 +21,7 @@ class TestApiFramework(ApiTestCase):
         )
         self._assert_status_code_is(create_response, 403)
 
+    @requires_admin
     def test_run_as_invalid_user(self):
         post_data = dict(name="TestHistory1")
         # admin user can run_as, but this user doesn't exist, expect 400.
@@ -31,6 +33,7 @@ class TestApiFramework(ApiTestCase):
         )
         self._assert_status_code_is(create_response, 400)
 
+    @requires_admin
     def test_run_as_valid_user(self):
         run_as_user = self._setup_user("for_run_as@bx.psu.edu")
         post_data = dict(name="TestHistory1")

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -4,6 +4,10 @@ from typing import (
 )
 
 from galaxy_test.api._framework import ApiTestCase
+from galaxy_test.base.decorators import (
+    requires_admin,
+    using_requirement,
+)
 from galaxy_test.base.populators import DatasetPopulator
 
 
@@ -14,6 +18,7 @@ class TestGroupRolesApi(ApiTestCase):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
+    @requires_admin
     def test_index(self, group_name: Optional[str] = None):
         group_name = group_name or "test-group_roles"
         group = self._create_group(group_name)
@@ -31,11 +36,13 @@ class TestGroupRolesApi(ApiTestCase):
         response = self._get(f"groups/{encoded_group_id}/roles")
         self._assert_status_code_is(response, 403)
 
+    @requires_admin
     def test_index_unknown_group_raises_400(self):
         encoded_group_id = "unknown-group-id"
         response = self._get(f"groups/{encoded_group_id}/roles", admin=True)
         self._assert_status_code_is(response, 400)
 
+    @requires_admin
     def test_show(self):
         encoded_role_id = self.dataset_populator.user_private_role_id()
         group = self._create_group("test-group-show-role", encoded_role_ids=[encoded_role_id])
@@ -51,6 +58,7 @@ class TestGroupRolesApi(ApiTestCase):
         response = self._get(f"groups/{encoded_group_id}/roles/{encoded_role_id}")
         self._assert_status_code_is(response, 403)
 
+    @requires_admin
     def test_show_unknown_raises_400(self):
         group = self._create_group("test-group-with-unknown-role")
         encoded_group_id = group["id"]
@@ -58,6 +66,7 @@ class TestGroupRolesApi(ApiTestCase):
         response = self._get(f"groups/{encoded_group_id}/roles/{encoded_role_id}", admin=True)
         self._assert_status_code_is(response, 400)
 
+    @requires_admin
     def test_update(self):
         group_name = "group-without-roles"
         group = self._create_group(group_name, encoded_role_ids=[])
@@ -73,12 +82,14 @@ class TestGroupRolesApi(ApiTestCase):
         self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
         assert group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}"
 
+    @requires_admin
     def test_update_only_admin(self):
         encoded_group_id = "any-group-id"
         encoded_role_id = "any-role-id"
         response = self._put(f"groups/{encoded_group_id}/roles/{encoded_role_id}")
         self._assert_status_code_is(response, 403)
 
+    @requires_admin
     def test_delete(self):
         group_name = "group-with-role-to-delete"
         encoded_role_id = self.dataset_populator.user_private_role_id()
@@ -102,6 +113,7 @@ class TestGroupRolesApi(ApiTestCase):
         response = self._delete(f"groups/{encoded_group_id}/roles/{encoded_role_id}")
         self._assert_status_code_is(response, 403)
 
+    @requires_admin
     def test_delete_unknown_raises_400(self):
         group_name = "group-without-role-to-delete"
         group = self._create_group(group_name, encoded_role_ids=[])
@@ -122,12 +134,14 @@ class TestGroupRolesApi(ApiTestCase):
             "name": group_name,
             "role_ids": role_ids,
         }
+        using_requirement("admin")
         response = self._post("groups", payload, admin=True, json=True)
         self._assert_status_code_is(response, 200)
         group = response.json()[0]  # POST /api/groups returns a list
         return group
 
     def _get_group_roles(self, encoded_group_id: str):
+        using_requirement("admin")
         response = self._get(f"groups/{encoded_group_id}/roles", admin=True)
         self._assert_status_code_is(response, 200)
         group_roles = response.json()

--- a/lib/galaxy_test/api/test_group_users.py
+++ b/lib/galaxy_test/api/test_group_users.py
@@ -4,6 +4,10 @@ from typing import (
 )
 
 from galaxy_test.api._framework import ApiTestCase
+from galaxy_test.base.decorators import (
+    requires_admin,
+    using_requirement,
+)
 from galaxy_test.base.populators import DatasetPopulator
 
 
@@ -14,6 +18,7 @@ class TestGroupUsersApi(ApiTestCase):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
+    @requires_admin
     def test_index(self, group_name: Optional[str] = None):
         group_name = group_name or "test-group_users"
         group = self._create_group(group_name)
@@ -31,11 +36,13 @@ class TestGroupUsersApi(ApiTestCase):
         response = self._get(f"groups/{encoded_group_id}/users")
         self._assert_status_code_is(response, 403)
 
+    @requires_admin
     def test_index_unknown_group_raises_400(self):
         encoded_group_id = "unknown-group-id"
         response = self._get(f"groups/{encoded_group_id}/users", admin=True)
         self._assert_status_code_is(response, 400)
 
+    @requires_admin
     def test_show(self):
         encoded_user_id = self.dataset_populator.user_id()
         group = self._create_group("test-group-show-user", encoded_user_ids=[encoded_user_id])
@@ -51,6 +58,7 @@ class TestGroupUsersApi(ApiTestCase):
         response = self._get(f"groups/{encoded_group_id}/users/{encoded_user_id}")
         self._assert_status_code_is(response, 403)
 
+    @requires_admin
     def test_show_unknown_raises_400(self):
         group = self._create_group("test-group-with-unknown-user")
         encoded_group_id = group["id"]
@@ -58,6 +66,7 @@ class TestGroupUsersApi(ApiTestCase):
         response = self._get(f"groups/{encoded_group_id}/users/{encoded_user_id}", admin=True)
         self._assert_status_code_is(response, 400)
 
+    @requires_admin
     def test_update(self):
         group_name = "group-without-users"
         group = self._create_group(group_name, encoded_user_ids=[])
@@ -79,6 +88,7 @@ class TestGroupUsersApi(ApiTestCase):
         response = self._put(f"groups/{encoded_group_id}/users/{encoded_user_id}")
         self._assert_status_code_is(response, 403)
 
+    @requires_admin
     def test_delete(self):
         group_name = "group-with-user-to-delete"
         encoded_user_id = self.dataset_populator.user_id()
@@ -102,6 +112,7 @@ class TestGroupUsersApi(ApiTestCase):
         response = self._delete(f"groups/{encoded_group_id}/users/{encoded_user_id}")
         self._assert_status_code_is(response, 403)
 
+    @requires_admin
     def test_delete_unknown_raises_400(self):
         group_name = "group-without-user-to-delete"
         group = self._create_group(group_name, encoded_user_ids=[])
@@ -122,12 +133,14 @@ class TestGroupUsersApi(ApiTestCase):
             "name": group_name,
             "user_ids": user_ids,
         }
+        using_requirement("admin")
         response = self._post("groups", payload, admin=True, json=True)
         self._assert_status_code_is(response, 200)
         group = response.json()[0]  # POST /api/groups returns a list
         return group
 
     def _get_group_users(self, encoded_group_id: str):
+        using_requirement("admin")
         response = self._get(f"groups/{encoded_group_id}/users", admin=True)
         self._assert_status_code_is(response, 200)
         group_users = response.json()

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -6,6 +6,7 @@ from galaxy.model.unittest_utils.store_fixtures import (
 )
 from galaxy.util.unittest_utils import skip_if_github_down
 from galaxy_test.base import api_asserts
+from galaxy_test.base.decorators import requires_new_library
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
@@ -25,6 +26,7 @@ class TestLibrariesApi(ApiTestCase):
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
         self.library_populator = LibraryPopulator(self.galaxy_interactor)
 
+    @requires_new_library
     def test_create(self):
         data = dict(name="CreateTestLibrary")
         create_response = self._post("libraries", data=data, admin=True, json=True)
@@ -34,6 +36,7 @@ class TestLibrariesApi(ApiTestCase):
         assert library["name"] == "CreateTestLibrary"
 
     @skip_without_asgi
+    @requires_new_library
     def test_create_from_store(self):
         response = self.library_populator.create_from_store(store_dict=one_ld_library_model_store_dict())
         assert isinstance(response, list)
@@ -44,6 +47,7 @@ class TestLibrariesApi(ApiTestCase):
         ld = self.library_populator.get_library_contents_with_path(library_summary["id"], "/my cool name")
         assert ld
 
+    @requires_new_library
     def test_delete(self):
         library = self.library_populator.new_library("DeleteTestLibrary")
         create_response = self._delete(f"libraries/{library['id']}", admin=True)
@@ -72,6 +76,7 @@ class TestLibrariesApi(ApiTestCase):
         create_response = self._patch(f"libraries/{library['id']}", data=data, admin=False, anon=True, json=True)
         self._assert_status_code_is(create_response, 403)
 
+    @requires_new_library
     def test_update(self):
         library = self.library_populator.new_library("UpdateTestLibrary")
         data = dict(name="ChangedName", description="ChangedDescription", synopsis="ChangedSynopsis")
@@ -83,6 +88,7 @@ class TestLibrariesApi(ApiTestCase):
         assert library["description"] == "ChangedDescription"
         assert library["synopsis"] == "ChangedSynopsis"
 
+    @requires_new_library
     def test_update_non_admins_with_permission(self):
         library = self.library_populator.new_library("UpdateTestLibraryNonAdmin")
         library_id = library["id"]
@@ -101,6 +107,7 @@ class TestLibrariesApi(ApiTestCase):
         assert library["description"] == "ChangedDescription"
         assert library["synopsis"] == "ChangedSynopsis"
 
+    @requires_new_library
     def test_create_private_library_legacy_permissions(self):
         library = self.library_populator.new_library("LegacyPermissionTestLibrary")
         library_id = library["id"]
@@ -113,6 +120,7 @@ class TestLibrariesApi(ApiTestCase):
             create_response = self._create_folder(library)
             self._assert_status_code_is(create_response, 403)
 
+    @requires_new_library
     def test_create_private_library_permissions(self):
         library = self.library_populator.new_library("PermissionTestLibrary")
         library_id = library["id"]
@@ -125,6 +133,7 @@ class TestLibrariesApi(ApiTestCase):
             create_response = self._create_folder(library)
             self._assert_status_code_is(create_response, 403)
 
+    @requires_new_library
     def test_get_library_current_permissions(self):
         library = self.library_populator.new_library("GetCurrentPermissionTestLibrary")
         library_id = library["id"]
@@ -145,6 +154,7 @@ class TestLibrariesApi(ApiTestCase):
         assert role_id in current["manage_library_role_list"][0]
         assert role_id in current["add_library_item_role_list"][0]
 
+    @requires_new_library
     def test_get_library_available_permissions(self):
         library = self.library_populator.new_library("GetAvailablePermissionTestLibrary")
         library_id = library["id"]
@@ -154,6 +164,7 @@ class TestLibrariesApi(ApiTestCase):
         available_role_ids = [role["id"] for role in available["roles"]]
         assert role_id in available_role_ids
 
+    @requires_new_library
     def test_get_library_available_permissions_with_query(self):
         library = self.library_populator.new_library("GetAvailablePermissionWithQueryTestLibrary")
         library_id = library["id"]
@@ -172,6 +183,7 @@ class TestLibrariesApi(ApiTestCase):
         assert available["total"] == 1
         assert available_role_emails[0] == email
 
+    @requires_new_library
     def test_create_library_dataset_bootstrap_user(self, library_name="private_dataset", wait=True):
         library = self.library_populator.new_private_library(library_name)
         payload, files = self.library_populator.create_dataset_request(library, file_type="txt", contents="create_test")
@@ -180,12 +192,14 @@ class TestLibrariesApi(ApiTestCase):
         )
         self._assert_status_code_is(create_response, 400)
 
+    @requires_new_library
     def test_create_dataset_denied(self):
         url, payload = self._create_dataset_kwargs()
         with self._different_user():
             create_response = self._post(url, payload, json=True)
             self._assert_status_code_is(create_response, 403)
 
+    @requires_new_library
     def test_create_dataset_bootstrap_admin_user(self):
         url, payload = self._create_dataset_kwargs()
         with self._different_user():
@@ -201,6 +215,7 @@ class TestLibrariesApi(ApiTestCase):
         hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3")["id"]
         return f"folders/{folder_id}/contents", {"from_hda_id": hda_id}
 
+    @requires_new_library
     def test_show_private_dataset_permissions(self):
         library, library_dataset = self.library_populator.new_library_dataset_in_private_library(
             "ForCreateDatasets", wait=True
@@ -210,6 +225,7 @@ class TestLibrariesApi(ApiTestCase):
             api_asserts.assert_status_code_is(response, 403)
             api_asserts.assert_error_code_is(response, 403002)
 
+    @requires_new_library
     def test_create_dataset(self):
         library, library_dataset = self.library_populator.new_library_dataset_in_private_library(
             "ForCreateDatasets", wait=True
@@ -228,6 +244,7 @@ class TestLibrariesApi(ApiTestCase):
         assert ldda["parent_library_id"] == library["id"]
         assert ldda["file_ext"] == "txt"
 
+    @requires_new_library
     def test_fetch_upload_to_folder(self):
         history_id, library, destination = self._setup_fetch_to_folder("flat_zip")
         items = [{"src": "files", "dbkey": "hg19", "info": "my cool bed", "created_from_basename": "4.bed"}]
@@ -245,6 +262,7 @@ class TestLibrariesApi(ApiTestCase):
         assert dataset["file_ext"] == "bed", dataset
         assert dataset["created_from_basename"] == "4.bed"
 
+    @requires_new_library
     def test_fetch_zip_to_folder(self):
         history_id, library, destination = self._setup_fetch_to_folder("flat_zip")
         bed_test_data_path = self.test_data_resolver.get_filename("4.bed.zip")
@@ -264,16 +282,19 @@ class TestLibrariesApi(ApiTestCase):
         dataset = self.library_populator.get_library_contents_with_path(library["id"], "/4.bed")
         assert dataset["file_size"] == 61, dataset
 
+    @requires_new_library
     def test_fetch_single_url_to_folder(self):
         library, response = self.library_populator.fetch_single_url_to_folder()
         dataset = self.library_populator.get_library_contents_with_path(library["id"], "/4.bed")
         assert dataset["file_size"] == 61, dataset
 
+    @requires_new_library
     def test_fetch_single_url_with_invalid_datatype(self):
         _, response = self.library_populator.fetch_single_url_to_folder("xxx", assert_ok=False)
         self._assert_status_code_is(response, 400)
         assert response.json()["err_msg"] == "Requested extension 'xxx' unknown, cannot upload dataset."
 
+    @requires_new_library
     def test_legacy_upload_unknown_datatype(self):
         library = self.library_populator.new_private_library("ForLegacyUpload")
         folder_response = self._create_folder(library)
@@ -291,6 +312,7 @@ class TestLibrariesApi(ApiTestCase):
         assert create_response.json() == "Requested extension 'xxx' unknown, cannot upload dataset."
 
     @skip_if_github_down
+    @requires_new_library
     def test_fetch_failed_validation(self):
         # Exception handling is really rough here - we should be creating a dataset in error instead
         # of just failing the job like this.
@@ -326,6 +348,7 @@ class TestLibrariesApi(ApiTestCase):
         assert dataset["state"] == "error", dataset
 
     @skip_if_github_down
+    @requires_new_library
     def test_fetch_url_archive_to_folder(self):
         history_id, library, destination = self._setup_fetch_to_folder("single_url")
         targets = [
@@ -370,6 +393,7 @@ class TestLibrariesApi(ApiTestCase):
     def _setup_fetch_to_folder(self, test_name):
         return self.library_populator.setup_fetch_to_folder(test_name)
 
+    @requires_new_library
     def test_create_dataset_in_folder(self):
         library = self.library_populator.new_private_library("ForCreateDatasets")
         folder_response = self._create_folder(library)
@@ -382,6 +406,7 @@ class TestLibrariesApi(ApiTestCase):
         self._assert_status_code_is(create_response, 200)
         self._assert_has_keys(create_response.json(), "name", "id")
 
+    @requires_new_library
     def test_create_dataset_in_subfolder(self):
         library = self.library_populator.new_private_library("ForCreateDatasets")
         folder_response = self._create_folder(library)
@@ -409,6 +434,7 @@ class TestLibrariesApi(ApiTestCase):
         library_id = ld["parent_library_id"]
         return self.library_populator.wait_on_library_dataset(library_id, ld["id"])
 
+    @requires_new_library
     def test_update_dataset_in_folder(self):
         ld = self._create_dataset_in_folder_in_library("ForUpdateDataset", content=">seq\nATGC", wait=True).json()
         data = {
@@ -420,6 +446,7 @@ class TestLibrariesApi(ApiTestCase):
         ld_updated = self._patch_library_dataset(ld["id"], data)
         self._assert_has_keys(ld_updated, "name", "file_ext", "misc_info", "genome_build")
 
+    @requires_new_library
     def test_update_dataset_tags(self):
         ld = self._create_dataset_in_folder_in_library("ForTagtestDataset", wait=True).json()
         data = {"tags": ["#Lancelot", "name:Holy Grail", "blue"]}
@@ -427,6 +454,7 @@ class TestLibrariesApi(ApiTestCase):
         self._assert_has_keys(ld_updated, "tags")
         assert ld_updated["tags"] == "name:Lancelot, name:HolyGrail, blue"
 
+    @requires_new_library
     def test_invalid_update_dataset_in_folder(self):
         ld = self._create_dataset_in_folder_in_library("ForInvalidUpdateDataset", wait=True).json()
         data = {"file_ext": "nonexisting_type"}
@@ -434,6 +462,7 @@ class TestLibrariesApi(ApiTestCase):
         self._assert_status_code_is(create_response, 400)
         assert "This Galaxy does not recognize the datatype of:" in create_response.json()["err_msg"]
 
+    @requires_new_library
     def test_detect_datatype_of_dataset_in_folder(self):
         ld = self._create_dataset_in_folder_in_library("ForDetectDataset", wait=True).json()
         data = {"file_ext": "data"}
@@ -445,12 +474,15 @@ class TestLibrariesApi(ApiTestCase):
         self._assert_has_keys(ld_updated, "file_ext")
         assert ld_updated["file_ext"] == "txt"
 
+    @requires_new_library
     def test_ldda_collection_import_to_history(self):
         self._import_to_history(visible=True)
 
+    @requires_new_library
     def test_ldda_collection_import_to_history_hide_source(self):
         self._import_to_history(visible=False)
 
+    @requires_new_library
     def test_import_paired_collection(self):
         ld = self._create_dataset_in_folder_in_library("ForHistoryImport").json()
         history_id = self.dataset_populator.new_history()
@@ -502,6 +534,7 @@ class TestLibrariesApi(ApiTestCase):
         assert element["element_identifier"] == element_identifer
         assert element["object"]["visible"] == visible
 
+    @requires_new_library
     def test_create_datasets_in_library_from_collection(self):
         library = self.library_populator.new_private_library("ForCreateDatasetsFromCollection")
         folder_response = self._create_folder(library)
@@ -515,6 +548,7 @@ class TestLibrariesApi(ApiTestCase):
         create_response = self._post(f"libraries/{library['id']}/contents", payload)
         self._assert_status_code_is(create_response, 200)
 
+    @requires_new_library
     def test_create_datasets_in_folder_from_collection(self):
         library = self.library_populator.new_private_library("ForCreateDatasetsFromCollection")
         history_id = self.dataset_populator.new_history()

--- a/lib/galaxy_test/api/test_roles.py
+++ b/lib/galaxy_test/api/test_roles.py
@@ -10,6 +10,7 @@ from galaxy_test.base.api_asserts import (
     assert_has_keys,
     assert_status_code_is,
 )
+from galaxy_test.base.decorators import requires_admin
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
@@ -21,6 +22,7 @@ class TestRolesApi(ApiTestCase):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
+    @requires_admin
     def test_list_and_show(self):
         def check_roles_response(response):
             assert_status_code_is(response, 200)
@@ -56,6 +58,7 @@ class TestRolesApi(ApiTestCase):
         role = role_response.json()
         self.check_role_dict(role, assert_id=user_role_id)
 
+    @requires_admin
     def test_create_invalid_params(self):
         # In theory these low-level validation test cases could be handled in more
         # of a unit test style but it makes sense during the transition from wsgi to
@@ -97,6 +100,7 @@ class TestRolesApi(ApiTestCase):
         assert "name" in response.json()["err_msg"]
         assert "validation_errors" in response.json()
 
+    @requires_admin
     def test_create_valid(self):
         name = self.dataset_populator.get_random_name()
         description = "A test role."
@@ -124,6 +128,7 @@ class TestRolesApi(ApiTestCase):
         assert role["id"] in user_roles_response_ids
         assert role["id"] in different_user_roles_response_ids
 
+    @requires_admin
     def test_show_error_codes(self):
         # Bad role ids are 400.
         response = self._get("roles/badroleid")
@@ -135,6 +140,7 @@ class TestRolesApi(ApiTestCase):
         response = self._get(f"roles/{different_user_role_id}")
         assert_status_code_is(response, 400)
 
+    @requires_admin
     def test_create_only_admin(self):
         response = self._post("roles", json=True)
         assert_status_code_is(response, 403)

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -340,39 +340,40 @@ class TestToolsApi(ApiTestCase, TestsTools):
         return tool_info
 
     @skip_without_tool("model_attributes")
-    def test_model_attributes_sanitization(self, history_id):
-        cool_name_with_quote = 'cool name with a quo"te'
-        cool_name_without_quote = "cool name with a quo__dq__te"
+    def test_model_attributes_sanitization(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            cool_name_with_quote = 'cool name with a quo"te'
+            cool_name_without_quote = "cool name with a quo__dq__te"
 
-        current_user = self._get("users/current").json()
-        user_info_url = self._api_url(f"users/{current_user['id']}/information/inputs", use_key=True)
-        put_response = put(user_info_url, data=json.dumps({"address_0|desc": cool_name_with_quote}))
-        put_response.raise_for_status()
+            current_user = self._get("users/current").json()
+            user_info_url = self._api_url(f"users/{current_user['id']}/information/inputs", use_key=True)
+            put_response = put(user_info_url, data=json.dumps({"address_0|desc": cool_name_with_quote}))
+            put_response.raise_for_status()
 
-        response = get(user_info_url).json()
-        assert len(response["addresses"]) == 1
-        assert response["addresses"][0]["desc"] == cool_name_with_quote
+            response = get(user_info_url).json()
+            assert len(response["addresses"]) == 1
+            assert response["addresses"][0]["desc"] == cool_name_with_quote
 
-        hda1 = self.dataset_populator.new_dataset(history_id, content="1\t2\t3", name=cool_name_with_quote)
-        assert hda1["name"] == cool_name_with_quote
+            hda1 = self.dataset_populator.new_dataset(history_id, content="1\t2\t3", name=cool_name_with_quote)
+            assert hda1["name"] == cool_name_with_quote
 
-        rval = self._run(
-            tool_id="model_attributes",
-            inputs={"input1": dataset_to_param(hda1)},
-            history_id=history_id,
-            assert_ok=True,
-            wait_for_job=True,
-        )
-        sanitized_dataset_name = self.dataset_populator.get_history_dataset_content(
-            history_id, dataset=rval["outputs"][0]
-        )
-        assert sanitized_dataset_name.strip() == cool_name_without_quote
+            rval = self._run(
+                tool_id="model_attributes",
+                inputs={"input1": dataset_to_param(hda1)},
+                history_id=history_id,
+                assert_ok=True,
+                wait_for_job=True,
+            )
+            sanitized_dataset_name = self.dataset_populator.get_history_dataset_content(
+                history_id, dataset=rval["outputs"][0]
+            )
+            assert sanitized_dataset_name.strip() == cool_name_without_quote
 
-        sanitized_email = self.dataset_populator.get_history_dataset_content(history_id, dataset=rval["outputs"][1])
-        assert '"' not in sanitized_email
+            sanitized_email = self.dataset_populator.get_history_dataset_content(history_id, dataset=rval["outputs"][1])
+            assert '"' not in sanitized_email
 
-        sanitized_address = self.dataset_populator.get_history_dataset_content(history_id, dataset=rval["outputs"][2])
-        assert sanitized_address.strip() == cool_name_without_quote
+            sanitized_address = self.dataset_populator.get_history_dataset_content(history_id, dataset=rval["outputs"][2])
+            assert sanitized_address.strip() == cool_name_without_quote
 
     @skip_without_tool("composite_output")
     def test_test_data_filepath_security(self):
@@ -472,74 +473,77 @@ class TestToolsApi(ApiTestCase, TestsTools):
         }
         assert set(namelist) == expected_names
 
-    def test_convert_dataset_explicit_history(self, history_id):
-        fasta1_contents = open(self.get_filename("1.fasta")).read()
-        hda1 = self.dataset_populator.new_dataset(history_id, content=fasta1_contents)
+    def test_convert_dataset_explicit_history(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            fasta1_contents = open(self.get_filename("1.fasta")).read()
+            hda1 = self.dataset_populator.new_dataset(history_id, content=fasta1_contents)
 
-        payload = {
-            "src": "hda",
-            "id": hda1["id"],
-            "source_type": "fasta",
-            "target_type": "tabular",
-            "history_id": history_id,
-        }
-        create_response = self._post("tools/CONVERTER_fasta_to_tabular/convert", data=payload)
-        self.dataset_populator.wait_for_job(create_response.json()["jobs"][0]["id"], assert_ok=True)
-        create_response.raise_for_status()
-        assert len(create_response.json()["implicit_collections"]) == 0
-        for output in create_response.json()["outputs"]:
-            assert output["file_ext"] == "tabular"
+            payload = {
+                "src": "hda",
+                "id": hda1["id"],
+                "source_type": "fasta",
+                "target_type": "tabular",
+                "history_id": history_id,
+            }
+            create_response = self._post("tools/CONVERTER_fasta_to_tabular/convert", data=payload)
+            self.dataset_populator.wait_for_job(create_response.json()["jobs"][0]["id"], assert_ok=True)
+            create_response.raise_for_status()
+            assert len(create_response.json()["implicit_collections"]) == 0
+            for output in create_response.json()["outputs"]:
+                assert output["file_ext"] == "tabular"
 
-    def test_convert_dataset_implicit_history(self, history_id):
-        fasta1_contents = open(self.get_filename("1.fasta")).read()
-        hda1 = self.dataset_populator.new_dataset(history_id, content=fasta1_contents)
+    def test_convert_dataset_implicit_history(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            fasta1_contents = open(self.get_filename("1.fasta")).read()
+            hda1 = self.dataset_populator.new_dataset(history_id, content=fasta1_contents)
 
-        payload = {"src": "hda", "id": hda1["id"], "source_type": "fasta", "target_type": "tabular"}
-        create_response = self._post("tools/CONVERTER_fasta_to_tabular/convert", data=payload)
-        self.dataset_populator.wait_for_job(create_response.json()["jobs"][0]["id"], assert_ok=True)
-        create_response.raise_for_status()
-        assert len(create_response.json()["implicit_collections"]) == 0
-        for output in create_response.json()["outputs"]:
-            assert output["file_ext"] == "tabular"
+            payload = {"src": "hda", "id": hda1["id"], "source_type": "fasta", "target_type": "tabular"}
+            create_response = self._post("tools/CONVERTER_fasta_to_tabular/convert", data=payload)
+            self.dataset_populator.wait_for_job(create_response.json()["jobs"][0]["id"], assert_ok=True)
+            create_response.raise_for_status()
+            assert len(create_response.json()["implicit_collections"]) == 0
+            for output in create_response.json()["outputs"]:
+                assert output["file_ext"] == "tabular"
 
-    def test_convert_hdca(self, history_id):
-        data = [
-            {
-                "name": "test0",
-                "elements": [
-                    {"src": "pasted", "paste_content": "123\n", "name": "forward", "ext": "fasta"},
-                    {"src": "pasted", "paste_content": "456\n", "name": "reverse", "ext": "fasta"},
-                ],
-            },
-            {
-                "name": "test1",
-                "elements": [
-                    {"src": "pasted", "paste_content": "789\n", "name": "forward", "ext": "fasta"},
-                    {"src": "pasted", "paste_content": "0ab\n", "name": "reverse", "ext": "fasta"},
-                ],
-            },
-        ]
-        hdca1 = self.dataset_collection_populator.upload_collection(history_id, "list:paired", elements=data, wait=True)
-        self._assert_status_code_is(hdca1, 200)
+    def test_convert_hdca(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            data = [
+                {
+                    "name": "test0",
+                    "elements": [
+                        {"src": "pasted", "paste_content": "123\n", "name": "forward", "ext": "fasta"},
+                        {"src": "pasted", "paste_content": "456\n", "name": "reverse", "ext": "fasta"},
+                    ],
+                },
+                {
+                    "name": "test1",
+                    "elements": [
+                        {"src": "pasted", "paste_content": "789\n", "name": "forward", "ext": "fasta"},
+                        {"src": "pasted", "paste_content": "0ab\n", "name": "reverse", "ext": "fasta"},
+                    ],
+                },
+            ]
+            hdca1 = self.dataset_collection_populator.upload_collection(history_id, "list:paired", elements=data, wait=True)
+            self._assert_status_code_is(hdca1, 200)
 
-        payload = {
-            "src": "hdca",
-            "id": hdca1.json()["outputs"][0]["id"],
-            "source_type": "fasta",
-            "target_type": "tabular",
-            "history_id": history_id,
-        }
-        create_response = self._post("tools/CONVERTER_fasta_to_tabular/convert", payload)
-        create_response.raise_for_status()
-        assert create_response.json()["implicit_collections"] != []
-        hid = create_response.json()["implicit_collections"][0]["hid"]
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        collection_details = self.dataset_populator.get_history_collection_details(history_id, hid=hid)
-        for element in collection_details["elements"][0]["object"]["elements"]:
-            assert element["object"]["file_ext"] == "tabular"
+            payload = {
+                "src": "hdca",
+                "id": hdca1.json()["outputs"][0]["id"],
+                "source_type": "fasta",
+                "target_type": "tabular",
+                "history_id": history_id,
+            }
+            create_response = self._post("tools/CONVERTER_fasta_to_tabular/convert", payload)
+            create_response.raise_for_status()
+            assert create_response.json()["implicit_collections"] != []
+            hid = create_response.json()["implicit_collections"][0]["hid"]
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            collection_details = self.dataset_populator.get_history_collection_details(history_id, hid=hid)
+            for element in collection_details["elements"][0]["object"]["elements"]:
+                assert element["object"]["file_ext"] == "tabular"
 
     def test_unzip_collection(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             hdca_id = self._build_pair(history_id, ["123", "456"])
             inputs = {
                 "input": {"src": "hdca", "id": hdca_id},
@@ -566,7 +570,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
             assert output_reverse["history_id"] == history_id
 
     def test_unzip_nested(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             response = self.dataset_collection_populator.upload_collection(
                 history_id,
                 "list:paired",
@@ -610,7 +614,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
             assert unzipped_hdca["elements"][0]["element_type"] == "hda", unzipped_hdca
 
     def test_zip_inputs(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             hda1 = dataset_to_param(self.dataset_populator.new_dataset(history_id, content="1\t2\t3"))
             hda2 = dataset_to_param(self.dataset_populator.new_dataset(history_id, content="4\t5\t6"))
             inputs = {
@@ -628,38 +632,40 @@ class TestToolsApi(ApiTestCase, TestsTools):
             assert zipped_hdca["collection_type"] == "paired"
 
     @skip_without_tool("__ZIP_COLLECTION__")
-    def test_collection_operation_dataset_input_permissions(self, history_id):
-        hda1 = dataset_to_param(self.dataset_populator.new_dataset(history_id, content="1\t2\t3"))
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        self.dataset_populator.make_private(history_id, hda1["id"])
-        inputs = {
-            "input_forward": hda1,
-            "input_reverse": hda1,
-        }
-        with self._different_user_and_history() as other_history_id:
-            response = self._run("__ZIP_COLLECTION__", other_history_id, inputs, assert_ok=False)
-            self._assert_dataset_permission_denied_response(response)
+    def test_collection_operation_dataset_input_permissions(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            hda1 = dataset_to_param(self.dataset_populator.new_dataset(history_id, content="1\t2\t3"))
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            self.dataset_populator.make_private(history_id, hda1["id"])
+            inputs = {
+                "input_forward": hda1,
+                "input_reverse": hda1,
+            }
+            with self._different_user_and_history() as other_history_id:
+                response = self._run("__ZIP_COLLECTION__", other_history_id, inputs, assert_ok=False)
+                self._assert_dataset_permission_denied_response(response)
 
     @skip_without_tool("__UNZIP_COLLECTION__")
-    def test_collection_operation_collection_input_permissions(self, history_id):
-        create_response = self.dataset_collection_populator.create_pair_in_history(
-            history_id, direct_upload=True, wait=True
-        )
-        self._assert_status_code_is(create_response, 200)
-        collection = create_response.json()["outputs"][0]
-        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        collection = self.dataset_populator.get_history_collection_details(history_id, hid=collection["hid"])
-        element_id = collection["elements"][0]["object"]["id"]
-        self.dataset_populator.make_private(history_id, element_id)
-        inputs = {
-            "input": {"src": "hdca", "id": collection["id"]},
-        }
-        with self._different_user_and_history() as other_history_id:
-            response = self._run("__UNZIP_COLLECTION__", other_history_id, inputs, assert_ok=False)
-            self._assert_dataset_permission_denied_response(response)
+    def test_collection_operation_collection_input_permissions(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            create_response = self.dataset_collection_populator.create_pair_in_history(
+                history_id, direct_upload=True, wait=True
+            )
+            self._assert_status_code_is(create_response, 200)
+            collection = create_response.json()["outputs"][0]
+            self.dataset_populator.wait_for_history(history_id, assert_ok=True)
+            collection = self.dataset_populator.get_history_collection_details(history_id, hid=collection["hid"])
+            element_id = collection["elements"][0]["object"]["id"]
+            self.dataset_populator.make_private(history_id, element_id)
+            inputs = {
+                "input": {"src": "hdca", "id": collection["id"]},
+            }
+            with self._different_user_and_history() as other_history_id:
+                response = self._run("__UNZIP_COLLECTION__", other_history_id, inputs, assert_ok=False)
+                self._assert_dataset_permission_denied_response(response)
 
     def test_zip_list_inputs(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             hdca1_id = self.dataset_collection_populator.create_list_in_history(
                 history_id, contents=["a\nb\nc\nd", "e\nf\ng\nh"], wait=True
             ).json()["outputs"][0]["id"]
@@ -683,7 +689,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("__FILTER_FAILED_DATASETS__")
     def test_filter_failed_list(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             ok_hdca_id = self.dataset_collection_populator.create_list_in_history(
                 history_id, contents=["0", "1", "0", "1"], wait=True
             ).json()["outputs"][0]["id"]
@@ -708,7 +714,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("__FILTER_FAILED_DATASETS__")
     def test_filter_failed_list_paired(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             pair1 = self.dataset_collection_populator.create_pair_in_history(
                 history_id, contents=["0", "0"], wait=True
             ).json()["outputs"][0]["id"]
@@ -776,7 +782,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
         return filtered_hdca
 
     def _apply_rules_and_check(self, example: Dict[str, Any]) -> None:
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             inputs = stage_rules_example(self.galaxy_interactor, history_id, example)
             hdca = inputs["input"]
             inputs = {"input": {"src": "hdca", "id": hdca["id"]}, "rules": example["rules"]}
@@ -808,7 +814,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("multi_select")
     def test_multi_select_as_list(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             inputs = {
                 "select_ex": ["--ex1", "ex2"],
             }
@@ -820,7 +826,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("multi_select")
     def test_multi_select_optional(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             inputs = {
                 "select_ex": ["--ex1"],
                 "select_optional": None,
@@ -834,7 +840,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("library_data")
     def test_library_data_param(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             ld = LibraryPopulator(self.galaxy_interactor).new_library_dataset("lda_test_library")
             inputs = {"library_dataset": ld["ldda_id"], "library_dataset_multiple": [ld["ldda_id"], ld["ldda_id"]]}
             response = self._run("library_data", history_id, inputs, assert_ok=True)
@@ -846,7 +852,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
 
     @skip_without_tool("multi_data_param")
     def test_multidata_param(self):
-        with self.dataset_populator.test_history() as history_id:
+        with self.dataset_populator.test_history(require_new=False) as history_id:
             hda1 = dataset_to_param(self.dataset_populator.new_dataset(history_id, content="1\t2\t3"))
             hda2 = dataset_to_param(self.dataset_populator.new_dataset(history_id, content="4\t5\t6"))
             inputs = {
@@ -862,38 +868,40 @@ class TestToolsApi(ApiTestCase, TestsTools):
             assert output2_content == "4\t5\t6\n1\t2\t3\n", output2_content
 
     @skip_without_tool("cat1")
-    def test_run_cat1(self, history_id):
-        # Run simple non-upload tool with an input data parameter.
-        new_dataset = self.dataset_populator.new_dataset(history_id, content="Cat1Test")
-        inputs = dict(
-            input1=dataset_to_param(new_dataset),
-        )
-        outputs = self._cat1_outputs(history_id, inputs=inputs)
-        assert len(outputs) == 1
-        output1 = outputs[0]
-        output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
-        assert output1_content.strip() == "Cat1Test"
+    def test_run_cat1(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            # Run simple non-upload tool with an input data parameter.
+            new_dataset = self.dataset_populator.new_dataset(history_id, content="Cat1Test")
+            inputs = dict(
+                input1=dataset_to_param(new_dataset),
+            )
+            outputs = self._cat1_outputs(history_id, inputs=inputs)
+            assert len(outputs) == 1
+            output1 = outputs[0]
+            output1_content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output1)
+            assert output1_content.strip() == "Cat1Test"
 
     @pytest.mark.require_new_history
     @skip_without_tool("cat1")
-    def test_run_cat1_use_cached_job(self, history_id):
-        # Run simple non-upload tool with an input data parameter.
-        new_dataset = self.dataset_populator.new_dataset(history_id, content="Cat1Test")
-        inputs = dict(
-            input1=dataset_to_param(new_dataset),
-        )
-        outputs_one = self._run_cat1(history_id, inputs=inputs, assert_ok=True, wait_for_job=True)
-        outputs_two = self._run_cat1(history_id, inputs=inputs, use_cached_job=False, assert_ok=True, wait_for_job=True)
-        outputs_three = self._run_cat1(
-            history_id, inputs=inputs, use_cached_job=True, assert_ok=True, wait_for_job=True
-        )
-        dataset_details = []
-        for output in [outputs_one, outputs_two, outputs_three]:
-            output_id = output["outputs"][0]["id"]
-            dataset_details.append(self._get(f"datasets/{output_id}").json())
-        filenames = [dd["file_name"] for dd in dataset_details]
-        assert len(filenames) == 3, filenames
-        assert len(set(filenames)) <= 2, filenames
+    def test_run_cat1_use_cached_job(self):
+        with self.dataset_populator.test_history(require_new=True) as history_id:
+            # Run simple non-upload tool with an input data parameter.
+            new_dataset = self.dataset_populator.new_dataset(history_id, content="Cat1Test")
+            inputs = dict(
+                input1=dataset_to_param(new_dataset),
+            )
+            outputs_one = self._run_cat1(history_id, inputs=inputs, assert_ok=True, wait_for_job=True)
+            outputs_two = self._run_cat1(history_id, inputs=inputs, use_cached_job=False, assert_ok=True, wait_for_job=True)
+            outputs_three = self._run_cat1(
+                history_id, inputs=inputs, use_cached_job=True, assert_ok=True, wait_for_job=True
+            )
+            dataset_details = []
+            for output in [outputs_one, outputs_two, outputs_three]:
+                output_id = output["outputs"][0]["id"]
+                dataset_details.append(self._get(f"datasets/{output_id}").json())
+            filenames = [dd["file_name"] for dd in dataset_details]
+            assert len(filenames) == 3, filenames
+            assert len(set(filenames)) <= 2, filenames
 
     @skip_without_tool("cat1")
     def test_run_cat1_listified_param(self, history_id):

--- a/lib/galaxy_test/base/decorators.py
+++ b/lib/galaxy_test/base/decorators.py
@@ -1,0 +1,103 @@
+"""Test decorators for test methods meant to be run on external Galaxy instances.
+
+These decorators should not be needed for integration tests, unit tests, etc... but
+are appropriate for the API and Selenium tests that are meant to be executable on
+external Galaxies.
+
+Running this class of tests should implicitly come with the expectation that new
+jobs, workflows, and datasets will be created. But tests creating new published objects,
+histories, libraries, etc... should be annotated ideally.
+"""
+import os
+import unittest
+from functools import wraps
+from typing import Union
+
+import pytest
+from typing_extensions import Literal
+
+KnownRequirementT = Union[
+    Literal["admin"],
+    Literal["new_history"],
+    Literal["new_library"],
+    Literal["new_published_objects"],
+    Literal["new_user"],
+]
+
+
+def has_requirement(method, tag: KnownRequirementT):
+    try:
+        # Skipping B009 (use of getattr with constant attribute) in
+        # this next line because method may be a bound class method
+        # and direct attribute access appends the class name and such.
+        return tag in getattr(method, "__required_galaxy_features")  # noqa: B009
+    except AttributeError:
+        return False
+
+
+def using_requirement(tag: KnownRequirementT):
+    """At runtime, indicate we're using a Galaxy feature.
+
+    This allows runtime test skips if the appropriate environment variable is set.
+    """
+    requirement = f"requires_{tag}"
+    skip_environment_variable = f"GALAXY_TEST_SKIP_IF_{requirement.upper()}"
+    env_value = os.environ.get(skip_environment_variable, "0")
+    if env_value != "0":
+        raise unittest.SkipTest(f"[{env_value}] Skipping due to {skip_environment_variable} being set to {env_value}")
+
+
+def _attach_requirements(method, tag: KnownRequirementT):
+    requirement = f"requires_{tag}"
+    try:
+        method.__required_galaxy_features
+    except AttributeError:
+        method.__required_galaxy_features = []
+    method.__required_galaxy_features.append(tag)
+    getattr(pytest.mark, requirement)(method)
+
+
+def _wrap_method_with_galaxy_requirement(method, tag: KnownRequirementT):
+    _attach_requirements(method, tag)
+
+    @wraps(method)
+    def wrapped_method(*args, **kwargs):
+        using_requirement(tag)
+        return method(*args, **kwargs)
+
+    return wrapped_method
+
+
+def requires_new_history(method):
+    return _wrap_method_with_galaxy_requirement(method, "new_history")
+
+
+def requires_new_user(method):
+    method = _wrap_method_with_galaxy_requirement(method, "new_user")
+    method = _wrap_method_with_galaxy_requirement(method, "admin")
+    return method
+
+
+def requires_new_library(method):
+    method = _wrap_method_with_galaxy_requirement(method, "new_library")
+    method = _wrap_method_with_galaxy_requirement(method, "admin")
+    return method
+
+
+def requires_new_published_objects(method):
+    method = _wrap_method_with_galaxy_requirement(method, "new_published_objects")
+
+
+def requires_admin(method):
+    return _wrap_method_with_galaxy_requirement(method, "admin")
+
+
+__all__ = (
+    "has_requirement",
+    "requires_admin",
+    "requires_new_history",
+    "requires_new_library",
+    "requires_new_published_objects",
+    "requires_new_user",
+    "using_requirement",
+)

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -832,7 +832,7 @@ class TestDriver:
         self.server_wrappers = []
         self.temp_directories = []
 
-    def setup(self):
+    def setup(self, config_object=None):
         """Called before tests are built."""
 
     def build_tests(self):

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -735,6 +735,9 @@ class SeleniumSessionDatasetPopulator(SeleniumSessionGetPostMixin, populators.Ba
         """Construct a dataset populator from a bioblend GalaxyInstance."""
         self.selenium_context = selenium_context
 
+    def _summarize_history(self, history_id: str) -> None:
+        pass
+
 
 class SeleniumSessionDatasetCollectionPopulator(SeleniumSessionGetPostMixin, populators.BaseDatasetCollectionPopulator):
 

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -44,6 +44,10 @@ from galaxy_test.base.api import (
     UsesCeleryTasks,
 )
 from galaxy_test.base.api_util import get_admin_api_key
+from galaxy_test.base.decorators import (
+    requires_new_history,
+    using_requirement,
+)
 from galaxy_test.base.env import (
     DEFAULT_WEB_HOST,
     get_ip_address,
@@ -106,6 +110,7 @@ def managed_history(f):
     Cleanup the history after the job is complete as well unless
     GALAXY_TEST_NO_CLEANUP is set in the environment.
     """
+    f = requires_new_history(f)
 
     @wraps(f)
     def func_wrapper(self, *args, **kwds):
@@ -247,7 +252,7 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin, Use
     # is required for the test to run properly. Override admin user
     # login info with GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL /
     # GALAXY_TEST_SELENIUM_ADMIN_USER_PASSWORD
-    requires_admin = False
+    run_as_admin = False
 
     def _target_url_from_selenium(self):
         # Deal with the case when Galaxy has a different URL when being accessed by Selenium
@@ -262,7 +267,7 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin, Use
         self.target_url_from_selenium = self._target_url_from_selenium()
         self.snapshots = []
         self.setup_driver_and_session()
-        if self.requires_admin and GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL == DEFAULT_ADMIN_USER:
+        if self.run_as_admin and GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL == DEFAULT_ADMIN_USER:
             self._setup_interactor()
             self._setup_user(GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL)
         self._try_setup_with_driver()
@@ -391,6 +396,7 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin, Use
         self.components.history_panel.empty_message.wait_for_visible()
 
     def admin_login(self):
+        using_requirement("admin")
         self.home()
         self.submit_login(GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL, GALAXY_TEST_SELENIUM_ADMIN_USER_PASSWORD)
         with self.main_panel():

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -1,3 +1,4 @@
+from galaxy_test.base.decorators import requires_admin
 from galaxy_test.base.populators import flakey
 from .framework import (
     selenium_test,
@@ -7,9 +8,10 @@ from .framework import (
 
 class TestAdminApp(SeleniumTestCase):
 
-    requires_admin = True
+    run_as_admin = True
 
     @selenium_test
+    @requires_admin
     def test_html_allowlist(self):
         admin_component = self.components.admin
         self.admin_login()
@@ -38,6 +40,7 @@ class TestAdminApp(SeleniumTestCase):
 
     @selenium_test
     @flakey
+    @requires_admin
     def test_admin_toolshed(self):
         """
         This tests installing a repository, checking for upgrades, and uninstalling.
@@ -99,6 +102,7 @@ class TestAdminApp(SeleniumTestCase):
         self.screenshot("admin_toolshed_repo_uninstalled")
 
     @selenium_test
+    @requires_admin
     def test_admin_dependencies_display(self):
         admin_component = self.components.admin
         self.admin_login()
@@ -120,6 +124,7 @@ class TestAdminApp(SeleniumTestCase):
         self.screenshot("admin_dependencies_unused")
 
     @selenium_test
+    @requires_admin
     def test_admin_jobs_display(self):
         admin_component = self.components.admin
         self.admin_login()
@@ -147,6 +152,7 @@ class TestAdminApp(SeleniumTestCase):
         assert lock_label.wait_for_text() == original_label
 
     @selenium_test
+    @requires_admin
     def test_admin_server_display(self):
         admin_component = self.components.admin
         self.admin_login()
@@ -174,6 +180,7 @@ class TestAdminApp(SeleniumTestCase):
         self.screenshot("admin_local_data")
 
     @selenium_test
+    @requires_admin
     def test_admin_user_display(self):
         admin_component = self.components.admin
         self.admin_login()
@@ -201,6 +208,7 @@ class TestAdminApp(SeleniumTestCase):
         self.screenshot("admin_roles")
 
     @selenium_test
+    @requires_admin
     def test_admin_data_manager(self):
         admin_component = self.components.admin
         self.admin_login()

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -1,5 +1,9 @@
 import os
 
+from galaxy_test.base.decorators import (
+    requires_admin,
+    requires_new_library,
+)
 from .framework import (
     retry_during_transitions,
     selenium_test,
@@ -10,9 +14,11 @@ from .framework import (
 
 class TestLibraryContents(SeleniumTestCase, UsesLibraryAssertions):
 
-    requires_admin = True
+    run_as_admin = True
 
     @selenium_test
+    @requires_admin
+    @requires_new_library
     def test_sub_folder(self):
         def change_description(description):
             self.components.libraries.folder.edit_folder_btn.wait_for_and_click()
@@ -52,6 +58,8 @@ class TestLibraryContents(SeleniumTestCase, UsesLibraryAssertions):
         assert shrinked_description == self.components.libraries.folder.description_field_shrinked.wait_for_text()
 
     @selenium_test
+    @requires_admin
+    @requires_new_library
     def test_import_dataset_from_history(self):
         self.admin_login()
         self.perform_upload(self.get_filename("1.txt"))
@@ -78,6 +86,8 @@ class TestLibraryContents(SeleniumTestCase, UsesLibraryAssertions):
         self.assert_num_displayed_items_is(1)
 
     @selenium_test
+    @requires_admin
+    @requires_new_library
     def download_dataset_from_library(self):
         self.test_import_dataset_from_history()
 
@@ -90,6 +100,8 @@ class TestLibraryContents(SeleniumTestCase, UsesLibraryAssertions):
         assert expected_filename in folder_files
 
     @selenium_test
+    @requires_admin
+    @requires_new_library
     def test_delete_dataset(self):
         self.test_import_dataset_from_history()
 
@@ -111,6 +123,8 @@ class TestLibraryContents(SeleniumTestCase, UsesLibraryAssertions):
     # Galaxy must be running so that test-data/1.txt would work but it just doesn't
     # for some reason. https://jenkins.galaxyproject.org/job/jmchilton-selenium/79/artifact/79-test-errors/test_import_dataset_from_path2017100413221507137721/
     @selenium_test
+    @requires_admin
+    @requires_new_library
     def test_import_dataset_from_path(self):
         self.navigate_to_new_library()
         self.assert_num_displayed_items_is(0)
@@ -146,6 +160,8 @@ class TestLibraryContents(SeleniumTestCase, UsesLibraryAssertions):
         assert table_as_dict["Genome build"] == "?", table_as_dict
 
     @selenium_test
+    @requires_admin
+    @requires_new_library
     def test_import_dataset_from_import_dir(self):
         self.navigate_to_new_library()
         self.assert_num_displayed_items_is(0)
@@ -154,6 +170,8 @@ class TestLibraryContents(SeleniumTestCase, UsesLibraryAssertions):
         self.assert_num_displayed_items_is(len(filenames))
 
     @selenium_test
+    @requires_admin
+    @requires_new_library
     def test_show_details(self):
         self.navigate_to_new_library()
         self.sleep_for(self.wait_types.UX_RENDER)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -239,6 +239,9 @@ GALAXY_TEST_TOOL_PATH           Path defaulting to 'tools'.
 GALAXY_TEST_SHED_TOOL_CONF      Shed toolbox conf (defaults to
                                 config/shed_tool_conf.xml) used when testing
                                 installed to tools with -installed.
+GALAXY_TEST_HISTORY_ID          Some tests can target existing history ids, this option
+                                is fairly limited and not compatible with parrallel testing
+                                so should be limited to debugging one off tests.
 TOOL_SHED_TEST_HOST             Host to use for shed server setup for testing.
 TOOL_SHED_TEST_PORT             Port to use for shed server setup for testing.
 TOOL_SHED_TEST_FILE_DIR         Defaults to lib/tool_shed/test/test_data.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -251,6 +251,15 @@ TOOL_SHED_TEST_OMIT_GALAXY      Do not launch a Galaxy server for tool shed
                                 testing.
 GALAXY_TEST_DISABLE_ACCESS_LOG  Do not log access messages
 
+We're tyring annotate API and Selenium tests with the resources they require
+and create to make them more appropriate to run on established Galaxy instances.
+The following variables can be used to disable certain classes of properly tests.
+
+GALAXY_TEST_SKIP_IF_REQUIRES_ADMIN
+GALAXY_TEST_SKIP_IF_REQUIRES_NEW_HISTORY
+GALAXY_TEST_SKIP_IF_REQUIRES_NEW_LIBRARY
+GALAXY_TEST_SKIP_IF_REQUIRES_NEW_USER
+GALAXY_TEST_SKIP_IF_REQUIRES_NEW_PUBLISHED_OBJECTS
 EOF
 }
 

--- a/test/integration_selenium/test_admin_dependencies.py
+++ b/test/integration_selenium/test_admin_dependencies.py
@@ -7,7 +7,7 @@ from .framework import (
 
 
 class TestAdminDependencyContainers(SeleniumIntegrationTestCase):
-    requires_admin = True
+    run_as_admin = True
 
     @selenium_test
     def test_admin_containers_display(self):

--- a/test/integration_selenium/test_upload_file_sources.py
+++ b/test/integration_selenium/test_upload_file_sources.py
@@ -14,7 +14,7 @@ class TestPosixFileSourceSeleniumIntegration(PosixFileSourceSetup, SeleniumInteg
     dataset_populator: "SeleniumSessionDatasetPopulator"
 
     # For simplicity, otherwise need to setup a different file_sources_config_file
-    requires_admin = True
+    run_as_admin = True
 
     @selenium_test
     def test_upload_from_posix(self):

--- a/test/integration_selenium/test_user_library_permissions.py
+++ b/test/integration_selenium/test_user_library_permissions.py
@@ -8,7 +8,7 @@ from .framework import (
 
 
 class TestUserLibraryImport(SeleniumIntegrationTestCase):
-    requires_admin = True
+    run_as_admin = True
     ensure_registered = True
 
     @classmethod

--- a/test/integration_selenium/test_workflow_repository_tool_update.py
+++ b/test/integration_selenium/test_workflow_repository_tool_update.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 class TestWorkflowEditorToolUpgradeWithToolShedTool(SeleniumIntegrationTestCase, UsesShed):
     dataset_populator: "SeleniumSessionDatasetPopulator"
-    requires_admin = True
+    run_as_admin = True
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):

--- a/test/unit/test_base/test_decorators.py
+++ b/test/unit/test_base/test_decorators.py
@@ -1,0 +1,91 @@
+import os
+import unittest
+
+from galaxy_test.base.decorators import (
+    has_requirement,
+    requires_admin,
+    requires_new_history,
+    requires_new_library,
+    requires_new_user,
+)
+
+
+@requires_admin
+@requires_new_history
+def foo():
+    # test metadata available from inside of function
+    assert has_requirement(foo, "admin")
+    assert has_requirement(foo, "new_history")
+    assert "requires_admin" in [m.name for m in foo.pytestmark]
+    assert "requires_new_history" in [m.name for m in foo.pytestmark]
+
+
+def test_foo():
+    # test metadata available from inside of function
+    assert has_requirement(foo, "admin")
+    assert has_requirement(foo, "new_history")
+    assert "requires_admin" in [m.name for m in foo.pytestmark]
+    assert "requires_new_history" in [m.name for m in foo.pytestmark]
+
+    # fun tests from inside of foo
+    foo()
+
+
+class FooClass:
+    @requires_admin
+    @requires_new_history
+    def foo(self):
+        assert has_requirement(self.foo, "admin")
+        assert has_requirement(self.foo, "new_history")
+        assert "requires_admin" in [m.name for m in self.foo.pytestmark]
+        assert "requires_new_history" in [m.name for m in self.foo.pytestmark]
+
+
+def test_foo_class_methods():
+    test_class = FooClass()
+    foo = test_class.foo
+
+    assert has_requirement(foo, "admin")
+    assert has_requirement(foo, "new_history")
+    assert "requires_admin" in [m.name for m in foo.pytestmark]
+    assert "requires_new_history" in [m.name for m in foo.pytestmark]
+
+    foo()
+
+
+# Uncomment and run pytest to ensure the unittest.SkipTest actually skips
+# def test_pytest_skips_this_should_be_skipped():
+#    os.environ["GALAXY_TEST_SKIP_IF_REQUIRES_ADMIN"] = "1"
+#    foo()
+#    del os.environ["GALAXY_TEST_SKIP_IF_REQUIRES_ADMIN"]
+
+
+def test_skipping_foo():
+    os.environ["GALAXY_TEST_SKIP_IF_REQUIRES_ADMIN"] = "1"
+    skip_raised = False
+    try:
+        foo()
+    except unittest.SkipTest:
+        skip_raised = True
+    assert skip_raised
+    del os.environ["GALAXY_TEST_SKIP_IF_REQUIRES_ADMIN"]
+
+
+@requires_new_library
+def library_func():
+    pass
+
+
+def test_requires_new_library_implies_requires_admin():
+    assert has_requirement(library_func, "admin")
+    assert has_requirement(library_func, "new_library")
+
+
+@requires_new_user
+def user_func():
+    pass
+
+
+def test_requires_new_user_implies_requires_admin():
+    assert has_requirement(user_func, "admin")
+    assert has_requirement(user_func, "new_user")


### PR DESCRIPTION
Custom decorators allow pytest marks and that is implemented but runtime support for variables such as GALAXY_TEST_SKIP_IF_REQUIRES_NEW_LIBRARY and GALAXY_TEST_SKIP_IF_REQUIRES_NEW_PUBLISHED_OBJECTS allow test skipping even for un-decorated or mis-decorated methods.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
