### PR TITLE
Restore toolshed masthead appearance

### DIFF
--- a/client/src/style/scss/toolshed.scss
+++ b/client/src/style/scss/toolshed.scss
@@ -20,7 +20,7 @@
     }
 }
 
-#toolshed-masthead {
+.masthead-toolshed {
     background-color: $brand-dark;
     height: $masthead-height;
     .navbar-brand {
@@ -30,11 +30,11 @@
             max-height: 2rem;
         }
     }
-    .nav-link {
-        color: $brand-light;
-    }
     .navbar-brand-title {
         color: $brand-light;
         font-size: 1.1rem;
+    }
+    .nav-link {
+        color: $brand-light !important;
     }
 }

--- a/client/src/style/scss/toolshed.scss
+++ b/client/src/style/scss/toolshed.scss
@@ -19,3 +19,22 @@
         list-style-type: none;
     }
 }
+
+#toolshed-masthead {
+    background-color: $brand-dark;
+    height: $masthead-height;
+    .navbar-brand {
+        position: absolute;
+        left: 0.5rem;
+        .navbar-brand-image {
+            max-height: 2rem;
+        }
+    }
+    .nav-link {
+        color: $brand-light;
+    }
+    .navbar-brand-title {
+        color: $brand-light;
+        font-size: 1.1rem;
+    }
+}

--- a/lib/tool_shed/webapp/templates/base/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/base/base_panels.mako
@@ -25,6 +25,26 @@
     ${h.dist_css(
         'base'
     )}
+    <style>
+        #masthead {
+            background: #2c3143;
+            height: 3rem;
+        }
+        .navbar-brand {
+            position: absolute;
+            left: 0.5rem;
+        }
+        .navbar-brand-image {
+            max-height: 2rem;
+        }
+        .navbar-brand-title {
+            color: white;
+            font-size: 1rem;
+        }
+        .nav-link {
+            color: white !important;
+        }
+    </style>
 </%def>
 
 ## Default javascripts

--- a/lib/tool_shed/webapp/templates/base/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/base/base_panels.mako
@@ -25,26 +25,6 @@
     ${h.dist_css(
         'base'
     )}
-    <style>
-        #masthead {
-            background: #2c3143;
-            height: 3rem;
-        }
-        .navbar-brand {
-            position: absolute;
-            left: 0.5rem;
-        }
-        .navbar-brand-image {
-            max-height: 2rem;
-        }
-        .navbar-brand-title {
-            color: white;
-            font-size: 1.1rem;
-        }
-        .nav-link {
-            color: white !important;
-        }
-    </style>
 </%def>
 
 ## Default javascripts

--- a/lib/tool_shed/webapp/templates/base/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/base/base_panels.mako
@@ -39,7 +39,7 @@
         }
         .navbar-brand-title {
             color: white;
-            font-size: 1rem;
+            font-size: 1.1rem;
         }
         .nav-link {
             color: white !important;

--- a/lib/tool_shed/webapp/templates/base/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/base/base_panels.mako
@@ -176,7 +176,7 @@
             <div id="background"></div>
 
             ## Layer iframes over backgrounds
-            <div id="masthead" class="navbar navbar-fixed-top navbar-inverse">
+            <div>
                 ${self.masthead()}
             </div>
 

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
@@ -56,7 +56,7 @@
     %endif
 
     ## start main tag
-    <nav id="toolshed-masthead" class="navbar navbar-expand navbar-fixed-top justify-content-center navbar-dark">
+    <nav id="masthead" class="masthead-toolshed navbar navbar-expand navbar-fixed-top justify-content-center navbar-dark">
 
         ## Logo, layered over tabs to be clickable
         <a href="${h.url_for( app.config.get( 'logo_url', '/' ) )}" aria-label="homepage" class="navbar-brand">

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
@@ -56,16 +56,17 @@
     %endif
 
     ## start main tag
-    <nav id="masthead" class="navbar navbar-expand fixed-top justify-content-center navbar-dark">
+    <nav id="masthead" class="navbar navbar-expand navbar-fixed-top justify-content-center navbar-dark">
 
         ## Logo, layered over tabs to be clickable
         <a href="${h.url_for( app.config.get( 'logo_url', '/' ) )}" aria-label="homepage" class="navbar-brand">
             <img alt="logo" class="navbar-brand-image" src="${h.url_for('/static/favicon.svg')}">
             <span class="navbar-brand-title">
-            Galaxy Tool Shed
-            %if app.config.brand:
-                / ${app.config.brand}
-            %endif
+                Tool Shed
+                %if app.config.brand:
+                    / ${app.config.brand}
+                %endif
+            </span>
         </a>
 
         ## Tab area, fills entire width

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
@@ -58,125 +58,124 @@
     ## start main tag
     <nav id="masthead" class="navbar navbar-expand fixed-top justify-content-center navbar-dark">
 
-      ## Logo, layered over tabs to be clickable
-      <a href="${h.url_for( app.config.get( 'logo_url', '/' ) )}" aria-label="homepage" class="navbar-brand">
-          <img alt="logo" class="navbar-brand-image" src="${h.url_for('/static/favicon.svg')}">
-          <span class="navbar-brand-title">
-          Galaxy Tool Shed
-          %if app.config.brand:
-              / ${app.config.brand}
-          %endif
-      </a>
+        ## Logo, layered over tabs to be clickable
+        <a href="${h.url_for( app.config.get( 'logo_url', '/' ) )}" aria-label="homepage" class="navbar-brand">
+            <img alt="logo" class="navbar-brand-image" src="${h.url_for('/static/favicon.svg')}">
+            <span class="navbar-brand-title">
+            Galaxy Tool Shed
+            %if app.config.brand:
+                / ${app.config.brand}
+            %endif
+        </a>
 
+        ## Tab area, fills entire width
+        <ul class="navbar-nav">
+            <%def name="tab( id, display, href, target='_parent', visible=True, extra_class='', menu_options=None )">
+                <%
+                cls = "nav-item"
+                a_cls = "nav-link"
+                extra = ""
+                if extra_class:
+                    cls = extra_class
+                if self.active_view == id:
+                    cls += " active"
+                if menu_options:
+                    cls += " dropdown"
+                    a_cls += " dropdown-toggle"
+                    extra = "<b class='caret'></b>"
+                style = ""
+                if not visible:
+                    style = "display: none;"
+                %>
 
-    ## Tab area, fills entire width
-            <ul class="navbar-nav">
-                <%def name="tab( id, display, href, target='_parent', visible=True, extra_class='', menu_options=None )">
-                    <%
-                    cls = "nav-item"
-                    a_cls = "nav-link"
-                    extra = ""
-                    if extra_class:
-                        cls = extra_class
-                    if self.active_view == id:
-                        cls += " active"
-                    if menu_options:
-                        cls += " dropdown"
-                        a_cls += " dropdown-toggle"
-                        extra = "<b class='caret'></b>"
-                    style = ""
-                    if not visible:
-                        style = "display: none;"
-                    %>
-
-                    <li class="${cls}" style="${style}">
-                      <a
-                        %if href:
-                            class="${a_cls}" target="${target}" href="${href}"
-                        %else:
-                            class="${a_cls}"
-                        %endif
-						%if menu_options:
-							role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-						%endif
-                        >
-							${display}${extra}
-						</a>
-                        %if menu_options:
-                            <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                                %for menu_item in menu_options:
-                                    %if not menu_item:
-                                        <div class="dropdown-divider"></div>
+                <li class="${cls}" style="${style}">
+                    <a
+                    %if href:
+                        class="${a_cls}" target="${target}" href="${href}"
+                    %else:
+                        class="${a_cls}"
+                    %endif
+                    %if menu_options:
+                        role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                    %endif
+                    >
+                        ${display}${extra}
+                    </a>
+                    %if menu_options:
+                        <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                            %for menu_item in menu_options:
+                                %if not menu_item:
+                                    <div class="dropdown-divider"></div>
+                                %else:
+                                    %if len ( menu_item ) == 1:
+                                        <a class="dropdown-item" href="javascript:void(0)" role="button">
+                                            ${menu_item[0]}
+                                        </a>
+                                    %elif len ( menu_item ) == 2:
+                                        <% name, link = menu_item %>
+                                        <a class="dropdown-item" href="${link}">${name | h}</a>
                                     %else:
-                                        %if len ( menu_item ) == 1:
-                                            <a class="dropdown-item" href="javascript:void(0)" role="button">
-                                                ${menu_item[0]}
-                                            </a>
-                                        %elif len ( menu_item ) == 2:
-                                            <% name, link = menu_item %>
-                                            <a class="dropdown-item" href="${link}">${name | h}</a>
-                                        %else:
-                                            <% name, link, target = menu_item %>
-                                            <a class="dropdown-item" target="${target}" href="${link}">${name | h}</a>
-                                        %endif
+                                        <% name, link, target = menu_item %>
+                                        <a class="dropdown-item" target="${target}" href="${link}">${name | h}</a>
                                     %endif
-                                %endfor
-                            </div>
-                        %endif
-                    </li>
-                </%def>
+                                %endif
+                            %endfor
+                        </div>
+                    %endif
+                </li>
+            </%def>
 
-                ## Repositories tab.
-                ${tab( "repositories", "Repositories", h.url_for( controller='/repository', action='index' ) )}
+            ## Repositories tab.
+            ${tab( "repositories", "Repositories", h.url_for( controller='/repository', action='index' ) )}
 
-                ## Groups tab.
-                ${tab( "groups", "Groups", h.url_for( controller='/groups', action='index' ) )}
+            ## Groups tab.
+            ${tab( "groups", "Groups", h.url_for( controller='/groups', action='index' ) )}
 
-                ## Admin tab.
-                ${tab( "admin", "Admin", h.url_for( controller='/admin', action='index' ), extra_class="admin-only", visible=( trans.user and app.config.is_admin_user( trans.user ) ) )}
+            ## Admin tab.
+            ${tab( "admin", "Admin", h.url_for( controller='/admin', action='index' ), extra_class="admin-only", visible=( trans.user and app.config.is_admin_user( trans.user ) ) )}
 
-                ## Help tab.
-                <%
-                    menu_options = []
-                    menu_options.extend( [
-                        ['About Tool Shed', app.config.get( "wiki_url", "https://galaxyproject.org/toolshed" ), "_blank" ],
-                        ['Support', app.config.get( "support_url", "https://galaxyproject.org/support" ), "_blank" ],
-                        ['Videos', app.config.get( "screencasts_url", "https://vimeo.com/galaxyproject" ), "_blank" ],
-                        ['How to Cite Tool Shed', app.config.get( "citation_url", "https://galaxyproject.org/citing-galaxy" ), "_blank" ]
-                    ] )
-                    tab( "help", "Help", None, menu_options=menu_options )
-                %>
+            ## Help tab.
+            <%
+                menu_options = []
+                menu_options.extend( [
+                    ['About Tool Shed', app.config.get( "wiki_url", "https://galaxyproject.org/toolshed" ), "_blank" ],
+                    ['Support', app.config.get( "support_url", "https://galaxyproject.org/support" ), "_blank" ],
+                    ['Videos', app.config.get( "screencasts_url", "https://vimeo.com/galaxyproject" ), "_blank" ],
+                    ['How to Cite Tool Shed', app.config.get( "citation_url", "https://galaxyproject.org/citing-galaxy" ), "_blank" ]
+                ] )
+                tab( "help", "Help", None, menu_options=menu_options )
+            %>
 
-                ## User tabs.
-                <%
-                    from markupsafe import escape
-                    # Menu for user who is not logged in.
-                    menu_options = [ [ "Login", h.url_for( controller='/user', action='login' ), "galaxy_main" ] ]
-                    if app.config.allow_user_creation:
-                        menu_options.append( [ "Register", h.url_for( controller='/user', action='create', cntrller='user' ), "galaxy_main" ] )
-                    extra_class = "loggedout-only"
-                    visible = ( trans.user == None )
-                    tab( "user", "User", None, visible=visible, menu_options=menu_options )
-                    # Menu for user who is logged in.
-                    if trans.user:
-                        email = escape( trans.user.email )
-                    else:
-                        email = ""
-                    menu_options = [ [ 'Logged in as <span id="user-email">%s</span>' %  email ] ]
-                    if app.config.use_remote_user:
-                        if app.config.remote_user_logout_href:
-                            menu_options.append( [ 'Logout', app.config.remote_user_logout_href, "_top" ] )
-                    else:
-                        menu_options.append( [ 'Preferences', h.url_for( controller='/user', action='index', cntrller='user' ), "galaxy_main" ] )
-                        menu_options.append( [ 'API Keys', h.url_for( controller='/user', action='api_keys', cntrller='user' ), "galaxy_main" ] )
-                        logout_url = h.url_for( controller='/user', action='logout' )
-                        menu_options.append( [ 'Logout', logout_url, "_top" ] )
-                    if app.config.use_remote_user:
-                        menu_options.append( [ 'Public Name', h.url_for( controller='/user', action='edit_username', cntrller='user' ), "galaxy_main" ] )
+            ## User tabs.
+            <%
+                from markupsafe import escape
+                # Menu for user who is not logged in.
+                menu_options = [ [ "Login", h.url_for( controller='/user', action='login' ), "galaxy_main" ] ]
+                if app.config.allow_user_creation:
+                    menu_options.append( [ "Register", h.url_for( controller='/user', action='create', cntrller='user' ), "galaxy_main" ] )
+                extra_class = "loggedout-only"
+                visible = ( trans.user == None )
+                tab( "user", "User", None, visible=visible, menu_options=menu_options )
+                # Menu for user who is logged in.
+                if trans.user:
+                    email = escape( trans.user.email )
+                else:
+                    email = ""
+                menu_options = [ [ 'Logged in as <span id="user-email">%s</span>' %  email ] ]
+                if app.config.use_remote_user:
+                    if app.config.remote_user_logout_href:
+                        menu_options.append( [ 'Logout', app.config.remote_user_logout_href, "_top" ] )
+                else:
+                    menu_options.append( [ 'Preferences', h.url_for( controller='/user', action='index', cntrller='user' ), "galaxy_main" ] )
+                    menu_options.append( [ 'API Keys', h.url_for( controller='/user', action='api_keys', cntrller='user' ), "galaxy_main" ] )
+                    logout_url = h.url_for( controller='/user', action='logout' )
+                    menu_options.append( [ 'Logout', logout_url, "_top" ] )
+                if app.config.use_remote_user:
+                    menu_options.append( [ 'Public Name', h.url_for( controller='/user', action='edit_username', cntrller='user' ), "galaxy_main" ] )
 
-                    extra_class = "loggedin-only"
-                    visible = ( trans.user != None )
-                    tab( "user", "User", None, visible=visible, menu_options=menu_options )
-                %>
-            </ul>
+                extra_class = "loggedin-only"
+                visible = ( trans.user != None )
+                tab( "user", "User", None, visible=visible, menu_options=menu_options )
+            %>
+        </ul>
 </%def>

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
@@ -56,7 +56,7 @@
     %endif
 
     ## start main tag
-    <nav id="masthead" class="navbar navbar-expand navbar-fixed-top justify-content-center navbar-dark">
+    <nav id="toolshed-masthead" class="navbar navbar-expand navbar-fixed-top justify-content-center navbar-dark">
 
         ## Logo, layered over tabs to be clickable
         <a href="${h.url_for( app.config.get( 'logo_url', '/' ) )}" aria-label="homepage" class="navbar-brand">

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/base_panels.mako
@@ -178,4 +178,5 @@
                 tab( "user", "User", None, visible=visible, menu_options=menu_options )
             %>
         </ul>
+    </nav>
 </%def>


### PR DESCRIPTION
Fixes #15138. This PR adds css to the toolshed scss, and refactors the markup in order to restore the toolshed masthead rendering. With our recent additions to Galaxy, masthead styles have been moved out of the large `base.scss` file to the single file components.

<img width="979" alt="image" src="https://user-images.githubusercontent.com/2105447/212183506-184cd441-b60f-4636-a1b7-34c55d2117fd.png">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
