### PR TITLE
History item color to hsla

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -227,9 +227,6 @@ export default {
 };
 </script>
 <style lang="scss">
-.content-item:hover {
-    filter: brightness(105%);
-}
 .content-item {
     .name {
         word-break: break-all;

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -398,6 +398,7 @@ $galaxy-state-border: (
     "error": $state-danger-border,
     "deleted": darken($state-default-border, 30%),
     "hidden": $state-default-border,
+    "setting_metadata": $state-warning-border,
 );
 
 $galaxy-state-bg: (
@@ -410,13 +411,18 @@ $galaxy-state-bg: (
     "error": $state-danger-bg,
     "deleted": darken($state-default-bg, 30%),
     "hidden": $state-default-bg,
+    "setting_metadata": $state-warning-bg,
 );
 
 @each $state in map-keys($galaxy-state-border) {
     .state-color-#{$state},
     [data-state="#{$state}"] {
         border-color: map-get($galaxy-state-border, $state);
-        background-color: map-get($galaxy-state-bg, $state);
+        background-color: change-color(map-get($galaxy-state-bg, $state), $alpha: 0.4, $lightness: 50%);
+
+        &:hover {
+            background-color: change-color(map-get($galaxy-state-bg, $state), $alpha: 0.4, $lightness: 60%);
+        }
 
         &:focus,
         &:focus-within {

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -421,12 +421,17 @@ $galaxy-state-bg: (
         background-color: change-color(map-get($galaxy-state-bg, $state), $alpha: 0.4, $lightness: 50%);
 
         &:hover {
-            background-color: change-color(map-get($galaxy-state-bg, $state), $alpha: 0.4, $lightness: 60%);
+            background-color: change-color(map-get($galaxy-state-bg, $state), $alpha: 0.4, $lightness: 66%);
         }
 
         &:focus,
         &:focus-within {
-            background-color: scale-color(map-get($galaxy-state-bg, $state), $lightness: -10%);
+            background-color: change-color(map-get($galaxy-state-bg, $state), $alpha: 0.4, $lightness: 33%);
+        }
+
+        &:focus:hover,
+        &:focus-within:hover {
+            background-color: change-color(map-get($galaxy-state-bg, $state), $alpha: 0.4, $lightness: 40%);
         }
 
         &.selected {


### PR DESCRIPTION
Fixes #14814 

![image](https://user-images.githubusercontent.com/8046843/203600771-2d744642-e93c-4ee2-a320-5d7a22e581c7.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Use multiple view with many histories until scrollable
  2. See the side shadows

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
