### PR TITLE
Update routing for collection info display, a11y tweaks.

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -4,7 +4,13 @@
         :class="['content-item m-1 p-0 rounded btn-transparent-background', contentCls]"
         :data-hid="id"
         :data-state="state">
-        <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @click.stop="onClick" @keypress="onClick">
+        <div
+            class="p-1 cursor-pointer"
+            draggable
+            tabindex="0"
+            @dragstart="onDragStart"
+            @click.stop="onClick"
+            @keypress="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1 font-weight-bold">
                     <span v-if="selectable" class="selector">
@@ -25,6 +31,7 @@
                         v-if="highlight == 'input'"
                         v-b-tooltip.hover
                         title="Input"
+                        tabindex="0"
                         @click.stop="toggleHighlights"
                         @keypress="toggleHighlights">
                         <font-awesome-icon class="text-info" icon="arrow-circle-up" />
@@ -33,6 +40,7 @@
                         v-else-if="highlight == 'noInputs'"
                         v-b-tooltip.hover
                         title="No Inputs for this item"
+                        tabindex="0"
                         @click.stop="toggleHighlights"
                         @keypress="toggleHighlights">
                         <font-awesome-icon icon="minus-circle" />
@@ -41,6 +49,7 @@
                         v-else-if="highlight == 'output'"
                         v-b-tooltip.hover
                         title="Inputs highlighted for this item"
+                        tabindex="0"
                         @click.stop="toggleHighlights"
                         @keypress="toggleHighlights">
                         <font-awesome-icon icon="check-circle" />

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -219,7 +219,7 @@ export default {
             this.$router.push(this.itemUrls.edit);
         },
         onShowCollectionInfo() {
-            backboneRoute(this.itemUrls.showDetails);
+            this.$router.push(this.itemUrls.showDetails);
         },
         onTags(newTags) {
             this.$emit("tag-change", this.item, newTags);

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -185,7 +185,7 @@ export default {
                     edit: `/collection/${id}/edit`,
                     showDetails:
                         this.item.job_source_id && this.item.job_source_type === "Job"
-                            ? `jobs/${this.item.job_source_id}/view`
+                            ? `/jobs/${this.item.job_source_id}/view`
                             : null,
                 };
             }

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -4,7 +4,7 @@
         :class="['content-item m-1 p-0 rounded btn-transparent-background', contentCls]"
         :data-hid="id"
         :data-state="state">
-        <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @click.stop="onClick">
+        <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @click.stop="onClick" @keypress="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1 font-weight-bold">
                     <span v-if="selectable" class="selector">
@@ -21,21 +21,28 @@
                             :icon="['far', 'square']"
                             @click.stop="$emit('update:selected', true)" />
                     </span>
-                    <span v-if="highlight == 'input'" v-b-tooltip.hover title="Input" @click.stop="toggleHighlights">
+                    <span
+                        v-if="highlight == 'input'"
+                        v-b-tooltip.hover
+                        title="Input"
+                        @click.stop="toggleHighlights"
+                        @keypress="toggleHighlights">
                         <font-awesome-icon class="text-info" icon="arrow-circle-up" />
                     </span>
                     <span
                         v-else-if="highlight == 'noInputs'"
                         v-b-tooltip.hover
                         title="No Inputs for this item"
-                        @click.stop="toggleHighlights">
+                        @click.stop="toggleHighlights"
+                        @keypress="toggleHighlights">
                         <font-awesome-icon icon="minus-circle" />
                     </span>
                     <span
                         v-else-if="highlight == 'output'"
                         v-b-tooltip.hover
                         title="Inputs highlighted for this item"
-                        @click.stop="toggleHighlights">
+                        @click.stop="toggleHighlights"
+                        @keypress="toggleHighlights">
                         <font-awesome-icon icon="check-circle" />
                     </span>
                     <span v-if="hasStateIcon" class="state-icon">


### PR DESCRIPTION
Fixes/updates routing of merged forward #15040 

While I was in there, I also fixed outstanding a11y issues where the expansion and input toggle click handlers weren't keyboard accessible.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
