### PR TITLE
Set accessible default font

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "vue-loader": "15.10.0"
   },
   "dependencies": {
+    "@fontsource/atkinson-hyperlegible": "^4.5.10",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/client/src/onload/index.js
+++ b/client/src/onload/index.js
@@ -9,6 +9,9 @@ import "scss/base.scss";
 // effects fixing webpack globals.
 import "./publicPath";
 
+// Default Font
+import "@fontsource/atkinson-hyperlegible";
+
 // Module exports appear as objects on window.config in the browser
 export { standardInit } from "./standardInit";
 export { initializations$, addInitialization, prependInitialization, clearInitQueue } from "./initQueue";

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -80,8 +80,8 @@ $state-success-bg: theme-color-level("success", $alert-bg-level);
 $state-success-border: theme-color-level("success", $alert-border-level);
 
 // Fonts and sizes
-$font-family-sans-serif: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+$font-family-sans-serif: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $font-family-monospace: Monaco, Menlo, Consolas, "Courier New", monospace;
 $font-family-base: $font-family-sans-serif;
 $font-size-base: 0.85rem; // default 1rem

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -80,7 +80,7 @@ $state-success-bg: theme-color-level("success", $alert-bg-level);
 $state-success-border: theme-color-level("success", $alert-border-level);
 
 // Fonts and sizes
-$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif,
+$font-family-sans-serif: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 $font-family-monospace: Monaco, Menlo, Consolas, "Courier New", monospace;
 $font-family-base: $font-family-sans-serif;

--- a/client/tests/jest/__mocks__/font.js
+++ b/client/tests/jest/__mocks__/font.js
@@ -1,0 +1,1 @@
+export default {};

--- a/client/tests/jest/jest.config.js
+++ b/client/tests/jest/jest.config.js
@@ -78,6 +78,7 @@ module.exports = {
     // Some of these should turn into true mocks, instead of this module name mapping hack.
     moduleNameMapper: {
         "\\.(css|scss)$": "<rootDir>/tests/jest/__mocks__/style.js",
+        "^@fontsource/.*": "<rootDir>/tests/jest/__mocks__/font.js",
         "^config$": "<rootDir>/tests/jest/__mocks__/config.js",
         "utils/localization$": "<rootDir>/tests/jest/__mocks__/localization.js",
         "viz/trackster$": "<rootDir>/tests/jest/__mocks__/trackster.js",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1233,6 +1233,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@fontsource/atkinson-hyperlegible@^4.5.10":
+  version "4.5.10"
+  resolved "https://registry.yarnpkg.com/@fontsource/atkinson-hyperlegible/-/atkinson-hyperlegible-4.5.10.tgz#7571e9d07acfc3c122d077c5c44be1c557c55a6d"
+  integrity sha512-UyKTkEGQnF5lbAYRIPCeAikkVgBPQ8n3ve/cdJX1tp0Kma3pe7cZOVESEK2oyTZqn7Jt3ZS51hbY7hR8u4dLXA==
+
 "@fortawesome/fontawesome-common-types@^0.2.36":
   version "0.2.36"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"


### PR DESCRIPTION
closes #15061

Sets a default font. For details see issue linked above.

![image](https://user-images.githubusercontent.com/44241786/204003443-7e11a300-8b98-46bc-b25d-8db1f4385c43.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
