### PR TITLE
[22.01] Rename removed tox configuration option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
     unit: bash run_tests.sh -u
     # start with test here but obviously someday all of it...
     mypy: mypy test lib
-whitelist_externals = bash
+allowlist_externals = bash
 passenv = 
     CI CONDA_EXE
     GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION


### PR DESCRIPTION
breaks our tox setup with 4.0.0

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
