### PR TITLE
rename removed tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
     mypy: mypy test lib
     test_galaxy_packages: make generate-cwl-conformance-tests
     test_galaxy_packages: bash packages/test.sh
-whitelist_externals =
+allowlist_externals =
     bash
     make
 passenv = 


### PR DESCRIPTION
this breaks our tox setup

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
