### PR TITLE
Convert sanitize_allow to fastAPI

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1054,6 +1054,26 @@ export interface paths {
         /** Show */
         get: operations["show_api_roles__id__get"];
     };
+    "/api/sanitize_allow": {
+        /**
+         * Index
+         * @description GET /api/sanitize_allow
+         * Return an object showing the current state of the toolbox and allow list.
+         */
+        get: operations["index_api_sanitize_allow_get"];
+        /**
+         * Create
+         * @description PUT /api/sanitize_allow
+         * Add a new tool_id to the allowlist.
+         */
+        put: operations["create_api_sanitize_allow_put"];
+        /**
+         * Delete
+         * @description DELETE /api/sanitize_allow
+         * Remove tool_id from allowlist.
+         */
+        delete: operations["delete_api_sanitize_allow_delete"];
+    };
     "/api/short_term_storage/{storage_request_id}": {
         /** Serve the staged download specified by request ID. */
         get: operations["serve_api_short_term_storage__storage_request_id__get"];
@@ -13314,6 +13334,93 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["RoleModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    index_api_sanitize_allow_get: {
+        /**
+         * Index
+         * @description GET /api/sanitize_allow
+         * Return an object showing the current state of the toolbox and allow list.
+         */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_api_sanitize_allow_put: {
+        /**
+         * Create
+         * @description PUT /api/sanitize_allow
+         * Add a new tool_id to the allowlist.
+         */
+        parameters: {
+            query: {
+                tool_id: Record<string, never>;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_api_sanitize_allow_delete: {
+        /**
+         * Delete
+         * @description DELETE /api/sanitize_allow
+         * Remove tool_id from allowlist.
+         */
+        parameters: {
+            query: {
+                tool_id: Record<string, never>;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1057,20 +1057,17 @@ export interface paths {
     "/api/sanitize_allow": {
         /**
          * Index
-         * @description GET /api/sanitize_allow
-         * Return an object showing the current state of the toolbox and allow list.
+         * @description Return an object showing the current state of the toolbox and allow list.
          */
         get: operations["index_api_sanitize_allow_get"];
         /**
          * Create
-         * @description PUT /api/sanitize_allow
-         * Add a new tool_id to the allowlist.
+         * @description Add a new tool_id to the allowlist.
          */
         put: operations["create_api_sanitize_allow_put"];
         /**
          * Delete
-         * @description DELETE /api/sanitize_allow
-         * Remove tool_id from allowlist.
+         * @description Remove tool_id from allowlist.
          */
         delete: operations["delete_api_sanitize_allow_delete"];
     };
@@ -13347,8 +13344,7 @@ export interface operations {
     index_api_sanitize_allow_get: {
         /**
          * Index
-         * @description GET /api/sanitize_allow
-         * Return an object showing the current state of the toolbox and allow list.
+         * @description Return an object showing the current state of the toolbox and allow list.
          */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
@@ -13374,12 +13370,12 @@ export interface operations {
     create_api_sanitize_allow_put: {
         /**
          * Create
-         * @description PUT /api/sanitize_allow
-         * Add a new tool_id to the allowlist.
+         * @description Add a new tool_id to the allowlist.
          */
         parameters: {
+            /** @description ID string of tool to add or delete */
             query: {
-                tool_id: Record<string, never>;
+                tool_id: string;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -13404,12 +13400,12 @@ export interface operations {
     delete_api_sanitize_allow_delete: {
         /**
          * Delete
-         * @description DELETE /api/sanitize_allow
-         * Remove tool_id from allowlist.
+         * @description Remove tool_id from allowlist.
          */
         parameters: {
+            /** @description ID string of tool to add or delete */
             query: {
-                tool_id: Record<string, never>;
+                tool_id: string;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -39,7 +39,7 @@ class FastAPISanitizeAllowController:
         return self._generate_allowlist(trans)
 
     @router.delete("/api/sanitize_allow", require_admin=True)
-    async def delete(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
+   def delete(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
         """
         DELETE /api/sanitize_allow
         Remove tool_id from allowlist.

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -40,7 +40,6 @@ class FastAPISanitizeAllowController:
     @router.delete("/api/sanitize_allow", require_admin=True)
    def delete(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
         """
-        DELETE /api/sanitize_allow
         Remove tool_id from allowlist.
         """
         if tool_id in trans.app.config.sanitize_allowlist:

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -3,12 +3,7 @@ API operations allowing clients to retrieve and modify the HTML sanitization all
 """
 
 import logging
-from typing import (
-    Any,
-    Dict,
-    List
-
-)
+from typing import Any, Dict, List
 
 from fastapi import Query
 

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -14,20 +14,20 @@ from . import Router
 
 log = logging.getLogger(__name__)
 
-router = Router(tags=["sanitize_allow"])
+router = Router(tags=["configuration"])
 
 
 @router.cbv
 class FastAPISanitizeAllowController:
     @router.get("/api/sanitize_allow", require_admin=True)
-    async def index(self, trans: ProvidesUserContext = DependsOnTrans):
+    def index(self, trans: ProvidesUserContext = DependsOnTrans):
         """
         Return an object showing the current state of the toolbox and allow list.
         """
         return self._generate_allowlist(trans)
 
     @router.put("/api/sanitize_allow", require_admin=True)
-   def create(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
+    def create(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
         """
         Add a new tool_id to the allowlist.
         """
@@ -37,7 +37,7 @@ class FastAPISanitizeAllowController:
         return self._generate_allowlist(trans)
 
     @router.delete("/api/sanitize_allow", require_admin=True)
-   def delete(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
+    def delete(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
         """
         Remove tool_id from allowlist.
         """

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -1,31 +1,45 @@
 """
 API operations allowing clients to retrieve and modify the HTML sanitization allow list.
 """
+
 import logging
 from typing import (
     Any,
     Dict,
 )
 
+from fastapi.routing import APIRouter
+from fastapi_utils.cbv import cbv
+
 from galaxy import web
 from galaxy.webapps.base.controller import BaseAPIController
+from galaxy.managers.context import ProvidesUserContext
+
+from galaxy.webapps.galaxy.api import (
+    depends,
+    DependsOnTrans,
+    Router,
+)
+
+from . import Router
 
 log = logging.getLogger(__name__)
 
+router = Router(tags=["sanitize_allow"])
 
-class SanitizeAllowController(BaseAPIController):
-    @web.require_admin
-    @web.expose_api
-    def index(self, trans, **kwd):
+
+@router.cbv
+class FastAPISanitizeAllowController:
+    @router.get("/api/sanitize_allow", require_admin=True)
+    async def index(self, trans: ProvidesUserContext = DependsOnTrans):
         """
         GET /api/sanitize_allow
         Return an object showing the current state of the toolbox and allow list.
         """
         return self._generate_allowlist(trans)
 
-    @web.require_admin
-    @web.expose_api
-    def create(self, trans, tool_id, **kwd):
+    @router.put("/api/sanitize_allow", require_admin=True)
+    async def create(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
         """
         PUT /api/sanitize_allow
         Add a new tool_id to the allowlist.
@@ -35,9 +49,8 @@ class SanitizeAllowController(BaseAPIController):
             self._save_allowlist(trans)
         return self._generate_allowlist(trans)
 
-    @web.require_admin
-    @web.expose_api
-    def delete(self, trans, tool_id, **kwd):
+    @router.delete("/api/sanitize_allow", require_admin=True)
+    async def delete(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
         """
         DELETE /api/sanitize_allow
         Remove tool_id from allowlist.

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -3,7 +3,11 @@ API operations allowing clients to retrieve and modify the HTML sanitization all
 """
 
 import logging
-from typing import Any, Dict, List
+from typing import (
+    Any,
+    Dict,
+    List,
+)
 
 from fastapi import Query
 

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -22,7 +22,6 @@ class FastAPISanitizeAllowController:
     @router.get("/api/sanitize_allow", require_admin=True)
     async def index(self, trans: ProvidesUserContext = DependsOnTrans):
         """
-        GET /api/sanitize_allow
         Return an object showing the current state of the toolbox and allow list.
         """
         return self._generate_allowlist(trans)

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -8,18 +8,9 @@ from typing import (
     Dict,
 )
 
-from fastapi.routing import APIRouter
-from fastapi_utils.cbv import cbv
-
-from galaxy import web
-from galaxy.webapps.base.controller import BaseAPIController
 from galaxy.managers.context import ProvidesUserContext
 
-from galaxy.webapps.galaxy.api import (
-    depends,
-    DependsOnTrans,
-    Router,
-)
+from galaxy.webapps.galaxy.api import DependsOnTrans
 
 from . import Router
 

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -9,9 +9,7 @@ from typing import (
 )
 
 from galaxy.managers.context import ProvidesUserContext
-
 from galaxy.webapps.galaxy.api import DependsOnTrans
-
 from . import Router
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -8,6 +8,8 @@ from typing import (
     Dict,
 )
 
+from fastapi import Query
+
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.webapps.galaxy.api import DependsOnTrans
 from . import Router
@@ -15,6 +17,11 @@ from . import Router
 log = logging.getLogger(__name__)
 
 router = Router(tags=["configuration"])
+
+ToolIDQueryParam: str = Query(
+    title="tool_id only",
+    description="ID string of tool to add or delete",
+)
 
 
 @router.cbv
@@ -27,7 +34,7 @@ class FastAPISanitizeAllowController:
         return self._generate_allowlist(trans)
 
     @router.put("/api/sanitize_allow", require_admin=True)
-    def create(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
+    def create(self, tool_id: str = ToolIDQueryParam, trans: ProvidesUserContext = DependsOnTrans):
         """
         Add a new tool_id to the allowlist.
         """
@@ -37,7 +44,7 @@ class FastAPISanitizeAllowController:
         return self._generate_allowlist(trans)
 
     @router.delete("/api/sanitize_allow", require_admin=True)
-    def delete(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
+    def delete(self, tool_id: str = ToolIDQueryParam, trans: ProvidesUserContext = DependsOnTrans):
         """
         Remove tool_id from allowlist.
         """

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -28,7 +28,7 @@ class FastAPISanitizeAllowController:
         return self._generate_allowlist(trans)
 
     @router.put("/api/sanitize_allow", require_admin=True)
-    async def create(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
+   def create(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
         """
         PUT /api/sanitize_allow
         Add a new tool_id to the allowlist.

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -29,7 +29,6 @@ class FastAPISanitizeAllowController:
     @router.put("/api/sanitize_allow", require_admin=True)
    def create(self, tool_id, trans: ProvidesUserContext = DependsOnTrans):
         """
-        PUT /api/sanitize_allow
         Add a new tool_id to the allowlist.
         """
         if tool_id not in trans.app.config.sanitize_allowlist:

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -6,6 +6,8 @@ import logging
 from typing import (
     Any,
     Dict,
+    List
+
 )
 
 from fastapi import Query
@@ -24,16 +26,31 @@ ToolIDQueryParam: str = Query(
 )
 
 
+class ToolDict(Dict):
+    tool_name: str
+    tool_id: List[str]
+    ids: List[str]
+    allowed: bool
+    toolshed: bool
+
+
+class ToolListResponse(Dict):
+    blocked_toolshed: List[ToolDict]
+    allowed_toolshed: List[ToolDict]
+    blocked_local: List[ToolDict]
+    allowed_local: List[ToolDict]
+
+
 @router.cbv
 class FastAPISanitizeAllowController:
-    @router.get("/api/sanitize_allow", require_admin=True)
+    @router.get("/api/sanitize_allow", require_admin=True, response_model=ToolListResponse)
     def index(self, trans: ProvidesUserContext = DependsOnTrans):
         """
         Return an object showing the current state of the toolbox and allow list.
         """
         return self._generate_allowlist(trans)
 
-    @router.put("/api/sanitize_allow", require_admin=True)
+    @router.put("/api/sanitize_allow", require_admin=True, response_model=ToolListResponse)
     def create(self, tool_id: str = ToolIDQueryParam, trans: ProvidesUserContext = DependsOnTrans):
         """
         Add a new tool_id to the allowlist.
@@ -43,7 +60,7 @@ class FastAPISanitizeAllowController:
             self._save_allowlist(trans)
         return self._generate_allowlist(trans)
 
-    @router.delete("/api/sanitize_allow", require_admin=True)
+    @router.delete("/api/sanitize_allow", require_admin=True, response_model=ToolListResponse)
     def delete(self, tool_id: str = ToolIDQueryParam, trans: ProvidesUserContext = DependsOnTrans):
         """
         Remove tool_id from allowlist.

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -421,16 +421,6 @@ def populate_api_routes(webapp, app):
     webapp.mapper.resource("tool", "tools", path_prefix="/api")
     webapp.mapper.resource("dynamic_tools", "dynamic_tools", path_prefix="/api")
 
-    webapp.mapper.connect(
-        "/api/sanitize_allow", action="index", controller="sanitize_allow", conditions=dict(method=["GET"])
-    )
-    webapp.mapper.connect(
-        "/api/sanitize_allow", action="create", controller="sanitize_allow", conditions=dict(method=["PUT"])
-    )
-    webapp.mapper.connect(
-        "/api/sanitize_allow", action="delete", controller="sanitize_allow", conditions=dict(method=["DELETE"])
-    )
-
     webapp.mapper.connect("/api/entry_points", action="index", controller="tool_entry_points")
     webapp.mapper.connect(
         "/api/entry_points/{id:.+?}/access", action="access_entry_point", controller="tool_entry_points"


### PR DESCRIPTION
Converting sanitize_allow to fastAPI, as per #10889

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
