### PR TITLE
Support for path-based proxying of interactive tools

### DIFF
--- a/lib/galaxy/managers/interactivetool.py
+++ b/lib/galaxy/managers/interactivetool.py
@@ -294,7 +294,8 @@ class InteractiveToolManager:
                     rval = "{}/{}".format(rval.rstrip("/"), entry_point.entry_url.lstrip("/"))
             else:
                 rval = self.get_entry_point_path(trans, entry_point)
-
+                if not self.app.config.interactivetools_upstream_proxy and self.app.config.interactivetools_proxy_host:
+                    rval = f"{protocol}//{request_host}{rval}"
             return rval
 
     def get_entry_point_subdomain(self, trans, entry_point):


### PR DESCRIPTION
Part of solution for galaxyproject/galaxy#14690. To be synced with https://github.com/galaxyproject/gx-it-proxy/pull/14 and https://github.com/galaxyproject/gravity/pull/96.

Implemented together with @morj-uio

Integration tests have yet to be carried out, so this is WIP.

Also lacks solution for providing the containers with correct path.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
