### PR TITLE
Fix ``test_mulled_build_files_cli`` mulled unit test

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -49,7 +49,7 @@ local conda_bin = VAR.CONDA_BIN
 
 local singularity_image = VAR.SINGULARITY_IMAGE
 if singularity_image == '' then
-    singularity_image = 'quay.io/biocontainers/singularity:2.4.6--0'
+    singularity_image = 'quay.io/singularity/singularity:v3.10.4'
 end
 
 local singularity_image_dir = VAR.SINGULARITY_IMAGE_DIR

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -1,3 +1,5 @@
+import os.path
+
 import pytest
 
 from galaxy.tool_util.deps.mulled.mulled_build import (
@@ -6,6 +8,7 @@ from galaxy.tool_util.deps.mulled.mulled_build import (
     CondaInDockerContext,
     DEFAULT_BASE_IMAGE,
     DEFAULT_EXTENDED_BASE_IMAGE,
+    InvolucroContext,
     mull_targets,
     target_str_to_targets,
 )
@@ -32,8 +35,10 @@ def test_base_image_for_targets(target, version, base_image):
 def test_mulled_build_files_cli(use_mamba, tmpdir):
     singularity_image_dir = tmpdir.mkdir("singularity image dir")
     target = build_target("zlib")
+    involucro_context = InvolucroContext(involucro_bin=os.path.join(tmpdir, "involucro"))
     mull_targets(
         [target],
+        involucro_context=involucro_context,
         command="build-and-test",
         singularity=True,
         use_mamba=use_mamba,


### PR DESCRIPTION
by updating the Singularity Docker image used by involucro.

Also:
- Download involucro in a temporary directory in unit tests instead of the current working directory.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
