### PR TITLE
[23.1] Enable job resubmissions in k8s runner

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -204,7 +204,7 @@ class CustosAuthnz(IdentityProvider):
                     ):
                         user = existing_user
                     else:
-                        message = f"There already exists a user with email {email}.  To associate this external login, you must first be logged in as that existing account."
+                        message = f"There already exists a user with email {email}. To associate this external login, you must first be logged in as that existing account."
                         log.info(message)
                         login_redirect_url = (
                             f"{login_redirect_url}login/start"

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -203,7 +203,7 @@ class ConditionalDependencies:
     def check_pbs_python(self):
         return "galaxy.jobs.runners.pbs:PBSJobRunner" in self.job_runners
 
-    def check_pykube(self):
+    def check_pykube_ng(self):
         return "galaxy.jobs.runners.kubernetes:KubernetesJobRunner" in self.job_runners or which("kubectl")
 
     def check_chronos_python(self):

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -35,7 +35,6 @@ custos-sdk
 chronos-python==1.2.1
 
 # Kubernetes job runner
-# pykube==0.15.0
 pykube-ng==22.9.0
 
 # Synnefo / Pithos+ object store client

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -35,7 +35,7 @@ custos-sdk
 chronos-python==1.2.1
 
 # Kubernetes job runner
-pykube-ng==22.9.0
+pykube-ng==23.6.0
 
 # Synnefo / Pithos+ object store client
 kamaki

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -35,7 +35,8 @@ custos-sdk
 chronos-python==1.2.1
 
 # Kubernetes job runner
-pykube==0.15.0
+# pykube==0.15.0
+pykube-ng==22.9.0
 
 # Synnefo / Pithos+ object store client
 kamaki

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -35,7 +35,7 @@ custos-sdk
 chronos-python==1.2.1
 
 # Kubernetes job runner
-pykube-ng==23.6.0
+pykube-ng==21.3.0
 
 # Synnefo / Pithos+ object store client
 kamaki

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -223,7 +223,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
     def __has_guest_ports(self, job_wrapper):
         # Check if job has guest ports or interactive tool entry points that would signal that
         log.debug(
-            f"Checking if job {job_wrapper.get_id_tag()} is an interactive tool. guest ports: {job_wrapper.guest_ports}. interactive entry points: {job_wrapper.interactivetool_entry_points}"
+            f"Checking if job {job_wrapper.get_id_tag()} is an interactive tool. guest ports: {job_wrapper.guest_ports}. interactive entry points: {job_wrapper.get_job().interactivetool_entry_points}"
         )
         return bool(job_wrapper.guest_ports) or bool(job_wrapper.get_job().interactivetool_entry_points)
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -782,8 +782,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                     job_state.job_wrapper.cleanup()
                 return None
             else:
-                log.debug(f"Job is failed and not deleted, looking at failure")
-                log.debug(f"Job id: {job_state.job_id} failed but has not been deleted yet. Current state: {job_state.job_wrapper.get_state()}")
+                log.debug(f"Job id: {job_state.job_id} failed and it is not a deletion case. Current state: {job_state.job_wrapper.get_state()}")
                 self._handle_job_failure(job, job_state)
                 # changes for resubmission (removed self.mark_as_failed from handle_job_failure)
                 self.work_queue.put((self.mark_as_failed, job_state))

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -956,7 +956,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         if (
             pod
             and "terminated" in pod["status"]["containerStatuses"][0]["state"]
-            and pod["status"]["containerStatuses"][0]["state"].get("exitCode")
+            and pod["status"]["containerStatuses"][0]["state"]["terminated"].get("exitCode")
         ):
             return True
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -1051,7 +1051,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         
         # TODO: These might not exist for running jobs at the upgrade to 19.XX, remove that
         # assumption in 20.XX.
-        tool_stderr = None
+        tool_stderr = "Galaxy issue: Stderr failed to be retrieved from the job working directory."
+        tool_stdout = "Galaxy issue: Stdout failed to be retrieved from the job working directory."
         if os.path.exists(tool_stdout_path):
             with open(tool_stdout_path, "rb") as stdout_file:
                 tool_stdout = self._job_io_for_db(stdout_file)
@@ -1060,7 +1061,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             tool_stdout = job_stdout
             job_stdout = None
 
-        tool_stdout = None
         if os.path.exists(tool_stderr_path):
             with open(tool_stderr_path, "rb") as stdout_file:
                 tool_stderr = self._job_io_for_db(stdout_file)

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -243,8 +243,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         k8s_service_obj = service_object_dict(self.runner_params, k8s_job_name, self.__get_k8s_service_spec(ajs))
 
         k8s_ingress_obj = ingress_object_dict(self.runner_params, k8s_job_name, self.__get_k8s_ingress_spec(ajs))
-        log.trace(f"Kubernetes service object: {json.dumps(k8s_service_obj, indent=4)}")
-        log.trace(f"Kubernetes ingress object: {json.dumps(k8s_ingress_obj, indent=4)}")
+        log.debug(f"Kubernetes service object: {json.dumps(k8s_service_obj, indent=4)}")
+        log.debug(f"Kubernetes ingress object: {json.dumps(k8s_ingress_obj, indent=4)}")
         # We avoid creating service and ingress if they already exist (e.g. when Galaxy is restarted or resubmitting a job)
         service = Service(self._pykube_api, k8s_service_obj)
         service.create()

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -3,14 +3,19 @@ Offload jobs to a Kubernetes cluster.
 """
 
 import logging
+import json # for debugging of API objects
 import math
 import os
 import re
+import time
 from datetime import datetime
 
 import yaml
 
 from galaxy import model
+from galaxy.util import (
+    unicodify,
+)
 from galaxy.jobs.runners import (
     AsynchronousJobRunner,
     AsynchronousJobState,
@@ -214,7 +219,11 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         self.monitor_queue.put(ajs)
 
     def __has_guest_ports(self, job_wrapper):
-        return bool(job_wrapper.guest_ports)
+        # Check if job has guest ports or interactive tool entry points that would signal that
+        # this is an interactive tool.
+        log.debug(f"Checking if job {job_wrapper.get_id_tag()} has guest ports: {job_wrapper.guest_ports}")
+        log.debug(f"Checking if job {job_wrapper.get_id_tag()} has interactive entry points: {job_wrapper.guest_ports}")
+        return bool(job_wrapper.guest_ports) or bool(job_wrapper.get_job().interactivetool_entry_points)
 
     def __configure_port_routing(self, ajs):
         # Configure interactive tool entry points first
@@ -231,9 +240,19 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         k8s_service_obj = service_object_dict(self.runner_params, k8s_job_name, self.__get_k8s_service_spec(ajs))
 
         k8s_ingress_obj = ingress_object_dict(self.runner_params, k8s_job_name, self.__get_k8s_ingress_spec(ajs))
+        # pretty print the objects for debugging
+        log.debug(f"Kubernetes service object: {json.dumps(k8s_service_obj, indent=4)}")
+        log.debug(f"Kubernetes ingress object: {json.dumps(k8s_ingress_obj, indent=4)}")
+        # We avoid creating service and ingress if they already exist (e.g. when Galaxy is restarted or resubmitting a job)
         service = Service(self._pykube_api, k8s_service_obj)
+        # if service.exists():
+        #     log.debug(f"Service {k8s_job_name} already exists, skipping creation")
+        # else:
         service.create()
         ingress = Ingress(self._pykube_api, k8s_ingress_obj)
+        # if ingress.exists():
+        #     log.debug(f"Ingress {k8s_job_name} already exists, skipping creation")
+        # else:
         ingress.create()
 
     def __get_overridable_params(self, job_wrapper, param_key):
@@ -456,26 +475,27 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 "annotations": {"app.galaxyproject.org/tool_id": ajs.job_wrapper.tool.id},
             },
             "spec": {
-                "rules": [
-                    {
-                        "host": ep["domain"],
-                        "http": {
-                            "paths": [
-                                {
-                                    "backend": {
-                                        "serviceName": self.__get_k8s_job_name(
-                                            self.__produce_k8s_job_prefix(), ajs.job_wrapper
-                                        ),
-                                        "servicePort": int(ep["tool_port"]),
-                                    },
-                                    "path": ep.get("entry_path", "/"),
-                                    "pathType": "Prefix",
-                                }
-                            ]
-                        },
-                    }
-                    for ep in entry_points
-                ]
+                "ingressClassName": "nginx",
+                "rules":[ {
+                                "host": ep["domain"],
+                                "http": {
+                                    "paths": [ {
+                                                    "backend": {
+                                                            "service":  {
+                                                                "name": self.__get_k8s_job_name(
+                                                                    self.__produce_k8s_job_prefix(), ajs.job_wrapper
+                                                                ),
+                                                                "port": { "number": int(ep["tool_port"])}
+                                                            }
+                                                    },
+                                                    "path": ep.get("entry_path", "/"),
+                                                    "pathType": "Prefix"
+                                                }
+                                            ]
+                                        },
+                            }
+                            for ep in entry_points
+                        ]
             },
         }
         if self.runner_params.get("k8s_interactivetools_use_ssl"):
@@ -741,12 +761,12 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             if succeeded > 0 or job_state == model.Job.states.STOPPED:
                 job_state.running = False
                 self.mark_as_finished(job_state)
-                log.debug("k8s job succeeded")
+                log.debug("Job succeeded")
                 return None
             elif active > 0 and failed < max_pod_retries + 1:
                 if not job_state.running:
                     if self.__job_pending_due_to_unschedulable_pod(job_state):
-                        log.debug("k8s job pending..")
+                        log.debug("PP Job pending..")
                         if self.runner_params.get("k8s_unschedulable_walltime_limit"):
                             creation_time_str = job.obj["metadata"].get("creationTimestamp")
                             creation_time = datetime.strptime(creation_time_str, "%Y-%m-%dT%H:%M:%SZ")
@@ -758,39 +778,39 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                         else:
                             pass
                     else:
-                        log.debug("k8s job is running..")
+                        log.debug("Job set to running..")
                         job_state.running = True
                         job_state.job_wrapper.change_state(model.Job.states.RUNNING)
                 return job_state
             elif job_persisted_state == model.Job.states.DELETED:
                 # Job has been deleted via stop_job and job has not been deleted,
                 # remove from watched_jobs by returning `None`
-                log.debug("PP Job is DELETED..")
+                log.debug("Job is DELETED..")
                 if job_state.job_wrapper.cleanup_job in ("always", "onsuccess"):
                     job_state.job_wrapper.cleanup()
                 return None
             else:
-                log.debug("k8s job is failed and not deleted, looking at failure")
+                log.debug(f"Job is failed and not deleted, looking at failure")
+                log.debug(f"Job state before handle job failure: {job_state.job_wrapper.get_state()}")
                 self._handle_job_failure(job, job_state)
                 # changes for resubmission (removed self.mark_as_failed from handle_job_failure)
                 self.work_queue.put((self.mark_as_failed, job_state))
-                # If the job was not resubmitted after being put in the failed queue,
-                # we mark it as finished as well for stderr / stdout detection. 
-                # Otherwise, the user doesn't see any stdout/stderr in the UI.
-                if job_state.job_wrapper.get_state() != model.Job.states.RESUBMITTED:
-                    self.mark_as_finished(job_state)
 
                 return None
 
         elif len(jobs.response["items"]) == 0:
             if job_state.job_wrapper.get_job().state == model.Job.states.DELETED:
-                # Job has been deleted via stop_job and job has been deleted,
-                # cleanup and remove from watched_jobs by returning `None`
                 if job_state.job_wrapper.cleanup_job in ("always", "onsuccess"):
                     job_state.job_wrapper.cleanup()
                 return None
+            if job_state.job_wrapper.get_job().state == model.Job.states.STOPPED and self.__has_guest_ports(job_state.job_wrapper):
+                # Interactive job has been stopped via stop_job (most likely by the user),
+                # cleanup and remove from watched_jobs by returning `None`. STOPPED jobs are cleaned up elsewhere.
+                # Marking as finished makes sure that the interactive job output is available in the UI.
+                self.mark_as_finished(job_state)
+                return None
             # there is no job responding to this job_id, it is either lost or something happened.
-            log.error("No Jobs are available under expected selector app=%s", job_state.job_id)
+            log.error(f"No Jobs are available under expected selector app={job_state.job_id} and they are not deleted or stopped either.")
             self.mark_as_failed(job_state)
             # job is no longer viable - remove from watched jobs
             return None
@@ -818,21 +838,24 @@ class KubernetesJobRunner(AsynchronousJobRunner):
     def _handle_job_failure(self, job, job_state):
         # Figure out why job has failed
         with open(job_state.error_file, "a") as error_file:
-            log.debug("Trying with error file in _handle_job_failure")
+            log.debug("PP Trying with error file in _handle_job_failure")
             if self.__job_failed_due_to_low_memory(job_state):
-                log.debug("OOM condition reached")
+                log.debug("PP OOM reached!")
                 error_file.write("Job killed after running out of memory. Try with more memory.\n")
                 job_state.fail_message = "Tool failed due to insufficient memory. Try with more memory."
                 job_state.runner_state = JobState.runner_states.MEMORY_LIMIT_REACHED
             elif self.__job_failed_due_to_walltime_limit(job):
-                log.debug("Walltime condition reached")
+                log.debug("PP checking for walltime")
                 error_file.write("DeadlineExceeded")
                 job_state.fail_message = "Job was active longer than specified deadline"
                 job_state.runner_state = JobState.runner_states.WALLTIME_REACHED
             else:
-                log.debug("Runner cannot detect a specific reason for failure, must be a tool failure.")
+                log.debug("PP no idea!")
                 error_file.write("Exceeded max number of job retries allowed for job\n")
-                job_state.fail_message = "More job retries failed than allowed. See standard output and standard error within the info section for details."
+                job_state.fail_message = "More job retries failed than allowed. See standard output within the info section for details."
+        # changes for resubmission
+        # job_state.running = False
+        # self.mark_as_failed(job_state)
         try:
             if self.__has_guest_ports(job_state.job_wrapper):
                 self.__cleanup_k8s_guest_ports(job_state.job_wrapper, job)
@@ -845,11 +868,11 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         k8s_cleanup_job = self.runner_params["k8s_cleanup_job"]
         delete_job(job, k8s_cleanup_job)
 
-    def __cleanup_k8s_ingress(self, ingress, job_failed):
+    def __cleanup_k8s_ingress(self, ingress, job_failed=False):
         k8s_cleanup_job = self.runner_params["k8s_cleanup_job"]
         delete_ingress(ingress, k8s_cleanup_job, job_failed)
 
-    def __cleanup_k8s_service(self, service, job_failed):
+    def __cleanup_k8s_service(self, service, job_failed=False):
         k8s_cleanup_job = self.runner_params["k8s_cleanup_job"]
         delete_service(service, k8s_cleanup_job, job_failed)
 
@@ -903,32 +926,48 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         k8s_job_prefix = self.__produce_k8s_job_prefix()
         k8s_job_name = f"{k8s_job_prefix}-{self.__force_label_conformity(job_wrapper.get_id_tag())}"
         log.debug(f"Deleting service/ingress for job with ID {job_wrapper.get_id_tag()}")
-        job_failed = k8s_job.obj["status"]["failed"] > 0 if "failed" in k8s_job.obj["status"] else False
         ingress_to_delete = find_ingress_object_by_name(
             self._pykube_api, k8s_job_name, self.runner_params["k8s_namespace"]
         )
         if ingress_to_delete and len(ingress_to_delete.response["items"]) > 0:
             k8s_ingress = Ingress(self._pykube_api, ingress_to_delete.response["items"][0])
-            self.__cleanup_k8s_ingress(k8s_ingress, job_failed)
+            self.__cleanup_k8s_ingress(k8s_ingress)
+        else:
+            log.debug(f"No ingress found for job with k8s_job_name {k8s_job_name}")
         service_to_delete = find_service_object_by_name(
             self._pykube_api, k8s_job_name, self.runner_params["k8s_namespace"]
         )
         if service_to_delete and len(service_to_delete.response["items"]) > 0:
             k8s_service = Service(self._pykube_api, service_to_delete.response["items"][0])
-            self.__cleanup_k8s_service(k8s_service, job_failed)
+            self.__cleanup_k8s_service(k8s_service)
+        else:
+            log.debug(f"No service found for job with k8s_job_name {k8s_job_name}")
+        # remove the interactive environment entrypoints
+        eps = job_wrapper.get_job().interactivetool_entry_points
+        if eps:
+            log.debug(f"Removing entry points for job with ID {job_wrapper.get_id_tag()}")
+            self.app.interactivetool_manager.remove_entry_points(eps)
 
     def stop_job(self, job_wrapper):
         """Attempts to delete a dispatched job to the k8s cluster"""
         job = job_wrapper.get_job()
         try:
+            log.debug(f"Attempting to stop job {job.id} ({job.job_runner_external_id})")
             job_to_delete = find_job_object_by_name(
                 self._pykube_api, job.get_job_runner_external_id(), self.runner_params["k8s_namespace"]
             )
             if job_to_delete and len(job_to_delete.response["items"]) > 0:
                 k8s_job = Job(self._pykube_api, job_to_delete.response["items"][0])
+                log.debug(f"Found job with id {job.get_job_runner_external_id()} to delete")
+                # For interactive jobs, at this point because the job stopping has been partly handled by the
+                # interactive tool manager, the job wrapper no longer shows any guest ports. We need another way
+                # to check if the job is an interactive job.
                 if self.__has_guest_ports(job_wrapper):
+                    log.debug(f"Job {job.id} ({job.job_runner_external_id}) has guest ports, cleaning them up")
                     self.__cleanup_k8s_guest_ports(job_wrapper, k8s_job)
                 self.__cleanup_k8s_job(k8s_job)
+            else:
+                log.debug(f"Could not find job with id {job.get_job_runner_external_id()} to delete")
             # TODO assert whether job parallelism == 0
             # assert not job_to_delete.exists(), "Could not delete job,"+job.job_runner_external_id+" it still exists"
             log.debug(f"({job.id}/{job.job_runner_external_id}) Terminated at user's request")
@@ -972,6 +1011,75 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             ajs.old_state = model.Job.states.QUEUED
             ajs.running = False
             self.monitor_queue.put(ajs)
+
+    # added to make sure that stdout and stderr is captured for Kubernetes
+    def fail_job(self, job_state: "JobState", exception=False, message="Job failed", full_status=None):
+        log.debug("PP Getting into fail_job in k8s runner")
+        job = job_state.job_wrapper.get_job()
+        
+        #### Get STDOUT and STDERR from the job and tool to be stored in the database ####
+        #### This is needed because when calling finish_job on a failed job, the check_output method
+        #### overrides the job error state and tries to figure it out from the job output files
+        #### breaking OOM resubmissions.
+        # To ensure that files below are readable, ownership must be reclaimed first
+        job_state.job_wrapper.reclaim_ownership()
+
+        # wait for the files to appear
+        which_try = 0
+        while which_try < self.app.config.retry_job_output_collection + 1:
+            try:
+                with open(job_state.output_file, "rb") as stdout_file, open(job_state.error_file, "rb") as stderr_file:
+                    job_stdout = self._job_io_for_db(stdout_file)
+                    job_stderr = self._job_io_for_db(stderr_file)
+                break
+            except Exception as e:
+                if which_try == self.app.config.retry_job_output_collection:
+                    job_stdout = ""
+                    job_stderr = job_state.runner_states.JOB_OUTPUT_NOT_RETURNED_FROM_CLUSTER
+                    log.error(f"{job.id}/{job.job_runner_external_id} {job_stderr}: {unicodify(e)}")
+                else:
+                    time.sleep(1)
+                which_try += 1
+
+        # get stderr and stdout to database
+        outputs_directory = os.path.join(job_state.job_wrapper.working_directory, "outputs")
+        if not os.path.exists(outputs_directory):
+            outputs_directory = job_state.job_wrapper.working_directory
+
+        tool_stdout_path = os.path.join(outputs_directory, "tool_stdout")
+        tool_stderr_path = os.path.join(outputs_directory, "tool_stderr")
+        
+        # TODO: These might not exist for running jobs at the upgrade to 19.XX, remove that
+        # assumption in 20.XX.
+        tool_stderr = None
+        if os.path.exists(tool_stdout_path):
+            with open(tool_stdout_path, "rb") as stdout_file:
+                tool_stdout = self._job_io_for_db(stdout_file)
+        else:
+            # Legacy job, were getting a merged output - assume it is mostly tool output.
+            tool_stdout = job_stdout
+            job_stdout = None
+
+        tool_stdout = None
+        if os.path.exists(tool_stderr_path):
+            with open(tool_stderr_path, "rb") as stdout_file:
+                tool_stderr = self._job_io_for_db(stdout_file)
+        else:
+            # Legacy job, were getting a merged output - assume it is mostly tool output.
+            tool_stderr = job_stderr
+            job_stderr = None
+
+        #### END Get STDOUT and STDERR from the job and tool to be stored in the database ####
+
+        # full status empty leaves the UI without stderr/stdout
+        full_status = { "stderr" : tool_stderr, "stdout" : tool_stdout}
+        log.debug(f"({job.id}/{job.job_runner_external_id}) tool_stdout: {tool_stdout}")
+        log.debug(f"({job.id}/{job.job_runner_external_id}) tool_stderr: {tool_stderr}")
+        log.debug(f"({job.id}/{job.job_runner_external_id}) job_stdout: {job_stdout}")
+        log.debug(f"({job.id}/{job.job_runner_external_id}) job_stderr: {job_stderr}")
+
+        # run super method
+        super().fail_job(job_state, exception, message, full_status)
         
 
     def finish_job(self, job_state):

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -243,8 +243,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         k8s_ingress_obj = ingress_object_dict(self.runner_params, k8s_job_name, self.__get_k8s_ingress_spec(ajs))
         # pretty print the objects for debugging
-        log.debug(f"Kubernetes service object: {json.dumps(k8s_service_obj, indent=4)}")
-        log.debug(f"Kubernetes ingress object: {json.dumps(k8s_ingress_obj, indent=4)}")
+        log.trace(f"Kubernetes service object: {json.dumps(k8s_service_obj, indent=4)}")
+        log.trace(f"Kubernetes ingress object: {json.dumps(k8s_ingress_obj, indent=4)}")
         # We avoid creating service and ingress if they already exist (e.g. when Galaxy is restarted or resubmitting a job)
         service = Service(self._pykube_api, k8s_service_obj)
         service.create()

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -3,7 +3,7 @@ Offload jobs to a Kubernetes cluster.
 """
 
 import logging
-import json # for debugging of API objects
+import json  # for debugging of API objects
 import math
 import os
 import re
@@ -100,8 +100,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 map=str, valid=lambda s: s == "$gid" or isinstance(s, int) or not s or s.isdigit(), default=None
             ),
             k8s_cleanup_job=dict(map=str, valid=lambda s: s in {"onsuccess", "always", "never"}, default="always"),
-            k8s_pod_retries=dict(map=int, valid=lambda x: int(x) >= 0, default=1), # note that if the backOffLimit is lower, this paramer will have no effect.
-            k8s_job_spec_back_off_limit=dict(map=int, valid=lambda x: int(x) >= 0, default=0), # this means that it will stop retrying after 1 failure.
+            k8s_pod_retries=dict(map=int, valid=lambda x: int(x) >= 0, default=1),  # note that if the backOffLimit is lower, this paramer will have no effect.
+            k8s_job_spec_back_off_limit=dict(map=int, valid=lambda x: int(x) >= 0, default=0),  # this means that it will stop retrying after 1 failure.
             k8s_walltime_limit=dict(map=int, valid=lambda x: int(x) >= 0, default=172800),
             k8s_unschedulable_walltime_limit=dict(map=int, valid=lambda x: not x or int(x) >= 0, default=None),
             k8s_interactivetools_use_ssl=dict(map=bool, default=False),
@@ -468,26 +468,26 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             },
             "spec": {
                 "ingressClassName": "nginx",
-                "rules":[ {
-                                "host": ep["domain"],
-                                "http": {
-                                    "paths": [ {
-                                                    "backend": {
-                                                            "service":  {
-                                                                "name": self.__get_k8s_job_name(
-                                                                    self.__produce_k8s_job_prefix(), ajs.job_wrapper
-                                                                ),
-                                                                "port": { "number": int(ep["tool_port"])}
-                                                            }
-                                                    },
-                                                    "path": ep.get("entry_path", "/"),
-                                                    "pathType": "Prefix"
-                                                }
-                                            ]
-                                        },
+                "rules": [ {
+                            "host": ep["domain"],
+                            "http": {
+                                "paths": [ {
+                                                "backend": {
+                                                        "service": {
+                                                            "name": self.__get_k8s_job_name(
+                                                                self.__produce_k8s_job_prefix(), ajs.job_wrapper
+                                                            ),
+                                                            "port": { "number": int(ep["tool_port"])}
+                                                        }
+                                                },
+                                                "path": ep.get("entry_path", "/"),
+                                                "pathType": "Prefix"
+                                            }
+                                        ]
+                                    },
                             }
                             for ep in entry_points
-                        ]
+                         ]
             },
         }
         if self.runner_params.get("k8s_interactivetools_use_ssl"):
@@ -1007,11 +1007,11 @@ class KubernetesJobRunner(AsynchronousJobRunner):
     def fail_job(self, job_state: "JobState", exception=False, message="Job failed", full_status=None):
         log.debug("PP Getting into fail_job in k8s runner")
         job = job_state.job_wrapper.get_job()
-        
-        #### Get STDOUT and STDERR from the job and tool to be stored in the database ####
-        #### This is needed because when calling finish_job on a failed job, the check_output method
-        #### overrides the job error state and tries to figure it out from the job output files
-        #### breaking OOM resubmissions.
+
+        # Get STDOUT and STDERR from the job and tool to be stored in the database #
+        # This is needed because when calling finish_job on a failed job, the check_output method
+        # overrides the job error state and tries to figure it out from the job output files
+        # breaking OOM resubmissions.
         # To ensure that files below are readable, ownership must be reclaimed first
         job_state.job_wrapper.reclaim_ownership()
 
@@ -1039,7 +1039,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         tool_stdout_path = os.path.join(outputs_directory, "tool_stdout")
         tool_stderr_path = os.path.join(outputs_directory, "tool_stderr")
-        
+
         # TODO: These might not exist for running jobs at the upgrade to 19.XX, remove that
         # assumption in 20.XX.
         tool_stderr = "Galaxy issue: stderr could not be retrieved from the job working directory."
@@ -1060,10 +1060,10 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             tool_stderr = job_stderr
             job_stderr = None
 
-        #### END Get STDOUT and STDERR from the job and tool to be stored in the database ####
+        # END Get STDOUT and STDERR from the job and tool to be stored in the database #
 
         # full status empty leaves the UI without stderr/stdout
-        full_status = { "stderr" : tool_stderr, "stdout" : tool_stdout}
+        full_status = {"stderr" : tool_stderr, "stdout" : tool_stdout}
         log.debug(f"({job.id}/{job.job_runner_external_id}) tool_stdout: {tool_stdout}")
         log.debug(f"({job.id}/{job.job_runner_external_id}) tool_stderr: {tool_stderr}")
         log.debug(f"({job.id}/{job.job_runner_external_id}) job_stdout: {job_stdout}")
@@ -1071,7 +1071,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         # run super method
         super().fail_job(job_state, exception, message, full_status)
-        
 
     def finish_job(self, job_state):
         self._handle_metadata_externally(job_state.job_wrapper, resolve_requirements=True)

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -108,6 +108,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_unschedulable_walltime_limit=dict(map=int, valid=lambda x: not x or int(x) >= 0, default=None),
             k8s_interactivetools_use_ssl=dict(map=bool, default=False),
             k8s_interactivetools_ingress_annotations=dict(map=str),
+            k8s_interactivetools_ingress_class=dict(map=str, default=None),
         )
 
         if "runner_param_specs" not in kwargs:
@@ -471,7 +472,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 "annotations": {"app.galaxyproject.org/tool_id": ajs.job_wrapper.tool.id},
             },
             "spec": {
-                "ingressClassName": "nginx",
                 "rules": [
                     {
                         "host": ep["domain"],
@@ -496,6 +496,9 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 ],
             },
         }
+        default_ingress_class = self.runner_params.get("k8s_interactivetools_ingress_class")
+        if default_ingress_class:
+            k8s_spec_template["spec"]["ingressClassName"] = default_ingress_class
         if self.runner_params.get("k8s_interactivetools_use_ssl"):
             domains = list({e["domain"] for e in entry_points})
             k8s_spec_template["spec"]["tls"] = [

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 
 DEFAULT_JOB_API_VERSION = "batch/v1"
 DEFAULT_SERVICE_API_VERSION = "v1"
-DEFAULT_INGRESS_API_VERSION = "extensions/v1beta1"
+DEFAULT_INGRESS_API_VERSION = "networking.k8s.io/v1"
 DEFAULT_NAMESPACE = "default"
 INSTANCE_ID_INVALID_MESSAGE = (
     "Galaxy instance [%s] is either too long "


### PR DESCRIPTION
This PR brings working resubmissions to the k8s runner (largely inspired in the LSF cli runner where I have used resubmissions for many years), plus a few additional changes:

- [x] Correctly detects OOM and labels jobs.
- [x] For the above to happen, the k8s cluster and the runner had to be made aware again that the job had failed. For some years, the k8s runner was made to detect every single job as a success, and then some other Galaxy process outside decided if this was actually a successful or failed job.
- [x] Introduces the usage of job_spec_backoff_limit, so that the runner doesn't blindly resubmit directly any jobs and that can be delegated with more confidence to the Galaxy resubmission handler. In time, the pod retrials variable and its usage should be deprecated, to simplify the runner's logic.
- [x] corrects the empty stdout and stderr of failed jobs. Currently, failed jobs that are detected by the runner and not the external galaxy setup are missing stdout and stderr. This should be somehow consumed from the job files for the tool stderr and tool stdout.
- [x]  Move to pykube-ng
- [x] Change ingress versions and modify creation dictionaries to fit newer version.
- [x] Test that interactive tools work correctly.
- [x] Interactive tools also work with resubmissions.

This solution both avoids extra API calls to the k8s masters (desirable in scenarios with many jobs) and reduces any chances of extra pods being sent to run.

Takes care of #15118

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

Please let me know where I should add testing for the resubmission capability, and what I can reuse from tests of this capability in other runners.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
