### PR TITLE
Do not OpenAPI schema lint for operation-4xx-response.

### DIFF
--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -27,18 +27,6 @@ _schema.json:
       #/paths/~1api~1dataset_collections~1{id}~1prepare_download/post/parameters/0/name
     - >-
       #/paths/~1api~1histories~1{history_id}~1contents~1archive~1{id}/get/parameters
-  operation-4xx-response:
-    - '#/paths/~1api~1datatypes~1converters/get/responses'
-    - '#/paths/~1api~1datatypes~1edam_data/get/responses'
-    - '#/paths/~1api~1datatypes~1edam_data~1detailed/get/responses'
-    - '#/paths/~1api~1datatypes~1edam_formats/get/responses'
-    - '#/paths/~1api~1datatypes~1edam_formats~1detailed/get/responses'
-    - '#/paths/~1api~1datatypes~1mapping/get/responses'
-    - '#/paths/~1api~1datatypes~1sniffers/get/responses'
-    - '#/paths/~1api~1licenses/get/responses'
-    - '#/paths/~1api~1tours/get/responses'
-    - '#/paths/~1api~1version/get/responses'
-    - '#/paths/~1ga4gh~1drs~1v1~1service-info/get/responses'
   security-defined:
     - '#/paths/~1api~1datatypes/get'
     - '#/paths/~1api~1datatypes~1converters/get'

--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -1,0 +1,5 @@
+organization: galaxyproject.org
+extends:
+  - recommended
+rules:
+  operation-4xx-response: off


### PR DESCRIPTION
We have good infrastructure for error handling in the API and it could be improved in many ways - but I don't think keeping a list of exclusions is helpful. This is just going to get in the way and encourage unhelpful boilerplate IMO. This is the equivalent of Java checked exceptions - a bad idea.

xref: https://redocly.com/docs/cli/rules/operation-4xx-response/

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
