### PR TITLE
[22.05] Fixes #15224 - tools token are created with a size of 10 chars when interactivetools_shorten_url is true

### DIFF
--- a/lib/galaxy/managers/interactivetool.py
+++ b/lib/galaxy/managers/interactivetool.py
@@ -163,6 +163,7 @@ class InteractiveToolManager:
                 entry_url=entry["url"],
                 name=entry["name"],
                 requires_domain=entry["requires_domain"],
+                short_token=self.app.config.interactivetools_shorten_url,
             )
             self.sa_session.add(ep)
         if flush:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2340,12 +2340,15 @@ class InteractiveToolEntryPoint(Base, Dictifiable, RepresentById):
     dict_collection_visible_keys = ["id", "name", "active", "created_time", "modified_time"]
     dict_element_visible_keys = ["id", "name", "active", "created_time", "modified_time"]
 
-    def __init__(self, requires_domain=True, configured=False, deleted=False, **kwd):
+    def __init__(self, requires_domain=True, configured=False, deleted=False, short_token=False, **kwd):
         super().__init__(**kwd)
         self.requires_domain = requires_domain
         self.configured = configured
         self.deleted = deleted
-        self.token = self.token or uuid4().hex
+        if short_token:
+            self.token = (self.token or uuid4().hex)[:10]
+        else:
+            self.token = self.token or uuid4().hex
         self.info = self.info or {}
 
     @property

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -147,6 +147,14 @@ class InteractiveToolsPulsarIntegrationTestCase(BaseInteractiveToolsIntegrationT
         disable_dependency_resolution(config)
 
 
+class InteractiveToolsShortURLIntegrationTestCase(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["interactivetools_shorten_url"] = True
+        config["job_config_file"] = DOCKERIZED_JOB_CONFIG_FILE
+
+
 class InteractiveToolsRemoteProxyIntegrationTestCase(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
     """
     $ cd gx-it-proxy


### PR DESCRIPTION
Strips token for interactive tools to 10 chars when the option interactivetools_shorten_url is true and add tests to check it works.
This should fix #15224 .

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
