### PR TITLE
Standardize local package imports with @ alias in TypeScript

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -180,6 +180,7 @@
     "style-loader": "^3.3.1",
     "ts-jest": "^29.0.3",
     "ts-loader": "^9.4.1",
+    "tsconfig-paths-webpack-plugin": "^4.0.0",
     "typescript": "^4.9.3",
     "typescript-eslint": "^0.0.1-alpha.0",
     "vue-loader": "^15.10.0",

--- a/client/src/components/AboutGalaxy.vue
+++ b/client/src/components/AboutGalaxy.vue
@@ -4,11 +4,11 @@
 
 import { computed } from "vue";
 
-import { getAppRoot } from "onload/loadConfig";
-import { useConfig } from "composables/config";
-import UtcDate from "components/UtcDate.vue";
-import License from "components/License/License.vue";
-import ExternalLink from "components/ExternalLink.vue";
+import { getAppRoot } from "@/onload/loadConfig";
+import { useConfig } from "@/composables/config";
+import UtcDate from "@/components/UtcDate.vue";
+import License from "@/components/License/License.vue";
+import ExternalLink from "@/components/ExternalLink.vue";
 
 const { config, isLoaded } = useConfig();
 

--- a/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
+++ b/client/src/components/AvailableDatatypes/AvailableDatatypes.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import { useDetailedDatatypes, type DetailedDatatypes } from "composables/datatypes";
-import { useFilterObjectArray } from "composables/utils/filter";
-import DelayedInput from "components/Common/DelayedInput.vue";
+import { useDetailedDatatypes, type DetailedDatatypes } from "@/composables/datatypes";
+import { useFilterObjectArray } from "@/composables/utils/filter";
+import DelayedInput from "@/components/Common/DelayedInput.vue";
 
 const filter = ref("");
 const filterFields: Array<keyof DetailedDatatypes> = ["extension"];

--- a/client/src/components/Common/models/exportRecordModel.ts
+++ b/client/src/components/Common/models/exportRecordModel.ts
@@ -1,5 +1,5 @@
 import { formatDistanceToNow, parseISO } from "date-fns";
-import type { components } from "schema";
+import type { components } from "@/schema";
 
 type ExportObjectRequestMetadata = components["schemas"]["ExportObjectRequestMetadata"];
 

--- a/client/src/components/Common/models/testData/exportData.ts
+++ b/client/src/components/Common/models/testData/exportData.ts
@@ -1,5 +1,5 @@
-import { ExportRecordModel } from "components/Common/models/exportRecordModel";
-import type { components } from "schema";
+import { ExportRecordModel } from "@/components/Common/models/exportRecordModel";
+import type { components } from "@/schema";
 
 type ObjectExportTaskResponse = components["schemas"]["ObjectExportTaskResponse"];
 type ExportObjectRequestMetadata = components["schemas"]["ExportObjectRequestMetadata"];

--- a/client/src/components/Dataset/services.ts
+++ b/client/src/components/Dataset/services.ts
@@ -1,6 +1,6 @@
-import { fetcher } from "schema";
-import { safePath } from "utils/redirect";
 import type { FetchArgType } from "openapi-typescript-fetch";
+import { fetcher } from "@/schema";
+import { safePath } from "@/utils/redirect";
 
 const _getDatasets = fetcher.path("/api/datasets").method("get").create();
 type GetDatasetsApiOptions = FetchArgType<typeof _getDatasets>;

--- a/client/src/components/Datatypes/model.ts
+++ b/client/src/components/Datatypes/model.ts
@@ -1,4 +1,4 @@
-import type { components } from "schema";
+import type { components } from "@/schema";
 
 export type DatatypesCombinedMap = components["schemas"]["DatatypesCombinedMap"];
 

--- a/client/src/components/Datatypes/services.ts
+++ b/client/src/components/Datatypes/services.ts
@@ -1,4 +1,4 @@
-import { fetcher } from "schema/fetcher";
+import { fetcher } from "@/schema/fetcher";
 
 const getTypesAndMappings = fetcher.path("/api/datatypes/types_and_mapping").method("get").create();
 

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -77,7 +77,7 @@
             :value="tags"
             :disabled="tagsDisabled"
             :clickable="filterable"
-            :useToggleLink="false"
+            :use-toggle-link="false"
             @input="onTags"
             @tag-click="onTagClick" />
         <!-- collections are not expandable, so we only need the DatasetDetails component here -->

--- a/client/src/components/History/Export/HistoryExport.test.ts
+++ b/client/src/components/History/Export/HistoryExport.test.ts
@@ -5,9 +5,9 @@ import {
     EXPIRED_STS_DOWNLOAD_RECORD,
     FILE_SOURCE_STORE_RECORD,
     RECENT_STS_DOWNLOAD_RECORD,
-} from "components/Common/models/testData/exportData";
+} from "@/components/Common/models/testData/exportData";
 import flushPromises from "flush-promises";
-import type { components } from "schema";
+import type { components } from "@/schema";
 import { getLocalVue } from "../../../../tests/jest/helpers";
 import HistoryExport from "./HistoryExport.vue";
 import { getExportRecords } from "./services";

--- a/client/src/components/History/Export/services.ts
+++ b/client/src/components/History/Export/services.ts
@@ -1,8 +1,8 @@
-import { ExportRecordModel } from "components/Common/models/exportRecordModel";
-import type { ObjectExportTaskResponse } from "components/Common/models/exportRecordModel";
-import { DEFAULT_EXPORT_PARAMS } from "composables/shortTermStorage";
-import type { components } from "schema";
-import { fetcher } from "schema";
+import { ExportRecordModel } from "@/components/Common/models/exportRecordModel";
+import type { ObjectExportTaskResponse } from "@/components/Common/models/exportRecordModel";
+import { DEFAULT_EXPORT_PARAMS } from "@/composables/shortTermStorage";
+import type { components } from "@/schema";
+import { fetcher } from "@/schema";
 
 type ModelStoreFormat = components["schemas"]["ModelStoreFormat"];
 

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -87,7 +87,6 @@ export async function bulkUpdate(history, operation, filters, items = [], params
         params,
     };
     const response = await axios.put(prependPath(url), payload);
-    console.debug(`Submitted request to ${operation} selected content in bulk. Parameters: ${params}`, response);
     return doResponse(response);
 }
 

--- a/client/src/components/StsDownloadButton.vue
+++ b/client/src/components/StsDownloadButton.vue
@@ -76,12 +76,14 @@ export default {
         },
         onDownload(config) {
             if (!config.enable_celery_tasks) {
-                console.log("celery tasks not enabled - setting href to fallback URL.");
                 window.location.assign(safePath(this.fallbackUrl));
-                return;
+            } else {
+                this.waiting = true;
+                axios
+                    .post(this.downloadEndpoint, this.postParameters)
+                    .then(this.handleInitialize)
+                    .catch(this.handleError);
             }
-            this.waiting = true;
-            axios.post(this.downloadEndpoint, this.postParameters).then(this.handleInitialize).catch(this.handleError);
         },
         handleInitialize(response) {
             const storageRequestId = response.data.storage_request_id;

--- a/client/src/components/TagsMultiselect/StatelessTags.vue
+++ b/client/src/components/TagsMultiselect/StatelessTags.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import Multiselect from "vue-multiselect";
-import Tag from "./Tag.vue";
 import { ref, computed } from "vue";
+import Multiselect from "vue-multiselect";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { useUserTags } from "composables/user";
-import { useToast } from "composables/toast";
-import { useUid } from "composables/utils/uid";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faTags, faCheck, faTimes, faPlus } from "@fortawesome/free-solid-svg-icons";
+import Tag from "./Tag.vue";
+import { useUserTags } from "@/composables/user";
+import { useToast } from "@/composables/toast";
+import { useUid } from "@/composables/utils/uid";
 
 import type { Ref } from "vue";
 
@@ -119,12 +119,12 @@ function onTagClicked(tag: string) {
             v-if="!disabled"
             ref="multiselectElement"
             placeholder="Add Tags"
-            openDirection="bottom"
+            open-direction="bottom"
             :value="tags"
             :options="userTags"
             :multiple="true"
             :taggable="true"
-            :closeOnSelect="false"
+            :close-on-select="false"
             @tag="onAddTag"
             @input="onInput"
             @open="onOpen"

--- a/client/src/components/TagsMultiselect/Tag.vue
+++ b/client/src/components/TagsMultiselect/Tag.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { keyedColorScheme } from "utils/color";
 import { computed } from "vue";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import { keyedColorScheme } from "@/utils/color";
 
 export interface TagProps {
     option: string;

--- a/client/src/components/ToolsList/ToolsListTable.vue
+++ b/client/src/components/ToolsList/ToolsListTable.vue
@@ -15,7 +15,7 @@
             :help="item.help"
             :local="item.target === 'galaxy_main'"
             :link="item.link"
-            :workflowCompatible="item.is_workflow_compatible"
+            :workflow-compatible="item.is_workflow_compatible"
             :version="item.version"
             @open="() => onOpen(item)" />
         <div>

--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -80,8 +80,6 @@ export default {
             const element = document.getElementById("galaxy_main");
             if (element) {
                 element.style["pointer-events"] = disableEvents ? "none" : "auto";
-            } else {
-                console.warn("UploadModal::setIframeEvents - `galaxy_main` not found.");
             }
         },
     },

--- a/client/src/components/Workflow/Editor/Forms/FormSection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormSection.vue
@@ -138,7 +138,6 @@ export default {
             if (pjas[this.emailPayloadKey]) {
                 pjas[this.emailActionKey] = true;
             }
-            console.debug("FormSection - Setting new data.", this.postJobActions, pjas);
             this.formData = pjas;
         },
         setEmailAction(pjas) {

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -189,14 +189,12 @@ export default {
         },
         postChanges(newVersion) {
             const payload = Object.assign({}, this.mainValues);
-            console.debug("FormTool - Posting changes.", payload);
             const options = this.configForm;
             let toolId = options.id;
             let toolVersion = options.version;
             if (newVersion) {
                 toolId = toolId.replace(toolVersion, newVersion);
                 toolVersion = newVersion;
-                console.debug("FormTool - Tool version changed.", toolId, toolVersion);
             }
             this.$emit("onSetData", this.nodeId, {
                 tool_id: toolId,

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -721,7 +721,6 @@ export default {
             this.lastQueue
                 .enqueue(loadWorkflow, { id, version, workflow: this })
                 .then((data) => {
-                    console.debug("Editor - Loading workflow:", id);
                     this._loadEditorData(data);
                 })
                 .catch((response) => {

--- a/client/src/composables/datatypes.ts
+++ b/client/src/composables/datatypes.ts
@@ -1,5 +1,5 @@
 import { ref } from "vue";
-import { fetcher } from "schema";
+import { fetcher } from "@/schema";
 
 import type { Ref } from "vue";
 

--- a/client/src/composables/toast.ts
+++ b/client/src/composables/toast.ts
@@ -1,7 +1,7 @@
 import { ref, type Ref } from "vue";
 
 import type Vue from "vue";
-import type ToastComponentFile from "components/Toast";
+import type ToastComponentFile from "@/components/Toast";
 
 export type ToastComponent = Vue & typeof ToastComponentFile.methods;
 

--- a/client/src/entry/analysis/index.ts
+++ b/client/src/entry/analysis/index.ts
@@ -1,11 +1,10 @@
-import { standardInit, addInitialization } from "onload";
-
 import Vue, { provide } from "vue";
-import App from "./App.vue";
-import store from "store";
-import { getRouter } from "./router";
-import { createPinia, PiniaVuePlugin } from "pinia";
+import { PiniaVuePlugin, createPinia } from "pinia";
 import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
+import App from "./App.vue";
+import { getRouter } from "./router";
+import { addInitialization, standardInit } from "@/onload";
+import store from "@/store";
 
 Vue.use(PiniaVuePlugin);
 const pinia = createPinia();

--- a/client/src/entry/analysis/router-push.js
+++ b/client/src/entry/analysis/router-push.js
@@ -17,8 +17,6 @@ export function patchRouterPush(VueRouter) {
         if (force) {
             location = addSearchParams(location, { __vkey__: Date.now() });
         }
-        // log upcoming location
-        console.debug("VueRouter - push: ", location);
         // verify if confirmation is required
         if (this.confirmation) {
             if (confirm("There are unsaved changes which will be lost.")) {

--- a/client/src/onload/getRootFromIndexLink.ts
+++ b/client/src/onload/getRootFromIndexLink.ts
@@ -1,9 +1,13 @@
-// Finds <link rel="index"> in head element and pulls root url fragment from
-// there That should probably be a <base> tag instead since that's how
-// they're using <link rel="index" />
-
 import { serverPath } from "@/utils/serverPath";
 
+/**
+ * Finds <link rel="index"> in head element and pulls root url fragment from
+ * there That should probably be a <base> tag instead since that's how
+ * they're using <link rel="index" />
+ *
+ * @param {string} [defaultRoot="/"]
+ * @returns {string}
+ */
 export function getRootFromIndexLink(defaultRoot = "/"): string {
     const links = document.getElementsByTagName("link");
     const indexLink = Array.from(links).find((link) => link.rel == "index");

--- a/client/src/onload/getRootFromIndexLink.ts
+++ b/client/src/onload/getRootFromIndexLink.ts
@@ -2,7 +2,7 @@
 // there That should probably be a <base> tag instead since that's how
 // they're using <link rel="index" />
 
-import { serverPath } from "utils/serverPath";
+import { serverPath } from "@/utils/serverPath";
 
 export function getRootFromIndexLink(defaultRoot = "/"): string {
     const links = document.getElementsByTagName("link");

--- a/client/src/schema/fetcher.ts
+++ b/client/src/schema/fetcher.ts
@@ -1,6 +1,6 @@
 import { Fetcher } from "openapi-typescript-fetch";
-import { getAppRoot } from "onload/loadConfig";
-import { rethrowSimple } from "utils/simple-error";
+import { getAppRoot } from "@/onload/loadConfig";
+import { rethrowSimple } from "@/utils/simple-error";
 import type { paths } from "./schema";
 import type { Middleware } from "openapi-typescript-fetch";
 

--- a/client/src/utils/serverPath.ts
+++ b/client/src/utils/serverPath.ts
@@ -1,3 +1,10 @@
+/**
+ * Returns the path of the current or given URL.
+ *
+ * @param {string} [rawUrl=window.location.href]
+ * @returns {string}
+ */
+
 export function serverPath(rawUrl: string = window.location.href): string {
     const url = new URL(rawUrl);
     return url.pathname;

--- a/client/src/utils/url.js
+++ b/client/src/utils/url.js
@@ -4,7 +4,6 @@ import { rethrowSimple } from "utils/simple-error";
 
 export async function urlData({ url, headers, params }) {
     try {
-        console.debug("Requesting data from: ", url);
         headers = headers || {};
         params = params || {};
         const { data } = await axios.get(safePath(url), { headers, params });

--- a/client/tests/jest/jest.config.js
+++ b/client/tests/jest/jest.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-
 const { defaults: tsjPreset } = require("ts-jest/presets");
 
 // For a detailed explanation regarding each configuration property, visit:
@@ -16,192 +15,36 @@ const modulesToTransform = [
 ].join("|");
 
 module.exports = {
-    // All imported modules in your tests should be mocked automatically
-    // automock: false,
-
-    // Stop running tests after `n` failures
-    // bail: 0,
-
-    // The directory where Jest should store its cached dependency information
-    // cacheDirectory: "/private/var/folders/gm/53ksmsz51njf80yl3snw6g500000gn/T/jest_dx",
-
-    // Automatically clear mock calls and instances between every test
+    preset: "ts-jest",
     clearMocks: true,
-
-    // Indicates whether the coverage information should be collected while executing the test
-    // collectCoverage: false,
-
-    // An array of glob patterns indicating a set of files for which coverage information should be collected
-    // collectCoverageFrom: undefined,
-
-    // The directory where Jest should output its coverage files
     coverageDirectory: "coverage",
-
-    // An array of regexp pattern strings used to skip coverage collection
-    // coveragePathIgnorePatterns: [
-    //   "/node_modules/"
-    // ],
-
-    // A list of reporter names that Jest uses when writing coverage reports
-    // coverageReporters: [
-    //   "json",
-    //   "text",
-    //   "lcov",
-    //   "clover"
-    // ],
-
-    // An object that configures minimum threshold enforcement for coverage results
-    // coverageThreshold: undefined,
-
-    // A path to a custom dependency extractor
-    // dependencyExtractor: undefined,
-
-    // Make calling deprecated APIs throw helpful error messages
-    // errorOnDeprecated: false,
-
-    // Force coverage collection from ignored files using an array of glob patterns
-    // forceCoverageMatch: [],
-
-    // A path to a module which exports an async function that is triggered once before all test suites
-    // globalSetup: undefined,
-
-    // A path to a module which exports an async function that is triggered once after all test suites
-    // globalTeardown: undefined,
-
-    // A set of global variables that need to be available in all test environments
     globals: { __webpack_public_path__: "" },
-
-    // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-    // maxWorkers: "50%",
-
-    // An array of directory names to be searched recursively up from the requiring module's location
-    // moduleDirectories: [
-    //   "node_modules"
-    // ],
-
-    // An array of file extensions your modules use
-    moduleFileExtensions: ["js", "json", "vue", "yml", "txt", "ts"],
-
+    moduleDirectories: ["<rootDir>/src", "<rootDir>/node_modules"],
+    moduleFileExtensions: ["js", "ts", "json", "vue", "yml", "txt"],
     modulePaths: ["<rootDir>/src/", "<rootDir>/tests/", "<rootDir>/node_modules/", "./"],
-
-    // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-    // Some of these should turn into true mocks, instead of this module name mapping hack.
     moduleNameMapper: {
         "\\.(css|scss)$": "<rootDir>/tests/jest/__mocks__/style.js",
         "^@fontsource/.*": "<rootDir>/tests/jest/__mocks__/font.js",
         "^config$": "<rootDir>/tests/jest/__mocks__/config.js",
-        "handsontable": "node_modules/handsontable/dist/handsontable.js",
+        handsontable: "node_modules/handsontable/dist/handsontable.js",
         "utils/localization$": "<rootDir>/tests/jest/__mocks__/localization.js",
         "viz/trackster$": "<rootDir>/tests/jest/__mocks__/trackster.js",
         "rxjs/internal/scheduler/AsyncScheduler":
             "<rootDir>/node_modules/rxjs/dist/esm/internal/scheduler/AsyncScheduler.js",
+        "^@/(.*)$": "<rootDir>/src/$1",
+        "^@tests/(.*)$": "<rootDir>/tests/$1",
     },
-
-    // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
     modulePathIgnorePatterns: ["<rootDir>/src/.*/__mocks__"],
-
-    // Activates notifications for test results
-    // notify: false,
-
-    // An enum that specifies notification mode. Requires { notify: true }
-    // notifyMode: "failure-change",
-
-    // A preset that is used as a base for Jest's configuration
-    preset: "ts-jest",
-
-    // Run tests from one or more projects
-    // projects: undefined,
-
-    // Use this configuration option to add custom reporters to Jest
-    // reporters: undefined,
-
-    // Automatically reset mock state between every test
-    // resetMocks: false,
-
-    // Reset the module registry before running each individual test
-    // resetModules: false,
-
-    // A path to a custom resolver
-    // resolver: undefined,
-
-    // Automatically restore mock state between every test
-    // restoreMocks: false,
-
-    // The root directory that Jest should scan for tests and modules within
-    // This should be the galaxy `client` directory.
     rootDir: path.join(__dirname, "../../"),
-
-    // A list of paths to directories that Jest should use to search for files in
-    roots: ["<rootDir>", "<rootDir>/src/", "<rootDir>/tests/jest/standalone/", "<rootDir>/docs/"],
-
-    // Allows you to use a custom runner instead of Jest's default test runner
-    // runner: "jest-runner",
-
-    // The paths to modules that run some code to configure or set up the testing environment before each test
-    // setupFiles: [],
-
-    // A list of paths to modules that run some code to configure or set up the testing framework before each test
+    roots: ["<rootDir>/src/", "<rootDir>/tests/jest/standalone/"],
     setupFilesAfterEnv: ["<rootDir>/tests/jest/jest.setup.js"],
-
-    // A list of paths to snapshot serializer modules Jest should use for snapshot testing
-    // snapshotSerializers: [],
-
-    // The test environment that will be used for testing
     testEnvironment: "jsdom",
-
-    // Options that will be passed to the testEnvironment
-    // testEnvironmentOptions: {},
-
-    // Adds a location field to test results
-    // testLocationInResults: false,
-
-    // The glob patterns Jest uses to detect test files
-    // testMatch: [
-    //   "**/__tests__/**/*.[jt]s?(x)",
-    //   "**/?(*.)+(spec|test).[tj]s?(x)"
-    // ],
-
-    // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-    // testPathIgnorePatterns: [
-    //   "/node_modules/"
-    // ],
-
-    // The regexp pattern or array of patterns that Jest uses to detect test files
-    // testRegex: [],
-
-    // This option allows the use of a custom results processor
-    // testResultsProcessor: undefined,
-
-    // This option allows use of a custom test runner
-    // testRunner: "jasmine2",
-
-    // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
-    // testURL: "http://localhost",
-
-    // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
-    // timers: "real",
-
-    // A map from regular expressions to paths to transformers
     transform: {
-        ...tsjPreset.transform,
         "^.+\\.js$": "babel-jest",
         "^.*\\.(vue)$": "@vue/vue2-jest",
         "^.+\\.ya?ml$": "<rootDir>/tests/jest/yaml-jest.js",
         "^.+\\.txt$": "<rootDir>/tests/jest/jest-raw-loader.js",
+        ...tsjPreset.transform,
     },
-
-    // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
     transformIgnorePatterns: [`/node_modules/(?!${modulesToTransform})`],
-
-    // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-    // unmockedModulePathPatterns: undefined,
-
-    // Indicates whether each individual test should be reported during the run
-    // verbose: undefined,
-
-    // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-    // watchPathIgnorePatterns: [],
-
-    // Whether to use watchman for file crawling
-    // watchman: true,
 };

--- a/client/tests/jest/jest.config.js
+++ b/client/tests/jest/jest.config.js
@@ -19,7 +19,6 @@ module.exports = {
     clearMocks: true,
     coverageDirectory: "coverage",
     globals: { __webpack_public_path__: "" },
-    moduleDirectories: ["<rootDir>/src", "<rootDir>/node_modules"],
     moduleFileExtensions: ["js", "ts", "json", "vue", "yml", "txt"],
     modulePaths: ["<rootDir>/src/", "<rootDir>/tests/", "<rootDir>/node_modules/", "./"],
     moduleNameMapper: {

--- a/client/tests/jest/jest.setup.js
+++ b/client/tests/jest/jest.setup.js
@@ -1,4 +1,9 @@
 import "@testing-library/jest-dom";
+import Vue from 'vue';
+
+// Set Vue to suppress production / devtools / etc. warnings
+Vue.config.productionTip = false;
+Vue.config.devtools = false;
 
 /* still don't understand what was invoking the following, but nothing should,
 and this makes the tag tests work correctly */

--- a/client/tests/jest/standalone/RuleDefinitions.test.ts
+++ b/client/tests/jest/standalone/RuleDefinitions.test.ts
@@ -1,4 +1,4 @@
-import RuleDefs from "components/RuleBuilder/rule-definitions";
+import RuleDefs from "@/components/RuleBuilder/rule-definitions";
 import SPEC_TEST_CASES from "./rules_dsl_spec.yml";
 
 function applyRules(rules: Array<any>, data: Array<Array<string>>, sources: Array<number>) {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -3,8 +3,12 @@
     "compilerOptions": {
         "target": "es2016",
         "module": "es6",
-        "baseUrl": "./src",
+        "baseUrl": ".",
 
+        "paths": {
+            "@/*": ["src/*"],
+            "@tests/*": ["tests/*"]
+        },
         "allowJs": true,
         "checkJs": false,
 
@@ -14,5 +18,5 @@
     "vueCompilerOptions": {
         "target": 2.7
     },
-    "include": ["./types/*.d.ts", "./src/**/*.ts", "./src/**/*.tsx", "./src/**/*.vue", "./tests/**/*.ts"],
+    "include": ["./types/*.d.ts", "./src/**/*.ts", "./src/**/*.tsx", "./src/**/*.vue", "./tests/**/*.ts"]
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -3,16 +3,16 @@
     "compilerOptions": {
         "target": "es2016",
         "module": "es6",
-        "baseUrl": ".",
 
+        "baseUrl": ".",
         "paths": {
             "@/*": ["src/*"],
             "@tests/*": ["tests/*"]
         },
+        "outDir": "./dist/build",
+
         "allowJs": true,
         "checkJs": false,
-
-        "outDir": "./dist/build",
         "allowSyntheticDefaultImports": true
     },
     "vueCompilerOptions": {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -6,6 +6,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const DuplicatePackageCheckerPlugin = require("@cerner/duplicate-package-checker-webpack-plugin");
 const { DumpMetaPlugin } = require("dumpmeta-webpack-plugin");
+const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 
 const scriptsBase = path.join(__dirname, "src");
 const testsBase = path.join(__dirname, "tests");
@@ -43,6 +44,7 @@ module.exports = (env = {}, argv = {}) => {
             filename: "[name].bundled.js",
         },
         resolve: {
+            plugins: [new TsconfigPathsPlugin({ extensions: [".ts", ".js", ".json", ".vue", ".scss"] })],
             extensions: [".ts", ".js", ".json", ".vue", ".scss"],
             modules: [scriptsBase, "node_modules", styleBase, testsBase],
             fallback: {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4432,6 +4432,14 @@ enhanced-resolve@^5.10.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
+enhanced-resolve@^5.7.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
+  integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 ent@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
@@ -10067,6 +10075,24 @@ ts-loader@^9.4.1:
     enhanced-resolve "^5.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
+
+tsconfig-paths-webpack-plugin@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz#84008fc3e3e0658fdb0262758b07b4da6265ff1a"
+  integrity sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.7.0"
+    tsconfig-paths "^4.0.0"
+
+tsconfig-paths@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.1.1.tgz#7f23094ce897fcf4a93f67c4776e813003e48b75"
+  integrity sha512-VgPrtLKpRgEAJsMj5Q/I/mXouC6A/7eJ/X4Nuk6o0cRPwBtznYxTCU4FodbexbzH9somBPEXYi0ZkUViUpJ21Q==
+  dependencies:
+    json5 "^2.2.1"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
 
 tsconfig@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
This pull request proposes to standardize the way local package imports are written in TypeScript by introducing an `@` alias for easier and more consistent import paths, spurred by discussion in on matrix (https://app.element.io/?updated=1.11.5#/room/#galaxyproject_ui-ux:gitter.im/$9e8C83-1BZzGHNMHdYER7B_fGmifg3l8X3u0B88mTdg) and a bug @davelopez ran into with imports in jest tests.

With this, the `@/` alias maps to `<galaxy-client-dir>/src/`, and `@tests/` maps to `<galaxy-client-dir>/tests/`.  Both of these are set in tsconfig, and webpack is configured to now use tsconfig path aliases for module resolution.

With the `@` alias, we can import local packages using a simple and intuitive syntax, like this:

Before:
```ts
import { someFunction } from '../../../utils/some-package';
// or
import { someFunction } from 'utils/some-package';
```

After:
```ts
import { someFunction } from '@/utils/some-package';
```

Looking forward to the package structure we'd like to have down the road, the `@` alias makes it easy to change the location of code within our project structure without breaking the import paths in our code.  It also makes more readable long and convoluted relative paths, and aligns with the convention used by many other JavaScript and TypeScript projects. 

We don't need to change all the javascript right now, but as components are migrated to typescript they should update to the explicit import aliases instead of assuming a single base path that has the contents of 'src' on it.

Also included, since I had to fight with Jest (and ts-jest) a bunch on this are several cleanups of extra jest output.  I don't think it's an issue to leave console.debug statements in the codebase in general, but these situations that I have removed are all better observed/accessed/debugged in the standard browser devtools (or in the vue-devtools plugin).

## NOTE:  (from resolved comments below)

For plain javascript files relying on tsconfig for type hinting, you can go ahead and update imports to use the aliases (in both .vue and regular .js) if you would like, and you'll get the right types.

So, something like this, in plain javascript (or .vue w/ js) will just work and will show (as seen in the tooltip) type hints in javascript.

```
import { rethrowSimple } from "utils/simple-error";
// to
import { rethrowSimple } from "@/utils/simple-error";

```
![image](https://user-images.githubusercontent.com/155398/207100859-2260c2ff-2812-4d6d-9011-b4b851e86984.png)

That said, we should strongly encourage just migrating the file to typescript.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
