### PR TITLE
Fix form builder in admin panel

### DIFF
--- a/client/src/mvc/ui/ui-misc.js
+++ b/client/src/mvc/ui/ui-misc.js
@@ -247,12 +247,14 @@ export var Upload = Backbone.View.extend({
         return this;
     },
     _readFile: function (e) {
-        var self = this;
         var file = e.target.files && e.target.files[0];
         if (file) {
             var reader = new FileReader();
-            reader.onload = function () {
-                self.model.set({ wait: false, value: this.result });
+            reader.onload = () => {
+                this.model.set({ wait: false, value: reader.result });
+                if (this.model.get("onchange")) {
+                    this.model.get("onchange")(this.value());
+                }
             };
             this.model.set({ wait: true, value: null });
             reader.readAsText(file);

--- a/lib/galaxy/webapps/galaxy/controllers/forms.py
+++ b/lib/galaxy/webapps/galaxy/controllers/forms.py
@@ -1,4 +1,5 @@
 import copy
+import csv
 import logging
 import re
 
@@ -140,16 +141,18 @@ class Forms(BaseUIController):
             index = 0
             if csv_file:
                 lines = csv_file.splitlines()
-                for line in lines:
-                    row = line.split(",")
+                rows = csv.reader(lines)
+                for row in rows:
                     if len(row) >= 6:
+                        for column in range(len(row)):
+                            row[column] = str(row[column]).strip('\"')
                         prefix = "fields_%i|" % index
                         payload[f"{prefix}name"] = "%i_imported_field" % (index + 1)
                         payload[f"{prefix}label"] = row[0]
                         payload[f"{prefix}helptext"] = row[1]
                         payload[f"{prefix}type"] = row[2]
                         payload[f"{prefix}default"] = row[3]
-                        payload[f"{prefix}selectlist"] = row[4].split(",")
+                        payload[f"{prefix}selectlist"] = row[4]
                         payload[f"{prefix}required"] = row[5].lower() == "true"
                     index = index + 1
             new_form, message = self.save_form_definition(trans, None, payload)
@@ -245,7 +248,6 @@ class Forms(BaseUIController):
                 field_attributes = ["name", "label", "helptext", "required", "type", "selectlist", "default"]
                 field_dict = {attr: payload.get(f"{prefix}{attr}") for attr in field_attributes}
                 field_dict["visible"] = True
-                field_dict["required"] = field_dict["required"] == "true"
                 if isinstance(field_dict["selectlist"], str):
                     field_dict["selectlist"] = field_dict["selectlist"].split(",")
                 else:

--- a/lib/galaxy/webapps/galaxy/controllers/forms.py
+++ b/lib/galaxy/webapps/galaxy/controllers/forms.py
@@ -200,7 +200,7 @@ class Forms(BaseUIController):
                     {
                         "name": "type",
                         "type": "select",
-                        "options": [("None", "none")] + [(ft[1], ft[1]) for ft in fd_types],
+                        "options": [(ft[1], ft[1]) for ft in fd_types],
                         "label": "Type",
                         "value": latest_form.type,
                     },

--- a/lib/galaxy/webapps/galaxy/controllers/forms.py
+++ b/lib/galaxy/webapps/galaxy/controllers/forms.py
@@ -123,7 +123,7 @@ class Forms(BaseUIController):
                     {
                         "name": "type",
                         "type": "select",
-                        "options": [("None", "none")] + [(ft[1], ft[1]) for ft in fd_types],
+                        "options": [(ft[1], ft[1]) for ft in fd_types],
                         "label": "Type",
                     },
                     {

--- a/lib/galaxy/webapps/galaxy/controllers/forms.py
+++ b/lib/galaxy/webapps/galaxy/controllers/forms.py
@@ -145,7 +145,7 @@ class Forms(BaseUIController):
                 for row in rows:
                     if len(row) >= 6:
                         for column in range(len(row)):
-                            row[column] = str(row[column]).strip('\"')
+                            row[column] = str(row[column]).strip('"')
                         prefix = "fields_%i|" % index
                         payload[f"{prefix}name"] = "%i_imported_field" % (index + 1)
                         payload[f"{prefix}label"] = row[0]
@@ -172,9 +172,7 @@ class Forms(BaseUIController):
         latest_form = form.latest_form
         if trans.request.method == "GET":
             fd_types = sorted(trans.app.model.FormDefinition.types.__members__.items())
-            ff_types = [
-                (t.__name__, t.__name__) for t in trans.model.FormDefinition.supported_field_types
-            ]
+            ff_types = [(t.__name__, t.__name__) for t in trans.model.FormDefinition.supported_field_types]
             field_cache = []
             field_inputs = [
                 {

--- a/lib/galaxy/webapps/galaxy/controllers/forms.py
+++ b/lib/galaxy/webapps/galaxy/controllers/forms.py
@@ -173,7 +173,7 @@ class Forms(BaseUIController):
         if trans.request.method == "GET":
             fd_types = sorted(trans.app.model.FormDefinition.types.__members__.items())
             ff_types = [
-                (t.__name__.replace("Field", ""), t.__name__) for t in trans.model.FormDefinition.supported_field_types
+                (t.__name__, t.__name__) for t in trans.model.FormDefinition.supported_field_types
             ]
             field_cache = []
             field_inputs = [

--- a/lib/galaxy/webapps/galaxy/controllers/forms.py
+++ b/lib/galaxy/webapps/galaxy/controllers/forms.py
@@ -130,6 +130,7 @@ class Forms(BaseUIController):
                         "label": "Import from CSV",
                         "type": "upload",
                         "help": "Import fields from CSV-file with the following format: Label, Help, Type, Value, Options, Required=True/False.",
+                        "optional": True,
                     },
                 ],
             }
@@ -188,7 +189,7 @@ class Forms(BaseUIController):
                     "label": "Options",
                     "help": "*Only for fields which allow multiple selections, provide comma-separated values.",
                 },
-                {"name": "required", "label": "Required", "type": "boolean"},
+                {"name": "required", "label": "Required", "type": "boolean", "value": False},
             ]
             form_dict = {
                 "title": "Edit form for '%s'" % (util.sanitize_text(latest_form.name)),

--- a/lib/galaxy/webapps/galaxy/controllers/forms.py
+++ b/lib/galaxy/webapps/galaxy/controllers/forms.py
@@ -281,7 +281,7 @@ class Forms(BaseUIController):
             desc=current_form["desc"],
             fields=current_form["fields"],
             form_definition_current=None,
-            form_type=current_form["type"],
+            type=current_form["type"],
             layout=current_form["layout"],
         )
         # save changes to the existing form


### PR DESCRIPTION
Fixes: #15269. The form builder in the admin panel is not a frequently used feature. Recently it had several issues and was not working properly. Unfortunately, it is not covered by current tests, it is not a lot of code, but probably needs to be refactored before it can be properly tested as an `api`. For now, this PR restores its functionality. The form builder allows uploading a csv file describing the form inputs, here is the example: [formbuilder_demo.csv](https://github.com/galaxyproject/galaxy/files/10340284/formbuilder_demo.csv), and here is demo screencast on how the form builder works.

https://user-images.githubusercontent.com/2105447/210455596-198166d8-72de-4131-a0a6-43f780ef8eaa.mov

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
