### PR TITLE
entrypoints - use timeout instead of interval to prevent stacking requests

### DIFF
--- a/client/src/stores/entryPointStore.js
+++ b/client/src/stores/entryPointStore.js
@@ -7,7 +7,7 @@ import isEqual from "lodash.isequal";
 export const useEntryPointStore = defineStore("entryPointStore", {
     state: () => ({
         entryPoints: [],
-        interval: undefined,
+        pollTimeout: undefined,
     }),
     getters: {
         entryPointsForJob: (state) => {
@@ -19,18 +19,17 @@ export const useEntryPointStore = defineStore("entryPointStore", {
         },
     },
     actions: {
-        ensurePollingEntryPoints() {
-            if (this.interval === undefined) {
-                this.fetchEntryPoints();
-                this.interval = setInterval(() => {
-                    this.fetchEntryPoints();
-                }, 5000);
-            }
+        async ensurePollingEntryPoints() {
+            await this.fetchEntryPoints();
+            this.pollTimeout = setTimeout(() => {
+                this.ensurePollingEntryPoints();
+            }, 10000);
         },
         stopPollingEntryPoints() {
-            this.interval = clearInterval(this.interval);
+            this.pollTimeout = clearTimeout(this.pollTimeout);
         },
         async fetchEntryPoints() {
+            this.stopPollingEntryPoints();
             const url = getAppRoot() + `api/entry_points`;
             const params = { running: true };
             axios

--- a/client/src/stores/entryPointStore.test.js
+++ b/client/src/stores/entryPointStore.test.js
@@ -26,9 +26,9 @@ describe("stores/EntryPointStore", () => {
         expect(store.entryPoints.length).toBe(2);
     });
     it("stops polling", async () => {
-        expect(store.interval >= 0).toBeTruthy();
+        expect(store.pollTimeout >= 0).toBeTruthy();
         store.stopPollingEntryPoints();
-        expect(store.interval === undefined).toBeTruthy();
+        expect(store.pollTimeout === undefined).toBeTruthy();
     });
     it("performs a partial update", async () => {
         store.stopPollingEntryPoints();


### PR DESCRIPTION
closes #15276

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
