### PR TITLE
Documents use of k8s_extra_job_envs in job_conf sample advanced

### DIFF
--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -292,6 +292,13 @@
                 </param> -->
             <!-- Apply additional labels and annotations to the k8s job spec -->
 
+            <!-- <param id="k8s_extra_job_envs">
+                    HDF5_USE_FILE_LOCKING: 'FALSE'
+                    MY_OTHER_ENV_VAR: its_value
+                </param> -->
+            <!-- Sets additional environment variables (in YAML) to be passed to the k8s Jobs that handle each Galaxy job. 
+                 This is probably possible to be set at the destination level as well, based on the source code. -->
+
             <!-- <param id="k8s_supplemental_group_id">0</param> -->
             <!-- <param id="k8s_fs_group_id">0</param> -->
             <!-- If mounting an NFS / GlusterFS or other shared file system which is administered to ONLY provide access


### PR DESCRIPTION
The ability to pass extra env vars to Galaxy jobs being sent to the k8s runner was not documented in the job_conf sample advanced. I had to figure it out based on the runner source code, hopefully that won't be needed in the future.

In all fairness, I'm not entirely sure if the example I wrote is adequate for the XML, as the use case that motivated this is in YAML in the helm chart (and that setup is using the job_conf.yml instead, so I cannot see the end product in XML). However, on the sample XML I do see some additional bits for the k8s runner being YAML encapsulated in XML, so I figured it would be fine. But please let me know to amend.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

This is mostly documentation change.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
