### PR TITLE
Ensure tool_id is null for subworkflow steps

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1327,8 +1327,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 "id": step.order_index,
                 "type": module.type,
                 "content_id": content_id,
-                "tool_id": content_id,  # For workflows exported to older Galaxies,
-                # eliminate after a few years...
+                "tool_id": None,
                 "tool_version": module.get_version() if allow_upgrade else step.tool_version,
                 "name": module.get_name(),
                 "tool_state": json.dumps(tool_state),
@@ -1337,6 +1336,8 @@ class WorkflowContentsManager(UsesAnnotations):
                 "label": step.label or None,
                 "annotation": annotation_str,
             }
+            if step.type == "tool":
+                step_dict["tool_id"] = step.tool_id
             # Add tool shed repository information and post-job actions to step dict.
             if module.type == "tool":
                 if module.tool and module.tool.tool_shed:

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1337,7 +1337,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 "annotation": annotation_str,
             }
             if step.type == "tool":
-                step_dict["tool_id"] = step.tool_id
+                step_dict["tool_id"] = content_id if allow_upgrade else step.tool_id
             # Add tool shed repository information and post-job actions to step dict.
             if module.type == "tool":
                 if module.tool and module.tool.tool_shed:


### PR DESCRIPTION
I contemplated dropping the key altogether, but that might have a bigger impact.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
