### PR TITLE
Fix type hints for alembic/env.py

### DIFF
--- a/lib/galaxy/model/migrations/alembic/env.py
+++ b/lib/galaxy/model/migrations/alembic/env.py
@@ -13,6 +13,7 @@ from sqlalchemy import create_engine
 
 from galaxy.model.migrations import (
     GXY,
+    ModelId,
     TSI,
 )
 
@@ -72,7 +73,7 @@ def _run_migrations_invoked_via_script(run_migrations: Callable[[str], None]) ->
     run_migrations(url)
 
 
-def _process_cmd_current(urls: Dict[str, str]) -> bool:
+def _process_cmd_current(urls: Dict[ModelId, str]) -> bool:
     if config.cmd_opts.cmd[0].__name__ == "current":  # type: ignore[union-attr]
         # Run command for each url only if urls are different; otherwise run once.
         are_urls_equal = len(set(urls.values())) == 1
@@ -127,9 +128,11 @@ def _get_url_from_config() -> str:
     return cast(str, url)
 
 
-def _load_urls() -> Dict[str, str]:
-    gxy_url = context.get_x_argument(as_dictionary=True).get(f"{GXY}_url")
-    tsi_url = context.get_x_argument(as_dictionary=True).get(f"{TSI}_url")
+def _load_urls() -> Dict[ModelId, str]:
+    context_dict = cast(Dict, context.get_x_argument(as_dictionary=True))
+    gxy_url = context_dict.get(f"{GXY}_url")
+    tsi_url = context_dict.get(f"{TSI}_url")
+    assert gxy_url and tsi_url
     return {
         GXY: gxy_url,
         TSI: tsi_url,


### PR DESCRIPTION
Three fixes:
1. str -> ModelId
2. We know `get_x_argument` returns a dict (see [ref](https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.environment.EnvironmentContext.get_x_argument))
3. url values are never None (called in the context of executing `run_alembic.sh`; both urls always have default values loaded: see logic in `model/migrations/scripts.py`)

xref  #15228

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
