### PR TITLE
[21.01] Rename removed tox configuration option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ commands =
     unit: bash run_tests.sh -u
     # start with test here but obviously someday all of it...
     mypy: mypy test lib
-whitelist_externals = bash
-passenv = 
+allowlist_externals = bash
+passenv =
     CI CONDA_EXE
     GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
 setenv =
@@ -55,7 +55,7 @@ commands = bash .ci/validate_test_tools.sh
 commands = bash .ci/check_controller.sh
 
 [testenv:check_indexes]
-commands = 
+commands =
     bash scripts/common_startup.sh
     bash create_db.sh
     bash check_model.sh


### PR DESCRIPTION
This very much breaks our tox setup. Opening this against 21.01 since it seems cheap and testing bug fixes is important.

xref. https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
