### PR TITLE
Fix export history to FTP using tasks

### DIFF
--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -47,13 +47,14 @@ def stream_url_to_file(
     file_sources: Optional["ConfiguredFileSources"] = None,
     prefix: str = "gx_file_stream",
     dir: Optional[str] = None,
+    user_context=None,
 ) -> str:
     temp_name: str
     if file_sources and file_sources.looks_like_uri(path):
         file_source_path = file_sources.get_file_source_path(path)
         with tempfile.NamedTemporaryFile(prefix=prefix, delete=False, dir=dir) as temp:
             temp_name = temp.name
-        file_source_path.file_source.realize_to(file_source_path.path, temp_name)
+        file_source_path.file_source.realize_to(file_source_path.path, temp_name, user_context=user_context)
     elif path.startswith("base64://"):
         with tempfile.NamedTemporaryFile(prefix=prefix, delete=False, dir=dir) as temp:
             temp_name = temp.name

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -3,7 +3,9 @@ from typing import Optional
 from galaxy import model
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.jobs.manager import JobManager
+from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.histories import HistoryManager
+from galaxy.managers.users import UserManager
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.model.store import (
     DirectoryModelExportStore,
@@ -32,6 +34,28 @@ from galaxy.web.short_term_storage import (
 )
 
 
+class ModelStoreUserContext(ProvidesUserContext):
+    def __init__(self, app: MinimalManagerApp, user: model.User) -> None:
+        self._app = app
+        self._user = user
+
+    @property
+    def app(self):
+        return self._app
+
+    @property
+    def url_builder(self):
+        raise NotImplementedError("URL builder not available in ModelStore context.")
+
+    def get_user(self):
+        return self._user
+
+    def set_user(self, user):
+        raise NotImplementedError("Cannot change user from ModelStore context.")
+
+    user = property(get_user, set_user)
+
+
 class ModelStoreManager:
     def __init__(
         self,
@@ -40,12 +64,14 @@ class ModelStoreManager:
         sa_session: galaxy_scoped_session,
         job_manager: JobManager,
         short_term_storage_monitor: ShortTermStorageMonitor,
+        user_manager: UserManager,
     ):
         self._app = app
         self._sa_session = sa_session
         self._job_manager = job_manager
         self._history_manager = history_manager
         self._short_term_storage_monitor = short_term_storage_monitor
+        self._user_manager = user_manager
 
     def setup_history_export_job(self, request: SetupHistoryExportJob):
         history_id = request.history_id
@@ -116,11 +142,13 @@ class ModelStoreManager:
         model_store_format = request.model_store_format
         export_files = "symlink" if request.include_files else None
         target_uri = request.target_uri
+        user_context = self._build_user_context(request.user.user_id)
         with model.store.get_export_store_factory(
             self._app,
             model_store_format,
             export_files=export_files,
             bco_export_options=self._bco_export_options(request),
+            user_context=user_context,
         )(target_uri) as export_store:
             invocation = self._sa_session.query(model.WorkflowInvocation).get(request.invocation_id)
             export_store.export_workflow_invocation(
@@ -142,9 +170,10 @@ class ModelStoreManager:
         model_store_format = request.model_store_format
         export_files = "symlink" if request.include_files else None
         target_uri = request.target_uri
-        with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
-            target_uri
-        ) as export_store:
+        user_context = self._build_user_context(request.user.user_id)
+        with model.store.get_export_store_factory(
+            self._app, model_store_format, export_files=export_files, user_context=user_context
+        )(target_uri) as export_store:
             if request.content_type == HistoryContentType.dataset:
                 hda = self._sa_session.query(model.HistoryDatasetAssociation).get(request.content_id)
                 export_store.add_dataset(hda)
@@ -158,9 +187,10 @@ class ModelStoreManager:
         model_store_format = request.model_store_format
         export_files = "symlink" if request.include_files else None
         target_uri = request.target_uri
-        with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
-            target_uri
-        ) as export_store:
+        user_context = self._build_user_context(request.user.user_id)
+        with model.store.get_export_store_factory(
+            self._app, model_store_format, export_files=export_files, user_context=user_context
+        )(target_uri) as export_store:
             history = self._history_manager.by_id(request.history_id)
             export_store.export_history(
                 history, include_hidden=request.include_hidden, include_deleted=request.include_deleted
@@ -175,17 +205,13 @@ class ModelStoreManager:
             history = self._sa_session.query(model.History).get(history_id)
         else:
             history = None
-        user_id = request.user.user_id
-        if user_id:
-            galaxy_user = self._sa_session.query(model.User).get(user_id)
-        else:
-            galaxy_user = None
+        user_context = self._build_user_context(request.user.user_id)
         model_import_store = source_to_import_store(
             request.source_uri,
             self._app,
-            galaxy_user,
             import_options,
             model_store_format=request.model_store_format,
+            user_context=user_context,
         )
         create_new_history = history is None and not request.for_library
         if create_new_history:
@@ -201,6 +227,11 @@ class ModelStoreManager:
             )
         return object_tracker
 
+    def _build_user_context(self, user_id: int):
+        user = self._user_manager.by_id(user_id)
+        user_context = ModelStoreUserContext(self._app, user)
+        return user_context
+
 
 def create_objects_from_store(
     app: MinimalManagerApp,
@@ -213,12 +244,13 @@ def create_objects_from_store(
         discarded_data=ImportDiscardedDataType.FORCE,
         allow_library_creation=for_library,
     )
+    user_context = ModelStoreUserContext(app, galaxy_user) if galaxy_user is not None else None
     model_import_store = source_to_import_store(
         payload.store_content_uri or payload.store_dict,
         app=app,
-        galaxy_user=galaxy_user,
         import_options=import_options,
         model_store_format=payload.model_store_format,
+        user_context=user_context,
     )
     create_new_history = history is None and not for_library
     if create_new_history:

--- a/lib/galaxy_test/driver/integration_setup.py
+++ b/lib/galaxy_test/driver/integration_setup.py
@@ -37,9 +37,15 @@ def get_posix_file_source_config(root_dir: str, roles: str, groups: str, include
     return rval
 
 
-def create_file_source_config_file_on(temp_dir, root_dir, include_test_data_dir):
+def create_file_source_config_file_on(
+    temp_dir,
+    root_dir,
+    include_test_data_dir,
+    required_role_expression,
+    required_group_expression,
+):
     file_contents = get_posix_file_source_config(
-        root_dir, REQUIRED_ROLE_EXPRESSION, REQUIRED_GROUP_EXPRESSION, include_test_data_dir
+        root_dir, required_role_expression, required_group_expression, include_test_data_dir
     )
     file_path = os.path.join(temp_dir, "file_sources_conf_posix.yml")
     with open(file_path, "w") as f:
@@ -53,14 +59,25 @@ class PosixFileSourceSetup:
     include_test_data_dir: ClassVar[bool] = False
 
     @classmethod
-    def handle_galaxy_config_kwds(cls, config, clazz_=None):
+    def handle_galaxy_config_kwds(
+        cls,
+        config,
+        clazz_=None,
+        # Require role for access but do not require groups by default on every test to simplify them
+        required_role_expression=REQUIRED_ROLE_EXPRESSION,
+        required_group_expression="",
+    ):
         temp_dir = os.path.realpath(mkdtemp())
         clazz_ = clazz_ or cls
         clazz_._test_driver.temp_directories.append(temp_dir)
         clazz_.root_dir = os.path.join(temp_dir, "root")
 
         file_sources_config_file = create_file_source_config_file_on(
-            temp_dir, clazz_.root_dir, clazz_.include_test_data_dir
+            temp_dir,
+            clazz_.root_dir,
+            clazz_.include_test_data_dir,
+            required_role_expression,
+            required_group_expression,
         )
         config["file_sources_config_file"] = file_sources_config_file
 

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -1,3 +1,4 @@
+import os
 import tarfile
 from uuid import uuid4
 
@@ -41,6 +42,14 @@ class TestImportExportHistoryViaTasksIntegration(
     def handle_galaxy_config_kwds(cls, config):
         PosixFileSourceSetup.handle_galaxy_config_kwds(config, cls)
         UsesCeleryTasks.handle_galaxy_config_kwds(config)
+        cls.setup_ftp_config(config)
+
+    @classmethod
+    def setup_ftp_config(cls, config):
+        ftp_dir = cls.temp_config_dir("ftp")
+        os.makedirs(ftp_dir)
+        config["ftp_upload_dir"] = ftp_dir
+        config["ftp_upload_site"] = "ftp://cow.com"
 
     def setUp(self):
         super().setUp()
@@ -92,6 +101,23 @@ class TestImportExportHistoryViaTasksIntegration(
                 )
                 bai_metadata = imported_bam_details["meta_files"][0]
                 assert bai_metadata["file_type"] == "bam_index"
+
+    def test_import_export_ftp(self):
+        history_name = f"for_export_ftp_async_{uuid4()}"
+        history_id = self.dataset_populator.setup_history_for_export_testing(history_name)
+
+        model_store_format = "rocrate.zip"
+        target_uri = f"gxftp://history.{model_store_format}"
+
+        self.dataset_populator.export_history_to_uri_async(history_id, target_uri, model_store_format)
+        self.dataset_populator.import_history_from_uri_async(target_uri, model_store_format)
+
+        last_history = self._get("histories?limit=1").json()
+        assert len(last_history) == 1
+        imported_history = last_history[0]
+        imported_history_id = imported_history["id"]
+        assert imported_history_id != history_id
+        assert imported_history["name"] == history_name
 
 
 class TestImportExportHistoryContentsViaTasksIntegration(IntegrationTestCase, UsesCeleryTasks):

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -18,6 +18,15 @@ from galaxy_test.driver.integration_setup import (
 class TestPosixFileSourceIntegration(PosixFileSourceSetup, integration_util.IntegrationTestCase):
     dataset_populator: DatasetPopulator
 
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        PosixFileSourceSetup.handle_galaxy_config_kwds(
+            config,
+            cls,
+            required_role_expression=REQUIRED_ROLE_EXPRESSION,
+            required_group_expression=REQUIRED_GROUP_EXPRESSION,
+        )
+
     def setUp(self):
         super().setUp()
         self._write_file_fixtures()


### PR DESCRIPTION
Detected while testing #14839

Currently investigating why this is happening in the context of export to FTP using Celery:
```
celery.app.trace ERROR 2022-11-30 14:28:17,024 [pN:main,p:307162,tN:Thread-2 (start)] Task galaxy.celery.tasks.write_history_to[819cb536-a161-4d71-858d-3cab36710311] raised unexpected: LookupError("cannot find 'ftp_dir' while searching for 'user.ftp_dir'")
Traceback (most recent call last):
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/davelopez/dev/galaxy/lib/galaxy/celery/__init__.py", line 164, in wrapper
    rval = app.magic_partial(func)(*args, **kwds)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/lagom/wrapping.py", line 28, in _bound_func
    return inner_func(*bound_args, **bound_kwargs)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/lagom/wrapping.py", line 45, in _error_handling_func
    return func(*args, **kwargs)
  File "/home/davelopez/dev/galaxy/lib/galaxy/celery/tasks.py", line 334, in write_history_to
    model_store_manager.write_history_to(request)
  File "/home/davelopez/dev/galaxy/lib/galaxy/managers/model_stores.py", line 161, in write_history_to
    with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
  File "/home/davelopez/dev/galaxy/lib/galaxy/model/store/__init__.py", line 2365, in __exit__
    self._finalize()
  File "/home/davelopez/dev/galaxy/lib/galaxy/model/store/__init__.py", line 2735, in _finalize
    file_source.write_from(file_source_path.path, rval)
  File "/home/davelopez/dev/galaxy/lib/galaxy/files/sources/__init__.py", line 158, in write_from
    self._write_from(target_path, native_path, user_context=user_context)
  File "/home/davelopez/dev/galaxy/lib/galaxy/files/sources/posix.py", line 74, in _write_from
    effective_root = self._effective_root(user_context)
  File "/home/davelopez/dev/galaxy/lib/galaxy/files/sources/posix.py", line 99, in _effective_root
    return self._evaluate_prop(self.root, user_context=user_context)
  File "/home/davelopez/dev/galaxy/lib/galaxy/files/sources/__init__.py", line 189, in _evaluate_prop
    rval = fill_template(prop_val, context=template_context, futurized=True)
  File "/home/davelopez/dev/galaxy/lib/galaxy/util/template.py", line 111, in fill_template
    raise first_exception or e
  File "/home/davelopez/dev/galaxy/lib/galaxy/util/template.py", line 83, in fill_template
    return unicodify(t, log_exception=False)
  File "/home/davelopez/dev/galaxy/lib/galaxy/util/__init__.py", line 1181, in unicodify
    value = str(value)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.10/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "DynamicallyCompiledCheetahTemplate.py", line 86, in respond
LookupError: cannot find 'ftp_dir' while searching for 'user.ftp_dir'
```

From the stack trace looks like there is no `user_context` defined, but I'm not sure how to provide it...

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
