### PR TITLE
fix interval_to_bgzip for sub gff classes

### DIFF
--- a/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_interval_to_bgzip_0" name="Convert Interval to BGZIP" version="1.0.1" hidden="true" profile="16.04">
+<tool id="CONVERTER_interval_to_bgzip_0" name="Convert Interval to BGZIP" version="1.0.2" hidden="true" profile="16.04">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
         <requirement type="package" version="0.15.4">pysam</requirement>

--- a/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
@@ -8,6 +8,8 @@
         python '$__tool_directory__/bgzip.py'
         #if $input1.ext in ['bed', 'gff', 'vcf']
             -P $input1.ext
+        #elif $input1.ext in ['gtf', 'gff3']
+            -P 'gff'
         #else
             -c ${input1.metadata.chromCol}
             -s ${input1.metadata.startCol}
@@ -46,6 +48,14 @@
         <test>
             <param name="input1" ftype="vcf" value="vcf_to_maf_in.vcf"/>
             <output name="output1" ftype="bgzip" value="bgzip_to_maf_in.bgzip"/>
+        </test>
+        <test>
+            <param name="input1" ftype="gtf" value="cufflinks_out1.gtf"/>
+            <output name="output1" ftype="bgzip" >
+                <assert_contents>
+                    <has_size value="270" delta="10" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help>

--- a/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bgzip_converter.xml
@@ -6,10 +6,12 @@
     </requirements>
     <command><![CDATA[
         python '$__tool_directory__/bgzip.py'
-        #if $input1.ext in ['bed', 'gff', 'vcf']
-            -P $input1.ext
-        #elif $input1.ext in ['gtf', 'gff3']
-            -P 'gff'
+        #if $input1.is_of_type('bed')
+            -P bed
+        #elif $input1.is_of_type('vcf')
+            -P vcf
+        #elif $input1.is_of_type('gff')
+            -P gff
         #else
             -c ${input1.metadata.chromCol}
             -s ${input1.metadata.startCol}

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -281,6 +281,7 @@ WORKFLOW_SAFE_TOOL_VERSION_UPDATES = {
     "Show beginning1": safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.2")),
     "Show tail1": safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
     "sort1": safe_update(packaging.version.parse("1.1.0"), packaging.version.parse("1.2.0")),
+    "CONVERTER_interval_to_bgzip_0": safe_update(packaging.version.parse("1.0.1"), packaging.version.parse("1.0.2"))
 }
 
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -281,7 +281,7 @@ WORKFLOW_SAFE_TOOL_VERSION_UPDATES = {
     "Show beginning1": safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.2")),
     "Show tail1": safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
     "sort1": safe_update(packaging.version.parse("1.1.0"), packaging.version.parse("1.2.0")),
-    "CONVERTER_interval_to_bgzip_0": safe_update(packaging.version.parse("1.0.1"), packaging.version.parse("1.0.2"))
+    "CONVERTER_interval_to_bgzip_0": safe_update(packaging.version.parse("1.0.1"), packaging.version.parse("1.0.2")),
 }
 
 


### PR DESCRIPTION
With the current version of the converter, 'gtf' which is a 'gff' subclass failed running the interval_to_bgzip as the first test was on 'file_ext'.
I fixed it by adding another test for 'gtf' and 'gff3'.

## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
