### PR TITLE
[22.05] Add missing celery dep to galaxy test base

### DIFF
--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -58,7 +58,7 @@ class UsesCeleryTasks:
             if os.environ.get("GALAXY_TEST_EXTERNAL") is None:
                 from galaxy.celery import celery_app
 
-                if celery_app.fork_pool:
+                if hasattr(celery_app, "fork_pool"):
                     celery_app.fork_pool.stop()
                     celery_app.fork_pool.join(timeout=5)
 

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -58,8 +58,9 @@ class UsesCeleryTasks:
             if os.environ.get("GALAXY_TEST_EXTERNAL") is None:
                 from galaxy.celery import celery_app
 
-                celery_app.fork_pool.stop()
-                celery_app.fork_pool.join(timeout=5)
+                if celery_app.fork_pool:
+                    celery_app.fork_pool.stop()
+                    celery_app.fork_pool.join(timeout=5)
 
     @pytest.fixture(autouse=True, scope="session")
     def _request_celery_worker(self, celery_session_worker, celery_config, celery_worker_parameters):

--- a/packages/test_base/setup.cfg
+++ b/packages/test_base/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     pytest
     PyYAML
     requests
+    celery[pytest]
 packages = find:
 python_requires = >=3.7
 

--- a/packages/test_base/setup.cfg
+++ b/packages/test_base/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     pytest
     PyYAML
     requests
-    celery[pytest]
+    pytest-celery
 packages = find:
 python_requires = >=3.7
 


### PR DESCRIPTION
I was seeing this error as a result of the missing celery dependency:

```console
_______________________________________________________________________________________ TestMapperResubmission.test_mapping_without_resubmission _______________________________________________________________________________________
file /Users/nuwan/work/total-perspective-vortex/tests/test_mapper_resubmit.py, line 38
      def test_mapping_without_resubmission(self):
file /Users/nuwan/work/total-perspective-vortex/.tox/py3.10/lib/python3.8/site-packages/galaxy_test/base/api.py, line 52
      @pytest.fixture(autouse=True, scope="session")
      def _request_celery_app(self, celery_session_app, celery_config):
E       fixture 'celery_session_app' not found
>       available fixtures: _request_celery_app, _request_celery_worker, _unittest_setUpClass_fixture_TestMapperResubmission, anyio_backend, anyio_backend_name, anyio_backend_options, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, celery_parameters, celery_worker_parameters, doctest_namespace, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.
```

It turned out that the `celery_session_app` fixture is coming from the celery app, which is not a declared dependency of galaxy_test_base.

Fixing that results in the next error:
```
self = <tests.test_mapper_resubmit.TestMapperResubmission testMethod=test_mapping_with_resubmission>, celery_session_app = <Celery celery.tests at 0x124fa6fd0>, celery_config = {}

    @pytest.fixture(autouse=True, scope="session")
    def _request_celery_app(self, celery_session_app, celery_config):
        try:
            self._celery_app = celery_session_app
            yield
        finally:
            if os.environ.get("GALAXY_TEST_EXTERNAL") is None:
                from galaxy.celery import celery_app

>               celery_app.fork_pool.stop()
E               AttributeError: 'Celery' object has no attribute 'fork_pool'
```

For which I've added the conditional stop. Why it's null in the first place, I don't know.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
