### PR TITLE
Apply all linters to data managers (which are applied to tools)

### DIFF
--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -46,6 +46,7 @@ In order to use this.
 
 import inspect
 from enum import IntEnum
+import logging
 from typing import (
     Callable,
     List,
@@ -60,6 +61,8 @@ from galaxy.util import (
     etree,
     submodules,
 )
+
+log = logging.getLogger(__name__)
 
 
 class LintLevel(IntEnum):
@@ -323,7 +326,7 @@ def lint_tool_source_with(lint_context, tool_source, extra_modules=None) -> Lint
     linter_modules = submodules.import_submodules(galaxy.tool_util.linters)
     linter_modules.extend(extra_modules)
     for module in linter_modules:
-        lint_tool_types = getattr(module, "lint_tool_types", ["default"])
+        lint_tool_types = getattr(module, "lint_tool_types", ["default", "manage_data"])
         if not ("*" in lint_tool_types or tool_type in lint_tool_types):
             continue
 

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -46,7 +46,6 @@ In order to use this.
 
 import inspect
 from enum import IntEnum
-import logging
 from typing import (
     Callable,
     List,
@@ -61,8 +60,6 @@ from galaxy.util import (
     etree,
     submodules,
 )
-
-log = logging.getLogger(__name__)
 
 
 class LintLevel(IntEnum):

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1619,6 +1619,37 @@ def test_xml_order(lint_ctx):
     assert not lint_ctx.error_messages
 
 
+DATA_MANAGER = """<tool id="test_dm" name="test dm" version="1" type="manage_data">
+    <inputs>
+        <param name="select" type="select">
+            <option value="a">a</option>
+            <option value="a">a</option>
+        </param>
+    </inputs>
+</tool>
+"""
+
+
+def test_data_manager(lint_ctx_xpath, lint_ctx):
+    """
+    test that all (not really testing 'all', but more than the general linter
+    which was the only one applied to data managers until 23.0) linters are applied
+    """
+    tool_xml = get_xml_tool_source(DATA_MANAGER)
+    tool_source = XmlToolSource(tool_xml)
+    lint_tool_source_with(lint_ctx, tool_source)
+    assert "No tests found, most tools should define test cases." in lint_ctx.warn_messages
+    assert "Tool contains no outputs section, most tools should produce outputs." in lint_ctx.warn_messages
+    assert "No help section found, consider adding a help section to your tool." in lint_ctx.warn_messages
+    assert "No citations found, consider adding citations to your tool." in lint_ctx.warn_messages
+    assert "Select parameter [select] has multiple options with the same text content" in lint_ctx.error_messages
+    assert "Select parameter [select] has multiple options with the same value" in lint_ctx.error_messages
+    assert "No command tag found, must specify a command template to execute." in lint_ctx.error_messages
+    assert lint_ctx.valid_messages
+    assert len(lint_ctx.warn_messages) == 4
+    assert len(lint_ctx.error_messages) == 3
+
+
 COMPLETE = """<tool>
     <macros>
         <import>macros.xml</import>


### PR DESCRIPTION
so far only the general linter was applied to data managers. I see no reason why the other linters that run on tools should not run on data managers

Alternatively, we can add selectively `lint_tool_types` to certain modules...

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
