### PR TITLE
Advanced tool search results page design changes

### DIFF
--- a/client/src/components/Tool/ToolHelp.vue
+++ b/client/src/components/Tool/ToolHelp.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { computed } from "vue";
-import { getAppRoot } from "onload/loadConfig";
+import { useFormattedToolHelp } from "composables/formattedToolHelp";
 
 const props = defineProps({
     content: {
@@ -9,57 +8,7 @@ const props = defineProps({
     },
 });
 
-const formattedContent = computed(() => {
-    const node = document.createElement("div");
-    node.innerHTML = props.content;
-
-    const links = node.getElementsByTagName("a");
-    Array.from(links).forEach((link) => {
-        link.target = "_blank";
-    });
-
-    const images = node.getElementsByTagName("img");
-    Array.from(images).forEach((image) => {
-        if (image.src.includes("admin_toolshed")) {
-            image.src = getAppRoot() + image.src;
-        }
-    });
-
-    // loop these levels backwards to avoid increasing heading twice
-    [5, 4, 3, 2, 1].forEach((level) => {
-        increaseHeadingLevel(node, level, 2);
-    });
-
-    return node.innerHTML;
-});
-
-/**
- * @param {HTMLElement} node
- * @param {number} level
- * @param {number} increaseBy
- */
-function increaseHeadingLevel(node, level, increaseBy) {
-    // cap target level at 6 (highest heading level)
-    let targetLevel = level + increaseBy;
-    if (targetLevel > 6) {
-        targetLevel = 6;
-    }
-
-    const headings = node.getElementsByTagName(`h${level}`);
-
-    // create new headings with target level and copy contents + attributes
-    Array.from(headings).forEach((heading) => {
-        const newTag = document.createElement(`h${targetLevel}`);
-        newTag.innerHTML = heading.innerHTML;
-
-        Array.from(heading.attributes).forEach((attribute) => {
-            newTag.setAttribute(attribute.name, attribute.value);
-        });
-
-        heading.insertAdjacentElement("beforebegin", newTag);
-        heading.remove();
-    });
-}
+const { formattedContent } = useFormattedToolHelp(props.content);
 </script>
 
 <template>

--- a/client/src/components/ToolsList/ScrollToTopButton.vue
+++ b/client/src/components/ToolsList/ScrollToTopButton.vue
@@ -1,17 +1,24 @@
 <template>
     <b-button
-        v-if="offset > 200"
         v-b-tooltip.noninteractive.hover
-        class="ui-btn-back-to-top btn-circle"
+        class="back-to-top"
+        :class="{ show: offset > 100 }"
         title="Scroll To Top"
         variant="info"
         @click="$emit('click')">
-        <i class="fa fa-arrow-up" />
+        <FontAwesomeIcon icon="fa-chevron-up" />
     </b-button>
 </template>
 
 <script>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faChevronUp } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faChevronUp);
+
 export default {
+    components: { FontAwesomeIcon },
     props: {
         offset: {
             type: Number,
@@ -20,3 +27,17 @@ export default {
     },
 };
 </script>
+
+<style lang="scss" scoped>
+.back-to-top {
+    bottom: 0.5rem;
+    left: 0.5rem;
+    position: absolute;
+    opacity: 0;
+    transition: opacity 0.4s;
+
+    &.show {
+        opacity: 1;
+    }
+}
+</style>

--- a/client/src/components/ToolsList/ToolsListItem.vue
+++ b/client/src/components/ToolsList/ToolsListItem.vue
@@ -52,7 +52,13 @@ library.add(faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp, faExcla
                 <span>
                     <FontAwesomeIcon v-if="props.local" icon="fa-wrench" fixed-width />
                     <FontAwesomeIcon v-else icon="fa-globe" fixed-width />
-                    <b>{{ props.name }}</b>
+
+                    <b-button v-if="props.local" class="ui-link text-dark" @click="() => emit('open')">
+                        <b>{{ props.name }}</b>
+                    </b-button>
+                    <b-button v-else class="ui-link text-dark" :href="props.link">
+                        <b>{{ props.name }}</b>
+                    </b-button>
                 </span>
                 <span itemprop="description">{{ props.description }}</span>
                 <span>(Galaxy Version {{ props.version }})</span>

--- a/client/src/components/ToolsList/ToolsListItem.vue
+++ b/client/src/components/ToolsList/ToolsListItem.vue
@@ -32,9 +32,17 @@ const formattedToolHelp = computed(() => {
 
 <script>
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp } from "@fortawesome/free-solid-svg-icons";
+import {
+    faWrench,
+    faGlobe,
+    faCheck,
+    faTimes,
+    faAngleDown,
+    faAngleUp,
+    faExclamationTriangle,
+} from "@fortawesome/free-solid-svg-icons";
 
-library.add(faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp);
+library.add(faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp, faExclamationTriangle);
 </script>
 
 <template>
@@ -65,25 +73,17 @@ library.add(faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp);
 
         <div class="portlet-content">
             <div class="d-flex flex-gapx-1 py-2">
-                <span class="info px-1 rounded">
+                <span v-if="props.section" class="info px-1 rounded">
                     <b>Section:</b> <b-link :to="`/tools/list?section=${props.section}`">{{ section }}</b-link>
                 </span>
 
-                <span v-if="props.local" class="info px-1 rounded">
-                    <FontAwesomeIcon icon="fa-wrench" fixed-width />
-                    Local Tool
-                </span>
-                <span v-else class="info px-1 rounded">
+                <span v-if="!props.local" class="info px-1 rounded">
                     <FontAwesomeIcon icon="fa-globe" fixed-width />
-                    External Tool
+                    External
                 </span>
 
-                <span v-if="props.workflowCompatible" class="success px-1 rounded">
-                    <FontAwesomeIcon icon="fa-check" fixed-width />
-                    Workflow compatible
-                </span>
-                <span v-else class="warn px-1 rounded">
-                    <FontAwesomeIcon icon="fa-times" fixed-width />
+                <span v-if="!props.workflowCompatible" class="warn px-1 rounded">
+                    <FontAwesomeIcon icon="fa-exclamation-triangle" />
                     Not Workflow compatible
                 </span>
             </div>

--- a/client/src/components/ToolsList/ToolsListItem.vue
+++ b/client/src/components/ToolsList/ToolsListItem.vue
@@ -1,0 +1,130 @@
+<script setup>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { ref, computed } from "vue";
+import { useFormattedToolHelp } from "composables/formattedToolHelp";
+import ToolFavoriteButton from "components/Tool/Buttons/ToolFavoriteButton";
+const props = defineProps({
+    id: { type: String, required: true },
+    name: { type: String, required: true },
+    section: { type: String, required: true },
+    description: { type: String, default: null },
+    summary: { type: String, default: null },
+    help: { type: String, default: null },
+    version: { type: String, default: null },
+    link: { type: String, default: null },
+    workflowCompatible: { type: Boolean, default: false },
+    local: { type: Boolean, default: false },
+});
+
+const emit = defineEmits(["open"]);
+
+const showHelp = ref(false);
+
+const formattedToolHelp = computed(() => {
+    if (showHelp.value) {
+        const { formattedContent } = useFormattedToolHelp(props.help);
+        return formattedContent.value;
+    } else {
+        return "";
+    }
+});
+</script>
+
+<script>
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp);
+</script>
+
+<template>
+    <div class="tool-list-item ui-portlet-section">
+        <div class="top-bar bg-secondary px-2 py-1 rounded-right">
+            <div class="py-1 d-flex flex-wrap flex-gapx-1">
+                <span>
+                    <FontAwesomeIcon v-if="props.local" icon="fa-wrench" fixed-width />
+                    <FontAwesomeIcon v-else icon="fa-globe" fixed-width />
+                    <b>{{ props.name }}</b>
+                </span>
+                <span itemprop="description">{{ props.description }}</span>
+                <span>(Galaxy Version {{ props.version }})</span>
+            </div>
+            <div>
+                <ToolFavoriteButton :id="props.id" />
+
+                <b-button v-if="props.local" variant="primary" size="sm" @click="() => emit('open')">
+                    <FontAwesomeIcon icon="fa-wrench" fixed-width />
+                    Open
+                </b-button>
+                <b-button v-else variant="primary" size="sm" :href="props.link">
+                    <FontAwesomeIcon icon="fa-globe" fixed-width />
+                    Open
+                </b-button>
+            </div>
+        </div>
+
+        <div class="portlet-content">
+            <div class="d-flex flex-gapx-1 py-2">
+                <span class="info px-1 rounded">
+                    <b>Section:</b> <b-link :to="`/tools/list?section=${props.section}`">{{ section }}</b-link>
+                </span>
+
+                <span v-if="props.local" class="info px-1 rounded">
+                    <FontAwesomeIcon icon="fa-wrench" fixed-width />
+                    Local Tool
+                </span>
+                <span v-else class="info px-1 rounded">
+                    <FontAwesomeIcon icon="fa-globe" fixed-width />
+                    External Tool
+                </span>
+
+                <span v-if="props.workflowCompatible" class="success px-1 rounded">
+                    <FontAwesomeIcon icon="fa-check" fixed-width />
+                    Workflow compatible
+                </span>
+                <span v-else class="warn px-1 rounded">
+                    <FontAwesomeIcon icon="fa-times" fixed-width />
+                    Not Workflow compatible
+                </span>
+            </div>
+
+            <div v-if="props.summary" v-html="props.summary"></div>
+
+            <div v-if="props.help" class="mt-2">
+                <b-button v-if="!showHelp" class="ui-link" @click="() => (showHelp = true)">
+                    <FontAwesomeIcon icon="fa-angle-down" />
+                    Show tool help
+                </b-button>
+                <b-button v-else class="ui-link" @click="() => (showHelp = false)">
+                    <FontAwesomeIcon icon="fa-angle-up" />
+                    Hide tool help
+                </b-button>
+
+                <div v-if="showHelp" class="mt-2" v-html="formattedToolHelp"></div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+@import "theme/blue.scss";
+
+.tool-list-item {
+    .info {
+        background-color: scale-color($brand-info, $lightness: +75%);
+    }
+
+    .success {
+        background-color: scale-color($brand-success, $lightness: +75%);
+    }
+
+    .warn {
+        background-color: scale-color($brand-warning, $lightness: +75%);
+    }
+
+    .top-bar {
+        display: flex;
+        justify-content: space-between;
+    }
+}
+</style>

--- a/client/src/components/ToolsList/ToolsListTable.vue
+++ b/client/src/components/ToolsList/ToolsListTable.vue
@@ -1,59 +1,25 @@
 <template>
-    <div v-infinite-scroll="loadTools" infinite-scroll-disabled="busy">
-        <b-table striped bordered :fields="fields" :items="buffer">
-            <template v-slot:cell(name)="row">
-                <span v-if="!row.item.help">
-                    <b>{{ row.item.name }}</b> {{ row.item.description }}
-                </span>
-                <span v-else>
-                    <b-link href="javascript:void(0)" role="button" @click.stop="row.toggleDetails()">
-                        <b>{{ row.item.name }}</b> {{ row.item.description }}
-                    </b-link>
-                    <p v-if="!row.item._showDetails && row.item.summary" v-html="row.item.summary" />
-                </span>
-            </template>
-            <template v-slot:row-details="row">
-                <b-card v-if="row.item.help">
-                    <p class="mb-1" v-html="row.item.help" />
-                    <a
-                        :href="row.item.target === 'galaxy_main' ? 'javascript:void(0)' : row.item.link"
-                        @click.stop="onOpen(row.item)">
-                        Click here to open the tool
-                    </a>
-                </b-card>
-            </template>
-            <template v-slot:cell(section)="row">
-                {{ row.item.panel_section_name }}
-            </template>
-            <template v-slot:cell(workflow)="row">
-                <span
-                    v-if="row.item.is_workflow_compatible"
-                    v-b-tooltip.hover
-                    class="fa fa-check text-success"
-                    title="Is Workflow Compatible" />
-                <span v-else v-b-tooltip.hover class="fa fa-times text-danger" title="Not Workflow Compatible" />
-            </template>
-            <template v-slot:cell(target)="row">
-                <span
-                    v-if="row.item.target === 'galaxy_main'"
-                    v-b-tooltip.hover
-                    class="fa fa-check text-success"
-                    title="Is Local" />
-                <span v-else v-b-tooltip.hover class="fa fa-times text-danger" title="Not Local" />
-            </template>
-            <template v-slot:cell(open)="row">
-                <b-button
-                    v-b-tooltip.hover.top
-                    :title="'Open Tool' | localize"
-                    class="fa fa-play"
-                    size="sm"
-                    variant="primary"
-                    :href="row.item.target === 'galaxy_main' ? 'javascript:void(0)' : row.item.link"
-                    @click.stop="onOpen(row.item)" />
-            </template>
-        </b-table>
+    <div
+        v-infinite-scroll="loadTools"
+        class="tools-list-table"
+        infinite-scroll-distance="200"
+        infinite-scroll-disabled="busy">
+        <ToolsListItem
+            v-for="item of buffer"
+            :id="item.id"
+            :key="item.id"
+            :name="item.name"
+            :section="item.panel_section_name"
+            :description="item.description"
+            :summary="item.summary"
+            :help="item.help"
+            :local="item.target === 'galaxy_main'"
+            :link="item.link"
+            :workflowCompatible="item.is_workflow_compatible"
+            :version="item.version"
+            @open="() => onOpen(item)" />
         <div>
-            <i v-if="allLoaded">All {{ tools.length > 1 ? tools.length : "" }} results loaded</i>
+            <div v-if="allLoaded" class="list-end my-2">- End of search results -</div>
             <b-overlay :show="busy" opacity="0.5" />
         </div>
     </div>
@@ -61,15 +27,16 @@
 
 <script>
 import Vue from "vue";
-import _l from "utils/localization";
 import infiniteScroll from "vue-infinite-scroll";
 import { openGlobalUploadModal } from "components/Upload";
 import { fetchData } from "./services";
+import ToolsListItem from "./ToolsListItem";
 
 const defaultBufferLen = 4;
 const loadTimeout = 100;
 
 export default {
+    components: { ToolsListItem },
     directives: { infiniteScroll },
     props: {
         tools: {
@@ -82,32 +49,6 @@ export default {
             allLoaded: false,
             bufferLen: 0,
             busy: false,
-            fields: [
-                {
-                    key: "name",
-                    label: _l("Name"),
-                    sortable: true,
-                },
-                {
-                    key: "section",
-                    label: _l("Section"),
-                    sortable: true,
-                },
-                {
-                    key: "workflow",
-                    label: _l("Workflow Compatible"),
-                    sortable: false,
-                },
-                {
-                    key: "target",
-                    label: _l("Local Tool"),
-                    sortable: false,
-                },
-                {
-                    key: "open",
-                    label: "",
-                },
-            ],
         };
     },
     computed: {
@@ -181,3 +122,19 @@ export default {
     },
 };
 </script>
+
+<style lang="scss" scoped>
+@import "theme/blue.scss";
+
+.tools-list-table {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    .list-end {
+        width: 100%;
+        text-align: center;
+        color: $text-light;
+    }
+}
+</style>

--- a/client/src/composables/formattedToolHelp.js
+++ b/client/src/composables/formattedToolHelp.js
@@ -1,0 +1,64 @@
+import { computed, unref } from "vue";
+import { getAppRoot } from "onload/loadConfig";
+
+/**
+ * Increase the heading levels of all child nodes of a node
+ * @param {HTMLElement} node
+ * @param {number} increaseBy
+ */
+function increaseHeadingLevels(node, increaseBy) {
+    [5, 4, 3, 2, 1].forEach((level) => {
+        increaseHeadingLevel(node, level, increaseBy);
+    });
+}
+
+/**
+ * Increase a single heading level
+ */
+function increaseHeadingLevel(node, level, increaseBy) {
+    // cap target level at 6 (highest heading level)
+    let targetLevel = level + increaseBy;
+    if (targetLevel > 6) {
+        targetLevel = 6;
+    }
+
+    const headings = node.getElementsByTagName(`h${level}`);
+
+    // create new headings with target level and copy contents + attributes
+    Array.from(headings).forEach((heading) => {
+        const newTag = document.createElement(`h${targetLevel}`);
+        newTag.innerHTML = heading.innerHTML;
+
+        Array.from(heading.attributes).forEach((attribute) => {
+            newTag.setAttribute(attribute.name, attribute.value);
+        });
+
+        heading.insertAdjacentElement("beforebegin", newTag);
+        heading.remove();
+    });
+}
+
+export function useFormattedToolHelp(helpContent, headingLevelIncrease = 2) {
+    const formattedContent = computed(() => {
+        const node = document.createElement("div");
+        node.innerHTML = unref(helpContent);
+
+        const links = node.getElementsByTagName("a");
+        Array.from(links).forEach((link) => {
+            link.target = "_blank";
+        });
+
+        const images = node.getElementsByTagName("img");
+        Array.from(images).forEach((image) => {
+            if (image.src.includes("admin_toolshed")) {
+                image.src = getAppRoot() + image.src;
+            }
+        });
+
+        increaseHeadingLevels(node, unref(headingLevelIncrease));
+
+        return node.innerHTML;
+    });
+
+    return { formattedContent };
+}

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -102,15 +102,6 @@ $ui-margin-horizontal-large: $margin-v * 2;
     cursor: pointer;
 }
 
-.ui-btn-back-to-top {
-    bottom: 2em;
-    position: fixed;
-    opacity: 0.5;
-}
-.ui-btn-back-to-top:hover {
-    opacity: 1;
-}
-
 // thumbnails
 .ui-thumbnails {
     .ui-thumbnails-item {
@@ -441,4 +432,19 @@ $ui-margin-horizontal-large: $margin-v * 2;
 
 .h-text {
     font-size: $font-size-base;
+}
+
+// makes a button element look like a link
+.ui-link {
+    border: none !important;
+    background: none !important;
+    padding: 0 !important;
+    color: $brand-primary;
+    display: inline;
+    line-height: unset;
+    vertical-align: unset;
+
+    &:hover {
+        text-decoration: underline;
+    }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44241786/206184617-f2f15efa-7171-4e7a-acca-ff8a0f4fad0e.png)

![image](https://user-images.githubusercontent.com/44241786/206185124-d85c4dae-27b1-4d32-875d-667425e95af4.png)

![image](https://user-images.githubusercontent.com/44241786/206185271-dfc3bb54-b403-4796-bc87-44a16c37b607.png)

This PR redesigns the results page of the advanced tool search. Changes Include:

* displays results as list
* show tool version
* show tool help toggle
* add favorite tool button
* several text changes
* smooth scroll to top

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
