### PR TITLE
Fix lxml deprecation warning

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -475,7 +475,7 @@ def lint_inputs(tool_xml, lint_ctx):
 
     # check if there is an output with the same name as an input
     outputs = tool_xml.find("./outputs")
-    if outputs:
+    if outputs is not None:
         for output in outputs:
             if output.get("name") in input_names:
                 lint_ctx.error(


### PR DESCRIPTION
Appears for each linting run

```
/home/berntm/miniconda3/envs/planemo0.74.11/lib/python3.9/site-packages/galaxy/tool_util/linters/inputs.py:478: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
  if outputs:
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
