### PR TITLE
Sort library folders by name by default

### DIFF
--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -405,6 +405,8 @@ class FolderManager:
         if payload.order_by in FOLDER_SORT_COLUMN_MAP:
             sort_column = FOLDER_SORT_COLUMN_MAP[payload.order_by](model.LibraryFolder)
             sub_folders_query = sub_folders_query.order_by(sort_column.desc() if payload.sort_desc else sort_column)
+        else:  # Sort by name alphabetically by default
+            sub_folders_query = sub_folders_query.order_by(model.LibraryFolder.name)
         if limit is not None:
             sub_folders_query = sub_folders_query.limit(limit)
         if offset is not None:

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -259,7 +259,7 @@ class TestFolderContentsApi(ApiTestCase):
         dataset_names = ["a", "b", "c"]
         ldda_messages = ["Message Z", "Message Y", "Message X"]
         dataset_sizes = [50, 100, 10]
-        file_types = ["txt", "csv", "txt"]
+        file_types = ["txt", "csv", "json"]
         for index, name in enumerate(dataset_names):
             self._create_dataset_in_folder(
                 history_id,
@@ -285,7 +285,7 @@ class TestFolderContentsApi(ApiTestCase):
         self._assert_folder_order_by_is_expected(folder_id, order_by, sort_desc, expected_order_by_name)
 
         order_by = "type"
-        expected_order_by_name = ["Folder_A", "Folder_B", "Folder_C", "b", "a", "c"]
+        expected_order_by_name = ["Folder_A", "Folder_B", "Folder_C", "b", "c", "a"]
         self._assert_folder_order_by_is_expected(folder_id, order_by, sort_desc, expected_order_by_name)
 
         order_by = "size"


### PR DESCRIPTION
Fixes #15005

If the library folder cannot be sorted by the specified column there is a chance that the database returns a different order.

This should hopefully get rid of the flaky ordering in `lib/galaxy_test/api/test_folder_contents.py::TestFolderContentsApi::test_index_order_by` and return consistent results.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
