### PR TITLE
[WIP] Attempt to fix transiently failing selenium test for paired uploads

### DIFF
--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -161,9 +161,10 @@ class TestUploads(SeleniumTestCase, UsesHistoryItemAssertions):
         self.upload_paired_list(
             [self.get_filename("1.tabular"), self.get_filename("2.tabular")], name="Test Paired List"
         )
-        self.history_panel_wait_for_hid_ok(3)
         # Make sure modals disappeared - both collection creator (TODO: upload).
+        self.sleep_for(self.wait_types.UX_RENDER)
         self.wait_for_selector_absent_or_hidden(".collection-creator")
+        self.history_panel_wait_for_hid_ok(3)
         self.assert_item_name(3, "Test Paired List")
 
         # Make sure source items are hidden when the collection is created.


### PR DESCRIPTION
This test consistently passes locally but fails when executed automatically in the repository. Experimenting here to narrow the issue down.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
