### PR TITLE
[22.05] Backport fixes #14989 and #15090

### DIFF
--- a/lib/galaxy/files/uris.py
+++ b/lib/galaxy/files/uris.py
@@ -47,13 +47,14 @@ def stream_url_to_file(
     file_sources: Optional["ConfiguredFileSources"] = None,
     prefix: str = "gx_file_stream",
     dir: Optional[str] = None,
+    user_context=None,
 ) -> str:
     temp_name: str
     if file_sources and file_sources.looks_like_uri(path):
         file_source_path = file_sources.get_file_source_path(path)
         with tempfile.NamedTemporaryFile(prefix=prefix, delete=False, dir=dir) as temp:
             temp_name = temp.name
-        file_source_path.file_source.realize_to(file_source_path.path, temp_name)
+        file_source_path.file_source.realize_to(file_source_path.path, temp_name, user_context=user_context)
     elif path.startswith("base64://"):
         with tempfile.NamedTemporaryFile(prefix=prefix, delete=False, dir=dir) as temp:
             temp_name = temp.name

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -168,6 +168,7 @@ class ModelStoreManager:
             self._app,
             galaxy_user,
             import_options,
+            model_store_format=request.model_store_format,
         )
         new_history = history is None and not request.for_library
         if new_history:

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -3,7 +3,9 @@ from typing import Optional
 from galaxy import model
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.jobs.manager import JobManager
+from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.histories import HistoryManager
+from galaxy.managers.users import UserManager
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.model.store import (
     ImportDiscardedDataType,
@@ -29,6 +31,28 @@ from galaxy.web.short_term_storage import (
 )
 
 
+class ModelStoreUserContext(ProvidesUserContext):
+    def __init__(self, app: MinimalManagerApp, user: model.User) -> None:
+        self._app = app
+        self._user = user
+
+    @property
+    def app(self):
+        return self._app
+
+    @property
+    def url_builder(self):
+        raise NotImplementedError("URL builder not available in ModelStore context.")
+
+    def get_user(self):
+        return self._user
+
+    def set_user(self, user):
+        raise NotImplementedError("Cannot change user from ModelStore context.")
+
+    user = property(get_user, set_user)
+
+
 class ModelStoreManager:
     def __init__(
         self,
@@ -37,12 +61,14 @@ class ModelStoreManager:
         sa_session: galaxy_scoped_session,
         job_manager: JobManager,
         short_term_storage_monitor: ShortTermStorageMonitor,
+        user_manager: UserManager,
     ):
         self._app = app
         self._sa_session = sa_session
         self._job_manager = job_manager
         self._history_manager = history_manager
         self._short_term_storage_monitor = short_term_storage_monitor
+        self._user_manager = user_manager
 
     def setup_history_export_job(self, request: SetupHistoryExportJob):
         history_id = request.history_id
@@ -112,9 +138,13 @@ class ModelStoreManager:
         model_store_format = request.model_store_format
         export_files = "symlink" if request.include_files else None
         target_uri = request.target_uri
-        with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
-            target_uri
-        ) as export_store:
+        user_context = self._build_user_context(request.user.user_id)
+        with model.store.get_export_store_factory(
+            self._app,
+            model_store_format,
+            export_files=export_files,
+            user_context=user_context,
+        )(target_uri) as export_store:
             invocation = self._sa_session.query(model.WorkflowInvocation).get(request.invocation_id)
             export_store.export_workflow_invocation(
                 invocation, include_hidden=request.include_hidden, include_deleted=request.include_deleted
@@ -124,9 +154,10 @@ class ModelStoreManager:
         model_store_format = request.model_store_format
         export_files = "symlink" if request.include_files else None
         target_uri = request.target_uri
-        with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
-            target_uri
-        ) as export_store:
+        user_context = self._build_user_context(request.user.user_id)
+        with model.store.get_export_store_factory(
+            self._app, model_store_format, export_files=export_files, user_context=user_context
+        )(target_uri) as export_store:
             if request.content_type == HistoryContentType.dataset:
                 hda = self._sa_session.query(model.HistoryDatasetAssociation).get(request.content_id)
                 export_store.add_dataset(hda)
@@ -140,9 +171,10 @@ class ModelStoreManager:
         model_store_format = request.model_store_format
         export_files = "symlink" if request.include_files else None
         target_uri = request.target_uri
-        with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
-            target_uri
-        ) as export_store:
+        user_context = self._build_user_context(request.user.user_id)
+        with model.store.get_export_store_factory(
+            self._app, model_store_format, export_files=export_files, user_context=user_context
+        )(target_uri) as export_store:
             history = self._history_manager.by_id(request.history_id)
             export_store.export_history(
                 history, include_hidden=request.include_hidden, include_deleted=request.include_deleted
@@ -157,17 +189,13 @@ class ModelStoreManager:
             history = self._sa_session.query(model.History).get(history_id)
         else:
             history = None
-        user_id = request.user.user_id
-        if user_id:
-            galaxy_user = self._sa_session.query(model.User).get(user_id)
-        else:
-            galaxy_user = None
+        user_context = self._build_user_context(request.user.user_id)
         model_import_store = source_to_import_store(
             request.source_uri,
             self._app,
-            galaxy_user,
             import_options,
             model_store_format=request.model_store_format,
+            user_context=user_context,
         )
         new_history = history is None and not request.for_library
         if new_history:
@@ -183,6 +211,11 @@ class ModelStoreManager:
             )
         return object_tracker
 
+    def _build_user_context(self, user_id: int):
+        user = self._user_manager.by_id(user_id)
+        user_context = ModelStoreUserContext(self._app, user)
+        return user_context
+
 
 def create_objects_from_store(
     app: MinimalManagerApp,
@@ -195,12 +228,13 @@ def create_objects_from_store(
         discarded_data=ImportDiscardedDataType.FORCE,
         allow_library_creation=for_library,
     )
+    user_context = ModelStoreUserContext(app, galaxy_user) if galaxy_user is not None else None
     model_import_store = source_to_import_store(
         payload.store_content_uri or payload.store_dict,
         app=app,
-        galaxy_user=galaxy_user,
         import_options=import_options,
         model_store_format=payload.model_store_format,
+        user_context=user_context,
     )
     new_history = history is None and not for_library
     if new_history:

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -150,7 +150,6 @@ class ModelStoreManager:
 
     def import_model_store(self, request: ImportModelStoreTaskRequest):
         import_options = ImportOptions(
-            discarded_data=ImportDiscardedDataType.FORCE,
             allow_library_creation=request.for_library,
         )
         history_id = request.history_id

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -584,9 +584,14 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                             pass
                         if not self.import_options.allow_edit:
                             # external import, metadata files need to be regenerated (as opposed to extended metadata dataset import)
-                            self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(
-                                dataset_instance, history, **regenerate_kwds
-                            )
+                            if self.app.datatypes_registry.set_external_metadata_tool:
+                                self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(
+                                    dataset_instance, history, **regenerate_kwds
+                                )
+                            else:
+                                # Try to set metadata directly. TODO: check efficiency of this?
+                                if dataset_instance.has_metadata_files:
+                                    dataset_instance.datatype.set_meta(dataset_instance)
 
                 if model_class == "HistoryDatasetAssociation":
                     if object_key in dataset_attrs:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -47,6 +47,7 @@ from galaxy.model.orm.util import (
     add_object_to_session,
     get_object_session,
 )
+from galaxy.model.tags import GalaxyTagHandler
 from galaxy.objectstore import ObjectStore
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import (
@@ -96,6 +97,7 @@ class StoreAppProtocol(Protocol):
     datatypes_registry: Registry
     object_store: ObjectStore
     security: IdEncodingHelper
+    tag_handler: GalaxyTagHandler
     model: GalaxyModelMapping
     file_sources: ConfiguredFileSources
 
@@ -2255,6 +2257,7 @@ def source_to_import_store(
     else:
         source_uri: str = str(source)
         delete = False
+        tag_handler = app.tag_handler.create_tag_handler_session()
         if source_uri.startswith("file://"):
             source_uri = source_uri[len("file://") :]
         if "://" in source_uri:
@@ -2273,7 +2276,7 @@ def source_to_import_store(
             )
         elif os.path.isdir(target_path):
             model_import_store = get_import_model_store_for_directory(
-                target_path, import_options=import_options, app=app, user=galaxy_user
+                target_path, import_options=import_options, app=app, user=galaxy_user, tag_handler=tag_handler
             )
         else:
             model_store_format = model_store_format or "tgz"
@@ -2285,7 +2288,7 @@ def source_to_import_store(
                     if delete:
                         os.remove(target_path)
                 model_import_store = get_import_model_store_for_directory(
-                    target_dir, import_options=import_options, app=app, user=galaxy_user
+                    target_dir, import_options=import_options, app=app, user=galaxy_user, tag_handler=tag_handler
                 )
             elif model_store_format in ["bag.gz", "bag.tar", "bag.zip"]:
                 model_import_store = BagArchiveImportModelStore(

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2241,7 +2241,7 @@ def source_to_import_store(
     app: StoreAppProtocol,
     galaxy_user: Optional[model.User],
     import_options: Optional[ImportOptions],
-    model_store_format: Optional[str] = None,
+    model_store_format: Optional[ModelStoreFormat] = None,
 ) -> ModelImportStore:
     if isinstance(source, dict):
         if model_store_format is not None:
@@ -2279,8 +2279,8 @@ def source_to_import_store(
                 target_path, import_options=import_options, app=app, user=galaxy_user, tag_handler=tag_handler
             )
         else:
-            model_store_format = model_store_format or "tgz"
-            if model_store_format in ["tar.gz", "tgz", "tar"]:
+            model_store_format = model_store_format or ModelStoreFormat.TGZ
+            if ModelStoreFormat.is_compressed(model_store_format):
                 try:
                     temp_dir = mkdtemp()
                     target_dir = CompressedFile(target_path).extract(temp_dir)
@@ -2290,7 +2290,7 @@ def source_to_import_store(
                 model_import_store = get_import_model_store_for_directory(
                     target_dir, import_options=import_options, app=app, user=galaxy_user, tag_handler=tag_handler
                 )
-            elif model_store_format in ["bag.gz", "bag.tar", "bag.zip"]:
+            elif ModelStoreFormat.is_bag(model_store_format):
                 model_import_store = BagArchiveImportModelStore(
                     target_path, import_options=import_options, app=app, user=galaxy_user
                 )

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1,6 +1,7 @@
 import abc
 import contextlib
 import datetime
+import logging
 import os
 import shutil
 import tarfile
@@ -64,6 +65,8 @@ from ..item_attrs import (
     get_item_annotation_str,
 )
 from ... import model
+
+log = logging.getLogger(__name__)
 
 ObjectKeyType = Union[str, int]
 
@@ -589,11 +592,12 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                                     dataset_instance, history, **regenerate_kwds
                                 )
                             else:
-                                # Try to set metadata directly. TODO: check efficiency of this?
+                                # Try to set metadata directly. @mvdbeek thinks we should only record the datasets
                                 try:
                                     if dataset_instance.has_metadata_files:
                                         dataset_instance.datatype.set_meta(dataset_instance)
                                 except Exception:
+                                    log.debug(f"Metadata setting failed on {dataset_instance}", exc_info=True)
                                     dataset_instance.dataset.state = dataset_instance.dataset.states.FAILED_METADATA
 
                 if model_class == "HistoryDatasetAssociation":

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -590,8 +590,11 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                                 )
                             else:
                                 # Try to set metadata directly. TODO: check efficiency of this?
-                                if dataset_instance.has_metadata_files:
-                                    dataset_instance.datatype.set_meta(dataset_instance)
+                                try:
+                                    if dataset_instance.has_metadata_files:
+                                        dataset_instance.datatype.set_meta(dataset_instance)
+                                except Exception:
+                                    dataset_instance.dataset.state = dataset_instance.dataset.states.FAILED_METADATA
 
                 if model_class == "HistoryDatasetAssociation":
                     if object_key in dataset_attrs:

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1291,6 +1291,14 @@ class ModelStoreFormat(str, Enum):
     BAG_DOT_TAR = "bag.tar"
     BAG_DOT_TGZ = "bag.tgz"
 
+    @classmethod
+    def is_compressed(cls, value: "ModelStoreFormat"):
+        return value in [cls.TAR_DOT_GZ, cls.TGZ, cls.TAR, cls.ROCRATE_ZIP]
+
+    @classmethod
+    def is_bag(cls, value: "ModelStoreFormat"):
+        return value in [cls.BAG_DOT_TAR, cls.BAG_DOT_TGZ, cls.BAG_DOT_ZIP]
+
 
 class StoreContentSource(Model):
     store_content_uri: Optional[str]

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1293,7 +1293,7 @@ class ModelStoreFormat(str, Enum):
 
     @classmethod
     def is_compressed(cls, value: "ModelStoreFormat"):
-        return value in [cls.TAR_DOT_GZ, cls.TGZ, cls.TAR, cls.ROCRATE_ZIP]
+        return value in [cls.TAR_DOT_GZ, cls.TGZ, cls.TAR]
 
     @classmethod
     def is_bag(cls, value: "ModelStoreFormat"):

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -8,6 +8,7 @@ from pydantic import (
 from .schema import (
     DatasetSourceType,
     HistoryContentType,
+    ModelStoreFormat,
     StoreExportPayload,
     WriteStoreToPayload,
 )
@@ -82,6 +83,7 @@ class ImportModelStoreTaskRequest(BaseModel):
     history_id: Optional[int]
     source_uri: str
     for_library: bool
+    model_store_format: Optional[ModelStoreFormat]
 
 
 class MaterializeDatasetInstanceTaskRequest(BaseModel):

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -278,6 +278,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             user=trans.async_request_user,
             source_uri=source_uri,
             for_library=False,
+            model_store_format=payload.model_store_format,
         )
         result = import_model_store.delay(request=request)
         return async_task_summary(result)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -436,17 +436,23 @@ class BaseDatasetPopulator(BasePopulator):
         return create_response
 
     def create_from_store(
-        self, store_dict: Optional[Dict[str, Any]] = None, store_path: Optional[str] = None
+        self,
+        store_dict: Optional[Dict[str, Any]] = None,
+        store_path: Optional[str] = None,
+        model_store_format: Optional[str] = None,
     ) -> Dict[str, Any]:
-        payload = _store_payload(store_dict=store_dict, store_path=store_path)
+        payload = _store_payload(store_dict=store_dict, store_path=store_path, model_store_format=model_store_format)
         create_response = self.create_from_store_raw(payload)
         api_asserts.assert_status_code_is_ok(create_response)
         return create_response.json()
 
     def create_from_store_async(
-        self, store_dict: Optional[Dict[str, Any]] = None, store_path: Optional[str] = None
+        self,
+        store_dict: Optional[Dict[str, Any]] = None,
+        store_path: Optional[str] = None,
+        model_store_format: Optional[str] = None,
     ) -> Dict[str, Any]:
-        payload = _store_payload(store_dict=store_dict, store_path=store_path)
+        payload = _store_payload(store_dict=store_dict, store_path=store_path, model_store_format=model_store_format)
         create_response = self.create_from_store_raw_async(payload)
         create_response.raise_for_status()
         return create_response.json()
@@ -1161,7 +1167,9 @@ class BaseDatasetPopulator(BasePopulator):
 
     def wait_on_task(self, async_task_response: Response):
         task_id = async_task_response.json()["id"]
+        return self.wait_on_task_id(task_id)
 
+    def wait_on_task_id(self, task_id: str):
         def state():
             state_response = self._get(f"tasks/{task_id}/state")
             state_response.raise_for_status()
@@ -1266,6 +1274,27 @@ class BaseDatasetPopulator(BasePopulator):
             content_format=content_format,
         )
         return request
+
+    def export_history_to_uri_async(
+        self, history_id: str, target_uri: str, model_store_format: str = "tgz", include_files: bool = True
+    ):
+        url = f"histories/{history_id}/write_store"
+        download_response = self._post(
+            url,
+            dict(target_uri=target_uri, include_files=include_files, model_store_format=model_store_format),
+            json=True,
+        )
+        api_asserts.assert_status_code_is_ok(download_response)
+        task_ok = self.wait_on_task(download_response)
+        assert task_ok, f"Task: Writing history to {target_uri} task failed"
+
+    def import_history_from_uri_async(self, target_uri: str, model_store_format: str):
+        import_async_response = self.create_from_store_async(
+            store_path=target_uri, model_store_format=model_store_format
+        )
+        task_id = import_async_response["id"]
+        task_ok = self.wait_on_task_id(task_id)
+        assert task_ok, f"Task: Import history from {target_uri} failed"
 
 
 class GalaxyInteractorHttpMixin:

--- a/lib/galaxy_test/driver/integration_setup.py
+++ b/lib/galaxy_test/driver/integration_setup.py
@@ -37,9 +37,15 @@ def get_posix_file_source_config(root_dir: str, roles: str, groups: str, include
     return rval
 
 
-def create_file_source_config_file_on(temp_dir, root_dir, include_test_data_dir):
+def create_file_source_config_file_on(
+    temp_dir,
+    root_dir,
+    include_test_data_dir,
+    required_role_expression,
+    required_group_expression,
+):
     file_contents = get_posix_file_source_config(
-        root_dir, REQUIRED_ROLE_EXPRESSION, REQUIRED_GROUP_EXPRESSION, include_test_data_dir
+        root_dir, required_role_expression, required_group_expression, include_test_data_dir
     )
     file_path = os.path.join(temp_dir, "file_sources_conf_posix.yml")
     with open(file_path, "w") as f:
@@ -53,14 +59,25 @@ class PosixFileSourceSetup:
     include_test_data_dir: ClassVar[bool] = False
 
     @classmethod
-    def handle_galaxy_config_kwds(cls, config, clazz_=None):
+    def handle_galaxy_config_kwds(
+        cls,
+        config,
+        clazz_=None,
+        # Require role for access but do not require groups by default on every test to simplify them
+        required_role_expression=REQUIRED_ROLE_EXPRESSION,
+        required_group_expression="",
+    ):
         temp_dir = os.path.realpath(mkdtemp())
         clazz_ = clazz_ or cls
         clazz_._test_driver.temp_directories.append(temp_dir)
         clazz_.root_dir = os.path.join(temp_dir, "root")
 
         file_sources_config_file = create_file_source_config_file_on(
-            temp_dir, clazz_.root_dir, clazz_.include_test_data_dir
+            temp_dir,
+            clazz_.root_dir,
+            clazz_.include_test_data_dir,
+            required_role_expression,
+            required_group_expression,
         )
         config["file_sources_config_file"] = file_sources_config_file
 

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -60,6 +60,10 @@ class ImportExportHistoryViaTasksIntegrationTestCase(
     def test_import_model_store_from_file_source_async_with_format(self):
         history_name = f"for_export_format_async_{uuid4()}"
         history_id = self.dataset_populator.setup_history_for_export_testing(history_name)
+        # Add bam dataset to test metadata generation on import
+        self.dataset_populator.new_dataset(
+            history_id, content=open(self.test_data_resolver.get_filename("1.bam"), "rb"), file_type="bam", wait=True
+        )
         model_store_format = "rocrate.zip"
         target_uri = f"gxfiles://posix_test/history.{model_store_format}"
 
@@ -72,14 +76,22 @@ class ImportExportHistoryViaTasksIntegrationTestCase(
         imported_history_id = imported_history["id"]
         assert imported_history_id != history_id
         assert imported_history["name"] == history_name
+        self.dataset_populator.wait_for_history(imported_history_id)
         history_contents = self.dataset_populator.get_history_contents(imported_history_id)
-        assert len(history_contents) == 2
+        assert len(history_contents) == 3
         # Only deleted datasets should appear as "discarded"
         for dataset in history_contents:
             if dataset["deleted"] is True:
                 assert dataset["state"] == "discarded"
             else:
                 assert dataset["state"] == "ok"
+                # Check metadata generation
+            if dataset["extension"] == "bam":
+                imported_bam_details = self.dataset_populator.get_history_dataset_details(
+                    imported_history_id, dataset_id=dataset["id"]
+                )
+                bai_metadata = imported_bam_details["meta_files"][0]
+                assert bai_metadata["file_type"] == "bam_index"
 
 
 class ImportExportHistoryContentsViaTasksIntegrationTestCase(IntegrationTestCase, UsesCeleryTasks):

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -1,4 +1,5 @@
 import tarfile
+from uuid import uuid4
 
 from galaxy.model.unittest_utils.store_fixtures import (
     deferred_hda_model_store_dict,
@@ -12,6 +13,7 @@ from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
 )
+from galaxy_test.driver.integration_setup import PosixFileSourceSetup
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
 
@@ -29,9 +31,16 @@ class ImportExportHistoryOutputsToWorkingDirIntegrationTestCase(ImportExportTest
         self._set_up_populators()
 
 
-class ImportExportHistoryViaTasksIntegrationTestCase(ImportExportTests, IntegrationTestCase, UsesCeleryTasks):
+class ImportExportHistoryViaTasksIntegrationTestCase(
+    ImportExportTests, IntegrationTestCase, UsesCeleryTasks, PosixFileSourceSetup
+):
     task_based = True
     framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        PosixFileSourceSetup.handle_galaxy_config_kwds(config, cls)
+        UsesCeleryTasks.handle_galaxy_config_kwds(config)
 
     def setUp(self):
         super().setUp()
@@ -47,6 +56,26 @@ class ImportExportHistoryViaTasksIntegrationTestCase(ImportExportTests, Integrat
             async_history_name,
             "task based import history",
         )
+
+    def test_import_model_store_from_file_source_async_with_format(self):
+        history_name = f"for_export_format_async_{uuid4()}"
+        history_id = self.dataset_populator.setup_history_for_export_testing(history_name)
+        model_store_format = "rocrate.zip"
+        target_uri = f"gxfiles://posix_test/history.{model_store_format}"
+
+        self.dataset_populator.export_history_to_uri_async(history_id, target_uri, model_store_format)
+        self.dataset_populator.import_history_from_uri_async(target_uri, model_store_format)
+
+        last_history = self._get("histories?limit=1").json()
+        assert len(last_history) == 1
+        imported_history = last_history[0]
+        imported_history_id = imported_history["id"]
+        assert imported_history_id != history_id
+        assert imported_history["name"] == history_name
+        history_contents = self.dataset_populator.get_history_contents(imported_history_id)
+        assert len(history_contents) == 2
+        for dataset in history_contents:
+            assert dataset["state"] == "ok"
 
 
 class ImportExportHistoryContentsViaTasksIntegrationTestCase(IntegrationTestCase, UsesCeleryTasks):

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -74,8 +74,12 @@ class ImportExportHistoryViaTasksIntegrationTestCase(
         assert imported_history["name"] == history_name
         history_contents = self.dataset_populator.get_history_contents(imported_history_id)
         assert len(history_contents) == 2
+        # Only deleted datasets should appear as "discarded"
         for dataset in history_contents:
-            assert dataset["state"] == "ok"
+            if dataset["deleted"] is True:
+                assert dataset["state"] == "discarded"
+            else:
+                assert dataset["state"] == "ok"
 
 
 class ImportExportHistoryContentsViaTasksIntegrationTestCase(IntegrationTestCase, UsesCeleryTasks):

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -73,7 +73,7 @@ class ImportExportHistoryViaTasksIntegrationTestCase(
         self.dataset_populator.new_dataset(
             history_id, content=open(self.test_data_resolver.get_filename("1.bam"), "rb"), file_type="bam", wait=True
         )
-        model_store_format = "rocrate.zip"
+        model_store_format = "tgz"  # Change to "rocrate.zip" when merging this forward and remove this comment, thanks!
         target_uri = f"gxfiles://posix_test/history.{model_store_format}"
 
         self.dataset_populator.export_history_to_uri_async(history_id, target_uri, model_store_format)
@@ -106,7 +106,7 @@ class ImportExportHistoryViaTasksIntegrationTestCase(
         history_name = f"for_export_ftp_async_{uuid4()}"
         history_id = self.dataset_populator.setup_history_for_export_testing(history_name)
 
-        model_store_format = "rocrate.zip"
+        model_store_format = "tgz"  # Change to "rocrate.zip" when merging this forward and remove this comment, thanks!
         target_uri = f"gxftp://history.{model_store_format}"
 
         self.dataset_populator.export_history_to_uri_async(history_id, target_uri, model_store_format)

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -1,3 +1,4 @@
+import os
 import tarfile
 from uuid import uuid4
 
@@ -41,6 +42,14 @@ class ImportExportHistoryViaTasksIntegrationTestCase(
     def handle_galaxy_config_kwds(cls, config):
         PosixFileSourceSetup.handle_galaxy_config_kwds(config, cls)
         UsesCeleryTasks.handle_galaxy_config_kwds(config)
+        cls.setup_ftp_config(config)
+
+    @classmethod
+    def setup_ftp_config(cls, config):
+        ftp_dir = cls.temp_config_dir("ftp")
+        os.makedirs(ftp_dir)
+        config["ftp_upload_dir"] = ftp_dir
+        config["ftp_upload_site"] = "ftp://cow.com"
 
     def setUp(self):
         super().setUp()
@@ -92,6 +101,23 @@ class ImportExportHistoryViaTasksIntegrationTestCase(
                 )
                 bai_metadata = imported_bam_details["meta_files"][0]
                 assert bai_metadata["file_type"] == "bam_index"
+
+    def test_import_export_ftp(self):
+        history_name = f"for_export_ftp_async_{uuid4()}"
+        history_id = self.dataset_populator.setup_history_for_export_testing(history_name)
+
+        model_store_format = "rocrate.zip"
+        target_uri = f"gxftp://history.{model_store_format}"
+
+        self.dataset_populator.export_history_to_uri_async(history_id, target_uri, model_store_format)
+        self.dataset_populator.import_history_from_uri_async(target_uri, model_store_format)
+
+        last_history = self._get("histories?limit=1").json()
+        assert len(last_history) == 1
+        imported_history = last_history[0]
+        imported_history_id = imported_history["id"]
+        assert imported_history_id != history_id
+        assert imported_history["name"] == history_name
 
 
 class ImportExportHistoryContentsViaTasksIntegrationTestCase(IntegrationTestCase, UsesCeleryTasks):

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -16,6 +16,15 @@ from galaxy_test.driver.integration_setup import (
 
 
 class PosixFileSourceIntegrationTestCase(PosixFileSourceSetup, integration_util.IntegrationTestCase):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        PosixFileSourceSetup.handle_galaxy_config_kwds(
+            config,
+            cls,
+            required_role_expression=REQUIRED_ROLE_EXPRESSION,
+            required_group_expression=REQUIRED_GROUP_EXPRESSION,
+        )
+
     def setUp(self):
         super().setUp()
         self._write_file_fixtures()


### PR DESCRIPTION
Backports fixes (#14989 and #15090) related to imports/exports of histories using tasks

I decided to backport both fixes together since #15090 predates changes introduced in #14989.

The last commit can be skipped when merging forward as is just to make the tests work on 22.05 because there is no fully RO-Crate support in that version. I had to resolve quite a few conflicts so hopefully, it will be easier when merging.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
