### PR TITLE
Fix collection drilldown in dataset details view

### DIFF
--- a/client/src/components/History/Content/GenericElement.test.js
+++ b/client/src/components/History/Content/GenericElement.test.js
@@ -1,0 +1,70 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "tests/jest/helpers";
+import GenericElement from "./GenericElement";
+
+const localVue = getLocalVue();
+
+describe("GenericElement", () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = mount(GenericElement, {
+            propsData: {
+                dsc: {
+                    elements: [
+                        {
+                            element_index: 1,
+                            element_identifier: "element-1",
+                            element_type: "hda",
+                            object: {
+                                id: "item-1",
+                            },
+                        },
+                        {
+                            element_index: 2,
+                            element_identifier: "element-2",
+                            element_type: "hdca",
+                            object: {
+                                id: "item-2",
+                                collection_type: "list",
+                                element_count: 2,
+                                elements_datatypes: ["txt"],
+                                elements: [
+                                    {
+                                        element_index: 3,
+                                        element_identifier: "element-3",
+                                        element_type: "hda",
+                                        object: {
+                                            id: "item_3",
+                                        },
+                                    },
+                                    {
+                                        element_index: 4,
+                                        element_identifier: "element-4",
+                                        element_type: "hda",
+                                        object: {
+                                            id: "item_4",
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+            localVue,
+        });
+    });
+
+    it("check basics", async () => {
+        const contentItems = wrapper.findAll(".content-item");
+        expect(contentItems.length).toBe(2);
+        expect(contentItems.at(0).attributes("data-hid")).toBe("1");
+        expect(contentItems.at(1).attributes("data-hid")).toBe("2");
+        await contentItems.at(1).find(".cursor-pointer").trigger("click");
+        const contentExpanded = wrapper.findAll(".content-item");
+        expect(contentExpanded.length).toBe(4);
+        expect(contentExpanded.at(2).attributes("data-hid")).toBe("3");
+        expect(contentExpanded.at(3).attributes("data-hid")).toBe("4");
+    });
+});

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import Vue from "vue";
-import type { PropType } from "vue";
 import ContentItem from "./ContentItem.vue";
 import { ref } from "vue";
 

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
 import Vue from "vue";
-import ContentItem from "./ContentItem.vue";
-import { ref } from "vue";
+import type { PropType } from "vue";
 import type { components } from "@/schema";
+import { ref } from "vue";
+import ContentItem from "./ContentItem.vue";
 
-defineProps<{
-    dsc: components.DCObject;
-}>();
+defineProps({
+    dsc: {
+        type: Object as PropType<components["schemas"]["DCObject"]>,
+        required: true,
+    },
+});
 
 const expandCollections = ref({});
 const expandDatasets = ref({});

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -27,6 +27,7 @@ function toggle(expansionMap: Record<string, boolean>, itemId: string) {
                 :name="item.element_identifier"
                 :is-dataset="item.element_type == 'hda'"
                 :expand-dataset="!!expandDatasets[item.id]"
+                class="mx-3"
                 @update:expand-dataset="toggle(expandDatasets, item.id)"
                 @view-collection="toggle(expandCollections, item.id)" />
             <div v-if="!!expandCollections[item.id]" class="mx-3">

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -1,3 +1,27 @@
+<script setup>
+import Vue from "vue";
+import ContentItem from "./ContentItem";
+import { ref } from "vue";
+
+const props = defineProps({
+    dsc: {
+        type: Object,
+        required: true,
+    },
+});
+
+const expandCollections = ref({});
+const expandDatasets = ref({});
+
+function viewCollection(itemId) {
+    Vue.set(this.expandCollections, itemId, !this.expandCollections[itemId]);
+}
+
+function viewDataset(itemId) {
+    Vue.set(this.expandDatasets, itemId, !this.expandDatasets[itemId]);
+}
+</script>
+
 <template>
     <div>
         <div v-for="(item, index) in dsc.elements" :key="index">
@@ -9,43 +33,9 @@
                 :expand-dataset="!!expandDatasets[item.id]"
                 @update:expand-dataset="viewDataset(item.id)"
                 @view-collection="viewCollection(item.id)" />
-            <div v-if="!!expandCollections[item.id]">
-                <GenericElementNode :dsc="item.object" />
+            <div v-if="!!expandCollections[item.id]" class="mx-3">
+                <GenericElement :dsc="item.object" />
             </div>
         </div>
     </div>
 </template>
-
-<script>
-import Vue from "vue";
-import ContentItem from "./ContentItem";
-import { CollectionElementsProvider } from "components/providers/storeProviders";
-
-export default {
-    name: "GenericElementNode",
-    components: {
-        CollectionElementsProvider,
-        ContentItem,
-    },
-    props: {
-        dsc: {
-            type: Object,
-            required: true,
-        },
-    },
-    data() {
-        return {
-            expandCollections: {},
-            expandDatasets: {},
-        };
-    },
-    methods: {
-        viewCollection(itemId) {
-            Vue.set(this.expandCollections, itemId, !this.expandCollections[itemId]);
-        },
-        viewDataset(itemId) {
-            Vue.set(this.expandDatasets, itemId, !this.expandDatasets[itemId]);
-        },
-    },
-};
-</script>

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -13,12 +13,8 @@ const props = defineProps({
 const expandCollections = ref({});
 const expandDatasets = ref({});
 
-function viewCollection(itemId) {
-    Vue.set(this.expandCollections, itemId, !this.expandCollections[itemId]);
-}
-
-function viewDataset(itemId) {
-    Vue.set(this.expandDatasets, itemId, !this.expandDatasets[itemId]);
+function toggle(expansionMap, itemId) {
+    Vue.set(expansionMap, itemId, !expansionMap[itemId]);
 }
 </script>
 
@@ -31,8 +27,8 @@ function viewDataset(itemId) {
                 :name="item.element_identifier"
                 :is-dataset="item.element_type == 'hda'"
                 :expand-dataset="!!expandDatasets[item.id]"
-                @update:expand-dataset="viewDataset(item.id)"
-                @view-collection="viewCollection(item.id)" />
+                @update:expand-dataset="toggle(expandDatasets, item.id)"
+                @view-collection="toggle(expandCollections, item.id)" />
             <div v-if="!!expandCollections[item.id]" class="mx-3">
                 <GenericElement :dsc="item.object" />
             </div>

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -1,14 +1,24 @@
 <script setup lang="ts">
 import Vue from "vue";
+import type { PropType } from "vue";
 import ContentItem from "./ContentItem.vue";
 import { ref } from "vue";
 
-defineProps({
-    dsc: {
-        type: Object,
-        required: true,
-    },
-});
+interface DatasetCollectionElement {
+    id: string;
+    element_index: number;
+    element_identifier: string;
+    element_type: string;
+    object: Record<string, any>;
+}
+
+interface DatasetCollection {
+    elements: DatasetCollectionElement[];
+}
+
+defineProps<{
+    dsc: DatasetCollection;
+}>();
 
 const expandCollections = ref({});
 const expandDatasets = ref({});

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -2,21 +2,10 @@
 import Vue from "vue";
 import ContentItem from "./ContentItem.vue";
 import { ref } from "vue";
-
-interface DatasetCollectionElement {
-    id: string;
-    element_index: number;
-    element_identifier: string;
-    element_type: string;
-    object: Record<string, any>;
-}
-
-interface DatasetCollection {
-    elements: DatasetCollectionElement[];
-}
+import type { components } from "@/schema";
 
 defineProps<{
-    dsc: DatasetCollection;
+    dsc: components.DCObject;
 }>();
 
 const expandCollections = ref({});

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -1,36 +1,51 @@
 <template>
     <div>
-        <ContentItem
-            :id="item.element_index"
-            :item="item.object"
-            :name="item.element_identifier"
-            :is-dataset="item.element_type == 'hda'"
-            :expand-dataset="expandDataset"
-            @update:expand-dataset="expandDataset = $event"
-            @view-collection="viewCollection = !viewCollection" />
-        <GenericItem v-if="viewCollection" :item-id="item.object.id" :item-src="item.object.history_content_type" />
+        <div v-for="(item, index) in dsc.elements" :key="index">
+            <ContentItem
+                :id="item.element_index"
+                :item="item.object"
+                :name="item.element_identifier"
+                :is-dataset="item.element_type == 'hda'"
+                :expand-dataset="!!expandDatasets[item.id]"
+                @update:expand-dataset="viewDataset(item.id)"
+                @view-collection="viewCollection(item.id)" />
+            <div v-if="!!expandCollections[item.id]">
+                <GenericElementNode :dsc="item.object" />
+            </div>
+        </div>
     </div>
 </template>
 
 <script>
+import Vue from "vue";
 import ContentItem from "./ContentItem";
+import { CollectionElementsProvider } from "components/providers/storeProviders";
 
 export default {
+    name: "GenericElementNode",
     components: {
+        CollectionElementsProvider,
         ContentItem,
-        GenericItem: () => import("components/History/Content/GenericItem"),
     },
     props: {
-        item: {
+        dsc: {
             type: Object,
             required: true,
         },
     },
     data() {
         return {
-            viewCollection: false,
-            expandDataset: false,
+            expandCollections: {},
+            expandDatasets: {},
         };
+    },
+    methods: {
+        viewCollection(itemId) {
+            Vue.set(this.expandCollections, itemId, !this.expandCollections[itemId]);
+        },
+        viewDataset(itemId) {
+            Vue.set(this.expandDatasets, itemId, !this.expandDatasets[itemId]);
+        },
     },
 };
 </script>

--- a/client/src/components/History/Content/GenericElement.vue
+++ b/client/src/components/History/Content/GenericElement.vue
@@ -1,9 +1,9 @@
-<script setup>
+<script setup lang="ts">
 import Vue from "vue";
-import ContentItem from "./ContentItem";
+import ContentItem from "./ContentItem.vue";
 import { ref } from "vue";
 
-const props = defineProps({
+defineProps({
     dsc: {
         type: Object,
         required: true,
@@ -13,7 +13,7 @@ const props = defineProps({
 const expandCollections = ref({});
 const expandDatasets = ref({});
 
-function toggle(expansionMap, itemId) {
+function toggle(expansionMap: Record<string, boolean>, itemId: string) {
     Vue.set(expansionMap, itemId, !expansionMap[itemId]);
 }
 </script>

--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -15,9 +15,7 @@
                 @undelete="onUndelete(item)"
                 @unhide="onUnhide(item)" />
             <div v-if="viewCollection">
-                <div v-for="(collectionItem, collectionIndex) in item.elements" :key="collectionIndex">
-                    <GenericElement :item="collectionItem" />
-                </div>
+                <GenericElement :dsc="item" />
             </div>
         </div>
     </component>


### PR DESCRIPTION
Currently drilling into collections on the datasets info / details view does not work properly for nested collection types like e.g. `list:paired`. This PR fixes this.

https://user-images.githubusercontent.com/2105447/212503388-09b0fe43-6751-47ba-aef0-71d6dad0e1d4.mov

(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
