### PR TITLE
Update Vue Virtual Scroll List

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -97,7 +97,7 @@
     "vue-prismjs": "^1.2.0",
     "vue-router": "^3.6.5",
     "vue-rx": "^6.2.0",
-    "vue-virtual-scroll-list": "^2.3.3",
+    "vue-virtual-scroll-list": "^2.3.4",
     "vuedraggable": "2.24.3",
     "vuex": "^3.6.2",
     "vuex-cache": "^3.4.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10544,10 +10544,10 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue-virtual-scroll-list@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/vue-virtual-scroll-list/-/vue-virtual-scroll-list-2.3.3.tgz#290f0d04be814b93585f2ef232097b671141e5b1"
-  integrity sha512-heuwlZ+lEdcVSp66CpVXnyNdsiHl/XU1cvqJb0yUHGlLv6DGK8OX16FH8I3w/wKNXtHSPF9itdBBGJFrXkyHeg==
+vue-virtual-scroll-list@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/vue-virtual-scroll-list/-/vue-virtual-scroll-list-2.3.4.tgz#0d08c2d26299d8609018b8c04f5e3ca608fbe2d6"
+  integrity sha512-a9bmmIhAdnKcp8NG0C9ZQ+pW9nAOrDv5SHqJfbbEpXxVVERCtbIgGeBnkwrGgmoILBoFz/WANIZgA22G44F0Yw==
 
 vue@2.7.8, vue@^2.6.10, vue@^2.7.8:
   version "2.7.8"


### PR DESCRIPTION
This PR updates to the vue virtual scroll list version, containing partial fixes for #15087. Particularly due to: https://github.com/tangbc/vue-virtual-scroll-list/pull/390.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
