### PR TITLE
Make weasyprint requirements a bit clearer

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -49,7 +49,9 @@ influxdb
 # Deep learning packages for tool recommendation
 tensorflow==2.7.2
 
-# weasyprint has problematic requirements so make it optional (i.e. cairo)
+# weasyprint has problematic requirements (cairo, Pango, see:
+# https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#linux)
+# so make it optional
 # xref https://github.com/galaxyproject/galaxy/pull/9651
 # Run run.sh or common_startup script with GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT=1
 # to install weasyprint as part of Galaxy's conditonal dependency instalation process.


### PR DESCRIPTION
This change is simply enhancing the comment about the weasyprint requirement.

With recent versions of WeasyPrint it is likely that this type of error occurs:

```
AttributeError: function/symbol 'pango_context_set_round_glyph_positions' not found in library 'libpango-1.0.so.0': /lib64/libpango-1.0.so.0: undefined symbol: pango_context_set_round_glyph_positions
```
If you cannot update, your system's libpango version, an option is to downgrade WeasyPrint as suggested in the linked to docs section.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
