### PR TITLE
Install involucro when resolvers are instantiated

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -54,11 +54,15 @@ jobs:
         run: docker system prune -a -f
       - name: Clean dotnet folder for space
         run: rm -Rf /usr/share/dotnet
+      - name: Install packages
+        # conntrack: mandatory for later k8s versions
+        # ffmpeg: ffprobe needed by media datatypes
+        run: sudo apt-get update && sudo apt-get -y install conntrack ffmpeg
       - name: Setup Minikube
         id: minikube
-        uses: CodingNagger/minikube-setup-action@v1.0.3
+        uses: CodingNagger/minikube-setup-action@v1.0.6
         with:
-          minikube-version: "1.9.0-0_amd64"
+          k8s-version: '1.19.16'
       - name: Launch Minikube
         run: eval ${{ steps.minikube.outputs.launcher }}
       - name: Check pods
@@ -85,8 +89,6 @@ jobs:
         with:
           path: 'galaxy root/.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-integration
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get -y install ffmpeg
       - name: Run tests
         run: |
           . .ci/minikube-test-setup/start_services.sh

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -313,6 +313,7 @@ mapping:
       tool_dependency_dir:
         type: str
         default: dependencies
+        path_resolves_to: data_dir
         required: false
         desc: |
           Various dependency resolver configuration parameters will have defaults set relative
@@ -322,8 +323,6 @@ mapping:
           Set the string to null to explicitly disable tool dependency handling.
           If this option is set to none or an invalid path, installing tools with dependencies
           from the Tool Shed or in Conda will fail.
-
-          The value of this option will be resolved with respect to <data_dir>.
 
       dependency_resolvers_config_file:
         type: str
@@ -586,6 +585,7 @@ mapping:
       involucro_path:
         type: str
         default: involucro
+        path_resolves_to: tool_dependency_dir
         required: false
         desc: |
           involucro is a tool used to build Docker or Singularity containers for tools from Conda
@@ -593,8 +593,6 @@ mapping:
           the location of involucro on the Galaxy host. This is ignored if the relevant
           container resolver isn't enabled, and will install on demand unless
           involucro_auto_init is set to false.
-
-          The value of this option will be resolved with respect to <tool_dependency_dir>.
 
       involucro_auto_init:
         type: bool

--- a/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
@@ -5,6 +5,7 @@ from abc import (
     abstractproperty,
 )
 from typing import (
+    Any,
     Optional,
     TYPE_CHECKING,
 )
@@ -14,6 +15,8 @@ from galaxy.util.dictifiable import Dictifiable
 
 if TYPE_CHECKING:
     from beaker.cache import Cache
+
+    from ..dependencies import AppInfo
 
 
 class ResolutionCache(Bunch):
@@ -35,17 +38,17 @@ class ContainerResolver(Dictifiable, metaclass=ABCMeta):
     builds_on_resolution = False
     read_only = True  # not used for containers, but set for when they are used like dependency resolvers
 
-    def __init__(self, app_info=None, **kwds):
+    def __init__(self, app_info: Optional["AppInfo"] = None, **kwds) -> None:
         """Default initializer for ``ContainerResolver`` subclasses."""
         self.app_info = app_info
         self.resolver_kwds = kwds
 
-    def _get_config_option(self, key, default=None):
+    def _get_config_option(self, key: str, default: Any = None) -> Any:
         """Look in resolver-specific settings for option and then fallback to
         global settings.
         """
-        if self.app_info and hasattr(self.app_info, key):
-            return getattr(self.app_info, key)
+        if self.app_info:
+            return getattr(self.app_info, key, default)
         else:
             return default
 

--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -54,11 +54,11 @@ ResolvedContainerDescription = collections.namedtuple(
 
 
 class ContainerFinder:
-    def __init__(self, app_info, mulled_resolution_cache=None):
+    def __init__(self, app_info: "AppInfo", mulled_resolution_cache: Optional["Cache"] = None) -> None:
         self.app_info = app_info
         self.mulled_resolution_cache = mulled_resolution_cache
         self.default_container_registry = ContainerRegistry(app_info, mulled_resolution_cache=mulled_resolution_cache)
-        self.destination_container_registeries = {}
+        self.destination_container_registeries: Dict[str, "ContainerRegistry"] = {}
 
     def _enabled_container_types(self, destination_info):
         return [t for t in ALL_CONTAINER_TYPES if self.__container_type_enabled(t, destination_info)]


### PR DESCRIPTION
i.e. at Galaxy startup. Should fix https://github.com/galaxyproject/galaxy/issues/15112 .

Also:
- Fix resolved default value of `tool_dependency_dir` and ``involucro_path`` config options, which caused `involucro` to be created in the Galaxy root directory during some tests.
- Update `minikube-setup-action` and use more recent k8s version. The older minikube/k8s fail to launch under Ubuntu 22.04, which is being deployed on GitHub action workers.
- Type annotations
- Code refactorings

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
