### PR TITLE
Convert localization from old amd module

### DIFF
--- a/client/src/app/galaxy.js
+++ b/client/src/app/galaxy.js
@@ -5,7 +5,7 @@ import BASE_MVC from "./base-mvc";
 import userModel from "./user-model";
 import metricsLogger from "utils/metrics-logger";
 import addLogging from "utils/add-logging";
-import localize from "utils/localization";
+import { localize, _setUserLocale, _getUserLocale } from "utils/localization";
 import { getGalaxyInstance } from "app";
 import { create, dialog } from "utils/data";
 
@@ -77,8 +77,8 @@ GalaxyApp.prototype._init = function (options, bootstrapped) {
     this._initUser(options.user || {});
     this.debug("GalaxyApp.user: ", this.user);
 
-    this.localize._setUserLocale(this.user, this.config);
-    this.localize._getUserLocale();
+    _setUserLocale(this.user, this.config);
+    _getUserLocale();
     this.debug("currentLocale: ", sessionStorage.getItem("currentLocale"));
 
     this._setUpListeners();

--- a/client/src/utils/localization.js
+++ b/client/src/utils/localization.js
@@ -1,54 +1,54 @@
-// eslint-disable-next-line no-undef
-define(["i18n!nls/locale"], function (localeStrings) {
-    /**
-     * @param {String} strToLocalize
-     * @returns
-     */
-    var localize = function (strToLocalize) {
-        return localeStrings[strToLocalize] || strToLocalize;
-    };
+import localeStrings from "i18n!nls/locale";
 
-    localize.cacheNonLocalized = false;
+/**
+ * @param {String} strToLocalize
+ * @returns
+ */
+var localize = function (strToLocalize) {
+    return localeStrings[strToLocalize] || strToLocalize;
+};
 
-    localize._setUserLocale = function _setUserLocale(user, config) {
-        const global_locale =
-            config.default_locale && config.default_locale != "auto" ? config.default_locale.toLowerCase() : false;
+localize.cacheNonLocalized = false;
 
-        let extra_user_preferences = {};
-        if (user && user.attributes.preferences && "extra_user_preferences" in user.attributes.preferences) {
-            extra_user_preferences = JSON.parse(user.attributes.preferences.extra_user_preferences);
+localize._setUserLocale = function _setUserLocale(user, config) {
+    const global_locale =
+        config.default_locale && config.default_locale != "auto" ? config.default_locale.toLowerCase() : false;
+
+    let extra_user_preferences = {};
+    if (user && user.attributes.preferences && "extra_user_preferences" in user.attributes.preferences) {
+        extra_user_preferences = JSON.parse(user.attributes.preferences.extra_user_preferences);
+    }
+
+    let user_locale =
+        "localization|locale" in extra_user_preferences
+            ? extra_user_preferences["localization|locale"].toLowerCase()
+            : false;
+
+    if (user_locale == "auto") {
+        user_locale = false;
+    }
+
+    const nav_locale =
+        typeof navigator === "undefined"
+            ? "__root"
+            : (navigator.language || navigator.userLanguage || "__root").toLowerCase();
+
+    const locale = user_locale || nav_locale || global_locale;
+
+    sessionStorage.setItem("currentLocale", locale);
+};
+
+localize._getUserLocale = function _getUserLocale(user, config) {
+    let locale = null;
+    if (Object.prototype.hasOwnProperty.call(localeStrings, "__root")) {
+        locale = sessionStorage.getItem("currentLocale");
+        if (locale) {
+            // eslint-disable-next-line no-import-assign
+            localeStrings =
+                localeStrings["__" + locale] || localeStrings["__" + locale.split("-")[0]] || localeStrings.__root;
         }
+    }
+    return locale;
+};
 
-        let user_locale =
-            "localization|locale" in extra_user_preferences
-                ? extra_user_preferences["localization|locale"].toLowerCase()
-                : false;
-
-        if (user_locale == "auto") {
-            user_locale = false;
-        }
-
-        const nav_locale =
-            typeof navigator === "undefined"
-                ? "__root"
-                : (navigator.language || navigator.userLanguage || "__root").toLowerCase();
-
-        const locale = user_locale || nav_locale || global_locale;
-
-        sessionStorage.setItem("currentLocale", locale);
-    };
-
-    localize._getUserLocale = function _getUserLocale(user, config) {
-        let locale = null;
-        if (Object.prototype.hasOwnProperty.call(localeStrings, "__root")) {
-            locale = sessionStorage.getItem("currentLocale");
-            if (locale) {
-                localeStrings =
-                    localeStrings["__" + locale] || localeStrings["__" + locale.split("-")[0]] || localeStrings.__root;
-            }
-        }
-        return locale;
-    };
-
-    return localize;
-});
+export default localize;

--- a/client/src/utils/localization.js
+++ b/client/src/utils/localization.js
@@ -7,7 +7,7 @@ import localeStrings from "i18n!nls/locale";
 
 let localeStringsSubset = [];
 
-export default function localize(strToLocalize) {
+export function localize(strToLocalize) {
     return localeStringsSubset[strToLocalize] || strToLocalize;
 }
 
@@ -50,3 +50,5 @@ export function _getUserLocale(user, config) {
     }
     return locale;
 }
+
+export default localize;

--- a/client/src/utils/localization.js
+++ b/client/src/utils/localization.js
@@ -4,13 +4,14 @@ import localeStrings from "i18n!nls/locale";
  * @param {String} strToLocalize
  * @returns
  */
-var localize = function (strToLocalize) {
-    return localeStrings[strToLocalize] || strToLocalize;
-};
 
-localize.cacheNonLocalized = false;
+let localeStringsSubset = [];
 
-localize._setUserLocale = function _setUserLocale(user, config) {
+export default function localize(strToLocalize) {
+    return localeStringsSubset[strToLocalize] || strToLocalize;
+}
+
+export function _setUserLocale(user, config) {
     const global_locale =
         config.default_locale && config.default_locale != "auto" ? config.default_locale.toLowerCase() : false;
 
@@ -36,19 +37,16 @@ localize._setUserLocale = function _setUserLocale(user, config) {
     const locale = user_locale || nav_locale || global_locale;
 
     sessionStorage.setItem("currentLocale", locale);
-};
+}
 
-localize._getUserLocale = function _getUserLocale(user, config) {
+export function _getUserLocale(user, config) {
     let locale = null;
     if (Object.prototype.hasOwnProperty.call(localeStrings, "__root")) {
         locale = sessionStorage.getItem("currentLocale");
         if (locale) {
-            // eslint-disable-next-line no-import-assign
-            localeStrings =
+            localeStringsSubset =
                 localeStrings["__" + locale] || localeStrings["__" + locale.split("-")[0]] || localeStrings.__root;
         }
     }
     return locale;
-};
-
-export default localize;
+}


### PR DESCRIPTION
Converts over the old localization functionality to a modern module.  Still uses the amd-i18n loader, and we want to swap to vue-i18n eventually, but this resolves the immediate issue I think of accessing localization from typescript.

xref https://matrix.to/#/!XciPHtOkuKNqKoVeKD:gitter.im/$iKoCHwkjNrVwLWz3HSC3jaOW4jvjFVNaKW1v5MtywKc?via=gitter.im&via=matrix.org

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
