### PR TITLE
Fix for Workflow Editor Tags Formatting

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -538,16 +538,13 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         ]
 
         # identify item tags
-        item_tags = [tag for tag in stored.tags if tag.user == trans.user]
-        item_tag_names = []
-        for ta in item_tags:
-            item_tag_names.append(escape(ta.tag.name))
+        item_tags = stored.make_tag_string_list()
 
         # build workflow editor model
         editor_config = {
             "id": trans.security.encode_id(stored.id),
             "name": stored.name,
-            "tags": item_tag_names,
+            "tags": item_tags,
             "initialVersion": version,
             "annotation": self.get_item_annotation_str(trans.sa_session, trans.user, stored),
             "moduleSections": module_sections,


### PR DESCRIPTION
Address issue #15212 which is a bug that occurs on both `release_22.05` branch and `dev` branch.

<img width="234" alt="screenshot_Workflow_Editor_Tags_Correct_Formatting" src="https://user-images.githubusercontent.com/3672779/208132584-eba7351f-b9d9-4751-a795-bcbcdc7e4caf.png">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
