### PR TITLE
Prepend Galaxy root to dataset download URLs in visualization plugins

### DIFF
--- a/client/src/mvc/visualization/chart/chart-client.js
+++ b/client/src/mvc/visualization/chart/chart-client.js
@@ -31,8 +31,12 @@ export default Backbone.View.extend({
         this.$buttons = this.$(".charts-buttons");
         this.chart = new Chart({}, options);
         this.chart.plugin = options.visualization_plugin;
-        this.chart.requiresConfirmation = asBoolean(this.chart.plugin.specs.confirm);
         this.chart.plugin.specs = this.chart.plugin.specs || {};
+        if (Object.keys(this.chart.plugin.specs).length === 0) {
+          this.chart.requiresConfirmation = false;
+        } else {
+          this.chart.requiresConfirmation = asBoolean(this.chart.plugin.specs.confirm);
+        }
         this.chart_load = options.chart_load;
         this.message = new Ui.Message();
         this.deferred = new Deferred();

--- a/client/src/mvc/visualization/chart/chart-client.js
+++ b/client/src/mvc/visualization/chart/chart-client.js
@@ -33,9 +33,9 @@ export default Backbone.View.extend({
         this.chart.plugin = options.visualization_plugin;
         this.chart.plugin.specs = this.chart.plugin.specs || {};
         if (Object.keys(this.chart.plugin.specs).length === 0) {
-          this.chart.requiresConfirmation = false;
+            this.chart.requiresConfirmation = false;
         } else {
-          this.chart.requiresConfirmation = asBoolean(this.chart.plugin.specs.confirm);
+            this.chart.requiresConfirmation = asBoolean(this.chart.plugin.specs.confirm);
         }
         this.chart_load = options.chart_load;
         this.message = new Ui.Message();

--- a/config/plugins/visualizations/annotate_image/src/script.js
+++ b/config/plugins/visualizations/annotate_image/src/script.js
@@ -437,11 +437,13 @@ window.bundleEntries.load = function (opt) {
         });
     };
 
+    const slash_cleanup = /(\/)+/g;
+    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
     $.ajax({
-        url: dataset.download_url,
+        url: safe_download_url,
         success: function(content) {
             const $chartViewer = $("#" + opt.target);
-            $chartViewer.html("<img id='image-annotate' src='" + dataset.download_url + "' />");
+            $chartViewer.html("<img id='image-annotate' src='" + safe_download_url + "' />");
             $chartViewer.css("overflow", "auto");
             $chartViewer.css("position", "relative");
             const $image = $chartViewer.find("img");

--- a/config/plugins/visualizations/annotate_image/src/script.js
+++ b/config/plugins/visualizations/annotate_image/src/script.js
@@ -437,8 +437,7 @@ window.bundleEntries.load = function (opt) {
         });
     };
 
-    const slash_cleanup = /(\/)+/g;
-    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
+    const safe_download_url = `${options.root}${dataset.download_url}`;
     $.ajax({
         url: safe_download_url,
         success: function(content) {

--- a/config/plugins/visualizations/cytoscape/src/script.js
+++ b/config/plugins/visualizations/cytoscape/src/script.js
@@ -166,8 +166,7 @@ window.bundleEntries.load = function (options) {
     cytoscape = null,
     sif_file_ext = "sif",
     highlighted_color = settings.get( 'color_picker_highlighted' );
-    const slash_cleanup = /(\/)+/g;
-    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
+    const safe_download_url = `${options.root}${dataset.download_url}`;
     $.ajax({
         url     : safe_download_url,
         success : function( content ) {

--- a/config/plugins/visualizations/cytoscape/src/script.js
+++ b/config/plugins/visualizations/cytoscape/src/script.js
@@ -87,7 +87,7 @@ function run_search_algorithm( cytoscape, root_id, type, self ) {
             // Add css class for the selected edge(s)
             algorithm.path[i].addClass( 'searchpath' );
             i++;
-            // Animate the edges and nodes coloring 
+            // Animate the edges and nodes coloring
             // of the path with a delay of 500ms
             setTimeout( selectNextElement, 500 );
         }
@@ -166,8 +166,10 @@ window.bundleEntries.load = function (options) {
     cytoscape = null,
     sif_file_ext = "sif",
     highlighted_color = settings.get( 'color_picker_highlighted' );
+    const slash_cleanup = /(\/)+/g;
+    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
     $.ajax({
-        url     : dataset.download_url,
+        url     : safe_download_url,
         success : function( content ) {
             // Select data for the graph
             if( dataset.file_ext === sif_file_ext ) {
@@ -246,7 +248,7 @@ window.bundleEntries.load = function (options) {
                 // On tapping any node, BFS or DFS start from that node
                 cytoscape.$( 'node' ).on('tap', function( e ) {
                     var ele = e.cyTarget,
-                        search_algorithm = settings.get( 'search_algorithm' ), 
+                        search_algorithm = settings.get( 'search_algorithm' ),
                         traversal_type = settings.get( 'graph_traversal' );
                     // If search algorithm and traversal both are chosen,
                     // search algorithm will take preference

--- a/config/plugins/visualizations/drawrna/src/script.js
+++ b/config/plugins/visualizations/drawrna/src/script.js
@@ -3,8 +3,10 @@ window.bundleEntries = window.bundleEntries || {};
 window.bundleEntries.load = function (options) {
     var chart = options.chart;
     var dataset = options.dataset;
+    const slash_cleanup = /(\/)+/g;
+    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
     $.ajax({
-        url: dataset.download_url,
+        url: safe_download_url,
         success: function(response) {
             var input = response.split('\n');
             var app = new DrawRNA({

--- a/config/plugins/visualizations/drawrna/src/script.js
+++ b/config/plugins/visualizations/drawrna/src/script.js
@@ -3,8 +3,7 @@ window.bundleEntries = window.bundleEntries || {};
 window.bundleEntries.load = function (options) {
     var chart = options.chart;
     var dataset = options.dataset;
-    const slash_cleanup = /(\/)+/g;
-    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
+    const safe_download_url = `${options.root}${dataset.download_url}`;
     $.ajax({
         url: safe_download_url,
         success: function(response) {

--- a/config/plugins/visualizations/msa/src/script.js
+++ b/config/plugins/visualizations/msa/src/script.js
@@ -14,8 +14,7 @@ Object.assign(window.bundleEntries || {}, {
             menu: "small",
             bootstrapMenu: "true" == settings.get("menu"),
         });
-        const slash_cleanup = /(\/)+/g;
-        const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
+        const safe_download_url = `${options.root}${dataset.download_url}`;
         msaViz.u.file.importURL(safe_download_url, () => {
             msaViz.render();
             chart.state("ok", "Chart drawn.");

--- a/config/plugins/visualizations/msa/src/script.js
+++ b/config/plugins/visualizations/msa/src/script.js
@@ -14,7 +14,9 @@ Object.assign(window.bundleEntries || {}, {
             menu: "small",
             bootstrapMenu: "true" == settings.get("menu"),
         });
-        msaViz.u.file.importURL(dataset.download_url, () => {
+        const slash_cleanup = /(\/)+/g;
+        const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
+        msaViz.u.file.importURL(safe_download_url, () => {
             msaViz.render();
             chart.state("ok", "Chart drawn.");
             options.process.resolve();

--- a/config/plugins/visualizations/ngl/src/ngl.js
+++ b/config/plugins/visualizations/ngl/src/ngl.js
@@ -19,8 +19,10 @@ window.bundleEntries.load = function (options) {
         opacity: settings.get("opacity"),
     };
     stage_parameters = { ext: dataset.extension, defaultRepresentation: true };
+    const slash_cleanup = /(\/)+/g;
+    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
     try {
-        stage.loadFile(dataset.download_url, stage_parameters).then(function (component) {
+        stage.loadFile(safe_download_url, stage_parameters).then(function (component) {
             component.addRepresentation(settings.get("mode"), representation_parameters);
             options.chart.state("ok", "Chart drawn.");
             options.process.resolve();

--- a/config/plugins/visualizations/ngl/src/ngl.js
+++ b/config/plugins/visualizations/ngl/src/ngl.js
@@ -19,8 +19,7 @@ window.bundleEntries.load = function (options) {
         opacity: settings.get("opacity"),
     };
     stage_parameters = { ext: dataset.extension, defaultRepresentation: true };
-    const slash_cleanup = /(\/)+/g;
-    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
+    const safe_download_url = `${options.root}${dataset.download_url}`;
     try {
         stage.loadFile(safe_download_url, stage_parameters).then(function (component) {
             component.addRepresentation(settings.get("mode"), representation_parameters);

--- a/config/plugins/visualizations/openlayers/src/script.js
+++ b/config/plugins/visualizations/openlayers/src/script.js
@@ -240,8 +240,7 @@ window.bundleEntries = window.bundleEntries || {};
 window.bundleEntries.load = function (options) {
     const chart = options.chart;
     const dataset = options.dataset;
-    const slash_cleanup = /(\/)+/g;
-    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
+    const safe_download_url = `${options.root}${dataset.download_url}`;
     $.ajax({
         url: safe_download_url,
         success: () => {

--- a/config/plugins/visualizations/openlayers/src/script.js
+++ b/config/plugins/visualizations/openlayers/src/script.js
@@ -240,10 +240,12 @@ window.bundleEntries = window.bundleEntries || {};
 window.bundleEntries.load = function (options) {
     const chart = options.chart;
     const dataset = options.dataset;
+    const slash_cleanup = /(\/)+/g;
+    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
     $.ajax({
-        url: dataset.download_url,
+        url: safe_download_url,
         success: () => {
-            MapViewer.loadFile(dataset.download_url, dataset.extension, options, chart);
+            MapViewer.loadFile(safe_download_url, dataset.extension, options, chart);
         },
         error: () => {
             chart.state("failed", "Failed to access dataset.");

--- a/config/plugins/visualizations/phylocanvas/src/script.js
+++ b/config/plugins/visualizations/phylocanvas/src/script.js
@@ -4,8 +4,7 @@ _.extend(window.bundleEntries || {}, {
         var chart = options.chart;
         var dataset = options.dataset;
         var settings = options.chart.settings;
-        const slash_cleanup = /(\/)+/g;
-        const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
+        const safe_download_url = `${options.root}${dataset.download_url}`;
         $.ajax( {
             url     : safe_download_url,
             success : function( content ) {

--- a/config/plugins/visualizations/phylocanvas/src/script.js
+++ b/config/plugins/visualizations/phylocanvas/src/script.js
@@ -4,8 +4,10 @@ _.extend(window.bundleEntries || {}, {
         var chart = options.chart;
         var dataset = options.dataset;
         var settings = options.chart.settings;
+        const slash_cleanup = /(\/)+/g;
+        const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
         $.ajax( {
-            url     : dataset.download_url,
+            url     : safe_download_url,
             success : function( content ) {
                 try {
                     var tree = Phylocanvas.default.createTree( options.target ),

--- a/config/plugins/visualizations/pv/src/pv.js
+++ b/config/plugins/visualizations/pv/src/pv.js
@@ -10,8 +10,10 @@ window.bundleEntries.load = function (options) {
         antialias: true,
         outline: true,
     });
+    const slash_cleanup = /(\/)+/g;
+    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
     var xhr = new XMLHttpRequest();
-    xhr.open("GET", options.dataset.download_url);
+    xhr.open("GET", safe_download_url);
     xhr.onload = function () {
         if (xhr.status === 200) {
             var structure = pv.io.pdb(xhr.response);

--- a/config/plugins/visualizations/pv/src/pv.js
+++ b/config/plugins/visualizations/pv/src/pv.js
@@ -10,8 +10,7 @@ window.bundleEntries.load = function (options) {
         antialias: true,
         outline: true,
     });
-    const slash_cleanup = /(\/)+/g;
-    const safe_download_url = `${options.root}/${dataset.download_url}`.replace(slash_cleanup, "/");
+    const safe_download_url = `${options.root}${dataset.download_url}`;
     var xhr = new XMLHttpRequest();
     xhr.open("GET", safe_download_url);
     xhr.onload = function () {


### PR DESCRIPTION
Most of the visualization plugins use `dataset.download_url` to get datasets for visualizing. This will work only when Galaxy is served without any prefix. This PR prepend Galaxy root to `dataset.download_url` for concerned plugins.

Fixes #15047

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
