### PR TITLE
Pinia history store init

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -67,6 +67,7 @@
     "markdown-it-regexp": "^0.4.0",
     "object-hash": "^3.0.0",
     "pinia": "^2.0.23",
+    "pinia-plugin-persistedstate": "^2.4.0",
     "popper.js": "^1.16.1",
     "pretty-bytes": "^6.0.0",
     "pyre-to-regexp": "^0.0.5",

--- a/client/src/components/History/Multiple/MultipleView.test.js
+++ b/client/src/components/History/Multiple/MultipleView.test.js
@@ -1,3 +1,4 @@
+import { createPinia } from "pinia";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "jest/helpers";
@@ -9,6 +10,8 @@ import store from "store/index";
 const COUNT = 8;
 const USER_ID = "test-user-id";
 const CURRENT_HISTORY_ID = "test-history-id-0";
+
+const pinia = createPinia();
 
 const getFakeHistorySummaries = (num, selectedIndex = 0) => {
     const result = Array.from({ length: num }, (_, index) => ({
@@ -32,6 +35,7 @@ describe("MultipleView", () => {
     beforeEach(async () => {
         wrapper = mount(MultipleView, {
             store,
+            pinia,
             stubs: {
                 CurrentUser: CurrentUserMock,
                 UserHistories: UserHistoriesMock,

--- a/client/src/components/History/Multiple/MultipleViewList.vue
+++ b/client/src/components/History/Multiple/MultipleViewList.vue
@@ -31,9 +31,10 @@
 </template>
 
 <script>
-import { mapActions, mapGetters } from "vuex";
+import { mapActions, mapState } from "pinia";
 import VirtualList from "vue-virtual-scroll-list";
 import MultipleViewItem from "./MultipleViewItem";
+import { useHistoryStore } from "stores/historyStore";
 import SelectorModal from "components/History/Modals/SelectorModal";
 
 export default {
@@ -65,9 +66,9 @@ export default {
         };
     },
     computed: {
-        ...mapGetters("history", ["getPinnedHistories"]),
+        ...mapState(useHistoryStore, ["pinnedHistories"]),
         selectedHistories() {
-            return this.getPinnedHistories();
+            return this.pinnedHistories;
         },
     },
     created() {
@@ -77,7 +78,7 @@ export default {
         }
     },
     methods: {
-        ...mapActions("history", ["pinHistory", "unpinHistory"]),
+        ...mapActions(useHistoryStore, ["pinHistory", "unpinHistory"]),
         addHistoriesToList(histories) {
             histories.forEach((history) => {
                 const historyExists = this.selectedHistories.find((h) => h.id == history.id);

--- a/client/src/entry/analysis/index.js
+++ b/client/src/entry/analysis/index.js
@@ -5,9 +5,11 @@ import App from "./App.vue";
 import store from "store";
 import { getRouter } from "./router";
 import { createPinia, PiniaVuePlugin } from "pinia";
+import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
 
 Vue.use(PiniaVuePlugin);
 const pinia = createPinia();
+pinia.use(piniaPluginPersistedstate);
 
 addInitialization((Galaxy) => {
     console.log("App setup");

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -19,7 +19,6 @@ const state = {
     // histories for current user
     histories: {},
     historiesLoading: false,
-    pinnedHistories: [],
 };
 
 const mutations = {
@@ -55,12 +54,6 @@ const mutations = {
     setHistoriesLoading(state, isLoading) {
         state.historiesLoading = isLoading;
     },
-    pinHistory: (state, historyId) => {
-        state.pinnedHistories.push({ id: historyId });
-    },
-    unpinHistory: (state, historyId) => {
-        state.pinnedHistories = state.pinnedHistories.filter((h) => h.id !== historyId);
-    },
 };
 
 const getters = {
@@ -95,9 +88,6 @@ const getters = {
     },
     historiesLoading: (state) => {
         return state.historiesLoading;
-    },
-    getPinnedHistories: (state) => () => {
-        return state.pinnedHistories;
     },
 };
 
@@ -182,12 +172,6 @@ const actions = {
         // properties that are to be updated on the server. A full history object is not required
         const saveResult = await updateHistoryFields(id, updateFields);
         commit("setHistory", saveResult);
-    },
-    pinHistory: ({ commit }, historyId) => {
-        commit("pinHistory", historyId);
-    },
-    unpinHistory: ({ commit }, historyId) => {
-        commit("unpinHistory", historyId);
     },
 };
 

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -42,11 +42,10 @@ const panelsPersistence = new VuexPersistence({
     storage: galaxyStorage,
     asyncStorage: true,
     reducer: (state) => {
-        const { panels, userFlags, history } = state;
+        const { panels, userFlags } = state;
         return {
             panels,
             userFlags,
-            history: { pinnedHistories: history.pinnedHistories },
         };
     },
 });

--- a/client/src/stores/historyStore.js
+++ b/client/src/stores/historyStore.js
@@ -1,0 +1,26 @@
+import { ref } from "vue";
+import { defineStore } from "pinia";
+
+export const useHistoryStore = defineStore(
+    "historyStore",
+    () => {
+        const pinnedHistories = ref([]);
+
+        const pinHistory = (historyId) => {
+            pinnedHistories.value.push({ id: historyId });
+        };
+
+        const unpinHistory = (historyId) => {
+            pinnedHistories.value = pinnedHistories.value.filter((h) => h.id !== historyId);
+        };
+
+        return {
+            pinnedHistories,
+            pinHistory,
+            unpinHistory,
+        };
+    },
+    {
+        persist: ["pinnedHistories"],
+    }
+);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8078,6 +8078,11 @@ pikaday@1.5.1:
   optionalDependencies:
     moment "2.x"
 
+pinia-plugin-persistedstate@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-2.4.0.tgz#fda569b3c397517a0cf8aba83a628283767da620"
+  integrity sha512-bQcpv47jk3ISl+InuJWsFaS/K7pRZ97kfoD2WCf/suhnlLy48k3BnFM2tI6YZ1xMsDaPv4yOsaPuPAUuSmEO2Q==
+
 pinia@^2.0.23:
   version "2.0.23"
   resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.0.23.tgz#570f5f82160b656b412602789683faa95502d227"


### PR DESCRIPTION
This pr creates the history store with pinia using composition API and uses the [@prazdevs/pinia-plugin-persistedstate](https://www.npmjs.com/package/pinia-plugin-persistedstate) to persist the state.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Use multiple history view, add more history and refresh the page. The previous state persists.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
