### PR TITLE
[22.05] Fix display collection error in history items

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -177,7 +177,10 @@ export default {
             if (this.isCollection) {
                 return {
                     edit: `collection/edit/${id}`,
-                    showDetails: this.item.job_source_id ? `jobs/${this.item.job_source_id}/view` : null,
+                    showDetails:
+                        this.item.job_source_id && this.item.job_source_type === "Job"
+                            ? `jobs/${this.item.job_source_id}/view`
+                            : null,
                 };
             }
             return {

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -56,6 +56,7 @@
                     :item-urls="itemUrls"
                     @delete="$emit('delete')"
                     @display="onDisplay"
+                    @showCollectionInfo="onShowCollectionInfo"
                     @edit="onEdit"
                     @undelete="$emit('undelete')"
                     @unhide="$emit('unhide')" />
@@ -176,6 +177,7 @@ export default {
             if (this.isCollection) {
                 return {
                     edit: `collection/edit/${id}`,
+                    showDetails: this.item.job_source_id ? `jobs/${this.item.job_source_id}/view` : null,
                 };
             }
             return {
@@ -206,6 +208,9 @@ export default {
         },
         onEdit() {
             backboneRoute(this.itemUrls.edit);
+        },
+        onShowCollectionInfo() {
+            backboneRoute(this.itemUrls.showDetails);
         },
         onTags(newTags) {
             this.$emit("tag-change", this.item, newTags);

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -1,5 +1,18 @@
 <template>
     <span class="align-self-start btn-group">
+        <!-- Special case for collections -->
+        <b-button
+            v-if="isCollection && canShowCollectionDetails"
+            class="collection-info-btn px-1"
+            title="Show Details"
+            size="sm"
+            variant="link"
+            :href="showCollectionDetailsUrl"
+            @click.prevent.stop="$emit('showCollectionInfo')">
+            <icon icon="info-circle" />
+        </b-button>
+
+        <!-- Common for all content items -->
         <b-button
             v-if="isDataset"
             :disabled="displayDisabled"
@@ -87,6 +100,15 @@ export default {
         },
         editUrl() {
             return prependPath(this.itemUrls.edit);
+        },
+        isCollection() {
+            return !this.isDataset;
+        },
+        canShowCollectionDetails() {
+            return !!this.itemUrls.showDetails;
+        },
+        showCollectionDetailsUrl() {
+            return prependPath(this.itemUrls.showDetails);
         },
     },
 };

--- a/client/src/components/History/Content/ContentOptions.vue
+++ b/client/src/components/History/Content/ContentOptions.vue
@@ -3,7 +3,7 @@
         <!-- Special case for collections -->
         <b-button
             v-if="isCollection && canShowCollectionDetails"
-            class="collection-info-btn px-1"
+            class="collection-job-details-btn px-1"
             title="Show Details"
             size="sm"
             variant="link"

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <job-details-provider auto-refresh :jobId="job_id" @update:result="updateJob" />
+        <job-details-provider auto-refresh :job-id="job_id" @update:result="updateJob" />
         <h3>Job Information</h3>
         <table id="job-information" class="tabletip info_data_table">
             <tbody>
@@ -46,7 +46,7 @@
                     :code-item="job.traceback" />
                 <tr v-if="job">
                     <td>Tool Exit Code:</td>
-                    <td id="exist-code">{{ job.exit_code }}</td>
+                    <td id="exit-code">{{ job.exit_code }}</td>
                 </tr>
                 <tr v-if="job && job.job_messages && job.job_messages.length > 0" id="job-messages">
                     <td>Job Messages</td>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -945,3 +945,9 @@ charts:
   selectors:
     visualize_button: '.ui-portlet .button i.fa-line-chart'  # without icon - it waits on other buttons that aren't visible, need more specific class
     viewport_canvas: 'svg.charts-viewport-canvas'
+
+job_details:
+  selectors:
+    galaxy_tool_id: '#galaxy-tool-id'
+    tool_exit_code: '#exit-code'
+

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -948,6 +948,8 @@ charts:
 
 job_details:
   selectors:
-    galaxy_tool_id: '#galaxy-tool-id'
+    galaxy_tool_with_id:
+      type: xpath
+      selector: '//td[@id="galaxy-tool-id"][normalize-space(text()) = "${tool_id}"]'
     tool_exit_code: '#exit-code'
 

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -179,6 +179,7 @@ history_panel:
       edit_button: '${_} .edit-btn'
       delete_button: '${_} .delete-btn'
       rerun_button: '${_} .rerun-btn'
+      collection_job_details_button: '${_} .collection-job-details-btn'
 
       # Action buttons...
       download_button: '${_} .download-btn'

--- a/lib/galaxy_test/selenium/test_history_panel_collections.py
+++ b/lib/galaxy_test/selenium/test_history_panel_collections.py
@@ -139,17 +139,15 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
         failed_collection_element = self.history_panel_wait_for_hid_state(failed_collection_hid, "error")
 
         ok_collection_element.collection_job_details_button.wait_for_and_click()
-        tool_id_component = self.components.job_details.galaxy_tool_id.wait_for_visible()
+        self.components.job_details.galaxy_tool_with_id(tool_id="collection_creates_list").wait_for_visible()
         tool_exit_code_component = self.components.job_details.tool_exit_code.wait_for_visible()
         self.screenshot("history_panel_collections_job_details_ok")
-        assert tool_id_component.text == "collection_creates_list"
         assert int(tool_exit_code_component.text) == 0
 
         failed_collection_element.collection_job_details_button.wait_for_and_click()
-        tool_id_component = self.components.job_details.galaxy_tool_id.wait_for_visible()
+        self.components.job_details.galaxy_tool_with_id(tool_id="collection_creates_list_fail").wait_for_visible()
         tool_exit_code_component = self.components.job_details.tool_exit_code.wait_for_visible()
         self.screenshot("history_panel_collections_job_details_failed")
-        assert tool_id_component.text == "collection_creates_list_fail"
         assert int(tool_exit_code_component.text) > 0
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_history_panel_collections.py
+++ b/lib/galaxy_test/selenium/test_history_panel_collections.py
@@ -134,18 +134,23 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_collection_job_details(self):
-        input_collection, failed_collection = self._generate_partially_failed_collection_with_input()
-        ok_hid = input_collection["hid"]
-        failed_hid = failed_collection["hid"]
-        self.home()
-
-        ok_collection_element = self.history_panel_wait_for_hid_state(ok_hid, "ok")
-        failed_collection_element = self.history_panel_wait_for_hid_state(failed_hid, "error")
+        ok_collection_hid, failed_collection_hid = self._generate_ok_and_failed_collections()
+        ok_collection_element = self.history_panel_wait_for_hid_state(ok_collection_hid, "ok")
+        failed_collection_element = self.history_panel_wait_for_hid_state(failed_collection_hid, "error")
 
         ok_collection_element.collection_job_details_button.wait_for_and_click()
+        tool_id_component = self.components.job_details.galaxy_tool_id.wait_for_visible()
+        tool_exit_code_component = self.components.job_details.tool_exit_code.wait_for_visible()
         self.screenshot("history_panel_collections_job_details_ok")
+        assert tool_id_component.text == "collection_creates_list"
+        assert int(tool_exit_code_component.text) == 0
+
         failed_collection_element.collection_job_details_button.wait_for_and_click()
+        tool_id_component = self.components.job_details.galaxy_tool_id.wait_for_visible()
+        tool_exit_code_component = self.components.job_details.tool_exit_code.wait_for_visible()
         self.screenshot("history_panel_collections_job_details_failed")
+        assert tool_id_component.text == "collection_creates_list_fail"
+        assert int(tool_exit_code_component.text) > 0
 
     @selenium_test
     def test_back_to_history_button(self):
@@ -317,3 +322,16 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
         self.history_panel_wait_for_hid_state(collection_hid, "ok")
 
         return input_collection
+
+    def _generate_ok_and_failed_collections(self):
+        history_id = self.current_history_id()
+        fetch_response = self.dataset_collection_populator.create_list_in_history(
+            history_id, contents=["0", "1", "0", "1"]
+        ).json()
+        hdca_id = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)["id"]
+        collection_input = {"input1": {"src": "hdca", "id": hdca_id}}
+        ok_response = self.dataset_populator.run_tool("collection_creates_list", collection_input, history_id)
+        failed_response = self.dataset_populator.run_tool("collection_creates_list_fail", collection_input, history_id)
+        ok_collection_hid = ok_response["output_collections"][0]["hid"]
+        failed_collection_hid = failed_response["output_collections"][0]["hid"]
+        return ok_collection_hid, failed_collection_hid

--- a/lib/galaxy_test/selenium/test_history_panel_collections.py
+++ b/lib/galaxy_test/selenium/test_history_panel_collections.py
@@ -133,6 +133,21 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
                 self.dataset_populator.cancel_job(job["id"])
 
     @selenium_test
+    def test_collection_job_details(self):
+        input_collection, failed_collection = self._generate_partially_failed_collection_with_input()
+        ok_hid = input_collection["hid"]
+        failed_hid = failed_collection["hid"]
+        self.home()
+
+        ok_collection_element = self.history_panel_wait_for_hid_state(ok_hid, "ok")
+        failed_collection_element = self.history_panel_wait_for_hid_state(failed_hid, "error")
+
+        ok_collection_element.collection_job_details_button.wait_for_and_click()
+        self.screenshot("history_panel_collections_job_details_ok")
+        failed_collection_element.collection_job_details_button.wait_for_and_click()
+        self.screenshot("history_panel_collections_job_details_failed")
+
+    @selenium_test
     def test_back_to_history_button(self):
         input_collection = self._populated_paired_and_wait_for_it()
         collection_hid = input_collection["hid"]


### PR DESCRIPTION
Fixes (partially) #14980

I assume the "3 dot menu" was dropped for a reason so the first pass at fixing this is just "shoving" the missing buttons in the `ContentOptions` component. I can explore other options if there are better ideas on where to put them.

If the collection has a `job_source_id` and `job_source_type='Job'` then the show details button is displayed for the collection:
![image](https://user-images.githubusercontent.com/46503462/203077224-080aca98-046e-442b-ab9f-f5caaf015943.png)

I'll follow up by adding an Error report button for collection on the `dev` branch since it's not directly supported for collections and will require some more changes/refactorings.


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Follow the steps on #14980 or use the `job_properties` testing tool with the failure property enabled.
  2. You can now access the job details and report an error.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
