### PR TITLE
Bump minimum pip version to 20.3 . Ignore ``--replace-pip`` and ``--no-replace-pip`` startup options

### DIFF
--- a/doc/source/admin/framework_dependencies.rst
+++ b/doc/source/admin/framework_dependencies.rst
@@ -43,7 +43,6 @@ A variety of options to ``run.sh`` are available to control the above behavior:
 - ``--skip-wheels``: Do not install wheels.
 - ``--no-create-venv``: Do not create a virtualenv, but use one if it exists at ``.venv`` or if ``$VIRTUAL_ENV`` is set
   (this variable is set by virtualenv's ``activate``).
-- ``--replace-pip/--no-replace-pip``: Do/do not upgrade pip if necessary.
 
 Managing dependencies manually
 ------------------------------

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -506,12 +506,8 @@ do
           no_create_venv='--no-create-venv'
           shift
           ;;
-      --no-replace-pip)
-          no_replace_pip='--no-replace-pip'
-          shift
-          ;;
-      --replace-pip)
-          replace_pip='--replace-pip'
+      --no-replace-pip|--replace-pip)
+          # Deprecated options
           shift
           ;;
       --skip-common-startup)
@@ -548,7 +544,7 @@ if [ -z "$skip_common_startup" ]; then
             GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION=$GALAXY_TEST_DBURI
             export GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
     fi
-    ./scripts/common_startup.sh $skip_venv $no_create_venv $no_replace_pip $replace_pip $skip_client_build --dev-wheels || exit 1
+    ./scripts/common_startup.sh $skip_venv $no_create_venv $skip_client_build --dev-wheels || exit 1
     unset GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
 fi
 

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -10,7 +10,7 @@ parse_common_args() {
     while :
     do
         case "$1" in
-            --skip-eggs|--skip-wheels|--skip-samples|--dev-wheels|--no-create-venv|--no-replace-pip|--replace-pip|--skip-client-build)
+            --skip-eggs|--skip-wheels|--skip-samples|--dev-wheels|--no-create-venv|--skip-client-build)
                 common_startup_args="$common_startup_args $1"
                 shift
                 ;;
@@ -55,6 +55,10 @@ parse_common_args() {
                 gravity_args="status"
                 paster_args="$paster_args $1"
                 add_pid_arg=1
+                shift
+                ;;
+            --no-replace-pip|--replace-pip)
+                # Deprecated options
                 shift
                 ;;
             "")
@@ -113,8 +117,6 @@ setup_python() {
         set_conda_exe
         if [ -n "$CONDA_EXE" ] && \
                 check_conda_env ${GALAXY_CONDA_ENV:="_galaxy_"}; then
-            # You almost surely have the required minimum pip version and running `conda install ... pip>=<min_ver>` every time is slow
-            REPLACE_PIP=0
             [ -n "$PYTHONPATH" ] && { echo 'Unsetting $PYTHONPATH'; unset PYTHONPATH; }
             if [ "$CONDA_DEFAULT_ENV" != "$GALAXY_CONDA_ENV" ]; then
                 conda_activate


### PR DESCRIPTION
Pip 20.3 added support for PEP 600, i.e. manylinux wheels using platform tags of the form `manylinux_${GLIBCMAJOR}_${GLIBCMINOR}_${ARCH}`. Fix installation of dependencies like pysam 0.20.0 wheels, which otherwise need to be built from source and can fail as reported by @assuntad23 in https://gist.github.com/assuntad23/3022db63a6878f044a209961dd40e592

Also:
- Install `wheel` to fix warning like `Using legacy setup.py install for beaker, since package 'wheel' is not installed.`
- Drop unnecessary `defaults` channel from conda commands.
- Fix "SC2223: This default assignment may cause DoS due to globbing. Quote it." errors reported by `shellcheck -x` .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
