### PR TITLE
Type+PydanticModel more tool test code.

### DIFF
--- a/lib/galaxy/tool_util/unittest_utils/interactor.py
+++ b/lib/galaxy/tool_util/unittest_utils/interactor.py
@@ -1,3 +1,15 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
+
+from galaxy.tool_util.verify.interactor import (
+    ToolTestCase,
+    ToolTestCaseList,
+)
+
 NEW_HISTORY = object()
 NEW_HISTORY_ID = "new"
 EXISTING_HISTORY = {"id": "existing"}
@@ -41,7 +53,7 @@ class MockGalaxyInteractor:
             },
         }
 
-    def get_tool_tests(self, tool_id, tool_version=None):
+    def get_tool_tests_model(self, tool_id, tool_version=None) -> ToolTestCaseList:
         tool_dict = self.get_tests_summary().get(tool_id)
         test_defs = []
         for this_tool_version, version_defs in tool_dict.items():
@@ -49,14 +61,19 @@ class MockGalaxyInteractor:
                 continue
 
             count = version_defs["count"]
-            for _ in range(count):
+            for index in range(count):
                 test_def = {
                     "tool_id": tool_id,
                     "tool_version": this_tool_version or "0.1.1-default",
+                    "name": tool_id,
+                    "test_index": index,
                 }
-                test_defs.append(test_def)
+                test_defs.append(ToolTestCase(**test_def))
 
             if tool_version is None or tool_version != "*":
                 break
 
-        return test_defs
+        return ToolTestCaseList(__root__=test_defs)
+
+    def get_tool_tests(self, tool_id: str, tool_version: Optional[str] = None) -> List[Dict[str, Any]]:
+        return [m.dict() for m in self.get_tool_tests_model(tool_id, tool_version).__root__]

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -107,7 +107,7 @@ ValidToolTestDict = TypedDict(
         "error": Literal[False],
         "tool_id": str,
         "tool_version": str,
-        "test_index": int,
+        "test_index": Optional[int],
     },
 )
 
@@ -117,7 +117,7 @@ InvalidToolTestDict = TypedDict(
         "error": Literal[True],
         "tool_id": str,
         "tool_version": str,
-        "test_index": int,
+        "test_index": Optional[int],
         "inputs": Any,
         "exception": str,
     },
@@ -1651,7 +1651,7 @@ class ToolTestDescription:
         maxseconds: int
         if not error_in_test_definition:
             processed_test_dict = cast(ValidToolTestDict, processed_test_dict)
-            maxseconds = int(processed_test_dict.get("maxseconds") or DEFAULT_TOOL_TEST_WAIT)
+            maxseconds = int(processed_test_dict.get("maxseconds") or DEFAULT_TOOL_TEST_WAIT or 86400)
             output_collections = processed_test_dict.get("output_collections", [])
         else:
             processed_test_dict = cast(InvalidToolTestDict, processed_test_dict)

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1731,11 +1731,36 @@ class ToolTestDescription:
             }
         )
 
-    def to_dict(self) -> Dict[str, Any]:
-        # For backward compatibility maintain a dict version - if
-        # this comment got merged the converter tests failed without this.
-        return self.to_model().dict()
+    def to_dict(self):
+        inputs_dict = {}
+        for key, value in self.inputs.items():
+            if hasattr(value, "to_dict"):
+                inputs_dict[key] = value.to_dict()
+            else:
+                inputs_dict[key] = value
 
+        return {
+            "inputs": inputs_dict,
+            "outputs": self.outputs,
+            "output_collections": [_.to_dict() for _ in self.output_collections],
+            "num_outputs": self.num_outputs,
+            "command_line": self.command_line,
+            "command_version": self.command_version,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "expect_exit_code": self.expect_exit_code,
+            "expect_failure": self.expect_failure,
+            "expect_test_failure": self.expect_test_failure,
+            "name": self.name,
+            "test_index": self.test_index,
+            "tool_id": self.tool_id,
+            "tool_version": self.tool_version,
+            "required_files": self.required_files,
+            "required_data_tables": self.required_data_tables,
+            "required_loc_files": self.required_loc_files,
+            "error": self.error,
+            "exception": self.exception,
+        }
 
 def test_data_iter(required_files):
     for fname, extra in required_files:

--- a/lib/galaxy/tool_util/verify/script.py
+++ b/lib/galaxy/tool_util/verify/script.py
@@ -26,6 +26,7 @@ import yaml
 from galaxy.tool_util.verify.interactor import (
     DictClientTestConfig,
     GalaxyInteractorApi,
+    ToolTestCase,
     verify_tool,
 )
 
@@ -338,9 +339,12 @@ def build_case_references(
                     test_reference = TestReference(tool_id, tool_version, test_index)
                     test_references.append(test_reference)
     else:
-        tool_test_dicts = galaxy_interactor.get_tool_tests(tool_id, tool_version=tool_version)
+        assert tool_id
+        tool_test_dicts: List[ToolTestCase] = galaxy_interactor.get_tool_tests_model(
+            tool_id, tool_version=tool_version
+        ).__root__
         for i, tool_test_dict in enumerate(tool_test_dicts):
-            this_tool_version = tool_test_dict.get("tool_version", tool_version)
+            this_tool_version = tool_test_dict.tool_version or tool_version
             this_test_index = i
             if test_index == ALL_TESTS or i == test_index:
                 test_reference = TestReference(tool_id, this_tool_version, this_test_index)

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -44,7 +44,7 @@ def description_from_tool_object(tool, test_index, raw_test_dict) -> ToolTestDes
     num_outputs = raw_test_dict.get("expect_num_outputs", None)
     if num_outputs:
         num_outputs = int(num_outputs)
-    maxseconds = raw_test_dict.get("maxseconds", None)
+    maxseconds = raw_test_dict.get("maxseconds", 86400)
     if maxseconds is not None:
         maxseconds = int(maxseconds)
 

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -31,6 +31,11 @@ from galaxy.schema.fetch_data import (
     FetchDataFormPayload,
     FetchDataPayload,
 )
+from galaxy.tool_util.verify.interactor import (
+    ToolTestCase,
+    ToolTestCaseList,
+)
+from galaxy.tools import Tool
 from galaxy.tools.evaluation import global_tool_errors
 from galaxy.util.zipstream import ZipstreamWrapper
 from galaxy.web import (
@@ -284,7 +289,7 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         return test_counts_by_tool
 
     @expose_api_anonymous_and_sessionless
-    def test_data(self, trans: GalaxyWebTransaction, id, **kwd):
+    def test_data(self, trans: GalaxyWebTransaction, id, **kwd) -> ToolTestCaseList:
         """
         GET /api/tools/{tool_id}/test_data?tool_version={tool_version}
 
@@ -299,6 +304,7 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         """
         kwd = _kwd_or_payload(kwd)
         tool_version = kwd.get("tool_version", None)
+        tools: List[Tool]
         if tool_version == "*":
             tools = self.app.toolbox.get_tool(id, get_all_versions=True)
             for tool in tools:
@@ -307,10 +313,10 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         else:
             tools = [self.service._get_tool(trans, id, tool_version=tool_version, user=trans.user)]
 
-        test_defs = []
+        test_defs: List[ToolTestCase] = []
         for tool in tools:
-            test_defs.extend([t.to_dict() for t in tool.tests])
-        return test_defs
+            test_defs.extend([t.to_model() for t in tool.tests])
+        return ToolTestCaseList(__root__=test_defs)
 
     @web.require_admin
     @expose_api

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -15,6 +15,7 @@ from requests import (
     put,
 )
 
+from galaxy.tool_util.verify.interactor import ToolTestCase
 from galaxy.util import galaxy_root_path
 from galaxy.util.unittest_utils import skip_if_github_down
 from galaxy_test.base import rules_test_data
@@ -1449,55 +1450,61 @@ class TestToolsApi(ApiTestCase, TestsTools):
         def register_job_data(job_data):
             job_data_list.append(job_data)
 
-        tool_test_dicts = [
+        def tool_test_case_list(inputs, required_files):
+            return [
+                ToolTestCase(
+                    **{
+                        "inputs": inputs,
+                        "outputs": {},
+                        "required_files": required_files,
+                        "name": "dbkey_output_action-0",
+                        "test_index": 0,
+                        "tool_version": "0.1.0",
+                        "tool_id": "dbkey_output_action",
+                    }
+                )
+            ]
+
+        tool_test_dicts = tool_test_case_list(
             {
-                "inputs": {
-                    "input": ["simple_line.txt"],
-                    "index": ["hg18_value"],
-                },
-                "outputs": {},
-                "required_files": [["simple_line.txt", {"value": "simple_line.txt", "dbkey": "hg18"}]],
-            }
-        ]
+                "input": ["simple_line.txt"],
+                "index": ["hg18_value"],
+            },
+            [["simple_line.txt", {"value": "simple_line.txt", "dbkey": "hg18"}]],
+        )
         dynamic_param_error = None
         test_driver = self.driver_or_skip_test_if_remote()
         try:
-            test_driver.run_tool_test("dbkey_output_action", tool_test_dicts=tool_test_dicts)
+            test_driver.run_tool_test("dbkey_output_action", _tool_test_dicts=tool_test_dicts)
         except Exception as e:
             dynamic_param_error = getattr(e, "dynamic_param_error", False)
         assert dynamic_param_error is None
 
-        tool_test_dicts = [
+        tool_test_dicts = tool_test_case_list(
             {
-                "inputs": {
-                    "input": ["simple_line.txt"],
-                    "index": ["hg18_value"],
-                },
-                "outputs": {},
-                "required_files": [["simple_line.txt", {"value": "simple_line.txt", "dbkey": "hgnot18"}]],
-            }
-        ]
+                "input": ["simple_line.txt"],
+                "index": ["hg18_value"],
+            },
+            [["simple_line.txt", {"value": "simple_line.txt", "dbkey": "hgnot18"}]],
+        )
         dynamic_param_error = None
         try:
-            test_driver.run_tool_test("dbkey_output_action", tool_test_dicts=tool_test_dicts)
+            test_driver.run_tool_test("dbkey_output_action", _tool_test_dicts=tool_test_dicts)
         except Exception as e:
             dynamic_param_error = getattr(e, "dynamic_param_error", False)
         assert dynamic_param_error
 
-        tool_test_dicts = [
+        tool_test_dicts = tool_test_case_list(
             {
-                "inputs": {
-                    "input": ["simple_line.txt"],
-                    "index": ["hgnot18"],
-                },
-                "outputs": {},
-                "required_files": [["simple_line.txt", {"value": "simple_line.txt", "dbkey": "hg18"}]],
-            }
-        ]
+                "input": ["simple_line.txt"],
+                "index": ["hgnot18"],
+            },
+            [["simple_line.txt", {"value": "simple_line.txt", "dbkey": "hg18"}]],
+        )
         dynamic_param_error = None
         try:
             test_driver.run_tool_test(
-                "dbkey_output_action", tool_test_dicts=tool_test_dicts, register_job_data=register_job_data
+                "dbkey_output_action", _tool_test_dicts=tool_test_dicts, register_job_data=register_job_data
             )
         except Exception as e:
             dynamic_param_error = getattr(e, "dynamic_param_error", False)
@@ -1511,7 +1518,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
         try:
             test_driver.run_tool_test(
                 "dbkey_output_action",
-                tool_test_dicts=tool_test_dicts,
+                _tool_test_dicts=tool_test_dicts,
                 skip_on_dynamic_param_errors=True,
                 register_job_data=register_job_data,
             )

--- a/test/integration/test_galaxy_interactor.py
+++ b/test/integration/test_galaxy_interactor.py
@@ -22,15 +22,16 @@ class TestGalaxyInteractor(integration_util.IntegrationTestCase):
     def test_get_tool_tests(self):
         # test that get_tool_tests will return the right tests when the tool_version has a '+' in it
         test_data = self.galaxy_interactor.get_tool_tests(tool_id="multiple_versions", tool_version="0.1+galaxy6")
-        print(test_data)
         assert isinstance(test_data, list)
         assert len(test_data) > 0
-        assert isinstance(test_data[0], dict)
-        assert test_data[0].get("tool_version") == "0.1+galaxy6"
+        test_data_dict = test_data[0]
+        assert isinstance(test_data_dict, dict)
+        assert test_data_dict.get("tool_version") == "0.1+galaxy6"
 
         test_data = self.galaxy_interactor.get_tool_tests(
             tool_id="multiple_versions"
         )  # test that tool_version=None does not break it
         assert isinstance(test_data, list)
         assert len(test_data) > 0
-        assert isinstance(test_data[0], dict)
+        test_data_dict = test_data[0]
+        assert isinstance(test_data_dict, dict)


### PR DESCRIPTION
Another small step toward more typing in these components for tool state work - Pydantic model at the API layer is also a step toward a more modern API (though no docs yet - still having pydantic do the runtime typing on both ends makes the API and client better IMO).

I dropped a parameter to verify_tool that was ... tricky... to type if an arbitrary value was being sent. I checked Planemo and Ephemeris and the verify/script.py in Galaxy and none of them seem to use that parameter - so I'm hoping it is just a typical John YAGNI extension point.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
