### PR TITLE
Fix js linting

### DIFF
--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -258,8 +258,8 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 :workflow-building-mode="workflowBuildingMode" />
             <FormSelection
                 v-else-if="props.type == 'select' && attrs.display == 'radio'"
-                v-model="currentValue"
                 :id="id"
+                v-model="currentValue"
                 :data="attrs.data"
                 :display="attrs.display"
                 :options="attrs.options"

--- a/client/src/entry/analysis/App.vue
+++ b/client/src/entry/analysis/App.vue
@@ -68,12 +68,6 @@ export default {
 
         return { toastRef, confirmDialogRef };
     },
-    setup() {
-        const toastRef = ref(null);
-        setToastComponentRef(toastRef);
-
-        return { toastRef };
-    },
     data() {
         return {
             config: getGalaxyInstance().config,


### PR DESCRIPTION
Fixes linting bug introduced in or after #15008 (although I'm not sure how: the old definition of `setup()` was removed in that PR; I can't find when it was added back.)

```
/home/circleci/repo/client/src/entry/analysis/App.vue
  71:5   error  Duplicate key 'setup'      no-dupe-keys
  75:18  error  Duplicated key 'toastRef'  vue/no-dupe-keys
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
