### PR TITLE
Convert UtcDate from options to composition+ts.

### DIFF
--- a/client/src/components/UtcDate.test.js
+++ b/client/src/components/UtcDate.test.js
@@ -5,16 +5,18 @@ import UtcDate from "./UtcDate.vue";
 describe("UTCDate component", () => {
     const localVue = getLocalVue();
 
-    it("Loads a date in default mode, can format outputs as expected.", () => {
+    it("Loads a date in default mode, can format outputs as expected.", async () => {
         const wrapper = shallowMount(UtcDate, {
             propsData: { date: "2015-10-21T16:29:00.000000" },
             localVue,
         });
-        // expect elapsed time to be 'years ago.
         expect(wrapper.text()).toBe("2015-10-21T16:29:00.000Z");
-        expect(wrapper.vm.elapsedTime).toContain("years ago");
-        expect(wrapper.vm.fullISO).toBe("2015-10-21T16:29:00.000Z");
-        expect(wrapper.vm.parsedDate).toEqual(new Date("2015-10-21T16:29:00.000Z"));
-        expect(wrapper.vm.pretty).toBe("Wednesday Oct 21st 16:29:00 2015 UTC");
+
+        await wrapper.setProps({ mode: "elapsed" });
+        expect(wrapper.text()).toContain("years ago");
+
+        await wrapper.setProps({ mode: "pretty" });
+        expect(wrapper.text()).toBe("Wednesday Oct 21st 16:29:00 2015 UTC");
+
     });
 });

--- a/client/src/components/UtcDate.test.js
+++ b/client/src/components/UtcDate.test.js
@@ -17,6 +17,5 @@ describe("UTCDate component", () => {
 
         await wrapper.setProps({ mode: "pretty" });
         expect(wrapper.text()).toBe("Wednesday Oct 21st 16:29:00 2015 UTC");
-
     });
 });

--- a/client/src/components/UtcDate.vue
+++ b/client/src/components/UtcDate.vue
@@ -1,3 +1,34 @@
+<script setup lang="ts">
+import { formatDistanceToNow, parseISO } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
+import { computed } from "vue";
+
+const props = defineProps({
+    date: { type: String, required: true },
+    mode: {
+        type: String,
+        default: "date",
+    },
+});
+
+// Component assumes ISO format date, but note that in Galaxy this won't have
+// TZinfo -- it will always be Zulu
+const parsedDate = computed(() => {
+    return parseISO(`${props.date}Z`);
+});
+
+const elapsedTime = computed(() => {
+    return formatDistanceToNow(parsedDate.value, { addSuffix: true });
+});
+
+const fullISO = computed(() => {
+    return parsedDate.value.toISOString();
+});
+
+const pretty = computed(() => {
+    return `${formatInTimeZone(parsedDate.value, "Etc/Zulu", "eeee MMM do H:mm:ss yyyy")} UTC`;
+});
+</script>
 <template>
     <span v-if="mode == 'date'" class="utc-time" :title="elapsedTime">
         {{ fullISO }}
@@ -9,36 +40,3 @@
         {{ pretty }}
     </span>
 </template>
-
-<script>
-import { formatDistanceToNow, parseISO } from "date-fns";
-import { formatInTimeZone } from "date-fns-tz";
-
-export default {
-    props: {
-        date: {
-            type: String,
-            required: true,
-        },
-        mode: {
-            type: String,
-            default: "date", // or elapsed
-        },
-    },
-    computed: {
-        elapsedTime: function () {
-            return formatDistanceToNow(this.parsedDate, { addSuffix: true });
-        },
-        fullISO: function () {
-            return this.parsedDate.toISOString();
-        },
-        parsedDate: function () {
-            // assume ISO format date, except in Galaxy this won't have TZinfo -- it will always be Zulu
-            return parseISO(`${this.date}Z`);
-        },
-        pretty: function () {
-            return `${formatInTimeZone(this.parsedDate, "Etc/Zulu", "eeee MMM do H:mm:ss yyyy")} UTC`;
-        },
-    },
-};
-</script>

--- a/client/src/components/UtcDate.vue
+++ b/client/src/components/UtcDate.vue
@@ -3,12 +3,13 @@ import { formatDistanceToNow, parseISO } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 import { computed } from "vue";
 
-const props = defineProps({
-    date: { type: String, required: true },
-    mode: {
-        type: String,
-        default: "date",
-    },
+interface UtcDateProps {
+    date: string;
+    mode?: "date" | "elapsed" | "pretty";
+}
+
+const props = withDefaults(defineProps<UtcDateProps>(), {
+    mode: "date",
 });
 
 // Component assumes ISO format date, but note that in Galaxy this won't have

--- a/client/src/components/UtcDate.vue
+++ b/client/src/components/UtcDate.vue
@@ -13,21 +13,10 @@ const props = defineProps({
 
 // Component assumes ISO format date, but note that in Galaxy this won't have
 // TZinfo -- it will always be Zulu
-const parsedDate = computed(() => {
-    return parseISO(`${props.date}Z`);
-});
-
-const elapsedTime = computed(() => {
-    return formatDistanceToNow(parsedDate.value, { addSuffix: true });
-});
-
-const fullISO = computed(() => {
-    return parsedDate.value.toISOString();
-});
-
-const pretty = computed(() => {
-    return `${formatInTimeZone(parsedDate.value, "Etc/Zulu", "eeee MMM do H:mm:ss yyyy")} UTC`;
-});
+const parsedDate = computed(() => parseISO(`${props.date}Z`));
+const elapsedTime = computed(() => formatDistanceToNow(parsedDate.value, { addSuffix: true }));
+const fullISO = computed(() => parsedDate.value.toISOString());
+const pretty = computed(() => `${formatInTimeZone(parsedDate.value, "Etc/Zulu", "eeee MMM do H:mm:ss yyyy")} UTC`);
 </script>
 <template>
     <span v-if="mode == 'date'" class="utc-time" :title="elapsedTime">

--- a/client/tests/jest/standalone/RuleDefinitions.test.ts
+++ b/client/tests/jest/standalone/RuleDefinitions.test.ts
@@ -1,5 +1,4 @@
 import RuleDefs from "components/RuleBuilder/rule-definitions";
-import { sources } from "webpack";
 import SPEC_TEST_CASES from "./rules_dsl_spec.yml";
 
 function applyRules(rules: Array<any>, data: Array<Array<string>>, sources: Array<number>) {


### PR DESCRIPTION
Small example for upcoming type-a-thon converting an options API component to composition with typescript.

The type-based prop declaration is potentially overkill (see the alternative in cc6402e13569b4e3e4ef6529f975c0b8a95c5411), but it is pretty nice for things like this, so I wanted an example for it:

![image](https://user-images.githubusercontent.com/155398/205768060-09a6355c-76b1-4f61-8f1e-f334fb306588.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
