### PR TITLE
add set_random_password to tool_shed User

### DIFF
--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import random
+import string
 import weakref
 from datetime import (
     datetime,
@@ -171,6 +173,14 @@ class User(Base, Dictifiable):
             raise Exception(f"Invalid password: {message}")
         # Set 'self.password' to the digest of 'cleartext'.
         self.password = new_insecure_hash(text_type=cleartext)
+
+    def set_random_password(self, length=16):
+        """
+        Sets user password to a random string of the given length.
+        :return: void
+        """
+        self.set_password_cleartext(
+            ''.join(random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(length)))
 
 
 class PasswordResetToken(Base):

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -180,7 +180,8 @@ class User(Base, Dictifiable):
         :return: void
         """
         self.set_password_cleartext(
-            ''.join(random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(length)))
+            "".join(random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(length))
+        )
 
 
 class PasswordResetToken(Base):


### PR DESCRIPTION
Fixes #15278
```
Traceback (most recent call last):
  File "lib/galaxy/web/framework/middleware/error.py", line 154, in __call__
    app_iter = self.application(environ, sr_checker)
  File "lib/galaxy/web/framework/middleware/xforwardedhost.py", line 23, in __call__
    return self.app(environ, start_response)
  File "/galaxy/.venv/lib/python3.6/site-packages/paste/translogger.py", line 69, in __call__
    return self.application(environ, replacement_start_response)
  File "/galaxy/.venv/lib/python3.6/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "/galaxy/.venv/lib/python3.6/site-packages/routes/middleware.py", line 153, in __call__
    response = self.app(environ, start_response)
  File "/galaxy/.venv/lib/python3.6/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "lib/galaxy/web/framework/base.py", line 138, in __call__
    return self.handle_request(environ, start_response)
  File "lib/galaxy/web/framework/base.py", line 217, in handle_request
    body = method(trans, **kwargs)
  File "lib/tool_shed/webapp/controllers/user.py", line 68, in login
    response = self.__validate_login(trans, **kwd)
  File "lib/galaxy/webapps/galaxy/controllers/user.py", line 139, in __validate_login
    message, user = self.__autoregistration(trans, login, password)
  File "lib/galaxy/webapps/galaxy/controllers/user.py", line 97, in __autoregistration
    user = self.user_manager.create(email=email, username=username, password="")
  File "lib/galaxy/managers/users.py", line 116, in create
    user.set_random_password()
AttributeError: 'User' object has no attribute 'set_random_password'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
