### PR TITLE
Fix add value tool, bump linter level for ``format="input"`` to error

### DIFF
--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -98,7 +98,7 @@ def __check_format(node, lint_ctx, allow_ext=False):
     if fmt is None:
         fmt = node.attrib.get("format")
     if fmt == "input":
-        lint_ctx.warn(
+        lint_ctx.error(
             f"Using format='input' on {node.tag}, format_source attribute is less ambiguous and should be used instead.",
             node=node,
         )

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1375,12 +1375,12 @@ def test_outputs_format_input(lint_ctx):
     assert "1 outputs found." in lint_ctx.info_messages
     assert (
         "Using format='input' on data, format_source attribute is less ambiguous and should be used instead."
-        in lint_ctx.warn_messages
+        in lint_ctx.error_messages
     )
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
-    assert len(lint_ctx.warn_messages) == 1
-    assert not lint_ctx.error_messages
+    assert not lint_ctx.warn_messages
+    assert len(lint_ctx.error_messages) == 1
 
 
 def test_outputs_collection_format_source(lint_ctx):

--- a/tools/filters/fixedValueColumn.xml
+++ b/tools/filters/fixedValueColumn.xml
@@ -18,14 +18,14 @@ perl '$__tool_directory__/fixedValueColumn.pl' '$input' '$out_file1' '$exp' $ite
     </param>
   </inputs>
   <outputs>
-    <data name="out_file1" format="input" metadata_source="input"/>
+    <data name="out_file1" format_source="input" metadata_source="input"/>
   </outputs>
   <tests>
     <test>
       <param name="exp" value="1"/>
-      <param name="input" value="1.bed"/>
+      <param name="input" value="1.bed" ftype="bed"/>
       <param name="iterate" value="no"/>
-      <output name="out_file1" file="eq-addvalue.dat"/>
+      <output name="out_file1" file="eq-addvalue.dat" ftype="bed"/>
     </test>
   </tests>
   <help>


### PR DESCRIPTION
Technically it's not an error if there's no profile version, but `format_source` works without profile version too, so that should be used either way.
Extended the tests too:

<img width="1287" alt="Screenshot 2023-01-13 at 10 23 06" src="https://user-images.githubusercontent.com/6804901/212285518-ba99c9b2-49f6-41d8-bfd2-4885dea3028a.png">


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

```
cp ../galaxy-test-data/eq-addvalue.dat test-data
planemo test tools/filters/fixedValueColumn.xml
```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
