### PR TITLE
[21.01] Fix `passenv` option for tox 4.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,8 @@ commands =
     mypy: mypy test lib
 allowlist_externals = bash
 passenv =
-    CI CONDA_EXE
+    CI
+    CONDA_EXE
     GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
 setenv =
     first_startup: GALAXY_PYTHON=python


### PR DESCRIPTION
See https://tox.wiki/en/latest/faq.html#tox-4-changed-ini-rules

This was already broken in tox 4.0.0 but silently ignored before 4.0.6, see https://tox.wiki/en/latest/changelog.html#v4-0-6-2022-12-10

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
