### PR TITLE
[22.05] Fix metadata setting for discovered datasets with extended metadata

### DIFF
--- a/test/functional/tools/discover_metadata_files.xml
+++ b/test/functional/tools/discover_metadata_files.xml
@@ -1,0 +1,23 @@
+<tool id="discover_metadata_files" name="discover metadata files" version="1.0.0" profile="16.04">
+  <command>
+    <![CDATA[
+mkdir outputs && cp '$input_bam' outputs/output.bam
+  ]]>
+  </command>
+  <inputs>
+    <param name="input_bam" type="data" format="bam" label="BAM File" />
+  </inputs>
+  <outputs>
+    <data format="txt" name="bam_output" label="discovered bam" hidden="true">
+      <discover_datasets pattern="__name__" directory="outputs" ext="bam" visible="true" />
+    </data>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input_bam" value="3.bam" ftype="bam" />
+      <output name="bam_output">
+        <discovered_dataset designation="output.bam" file="3.bam" ftype="bam" />
+      </output>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -66,6 +66,7 @@
   <tool file="vcf_bgzip.xml" />
   <tool file="metadata.xml" />
   <tool file="metadata_bam.xml" />
+  <tool file="discover_metadata_files.xml" />
   <tool file="metadata_bcf.xml" />
   <tool file="metadata_bed.xml" />
   <tool file="metadata_biom1.xml" />

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -28,6 +28,7 @@ TEST_TOOL_IDS = [
     "composite_output_tests",
     "metadata",
     "metadata_bam",
+    "discover_metadata_files",
     "output_format",
     "output_auto_format",
     "collection_paired_test",
@@ -123,7 +124,6 @@ class ExtendedMetadataDeferredIntegrationTestCase(integration_util.IntegrationTe
 
 
 class ExtendedMetadataIntegrationInstance(integration_util.IntegrationInstance):
-    """Describe a Galaxy test instance with embedded pulsar configured."""
 
     framework_tool_and_types = True
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15036. The root of the bug is that discovered files don't have an "id" yet, so when we reach https://github.com/mvdbeek/galaxy/blob/31d9bd4558d35e66d9d01b8035279f79eb4586c4/lib/galaxy/model/store/__init__.py#L357 regular declared datasets pass the if statement and discovered datasets (correctly) don't. We just need to attach the metadata files when we're importing discovered datasets just like we do in the if branch. That also means we can skip the metadata regeneration in that case.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
