### PR TITLE
Fix tests.lint_tsts attribute

### DIFF
--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1602,7 +1602,7 @@ def test_tests_discover_outputs(lint_ctx):
 
 def test_tests_expect_num_outputs_filter(lint_ctx):
     tool_source = get_xml_tool_source(TESTS_EXPECT_NUM_OUTPUTS_FILTER)
-    run_lint(lint_ctx, tests.lint_tsts, tool_source)
+    run_lint(lint_ctx, tests.lint_tests, tool_source)
     assert "Test should specify 'expect_num_outputs' if outputs have filters" in lint_ctx.warn_messages
     assert len(lint_ctx.warn_messages) == 1
     assert len(lint_ctx.error_messages) == 0


### PR DESCRIPTION
Broken when merging in a PR with an older base (probably https://github.com/galaxyproject/galaxy/pull/12975)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
