### PR TITLE
Enhance RO-Crate export of Galaxy invocations.

### DIFF
--- a/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.test.js
+++ b/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.test.js
@@ -12,7 +12,12 @@ const FAKE_INVOCATION_ID = "fake-invocation-id";
 const FAKE_EXPORT_PLUGIN = new InvocationExportPlugin({
     title: "Plugin Title",
     markdownDescription: `some **markdown** description`,
-    downloadFormat: "tgz",
+    exportParams: {
+        modelStoreFormat: "tgz",
+        includeFiles: false,
+        includeDeleted: false,
+        includeHidden: false,
+    },
     additionalActions: [
         new InvocationExportPluginAction({
             id: "fake-action-1",

--- a/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.vue
+++ b/client/src/components/Workflow/Invocation/Export/InvocationExportPluginCard.vue
@@ -26,11 +26,12 @@ provide("invocationId", props.invocationId);
 const descriptionRendered = computed(() => renderMarkdown(props.exportPlugin.markdownDescription));
 const invocationDownloadUrl = computed(() => `/api/invocations/${props.invocationId}/prepare_store_download`);
 const downloadParams = computed(() => {
+    const exportParams = props.exportPlugin.exportParams;
     return {
-        model_store_format: props.exportPlugin.downloadFormat,
-        include_files: false,
-        include_deleted: false,
-        include_hidden: false,
+        model_store_format: exportParams.modelStoreFormat,
+        include_files: exportParams.includeFiles,
+        include_deleted: exportParams.includeDeleted,
+        include_hidden: exportParams.includeHidden,
     };
 });
 
@@ -39,7 +40,8 @@ function openRemoteExportDialog() {
 }
 
 function exportToFileSource(exportDirectory, fileName) {
-    const exportDirectoryUri = `${exportDirectory}/${fileName}.${props.exportPlugin.downloadFormat}`;
+    const exportFormat = props.exportPlugin.exportParams.modelStoreFormat;
+    const exportDirectoryUri = `${exportDirectory}/${fileName}.${exportFormat}`;
     const writeStoreParams = {
         target_uri: exportDirectoryUri,
         ...downloadParams.value,

--- a/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/BioComputeObjectExportPlugin.js
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/BioComputeObjectExportPlugin.js
@@ -13,7 +13,12 @@ A BCO is designed to communicate High-throughput Sequencing (HTS) analysis resul
 Learn more about [BioCompute Objects](https://biocomputeobject.org/).
 
 Instructions for [creating a BCO using Galaxy](https://w3id.org/biocompute/tutorials/galaxy_quick_start).`,
-    downloadFormat: "bco.json",
+    exportParams: {
+        modelStoreFormat: "bco.json",
+        includeFiles: false,
+        includeDeleted: false,
+        includeHidden: false,
+    },
     additionalActions: [
         new InvocationExportPluginAction({
             id: "send-to-bco-db",

--- a/client/src/components/Workflow/Invocation/Export/Plugins/DefaultFileExportPlugin.js
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/DefaultFileExportPlugin.js
@@ -3,6 +3,11 @@ import { InvocationExportPlugin } from "../model";
 export const DEFAULT_FILE_EXPORT_PLUGIN = new InvocationExportPlugin({
     title: "File",
     markdownDescription: `Export the invocation to a compressed File containing the invocation data in Galaxy native format.`,
-    downloadFormat: "tgz",
+    exportParams: {
+        modelStoreFormat: "tgz",
+        includeFiles: false,
+        includeDeleted: false,
+        includeHidden: false,
+    },
     additionalActions: [],
 });

--- a/client/src/components/Workflow/Invocation/Export/Plugins/ROCrateExportPlugin.js
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/ROCrateExportPlugin.js
@@ -6,5 +6,10 @@ export const RO_CRATE_EXPORT_PLUGIN = new InvocationExportPlugin({
 RO-Crate is a community effort to establish a lightweight approach to packaging research data with their metadata. It is based on schema.org annotations in JSON-LD, and aims to make best-practice in formal metadata description accessible and practical for use in a wider variety of situations, from an individual researcher working with a folder of data, to large data-intensive computational research environments.
 
 Learn more about [RO Crate](https://www.researchobject.org/ro-crate/).`,
-    downloadFormat: "rocrate.zip",
+    exportParams: {
+        modelStoreFormat: "rocrate.zip",
+        includeFiles: true,
+        includeDeleted: false,
+        includeHidden: false,
+    },
 });

--- a/client/src/components/Workflow/Invocation/Export/model.js
+++ b/client/src/components/Workflow/Invocation/Export/model.js
@@ -22,11 +22,11 @@ export class InvocationExportPlugin {
         this.markdownDescription = props.markdownDescription ?? "No description provided";
 
         /**
-         * A string used to identify the Galaxy export store that handles the download format in the backend.
+         * An object with parameters for the Galaxy export store that handles the download format in the backend.
          * Check lib/galaxy/model/store/__init__.py::get_export_store_factory for more info.
-         * @type {string}
+         * @type {Object}
          */
-        this.downloadFormat = props.downloadFormat ?? "unknown format";
+        this.exportParams = props.exportParams ?? null;
 
         /**
          * A list of additional actions that this plugin can do with the exported invocation in addition

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2433,14 +2433,12 @@ class WriteCrates:
                 )
 
         workflows_directory = self.workflows_directory
-
         if os.path.exists(workflows_directory):
             for filename in os.listdir(workflows_directory):
                 is_computational_wf = not filename.endswith(".cwl")
                 workflow_cls = ComputationalWorkflow if is_computational_wf else WorkflowDescription
                 lang = "galaxy" if not filename.endswith(".cwl") else "cwl"
                 dest_path = os.path.join("workflows", filename)
-
                 is_main_entity = is_invocation_export and is_computational_wf
                 ro_crate.add_workflow(
                     source=os.path.join(workflows_directory, filename),

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -14,9 +14,12 @@ from rocrate.model.softwareapplication import SoftwareApplication
 from rocrate.rocrate import ROCrate
 
 from galaxy.model import (
-    Workflow, WorkflowInvocation, WorkflowStep, 
-    JobParameter, WorkflowRequestInputStepParameter,
-    JobToInputDatasetAssociation, JobToOutputDatasetAssociation
+    JobToInputDatasetAssociation,
+    JobToOutputDatasetAssociation,
+    Workflow,
+    WorkflowInvocation,
+    WorkflowRequestInputStepParameter,
+    WorkflowStep,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,7 +42,7 @@ class WorkflowRunCrateProfileBuilder:
             "__workflow_invocation_uuid__",
             "chromInfo",
             "dbkey",
-            "__input_ext"
+            "__input_ext",
         ]
 
     def build_crate(self):
@@ -58,7 +61,7 @@ class WorkflowRunCrateProfileBuilder:
             if dataset.dataset.id in self.model_store.dataset_id_to_path:
                 file_name, _ = self.model_store.dataset_id_to_path[dataset.dataset.id]
                 if not file_name:
-                    file_name = "datasets/dataset_"+str(dataset.dataset.id)
+                    file_name = f"datasets/dataset_{dataset.dataset.id}"
                 name = dataset.name
                 encoding_format = dataset.datatype.get_mime()
                 properties = {
@@ -110,7 +113,6 @@ class WorkflowRunCrateProfileBuilder:
         self.roc_engine_run = roc_engine_run
 
     def _add_actions(self, crate: ROCrate, file_entities: Dict[int, Any]):
-        
         input_formal_params = []
         output_formal_params = []
         workflow_inputs = []
@@ -165,7 +167,9 @@ class WorkflowRunCrateProfileBuilder:
                 step.uuid.urn,
                 properties={
                     "@type": "FormalParameter",
-                    "additionalType": self.param_type_mapping[step.annotations[0].workflow_step.tool_inputs['parameter_type']],
+                    "additionalType": self.param_type_mapping[
+                        step.annotations[0].workflow_step.tool_inputs["parameter_type"]
+                    ],
                     "description": step.annotations[0].annotation if step.annotations else "",
                     "name": step.label,
                     "valueRequired": not step.input_optional,
@@ -187,7 +191,7 @@ class WorkflowRunCrateProfileBuilder:
                 },
             )
         )
-        
+
     def _add_formal_parameter_output(self, crate: ROCrate, output: JobToOutputDatasetAssociation):
         # TODO: add more details for output formal definitions?
         return crate.add(
@@ -204,16 +208,16 @@ class WorkflowRunCrateProfileBuilder:
         )
 
     def _add_property_value(self, crate: ROCrate, param: WorkflowRequestInputStepParameter):
-        # TODO: 
+        input_name = param.workflow_step.output_connections[0].input_name
         return crate.add(
-                ContextEntity(
-                    crate,
-                    str(param.workflow_step.output_connections[0].input_name)+"-pv",
-                    properties={
-                        "@type": "PropertyValue",
-                        "name": param.workflow_step.output_connections[0].input_name,
-                        "value": param.parameter_value,
-                        "exampleOfWork": {"@id": param.workflow_step.uuid.urn},
-                    },
-                )
+            ContextEntity(
+                crate,
+                f"{input_name}-pv",
+                properties={
+                    "@type": "PropertyValue",
+                    "name": input_name,
+                    "value": param.parameter_value,
+                    "exampleOfWork": {"@id": param.workflow_step.uuid.urn},
+                },
             )
+        )

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -19,8 +19,8 @@ from galaxy.model import (
     JobToOutputDatasetAssociation,
     Workflow,
     WorkflowInvocation,
-    WorkflowRequestInputStepParameter,
     WorkflowInvocationStep,
+    WorkflowRequestInputStepParameter,
     WorkflowStep,
 )
 
@@ -65,21 +65,21 @@ class WorkflowRunCrateProfileBuilder:
             "__workflow_invocation_uuid__",
             "chromInfo",
             "dbkey",
-            "__input_ext"
+            "__input_ext",
         ]
-        self.pv_entities = {}
+        self.pv_entities: Dict[str, Any] = {}
 
     def build_crate(self):
         crate = ROCrate()
         file_entities = self._add_files(crate)
-        collection_entities = self._add_collections(crate, file_entities)
+        self._add_collections(crate, file_entities)
         self._add_workflows(crate)
         self._add_engine_run(crate)
         self._add_actions(crate, file_entities)
         return crate
 
     def _add_files(self, crate: ROCrate) -> Dict[int, Any]:
-        file_entities = {}
+        file_entities: Dict[int, Any] = {}
         for dataset, _ in self.model_store.included_datasets.values():
             if dataset.dataset.id in self.model_store.dataset_id_to_path:
                 filename, _ = self.model_store.dataset_id_to_path[dataset.dataset.id]
@@ -109,7 +109,8 @@ class WorkflowRunCrateProfileBuilder:
             for dataset in collection.dataset_instances:
                 if dataset.dataset:
                     dataset_id = file_entities.get(dataset.dataset.id)
-                    dataset_ids.append({"@id": dataset_id.id})
+                    if dataset_id:
+                        dataset_ids.append({"@id": dataset_id.id})
 
             properties = {
                 "name": name,
@@ -228,9 +229,9 @@ class WorkflowRunCrateProfileBuilder:
             param_id = step.output_connections[0].input_name
             param_type = None
             if step.annotations:
-                param_type = step.annotations[0].workflow_step.tool_inputs.get('parameter_type')
+                param_type = step.annotations[0].workflow_step.tool_inputs.get("parameter_type")
 
-            param_type = param_type or step.tool_inputs.get('parameter_type')
+            param_type = param_type or step.tool_inputs.get("parameter_type")
         else:
             param_id = tool_input
             param_type = None

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -15,9 +15,9 @@ from rocrate.model.softwareapplication import SoftwareApplication
 from rocrate.rocrate import ROCrate
 
 from galaxy.model import (
+    JobParameter,
     JobToInputDatasetAssociation,
     JobToOutputDatasetAssociation,
-    JobParameter,
     Workflow,
     WorkflowInvocation,
     WorkflowInvocationStep,
@@ -258,33 +258,6 @@ class WorkflowRunCrateProfileBuilder:
                 },
             )
         )
-
-    # def _add_formal_parameter_job(self, crate: ROCrate, param: JobParameter):
-    #     if not tool_input:
-    #         param_id = step.output_connections[0].input_name
-    #         param_type = None
-    #         if step.annotations:
-    #             param_type = step.annotations[0].workflow_step.tool_inputs.get("parameter_type")
-
-    #         param_type = param_type or step.tool_inputs.get("parameter_type")
-    #     else:
-    #         param_id = tool_input
-    #         param_type = None
-
-    #     return crate.add(
-    #         ContextEntity(
-    #             crate,
-    #             f"{param}-param",
-    #             # step.uuid.urn,
-    #             properties={
-    #                 "@type": "FormalParameter",
-    #                 "additionalType": self.param_type_mapping[param_type],
-    #                 "description": step.annotations[0].annotation if step.annotations else "",
-    #                 "name": f"{step.label} parameter",
-    #                 "valueRequired": not step.input_optional,
-    #             },
-    #         )
-    #     )
 
     def _add_formal_parameter_input(self, crate: ROCrate, input: JobToInputDatasetAssociation):
         # TODO: add more details for output formal definitions?

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -22,8 +22,6 @@ class WorkflowRunCrateProfileBuilder:
     def __init__(self, model_store: Any):
         self.model_store = model_store
         self.invocation: WorkflowInvocation = model_store.included_invocations[0]
-        logger.info(self.invocation.input_parameters)
-        logger.info(self.invocation.input_step_parameters)
         self.workflow: Workflow = self.invocation.workflow
         self.input_type_to_param_type = {
             "parameter": "parameter-type#TODO",
@@ -41,6 +39,8 @@ class WorkflowRunCrateProfileBuilder:
     def _add_files(self, crate: ROCrate) -> Dict[int, Any]:
         file_entities = {}
         for dataset, _ in self.model_store.included_datasets.values():
+            logger.info("dataset: %s" % (dataset.dataset.id,))
+            logger.info("dataset_id_to_path: %s" % str(self.model_store.dataset_id_to_path))
             if dataset.dataset.id in self.model_store.dataset_id_to_path:
                 file_name, _ = self.model_store.dataset_id_to_path[dataset.dataset.id]
                 name = dataset.name
@@ -55,6 +55,8 @@ class WorkflowRunCrateProfileBuilder:
                     properties=properties,
                 )
                 file_entities[dataset.dataset.id] = file_entity
+                logger.info("FN:",file_name)
+                logger.info("NAME:",name)
         return file_entities
 
     def _add_workflows(self, crate: ROCrate):
@@ -122,21 +124,6 @@ class WorkflowRunCrateProfileBuilder:
         crate.mainEntity["output"] = wf_output_param_ids
         wf_output_ids = [{"@id": output.id} for output in workflow_outputs if output]
         wf_input_values_ids = [{"@id": entity.id} for entity in input_values]
-        
-        # TODO: these are not the correct ones. We need to find the real runtime values
-        # for param in self.invocation.input_parameters:
-        #     input_param_value = crate.add(
-        #         ContextEntity(
-        #             crate,
-        #             properties={
-        #                 "@type": "PropertyValue",
-        #                 "name": param.name,
-        #                 "value": param.value,
-        #             },
-        #         )
-        #     )
-        #     input_values.append(input_param_value)
-        
 
         input_param_value = crate.add(
             ContextEntity(

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -1,0 +1,67 @@
+from galaxy.model import WorkflowInvocation
+from rocrate.rocrate import ROCrate
+from rocrate.model.contextentity import ContextEntity
+from rocrate.model.softwareapplication import SoftwareApplication
+
+
+class InvocationCrateBuilder:
+    def __init__(self, crate: ROCrate, invocation: WorkflowInvocation):
+        self.crate = crate
+        self.invocation = invocation
+        self.workflow_entity = self.crate.mainEntity
+        self.roc_engine_run = None
+        self.main_action = None
+
+    def add_engine_run(self):
+        roc_engine = self.crate.add(SoftwareApplication(self.crate, properties={"name": "Galaxy workflow engine"}))
+        roc_engine_run = self.crate.add(
+            ContextEntity(
+                self.crate,
+                properties={
+                    "@type": "OrganizeAction",
+                    "name": f"Run of {roc_engine['name']}",
+                    "startTime": self.invocation.create_time.isoformat(),
+                },
+            )
+        )
+        roc_engine_run["instrument"] = roc_engine
+        # TODO: add engine Agent?
+        self.roc_engine_run = roc_engine_run
+
+    def add_actions(self, activity=None, parent_instrument=None):
+        workflow = self.invocation.workflow
+
+        workflow_input_actions = []
+        for input_step in workflow.input_steps:
+            action = self.crate.add(
+                ContextEntity(
+                    self.crate,
+                    properties={
+                        "@type": "CreateAction",
+                        "name": input_step.label,
+                    },
+                )
+            )
+            workflow_input_actions.append(action)
+
+        workflow_output_actions = []
+        # for output_step in workflow.workflow_outputs:
+        #     output_step.name
+
+        # for step in self.invocation.steps:
+        #     step = cast(WorkflowInvocationStep, step)
+
+        wf_input_ids = [{"@id": input.id} for input in workflow_input_actions]
+        wf_output_ids = [{"@id": output.id} for output in workflow_output_actions]
+        main_action = self.crate.add(
+            ContextEntity(
+                self.crate,
+                properties={
+                    "@type": "CreateAction",
+                    "name": workflow.name,
+                    "object": wf_input_ids,
+                    "result": wf_output_ids,
+                },
+            )
+        )
+        self.main_action = main_action

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -36,19 +36,12 @@ class WorkflowRunCrateProfileBuilder:
             # "dataset": "File",
             # "dataset_collection": "collection#TODO",
         }
-        self.ignored_parameter_type = [
-            "queries",
-            "input1",
-            "__workflow_invocation_uuid__",
-            "chromInfo",
-            "dbkey",
-            "__input_ext",
-        ]
 
     def build_crate(self):
         crate = ROCrate()
         file_entities = self._add_files(crate)
         self._add_workflows(crate)
+        self._add_engine_run(crate)
         self._add_actions(crate, file_entities)
         return crate
 
@@ -94,6 +87,8 @@ class WorkflowRunCrateProfileBuilder:
                     cls=workflow_cls,
                     lang=lang,
                 )
+
+            crate.license = self.workflow.license  or ""
             crate.mainEntity["name"] = self.workflow.name
 
     def _add_engine_run(self, crate: ROCrate):
@@ -153,6 +148,7 @@ class WorkflowRunCrateProfileBuilder:
                 properties={
                     "@type": "CreateAction",
                     "name": self.workflow.name,
+                    "instrument": {"@id": crate.mainEntity["@id"]},
                     "object": wf_input_ids,
                     "result": wf_output_ids,
                 },

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -1,22 +1,84 @@
-from galaxy.model import WorkflowInvocation
-from rocrate.rocrate import ROCrate
+import logging
+import os
+from typing import (
+    Any,
+    Dict,
+)
+
+from rocrate.model.computationalworkflow import (
+    ComputationalWorkflow,
+    WorkflowDescription,
+)
 from rocrate.model.contextentity import ContextEntity
 from rocrate.model.softwareapplication import SoftwareApplication
+from rocrate.rocrate import ROCrate
+
+from galaxy.model import Workflow, WorkflowInvocation, WorkflowStep
+
+logger = logging.getLogger(__name__)
 
 
-class InvocationCrateBuilder:
-    def __init__(self, crate: ROCrate, invocation: WorkflowInvocation):
-        self.crate = crate
-        self.invocation = invocation
-        self.workflow_entity = self.crate.mainEntity
-        self.roc_engine_run = None
-        self.main_action = None
+class WorkflowRunCrateProfileBuilder:
+    def __init__(self, model_store: Any):
+        self.model_store = model_store
+        self.invocation: WorkflowInvocation = model_store.included_invocations[0]
+        self.workflow: Workflow = self.invocation.workflow
+        self.input_type_to_param_type = {
+            "parameter": "parameter-type#TODO",
+            "dataset": "File",
+            "dataset_collection": "collection#TODO",
+        }
 
-    def add_engine_run(self):
-        roc_engine = self.crate.add(SoftwareApplication(self.crate, properties={"name": "Galaxy workflow engine"}))
-        roc_engine_run = self.crate.add(
+    def build_crate(self):
+        crate = ROCrate()
+        file_entities = self._add_files(crate)
+        self._add_workflows(crate)
+        self._add_actions(crate, file_entities)
+        return crate
+
+    def _add_files(self, crate: ROCrate) -> Dict[int, Any]:
+        file_entities = {}
+        for dataset, _ in self.model_store.included_datasets.values():
+            if dataset.dataset.id in self.model_store.dataset_id_to_path:
+                file_name, _ = self.model_store.dataset_id_to_path[dataset.dataset.id]
+                name = dataset.name
+                encoding_format = dataset.datatype.get_mime()
+                properties = {
+                    "name": name,
+                    "encodingFormat": encoding_format,
+                }
+                file_entity = crate.add_file(
+                    file_name,
+                    dest_path=file_name,
+                    properties=properties,
+                )
+                file_entities[dataset.dataset.id] = file_entity
+        return file_entities
+
+    def _add_workflows(self, crate: ROCrate):
+        workflows_directory = self.model_store.workflows_directory
+
+        if os.path.exists(workflows_directory):
+            for filename in os.listdir(workflows_directory):
+                is_computational_wf = not filename.endswith(".cwl")
+                workflow_cls = ComputationalWorkflow if is_computational_wf else WorkflowDescription
+                lang = "galaxy" if not filename.endswith(".cwl") else "cwl"
+                dest_path = os.path.join("workflows", filename)
+
+                crate.add_workflow(
+                    source=os.path.join(workflows_directory, filename),
+                    dest_path=dest_path,
+                    main=is_computational_wf,
+                    cls=workflow_cls,
+                    lang=lang,
+                )
+            crate.mainEntity["name"] = self.workflow.name
+
+    def _add_engine_run(self, crate: ROCrate):
+        roc_engine = crate.add(SoftwareApplication(crate, properties={"name": "Galaxy workflow engine"}))
+        roc_engine_run = crate.add(
             ContextEntity(
-                self.crate,
+                crate,
                 properties={
                     "@type": "OrganizeAction",
                     "name": f"Run of {roc_engine['name']}",
@@ -28,40 +90,71 @@ class InvocationCrateBuilder:
         # TODO: add engine Agent?
         self.roc_engine_run = roc_engine_run
 
-    def add_actions(self, activity=None, parent_instrument=None):
-        workflow = self.invocation.workflow
+    def _add_actions(self, crate: ROCrate, file_entities: Dict[int, Any]):
 
-        workflow_input_actions = []
-        for input_step in workflow.input_steps:
-            action = self.crate.add(
+        input_formal_params = []
+        for step in self.workflow.input_steps:
+            formal_param = self._add_formal_parameter(crate, step)
+            input_formal_params.append(formal_param)
+
+        wf_input_values_ids = [{"@id": entity.id} for entity in input_formal_params]
+        crate.mainEntity["input"] = wf_input_values_ids
+
+        output_formal_params = []
+        workflow_outputs = []
+        for output_step in self.workflow.workflow_outputs:
+            formal_param = self._add_formal_parameter(crate, step)
+            output_formal_params.append(formal_param)
+
+            output_obj = self.invocation.get_output_object(output_step.label)
+            output_file_entity = file_entities.get(output_obj.dataset.id)
+            if output_file_entity:
+                logger.debug(f"[FOUND] label: {output_step.label} -> obj.id: {output_obj.id}")
+                workflow_outputs.append(output_file_entity)
+
+        wf_output_param_ids = [{"@id": entity.id} for entity in output_formal_params]
+        crate.mainEntity["output"] = wf_output_param_ids
+        wf_output_ids = [{"@id": output.id} for output in workflow_outputs]
+
+        input_values = []
+        for param in self.invocation.input_parameters:
+            input_param_value = crate.add(
                 ContextEntity(
-                    self.crate,
+                    crate,
                     properties={
-                        "@type": "CreateAction",
-                        "name": input_step.label,
+                        "@type": "PropertyValue",
+                        # "exampleOfWork": {"@id": "#verbose-param"},
+                        "name": param.name,
+                        "value": param.value,
                     },
                 )
             )
-            workflow_input_actions.append(action)
+            input_values.append(input_param_value)
+        wf_input_values_ids = [{"@id": entity.id} for entity in input_values]
 
-        workflow_output_actions = []
-        # for output_step in workflow.workflow_outputs:
-        #     output_step.name
-
-        # for step in self.invocation.steps:
-        #     step = cast(WorkflowInvocationStep, step)
-
-        wf_input_ids = [{"@id": input.id} for input in workflow_input_actions]
-        wf_output_ids = [{"@id": output.id} for output in workflow_output_actions]
-        main_action = self.crate.add(
+        input_param_value = crate.add(
             ContextEntity(
-                self.crate,
+                crate,
                 properties={
                     "@type": "CreateAction",
-                    "name": workflow.name,
-                    "object": wf_input_ids,
+                    "name": self.workflow.name,
+                    "object": wf_input_values_ids,
                     "result": wf_output_ids,
                 },
             )
         )
-        self.main_action = main_action
+        self.main_action = input_param_value
+
+    def _add_formal_parameter(self, crate: ROCrate, step: WorkflowStep):
+        return crate.add(
+            ContextEntity(
+                crate,
+                properties={
+                    "@type": "FormalParameter",
+                    "additionalType": self.input_type_to_param_type[step.input_type],
+                    "description": "TODO",  # ",".join(input_step.annotations),
+                    "name": step.label,
+                    "valueRequired": not step.input_optional,
+                },
+            )
+        )

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -195,7 +195,7 @@ class WorkflowRunCrateProfileBuilder:
                     property_value = self._add_job_property_value(crate, param)
                     workflow_inputs.append(property_value)
                     # need a new function?
-                    formal_param = self._add_formal_parameter(crate, output_step.workflow_step)
+                    formal_param = self._add_formal_parameter(crate, output_step.workflow_step, param.name)
                     input_formal_params.append(formal_param)
             if output_step.workflow_step.type == "parameter_input":
                 property_value = self._add_param_property_value(crate, output_step)
@@ -258,7 +258,7 @@ class WorkflowRunCrateProfileBuilder:
                 },
             )
         )
-    
+
     # def _add_formal_parameter_job(self, crate: ROCrate, param: JobParameter):
     #     if not tool_input:
     #         param_id = step.output_connections[0].input_name
@@ -328,7 +328,7 @@ class WorkflowRunCrateProfileBuilder:
                     "@type": "PropertyValue",
                     "name": input_name,
                     "value": param.value,
-                    "exampleOfWork": {"@id": f"{input_name}-param"},
+                    "exampleOfWork": {"@id": f"#{input_name}-param"},
                 },
             )
         )
@@ -347,7 +347,7 @@ class WorkflowRunCrateProfileBuilder:
                     "@type": "PropertyValue",
                     "name": input_name,
                     "value": param.parameter_value,
-                    "exampleOfWork": {"@id": f"{input_name}-param"},
+                    "exampleOfWork": {"@id": f"#{input_name}-param"},
                     # param.workflow_step.uuid.urn
                 },
             )
@@ -367,7 +367,7 @@ class WorkflowRunCrateProfileBuilder:
                     "@type": "PropertyValue",
                     "name": tool_input,
                     "value": invocation_step.workflow_step.tool_inputs[tool_input],
-                    "exampleOfWork": {"@id": f"{tool_input}-param"},
+                    "exampleOfWork": {"@id": f"#{tool_input}-param"},
                 },
             )
         )
@@ -386,7 +386,7 @@ class WorkflowRunCrateProfileBuilder:
                     "@type": "PropertyValue",
                     "name": invocation_step.workflow_step.label,
                     "value": invocation_step.output_value.value,
-                    "exampleOfWork": {"@id": f"{input_name}-param"},
+                    "exampleOfWork": {"@id": f"#{input_name}-param"},
                     # invocation_step.workflow_step.uuid.urn
                 },
             )

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2380,9 +2380,9 @@ input collection 2:
             # TODO: make more assertions about collections and parameters
             collections = [_ for _ in crate.contextual_entities if "Collection" in _.type]
             assert len(collections) == 3
-            assert collections[0]["additionalType"] == 'list'
+            assert collections[0]["additionalType"] == "list"
             coll_dataset = collections[0]["hasPart"][0].id
-            assert coll_dataset in [_.id for _ in collections[2]['hasPart']]
+            assert coll_dataset in [_.id for _ in collections[2]["hasPart"]]
 
     @skip_without_tool("__APPLY_RULES__")
     def test_workflow_run_apply_rules(self):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2378,8 +2378,11 @@ input collection 2:
             invocation_id = summary.invocation_id
             crate = self.workflow_populator.get_ro_crate(invocation_id, include_files=True)
             # TODO: make more assertions about collections and parameters
-            workflow = crate.mainEntity
-            assert workflow
+            collections = [_ for _ in crate.contextual_entities if "Collection" in _.type]
+            assert len(collections) == 3
+            assert collections[0]["additionalType"] == 'list'
+            coll_dataset = collections[0]["hasPart"][0].id
+            assert coll_dataset in [_.id for _ in collections[2]['hasPart']]
 
     @skip_without_tool("__APPLY_RULES__")
     def test_workflow_run_apply_rules(self):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1571,7 +1571,7 @@ class BaseWorkflowPopulator(BasePopulator):
         r.raise_for_status()
         return r.json()
 
-    def download_invocation_to_store(self, invocation_id, include_files, extension="tgz"):
+    def download_invocation_to_store(self, invocation_id, include_files=False, extension="tgz"):
         url = f"invocations/{invocation_id}/prepare_store_download"
         download_response = self._post(url, dict(include_files=include_files, model_store_format=extension), json=True)
         storage_request_id = self.dataset_populator.assert_download_request_ok(download_response)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -77,6 +77,7 @@ from gxformat2 import (
 )
 from gxformat2._yaml import ordered_load
 from requests import Response
+from rocrate.rocrate import ROCrate
 from typing_extensions import Literal
 
 from galaxy.tool_util.client.staging import InteractorStaging
@@ -1570,9 +1571,9 @@ class BaseWorkflowPopulator(BasePopulator):
         r.raise_for_status()
         return r.json()
 
-    def download_invocation_to_store(self, invocation_id, extension="tgz"):
+    def download_invocation_to_store(self, invocation_id, include_files, extension="tgz"):
         url = f"invocations/{invocation_id}/prepare_store_download"
-        download_response = self._post(url, dict(include_files=False, model_store_format=extension), json=True)
+        download_response = self._post(url, dict(include_files=include_files, model_store_format=extension), json=True)
         storage_request_id = self.dataset_populator.assert_download_request_ok(download_response)
         self.dataset_populator.wait_for_download_ready(storage_request_id)
         return self._get_to_tempfile(f"short_term_storage/{storage_request_id}")
@@ -1621,6 +1622,19 @@ class BaseWorkflowPopulator(BasePopulator):
         self, bco, expected_schema_version="https://w3id.org/ieee/ieee-2791-schema/2791object.json"
     ):
         JsonSchemaValidator.validate_using_schema_url(bco, expected_schema_version)
+
+    def get_ro_crate(self, invocation_id, include_files=False):
+        crate_response = self.download_invocation_to_store(
+            invocation_id=invocation_id, include_files=include_files, extension="rocrate.zip"
+        )
+        return ROCrate(crate_response)
+
+    def validate_invocation_crate_directory(self, crate_directory):
+        # TODO: where can a ro_crate be extracted
+        metadata_json_path = crate_directory / "ro-crate-metadata.json"
+        with metadata_json_path.open() as f:
+            metadata_json = json.load(f)
+            assert metadata_json["@context"] == "https://w3id.org/ro/crate/1.1/context"
 
     def invoke_workflow_raw(self, workflow_id: str, request: dict, assert_ok: bool = False) -> Response:
         url = f"workflows/{workflow_id}/invocations"

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -470,7 +470,7 @@ def test_export_invocation_to_ro_crate_archive(tmp_path):
     workflow_invocation = _setup_invocation(app)
 
     crate_zip = tmp_path / "crate.zip"
-    with store.ROCrateArchiveModelExportStore(crate_zip, app=app) as export_store:
+    with store.ROCrateArchiveModelExportStore(crate_zip, app=app, export_files="symlink") as export_store:
         export_store.export_workflow_invocation(workflow_invocation)
     compressed_file = CompressedFile(crate_zip)
     assert compressed_file.file_type == "zip"

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -409,7 +409,7 @@ def validate_create_action(ro_crate: ROCrate):
     assert wf_action["instrument"] is workflow
     wf_objects = wf_action["object"]
     wf_results = wf_action["result"]
-    assert len(wf_objects) == 0
+    assert len(wf_objects) == 1
     assert len(wf_results) == 1
     for entity in wf_results:
         if entity.id.endswith(".txt"):
@@ -804,10 +804,12 @@ def _setup_invocation(app):
     sa_session = app.model.context
 
     u, h, d1, d2, j = _setup_simple_cat_job(app)
+    j.parameters = [model.JobParameter(name="index_path", value='"/old/path/human"')]
 
     workflow_step_1 = model.WorkflowStep()
     workflow_step_1.order_index = 0
     workflow_step_1.type = "data_input"
+    workflow_step_1.tool_inputs = "data_input"
     sa_session.add(workflow_step_1)
     workflow_1 = _workflow_from_steps(u, [workflow_step_1])
     workflow_1.license = "MIT"
@@ -819,6 +821,8 @@ def _setup_invocation(app):
     invocation_step.job = j
     sa_session.add(invocation_step)
     input_assoc = model.WorkflowRequestToInputDatasetAssociation()
+    input_assoc.workflow_invocation = workflow_invocation
+    input_assoc.workflow_step = workflow_step_1
     input_assoc.dataset = d1
     invocation_step.input_datasets = [input_assoc]
     output_assoc = model.WorkflowInvocationStepOutputDatasetAssociation()

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -341,12 +341,17 @@ def validate_crate_metadata(as_dict):
 
 
 def validate_has_pl_galaxy(ro_crate: ROCrate):
-    found = False
-    for e in ro_crate.get_entities():
-        if e.id == "https://w3id.org/workflowhub/workflow-ro-crate#galaxy":
-            found = True
-            assert e.url == "https://galaxyproject.org/"
-    assert found
+    programming_language = ro_crate.mainEntity.get("programmingLanguage")
+    assert programming_language
+    assert programming_language.id == "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
+    assert programming_language.name == "Galaxy"
+    assert programming_language.url == "https://galaxyproject.org/"
+    assert programming_language.version
+
+
+def validate_organize_action(ro_crate: ROCrate):
+    organize_action = next((x for x in ro_crate.contextual_entities if x.type == "OrganizeAction"), None)
+    assert organize_action
 
 
 def validate_has_mit_license(ro_crate: ROCrate):
@@ -385,7 +390,10 @@ def validate_history_crate_directory(crate_directory):
 
 def validate_invocation_crate_directory(crate_directory):
     crate = open_ro_crate(crate_directory)
+    workflow = crate.mainEntity
+    assert workflow
     validate_has_pl_galaxy(crate)
+    validate_organize_action(crate)
     validate_has_mit_license(crate)
     validate_has_readme(crate)
     # print(json.dumps(metadata_json, indent=4))

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -391,7 +391,7 @@ def validate_history_crate_directory(crate_directory):
 def validate_main_entity(ro_crate: ROCrate):
     workflow = ro_crate.mainEntity
     assert workflow
-    assert workflow.id.endswith('.gxwf.yml')
+    assert workflow.id.endswith(".gxwf.yml")
     assert workflow["name"]
     assert workflow["name"] == "Test Workflow"
     assert "SoftwareSourceCode" in workflow.type
@@ -415,8 +415,8 @@ def validate_create_action(ro_crate: ROCrate):
         if entity.id.endswith(".txt"):
             assert "File" in entity.type
             wf_output_file = entity
-            wf_output_file["encodingFormat"] == "text/plain"
-            wf_output_file["exampleOfWork"] is workflow["output"][0]         
+            assert wf_output_file["encodingFormat"] == "text/plain"
+            assert wf_output_file["exampleOfWork"] is workflow["output"][0]
 
 
 def validate_other_entities(ro_crate: ROCrate):

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -396,7 +396,7 @@ def validate_main_entity(ro_crate: ROCrate):
     assert workflow["name"] == "Test Workflow"
     assert "SoftwareSourceCode" in workflow.type
     assert "ComputationalWorkflow" in workflow.type
-    assert len(workflow["input"]) == 1
+    assert len(workflow["input"]) == 2
     assert len(workflow["output"]) == 1
 
 
@@ -409,7 +409,7 @@ def validate_create_action(ro_crate: ROCrate):
     assert wf_action["instrument"] is workflow
     wf_objects = wf_action["object"]
     wf_results = wf_action["result"]
-    assert len(wf_objects) == 1
+    assert len(wf_objects) == 2
     assert len(wf_results) == 1
     for entity in wf_results:
         if entity.id.endswith(".txt"):
@@ -423,9 +423,13 @@ def validate_other_entities(ro_crate: ROCrate):
     workflow = ro_crate.mainEntity
     inputs = workflow["input"]
     outputs = workflow["output"]
+    assert inputs[0]["additionalType"] == "File"
+    assert inputs[1]["additionalType"] == "None"
+    assert outputs[0]["additionalType"] == "File"
+
     for entity in inputs + outputs:
         assert "FormalParameter" in entity.type
-        assert "File" in entity["additionalType"]
+
     sel = [_ for _ in ro_crate.contextual_entities if "OrganizeAction" in _.type]
     assert len(sel) == 1
     engine_action = sel[0]
@@ -809,7 +813,8 @@ def _setup_invocation(app):
     workflow_step_1 = model.WorkflowStep()
     workflow_step_1.order_index = 0
     workflow_step_1.type = "data_input"
-    workflow_step_1.tool_inputs = "data_input"
+    workflow_step_1.tool_inputs = {}
+    # workflow_step_1.input_optional = False
     sa_session.add(workflow_step_1)
     workflow_1 = _workflow_from_steps(u, [workflow_step_1])
     workflow_1.license = "MIT"


### PR DESCRIPTION
Follow up on https://github.com/galaxyproject/galaxy/pull/14595 and https://github.com/galaxyproject/galaxy/pull/14606 which implements the [Workflow Run Crate Profile](https://www.researchobject.org/workflow-run-crate/profiles/workflow_run_crate).

I think this writes the correct packaged file to the file source.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
