### PR TITLE
Visualization specs are optional

### DIFF
--- a/client/src/mvc/visualization/chart/chart-client.js
+++ b/client/src/mvc/visualization/chart/chart-client.js
@@ -31,7 +31,7 @@ export default Backbone.View.extend({
         this.$buttons = this.$(".charts-buttons");
         this.chart = new Chart({}, options);
         this.chart.plugin = options.visualization_plugin;
-        this.chart.requiresConfirmation = asBoolean(this.chart.plugin.specs.confirm);
+        this.chart.requiresConfirmation = asBoolean(this.chart.plugin.specs?.confirm);
         this.chart.plugin.specs = this.chart.plugin.specs || {};
         this.chart_load = options.chart_load;
         this.message = new Ui.Message();


### PR DESCRIPTION
This PR fixes the currently broken NGL pdb viewer and other chart-plugin visualizations, by respecting the optional character of the `specs` declaration.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
