### PR TITLE
Convert Checkbox component to Vue

### DIFF
--- a/client/src/components/Form/Elements/FormCheck.test.js
+++ b/client/src/components/Form/Elements/FormCheck.test.js
@@ -1,0 +1,39 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import MountTarget from "./FormCheck";
+
+const localVue = getLocalVue(true);
+
+describe("FormCheck", () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = mount(MountTarget, {
+            propsData: {
+                value: false,
+                options: [],
+            },
+            localVue,
+        });
+    });
+
+    it("basics", async () => {
+        const noInput = wrapper.find("[type='checkbox']");
+        expect(noInput.exists()).toBe(false);
+        const n = 3;
+        const options = [];
+        for (let i = 0; i < n; i++) {
+            options.push([`label_${i}`, `value_${i}`]);
+        }
+        await wrapper.setProps({ options });
+        const inputs = wrapper.findAll("[type='checkbox']");
+        const labels = wrapper.findAll(".custom-control-label");
+        expect(inputs.length).toBe(n);
+        for (let i = 0; i < n; i++) {
+            await inputs.at(i).setChecked();
+            expect(labels.at(i).text()).toBe(`label_${i}`);
+            expect(inputs.at(i).attributes("value")).toBe(`value_${i}`);
+            expect(wrapper.emitted()["input"][i][0]).toBe(`value_${i}`);
+        }
+    });
+});

--- a/client/src/components/Form/Elements/FormCheck.test.js
+++ b/client/src/components/Form/Elements/FormCheck.test.js
@@ -55,4 +55,35 @@ describe("FormCheck", () => {
             expect(wrapper.emitted()["input"][i][0]).toEqual(expectedValues);
         }
     });
+    it("Confirm Select-All checkbox works in various states: select-all, unselect-all, indeterminate/partial-list-selection.", async () => {
+        const n = 3;
+        const options = [];
+        for (let i = 0; i < n; i++) {
+            options.push([`label_${i}`, `value_${i}`]);
+        }
+        await wrapper.setProps({ options });
+        const inputs = wrapper.findAll("[type='checkbox']");
+        /* confirm number of checkboxes requested matches number checkboxes created */
+        expect(inputs.length).toBe(n + 1);
+        /* confirm component loads unchecked */
+        for (let i = 0; i < n + 1; i++) {
+            expect(inputs.at(i).element.checked).toBeFalsy();
+        }
+        /* 1 - confirm select-all option checked */
+        await inputs.at(0).setChecked();
+        expect(inputs.at(0).element.checked).toBeTruthy();
+        /* ...confirm corresponding options checked */
+        const values = options.map(option => option[1]);
+        expect(wrapper.emitted()["input"][0][0]).toStrictEqual(values);
+        /* 2 - confirm select-all option UNchecked */
+        await inputs.at(0).setChecked(false);
+        expect(inputs.at(0).element.checked).toBeFalsy();
+        /* ...confirm corresponding options UNchecked */
+        for (let i = 0; i < n; i++) {
+            expect(inputs.at(i + 1).element.checked).toBeFalsy();
+        }
+        /* 3 - confirm corresponding options indeterminate-state */
+        await inputs.at(1).setChecked(true);
+        expect(wrapper.emitted()["indeterminate"][0][0]).toBeTruthy();
+    });
 });

--- a/client/src/components/Form/Elements/FormCheck.test.js
+++ b/client/src/components/Form/Elements/FormCheck.test.js
@@ -10,7 +10,7 @@ describe("FormCheck", () => {
     beforeEach(() => {
         wrapper = mount(MountTarget, {
             propsData: {
-                value: false,
+                value: null,
                 options: [],
             },
             localVue,
@@ -28,12 +28,15 @@ describe("FormCheck", () => {
         await wrapper.setProps({ options });
         const inputs = wrapper.findAll("[type='checkbox']");
         const labels = wrapper.findAll(".custom-control-label");
-        expect(inputs.length).toBe(n);
+        expect(inputs.length).toBe(n + 1);
+        let value = [];
         for (let i = 0; i < n; i++) {
-            await inputs.at(i).setChecked();
-            expect(labels.at(i).text()).toBe(`label_${i}`);
-            expect(inputs.at(i).attributes("value")).toBe(`value_${i}`);
-            expect(wrapper.emitted()["input"][i][0]).toBe(`value_${i}`);
+            const j = i + 1;
+            await inputs.at(j).setChecked();
+            expect(labels.at(j).text()).toBe(`label_${i}`);
+            expect(inputs.at(j).attributes("value")).toBe(`value_${i}`);
+            value = [...value, `value_${i}`];
+            expect(wrapper.emitted()["input"][i][0]).toEqual(value);
         }
     });
 });

--- a/client/src/components/Form/Elements/FormCheck.test.js
+++ b/client/src/components/Form/Elements/FormCheck.test.js
@@ -1,5 +1,5 @@
 import { mount } from "@vue/test-utils";
-import { getLocalVue } from "jest/helpers";
+import { getLocalVue } from "tests/jest/helpers";
 import MountTarget from "./FormCheck";
 
 const localVue = getLocalVue(true);

--- a/client/src/components/Form/Elements/FormCheck.test.js
+++ b/client/src/components/Form/Elements/FormCheck.test.js
@@ -17,7 +17,7 @@ describe("FormCheck", () => {
         });
     });
 
-    it("basics", async () => {
+    it("Confirm 'n + 1' checkboxes created (eg. includes the Select-All). Confirm labels and values match. Confirm correct values emitted.", async () => {
         const noInput = wrapper.find("[type='checkbox']");
         expect(noInput.exists()).toBe(false);
         const n = 3;
@@ -35,6 +35,23 @@ describe("FormCheck", () => {
             expect(labels.at(i + 1).text()).toBe(`label_${i}`);
             expect(inputs.at(i + 1).attributes("value")).toBe(`value_${i}`);
             expectedValues.push(`value_${i}`);
+            expect(wrapper.emitted()["input"][i][0]).toEqual(expectedValues);
+        }
+    });
+    it("Confirm checkboxes are created when various 'empty values' are passed.", async () => {
+        const emptyValues = [0, null, false, true, undefined];
+        const options = [];
+        for (let i = 0; i < emptyValues.length; i++) {
+            options.push([`label_${i}`, emptyValues[i]]);
+        }
+        await wrapper.setProps({ options });
+        const inputs = wrapper.findAll("[type='checkbox']");
+        expect(inputs.length).toBe(emptyValues.length + 1);
+        const expectedValues = [];
+        for (let i = 0; i < emptyValues; i++) {
+            await inputs.at(i + 1).setChecked();
+            expect(inputs.at(i + 1).attributes("value")).toBe(emptyValues[i]);
+            expectedValues.push(expectedValues[i]);
             expect(wrapper.emitted()["input"][i][0]).toEqual(expectedValues);
         }
     });

--- a/client/src/components/Form/Elements/FormCheck.test.js
+++ b/client/src/components/Form/Elements/FormCheck.test.js
@@ -29,14 +29,13 @@ describe("FormCheck", () => {
         const inputs = wrapper.findAll("[type='checkbox']");
         const labels = wrapper.findAll(".custom-control-label");
         expect(inputs.length).toBe(n + 1);
-        let value = [];
+        const expectedValues = [];
         for (let i = 0; i < n; i++) {
-            const j = i + 1;
-            await inputs.at(j).setChecked();
-            expect(labels.at(j).text()).toBe(`label_${i}`);
-            expect(inputs.at(j).attributes("value")).toBe(`value_${i}`);
-            value = [...value, `value_${i}`];
-            expect(wrapper.emitted()["input"][i][0]).toEqual(value);
+            await inputs.at(i + 1).setChecked();
+            expect(labels.at(i + 1).text()).toBe(`label_${i}`);
+            expect(inputs.at(i + 1).attributes("value")).toBe(`value_${i}`);
+            expectedValues.push(`value_${i}`);
+            expect(wrapper.emitted()["input"][i][0]).toEqual(expectedValues);
         }
     });
 });

--- a/client/src/components/Form/Elements/FormCheck.test.js
+++ b/client/src/components/Form/Elements/FormCheck.test.js
@@ -73,7 +73,7 @@ describe("FormCheck", () => {
         await inputs.at(0).setChecked();
         expect(inputs.at(0).element.checked).toBeTruthy();
         /* ...confirm corresponding options checked */
-        const values = options.map(option => option[1]);
+        const values = options.map((option) => option[1]);
         expect(wrapper.emitted()["input"][0][0]).toStrictEqual(values);
         /* 2 - confirm select-all option UNchecked */
         await inputs.at(0).setChecked(false);

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -1,0 +1,36 @@
+<script setup>
+import { computed, defineProps, defineEmits } from "vue";
+
+const $emit = defineEmits(["input"]);
+const props = defineProps({
+    value: {
+        default: null,
+    },
+    options: {
+        type: Array,
+        required: true,
+    },
+});
+
+const currentValue = computed({
+    get: () => {
+        return props.value;
+    },
+    set: (val) => {
+        $emit("input", val);
+    },
+});
+</script>
+
+<template>
+    <b-form-checkbox-group
+        v-model="currentValue"
+        v-for="(option, index) in options" 
+        :key="index" 
+        :value="option[1]"
+        :options="formattedOptions"
+        value-field="value"
+        :text-field="option[0]"
+        stacked>
+    </b-form-checkbox-group>
+</template>

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -16,11 +16,15 @@ const selectAll = ref(false);
 const currentValue = computed({
     get: () => {
         const val = props.value ?? [];
-        return !Array.isArray(val) ? [val] : val;
+        return Array.isArray(val) ? val : [val];
     },
     set: (val) => {
         emit("input", val);
     },
+});
+
+const hasOptions = computed(() => {
+    return props.options.length > 0;
 });
 
 function onSelectAll() {
@@ -34,12 +38,13 @@ function onSelectAll() {
 </script>
 
 <template>
-    <div>
-        <b-form-checkbox v-model="selectAll" @input="onSelectAll">{{ "Select/Unselect all" | l }}</b-form-checkbox>
+    <div v-if="hasOptions">
+        <b-form-checkbox v-model="selectAll" v-localize @input="onSelectAll"> Select/Unselect all </b-form-checkbox>
         <b-form-checkbox-group v-model="currentValue" stacked>
             <b-form-checkbox v-for="(option, index) in options" :key="index" :value="option[1]">
                 {{ option[0] }}
             </b-form-checkbox>
         </b-form-checkbox-group>
     </div>
+    <b-alert v-else v-localize variant="warning" show> No options available. </b-alert>
 </template>

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 const $emit = defineEmits(["input"]);
 const props = defineProps({
@@ -11,6 +11,7 @@ const props = defineProps({
         required: true,
     },
 });
+const selectAll = ref(false);
 
 const currentValue = computed({
     get: () => {
@@ -21,15 +22,27 @@ const currentValue = computed({
         $emit("input", val);
     },
 });
+
+function onSelectAll() {
+    if (selectAll.value) {
+        const allValues = props.options.map((x) => x[1]);
+        $emit("input", allValues)
+    } else {
+        $emit("input", []);
+    }
+}
 </script>
 
 <template>
-    <b-form-checkbox-group v-model="currentValue" stacked>
-        <b-form-checkbox 
-            v-for="(option, index) in options" 
-            :key="index" 
-            :value="option[1]">
-                {{ option[0] }}
-        </b-form-checkbox>
-    </b-form-checkbox-group>
+    <div>
+        <b-form-checkbox v-model="selectAll" @input="onSelectAll">{{ "Select/Unselect all" | l }}</b-form-checkbox>
+        <b-form-checkbox-group v-model="currentValue" stacked>
+            <b-form-checkbox 
+                v-for="(option, index) in options" 
+                :key="index" 
+                :value="option[1]">
+                    {{ option[0] }}
+            </b-form-checkbox>
+        </b-form-checkbox-group>
+    </div>
 </template>

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 
 const emit = defineEmits(["input"]);
 const props = defineProps({
@@ -12,6 +12,7 @@ const props = defineProps({
     },
 });
 const selectAll = ref(false);
+const indeterminate = ref(false);
 
 const currentValue = computed({
     get: () => {
@@ -27,11 +28,6 @@ const hasOptions = computed(() => {
     return props.options.length > 0;
 });
 
-const indeterminate = computed(() => {
-    const valueLength = currentValue.value.length;
-    return valueLength !== 0 && valueLength !== props.options.length;
-});
-
 function onSelectAll() {
     if (selectAll.value) {
         const allValues = props.options.map((option) => option[1]);
@@ -40,6 +36,19 @@ function onSelectAll() {
         emit("input", []);
     }
 }
+
+watch(currentValue, () => {
+    const valueLength = currentValue.value.length;
+    if (valueLength === 0) {
+        selectAll.value = false;
+        indeterminate.value = false;
+    } else if (valueLength === props.options.length) {
+        selectAll.value = true;
+        indeterminate.value = false;
+    } else {
+        indeterminate.value = true;
+    }
+});
 </script>
 
 <template>

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, defineProps, defineEmits } from "vue";
+import { computed } from "vue";
 
 const $emit = defineEmits(["input"]);
 const props = defineProps({
@@ -23,14 +23,12 @@ const currentValue = computed({
 </script>
 
 <template>
-    <b-form-checkbox-group
-        v-model="currentValue"
-        v-for="(option, index) in options" 
-        :key="index" 
-        :value="option[1]"
-        :options="formattedOptions"
-        value-field="value"
-        :text-field="option[0]"
-        stacked>
+    <b-form-checkbox-group v-model="currentValue" stacked>
+        <b-form-checkbox 
+            v-for="(option, index) in options" 
+            :key="index" 
+            :value="option[1]">
+                {{ option[0] }}
+        </b-form-checkbox>
     </b-form-checkbox-group>
 </template>

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, ref } from "vue";
 
-const $emit = defineEmits(["input"]);
+const emit = defineEmits(["input"]);
 const props = defineProps({
     value: {
         default: null,
@@ -15,20 +15,20 @@ const selectAll = ref(false);
 
 const currentValue = computed({
     get: () => {
-        const val = props.value || [];
+        const val = props.value ?? [];
         return !Array.isArray(val) ? [val] : val;
     },
     set: (val) => {
-        $emit("input", val);
+        emit("input", val);
     },
 });
 
 function onSelectAll() {
     if (selectAll.value) {
-        const allValues = props.options.map((x) => x[1]);
-        $emit("input", allValues)
+        const allValues = props.options.map((option) => option[1]);
+        emit("input", allValues);
     } else {
-        $emit("input", []);
+        emit("input", []);
     }
 }
 </script>
@@ -37,11 +37,8 @@ function onSelectAll() {
     <div>
         <b-form-checkbox v-model="selectAll" @input="onSelectAll">{{ "Select/Unselect all" | l }}</b-form-checkbox>
         <b-form-checkbox-group v-model="currentValue" stacked>
-            <b-form-checkbox 
-                v-for="(option, index) in options" 
-                :key="index" 
-                :value="option[1]">
-                    {{ option[0] }}
+            <b-form-checkbox v-for="(option, index) in options" :key="index" :value="option[1]">
+                {{ option[0] }}
             </b-form-checkbox>
         </b-form-checkbox-group>
     </div>

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -14,7 +14,8 @@ const props = defineProps({
 
 const currentValue = computed({
     get: () => {
-        return props.value;
+        const val = props.value || [];
+        return !Array.isArray(val) ? [val] : val;
     },
     set: (val) => {
         $emit("input", val);

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -56,14 +56,13 @@ watch(currentValue, () => {
         <b-form-checkbox
             v-model="selectAll"
             v-localize
-            size="sm"
             class="mb-1"
             :indeterminate="indeterminate"
             @input="onSelectAll"
             @change="emit('indeterminate', selectAll)">
-            Select/Unselect all
+            Select / Deselect all
         </b-form-checkbox>
-        <b-form-checkbox-group v-model="currentValue" stacked>
+        <b-form-checkbox-group v-model="currentValue" stacked class="pl-3">
             <b-form-checkbox v-for="(option, index) in options" :key="index" :value="option[1]">
                 {{ option[0] }}
             </b-form-checkbox>

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, ref, watch } from "vue";
 
-const emit = defineEmits(["input"]);
+const emit = defineEmits(["input", "indeterminate"]);
 const props = defineProps({
     value: {
         default: null,
@@ -59,7 +59,8 @@ watch(currentValue, () => {
             size="sm"
             class="mb-1"
             :indeterminate="indeterminate"
-            @input="onSelectAll">
+            @input="onSelectAll"
+            @change="emit('indeterminate', selectAll)">
             Select/Unselect all
         </b-form-checkbox>
         <b-form-checkbox-group v-model="currentValue" stacked>

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -27,6 +27,11 @@ const hasOptions = computed(() => {
     return props.options.length > 0;
 });
 
+const indeterminate = computed(() => {
+    const valueLength = currentValue.value.length;
+    return valueLength !== 0 && valueLength !== props.options.length;
+});
+
 function onSelectAll() {
     if (selectAll.value) {
         const allValues = props.options.map((option) => option[1]);
@@ -39,7 +44,15 @@ function onSelectAll() {
 
 <template>
     <div v-if="hasOptions">
-        <b-form-checkbox v-model="selectAll" v-localize @input="onSelectAll"> Select/Unselect all </b-form-checkbox>
+        <b-form-checkbox
+            v-model="selectAll"
+            v-localize
+            size="sm"
+            class="mb-1"
+            :indeterminate="indeterminate"
+            @input="onSelectAll">
+            Select/Unselect all
+        </b-form-checkbox>
         <b-form-checkbox-group v-model="currentValue" stacked>
             <b-form-checkbox v-for="(option, index) in options" :key="index" :value="option[1]">
                 {{ option[0] }}

--- a/client/src/components/Form/Elements/FormRadio.vue
+++ b/client/src/components/Form/Elements/FormRadio.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from "vue";
 
-const $emit = defineEmits(["input"]);
+const emit = defineEmits(["input"]);
 const props = defineProps({
     value: {
         default: null,
@@ -17,15 +17,20 @@ const currentValue = computed({
         return props.value;
     },
     set: (val) => {
-        $emit("input", val);
+        emit("input", val);
     },
+});
+
+const hasOptions = computed(() => {
+    return props.options.length > 0;
 });
 </script>
 
 <template>
-    <b-form-radio-group v-model="currentValue" stacked>
+    <b-form-radio-group v-if="hasOptions" v-model="currentValue" stacked>
         <b-form-radio v-for="(option, index) in options" :key="index" :value="option[1]">
             {{ option[0] }}
         </b-form-radio>
     </b-form-radio-group>
+    <b-alert v-else v-localize variant="warning" show> No options available. </b-alert>
 </template>

--- a/client/src/components/Form/Elements/FormSelection.vue
+++ b/client/src/components/Form/Elements/FormSelection.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from "vue";
+import FormCheck from "./FormCheck";
 import FormRadio from "./FormRadio";
 
 const $emit = defineEmits(["input"]);
@@ -50,5 +51,6 @@ const currentOptions = computed(() => {
 </script>
 
 <template>
-    <form-radio v-if="display == 'radio'" v-model="currentValue" :options="currentOptions" />
+    <form-check v-if="display == 'checkboxes'" v-model="currentValue" :options="currentOptions" />
+    <form-radio v-else-if="display == 'radio'" v-model="currentValue" :options="currentOptions" />
 </template>

--- a/client/src/components/Form/Elements/FormSelection.vue
+++ b/client/src/components/Form/Elements/FormSelection.vue
@@ -51,6 +51,6 @@ const currentOptions = computed(() => {
 </script>
 
 <template>
-    <form-check v-if="display == 'checkboxes'" v-model="currentValue" :options="currentOptions" />
-    <form-radio v-else-if="display == 'radio'" v-model="currentValue" :options="currentOptions" />
+    <form-check v-if="display === 'checkboxes'" v-model="currentValue" :options="currentOptions" />
+    <form-radio v-else-if="display === 'radio'" v-model="currentValue" :options="currentOptions" />
 </template>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -260,7 +260,7 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 :type="type"
                 :workflow-building-mode="workflowBuildingMode" />
             <FormSelection
-                v-else-if="props.type == 'select' && ['radio', 'checkboxes'].includes(attrs.display)"
+                v-else-if="props.type === 'select' && ['radio', 'checkboxes'].includes(attrs.display)"
                 :id="id"
                 v-model="currentValue"
                 :data="attrs.data"

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -260,7 +260,7 @@ library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSqua
                 :type="type"
                 :workflow-building-mode="workflowBuildingMode" />
             <FormSelection
-                v-else-if="props.type == 'select' && attrs.display == 'radio'"
+                v-else-if="props.type == 'select' && ['radio', 'checkboxes'].includes(attrs.display)"
                 :id="id"
                 v-model="currentValue"
                 :data="attrs.data"


### PR DESCRIPTION
This PR migrates the backbone-based display of `checkboxes` to Vue. It adds a new `FormCheck` component and utilizes Bootstrap Vue. It also adds a warning message which is shown when no options are available. Additionally, this PR introduces a indeterminate state for the select/unselect all button.

<img width="189" alt="image" src="https://user-images.githubusercontent.com/2105447/205194258-69e42fa8-fd49-4201-8031-de3bca26cfa5.png">

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
