### PR TITLE
Exclude `packages` dir from pytest test discovery 

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -597,7 +597,7 @@ if [ -n "$marker" ]; then
 else
     marker_args=()
 fi
-args=(-v $debug $structured_data_args --html "$report_file" --self-contained-html $coverage_arg $xunit_args $extra_args "${marker_args[@]}" "$@")
+args=(--ignore=packages -v $debug $structured_data_args --html "$report_file" --self-contained-html $coverage_arg $xunit_args $extra_args "${marker_args[@]}" "$@")
 "$test_script" "${args[@]}"
 exit_status=$?
 echo "Testing complete. HTML report is in \"$report_file\"." 1>&2


### PR DESCRIPTION
Fixes error when running `pytest` or `run_tests.sh` from Galaxy root with no arguments.

`ERROR  - ModuleNotFoundError: No module named 'tests.data'`


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run `./run_tests.sh` on current dev, observe error. Then run this branch, observe no error.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
