### PR TITLE
Add Storage Management API

### DIFF
--- a/client/src/components/User/DiskUsage/Management/Cleanup/CleanupOperationSummary.test.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/CleanupOperationSummary.test.ts
@@ -2,12 +2,17 @@ import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "@tests/jest/helpers";
 import CleanupOperationSummary from "./CleanupOperationSummary.vue";
-import { CleanableSummary, type CleanupOperation, CleanupResult } from "./model";
+import { CleanableSummary, type CleanupOperation, CleanupResult, type CleanableItem } from "./model";
 
 const localVue = getLocalVue();
 
 const REVIEW_ITEMS_LINK = '[data-test-id="review-link"]';
 const NO_ITEMS_INDICATOR = '[data-test-id="no-items-indicator"]';
+
+const EXPECTED_ITEMS: CleanableItem[] = [
+    { id: "1", name: "Item 1", size: 512, type: "dataset", update_time: new Date().toISOString() },
+    { id: "2", name: "Item 2", size: 512, type: "dataset", update_time: new Date().toISOString() },
+];
 
 /** Operation that can clean some items */
 const CLEANUP_OPERATION: CleanupOperation = {
@@ -16,16 +21,20 @@ const CLEANUP_OPERATION: CleanupOperation = {
     description: "operation description",
     fetchSummary: async () =>
         new CleanableSummary({
-            totalSize: 1024,
-            totalItems: 2,
+            total_size: 1024,
+            total_items: 2,
         }),
     fetchItems: async () => [],
     cleanupItems: async () =>
-        new CleanupResult({
-            totalItemCount: 2,
-            totalFreeBytes: 1024,
-            errors: [],
-        }),
+        new CleanupResult(
+            {
+                total_item_count: 2,
+                success_item_count: 2,
+                total_free_bytes: 1024,
+                errors: [],
+            },
+            EXPECTED_ITEMS
+        ),
 };
 /** Operation without items to clean*/
 const EMPTY_CLEANUP_OPERATION: CleanupOperation = {
@@ -34,8 +43,8 @@ const EMPTY_CLEANUP_OPERATION: CleanupOperation = {
     description: "operation that has no items to clean",
     fetchSummary: async () =>
         new CleanableSummary({
-            totalSize: 0,
-            totalItems: 0,
+            total_size: 0,
+            total_items: 0,
         }),
     fetchItems: async () => [],
     cleanupItems: async () => new CleanupResult(),

--- a/client/src/components/User/DiskUsage/Management/Cleanup/CleanupResultDialog.test.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/CleanupResultDialog.test.ts
@@ -2,7 +2,7 @@ import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
 import CleanupResultDialog from "./CleanupResultDialog.vue";
-import { CleanupResult } from "./model";
+import { CleanupResult, type CleanableItem } from "./model";
 
 const localVue = getLocalVue();
 
@@ -14,25 +14,41 @@ const ERRORS_TABLE = '[data-test-id="errors-table"]';
 
 const NO_RESULT_YET = undefined;
 const FAILED_RESULT = () => {
-    return new CleanupResult({
-        errorMessage: "The operation failed",
-        totalFreeBytes: 0,
-        totalItemCount: 0,
-        errors: [],
-    });
+    return new CleanupResult(
+        {
+            total_item_count: 0,
+            errors: [],
+            success_item_count: 0,
+            total_free_bytes: 0,
+        },
+        [],
+        "The operation failed"
+    );
 };
+const TEST_ITEMS: CleanableItem[] = [
+    { id: "1", name: "Dataset X", size: 512, type: "dataset", update_time: new Date().toISOString() },
+    { id: "2", name: "Dataset Y", size: 512, type: "dataset", update_time: new Date().toISOString() },
+    { id: "3", name: "Dataset Z", size: 512, type: "dataset", update_time: new Date().toISOString() },
+];
 const PARTIAL_SUCCESS_RESULT = () => {
-    return new CleanupResult({
-        totalItemCount: 3,
-        totalFreeBytes: 1,
-        errors: [
-            { name: "Dataset X", reason: "Failed because of X" },
-            { name: "Dataset Y", reason: "Failed because of Y" },
-        ],
-    });
+    return new CleanupResult(
+        {
+            total_item_count: 3,
+            success_item_count: 1,
+            total_free_bytes: 512,
+            errors: [
+                { item_id: "1", error: "Failed because of X" },
+                { item_id: "2", error: "Failed because of Y" },
+            ],
+        },
+        TEST_ITEMS
+    );
 };
 const SUCCESS_RESULT = () => {
-    return new CleanupResult({ totalItemCount: 2, totalFreeBytes: 2, errors: [] });
+    return new CleanupResult(
+        { total_item_count: 3, success_item_count: 3, total_free_bytes: 512 * 3, errors: [] },
+        TEST_ITEMS
+    );
 };
 async function mountCleanupResultDialogWith(result?: CleanupResult) {
     const wrapper = mount(CleanupResultDialog, { propsData: { result, show: true }, localVue });

--- a/client/src/components/User/DiskUsage/Management/Cleanup/CleanupResultDialog.vue
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/CleanupResultDialog.vue
@@ -2,6 +2,7 @@
 import localize from "@/utils/localization";
 import { computed, ref } from "vue";
 import type { CleanupResult } from "./model";
+import Alert from "components/Alert.vue";
 
 interface CleanupResultDialogProps {
     result?: CleanupResult;
@@ -46,6 +47,9 @@ defineExpose({
 <template>
     <b-modal id="cleanup-result-modal" v-model="showModal" :title="title" title-tag="h2" hide-footer static>
         <div class="text-center">
+            <Alert
+                variant="info"
+                message="After the operation, the storage space that will be freed up will only be for the unique items. This means that some items may not free up any storage space because they are duplicates of other items." />
             <b-spinner v-if="isLoading" class="mx-auto" data-test-id="loading-spinner" />
             <div v-else>
                 <b-alert v-if="result.hasFailed" show variant="danger" data-test-id="error-alert">

--- a/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.test.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.test.ts
@@ -1,7 +1,7 @@
 import { mount, type WrapperArray } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { getLocalVue } from "tests/jest/helpers";
-import { CleanableSummary, type CleanupOperation, CleanupResult } from "./model";
+import { CleanableSummary, type CleanupOperation, CleanupResult, type CleanableItem } from "./model";
 import ReviewCleanupDialog from "./ReviewCleanupDialog.vue";
 
 const localVue = getLocalVue();
@@ -12,26 +12,31 @@ const SELECT_ALL_CHECKBOX = '[data-test-id="select-all-checkbox"]';
 const AGREEMENT_CHECKBOX = '[data-test-id="agreement-checkbox"]';
 const CONFIRMATION_MODAL = "#confirmation-modal";
 
-const EXPECTED_TOTAL_ITEMS = 2;
+const EXPECTED_ITEMS: CleanableItem[] = [
+    { id: "1", name: "Item 1", size: 512, type: "dataset", update_time: new Date().toISOString() },
+    { id: "2", name: "Item 2", size: 512, type: "dataset", update_time: new Date().toISOString() },
+];
+const EXPECTED_TOTAL_ITEMS = EXPECTED_ITEMS.length;
 const FAKE_OPERATION: CleanupOperation = {
     id: "operation-id",
     name: "operation name",
     description: "operation description",
     fetchSummary: async () =>
         new CleanableSummary({
-            totalSize: 1024,
-            totalItems: EXPECTED_TOTAL_ITEMS,
+            total_size: 1024,
+            total_items: EXPECTED_TOTAL_ITEMS,
         }),
-    fetchItems: async () => [
-        { id: "1", name: "Item 1", size: 512, update_time: new Date().toISOString(), hda_ldda: "hda" },
-        { id: "2", name: "Item 2", size: 512, update_time: new Date().toISOString(), hda_ldda: "hda" },
-    ],
+    fetchItems: async () => EXPECTED_ITEMS,
     cleanupItems: async () =>
-        new CleanupResult({
-            totalItemCount: EXPECTED_TOTAL_ITEMS,
-            totalFreeBytes: 1024,
-            errors: [],
-        }),
+        new CleanupResult(
+            {
+                total_item_count: EXPECTED_TOTAL_ITEMS,
+                success_item_count: EXPECTED_TOTAL_ITEMS,
+                total_free_bytes: 1024,
+                errors: [],
+            },
+            EXPECTED_ITEMS
+        ),
 };
 
 async function mountReviewCleanupDialogWith(operation: CleanupOperation, totalItems = EXPECTED_TOTAL_ITEMS) {

--- a/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
@@ -46,7 +46,6 @@ const fields = [
     },
 ];
 
-const MAXIMUM_REVIEWABLE_ITEM_LIMIT = 200;
 const MAXIMUM_ITEMS_PER_PAGE = 25;
 
 const sortBy = ref<SortableKey>("size");
@@ -93,20 +92,9 @@ const confirmButtonVariant = computed(() => {
     return confirmChecked.value ? "danger" : "";
 });
 
-const rowLimitReached = computed(() => {
-    return totalRows.value >= MAXIMUM_REVIEWABLE_ITEM_LIMIT;
-});
-
-const rowLimitReachedText = computed(() => {
-    return localize(
-        `Displaying a maximum of ${MAXIMUM_REVIEWABLE_ITEM_LIMIT} items here. If there are more, you can rerun this operation after deleting some.`
-    );
-});
-
 watch(props, (newVal) => {
     currentPage.value = 1;
-    totalRows.value =
-        newVal.totalItems > MAXIMUM_REVIEWABLE_ITEM_LIMIT ? MAXIMUM_REVIEWABLE_ITEM_LIMIT : newVal.totalItems;
+    totalRows.value = newVal.totalItems;
 });
 
 watch(selectedItems, (newVal) => {
@@ -210,7 +198,7 @@ defineExpose({
     <b-modal v-model="showDialog" title-tag="h2" :static="modalStatic" centered @show="onShowModal">
         <template v-slot:modal-title>
             {{ title }}
-            <span class="text-primary h3">{{ totalRows }}<span v-if="rowLimitReached">+</span> items</span>
+            <span class="text-primary h3">{{ totalRows }} items</span>
         </template>
         <div>
             {{ captionText }}
@@ -248,7 +236,6 @@ defineExpose({
             </template>
         </b-table>
         <template v-slot:modal-footer>
-            <span v-if="rowLimitReached" class="font-italic">{{ rowLimitReachedText }}</span>
             <b-pagination
                 v-if="hasPages"
                 v-model="currentPage"

--- a/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import localize from "@/utils/localization";
 import { bytesToString } from "@/utils/utils";
-import { BModal, BTable, BFormCheckbox, BLink, BPagination, BButton } from "bootstrap-vue";
+import { BModal, BTable, BFormCheckbox, BPagination, BButton } from "bootstrap-vue";
 import UtcDate from "@/components/UtcDate.vue";
 import { type CleanableItem, type CleanupOperation, type SortableKey, PaginationOptions } from "./model";
 import { computed, ref, watch } from "vue";
@@ -22,7 +22,7 @@ const emit = defineEmits<{
 }>();
 
 const permanentlyDeleteText = localize("Permanently delete");
-const captionText = localize("To free up account space, review and select items to be permanently deleted or");
+const captionText = localize("To free up account space, review and select items to be permanently deleted here.");
 const agreementText = localize("I understand that once I delete the items, they cannot be recovered.");
 const fields = [
     {
@@ -116,9 +116,9 @@ function toNiceSize(sizeInBytes: number) {
 
 async function toggleSelectAll(checked: boolean) {
     if (checked) {
-        await onSelectAllItems();
+        await selectAllItems();
     } else {
-        unselectAll();
+        unselectAllItems();
     }
 }
 
@@ -135,7 +135,7 @@ function onShowModal() {
 }
 
 function resetModal() {
-    unselectAll();
+    unselectAllItems();
 }
 
 function resetConfirmationModal() {
@@ -169,7 +169,7 @@ async function itemsProvider(ctx: { currentPage: number; perPage: number }) {
     }
 }
 
-async function onSelectAllItems() {
+async function selectAllItems() {
     isBusy.value = true;
     const allItems = await props.operation.fetchItems(
         new PaginationOptions({
@@ -184,7 +184,7 @@ async function onSelectAllItems() {
     isBusy.value = false;
 }
 
-function unselectAll() {
+function unselectAllItems() {
     selectedItems.value = [];
 }
 
@@ -202,9 +202,6 @@ defineExpose({
         </template>
         <div>
             {{ captionText }}
-            <b>
-                <b-link @click="onSelectAllItems">select all {{ totalRows }} items</b-link>
-            </b>
         </div>
         <b-table
             v-if="operation"

--- a/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/ReviewCleanupDialog.vue
@@ -3,7 +3,7 @@ import localize from "@/utils/localization";
 import { bytesToString } from "@/utils/utils";
 import { BModal, BTable, BFormCheckbox, BLink, BPagination, BButton } from "bootstrap-vue";
 import UtcDate from "@/components/UtcDate.vue";
-import type { CleanableItem, CleanupOperation } from "./model";
+import { type CleanableItem, type CleanupOperation, type SortableKey, PaginationOptions } from "./model";
 import { computed, ref, watch } from "vue";
 
 interface ReviewCleanupDialogProps {
@@ -46,9 +46,7 @@ const fields = [
     },
 ];
 
-type SortableKey = "name" | "size" | "update_time";
-
-const sortBy = ref(<SortableKey>"size");
+const sortBy = ref<SortableKey>("size");
 const sortDesc = ref(true);
 const perPage = ref(50);
 const currentPage = ref(1);
@@ -164,12 +162,12 @@ async function itemsProvider(ctx: { currentPage: number; perPage: number }) {
     try {
         const page = ctx.currentPage > 0 ? ctx.currentPage - 1 : 0;
         const offset = page * ctx.perPage;
-        const options = {
+        const options = new PaginationOptions({
             offset: offset,
             limit: ctx.perPage,
             sortBy: sortBy.value,
             sortDesc: sortDesc.value,
-        };
+        });
         const result = await props.operation.fetchItems(options);
         return result;
     } catch (error) {
@@ -179,12 +177,14 @@ async function itemsProvider(ctx: { currentPage: number; perPage: number }) {
 
 async function onSelectAllItems() {
     isBusy.value = true;
-    const allItems = await props.operation.fetchItems({
-        offset: 0,
-        limit: totalRows.value,
-        sortBy: sortBy.value,
-        sortDesc: sortDesc.value,
-    });
+    const allItems = await props.operation.fetchItems(
+        new PaginationOptions({
+            offset: 0,
+            limit: totalRows.value,
+            sortBy: sortBy.value,
+            sortDesc: sortDesc.value,
+        })
+    );
     selectedItems.value = allItems;
     isBusy.value = false;
 }

--- a/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanableSummary.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanableSummary.ts
@@ -1,32 +1,28 @@
 import { bytesToString } from "@/utils/utils";
+import type { components } from "@/schema";
 
-interface SummaryDataResponse {
-    totalSize: number;
-    totalItems: number;
-}
+type CleanableItemsSummaryResponse = components["schemas"]["CleanableItemsSummary"];
 
 /**
  * Contains summary information about how much storage space can be recovered by removing
  * a collection of items from it.
  */
 export class CleanableSummary {
-    private _data: SummaryDataResponse;
+    private _data: CleanableItemsSummaryResponse;
 
-    constructor(data: SummaryDataResponse) {
+    constructor(data: CleanableItemsSummaryResponse) {
         this._data = data;
     }
 
     /**
      * The total size in bytes that can be recovered by removing all the items.
-     * @returns {Number}
      */
     get totalSize(): number {
-        return this._data.totalSize;
+        return this._data.total_size;
     }
 
     /**
      * The human readable total amount of disk space that can be recovered.
-     * @returns {String}
      */
     get niceTotalSize(): string {
         return bytesToString(this.totalSize, true, undefined);
@@ -36,6 +32,6 @@ export class CleanableSummary {
      * The total number of items that could be removed.
      */
     get totalItems() {
-        return this._data.totalItems;
+        return this._data.total_items;
     }
 }

--- a/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupOperation.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupOperation.ts
@@ -1,17 +1,27 @@
 import type { CleanableSummary } from "./CleanableSummary";
 import type { CleanupResult } from "./CleanupResult";
+import type { components } from "@/schema";
 
-export interface PaginationOptions {
+export type CleanableItem = components["schemas"]["StoredItem"];
+export type SortableKey = "name" | "size" | "update_time";
+type StoredItemOrderBy = components["schemas"]["StoredItemOrderBy"];
+
+export class PaginationOptions {
     limit?: number;
     offset?: number;
-    sortBy?: string;
+    sortBy?: SortableKey;
     sortDesc?: boolean;
-}
 
-export interface CleanableItem {
-    id: string;
-    name: string;
-    size: number;
+    constructor(props?: { limit?: number; offset?: number; sortBy?: SortableKey; sortDesc?: boolean }) {
+        this.limit = props?.limit;
+        this.offset = props?.offset;
+        this.sortBy = props?.sortBy;
+        this.sortDesc = props?.sortDesc;
+    }
+
+    get order(): StoredItemOrderBy | undefined {
+        return this.sortBy ? `${this.sortBy}${this.sortDesc ? "-dsc" : "-asc"}` : undefined;
+    }
 }
 
 /**
@@ -46,7 +56,7 @@ export interface CleanupOperation {
      * @param options The filter options for sorting and pagination of the items.
      * @returns An array of items that can be potentially `cleaned` and match the filtering params.
      */
-    fetchItems: (options: PaginationOptions) => Promise<CleanableItem[]>;
+    fetchItems: (options?: PaginationOptions) => Promise<CleanableItem[]>;
 
     /**
      * Processes the given items to free up some user storage space and provides a result

--- a/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupResult.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupResult.ts
@@ -98,14 +98,22 @@ export class CleanupResult {
      * The number of items successfully cleaned.
      */
     get totalCleaned(): number {
-        return this._data.total_item_count - this._data.errors.length;
+        return this._data.success_item_count;
     }
 
     /**
      * Whether the cleanup operation managed to free some items but not all of them.
      */
     get isPartialSuccess(): boolean {
-        return this._data.errors.length > 0 && this.totalCleaned > 0;
+        return this.hasSomeErrors && this._data.success_item_count > 0;
+    }
+
+    /**
+     * Whether the cleanup operation managed to free some space or remove some items.
+     * It can happen that only "copy" items were removed effectively recovering 0 bytes.
+     */
+    get hasUpdatedResults(): boolean {
+        return this.totalFreeBytes > 0 || this.totalCleaned > 0;
     }
 
     /**

--- a/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupResult.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/model/CleanupResult.ts
@@ -1,47 +1,79 @@
 import { bytesToString } from "@/utils/utils";
+import type { components } from "@/schema";
+import type { CleanableItem } from "./CleanupOperation";
 
+export type StorageItemsCleanupResult = components["schemas"]["StorageItemsCleanupResult"];
+
+/**
+ * Associates the name of an item with the error message when failed.
+ * Simplifies displaying information to the final user.
+ */
 export interface ItemError {
+    /** Name of the item. */
     name: string;
+    /** The reason why it couldn't be cleaned. */
     reason: string;
 }
 
-export interface CleanupResultResponse {
-    totalItemCount: number;
-    totalFreeBytes: number;
-    errors: ItemError[];
-    errorMessage?: string;
-}
-
 /**
- * Contains information about the result of the cleaning operation.
+ * Provides additional information about the result of the cleaning operation.
  */
 export class CleanupResult {
-    private _data: CleanupResultResponse;
+    private _data: StorageItemsCleanupResult;
+    private _item_id_map: Map<string, CleanableItem>;
+    private _errorMessage?: string;
 
-    constructor(data: CleanupResultResponse = { totalFreeBytes: 0, totalItemCount: 0, errors: [] }) {
-        this._data = data;
-    }
-
-    get totalItemCount(): number {
-        return this._data.totalItemCount;
-    }
-
-    get totalFreeBytes(): number {
-        return this._data.totalFreeBytes;
-    }
-
-    get errors(): ItemError[] {
-        return this._data.errors;
-    }
-
-    get errorMessage(): string | undefined {
-        return this._data.errorMessage;
+    /**
+     * Creates a new CleanupResult.
+     * @param data The server response data for a cleanup operation.
+     * @param items The list of requested items to be cleaned.
+     * @param errorMessage A possible error message if the request completely failed.
+     */
+    constructor(data?: StorageItemsCleanupResult, items?: CleanableItem[], errorMessage?: string) {
+        this._data = data ?? { total_item_count: 0, success_item_count: 0, total_free_bytes: 0, errors: [] };
+        items = items ?? [];
+        this._item_id_map = new Map<string, CleanableItem>();
+        items.forEach((item) => {
+            this._item_id_map.set(item.id, item);
+        });
+        this._errorMessage = errorMessage;
     }
 
     /**
-     * Whether the cleanup operation yielded some errors.
-     * It doesn't mean the operation completely failed.
-     * @returns {boolean}
+     * The total number of items requested to be cleaned.
+     */
+    get totalItemCount(): number {
+        return this._data.total_item_count;
+    }
+
+    /**
+     * The total amount of space in bytes recovered after trying to cleanup all the requested items.
+     */
+    get totalFreeBytes(): number {
+        return this._data.total_free_bytes;
+    }
+
+    /**
+     * List of error messages associated with a particular item ID.
+     * When an item cannot be cleaned it will be registered in this list.
+     */
+    get errors(): ItemError[] {
+        return this._data.errors.map((e) => {
+            return { name: this._item_id_map.get(e.item_id)?.name ?? "Unknown", reason: e.error };
+        });
+    }
+
+    /**
+     * A general error message, usually indicating that the whole cleanup operation failed with
+     * no partial success.
+     */
+    get errorMessage(): string | undefined {
+        return this._errorMessage;
+    }
+
+    /**
+     * Whether the cleanup operation could not success for every requested item.
+     * It doesn't mean the operation completely failed, some items could have been successfully cleaned.
      */
     get hasSomeErrors(): boolean {
         return this._data.errors.length > 0;
@@ -50,32 +82,27 @@ export class CleanupResult {
     /**
      * Whether the cleanup operation completely failed.
      * This means not even partial cleaning was made.
-     * @returns {boolean}
      */
     get hasFailed(): boolean {
-        return Boolean(this._data.errorMessage);
+        return Boolean(this._errorMessage);
     }
 
     /**
      * Whether the cleanup operation was executed without errors.
-     * @returns {boolean}
      */
     get success(): boolean {
-        return !this.hasSomeErrors && !this._data.errorMessage;
+        return !this.hasSomeErrors && !this.hasFailed;
     }
 
     /**
      * The number of items successfully cleaned.
-     * @returns {number}
      */
     get totalCleaned(): number {
-        return this._data.totalItemCount - this._data.errors.length;
+        return this._data.total_item_count - this._data.errors.length;
     }
 
     /**
-     * Whether the cleanup operation managed to
-     * free some items but not all of them.
-     * @returns {boolean}
+     * Whether the cleanup operation managed to free some items but not all of them.
      */
     get isPartialSuccess(): boolean {
         return this._data.errors.length > 0 && this.totalCleaned > 0;
@@ -83,9 +110,8 @@ export class CleanupResult {
 
     /**
      * The total amount of disk space freed by the cleanup operation.
-     * @returns {String}
      */
     get niceTotalFreeBytes(): string {
-        return bytesToString(this._data.totalFreeBytes, true, undefined);
+        return bytesToString(this._data.total_free_bytes, true, undefined);
     }
 }

--- a/client/src/components/User/DiskUsage/Management/Cleanup/model/index.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/model/index.ts
@@ -1,4 +1,4 @@
 export { CleanableSummary } from "./CleanableSummary";
 export type { CleanupCategory } from "./CleanupCategory";
-export type { CleanableItem, CleanupOperation, PaginationOptions } from "./CleanupOperation";
-export { CleanupResult, type CleanupResultResponse, type ItemError } from "./CleanupResult";
+export { type CleanableItem, type CleanupOperation, type SortableKey, PaginationOptions } from "./CleanupOperation";
+export { CleanupResult } from "./CleanupResult";

--- a/client/src/components/User/DiskUsage/Management/StorageManager.vue
+++ b/client/src/components/User/DiskUsage/Management/StorageManager.vue
@@ -39,7 +39,7 @@ async function onConfirmCleanupSelected(selectedItems: CleanableItem[]) {
     await delay(1000);
     if (currentOperation.value) {
         cleanupResult.value = await currentOperation.value.cleanupItems(selectedItems);
-        if (cleanupResult.value.totalFreeBytes) {
+        if (cleanupResult.value.hasUpdatedResults) {
             refreshOperationId.value = currentOperation.value.id.toString();
         }
     }

--- a/client/src/components/User/DiskUsage/Management/StorageManager.vue
+++ b/client/src/components/User/DiskUsage/Management/StorageManager.vue
@@ -39,7 +39,7 @@ async function onConfirmCleanupSelected(selectedItems: CleanableItem[]) {
     await delay(1000);
     if (currentOperation.value) {
         cleanupResult.value = await currentOperation.value.cleanupItems(selectedItems);
-        if (cleanupResult.value.success) {
+        if (cleanupResult.value.totalFreeBytes) {
             refreshOperationId.value = currentOperation.value.id.toString();
         }
     }

--- a/client/src/components/User/DiskUsage/Management/services.ts
+++ b/client/src/components/User/DiskUsage/Management/services.ts
@@ -1,240 +1,85 @@
-import { getAppRoot } from "@/onload/loadConfig";
 import { rethrowSimple } from "@/utils/simple-error";
-import axios from "axios";
-import {
-    CleanableSummary,
-    CleanupResult,
-    type CleanableItem,
-    type CleanupResultResponse,
-    type ItemError,
-    type PaginationOptions,
-} from "./Cleanup/model";
+import { CleanableSummary, CleanupResult, PaginationOptions, type CleanableItem } from "./Cleanup/model";
+import { fetcher } from "@/schema";
 
-const datasetKeys = "id,name,size,update_time,hda_ldda";
-const isDataset = "q=history_content_type-eq&qv=dataset";
-const isDeleted = "q=deleted-eq&qv=True";
-const isNotPurged = "q=purged-eq&qv=False";
-const maxItemsToFetch = 500;
-const discardedDatasetsQueryParams = `${isDataset}&${isDeleted}&${isNotPurged}&limit=${maxItemsToFetch}`;
+const _fetchDiscardedDatasetsSummary = fetcher.path("/api/storage/datasets/discarded/summary").method("get").create();
 
-const historyKeys = "id,name,size,update_time";
-const discardedHistoriesQueryParams = `&${isDeleted}&${isNotPurged}&limit=${maxItemsToFetch}`;
-
-interface DiscardedDataset extends CleanableItem {
-    hda_ldda: string;
-}
-
-interface DatasetSourceId {
-    id: string;
-    src: string;
-}
-
-interface DatasetErrorMessage {
-    dataset: DatasetSourceId;
-    error_message: string;
-}
-
-interface DeleteDatasetBatchResult {
-    success_count: number;
-    errors?: DatasetErrorMessage[];
-}
-
-type DiscardedHistory = CleanableItem;
-
-/**
- * Calculates the total amount of bytes that can be cleaned by permanently removing
- * deleted datasets.
- * @returns Object containing information about how much can be cleaned.
- */
 export async function fetchDiscardedDatasetsSummary(): Promise<CleanableSummary> {
-    //TODO: possible optimization -> moving this to specific API endpoint so we don't have to parse
-    //      potentially a huge number of items
-    const summaryKeys = "size";
-    const url = `${getAppRoot()}api/datasets?keys=${summaryKeys}&${discardedDatasetsQueryParams}`;
     try {
-        const { data } = await axios.get(url);
-        const totalSizeInBytes = data.reduce(
-            (partial_sum: number, item: DiscardedDataset) => partial_sum + item.size,
-            0
-        );
-        return new CleanableSummary({
-            totalSize: totalSizeInBytes,
-            totalItems: data.length,
+        const { data } = await _fetchDiscardedDatasetsSummary({});
+        return new CleanableSummary(data);
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}
+
+const _fetchDiscardedDatasets = fetcher.path("/api/storage/datasets/discarded").method("get").create();
+
+export async function fetchDiscardedDatasets(options?: PaginationOptions): Promise<CleanableItem[]> {
+    try {
+        options = options ?? new PaginationOptions();
+        const { data } = await _fetchDiscardedDatasets({
+            offset: options.offset,
+            limit: options.limit,
+            order: options.order,
         });
-    } catch (e) {
-        rethrowSimple(e);
-    }
-}
-
-/**
- * Retrieves all deleted datasets of the current user that haven't been purged yet using pagination.
- * @param options Filtering options for pagination and sorting.
- * @returns Array of dataset objects with the fields defined in `datasetKeys` constant.
- */
-export async function fetchDiscardedDatasets(options: PaginationOptions = {}): Promise<DiscardedDataset[]> {
-    let params = "";
-    if (options.sortBy) {
-        const sortPostfix = options.sortDesc ? "-dsc" : "-asc";
-        params += `order=${options.sortBy}${sortPostfix}&`;
-    }
-    if (options.limit) {
-        params += `limit=${options.limit}&`;
-    }
-    if (options.offset) {
-        params += `offset=${options.offset}&`;
-    }
-    const url = `${getAppRoot()}api/datasets?keys=${datasetKeys}&${discardedDatasetsQueryParams}&${params}`;
-    try {
-        const { data } = await axios.get(url);
-        return data as DiscardedDataset[];
-    } catch (e) {
-        rethrowSimple(e);
-    }
-}
-
-/**
- * Purges a collection of datasets.
- * @param datasetSourceIds Array of objects with datasets {id, src} to be purged.
- * @returns Result object with `success_count` and `errors`.
- */
-export async function purgeDatasets(datasetSourceIds: DatasetSourceId[]): Promise<DeleteDatasetBatchResult> {
-    const payload = {
-        purge: true,
-        datasets: datasetSourceIds,
-    };
-    const url = `${getAppRoot()}api/datasets`;
-    try {
-        const { data } = await axios.delete(url, { data: payload });
         return data;
     } catch (e) {
         rethrowSimple(e);
     }
 }
 
-/**
- * Purges a set of datasets instances (HDA, LDDA, ...) from disk and returns the total space freed in bytes
- * taking into account possible datasets that couldn't be deleted.
- * @param items Array of datasets to be removed from disk.
- *                         Each dataset must contain `id` and `size`.
- * @returns Information about the result of the cleanup operation.
- */
+const _cleanupDiscardedDatasets = fetcher.path("/api/storage/datasets").method("delete").create();
+
 export async function cleanupDiscardedDatasets(items: CleanableItem[]): Promise<CleanupResult> {
-    const resultResponse: CleanupResultResponse = { errors: [], totalFreeBytes: 0, totalItemCount: 0 };
     try {
-        const datasetsTable = items.reduce(
-            (acc: { [key: string]: CleanableItem }, item: CleanableItem) => ((acc[item.id] = item), acc),
-            {}
-        );
-
-        const datasetSourceIds: DatasetSourceId[] = items.map((item: CleanableItem) => {
-            const dataset = item as DiscardedDataset;
-            return { id: dataset.id, src: dataset.hda_ldda };
+        const item_ids = items.map((item) => item.id);
+        const { data } = await _cleanupDiscardedDatasets({
+            item_ids,
         });
-
-        const requestResult = await purgeDatasets(datasetSourceIds);
-
-        resultResponse.totalItemCount = items.length;
-
-        if (requestResult.errors) {
-            resultResponse.errors = mapErrors(datasetsTable, requestResult.errors);
-
-            const erroredIds = requestResult.errors?.reduce((acc: string[], error) => [...acc, error.dataset.id], []);
-
-            resultResponse.totalFreeBytes = datasetSourceIds.reduce((partial_sum, item) => {
-                if (erroredIds?.includes(item.id)) {
-                    return partial_sum;
-                } else {
-                    return partial_sum + (datasetsTable[item.id]?.size ?? 0);
-                }
-            }, 0);
-        }
+        return new CleanupResult(data, items);
     } catch (error) {
-        resultResponse.errorMessage = error as string;
+        return new CleanupResult(undefined, items, error as string);
     }
-    return new CleanupResult(resultResponse);
 }
+
+const _fetchDiscardedHistoriesSummary = fetcher.path("/api/storage/histories/discarded/summary").method("get").create();
 
 export async function fetchDiscardedHistoriesSummary(): Promise<CleanableSummary> {
-    const summaryKeys = "size";
-    const url = `${getAppRoot()}api/histories?keys=${summaryKeys}&${discardedHistoriesQueryParams}`;
     try {
-        const { data } = await axios.get(url);
-        const totalSizeInBytes = data.reduce(
-            (partial_sum: number, item: DiscardedHistory) => partial_sum + item.size,
-            0
-        );
-        return new CleanableSummary({
-            totalSize: totalSizeInBytes,
-            totalItems: data.length,
+        const { data } = await _fetchDiscardedHistoriesSummary({});
+        return new CleanableSummary(data);
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}
+
+const _fetchDiscardedHistories = fetcher.path("/api/storage/histories/discarded").method("get").create();
+
+export async function fetchDiscardedHistories(options?: PaginationOptions): Promise<CleanableItem[]> {
+    try {
+        options = options ?? new PaginationOptions();
+        const { data } = await _fetchDiscardedHistories({
+            offset: options.offset,
+            limit: options.limit,
+            order: options.order,
         });
-    } catch (e) {
-        rethrowSimple(e);
-    }
-}
-
-export async function fetchDiscardedHistories(options: PaginationOptions = {}): Promise<DiscardedHistory[]> {
-    let params = "";
-    if (options.sortBy) {
-        const sortPostfix = options.sortDesc ? "-dsc" : "-asc";
-        params += `order=${options.sortBy}${sortPostfix}&`;
-    }
-    if (options.limit) {
-        params += `limit=${options.limit}&`;
-    }
-    if (options.offset) {
-        params += `offset=${options.offset}&`;
-    }
-    const url = `${getAppRoot()}api/histories?keys=${historyKeys}&${discardedHistoriesQueryParams}&${params}`;
-    try {
-        const { data } = await axios.get(url);
-        return data as DiscardedHistory[];
-    } catch (e) {
-        rethrowSimple(e);
-    }
-}
-
-async function purgeHistory(historyId: string) {
-    const payload = {
-        purge: true,
-    };
-    const url = `${getAppRoot()}api/histories/${historyId}`;
-    try {
-        const { data } = await axios.delete(url, { data: payload });
         return data;
     } catch (e) {
         rethrowSimple(e);
     }
 }
 
-export async function cleanupDiscardedHistories(histories: DiscardedHistory[]) {
-    const resultResponse: CleanupResultResponse = { errors: [], totalFreeBytes: 0, totalItemCount: 0 };
-    const historiesTable = histories.reduce(
-        (acc: { [key: string]: DiscardedHistory }, item: DiscardedHistory) => ((acc[item.id] = item), acc),
-        {}
-    );
-    // TODO: Promise.all() and do this in parallel?  Or add a bulk delete endpoint?
+const _cleanupDiscardedHistories = fetcher.path("/api/storage/histories").method("delete").create();
+
+export async function cleanupDiscardedHistories(items: CleanableItem[]) {
     try {
-        for (const history of histories) {
-            await purgeHistory(history.id);
-            resultResponse.totalFreeBytes += historiesTable[history.id]?.size ?? 0;
-            resultResponse.totalItemCount += 1;
-        }
+        const item_ids = items.map((item) => item.id);
+        const { data } = await _cleanupDiscardedHistories({
+            item_ids,
+        });
+        return new CleanupResult(data, items);
     } catch (error) {
-        resultResponse.errorMessage = error as string;
+        return new CleanupResult(undefined, items, error as string);
     }
-
-    return new CleanupResult(resultResponse);
-}
-
-/**
- * Maps the error messages with the dataset name for user display.
- * @param datasetsTable Datasets dictionary indexed by ID
- * @param errors List of errors associated with each dataset ID
- * @returns A list with the name of the dataset and the associated error message.
- */
-function mapErrors(datasetsTable: { [key: string]: CleanableItem }, errors: DatasetErrorMessage[]): ItemError[] {
-    return errors.map((error) => {
-        const name = datasetsTable[error.dataset.id]?.name ?? "Unknown Dataset";
-        return { name: name, reason: error.error_message };
-    });
 }

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -6797,6 +6797,12 @@ export interface components {
             update_time: string;
         };
         /**
+         * StoredItemOrderBy
+         * @description Available options for sorting Stored Items results.
+         * @enum {string}
+         */
+        StoredItemOrderBy: "name-asc" | "name-dsc" | "size-asc" | "size-dsc" | "update_time-asc" | "update_time-dsc";
+        /**
          * SuitableConverter
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -13517,6 +13523,14 @@ export interface operations {
     discarded_datasets_api_storage_datasets_discarded_get: {
         /** Returns discarded datasets owned by the given user. The results can be paginated. */
         parameters?: {
+            /** @description Starts at the beginning skip the first ( offset - 1 ) items and begin returning at the Nth item */
+            /** @description The maximum number of items to return. */
+            /** @description String containing one of the valid ordering attributes followed by '-asc' or '-dsc' for ascending and descending order respectively. */
+            query?: {
+                offset?: number;
+                limit?: number;
+                order?: components["schemas"]["StoredItemOrderBy"];
+            };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
                 "run-as"?: string;
@@ -13596,9 +13610,11 @@ export interface operations {
         parameters?: {
             /** @description Starts at the beginning skip the first ( offset - 1 ) items and begin returning at the Nth item */
             /** @description The maximum number of items to return. */
+            /** @description String containing one of the valid ordering attributes followed by '-asc' or '-dsc' for ascending and descending order respectively. */
             query?: {
                 offset?: number;
                 limit?: number;
+                order?: components["schemas"]["StoredItemOrderBy"];
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1070,6 +1070,36 @@ export interface paths {
         /** Determine if specified storage request ID is ready for download. */
         get: operations["is_ready_api_short_term_storage__storage_request_id__ready_get"];
     };
+    "/api/storage/datasets": {
+        /**
+         * Purges a set of datasets by ID from disk. The datasets must be owned by the user.
+         * @description **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
+         */
+        delete: operations["cleanup_datasets_api_storage_datasets_delete"];
+    };
+    "/api/storage/datasets/discarded": {
+        /** Returns discarded datasets owned by the given user. The results can be paginated. */
+        get: operations["discarded_datasets_api_storage_datasets_discarded_get"];
+    };
+    "/api/storage/datasets/discarded/summary": {
+        /** Returns information with the total storage space taken by discarded datasets owned by the given user. */
+        get: operations["discarded_datasets_summary_api_storage_datasets_discarded_summary_get"];
+    };
+    "/api/storage/histories": {
+        /**
+         * Purges a set of histories by ID. The histories must be owned by the user.
+         * @description **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
+         */
+        delete: operations["cleanup_histories_api_storage_histories_delete"];
+    };
+    "/api/storage/histories/discarded": {
+        /** Returns all discarded histories associated with the given user. */
+        get: operations["discarded_histories_api_storage_histories_discarded_get"];
+    };
+    "/api/storage/histories/discarded/summary": {
+        /** Returns information with the total storage space taken by discarded histories associated with the given user. */
+        get: operations["discarded_histories_summary_api_storage_histories_discarded_summary_get"];
+    };
     "/api/tags": {
         /**
          * Apply a new set of tags to an item.
@@ -1587,6 +1617,14 @@ export interface components {
              * @example sha-256
              */
             type: string;
+        };
+        /**
+         * CleanupStorageItemsRequest
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CleanupStorageItemsRequest: {
+            /** Item Ids */
+            item_ids: string[];
         };
         /**
          * CollectionElementIdentifier
@@ -2823,6 +2861,22 @@ export interface components {
              * @default false
              */
             purge?: boolean;
+        };
+        /**
+         * DiscardedItemsSummary
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        DiscardedItemsSummary: {
+            /**
+             * Total Items
+             * @description The total number of items that could be purged.
+             */
+            total_items: number;
+            /**
+             * Total Size
+             * @description The total size in bytes that can be recovered by purging all the items.
+             */
+            total_size: number;
         };
         /**
          * DisplayApp
@@ -6660,6 +6714,35 @@ export interface components {
          */
         Src: "url" | "pasted" | "files" | "path" | "composite" | "ftp_import" | "server_dir";
         /**
+         * StorageItemCleanupError
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        StorageItemCleanupError: {
+            /** Error */
+            error: string;
+            /**
+             * Item Id
+             * @example [
+             *   "0123456789ABCDEF"
+             * ]
+             */
+            item_id: string;
+        };
+        /**
+         * StorageItemsCleanupResult
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        StorageItemsCleanupResult: {
+            /** Errors */
+            errors: components["schemas"]["StorageItemCleanupError"][];
+            /** Success Item Count */
+            success_item_count: number;
+            /** Total Free Bytes */
+            total_free_bytes: number;
+            /** Total Item Count */
+            total_item_count: number;
+        };
+        /**
          * StoreExportPayload
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -6687,6 +6770,31 @@ export interface components {
              * @default tar.gz
              */
             model_store_format?: components["schemas"]["ModelStoreFormat"];
+        };
+        /**
+         * StoredItem
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        StoredItem: {
+            /**
+             * Id
+             * @example [
+             *   "0123456789ABCDEF"
+             * ]
+             */
+            id: string;
+            /** Name */
+            name: string;
+            /** Size */
+            size: number;
+            /** Type */
+            type: "history" | "dataset";
+            /**
+             * Update Time
+             * Format: date-time
+             * @description The last time and date this item was updated.
+             */
+            update_time: string;
         };
         /**
          * SuitableConverter
@@ -13365,6 +13473,166 @@ export interface operations {
             200: {
                 content: {
                     "application/json": boolean;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cleanup_datasets_api_storage_datasets_delete: {
+        /**
+         * Purges a set of datasets by ID from disk. The datasets must be owned by the user.
+         * @description **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
+         */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CleanupStorageItemsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["StorageItemsCleanupResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    discarded_datasets_api_storage_datasets_discarded_get: {
+        /** Returns discarded datasets owned by the given user. The results can be paginated. */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["StoredItem"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    discarded_datasets_summary_api_storage_datasets_discarded_summary_get: {
+        /** Returns information with the total storage space taken by discarded datasets owned by the given user. */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["DiscardedItemsSummary"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cleanup_histories_api_storage_histories_delete: {
+        /**
+         * Purges a set of histories by ID. The histories must be owned by the user.
+         * @description **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
+         */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CleanupStorageItemsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["StorageItemsCleanupResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    discarded_histories_api_storage_histories_discarded_get: {
+        /** Returns all discarded histories associated with the given user. */
+        parameters?: {
+            /** @description Starts at the beginning skip the first ( offset - 1 ) items and begin returning at the Nth item */
+            /** @description The maximum number of items to return. */
+            query?: {
+                offset?: number;
+                limit?: number;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["StoredItem"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    discarded_histories_summary_api_storage_histories_discarded_summary_get: {
+        /** Returns information with the total storage space taken by discarded histories associated with the given user. */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["DiscardedItemsSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -6547,9 +6547,9 @@ export interface components {
              * Share Option
              * @description User choice for sharing resources which its contents may be restricted:
              *  - None: The user did not choose anything yet or no option is needed.
-             *  - SharingOptions.make_public: The contents of the resource will be made publicly accessible.
-             *  - SharingOptions.make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
-             *  - SharingOptions.no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
+             *  - make_public: The contents of the resource will be made publicly accessible.
+             *  - make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
+             *  - no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
              */
             share_option?: components["schemas"]["SharingOptions"];
             /**
@@ -8989,7 +8989,7 @@ export interface operations {
          * @description Sets the permissions to manage a library folder.
          */
         parameters: {
-            /** @description Indicates what action should be performed on the Library. Currently only `LibraryFolderPermissionAction.set_permissions` is supported. */
+            /** @description Indicates what action should be performed on the Library. Currently only `set_permissions` is supported. */
             query?: {
                 action?: components["schemas"]["LibraryFolderPermissionAction"];
             };

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -6547,9 +6547,9 @@ export interface components {
              * Share Option
              * @description User choice for sharing resources which its contents may be restricted:
              *  - None: The user did not choose anything yet or no option is needed.
-             *  - make_public: The contents of the resource will be made publicly accessible.
-             *  - make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
-             *  - no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
+             *  - SharingOptions.make_public: The contents of the resource will be made publicly accessible.
+             *  - SharingOptions.make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
+             *  - SharingOptions.no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
              */
             share_option?: components["schemas"]["SharingOptions"];
             /**
@@ -6722,9 +6722,7 @@ export interface components {
             error: string;
             /**
              * Item Id
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             item_id: string;
         };
@@ -6778,9 +6776,7 @@ export interface components {
         StoredItem: {
             /**
              * Id
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /** Name */
@@ -8993,7 +8989,7 @@ export interface operations {
          * @description Sets the permissions to manage a library folder.
          */
         parameters: {
-            /** @description Indicates what action should be performed on the Library. Currently only `set_permissions` is supported. */
+            /** @description Indicates what action should be performed on the Library. Currently only `LibraryFolderPermissionAction.set_permissions` is supported. */
             query?: {
                 action?: components["schemas"]["LibraryFolderPermissionAction"];
             };

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1619,6 +1619,22 @@ export interface components {
             type: string;
         };
         /**
+         * CleanableItemsSummary
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CleanableItemsSummary: {
+            /**
+             * Total Items
+             * @description The total number of items that could be purged.
+             */
+            total_items: number;
+            /**
+             * Total Size
+             * @description The total size in bytes that can be recovered by purging all the items.
+             */
+            total_size: number;
+        };
+        /**
          * CleanupStorageItemsRequest
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -2861,22 +2877,6 @@ export interface components {
              * @default false
              */
             purge?: boolean;
-        };
-        /**
-         * DiscardedItemsSummary
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        DiscardedItemsSummary: {
-            /**
-             * Total Items
-             * @description The total number of items that could be purged.
-             */
-            total_items: number;
-            /**
-             * Total Size
-             * @description The total size in bytes that can be recovered by purging all the items.
-             */
-            total_size: number;
         };
         /**
          * DisplayApp
@@ -13549,7 +13549,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["DiscardedItemsSummary"];
+                    "application/json": components["schemas"]["CleanableItemsSummary"];
                 };
             };
             /** @description Validation Error */
@@ -13632,7 +13632,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["DiscardedItemsSummary"];
+                    "application/json": components["schemas"]["CleanableItemsSummary"];
                 };
             };
             /** @description Validation Error */

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -43,6 +43,7 @@ from galaxy.schema.tasks import (
     ImportModelStoreTaskRequest,
     MaterializeDatasetInstanceTaskRequest,
     PrepareDatasetCollectionDownload,
+    PurgeDatasetsTaskRequest,
     SetupHistoryExportJob,
     WriteHistoryContentTo,
     WriteHistoryTo,
@@ -82,6 +83,11 @@ def recalculate_user_disk_usage(session: galaxy_scoped_session, user_id: Optiona
 def purge_hda(hda_manager: HDAManager, hda_id: int):
     hda = hda_manager.by_id(hda_id)
     hda_manager._purge(hda)
+
+
+@galaxy_task(ignore_result=True, action="completely removes a set of datasets from the object_store")
+def purge_datasets(dataset_manager: DatasetManager, request: PurgeDatasetsTaskRequest):
+    dataset_manager.purge_datasets(request)
 
 
 @galaxy_task(ignore_result=True, action="materializing dataset instance")

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -57,7 +57,7 @@ from galaxy.model import tool_shed_install
 from galaxy.schema import ValueFilterQueryParams
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.storage_cleaner import (
-    DiscardedItemsSummary,
+    CleanableItemsSummary,
     StorageItemsCleanupResult,
     StoredItem,
 )
@@ -1310,7 +1310,7 @@ class StorageCleanerManager(Protocol):
     Interface for monitoring storage usage and managing deletion/purging of objects that consume user's storage space.
     """
 
-    def get_discarded_summary(self, user: model.User) -> DiscardedItemsSummary:
+    def get_discarded_summary(self, user: model.User) -> CleanableItemsSummary:
         """Returns information with the total storage space taken by discarded items for the given user.
 
         Discarded items are those that are deleted but not purged yet.

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -56,6 +56,11 @@ from galaxy import (
 from galaxy.model import tool_shed_install
 from galaxy.schema import ValueFilterQueryParams
 from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.storage_cleaner import (
+    DiscardedItemsSummary,
+    StorageItemsCleanupResult,
+    StoredItem,
+)
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import (
     BasicSharedApp,
@@ -1297,4 +1302,25 @@ class SortableManager:
     def parse_order_by(self, order_by_string, default=None):
         """Return an ORM compatible order_by clause using the given string (i.e.: 'name-dsc,create_time').
         This must be implemented by the manager."""
+        raise NotImplementedError
+
+
+class StorageCleanerManager(Protocol):
+    """
+    Interface for monitoring storage usage and managing deletion/purging of objects that consume user's storage space.
+    """
+
+    def get_discarded_summary(self, user: model.User) -> DiscardedItemsSummary:
+        """Returns information with the total storage space taken by discarded items for the given user.
+
+        Discarded items are those that are deleted but not purged yet.
+        """
+        raise NotImplementedError
+
+    def get_discarded(self, user: model.User, offset: Optional[int], limit: Optional[int]) -> List[StoredItem]:
+        """Returns a paginated list of items deleted by the given user that are not yet purged."""
+        raise NotImplementedError
+
+    def cleanup_items(self, user: model.User, item_ids: Set[int]) -> StorageItemsCleanupResult:
+        """Purges the given list of items by ID. The items must be owned by the user."""
         raise NotImplementedError

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -60,6 +60,7 @@ from galaxy.schema.storage_cleaner import (
     CleanableItemsSummary,
     StorageItemsCleanupResult,
     StoredItem,
+    StoredItemOrderBy,
 )
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import (
@@ -1310,6 +1311,8 @@ class StorageCleanerManager(Protocol):
     Interface for monitoring storage usage and managing deletion/purging of objects that consume user's storage space.
     """
 
+    sort_map: Dict[StoredItemOrderBy, Any]
+
     def get_discarded_summary(self, user: model.User) -> CleanableItemsSummary:
         """Returns information with the total storage space taken by discarded items for the given user.
 
@@ -1317,7 +1320,13 @@ class StorageCleanerManager(Protocol):
         """
         raise NotImplementedError
 
-    def get_discarded(self, user: model.User, offset: Optional[int], limit: Optional[int]) -> List[StoredItem]:
+    def get_discarded(
+        self,
+        user: model.User,
+        offset: Optional[int],
+        limit: Optional[int],
+        order: Optional[StoredItemOrderBy],
+    ) -> List[StoredItem]:
         """Returns a paginated list of items deleted by the given user that are not yet purged."""
         raise NotImplementedError
 

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -416,7 +416,7 @@ class HDAStorageCleanerManager(base.StorageCleanerManager):
                     hda: model.HistoryDatasetAssociation = self.hda_manager.get_owned(hda_id, user)
                     hda.deleted = True
                     quota_amount = int(hda.quota_amount(user))
-                    hda.purge_usage_from_quota(user)
+                    hda.purge_usage_from_quota(user, hda.dataset.quota_source_info)
                     hda.purged = True
                     dataset_ids_to_remove.add(hda.dataset.id)
                     success_item_count += 1

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -407,17 +407,16 @@ class HDAStorageCleanerManager(base.StorageCleanerManager):
         total_free_bytes = 0
         errors: List[StorageItemCleanupError] = []
 
-        for hda_id in item_ids:
-            try:
-                hda = self.hda_manager.get_owned(hda_id, user)
-                self.hda_manager.purge(hda)
-                success_item_count += 1
-                total_free_bytes += int(hda.get_size())
-            except BaseException as e:
-                errors.append(StorageItemCleanupError(item_id=hda_id, error=str(e)))
+        with self.hda_manager.session().begin():
+            for hda_id in item_ids:
+                try:
+                    hda = self.hda_manager.get_owned(hda_id, user)
+                    self.hda_manager.purge(hda)
+                    success_item_count += 1
+                    total_free_bytes += int(hda.get_size())
+                except BaseException as e:
+                    errors.append(StorageItemCleanupError(item_id=hda_id, error=str(e)))
 
-        if success_item_count:
-            self.hda_manager.session().flush()
         return StorageItemsCleanupResult(
             total_item_count=len(item_ids),
             success_item_count=success_item_count,

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -42,7 +42,7 @@ from galaxy.model.deferred import materializer_factory
 from galaxy.model.tags import GalaxyTagHandler
 from galaxy.schema.schema import DatasetSourceType
 from galaxy.schema.storage_cleaner import (
-    DiscardedItemsSummary,
+    CleanableItemsSummary,
     StorageItemCleanupError,
     StorageItemsCleanupResult,
     StoredItem,
@@ -333,7 +333,7 @@ class HDAStorageCleanerManager(base.StorageCleanerManager):
     def __init__(self, hda_manager: HDAManager):
         self.hda_manager = hda_manager
 
-    def get_discarded_summary(self, user: model.User) -> DiscardedItemsSummary:
+    def get_discarded_summary(self, user: model.User) -> CleanableItemsSummary:
         stmt = (
             select([func.sum(model.Dataset.total_size), func.count(model.HistoryDatasetAssociation.id)])
             .select_from(model.HistoryDatasetAssociation)
@@ -349,7 +349,7 @@ class HDAStorageCleanerManager(base.StorageCleanerManager):
         )
         result = self.hda_manager.session().execute(stmt).fetchone()
         total_size = 0 if result[0] is None else result[0]
-        return DiscardedItemsSummary(total_size=total_size, total_items=result[1])
+        return CleanableItemsSummary(total_size=total_size, total_items=result[1])
 
     def get_discarded(self, user: model.User, offset: Optional[int], limit: Optional[int]) -> List[StoredItem]:
         stmt = (

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -397,7 +397,7 @@ class HDAStorageCleanerManager(base.StorageCleanerManager):
             stmt = stmt.order_by(self.sort_map[order])
         result = self.hda_manager.session().execute(stmt)
         discarded = [
-            StoredItem(id=row.id, name=row.name, type="dataset", size=row.total_size, update_time=row.update_time)
+            StoredItem(id=row.id, name=row.name, type="dataset", size=row.total_size or 0, update_time=row.update_time)
             for row in result
         ]
         return discarded

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -51,7 +51,7 @@ from galaxy.schema.schema import (
     ShareHistoryExtra,
 )
 from galaxy.schema.storage_cleaner import (
-    DiscardedItemsSummary,
+    CleanableItemsSummary,
     StorageItemCleanupError,
     StorageItemsCleanupResult,
     StoredItem,
@@ -371,7 +371,7 @@ class HistoryStorageCleanerManager(StorageCleanerManager):
     def __init__(self, history_manager: HistoryManager):
         self.history_manager = history_manager
 
-    def get_discarded_summary(self, user: model.User) -> DiscardedItemsSummary:
+    def get_discarded_summary(self, user: model.User) -> CleanableItemsSummary:
         stmt = select([func.sum(model.History.disk_size), func.count(model.History.id)]).where(
             model.History.user_id == user.id,
             model.History.deleted == true(),
@@ -379,7 +379,7 @@ class HistoryStorageCleanerManager(StorageCleanerManager):
         )
         result = self.history_manager.session().execute(stmt).fetchone()
         total_size = 0 if result[0] is None else result[0]
-        return DiscardedItemsSummary(total_size=total_size, total_items=result[1])
+        return CleanableItemsSummary(total_size=total_size, total_items=result[1])
 
     def get_discarded(self, user: model.User, offset: Optional[int], limit: Optional[int]) -> List[StoredItem]:
         stmt = select(model.History).where(

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -374,7 +374,8 @@ class HistoryManager(
             model.History.purged == false(),
         )
         result = self.session().execute(stmt).fetchone()
-        return DiscardedItemsSummary(total_size=result[0], total_items=result[1])
+        total_size = 0 if result[0] is None else result[0]
+        return DiscardedItemsSummary(total_size=total_size, total_items=result[1])
 
     def get_discarded(self, user: model.User, offset: Optional[int], limit: Optional[int]) -> List[StoredItem]:
         stmt = select(model.History).where(

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -19,6 +19,10 @@ from sqlalchemy import (
     and_,
     asc,
     desc,
+    false,
+    func,
+    select,
+    true,
 )
 from typing_extensions import Literal
 
@@ -36,6 +40,7 @@ from galaxy.managers.base import (
     ModelDeserializingError,
     Serializer,
     SortableManager,
+    StorageCleanerManager,
 )
 from galaxy.managers.export_tracker import StoreExportTracker
 from galaxy.schema.fields import DecodedDatabaseIdField
@@ -45,13 +50,21 @@ from galaxy.schema.schema import (
     HDABasicInfo,
     ShareHistoryExtra,
 )
+from galaxy.schema.storage_cleaner import (
+    DiscardedItemsSummary,
+    StorageItemCleanupError,
+    StorageItemsCleanupResult,
+    StoredItem,
+)
 from galaxy.security.validate_user_input import validate_preferred_object_store_id
 from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
 
 
-class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMixin, SortableManager):
+class HistoryManager(
+    sharable.SharableModelManager, deletable.PurgableManagerMixin, SortableManager, StorageCleanerManager
+):
     model_class = model.History
     foreign_key_name = "history"
     user_share_model = model.HistoryUserShareAssociation
@@ -353,6 +366,57 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
                         log.warning(f"Unable to make dataset with id: {dataset.id} public")
                 else:
                     log.warning(f"User without permissions tried to make dataset with id: {dataset.id} public")
+
+    def get_discarded_summary(self, user: model.User) -> DiscardedItemsSummary:
+        stmt = select([func.sum(model.History.disk_size), func.count(model.History.id)]).where(
+            model.History.user_id == user.id,
+            model.History.deleted == true(),
+            model.History.purged == false(),
+        )
+        result = self.session().execute(stmt).fetchone()
+        return DiscardedItemsSummary(total_size=result[0], total_items=result[1])
+
+    def get_discarded(self, user: model.User, offset: Optional[int], limit: Optional[int]) -> List[StoredItem]:
+        stmt = select(model.History).where(
+            model.History.user_id == user.id,
+            model.History.deleted == true(),
+            model.History.purged == false(),
+        )
+        if offset:
+            stmt = stmt.offset(offset)
+        if limit:
+            stmt = stmt.limit(limit)
+        result = self.session().execute(stmt).scalars()
+        discarded = [self._history_to_stored_item(item) for item in result]
+        return discarded
+
+    def cleanup_items(self, user: model.User, item_ids: Set[int]) -> StorageItemsCleanupResult:
+        success_item_count = 0
+        total_free_bytes = 0
+        errors: List[StorageItemCleanupError] = []
+
+        for history_id in item_ids:
+            try:
+                history = self.get_owned(history_id, user)
+                self.purge(history, flush=False)
+                success_item_count += 1
+                total_free_bytes += int(history.disk_size)
+            except BaseException as e:
+                errors.append(StorageItemCleanupError(item_id=history_id, error=str(e)))
+
+        if success_item_count:
+            self.session().flush()
+        return StorageItemsCleanupResult(
+            total_item_count=len(item_ids),
+            success_item_count=success_item_count,
+            total_free_bytes=total_free_bytes,
+            errors=errors,
+        )
+
+    def _history_to_stored_item(self, history: model.History) -> StoredItem:
+        return StoredItem(
+            id=history.id, name=history.name, type="history", size=history.disk_size, update_time=history.update_time
+        )
 
 
 class HistoryExportManager:

--- a/lib/galaxy/schema/storage_cleaner.py
+++ b/lib/galaxy/schema/storage_cleaner.py
@@ -17,7 +17,7 @@ from galaxy.schema.schema import (
 )
 
 
-class DiscardedItemsSummary(Model):
+class CleanableItemsSummary(Model):
     total_size: int = Field(
         ...,
         title="Total Size",

--- a/lib/galaxy/schema/storage_cleaner.py
+++ b/lib/galaxy/schema/storage_cleaner.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from enum import Enum
 from typing import (
     List,
     Union,
@@ -39,6 +40,17 @@ class StoredItem(Model):
     type: StoredItemType
     size: int
     update_time: datetime = UpdateTimeField
+
+
+class StoredItemOrderBy(str, Enum):
+    """Available options for sorting Stored Items results."""
+
+    NAME_ASC = "name-asc"
+    NAME_DSC = "name-dsc"
+    SIZE_ASC = "size-asc"
+    SIZE_DSC = "size-dsc"
+    UPDATE_TIME_ASC = "update_time-asc"
+    UPDATE_TIME_DSC = "update_time-dsc"
 
 
 class StorageItemCleanupError(Model):

--- a/lib/galaxy/schema/storage_cleaner.py
+++ b/lib/galaxy/schema/storage_cleaner.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from typing import (
+    List,
+    Union,
+)
+
+from pydantic import Field
+from typing_extensions import Literal
+
+from galaxy.schema.fields import (
+    DecodedDatabaseIdField,
+    EncodedDatabaseIdField,
+)
+from galaxy.schema.schema import (
+    Model,
+    UpdateTimeField,
+)
+
+
+class DiscardedItemsSummary(Model):
+    total_size: int = Field(
+        ...,
+        title="Total Size",
+        description="The total size in bytes that can be recovered by purging all the items.",
+    )
+    total_items: int = Field(
+        ...,
+        title="Total Items",
+        description="The total number of items that could be purged.",
+    )
+
+
+StoredItemType = Union[Literal["history"], Literal["hda"]]
+
+
+class StoredItem(Model):
+    id: EncodedDatabaseIdField
+    name: str
+    type: StoredItemType
+    size: int
+    update_time: datetime = UpdateTimeField
+
+
+class StorageItemCleanupError(Model):
+    item_id: EncodedDatabaseIdField
+    error: str
+
+
+class CleanupStorageItemsRequest(Model):
+    item_ids: List[DecodedDatabaseIdField]
+
+
+class StorageItemsCleanupResult(Model):
+    total_item_count: int
+    success_item_count: int
+    total_free_bytes: int
+    errors: List[StorageItemCleanupError]

--- a/lib/galaxy/schema/storage_cleaner.py
+++ b/lib/galaxy/schema/storage_cleaner.py
@@ -30,7 +30,7 @@ class DiscardedItemsSummary(Model):
     )
 
 
-StoredItemType = Union[Literal["history"], Literal["hda"]]
+StoredItemType = Union[Literal["history"], Literal["dataset"]]
 
 
 class StoredItem(Model):

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -1,4 +1,7 @@
-from typing import Optional
+from typing import (
+    List,
+    Optional,
+)
 from uuid import UUID
 
 from pydantic import (
@@ -116,3 +119,7 @@ class ComputeDatasetHashTaskRequest(BaseModel):
     extra_files_path: Optional[str]
     hash_function: HashFunctionNameEnum
     user: Optional[RequestUser]  # access checks should be done pre-celery so this is optional
+
+
+class PurgeDatasetsTaskRequest(BaseModel):
+    dataset_ids: List[int]

--- a/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
@@ -11,8 +11,8 @@ from fastapi import Body
 
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.schema.storage_cleaner import (
+    CleanableItemsSummary,
     CleanupStorageItemsRequest,
-    DiscardedItemsSummary,
     StorageItemsCleanupResult,
     StoredItem,
 )
@@ -44,7 +44,7 @@ class FastAPIStorageCleaner:
     def discarded_histories_summary(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ) -> DiscardedItemsSummary:
+    ) -> CleanableItemsSummary:
         return self.service.get_discarded_histories_summary(trans)
 
     @router.get(
@@ -78,7 +78,7 @@ class FastAPIStorageCleaner:
     def discarded_datasets_summary(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ) -> DiscardedItemsSummary:
+    ) -> CleanableItemsSummary:
         return self.service.get_discarded_datasets_summary(trans)
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
@@ -58,7 +58,7 @@ class FastAPIStorageCleaner:
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
     ) -> CleanableItemsSummary:
-        return self.service.get_discarded_histories_summary(trans)
+        return self.service.get_discarded_summary(trans, stored_item_type="history")
 
     @router.get(
         "/api/storage/histories/discarded",
@@ -71,7 +71,7 @@ class FastAPIStorageCleaner:
         limit: Optional[int] = LimitQueryParam,
         order: Optional[StoredItemOrderBy] = OrderQueryParam,
     ) -> List[StoredItem]:
-        return self.service.get_discarded_histories(trans, offset, limit, order)
+        return self.service.get_discarded(trans, "history", offset, limit, order)
 
     @router.delete(
         "/api/storage/histories",
@@ -83,7 +83,7 @@ class FastAPIStorageCleaner:
         """
         **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
         """
-        return self.service.cleanup_histories(trans, set(payload.item_ids))
+        return self.service.cleanup_items(trans, stored_item_type="history", item_ids=set(payload.item_ids))
 
     @router.get(
         "/api/storage/datasets/discarded/summary",
@@ -93,7 +93,7 @@ class FastAPIStorageCleaner:
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
     ) -> CleanableItemsSummary:
-        return self.service.get_discarded_datasets_summary(trans)
+        return self.service.get_discarded_summary(trans, stored_item_type="dataset")
 
     @router.get(
         "/api/storage/datasets/discarded",
@@ -106,7 +106,7 @@ class FastAPIStorageCleaner:
         limit: Optional[int] = LimitQueryParam,
         order: Optional[StoredItemOrderBy] = OrderQueryParam,
     ) -> List[StoredItem]:
-        return self.service.get_discarded_datasets(trans, offset, limit, order)
+        return self.service.get_discarded(trans, "dataset", offset, limit, order)
 
     @router.delete(
         "/api/storage/datasets",
@@ -118,4 +118,4 @@ class FastAPIStorageCleaner:
         """
         **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
         """
-        return self.service.cleanup_datasets(trans, set(payload.item_ids))
+        return self.service.cleanup_items(trans, stored_item_type="dataset", item_ids=set(payload.item_ids))

--- a/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
@@ -1,0 +1,69 @@
+"""
+API operations on User storage management.
+"""
+import logging
+from typing import (
+    List,
+    Optional,
+)
+
+from fastapi import Body
+
+from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.schema.storage_cleaner import (
+    CleanupStorageItemsRequest,
+    DiscardedItemsSummary,
+    StorageItemsCleanupResult,
+    StoredItem,
+)
+from galaxy.webapps.galaxy.api import (
+    depends,
+    DependsOnTrans,
+    Router,
+)
+from galaxy.webapps.galaxy.api.common import (
+    LimitQueryParam,
+    OffsetQueryParam,
+)
+from galaxy.webapps.galaxy.services.storage_cleaner import StorageCleanerService
+
+log = logging.getLogger(__name__)
+
+
+router = Router(tags=["storage management"])
+
+
+@router.cbv
+class FastAPIStorageCleaner:
+    service: StorageCleanerService = depends(StorageCleanerService)
+
+    @router.get(
+        "/api/storage/summary/discarded/histories",
+        summary="Returns information with the total storage space taken by discarded histories associated with the given user.",
+    )
+    def discarded_histories_summary(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> DiscardedItemsSummary:
+        return self.service.get_discarded_histories_summary(trans)
+
+    @router.get(
+        "/api/storage/discarded/histories",
+        summary="Returns all discarded histories associated with the given user.",
+    )
+    def discarded_histories(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        offset: Optional[int] = OffsetQueryParam,
+        limit: Optional[int] = LimitQueryParam,
+    ) -> List[StoredItem]:
+        return self.service.get_discarded_histories(trans, offset, limit)
+
+    @router.delete(
+        "/api/storage/discarded/histories",
+        summary="Purges histories that has been previously deleted by the user.",
+    )
+    def cleanup_histories(
+        self, trans: ProvidesHistoryContext = DependsOnTrans, payload: CleanupStorageItemsRequest = Body(...)
+    ) -> StorageItemsCleanupResult:
+        return self.service.cleanup_histories(trans, set(payload.item_ids))

--- a/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
@@ -38,7 +38,7 @@ class FastAPIStorageCleaner:
     service: StorageCleanerService = depends(StorageCleanerService)
 
     @router.get(
-        "/api/storage/summary/discarded/histories",
+        "/api/storage/discarded/histories/summary",
         summary="Returns information with the total storage space taken by discarded histories associated with the given user.",
     )
     def discarded_histories_summary(

--- a/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
@@ -38,7 +38,7 @@ class FastAPIStorageCleaner:
     service: StorageCleanerService = depends(StorageCleanerService)
 
     @router.get(
-        "/api/storage/discarded/histories/summary",
+        "/api/storage/histories/discarded/summary",
         summary="Returns information with the total storage space taken by discarded histories associated with the given user.",
     )
     def discarded_histories_summary(
@@ -48,7 +48,7 @@ class FastAPIStorageCleaner:
         return self.service.get_discarded_histories_summary(trans)
 
     @router.get(
-        "/api/storage/discarded/histories",
+        "/api/storage/histories/discarded",
         summary="Returns all discarded histories associated with the given user.",
     )
     def discarded_histories(

--- a/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
@@ -7,7 +7,10 @@ from typing import (
     Optional,
 )
 
-from fastapi import Body
+from fastapi import (
+    Body,
+    Query,
+)
 
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.schema.storage_cleaner import (
@@ -15,6 +18,7 @@ from galaxy.schema.storage_cleaner import (
     CleanupStorageItemsRequest,
     StorageItemsCleanupResult,
     StoredItem,
+    StoredItemOrderBy,
 )
 from galaxy.webapps.galaxy.api import (
     depends,
@@ -31,6 +35,15 @@ log = logging.getLogger(__name__)
 
 
 router = Router(tags=["storage management"])
+
+OrderQueryParam: Optional[StoredItemOrderBy] = Query(
+    default=None,
+    title="Order",
+    description=(
+        "String containing one of the valid ordering attributes followed "
+        "by '-asc' or '-dsc' for ascending and descending order respectively."
+    ),
+)
 
 
 @router.cbv
@@ -56,8 +69,9 @@ class FastAPIStorageCleaner:
         trans: ProvidesHistoryContext = DependsOnTrans,
         offset: Optional[int] = OffsetQueryParam,
         limit: Optional[int] = LimitQueryParam,
+        order: Optional[StoredItemOrderBy] = OrderQueryParam,
     ) -> List[StoredItem]:
-        return self.service.get_discarded_histories(trans, offset, limit)
+        return self.service.get_discarded_histories(trans, offset, limit, order)
 
     @router.delete(
         "/api/storage/histories",
@@ -88,8 +102,11 @@ class FastAPIStorageCleaner:
     def discarded_datasets(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
+        offset: Optional[int] = OffsetQueryParam,
+        limit: Optional[int] = LimitQueryParam,
+        order: Optional[StoredItemOrderBy] = OrderQueryParam,
     ) -> List[StoredItem]:
-        return self.service.get_discarded_datasets(trans)
+        return self.service.get_discarded_datasets(trans, offset, limit, order)
 
     @router.delete(
         "/api/storage/datasets",

--- a/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
@@ -60,10 +60,13 @@ class FastAPIStorageCleaner:
         return self.service.get_discarded_histories(trans, offset, limit)
 
     @router.delete(
-        "/api/storage/discarded/histories",
-        summary="Purges histories that has been previously deleted by the user.",
+        "/api/storage/histories",
+        summary="Purges a set of histories by ID. The histories must be owned by the user.",
     )
     def cleanup_histories(
         self, trans: ProvidesHistoryContext = DependsOnTrans, payload: CleanupStorageItemsRequest = Body(...)
     ) -> StorageItemsCleanupResult:
+        """
+        **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
+        """
         return self.service.cleanup_histories(trans, set(payload.item_ids))

--- a/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
@@ -70,3 +70,35 @@ class FastAPIStorageCleaner:
         **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
         """
         return self.service.cleanup_histories(trans, set(payload.item_ids))
+
+    @router.get(
+        "/api/storage/datasets/discarded/summary",
+        summary="Returns information with the total storage space taken by discarded datasets owned by the given user.",
+    )
+    def discarded_datasets_summary(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> DiscardedItemsSummary:
+        return self.service.get_discarded_datasets_summary(trans)
+
+    @router.get(
+        "/api/storage/datasets/discarded",
+        summary="Returns discarded datasets owned by the given user. The results can be paginated.",
+    )
+    def discarded_datasets(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> List[StoredItem]:
+        return self.service.get_discarded_datasets(trans)
+
+    @router.delete(
+        "/api/storage/datasets",
+        summary="Purges a set of datasets by ID from disk. The datasets must be owned by the user.",
+    )
+    def cleanup_datasets(
+        self, trans: ProvidesHistoryContext = DependsOnTrans, payload: CleanupStorageItemsRequest = Body(...)
+    ) -> StorageItemsCleanupResult:
+        """
+        **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
+        """
+        return self.service.cleanup_datasets(trans, set(payload.item_ids))

--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -44,6 +44,10 @@ def ensure_celery_tasks_enabled(config):
         )
 
 
+class SecurityNotProvidedError(Exception):
+    pass
+
+
 class ServiceBase:
     """Base class with common logic and utils reused by other services.
 
@@ -56,8 +60,16 @@ class ServiceBase:
        the required parameters and outputs of each operation.
     """
 
-    def __init__(self, security: IdEncodingHelper):
-        self.security = security
+    def __init__(self, security: Optional[IdEncodingHelper] = None):
+        self._security = security
+
+    @property
+    def security(self) -> IdEncodingHelper:
+        if self._security is None:
+            raise SecurityNotProvidedError(
+                "Security encoding helper must be set in the service constructor to encode/decode ids."
+            )
+        return self._security
 
     def decode_id(self, id: EncodedDatabaseIdField, kind: Optional[str] = None) -> int:
         """Decodes a previously encoded database ID."""

--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -8,7 +8,6 @@ from typing import (
 )
 
 from celery.result import AsyncResult
-from deprecated import deprecated
 
 from galaxy.exceptions import (
     AuthenticationRequired,
@@ -49,11 +48,6 @@ class SecurityNotProvidedError(Exception):
     pass
 
 
-MANUAL_ENCODING_DEPRECATION_MESSAGE = (
-    "Use model decoding/encoding instead with DecodedDatabaseIdField or EncodedDatabaseIdField."
-)
-
-
 class ServiceBase:
     """Base class with common logic and utils reused by other services.
 
@@ -70,7 +64,6 @@ class ServiceBase:
         self._security = security
 
     @property
-    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def security(self) -> IdEncodingHelper:
         if self._security is None:
             raise SecurityNotProvidedError(
@@ -78,24 +71,20 @@ class ServiceBase:
             )
         return self._security
 
-    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def decode_id(self, id: EncodedDatabaseIdField, kind: Optional[str] = None) -> int:
         """Decodes a previously encoded database ID."""
         return decode_with_security(self.security, id, kind=kind)
 
-    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def encode_id(self, id: int, kind: Optional[str] = None) -> EncodedDatabaseIdField:
         """Encodes a raw database ID."""
         return encode_with_security(self.security, id, kind=kind)
 
-    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def decode_ids(self, ids: List[EncodedDatabaseIdField]) -> List[int]:
         """
         Decodes all encoded IDs in the given list.
         """
         return [self.decode_id(id) for id in ids]
 
-    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def encode_all_ids(self, rval, recursive: bool = False):
         """
         Encodes all integer values in the dict rval whose keys are 'id' or end with '_id'

--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -8,6 +8,7 @@ from typing import (
 )
 
 from celery.result import AsyncResult
+from deprecated import deprecated
 
 from galaxy.exceptions import (
     AuthenticationRequired,
@@ -48,6 +49,11 @@ class SecurityNotProvidedError(Exception):
     pass
 
 
+MANUAL_ENCODING_DEPRECATION_MESSAGE = (
+    "Use model decoding/encoding instead with DecodedDatabaseIdField or EncodedDatabaseIdField."
+)
+
+
 class ServiceBase:
     """Base class with common logic and utils reused by other services.
 
@@ -64,6 +70,7 @@ class ServiceBase:
         self._security = security
 
     @property
+    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def security(self) -> IdEncodingHelper:
         if self._security is None:
             raise SecurityNotProvidedError(
@@ -71,20 +78,24 @@ class ServiceBase:
             )
         return self._security
 
+    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def decode_id(self, id: EncodedDatabaseIdField, kind: Optional[str] = None) -> int:
         """Decodes a previously encoded database ID."""
         return decode_with_security(self.security, id, kind=kind)
 
+    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def encode_id(self, id: int, kind: Optional[str] = None) -> EncodedDatabaseIdField:
         """Encodes a raw database ID."""
         return encode_with_security(self.security, id, kind=kind)
 
+    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def decode_ids(self, ids: List[EncodedDatabaseIdField]) -> List[int]:
         """
         Decodes all encoded IDs in the given list.
         """
         return [self.decode_id(id) for id in ids]
 
+    @deprecated(reason=MANUAL_ENCODING_DEPRECATION_MESSAGE)
     def encode_all_ids(self, rval, recursive: bool = False):
         """
         Encodes all integer values in the dict rval whose keys are 'id' or end with '_id'

--- a/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
@@ -1,14 +1,19 @@
 import logging
 from typing import (
+    Dict,
     Optional,
     Set,
 )
 
+from galaxy.managers.base import StorageCleanerManager
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.managers.hdas import HDAStorageCleanerManager
 from galaxy.managers.histories import HistoryStorageCleanerManager
 from galaxy.managers.users import UserManager
-from galaxy.schema.storage_cleaner import StoredItemOrderBy
+from galaxy.schema.storage_cleaner import (
+    StoredItemOrderBy,
+    StoredItemType,
+)
 from galaxy.webapps.galaxy.services.base import ServiceBase
 
 log = logging.getLogger(__name__)
@@ -26,39 +31,26 @@ class StorageCleanerService(ServiceBase):
         self.user_manager = user_manager
         self.history_cleaner = history_cleaner
         self.hda_cleaner = hda_cleaner
+        self.storage_cleaner_map: Dict[StoredItemType, StorageCleanerManager] = {
+            "history": self.history_cleaner,
+            "dataset": self.hda_cleaner,
+        }
 
-    def get_discarded_histories_summary(self, trans: ProvidesHistoryContext):
+    def get_discarded_summary(self, trans: ProvidesHistoryContext, stored_item_type: StoredItemType):
         user = self.get_authenticated_user(trans)
-        return self.history_cleaner.get_discarded_summary(user)
+        return self.storage_cleaner_map[stored_item_type].get_discarded_summary(user)
 
-    def get_discarded_histories(
+    def get_discarded(
         self,
         trans: ProvidesHistoryContext,
+        stored_item_type: StoredItemType,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         order: Optional[StoredItemOrderBy] = None,
     ):
         user = self.get_authenticated_user(trans)
-        return self.history_cleaner.get_discarded(user, offset, limit, order)
+        return self.storage_cleaner_map[stored_item_type].get_discarded(user, offset, limit, order)
 
-    def cleanup_histories(self, trans: ProvidesHistoryContext, item_ids: Set[int]):
+    def cleanup_items(self, trans: ProvidesHistoryContext, stored_item_type: StoredItemType, item_ids: Set[int]):
         user = self.get_authenticated_user(trans)
-        return self.history_cleaner.cleanup_items(user, item_ids)
-
-    def get_discarded_datasets_summary(self, trans: ProvidesHistoryContext):
-        user = self.get_authenticated_user(trans)
-        return self.hda_cleaner.get_discarded_summary(user)
-
-    def get_discarded_datasets(
-        self,
-        trans: ProvidesHistoryContext,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
-        order: Optional[StoredItemOrderBy] = None,
-    ):
-        user = self.get_authenticated_user(trans)
-        return self.hda_cleaner.get_discarded(user, offset, limit, order)
-
-    def cleanup_datasets(self, trans: ProvidesHistoryContext, item_ids: Set[int]):
-        user = self.get_authenticated_user(trans)
-        return self.hda_cleaner.cleanup_items(user, item_ids)
+        return self.storage_cleaner_map[stored_item_type].cleanup_items(user, item_ids)

--- a/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
@@ -1,0 +1,38 @@
+import logging
+from typing import (
+    Optional,
+    Set,
+)
+
+from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.managers.histories import HistoryManager
+from galaxy.managers.users import UserManager
+from galaxy.webapps.galaxy.services.base import ServiceBase
+
+log = logging.getLogger(__name__)
+
+
+class StorageCleanerService(ServiceBase):
+    """Service providing actions to monitor and recover storage space used by the user."""
+
+    def __init__(
+        self,
+        user_manager: UserManager,
+        history_manager: HistoryManager,
+    ):
+        self.user_manager = user_manager
+        self.history_manager = history_manager
+
+    def get_discarded_histories_summary(self, trans: ProvidesHistoryContext):
+        user = self.get_authenticated_user(trans)
+        return self.history_manager.get_discarded_summary(user)
+
+    def get_discarded_histories(
+        self, trans: ProvidesHistoryContext, offset: Optional[int] = None, limit: Optional[int] = None
+    ):
+        user = self.get_authenticated_user(trans)
+        return self.history_manager.get_discarded(user, offset, limit)
+
+    def cleanup_histories(self, trans: ProvidesHistoryContext, item_ids: Set[int]):
+        user = self.get_authenticated_user(trans)
+        return self.history_manager.cleanup_items(user, item_ids)

--- a/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
@@ -8,6 +8,7 @@ from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.managers.hdas import HDAStorageCleanerManager
 from galaxy.managers.histories import HistoryStorageCleanerManager
 from galaxy.managers.users import UserManager
+from galaxy.schema.storage_cleaner import StoredItemOrderBy
 from galaxy.webapps.galaxy.services.base import ServiceBase
 
 log = logging.getLogger(__name__)
@@ -31,10 +32,14 @@ class StorageCleanerService(ServiceBase):
         return self.history_cleaner.get_discarded_summary(user)
 
     def get_discarded_histories(
-        self, trans: ProvidesHistoryContext, offset: Optional[int] = None, limit: Optional[int] = None
+        self,
+        trans: ProvidesHistoryContext,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        order: Optional[StoredItemOrderBy] = None,
     ):
         user = self.get_authenticated_user(trans)
-        return self.history_cleaner.get_discarded(user, offset, limit)
+        return self.history_cleaner.get_discarded(user, offset, limit, order)
 
     def cleanup_histories(self, trans: ProvidesHistoryContext, item_ids: Set[int]):
         user = self.get_authenticated_user(trans)
@@ -45,10 +50,14 @@ class StorageCleanerService(ServiceBase):
         return self.hda_cleaner.get_discarded_summary(user)
 
     def get_discarded_datasets(
-        self, trans: ProvidesHistoryContext, offset: Optional[int] = None, limit: Optional[int] = None
+        self,
+        trans: ProvidesHistoryContext,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        order: Optional[StoredItemOrderBy] = None,
     ):
         user = self.get_authenticated_user(trans)
-        return self.hda_cleaner.get_discarded(user, offset, limit)
+        return self.hda_cleaner.get_discarded(user, offset, limit, order)
 
     def cleanup_datasets(self, trans: ProvidesHistoryContext, item_ids: Set[int]):
         user = self.get_authenticated_user(trans)

--- a/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
@@ -6,7 +6,7 @@ from typing import (
 
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.managers.hdas import HDAStorageCleanerManager
-from galaxy.managers.histories import HistoryManager
+from galaxy.managers.histories import HistoryStorageCleanerManager
 from galaxy.managers.users import UserManager
 from galaxy.webapps.galaxy.services.base import ServiceBase
 
@@ -19,26 +19,26 @@ class StorageCleanerService(ServiceBase):
     def __init__(
         self,
         user_manager: UserManager,
-        history_manager: HistoryManager,
+        history_cleaner: HistoryStorageCleanerManager,
         hda_cleaner: HDAStorageCleanerManager,
     ):
         self.user_manager = user_manager
-        self.history_manager = history_manager
+        self.history_cleaner = history_cleaner
         self.hda_cleaner = hda_cleaner
 
     def get_discarded_histories_summary(self, trans: ProvidesHistoryContext):
         user = self.get_authenticated_user(trans)
-        return self.history_manager.get_discarded_summary(user)
+        return self.history_cleaner.get_discarded_summary(user)
 
     def get_discarded_histories(
         self, trans: ProvidesHistoryContext, offset: Optional[int] = None, limit: Optional[int] = None
     ):
         user = self.get_authenticated_user(trans)
-        return self.history_manager.get_discarded(user, offset, limit)
+        return self.history_cleaner.get_discarded(user, offset, limit)
 
     def cleanup_histories(self, trans: ProvidesHistoryContext, item_ids: Set[int]):
         user = self.get_authenticated_user(trans)
-        return self.history_manager.cleanup_items(user, item_ids)
+        return self.history_cleaner.cleanup_items(user, item_ids)
 
     def get_discarded_datasets_summary(self, trans: ProvidesHistoryContext):
         user = self.get_authenticated_user(trans)

--- a/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
@@ -5,6 +5,7 @@ from typing import (
 )
 
 from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.managers.hdas import HDAStorageCleanerManager
 from galaxy.managers.histories import HistoryManager
 from galaxy.managers.users import UserManager
 from galaxy.webapps.galaxy.services.base import ServiceBase
@@ -19,9 +20,11 @@ class StorageCleanerService(ServiceBase):
         self,
         user_manager: UserManager,
         history_manager: HistoryManager,
+        hda_cleaner: HDAStorageCleanerManager,
     ):
         self.user_manager = user_manager
         self.history_manager = history_manager
+        self.hda_cleaner = hda_cleaner
 
     def get_discarded_histories_summary(self, trans: ProvidesHistoryContext):
         user = self.get_authenticated_user(trans)
@@ -36,3 +39,17 @@ class StorageCleanerService(ServiceBase):
     def cleanup_histories(self, trans: ProvidesHistoryContext, item_ids: Set[int]):
         user = self.get_authenticated_user(trans)
         return self.history_manager.cleanup_items(user, item_ids)
+
+    def get_discarded_datasets_summary(self, trans: ProvidesHistoryContext):
+        user = self.get_authenticated_user(trans)
+        return self.hda_cleaner.get_discarded_summary(user)
+
+    def get_discarded_datasets(
+        self, trans: ProvidesHistoryContext, offset: Optional[int] = None, limit: Optional[int] = None
+    ):
+        user = self.get_authenticated_user(trans)
+        return self.hda_cleaner.get_discarded(user, offset, limit)
+
+    def cleanup_datasets(self, trans: ProvidesHistoryContext, item_ids: Set[int]):
+        user = self.get_authenticated_user(trans)
+        return self.hda_cleaner.cleanup_items(user, item_ids)

--- a/lib/galaxy_test/api/test_storage_cleaner.py
+++ b/lib/galaxy_test/api/test_storage_cleaner.py
@@ -56,7 +56,7 @@ class TestStorageCleanerApi(ApiTestCase):
 
         # Cleanup all the histories
         payload = {"item_ids": list(history_name_id_map.values())}
-        cleanup_response = self._delete("storage/discarded/histories", data=payload, json=True)
+        cleanup_response = self._delete("storage/histories", data=payload, json=True)
         self._assert_status_code_is_ok(cleanup_response)
         cleanup_result = cleanup_response.json()
         assert cleanup_result["total_item_count"] == expected_discarded_histories_count

--- a/lib/galaxy_test/api/test_storage_cleaner.py
+++ b/lib/galaxy_test/api/test_storage_cleaner.py
@@ -83,6 +83,15 @@ class TestStorageCleanerApi(ApiTestCase):
         assert len(paginated_items) == expected_discarded_item_count
         assert sum([item["size"] for item in paginated_items]) == expected_total_size
 
+        # Check pagination
+        offset = 1
+        limit = 1
+        paginated_items_response = self._get(f"{discarded_storage_items_uri}?offset={offset}&limit={limit}")
+        self._assert_status_code_is_ok(paginated_items_response)
+        paginated_items = paginated_items_response.json()
+        assert len(paginated_items) == 1
+        assert paginated_items[0]["name"] == test_items[1].name
+
         # Check listing order by
         item_names_forward_order = [test_items[0].name, test_items[1].name, test_items[2].name]
         item_names_reverse_order = list(reversed(item_names_forward_order))

--- a/lib/galaxy_test/api/test_storage_cleaner.py
+++ b/lib/galaxy_test/api/test_storage_cleaner.py
@@ -1,0 +1,81 @@
+from typing import (
+    Dict,
+    List,
+    NamedTuple,
+)
+from uuid import uuid4
+
+from galaxy_test.base.populators import DatasetPopulator
+from ._framework import ApiTestCase
+
+
+class TestHistoryData(NamedTuple):
+    name: str
+    size: int
+
+
+class TestStorageCleanerApi(ApiTestCase):
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def test_discarded_histories_monitoring_and_cleanup(self):
+        # Create some histories for testing
+        history_data_01 = TestHistoryData(name=f"TestHistory01_{uuid4()}", size=10)
+        history_data_02 = TestHistoryData(name=f"TestHistory02_{uuid4()}", size=25)
+        history_data_03 = TestHistoryData(name=f"TestHistory03_{uuid4()}", size=50)
+        test_histories = [history_data_01, history_data_02, history_data_03]
+        history_name_id_map = self._create_histories(test_histories)
+
+        # Initially, there shouldn't be any deleted and not purged (discarded) histories
+        summary_response = self._get("storage/discarded/histories/summary")
+        self._assert_status_code_is_ok(summary_response)
+        summary = summary_response.json()
+        assert summary["total_items"] == 0
+        assert summary["total_size"] == 0
+
+        # Delete the histories
+        for history_id in history_name_id_map.values():
+            self._delete(f"histories/{history_id}", json=True)
+        expected_discarded_histories_count = len(test_histories)
+        expected_total_size = sum([test_history.size for test_history in test_histories])
+
+        # All the `test_histories` should be in the summary
+        summary_response = self._get("storage/discarded/histories/summary")
+        self._assert_status_code_is_ok(summary_response)
+        summary = summary_response.json()
+        assert summary["total_items"] == expected_discarded_histories_count
+        assert summary["total_size"] == expected_total_size
+
+        # Check listing all the discarded histories
+        discarded_histories_response = self._get("storage/discarded/histories")
+        self._assert_status_code_is_ok(discarded_histories_response)
+        discarded_histories = discarded_histories_response.json()
+        assert len(discarded_histories) == expected_discarded_histories_count
+        assert sum([history["size"] for history in discarded_histories]) == expected_total_size
+
+        # Cleanup all the histories
+        payload = {"item_ids": list(history_name_id_map.values())}
+        cleanup_response = self._delete("storage/discarded/histories", data=payload, json=True)
+        self._assert_status_code_is_ok(cleanup_response)
+        cleanup_result = cleanup_response.json()
+        assert cleanup_result["total_item_count"] == expected_discarded_histories_count
+        assert cleanup_result["success_item_count"] == expected_discarded_histories_count
+        assert cleanup_result["total_free_bytes"] == expected_total_size
+        assert not cleanup_result["errors"]
+
+    def _create_histories(self, test_histories: List[TestHistoryData], wait_for_histories=True) -> Dict[str, str]:
+        history_name_id_map = {}
+        for history_data in test_histories:
+            post_data = dict(name=history_data.name)
+            create_response = self._post("histories", data=post_data).json()
+            self._assert_has_keys(create_response, "name", "id")
+            history_id = create_response["id"]
+            history_name_id_map[history_data.name] = history_id
+            # Create a dataset with content equal to the expected size of the history
+            if history_data.size:
+                self.dataset_populator.new_dataset(history_id, content=f"{'0'*(history_data.size-1)}\n")
+        if wait_for_histories:
+            for history_id in history_name_id_map.values():
+                self.dataset_populator.wait_for_history(history_id)
+        return history_name_id_map

--- a/lib/galaxy_test/api/test_storage_cleaner.py
+++ b/lib/galaxy_test/api/test_storage_cleaner.py
@@ -1,5 +1,4 @@
 from typing import (
-    Dict,
     List,
     NamedTuple,
 )
@@ -10,7 +9,7 @@ from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
 
-class HistoryDataForTests(NamedTuple):
+class StoredItemDataForTests(NamedTuple):
     name: str
     size: int
 
@@ -25,11 +24,11 @@ class TestStorageCleanerApi(ApiTestCase):
     @requires_new_history
     def test_discarded_histories_monitoring_and_cleanup(self):
         # Create some histories for testing
-        history_data_01 = HistoryDataForTests(name=f"TestHistory01_{uuid4()}", size=10)
-        history_data_02 = HistoryDataForTests(name=f"TestHistory02_{uuid4()}", size=25)
-        history_data_03 = HistoryDataForTests(name=f"TestHistory03_{uuid4()}", size=50)
+        history_data_01 = StoredItemDataForTests(name=f"TestHistory01_{uuid4()}", size=10)
+        history_data_02 = StoredItemDataForTests(name=f"TestHistory02_{uuid4()}", size=25)
+        history_data_03 = StoredItemDataForTests(name=f"TestHistory03_{uuid4()}", size=50)
         test_histories = [history_data_01, history_data_02, history_data_03]
-        history_name_id_map = self._create_histories(test_histories)
+        history_ids = self._create_histories_with(test_histories)
 
         # Initially, there shouldn't be any deleted and not purged (discarded) histories
         summary_response = self._get("storage/histories/discarded/summary")
@@ -39,7 +38,7 @@ class TestStorageCleanerApi(ApiTestCase):
         assert summary["total_size"] == 0
 
         # Delete the histories
-        for history_id in history_name_id_map.values():
+        for history_id in history_ids:
             self._delete(f"histories/{history_id}", json=True)
         expected_discarded_histories_count = len(test_histories)
         expected_total_size = sum([test_history.size for test_history in test_histories])
@@ -52,14 +51,35 @@ class TestStorageCleanerApi(ApiTestCase):
         assert summary["total_size"] == expected_total_size
 
         # Check listing all the discarded histories
-        discarded_histories_response = self._get("storage/histories/discarded")
+        storage_items_url = "storage/histories/discarded"
+        discarded_histories_response = self._get(storage_items_url)
         self._assert_status_code_is_ok(discarded_histories_response)
         discarded_histories = discarded_histories_response.json()
         assert len(discarded_histories) == expected_discarded_histories_count
         assert sum([history["size"] for history in discarded_histories]) == expected_total_size
 
+        # Check listing order by
+        order_by = "name-asc"
+        expected_ordered_names = [history_data_01.name, history_data_02.name, history_data_03.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "name-dsc"
+        expected_ordered_names = [history_data_03.name, history_data_02.name, history_data_01.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "size-asc"
+        expected_ordered_names = [history_data_01.name, history_data_02.name, history_data_03.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "size-dsc"
+        expected_ordered_names = [history_data_03.name, history_data_02.name, history_data_01.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "update_time-asc"
+        expected_ordered_names = [history_data_01.name, history_data_02.name, history_data_03.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "update_time-dsc"
+        expected_ordered_names = [history_data_03.name, history_data_02.name, history_data_01.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+
         # Cleanup all the histories
-        payload = {"item_ids": list(history_name_id_map.values())}
+        payload = {"item_ids": history_ids}
         cleanup_response = self._delete("storage/histories", data=payload, json=True)
         self._assert_status_code_is_ok(cleanup_response)
         cleanup_result = cleanup_response.json()
@@ -68,33 +88,15 @@ class TestStorageCleanerApi(ApiTestCase):
         assert cleanup_result["total_free_bytes"] == expected_total_size
         assert not cleanup_result["errors"]
 
-    def _create_histories(self, test_histories: List[HistoryDataForTests], wait_for_histories=True) -> Dict[str, str]:
-        history_name_id_map = {}
-        for history_data in test_histories:
-            post_data = dict(name=history_data.name)
-            create_response = self._post("histories", data=post_data).json()
-            self._assert_has_keys(create_response, "name", "id")
-            history_id = create_response["id"]
-            history_name_id_map[history_data.name] = history_id
-            # Create a dataset with content equal to the expected size of the history
-            if history_data.size:
-                self.dataset_populator.new_dataset(history_id, content=f"{'0'*(history_data.size-1)}\n")
-        if wait_for_histories:
-            for history_id in history_name_id_map.values():
-                self.dataset_populator.wait_for_history(history_id)
-        return history_name_id_map
-
     @requires_new_history
     def test_discarded_datasets_monitoring_and_cleanup(self):
         # Prepare history with some datasets
         history_id = self.dataset_populator.new_history(f"History for discarded datasets {uuid4()}")
-        num_datasets = 3
-        dataset_size = 30
-        dataset_ids = []
-        for _ in range(num_datasets):
-            dataset = self.dataset_populator.new_dataset(history_id, content=f"{'0'*(dataset_size-1)}\n")
-            dataset_ids.append(dataset["id"])
-        self.dataset_populator.wait_for_history(history_id)
+        dataset_data_01 = StoredItemDataForTests(name=f"Dataset01_{uuid4()}", size=10)
+        dataset_data_02 = StoredItemDataForTests(name=f"Dataset02_{uuid4()}", size=25)
+        dataset_data_03 = StoredItemDataForTests(name=f"Dataset03_{uuid4()}", size=50)
+        test_datasets = [dataset_data_01, dataset_data_02, dataset_data_03]
+        dataset_ids = self._create_datasets_in_history_with(history_id, test_datasets)
 
         # Initially, there shouldn't be any deleted and not purged (discarded) datasets
         summary_response = self._get("storage/datasets/discarded/summary")
@@ -109,7 +111,7 @@ class TestStorageCleanerApi(ApiTestCase):
 
         # All datasets should be in the summary
         expected_num_discarded_datasets = len(dataset_ids)
-        expected_total_size = expected_num_discarded_datasets * dataset_size
+        expected_total_size = sum([test_dataset.size for test_dataset in test_datasets])
         summary_response = self._get("storage/datasets/discarded/summary")
         self._assert_status_code_is_ok(summary_response)
         summary = summary_response.json()
@@ -117,12 +119,32 @@ class TestStorageCleanerApi(ApiTestCase):
         assert summary["total_size"] == expected_total_size
 
         # Check listing all the discarded datasets
-        discarded_datasets_response = self._get("storage/datasets/discarded")
+        storage_items_url = "storage/datasets/discarded"
+        discarded_datasets_response = self._get(storage_items_url)
         self._assert_status_code_is_ok(discarded_datasets_response)
         discarded_datasets = discarded_datasets_response.json()
         assert len(discarded_datasets) == expected_num_discarded_datasets
-        for dataset in discarded_datasets:
-            assert dataset["size"] == dataset_size
+        assert sum([item["size"] for item in discarded_datasets]) == expected_total_size
+
+        # Check listing order by
+        order_by = "name-asc"
+        expected_ordered_names = [dataset_data_01.name, dataset_data_02.name, dataset_data_03.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "name-dsc"
+        expected_ordered_names = [dataset_data_03.name, dataset_data_02.name, dataset_data_01.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "size-asc"
+        expected_ordered_names = [dataset_data_01.name, dataset_data_02.name, dataset_data_03.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "size-dsc"
+        expected_ordered_names = [dataset_data_03.name, dataset_data_02.name, dataset_data_01.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "update_time-asc"
+        expected_ordered_names = [dataset_data_01.name, dataset_data_02.name, dataset_data_03.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
+        order_by = "update_time-dsc"
+        expected_ordered_names = [dataset_data_03.name, dataset_data_02.name, dataset_data_01.name]
+        self._assert_order_is_respected(storage_items_url, order_by, expected_ordered_names)
 
         # Cleanup all the datasets
         payload = {"item_ids": dataset_ids}
@@ -133,3 +155,41 @@ class TestStorageCleanerApi(ApiTestCase):
         assert cleanup_result["success_item_count"] == expected_num_discarded_datasets
         assert cleanup_result["total_free_bytes"] == expected_total_size
         assert not cleanup_result["errors"]
+
+    def _create_histories_with(
+        self, test_histories: List[StoredItemDataForTests], wait_for_histories=True
+    ) -> List[str]:
+        history_ids = []
+        for history_data in test_histories:
+            post_data = dict(name=history_data.name)
+            create_response = self._post("histories", data=post_data).json()
+            self._assert_has_keys(create_response, "name", "id")
+            history_id = create_response["id"]
+            history_ids.append(history_id)
+            # Create a dataset with content equal to the expected size of the history
+            if history_data.size:
+                self.dataset_populator.new_dataset(history_id, content=f"{'0'*(history_data.size-1)}\n")
+        if wait_for_histories:
+            for history_id in history_ids:
+                self.dataset_populator.wait_for_history(history_id)
+        return history_ids
+
+    def _create_datasets_in_history_with(
+        self, history_id: str, test_datasets: List[StoredItemDataForTests], wait_for_history=True
+    ) -> List[str]:
+        dataset_ids = []
+        for dataset_data in test_datasets:
+            dataset = self.dataset_populator.new_dataset(
+                history_id, name=dataset_data.name, content=f"{'0'*(dataset_data.size-1)}\n"
+            )
+            dataset_ids.append(dataset["id"])
+        if wait_for_history:
+            self.dataset_populator.wait_for_history(history_id)
+        return dataset_ids
+
+    def _assert_order_is_respected(self, storage_items_url: str, order_by: str, expected_ordered_names: List[str]):
+        items_response = self._get(f"{storage_items_url}?order={order_by}")
+        self._assert_status_code_is_ok(items_response)
+        items = items_response.json()
+        for index, item in enumerate(items):
+            assert item["name"] == expected_ordered_names[index]

--- a/lib/galaxy_test/api/test_storage_cleaner.py
+++ b/lib/galaxy_test/api/test_storage_cleaner.py
@@ -28,7 +28,7 @@ class TestStorageCleanerApi(ApiTestCase):
         history_name_id_map = self._create_histories(test_histories)
 
         # Initially, there shouldn't be any deleted and not purged (discarded) histories
-        summary_response = self._get("storage/discarded/histories/summary")
+        summary_response = self._get("storage/histories/discarded/summary")
         self._assert_status_code_is_ok(summary_response)
         summary = summary_response.json()
         assert summary["total_items"] == 0
@@ -41,14 +41,14 @@ class TestStorageCleanerApi(ApiTestCase):
         expected_total_size = sum([test_history.size for test_history in test_histories])
 
         # All the `test_histories` should be in the summary
-        summary_response = self._get("storage/discarded/histories/summary")
+        summary_response = self._get("storage/histories/discarded/summary")
         self._assert_status_code_is_ok(summary_response)
         summary = summary_response.json()
         assert summary["total_items"] == expected_discarded_histories_count
         assert summary["total_size"] == expected_total_size
 
         # Check listing all the discarded histories
-        discarded_histories_response = self._get("storage/discarded/histories")
+        discarded_histories_response = self._get("storage/histories/discarded")
         self._assert_status_code_is_ok(discarded_histories_response)
         discarded_histories = discarded_histories_response.json()
         assert len(discarded_histories) == expected_discarded_histories_count

--- a/lib/galaxy_test/api/test_storage_cleaner.py
+++ b/lib/galaxy_test/api/test_storage_cleaner.py
@@ -5,25 +5,29 @@ from typing import (
 )
 from uuid import uuid4
 
+from galaxy_test.base.decorators import requires_new_history
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
 
-class TestHistoryData(NamedTuple):
+class HistoryDataForTests(NamedTuple):
     name: str
     size: int
 
 
 class TestStorageCleanerApi(ApiTestCase):
+    dataset_populator: DatasetPopulator
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
+    @requires_new_history
     def test_discarded_histories_monitoring_and_cleanup(self):
         # Create some histories for testing
-        history_data_01 = TestHistoryData(name=f"TestHistory01_{uuid4()}", size=10)
-        history_data_02 = TestHistoryData(name=f"TestHistory02_{uuid4()}", size=25)
-        history_data_03 = TestHistoryData(name=f"TestHistory03_{uuid4()}", size=50)
+        history_data_01 = HistoryDataForTests(name=f"TestHistory01_{uuid4()}", size=10)
+        history_data_02 = HistoryDataForTests(name=f"TestHistory02_{uuid4()}", size=25)
+        history_data_03 = HistoryDataForTests(name=f"TestHistory03_{uuid4()}", size=50)
         test_histories = [history_data_01, history_data_02, history_data_03]
         history_name_id_map = self._create_histories(test_histories)
 
@@ -64,7 +68,7 @@ class TestStorageCleanerApi(ApiTestCase):
         assert cleanup_result["total_free_bytes"] == expected_total_size
         assert not cleanup_result["errors"]
 
-    def _create_histories(self, test_histories: List[TestHistoryData], wait_for_histories=True) -> Dict[str, str]:
+    def _create_histories(self, test_histories: List[HistoryDataForTests], wait_for_histories=True) -> Dict[str, str]:
         history_name_id_map = {}
         for history_data in test_histories:
             post_data = dict(name=history_data.name)

--- a/test/integration/test_storage_cleaner.py
+++ b/test/integration/test_storage_cleaner.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from galaxy_test.base.decorators import requires_new_history
 from galaxy_test.base.populators import DatasetPopulator
-from ._framework import ApiTestCase
+from galaxy_test.driver import integration_util
 
 
 class StoredItemDataForTests(NamedTuple):
@@ -15,7 +15,7 @@ class StoredItemDataForTests(NamedTuple):
     size: int
 
 
-class TestStorageCleanerApi(ApiTestCase):
+class TestStorageCleaner(integration_util.IntegrationTestCase):
     dataset_populator: DatasetPopulator
 
     def setUp(self):
@@ -56,6 +56,7 @@ class TestStorageCleanerApi(ApiTestCase):
         """Tests the storage cleaner API for a particular resource (histories or datasets)"""
         delete_resource_uri = delete_resource_uri if delete_resource_uri else resource
         discarded_storage_items_uri = f"storage/{resource}/discarded"
+
         # Initially, there shouldn't be any deleted and not purged (discarded) items
         summary_response = self._get(f"{discarded_storage_items_uri}/summary")
         self._assert_status_code_is_ok(summary_response)


### PR DESCRIPTION
This adds some new API endpoints to simplify the user's monitoring and cleanup of used storage.

Before these changes, the Storage Dashboard (#13113) in the client had to do some extra logic and workarounds to use the existing API. This also offers the opportunity to improve the performance of some of the requests.

<del>I'm still a bit unsure about the route naming</del>, so far this is the convention I will follow unless there are other ideas:
`/api/storage/{object}/{condition}/[summary]`, where `{object}` can be either `history` or `datasets` and `{condition}` refers to the way they are discovered, for example:
- For deleted and non-purged histories (discarded) the relevant endpoints will look like this:
  ```
  GET /api/storage/histories/discarded/summary
  GET /api/storage/histories/discarded
  ```
- For "big" datasets (bigger than a certain user-defined amount) it will look like this:
  ```
  GET /api/storage/datasets/big/summary
  GET /api/storage/datasets/big
  ```
- For old histories and datasets, etc... you get the idea :)

The `summary` endpoints will just return the *total number of objects* and *total size* that is taken by them,
```json
{
  "total_size": 4242283,
  "total_items": 2
}
```
while the regular endpoint will return a paginated list of objects with the following information for each object:
```jsonc
[
  {
      "id": "79966582feb6c081",
      "name": "The name of the history",
      "type": "history", // or "dataset"
      "size": 2444027,
      "update_time": "2022-12-17T09:54:59.292171"
  },
  //...
]
```

There is also an endpoint for purging objects in batch ``, you can pass a list of object IDs and it will purge all of them and return detailed information about the result:
```json
{
  "total_item_count": 5,
  "success_item_count": 4,
  "total_free_bytes": 546987560,
  "errors": [
    {
      "item_id": "79966582feb6c081",
      "error": "This item couldn't be cleaned for some reason"
    }
  ]
}
```

## TODO
- [x] Implement endpoints for discarded histories
- [x] Implement endpoints for discarded datasets
- [x] Adapt client to new endpoints

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
