### PR TITLE
[PROCEDURES] Security policy update -- using github advisories.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,7 @@ embargo, we will:
 - Patch the oldest release within the 12 month support window, and merge that fix forward.
   - Updates will be available on the `release_XX.YY` branches.
 - Update each release branch
-- Post a notice to the [galaxy-announce mailing list](https://lists.galaxyproject.org/listinfo/galaxy-announce) with:
+- Publish a security advisory on GitHub containing:
   - A description of the issue
   - List of supported versions that are affected
   - Steps to update or patch your Galaxy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,6 +58,7 @@ embargo, we will:
   - A description of the issue
   - List of supported versions that are affected
   - Steps to update or patch your Galaxy
+  - A CVE identifier (if applicable)
 
 If an issue is deemed to be time-sensitive – e.g. due to active and ongoing exploits in the wild – the embargo may be shortened considerably.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,7 @@ embargo, we will:
 - Patch the oldest release within the 12 month support window, and merge that fix forward.
   - Updates will be available on the `release_XX.YY` branches.
 - Update each release branch
-- Publish a security advisory on GitHub containing:
+- Publish a repository security advisory on GitHub containing:
   - A description of the issue
   - List of supported versions that are affected
   - Steps to update or patch your Galaxy


### PR DESCRIPTION
Updates the security procedure to utilize github advisories for announcement. Per discussion at wg-backend meeting earlier today, -announce just isn't appropriate for this kind of message.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
