### PR TITLE
Add x-forwarded-proto to middleware

### DIFF
--- a/lib/galaxy/web/framework/middleware/xforwardedhost.py
+++ b/lib/galaxy/web/framework/middleware/xforwardedhost.py
@@ -15,8 +15,11 @@ class XForwardedHostMiddleware:
         x_forwarded_for = environ.get("HTTP_X_FORWARDED_FOR", None)
         if x_forwarded_for:
             environ["ORGINAL_REMOTE_ADDR"] = environ["REMOTE_ADDR"]
-            environ["REMOTE_ADDR"] = x_forwarded_for.split(", ", 1)[0]
-        x_url_scheme = environ.get("HTTP_X_URL_SCHEME", None)
+            environ["REMOTE_ADDR"] = x_forwarded_for.split(",", 1)[0].strip()
+        x_forwarded_proto = environ.get("HTTP_X_FORWARDED_PROTO", None)
+        if x_forwarded_proto:
+            x_forwarded_proto = x_forwarded_proto.split(",", 1)[0].strip()
+        x_url_scheme = environ.get("HTTP_X_URL_SCHEME", x_forwarded_proto)
         if x_url_scheme:
             environ["original_wsgi.url_scheme"] = environ["wsgi.url_scheme"]
             environ["wsgi.url_scheme"] = x_url_scheme


### PR DESCRIPTION
Modifies the XForwardedHostMiddleware middleware to support `HTTP_X_FORWARDED_PROTO`.

Background:
`trans.request.url` in custos_authnz: https://github.com/galaxyproject/galaxy/blob/cafcf5140145a9515b05e45597bfd3994c0dae1b/lib/galaxy/authnz/custos_authnz.py#L278 was returning `http` instead of `https`, even though the HTTP_X_FORWARDED_PROTO header was set. It appears to respect only the `X-Url-Scheme` header, as opposed to the more standard `X-Forwaded-Proto` header.

xref: https://github.com/galaxyproject/galaxy-helm/pull/395

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
