### PR TITLE
Add wiff2 composite/tar datatypes

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -296,6 +296,7 @@
     <datatype extension="agilentmasshunter.d.tar" type="galaxy.datatypes.binary:MassHunterTar" display_in_upload="true"/>
     <datatype extension="watersmasslynx.raw.tar" type="galaxy.datatypes.binary:MassLynxTar" display_in_upload="true"/>
     <datatype extension="wiff.tar" type="galaxy.datatypes.binary:WiffTar" display_in_upload="true"/>
+    <datatype extension="wiff2.tar" type="galaxy.datatypes.binary:Wiff2Tar" display_in_upload="true"/>
     <datatype extension="mascotxml" type="galaxy.datatypes.proteomics:MascotXML" mimetype="application/xml" display_in_upload="true"/>
     <datatype extension="mztab" type="galaxy.datatypes.proteomics:MzTab" display_in_upload="true"/>
     <datatype extension="mztab2" type="galaxy.datatypes.proteomics:MzTab2" display_in_upload="true"/>
@@ -305,6 +306,7 @@
     <datatype extension="bref3" type="galaxy.datatypes.binary:Bref3" display_in_upload="true" description="Bref3 format is a binary format for storing phased, non-missing genotypes for a list of samples. More information in https://faculty.washington.edu/browning/beagle/bref3.14May18.pdf" />
     <datatype extension="mgf" type="galaxy.datatypes.proteomics:Mgf" display_in_upload="true"/>
     <datatype extension="wiff" type="galaxy.datatypes.proteomics:Wiff" display_in_upload="true"/>
+    <datatype extension="wiff2" type="galaxy.datatypes.proteomics:Wiff2" display_in_upload="true"/>
     <datatype extension="mzxml" type="galaxy.datatypes.proteomics:MzXML" mimetype="application/xml" display_in_upload="true"/>
     <datatype extension="mzdata" type="galaxy.datatypes.proteomics:MzData" mimetype="application/xml" display_in_upload="true"/>
     <datatype extension="ms2" type="galaxy.datatypes.proteomics:Ms2" display_in_upload="true"/>

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -4002,6 +4002,34 @@ class WiffTar(BafTar):
         return "Sciex WIFF/SCAN archive"
 
 
+class Wiff2Tar(BafTar):
+    """
+    A tar'd up .wiff2/.scan pair containing Sciex WIFF format data
+
+    >>> from galaxy.datatypes.sniff import get_test_fname
+    >>> fname = get_test_fname('some.wiff2.tar')
+    >>> Wiff2Tar().sniff(fname)
+    True
+    >>> fname = get_test_fname('brukerbaf.d.tar')
+    >>> Wiff2Tar().sniff(fname)
+    False
+    >>> fname = get_test_fname('test.fast5.tar')
+    >>> Wiff2Tar().sniff(fname)
+    False
+    """
+
+    file_ext = "wiff2.tar"
+
+    def sniff(self, filename: str) -> bool:
+        if tarfile.is_tarfile(filename):
+            with tarfile.open(filename) as rawtar:
+                return ".wiff2" in [os.path.splitext(os.path.basename(f).lower())[1] for f in rawtar.getnames()]
+        return False
+
+    def get_type(self) -> str:
+        return "Sciex WIFF2/SCAN archive"
+
+
 @build_sniff_from_prefix
 class Pretext(Binary):
     """

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -75,6 +75,47 @@ class Wiff(Binary):
         rval.append("</ul></div></html>")
         return "\n".join(rval)
 
+class Wiff2(Binary):
+    """Class for wiff2 files."""
+
+    edam_data = "data_2536"
+    edam_format = "format_3710"
+    file_ext = "wiff2"
+    composite_type = "auto_primary_file"
+
+    def __init__(self, **kwd):
+        super().__init__(**kwd)
+
+        self.add_composite_file(
+            "wiff2",
+            description="AB SCIEX files in .wiff2 format. This can contain all needed information or only metadata.",
+            is_binary=True,
+        )
+
+        self.add_composite_file(
+            "wiff_scan",
+            description="AB SCIEX spectra file (wiff.scan), if the corresponding .wiff2 file only contains metadata.",
+            optional="True",
+            is_binary=True,
+        )
+
+    def generate_primary_file(self, dataset: GeneratePrimaryFileDataset) -> str:
+        rval = ["<html><head><title>Wiff2 Composite Dataset </title></head><p/>"]
+        rval.append("<div>This composite dataset is composed of the following files:<p/><ul>")
+        for composite_name, composite_file in self.get_composite_files(dataset=dataset).items():
+            fn = composite_name
+            opt_text = ""
+            if composite_file.optional:
+                opt_text = " (optional)"
+            if composite_file.get("description"):
+                rval.append(
+                    f"<li><a href=\"{fn}\" type=\"text/plain\">{fn} ({composite_file.get('description')})</a>{opt_text}</li>"
+                )
+            else:
+                rval.append(f'<li><a href="{fn}" type="text/plain">{fn}</a>{opt_text}</li>')
+        rval.append("</ul></div></html>")
+        return "\n".join(rval)
+
 
 @build_sniff_from_prefix
 class MzTab(Text):

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -75,6 +75,7 @@ class Wiff(Binary):
         rval.append("</ul></div></html>")
         return "\n".join(rval)
 
+
 class Wiff2(Binary):
     """Class for wiff2 files."""
 


### PR DESCRIPTION
Resolves https://github.com/galaxyproject/galaxy/issues/15230 by adding `wiff2` and `wiff2.tar` datatypes (basically a clone of existing `wiff` datatypes).