### PR TITLE
Prevent ContentItem header from having a redundant selection outline

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -250,7 +250,7 @@ export default {
     },
 };
 </script>
-<style lang="scss">
+<style scoped lang="scss">
 .content-item {
     .name {
         word-break: break-all;

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -5,7 +5,7 @@
         :data-hid="id"
         :data-state="state">
         <div
-            class="p-1 cursor-pointer"
+            class="p-1 cursor-pointer content-item-header"
             draggable
             tabindex="0"
             @dragstart="onDragStart"
@@ -254,6 +254,9 @@ export default {
 .content-item {
     .name {
         word-break: break-all;
+    }
+    .content-item-header {
+        outline: none;
     }
 }
 </style>


### PR DESCRIPTION
This is the blue box that appears (in ff when you tab to the element, but in safari always apparently) now that it's in the tabindex for toggling expansion.  We already have an indication that you have selected the box with a darker background and don't need the redundant (and garish) blue.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Tab to history contentitems, observe.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
