### PR TITLE
Shorten long text in content assertion output

### DIFF
--- a/lib/galaxy/tool_util/verify/asserts/_util.py
+++ b/lib/galaxy/tool_util/verify/asserts/_util.py
@@ -1,4 +1,5 @@
 from math import inf
+from typing import Optional
 
 from galaxy.util import asbool
 from galaxy.util.bytesize import parse_bytesize
@@ -59,9 +60,24 @@ def _assert_presence_number(
     expected = "Expected" if not negate else "Did not expect"
     if n is None and min is None and max is None:
         assert (not negate) == check_presence_foo(output, text), presence_text.format(
-            expected=expected, output=output, text=text
+            expected=expected, output=_nice_output(output), text=text
         )
     try:
         _assert_number(count_foo(output, text), n, delta, min, max, negate, n_text, min_max_text)
     except AssertionError as e:
-        raise AssertionError(str(e).format(output=output, text=text))
+        raise AssertionError(str(e).format(output=_nice_output(output), text=text))
+
+
+def _nice_output(output: Optional[str]):
+    """
+    shorten output if to long
+    """
+    if not output:
+        return output
+    if len(output) < 60:
+        return output
+    else:
+        return f"""{output[:30]}
+********
+SNIP ({len(output) - 60} characters not shown)
+******** {output[-30:]}"""

--- a/test/unit/tool_util/verify/test_asserts.py
+++ b/test/unit/tool_util/verify/test_asserts.py
@@ -342,6 +342,13 @@ TESTS = [
         TEXT_DATA_HAS_TEXT_NEG,
         lambda x: "Expected text 'test text' in output ('desired content\nis not here\n')" in x,
     ),
+    # test has_text .. negative test with "very" long input
+    (
+        TEXT_HAS_TEXT_ASSERTION,
+        100 * TEXT_DATA_HAS_TEXT_NEG,
+        lambda x: "Expected text 'test text' in output ('desired content\nis not here\nde\n********\nSNIP (2740 characters not shown)\n******** e\ndesired content\nis not here\n')"
+        in x,
+    ),
     # test has_text with None output
     (TEXT_HAS_TEXT_ASSERTION, TEXT_DATA_NONE, lambda x: "Checking has_text assertion on empty output (None)" in x),
     # test has_text with empty output
@@ -914,6 +921,7 @@ TEST_IDS = [
     "has_n_columns with comments",
     "has_text success",
     "has_text failure",
+    "has_text failure with long text",
     "has_text None output",
     "has_text empty output",
     "has_text n success",


### PR DESCRIPTION
I had a case where the assertion was applied on a very long file. This just flooded my terminal which was not helpful during debugging. So I thought maybe a shortened output (like for compare="diff") in case of long data maybe usefull.

Output format and length threshold are inspiered by the output for compare="diff". Not entirely sure if optimal.

TODO:

- [x] test

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
