### PR TITLE
Use absolute imports

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -109,10 +109,9 @@ from ..item_attrs import (
 from ... import model
 
 if TYPE_CHECKING:
-    from tags import GalaxyTagHandlerSession
-
     from galaxy.managers.workflows import WorkflowContentsManager
     from galaxy.model import ImplicitCollectionJobs
+    from galaxy.model.tags import GalaxyTagHandlerSession
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
If there is a `tags` file in the Galaxy root (you have one if you use ctags) , this will cause a mypy error. Also, let's use absolute imports for consistency, simpler grep, etc.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
