### PR TITLE
Refine scroll behavior, avoid redundant refresh requests

### DIFF
--- a/client/src/components/History/Layout/ListingLayout.vue
+++ b/client/src/components/History/Layout/ListingLayout.vue
@@ -37,8 +37,6 @@ export default {
     data() {
         return {
             previousStart: undefined,
-            throttlePeriod: 20,
-            deltaMax: 20,
         };
     },
     watch: {
@@ -46,34 +44,7 @@ export default {
             this.$refs.listing.scrollToOffset(0);
         },
     },
-    created() {
-        this.onScrollThrottle = throttle((event) => {
-            this.onScroll(event);
-        }, this.throttlePeriod);
-    },
     methods: {
-        onScrollHandler(event) {
-            /* CURRENTLY UNUSED
-            // this avoids diagonal scrolling, we either scroll left/right or top/down
-            // both events are throttled and the default handler has been prevented.
-            if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
-                // handle vertical scrolling with virtual scroller
-                const listing = this.$refs.listing;
-                const deltaMax = this.deltaMax;
-                const deltaY = Math.max(Math.min(event.deltaY, deltaMax), -deltaMax);
-                this.offset = Math.max(0, listing.getOffset() + deltaY);
-                this.$refs.listing.scrollToOffset(this.offset);
-            } else {
-                // dispatch horizontal scrolling as regular event
-                var wheelEvent = new WheelEvent("wheel", {
-                    deltaX: event.deltaX,
-                    bubbles: true,
-                    cancelable: false,
-                });
-                event.target.dispatchEvent(wheelEvent);
-            }
-            */
-        },
         onScroll() {
             const rangeStart = this.$refs.listing.range.start;
             if (this.previousStart !== rangeStart) {

--- a/client/src/components/History/Layout/ListingLayout.vue
+++ b/client/src/components/History/Layout/ListingLayout.vue
@@ -36,6 +36,7 @@ export default {
     },
     data() {
         return {
+            previousStart: undefined,
             throttlePeriod: 20,
             deltaMax: 20,
         };
@@ -75,7 +76,10 @@ export default {
         },
         onScroll() {
             const rangeStart = this.$refs.listing.range.start;
-            this.$emit("scroll", rangeStart);
+            if (this.previousStart !== rangeStart) {
+                this.previousStart = rangeStart;
+                this.$emit("scroll", rangeStart);
+            }
         },
         getOffset() {
             return this.$refs.listing?.getOffset() || 0;

--- a/client/src/components/History/Layout/ListingLayout.vue
+++ b/client/src/components/History/Layout/ListingLayout.vue
@@ -20,7 +20,6 @@
 </template>
 <script>
 import VirtualList from "vue-virtual-scroll-list";
-import { throttle } from "lodash";
 import LoadingSpan from "components/LoadingSpan";
 
 export default {


### PR DESCRIPTION
This PR avoids the emission of redundant refresh requests, which previously lead to a small number of additional server requests, but to a large number of ui refresh requests. This improves scrolling behavior, which should be smoother now, particularly when using the `wheel`. It does not resolve all scrolling issues when using the `wheel` events but it's a step forward.

To verify this, I logged scroll event emissions, before this PR:
<img width="400" alt="image" src="https://user-images.githubusercontent.com/2105447/208771435-13343be6-cf52-4998-b0c3-1e77f45bd03f.png">

Although our `promise-queue` does prevent most of these requests to result in actual server requests, there is still some redundancy which can lead to unnecessarily refreshing ui elements. This also points to potential opportunities for additional improvements in follow-ups. We could e.g. ensure that requests are made with offsets binned to sizes of tens, or hundreds, and then avoid requests altogether within the store if a request has already been made previously.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
