### PR TITLE
[PROCEDURES] Update security process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,7 @@ embargo, we will:
 - Patch the oldest release within the 12 month support window, and merge that fix forward.
   - Updates will be available on the `release_XX.YY` branches.
 - Update each release branch
-- Post a notice to the [galaxy-announce mailing list](https://lists.galaxyproject.org/listinfo/galaxy-announce) with:
+- Publish a security advisory on GitHub containing
   - A description of the issue
   - List of supported versions that are affected
   - Steps to update or patch your Galaxy


### PR DESCRIPTION
Updates the security procedure to utilize github advisories for announcement.  Per discussion at wg-backend meeting earlier today, -announce just isn't appropriate for this kind of message.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
