### PR TITLE
Implement conditional workflow editor UI, optional connections, track and display invalid connections

### DIFF
--- a/client/src/components/Workflow/Editor/ConnectionMenu.vue
+++ b/client/src/components/Workflow/Editor/ConnectionMenu.vue
@@ -24,7 +24,7 @@
 <script lang="ts" setup>
 import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 import { computed, onMounted, ref, watch, type ComputedRef } from "vue";
-import { type OutputTerminals, type InputTerminals, terminalFactory } from "./modules/terminals";
+import { type OutputTerminals, type InputTerminalsAndInvalid, terminalFactory } from "./modules/terminals";
 import { useFocusWithin } from "@/composables/useActiveElement";
 
 const props = defineProps<{
@@ -78,13 +78,15 @@ function decrement() {
     }
 }
 
-function terminalToInputObject(terminal: InputTerminals, connected: boolean): InputObject {
+function terminalToInputObject(terminal: InputTerminalsAndInvalid, connected: boolean): InputObject {
     const step = stepStore.getStep(terminal.stepId);
     const inputLabel = `${terminal.name} in step ${step.id + 1}: ${step.label}`;
     return { stepId: step.id, inputName: terminal.name, inputLabel, connected };
 }
 
-function inputObjectToTerminal(inputObject: InputObject): InputTerminals {
+function inputObjectToTerminal(inputObject: InputObject): InputTerminalsAndInvalid {
+    // TODO: this isn't ideal, we may not actually have a step .. except we do.
+    // Generalize connection.<input | output> to terminalSource ?
     const inputSource = stepStore
         .getStep(inputObject.stepId)
         .inputs.find((input) => input.name == inputObject.inputName)!;

--- a/client/src/components/Workflow/Editor/Connector.vue
+++ b/client/src/components/Workflow/Editor/Connector.vue
@@ -1,12 +1,7 @@
 <template>
-    <g :id="id" class="ribbon">
+    <g :id="id" :class="ribbonClasses">
         <g v-for="svgLine in paths" :key="svgLine">
-            <path
-                v-b-tooltip:hover="`my message`"
-                class="ribbon-outer"
-                :d="svgLine"
-                :stroke-width="stroke.outerStroke"
-                fill="none"></path>
+            <path class="ribbon-outer" :d="svgLine" :stroke-width="stroke.outerStroke" fill="none"></path>
             <path :class="innerClass" :d="svgLine" :stroke-width="stroke.innerStroke" fill="none"></path>
         </g>
     </g>
@@ -23,12 +18,14 @@ const props = withDefaults(
         inputIsMappedOver: boolean;
         outputIsMappedOver: boolean;
         connectionIsValid?: boolean;
+        nullable?: boolean;
     }>(),
     {
         id: undefined,
         inputIsMappedOver: false,
         outputIsMappedOver: false,
         connectionIsValid: true,
+        nullable: false,
     }
 );
 
@@ -47,6 +44,7 @@ const stroke = computed(() => {
     return { innerStroke, outerStroke };
 });
 
+const ribbonClasses = computed(() => (props.nullable ? "ribbon dashed" : "ribbon"));
 const innerClass = computed(() => (props.connectionIsValid ? "ribbon-inner" : "ribbon-inner ribbon-inner-invalid"));
 
 const offsets = computed(() => {

--- a/client/src/components/Workflow/Editor/Connector.vue
+++ b/client/src/components/Workflow/Editor/Connector.vue
@@ -1,8 +1,13 @@
 <template>
     <g :id="id" class="ribbon">
         <g v-for="svgLine in paths" :key="svgLine">
-            <path class="ribbon-outer" :d="svgLine" :stroke-width="stroke.outerStroke" fill="none"></path>
-            <path class="ribbon-inner" :d="svgLine" :stroke-width="stroke.innerStroke" fill="none"></path>
+            <path
+                v-b-tooltip:hover="`my message`"
+                class="ribbon-outer"
+                :d="svgLine"
+                :stroke-width="stroke.outerStroke"
+                fill="none"></path>
+            <path :class="innerClass" :d="svgLine" :stroke-width="stroke.innerStroke" fill="none"></path>
         </g>
     </g>
 </template>
@@ -17,11 +22,13 @@ const props = withDefaults(
         position: TerminalPosition;
         inputIsMappedOver: boolean;
         outputIsMappedOver: boolean;
+        connectionIsValid?: boolean;
     }>(),
     {
         id: undefined,
         inputIsMappedOver: false,
         outputIsMappedOver: false,
+        connectionIsValid: true,
     }
 );
 
@@ -39,6 +46,8 @@ const stroke = computed(() => {
     }
     return { innerStroke, outerStroke };
 });
+
+const innerClass = computed(() => (props.connectionIsValid ? "ribbon-inner" : "ribbon-inner ribbon-inner-invalid"));
 
 const offsets = computed(() => {
     const _offsets = [-2 * ribbonMargin, -ribbonMargin, 0, ribbonMargin, 2 * ribbonMargin];

--- a/client/src/components/Workflow/Editor/Forms/FormConditional.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormConditional.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+
+import FormElement from "@/components/Form/FormElement.vue";
+import { computed } from 'vue';
+import type { Step } from '@/stores/workflowStepStore';
+
+const emit = defineEmits<{
+    (e: "onUpdateStep", value: Step): void;
+}>();
+const props = defineProps<{
+    step: Step
+}>();
+
+const conditionalDefined = computed(() => {
+    return Boolean(props.step.when);
+});
+
+function onSkipBoolean(value: boolean) {
+    if (props.step.when && value === false) {
+        emit("onUpdateStep", { ...props.step, when: undefined });
+    } else if (value === true && !props.step.when) {
+        const when = "${inputs.when}";
+        const newStep = {
+            ...props.step,
+            when,
+            input_connections: { ...props.step.input_connections, when: undefined },
+        };
+        emit("onUpdateStep", newStep);
+    }
+}
+
+</script>
+
+<template>
+    <FormElement
+    id="__conditional"
+    :value="conditionalDefined"
+    title="Conditionally skip step?"
+    help="Set to true and connect a boolean parameter that determines whether step will be skipped"
+    type="boolean"
+    @input="onSkipBoolean"></FormElement>
+    <!-- We don't seem to have a disabled text field
+        <FormElement
+            v-if="setConditional"
+            id="__when"
+            :value="step.when"
+            type="text"
+            help="Step will be executed if javascript expression below evaluates to true."
+            >
+        </FormElement>
+    -->
+</template>

--- a/client/src/components/Workflow/Editor/Forms/FormConditional.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormConditional.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
-
 import FormElement from "@/components/Form/FormElement.vue";
-import { computed } from 'vue';
-import type { Step } from '@/stores/workflowStepStore';
+import { computed } from "vue";
+import type { Step } from "@/stores/workflowStepStore";
 
 const emit = defineEmits<{
     (e: "onUpdateStep", value: Step): void;
 }>();
 const props = defineProps<{
-    step: Step
+    step: Step;
 }>();
 
 const conditionalDefined = computed(() => {
@@ -28,17 +27,16 @@ function onSkipBoolean(value: boolean) {
         emit("onUpdateStep", newStep);
     }
 }
-
 </script>
 
 <template>
     <FormElement
-    id="__conditional"
-    :value="conditionalDefined"
-    title="Conditionally skip step?"
-    help="Set to true and connect a boolean parameter that determines whether step will be skipped"
-    type="boolean"
-    @input="onSkipBoolean"></FormElement>
+        id="__conditional"
+        :value="conditionalDefined"
+        title="Conditionally skip step?"
+        help="Set to true and connect a boolean parameter that determines whether step will be skipped"
+        type="boolean"
+        @input="onSkipBoolean"></FormElement>
     <!-- We don't seem to have a disabled text field
         <FormElement
             v-if="setConditional"

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
@@ -40,7 +40,7 @@ describe("FormDefault", () => {
         const title = wrapper.find(".portlet-title-text").text();
         expect(title).toBe("label");
         const inputCount = wrapper.findAll("input").length;
-        expect(inputCount).toBe(3);
+        expect(inputCount).toBe(4);
         const outputLabelCount = wrapper.findAll("#__label__output-name").length;
         expect(outputLabelCount).toBe(1);
         const otherLabelCount = wrapper.findAll("#__label__other-name").length;

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -39,6 +39,7 @@
                 :area="true"
                 help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
                 @input="onAnnotation" />
+            <FormConditional v-if="isSubworkflow" :step="step" v-on="$listeners"/>
             <FormDisplay
                 v-if="configForm?.inputs"
                 :id="formDisplayId"
@@ -61,6 +62,7 @@ import FormDisplay from "@/components/Form/FormDisplay.vue";
 import FormCard from "@/components/Form/FormCard.vue";
 import FormElement from "@/components/Form/FormElement.vue";
 import FormOutputLabel from "@/components/Workflow/Editor/Forms/FormOutputLabel.vue";
+import FormConditional from "./FormConditional.vue"
 import WorkflowIcons from "@/components/Workflow/icons";
 import { useWorkflowStepStore, type Step } from "@/stores/workflowStepStore";
 import { useUniqueLabelError } from "../composables/useUniqueLabelError";

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -39,7 +39,7 @@
                 :area="true"
                 help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
                 @input="onAnnotation" />
-            <FormConditional v-if="isSubworkflow" :step="step" v-on="$listeners"/>
+            <FormConditional v-if="isSubworkflow" :step="step" v-on="$listeners" />
             <FormDisplay
                 v-if="configForm?.inputs"
                 :id="formDisplayId"
@@ -62,7 +62,7 @@ import FormDisplay from "@/components/Form/FormDisplay.vue";
 import FormCard from "@/components/Form/FormCard.vue";
 import FormElement from "@/components/Form/FormElement.vue";
 import FormOutputLabel from "@/components/Workflow/Editor/Forms/FormOutputLabel.vue";
-import FormConditional from "./FormConditional.vue"
+import FormConditional from "./FormConditional.vue";
 import WorkflowIcons from "@/components/Workflow/icons";
 import { useWorkflowStepStore, type Step } from "@/stores/workflowStepStore";
 import { useUniqueLabelError } from "../composables/useUniqueLabelError";
@@ -79,7 +79,16 @@ const stepRef = toRef(props, "step");
 const { stepId, contentId, annotation, label, name, type, configForm } = useStepProps(stepRef);
 const stepStore = useWorkflowStepStore();
 const uniqueErrorLabel = useUniqueLabelError(stepStore, label?.value);
-const stepTitle = computed(() => (label?.value || contentId?.value || name.value)!);
+const stepTitle = computed(() => {
+    if (label?.value) {
+        return label.value;
+    }
+    if (isSubworkflow.value) {
+        return name.value;
+    } else {
+        return contentId?.value || name.value;
+    }
+});
 const nodeIcon = computed(() => WorkflowIcons[type.value]);
 const formDisplayId = computed(() => stepId.value.toString());
 const isSubworkflow = computed(() => type.value === "subworkflow");

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -27,6 +27,7 @@
                     :area="true"
                     help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
                     @input="onAnnotation" />
+                <FormConditional :step="step" v-on="$listeners"/>
                 <div class="mt-2 mb-4">
                     <Heading h2 separator bold size="sm"> Tool Parameters </Heading>
                     <FormDisplay
@@ -55,14 +56,15 @@
 </template>
 
 <script>
-import CurrentUser from "components/providers/CurrentUser";
-import FormDisplay from "components/Form/FormDisplay";
-import ToolCard from "components/Tool/ToolCard";
-import FormSection from "./FormSection";
-import FormElement from "components/Form/FormElement";
+import CurrentUser from "@/components/providers/CurrentUser";
+import FormDisplay from "@/components/Form/FormDisplay.vue";
+import ToolCard from "@/components/Tool/ToolCard.vue";
+import FormSection from "./FormSection.vue";
+import FormElement from "@/components/Form/FormElement.vue";
+import FormConditional from "./FormConditional.vue"
 import Utils from "utils/utils";
-import Heading from "components/Common/Heading";
-import { useWorkflowStepStore, Step } from "@/stores/workflowStepStore";
+import Heading from "@/components/Common/Heading.vue";
+import { useWorkflowStepStore,} from "@/stores/workflowStepStore";
 import { useUniqueLabelError } from "../composables/useUniqueLabelError";
 import { useStepProps } from "../composables/useStepProps";
 import { toRef } from "vue";
@@ -73,12 +75,13 @@ export default {
         FormDisplay,
         ToolCard,
         FormElement,
+        FormConditional,
         FormSection,
         Heading,
     },
     props: {
         step: {
-            type: Step,
+            type: Object,
             required: true,
         },
         datatypes: {
@@ -86,13 +89,24 @@ export default {
             required: true,
         },
     },
-    setup(props) {
+    emits: ["onSetData", "onUpdateStep", "onChangePostJobActions", "onAnnotation", "onLabel"],
+    setup(props, { emit }) {
         const { stepId, annotation, label, stepInputs, stepOutputs, configForm, postJobActions } = useStepProps(
             toRef(props, "step")
         );
         const stepStore = useWorkflowStepStore();
         const uniqueErrorLabel = useUniqueLabelError(stepStore, label);
-        return { stepId, annotation, label, stepInputs, stepOutputs, configForm, postJobActions, uniqueErrorLabel };
+
+        return {
+            stepId,
+            annotation,
+            label,
+            stepInputs,
+            stepOutputs,
+            configForm,
+            postJobActions,
+            uniqueErrorLabel,
+        };
     },
     data() {
         return {

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -27,7 +27,7 @@
                     :area="true"
                     help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
                     @input="onAnnotation" />
-                <FormConditional :step="step" v-on="$listeners"/>
+                <FormConditional :step="step" v-on="$listeners" />
                 <div class="mt-2 mb-4">
                     <Heading h2 separator bold size="sm"> Tool Parameters </Heading>
                     <FormDisplay
@@ -61,10 +61,10 @@ import FormDisplay from "@/components/Form/FormDisplay.vue";
 import ToolCard from "@/components/Tool/ToolCard.vue";
 import FormSection from "./FormSection.vue";
 import FormElement from "@/components/Form/FormElement.vue";
-import FormConditional from "./FormConditional.vue"
+import FormConditional from "./FormConditional.vue";
 import Utils from "utils/utils";
 import Heading from "@/components/Common/Heading.vue";
-import { useWorkflowStepStore,} from "@/stores/workflowStepStore";
+import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 import { useUniqueLabelError } from "../composables/useUniqueLabelError";
 import { useStepProps } from "../composables/useStepProps";
 import { toRef } from "vue";

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -113,6 +113,7 @@
                                     @onChangePostJobActions="onChangePostJobActions"
                                     @onAnnotation="onAnnotation"
                                     @onLabel="onLabel"
+                                    @onUpdateStep="onUpdateStep"
                                     @onSetData="onSetData" />
                                 <FormDefault
                                     v-else-if="hasActiveNodeDefault"
@@ -122,6 +123,7 @@
                                     @onLabel="onLabel"
                                     @onEditSubworkflow="onEditSubworkflow"
                                     @onAttemptRefactor="onAttemptRefactor"
+                                    @onUpdateStep="onUpdateStep"
                                     @onSetData="onSetData" />
                                 <WorkflowAttributes
                                     v-else-if="showAttributes"
@@ -642,6 +644,7 @@ export default {
                 name: name,
                 content_id: contentId,
                 type: type,
+                outputs: [],
                 position: defaultPosition(this.graphOffset, this.transform),
                 post_job_actions: {},
             };

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -91,6 +91,7 @@
                             <div class="unified-panel-header-inner">
                                 <WorkflowOptions
                                     :has-changes="hasChanges"
+                                    :has-invalid-connections="hasInvalidConnections"
                                     @onSave="onSave"
                                     @onSaveAs="onSaveAs"
                                     @onRun="onRun"
@@ -185,7 +186,7 @@ import WorkflowGraph from "./WorkflowGraph.vue";
 import { defaultPosition } from "./composables/useDefaultStepPosition";
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 
-import Vue, { onUnmounted, computed } from "vue";
+import Vue, { onUnmounted, computed, ref } from "vue";
 import { ConfirmDialog } from "@/composables/confirmDialog";
 import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
@@ -247,6 +248,9 @@ export default {
             return null;
         });
 
+        const hasChanges = ref(false);
+        const hasInvalidConnections = computed(() => Object.keys(connectionsStore.invalidConnections).length > 0);
+
         function resetStores() {
             connectionsStore.$reset();
             stepStore.$reset();
@@ -257,6 +261,8 @@ export default {
         });
         return {
             connectionsStore,
+            hasChanges,
+            hasInvalidConnections,
             stepStore,
             steps,
             nodeIndex: getStepIndex,
@@ -276,7 +282,6 @@ export default {
             markdownText: null,
             versions: [],
             parameters: null,
-            hasChanges: false,
             report: {},
             labels: {},
             license: null,

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -57,6 +57,9 @@
                 </b-popover>
             </b-button-group>
             <i :class="iconClass" />
+            <span v-if="step.when" v-b-tooltip.hover title="This step is conditionally executed.">
+                <font-awesome-icon icon="fa-code-branch" />
+            </span>
             <span
                 v-b-tooltip.hover
                 title="Index of the step in the workflow run form. Steps are ordered by distance to the upper-left corner of the window; inputs are listed first."
@@ -119,8 +122,14 @@ import type { Step } from "@/stores/workflowStepStore";
 import { DatatypesMapperModel } from "@/components/Datatypes/model";
 import type { UseElementBoundingReturn, UseScrollReturn } from "@vueuse/core";
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
+import { faCodeBranch } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
 
 Vue.use(BootstrapVue);
+
+// @ts-ignore
+library.add(faCodeBranch);
 
 const props = defineProps({
     id: { type: Number, required: true },

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -72,8 +72,8 @@
         </b-alert>
         <div v-else class="node-body" @click="makeActive" @keyup.enter="makeActive">
             <node-input
-                v-for="input in inputs"
-                :key="input.name"
+                v-for="(input, index) in inputs"
+                :key="`${index}-${input.name}`"
                 :input="input"
                 :step-id="id"
                 :datatypes-mapper="datatypesMapper"
@@ -85,8 +85,8 @@
                 @onChange="onChange" />
             <div v-if="showRule" class="rule" />
             <node-output
-                v-for="output in outputs"
-                :key="output.name"
+                v-for="(output, index) in outputs"
+                :key="`${index + inputs.length}-${output.name}`"
                 :output="output"
                 :workflow-outputs="workflowOutputs"
                 :post-job-actions="postJobActions"

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -183,7 +183,6 @@ export default {
         function onToggleActive() {
             const step = stepStore.getStep(stepId.value);
             if (workflowOutput.value) {
-                console.log("wfo", workflowOutput.value);
                 step.workflow_outputs = step.workflow_outputs.filter(
                     (workflowOutput) => workflowOutput.output_name !== output.value.name
                 );

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="form-row dataRow output-data-row">
+    <div :class="rowClass">
         <div
             v-if="showCalloutActiveOutput"
             v-b-tooltip
@@ -154,6 +154,13 @@ export default {
             const activeLabel = workflowOutput.value?.label || props.output.name;
             return `${activeLabel} (${extensions.value.join(", ")})`;
         });
+        const rowClass = computed(() => {
+            const classes = ["form-row", "dataRow", "output-data-row"];
+            if (props.output?.valid === false) {
+                classes.push("form-row-error");
+            }
+            return classes;
+        });
 
         const menu = ref(null);
         const icon = ref(null);
@@ -212,6 +219,7 @@ export default {
             activeClass,
             visibleClass,
             visibleHint,
+            rowClass,
             isVisible,
             terminal,
             isMultiple,

--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -11,14 +11,14 @@
             @click="$emit('onAttributes')">
             <span class="fa fa-pencil-alt" />
         </b-button>
-        <b-button-group v-b-tooltip class="editor-button-save-group" title="Save Workflow">
+        <b-button-group v-b-tooltip class="editor-button-save-group" :title="saveHover">
             <b-button
                 id="workflow-save-button"
                 role="button"
                 variant="link"
                 aria-label="Save Workflow"
                 class="editor-button-save"
-                :disabled="!hasChanges"
+                :disabled="!hasChanges || hasInvalidConnections"
                 @click="$emit('onSave')">
                 <span class="fa fa-floppy-o" />
             </b-button>
@@ -77,22 +77,23 @@
     </div>
 </template>
 
-<script>
+<script setup lang="ts">
+import { computed } from "vue";
 import { BDropdown, BDropdownItem, BButton } from "bootstrap-vue";
 
-export default {
-    components: {
-        BDropdown,
-        BDropdownItem,
-        BButton,
-    },
-    props: {
-        hasChanges: {
-            type: Boolean,
-        },
-        requiredReindex: {
-            type: Boolean,
-        },
-    },
-};
+const props = defineProps<{
+    hasChanges?: boolean;
+    hasInvalidConnections?: boolean;
+    requiredReindex?: boolean;
+}>();
+
+const saveHover = computed(() => {
+    if (!props.hasChanges) {
+        return "Workflow has no changes";
+    } else if (props.hasInvalidConnections) {
+        return "Workflow has invalid connections, review and remove invalid connections";
+    } else {
+        return "Save Workflow";
+    }
+});
 </script>

--- a/client/src/components/Workflow/Editor/TerminalConnector.vue
+++ b/client/src/components/Workflow/Editor/TerminalConnector.vue
@@ -36,7 +36,7 @@ const outputIsOptional = computed(() => {
 // move into connection store ?
 // move all of terminal logic into connection store ?
 const connectionIsValid = computed(() => {
-    return !Boolean(connectionStore.invalidConnections[props.connection.id]);
+    return !connectionStore.invalidConnections[props.connection.id];
 });
 
 const stateStore = useWorkflowStateStore();

--- a/client/src/components/Workflow/Editor/TerminalConnector.vue
+++ b/client/src/components/Workflow/Editor/TerminalConnector.vue
@@ -4,14 +4,15 @@
         :id="connectionId"
         :position="position"
         :output-is-mapped-over="outputIsMappedOver"
-        :input-is-mapped-over="inputIsMappedOver"></raw-connector>
+        :input-is-mapped-over="inputIsMappedOver"
+        :connection-is-valid="connectionIsValid"></raw-connector>
 </template>
 
 <script lang="ts" setup>
 import RawConnector from "@/components/Workflow/Editor/Connector.vue";
 import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
 import { useWorkflowStepStore } from "@/stores/workflowStepStore";
-import type { Connection } from "@/stores/workflowConnectionStore";
+import { useConnectionStore, type Connection } from "@/stores/workflowConnectionStore";
 import { computed } from "vue";
 
 const props = defineProps<{
@@ -19,8 +20,15 @@ const props = defineProps<{
 }>();
 
 const stepStore = useWorkflowStepStore();
+const connectionStore = useConnectionStore();
 const outputIsMappedOver = computed(() => stepStore.stepMapOver[props.connection.output.stepId]?.isCollection);
 const inputIsMappedOver = computed(() => stepStore.stepMapOver[props.connection.input.stepId]?.isCollection);
+
+// move into connection store ?
+// move all of terminal logic into connection store ?
+const connectionIsValid = computed(() => {
+    return !Boolean(connectionStore.invalidConnections[props.connection.id]);
+});
 
 const stateStore = useWorkflowStateStore();
 const connectionId = computed(() => {

--- a/client/src/components/Workflow/Editor/TerminalConnector.vue
+++ b/client/src/components/Workflow/Editor/TerminalConnector.vue
@@ -5,7 +5,8 @@
         :position="position"
         :output-is-mapped-over="outputIsMappedOver"
         :input-is-mapped-over="inputIsMappedOver"
-        :connection-is-valid="connectionIsValid"></raw-connector>
+        :connection-is-valid="connectionIsValid"
+        :nullable="outputIsOptional"></raw-connector>
 </template>
 
 <script lang="ts" setup>
@@ -23,6 +24,14 @@ const stepStore = useWorkflowStepStore();
 const connectionStore = useConnectionStore();
 const outputIsMappedOver = computed(() => stepStore.stepMapOver[props.connection.output.stepId]?.isCollection);
 const inputIsMappedOver = computed(() => stepStore.stepMapOver[props.connection.input.stepId]?.isCollection);
+const outputIsOptional = computed(() => {
+    return Boolean(
+        stepStore.getStep(props.connection.output.stepId)?.when ||
+            stepStore
+                .getStep(props.connection.output.stepId)
+                ?.outputs.find((output) => output.name === props.connection.output.name && output.optional)
+    );
+});
 
 // move into connection store ?
 // move all of terminal logic into connection store ?

--- a/client/src/components/Workflow/Editor/WorkflowEdges.vue
+++ b/client/src/components/Workflow/Editor/WorkflowEdges.vue
@@ -26,6 +26,10 @@ const dragStyle = computed(() => {
     }
     return dragStyle;
 });
+
+const dragIsOptional = computed(() => {
+    return props.draggingTerminal?.optional;
+});
 </script>
 <template>
     <div>
@@ -35,7 +39,8 @@ const dragStyle = computed(() => {
                 v-if="draggingTerminal && draggingConnection"
                 :position="draggingConnection"
                 :input-is-mapped-over="false"
-                :output-is-mapped-over="draggingTerminal.mapOver.isCollection"></raw-connector>
+                :output-is-mapped-over="draggingTerminal.mapOver.isCollection"
+                :nullable="dragIsOptional"></raw-connector>
             <terminal-connector
                 v-for="connection in connections"
                 :key="connection.id"

--- a/client/src/components/Workflow/Editor/composables/useTerminal.ts
+++ b/client/src/components/Workflow/Editor/composables/useTerminal.ts
@@ -13,7 +13,7 @@ export function useTerminal(
     watchEffect(() => {
         // rebuild terminal if any of the tracked dependencies change
         const newTerminal = terminalFactory(stepId.value, terminalSource.value, datatypesMapper.value);
-        newTerminal.destroyInvalidConnections();
+        newTerminal.getInvalidConnectedTerminals();
         terminal.value = newTerminal;
         isMappedOver.value = newTerminal.isMappedOver();
     });

--- a/client/src/components/Workflow/Editor/modules/model.ts
+++ b/client/src/components/Workflow/Editor/modules/model.ts
@@ -27,16 +27,20 @@ export async function fromSimple(data: Workflow, appendData = false, defaultPosi
             step.position.left += defaultPosition.left;
             step.position.top += defaultPosition.top;
             Object.values(step.input_connections).forEach((link) => {
-                let linkArray: ConnectionOutputLink[];
-                if (!Array.isArray(link)) {
-                    linkArray = [link];
+                if (link === undefined) {
+                    console.error("input connections invalid", step.input_connections)
                 } else {
-                    linkArray = link;
+                    let linkArray: ConnectionOutputLink[];
+                    if (!Array.isArray(link)) {
+                        linkArray = [link];
+                    } else {
+                        linkArray = link;
+                    }
+                    linkArray.forEach((link) => {
+                        link.id += stepIdOffset;
+                    });
                 }
-                linkArray.forEach((link) => {
-                    link.id += stepIdOffset;
-                });
-            });
+           });
         }
     });
     Object.values(data.steps).map((step) => {

--- a/client/src/components/Workflow/Editor/modules/model.ts
+++ b/client/src/components/Workflow/Editor/modules/model.ts
@@ -28,7 +28,7 @@ export async function fromSimple(data: Workflow, appendData = false, defaultPosi
             step.position.top += defaultPosition.top;
             Object.values(step.input_connections).forEach((link) => {
                 if (link === undefined) {
-                    console.error("input connections invalid", step.input_connections)
+                    console.error("input connections invalid", step.input_connections);
                 } else {
                     let linkArray: ConnectionOutputLink[];
                     if (!Array.isArray(link)) {
@@ -40,7 +40,7 @@ export async function fromSimple(data: Workflow, appendData = false, defaultPosi
                         link.id += stepIdOffset;
                     });
                 }
-           });
+            });
         }
     });
     Object.values(data.steps).map((step) => {

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -10,6 +10,7 @@ import {
     OutputTerminal,
     OutputParameterTerminal,
     producesAcceptableDatatype,
+    InvalidOutputTerminal,
 } from "./terminals";
 import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
@@ -472,6 +473,14 @@ describe("Input terminal", () => {
         expect(dataInputOutputTerminal.validInputTerminals().length).toBe(1);
         connectionStore.addConnection(connection);
         expect(firstInputTerminal.canAccept(dataInputOutputTerminal).canAccept).toBe(false);
+    });
+    it("will maintain invalid connections", () => {
+        const connection = connectionStore.connections[0];
+        connection.output.name = "I don't exist";
+        const firstInputTerminal = terminals[1]["input"] as InputTerminal;
+        const invalidTerminals = firstInputTerminal.getConnectedTerminals();
+        expect(invalidTerminals.length).toBe(1);
+        expect(invalidTerminals[0]).toBeInstanceOf(InvalidOutputTerminal);
     });
 });
 

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -143,7 +143,7 @@ describe("canAccept", () => {
         const dataOut = terminals["simple data"]["out_file1"] as OutputTerminal;
         const dataIn = terminals["simple data"]["input"] as InputTerminal;
         expect(dataIn.canAccept(dataOut).canAccept).toBe(false);
-        expect(dataIn.canAccept(dataOut).reason).toBe("Cannot connection output to input of same step.");
+        expect(dataIn.canAccept(dataOut).reason).toBe("Cannot connect output to input of same step.");
     });
     it("rejects paired input on multi-data input", () => {
         const multiDataIn = terminals["multi data"]["f1"] as InputTerminal;

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -42,6 +42,7 @@ interface InputTerminalInputs {
 
 interface InputTerminalArgs extends BaseTerminalArgs {
     input: InputTerminalInputs;
+    input_type: "dataset" | "dataset_collection" | "parameter";
 }
 
 class Terminal extends EventEmitter {
@@ -295,14 +296,26 @@ class BaseInputTerminal extends Terminal {
     getConnectedTerminals() {
         return this.connections.map((connection) => {
             const outputStep = this.stepStore.getStep(connection.output.stepId);
+            if (!outputStep) {
+                return new InvalidOutputTerminal({
+                    stepId: -1,
+                    optional: false,
+                    datatypes: [],
+                    name: connection.output.name,
+                    valid: false,
+                    datatypesMapper: this.datatypesMapper,
+                });
+            }
             let terminalSource = outputStep.outputs.find((output) => output.name === connection.output.name);
             if (!terminalSource) {
-                /*
-                / This can't happen, I think, because we'd drop the connection.
-                / We (probably) want to eventually display invalid connections,
-                / so maybe generate a NullTerminal when there is no terminalSource ?
-                */
-                throw `Could not find output ${connection.output.name} on step ${connection.output.stepId}`;
+                return new InvalidOutputTerminal({
+                    stepId: -1,
+                    optional: false,
+                    datatypes: [],
+                    name: connection.output.name,
+                    valid: false,
+                    datatypesMapper: this.datatypesMapper,
+                });
             }
             const postJobActionKey = `ChangeDatatypeAction${connection.output.name}`;
             if (
@@ -318,12 +331,38 @@ class BaseInputTerminal extends Terminal {
             return terminalFactory(outputStep.id, terminalSource, this.datatypesMapper);
         });
     }
-    destroyInvalidConnections() {
-        this.getConnectedTerminals().forEach((terminal) => {
-            if (!this.attachable(terminal).canAccept) {
-                this.disconnect(terminal);
+
+    getInvalidConnectedTerminals() {
+        return this.getConnectedTerminals().filter((terminal) => {
+            const canAccept = this.attachable(terminal);
+            if (!canAccept.canAccept) {
+                const connectionId = `${this.stepId}-${this.name}-${terminal.stepId}-${terminal.name}`;
+                this.connectionStore.addInvalidConnection(connectionId, canAccept.reason ?? "Unknown");
+                return true;
             }
+            return false;
         });
+    }
+
+    destroyInvalidConnections() {
+        this.getInvalidConnectedTerminals().forEach((terminal) => this.disconnect(terminal));
+    }
+}
+
+interface InvalidInputTerminalArgs extends InputTerminalArgs {
+    valid: false;
+}
+
+export class InvalidInputTerminal extends BaseInputTerminal {
+    valid: false;
+
+    constructor(attr: InvalidInputTerminalArgs) {
+        super(attr);
+        this.valid = false;
+    }
+
+    attachable(terminal: BaseOutputTerminal) {
+        return new ConnectionAcceptable(false, "Cannot attach to invalid input.");
     }
 }
 
@@ -519,6 +558,8 @@ interface BaseOutputTerminalArgs extends BaseTerminalArgs {
     optional: boolean;
 }
 
+export type InputTerminalsAndInvalid = InputTerminals | InvalidInputTerminal;
+
 class BaseOutputTerminal extends Terminal {
     datatypes: BaseOutputTerminalArgs["datatypes"];
     optional: BaseOutputTerminalArgs["optional"];
@@ -532,16 +573,40 @@ class BaseOutputTerminal extends Terminal {
         this.optional = attr.optional;
         this.terminalType = "output";
     }
-    getConnectedTerminals() {
+    getConnectedTerminals(): InputTerminalsAndInvalid[] {
         return this.connections.map((connection) => {
             const inputStep = this.stepStore.getStep(connection.input.stepId);
             const terminalSource = inputStep.inputs.find((input) => input.name === connection.input.name);
             if (!terminalSource) {
-                throw `Could not find input ${connection.input.name} on step ${connection.input.stepId}`;
+                return new InvalidInputTerminal({
+                    valid: false,
+                    name: connection.input.name,
+                    stepId: connection.input.stepId,
+                    datatypesMapper: this.datatypesMapper,
+                    input_type: "dataset",
+                    input: {
+                        datatypes: [],
+                        optional: false,
+                        multiple: false,
+                    },
+                });
             }
             return terminalFactory(inputStep.id, terminalSource, this.datatypesMapper);
         });
     }
+
+    getInvalidConnectedTerminals() {
+        return this.getConnectedTerminals().filter((terminal: any) => {
+            const canAccept = terminal.attachable(this);
+            if (!canAccept.canAccept) {
+                const connectionId = `${terminal.stepId}-${terminal.name}-${this.stepId}-${this.name}`;
+                this.connectionStore.addInvalidConnection(connectionId, canAccept.reason ?? "Unknown");
+                return true;
+            }
+            return false;
+        });
+    }
+
     destroyInvalidConnections() {
         this.getConnectedTerminals().forEach((terminal) => {
             if (!terminal.attachable(this).canAccept) {
@@ -597,6 +662,27 @@ export class OutputParameterTerminal extends BaseOutputTerminal {
     }
 }
 
+interface InvalidOutputTerminalArgs extends BaseOutputTerminalArgs {
+    valid: false;
+}
+
+export class InvalidOutputTerminal extends BaseOutputTerminal {
+    valid: false;
+
+    constructor(attr: InvalidOutputTerminalArgs) {
+        super(attr);
+        this.valid = false;
+    }
+
+    validInputTerminals() {
+        return [];
+    }
+
+    canAccept() {
+        return new ConnectionAcceptable(false, "Can't connect to invalid terminal.");
+    }
+}
+
 export type OutputTerminals = OutputTerminal | OutputCollectionTerminal | OutputParameterTerminal;
 export type InputTerminals = InputTerminal | InputCollectionTerminal | InputParameterTerminal;
 
@@ -639,7 +725,27 @@ export function producesAcceptableDatatype(
     );
 }
 
-type TerminalOf<T extends TerminalSource> = T extends DataStepInput
+type TerminalSourceAndInvalid = TerminalSource | InvalidOutputTerminalArgs | InvalidInputTerminalArgs;
+
+function isInvalidOutputArg(arg: TerminalSourceAndInvalid): arg is InvalidOutputTerminalArgs {
+    return "name" in arg && "valid" in arg && arg.valid === false;
+}
+
+function isOutputParameterArg(arg: TerminalSourceAndInvalid): arg is ParameterOutput {
+    return "name" in arg && "parameter" in arg && arg.parameter === true;
+}
+
+function isOutputCollectionArg(arg: TerminalSourceAndInvalid): arg is CollectionOutput {
+    return "name" in arg && "collection" in arg && arg.collection;
+}
+
+function isOutputArg(arg: TerminalSourceAndInvalid): arg is DataOutput {
+    return "name" in arg && "extensions" in arg;
+}
+
+type TerminalOf<T extends TerminalSourceAndInvalid> = T extends InvalidInputTerminalArgs
+    ? InvalidInputTerminal
+    : T extends DataStepInput
     ? InputTerminal
     : T extends DataCollectionStepInput
     ? InputCollectionTerminal
@@ -651,9 +757,11 @@ type TerminalOf<T extends TerminalSource> = T extends DataStepInput
     ? OutputCollectionTerminal
     : T extends ParameterOutput
     ? OutputParameterTerminal
+    : T extends BaseOutputTerminalArgs
+    ? InvalidOutputTerminal
     : never;
 
-export function terminalFactory<T extends TerminalSource>(
+export function terminalFactory<T extends TerminalSourceAndInvalid>(
     stepId: number,
     terminalSource: T,
     datatypesMapper: DatatypesMapperModel
@@ -661,36 +769,49 @@ export function terminalFactory<T extends TerminalSource>(
     if ("input_type" in terminalSource) {
         const terminalArgs = {
             datatypesMapper: datatypesMapper,
+            input_type: terminalSource.input_type,
             name: terminalSource.name,
             stepId: stepId,
         };
-        const inputArgs = {
-            datatypes: terminalSource.extensions,
-            multiple: terminalSource.multiple,
-            optional: terminalSource.optional,
-        };
-        if (terminalSource.input_type == "dataset") {
-            // type cast appears to be necessary: https://github.com/Microsoft/TypeScript/issues/13995
-            return new InputTerminal({
+        if ("valid" in terminalSource) {
+            return new InvalidInputTerminal({
                 ...terminalArgs,
-                input: inputArgs,
-            }) as TerminalOf<T>;
-        } else if (terminalSource.input_type === "dataset_collection") {
-            return new InputCollectionTerminal({
-                ...terminalArgs,
-                collection_types: terminalSource.collection_types,
                 input: {
-                    ...inputArgs,
+                    datatypes: [],
+                    multiple: false,
+                    optional: false,
                 },
+                valid: terminalSource.valid,
             }) as TerminalOf<T>;
-        } else if (terminalSource.input_type === "parameter") {
-            return new InputParameterTerminal({
-                ...terminalArgs,
-                type: terminalSource.type,
-                input: {
-                    ...inputArgs,
-                },
-            }) as TerminalOf<T>;
+        } else {
+            const inputArgs = {
+                datatypes: terminalSource.extensions,
+                multiple: terminalSource.multiple,
+                optional: terminalSource.optional,
+            };
+            if (terminalSource.input_type == "dataset") {
+                // type cast appears to be necessary: https://github.com/Microsoft/TypeScript/issues/13995
+                return new InputTerminal({
+                    ...terminalArgs,
+                    input: inputArgs,
+                }) as TerminalOf<T>;
+            } else if (terminalSource.input_type === "dataset_collection") {
+                return new InputCollectionTerminal({
+                    ...terminalArgs,
+                    collection_types: terminalSource.collection_types,
+                    input: {
+                        ...inputArgs,
+                    },
+                }) as TerminalOf<T>;
+            } else if (terminalSource.input_type === "parameter") {
+                return new InputParameterTerminal({
+                    ...terminalArgs,
+                    type: terminalSource.type,
+                    input: {
+                        ...inputArgs,
+                    },
+                }) as TerminalOf<T>;
+            }
         }
     } else if (terminalSource.name) {
         const outputArgs = {
@@ -699,24 +820,27 @@ export function terminalFactory<T extends TerminalSource>(
             stepId: stepId,
             datatypesMapper: datatypesMapper,
         };
-        if ("parameter" in terminalSource) {
+        if (isOutputParameterArg(terminalSource)) {
             return new OutputParameterTerminal({
                 ...outputArgs,
                 type: terminalSource.type,
             }) as TerminalOf<T>;
-        } else if ("collection" in terminalSource && terminalSource.collection) {
+        } else if (isOutputCollectionArg(terminalSource)) {
             return new OutputCollectionTerminal({
                 ...outputArgs,
                 datatypes: terminalSource.extensions,
                 collection_type: terminalSource.collection_type,
                 collection_type_source: terminalSource.collection_type_source,
             }) as TerminalOf<T>;
-        } else {
+        } else if (isOutputArg(terminalSource)) {
             return new OutputTerminal({
                 ...outputArgs,
                 datatypes: terminalSource.extensions,
             }) as TerminalOf<T>;
         }
+    }
+    if (isInvalidOutputArg(terminalSource)) {
+        return new InvalidOutputTerminal(terminalSource) as TerminalOf<T>;
     }
     throw `Could not build terminal for ${terminalSource}`;
 }

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -576,7 +576,10 @@ class BaseOutputTerminal extends Terminal {
     getConnectedTerminals(): InputTerminalsAndInvalid[] {
         return this.connections.map((connection) => {
             const inputStep = this.stepStore.getStep(connection.input.stepId);
-            const terminalSource = inputStep.inputs.find((input) => input.name === connection.input.name);
+            const extraStepInput = this.stepStore.getStepExtraInputs(inputStep.id);
+            const terminalSource = [...extraStepInput, ...inputStep.inputs].find(
+                (input) => input.name === connection.input.name
+            );
             if (!terminalSource) {
                 return new InvalidInputTerminal({
                     valid: false,

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -19,7 +19,7 @@ import type {
 } from "@/stores/workflowStepStore";
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 
-class ConnectionAcceptable {
+export class ConnectionAcceptable {
     reason: string | null;
     canAccept: boolean;
     constructor(canAccept: boolean, reason: string | null) {
@@ -179,7 +179,7 @@ class BaseInputTerminal extends Terminal {
     }
     canAccept(outputTerminal: BaseOutputTerminal) {
         if (this.stepId == outputTerminal.stepId) {
-            return new ConnectionAcceptable(false, "Cannot connection output to input of same step.");
+            return new ConnectionAcceptable(false, "Cannot connect output to input of same step.");
         }
         if (this._inputFilled()) {
             return new ConnectionAcceptable(

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -318,6 +318,9 @@ class BaseInputTerminal extends Terminal {
                 });
             }
             const postJobActionKey = `ChangeDatatypeAction${connection.output.name}`;
+            if (outputStep.when) {
+                terminalSource = { ...terminalSource, optional: true };
+            }
             if (
                 "extensions" in terminalSource &&
                 outputStep.post_job_actions &&
@@ -335,10 +338,12 @@ class BaseInputTerminal extends Terminal {
     getInvalidConnectedTerminals() {
         return this.getConnectedTerminals().filter((terminal) => {
             const canAccept = this.attachable(terminal);
+            const connectionId = `${this.stepId}-${this.name}-${terminal.stepId}-${terminal.name}`;
             if (!canAccept.canAccept) {
-                const connectionId = `${this.stepId}-${this.name}-${terminal.stepId}-${terminal.name}`;
-                this.connectionStore.addInvalidConnection(connectionId, canAccept.reason ?? "Unknown");
+                this.connectionStore.markInvalidConnection(connectionId, canAccept.reason ?? "Unknown");
                 return true;
+            } else if (this.connectionStore.invalidConnections[connectionId]) {
+                this.connectionStore.dropFromInvalidConnections(connectionId);
             }
             return false;
         });
@@ -601,10 +606,12 @@ class BaseOutputTerminal extends Terminal {
     getInvalidConnectedTerminals() {
         return this.getConnectedTerminals().filter((terminal: any) => {
             const canAccept = terminal.attachable(this);
+            const connectionId = `${terminal.stepId}-${terminal.name}-${this.stepId}-${this.name}`;
             if (!canAccept.canAccept) {
-                const connectionId = `${terminal.stepId}-${terminal.name}-${this.stepId}-${this.name}`;
-                this.connectionStore.addInvalidConnection(connectionId, canAccept.reason ?? "Unknown");
+                this.connectionStore.markInvalidConnection(connectionId, canAccept.reason ?? "Unknown");
                 return true;
+            } else if (this.connectionStore.invalidConnections[connectionId]) {
+                this.connectionStore.dropFromInvalidConnections(connectionId);
             }
             return false;
         });

--- a/client/src/stores/workflowConnectionStore.ts
+++ b/client/src/stores/workflowConnectionStore.ts
@@ -4,7 +4,7 @@ import { state } from "@/store/tagStore";
 import Vue from "vue";
 
 interface InvalidConnections {
-    [index: string]: string;
+    [index: string]: string | undefined;
 }
 
 export interface State {
@@ -120,8 +120,11 @@ export const useConnectionStore = defineStore("workflowConnectionStore", {
             const stepStore = useWorkflowStepStore();
             stepStore.addConnection(connection);
         },
-        addInvalidConnection(this: State, connectionId: string, reason: string) {
+        markInvalidConnection(this: State, connectionId: string, reason: string) {
             Vue.set(this.invalidConnections, connectionId, reason);
+        },
+        dropFromInvalidConnections(this: State, connectionId: string) {
+            this.invalidConnections[connectionId] = undefined;
         },
         removeConnection(this: State, terminal: InputTerminal | OutputTerminal | Connection["id"]) {
             const stepStore = useWorkflowStepStore();

--- a/client/src/stores/workflowConnectionStore.ts
+++ b/client/src/stores/workflowConnectionStore.ts
@@ -1,8 +1,15 @@
 import { defineStore } from "pinia";
 import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { state } from "@/store/tagStore";
+import Vue from "vue";
+
+interface InvalidConnections {
+    [index: string]: string;
+}
 
 export interface State {
     connections: Connection[];
+    invalidConnections: InvalidConnections;
 }
 
 export class Connection {
@@ -44,6 +51,7 @@ interface TerminalToInputTerminals {
 export const useConnectionStore = defineStore("workflowConnectionStore", {
     state: (): State => ({
         connections: [] as Connection[],
+        invalidConnections: {} as InvalidConnections,
     }),
     getters: {
         getOutputTerminalsForInputTerminal(state: State) {
@@ -112,12 +120,16 @@ export const useConnectionStore = defineStore("workflowConnectionStore", {
             const stepStore = useWorkflowStepStore();
             stepStore.addConnection(connection);
         },
+        addInvalidConnection(this: State, connectionId: string, reason: string) {
+            Vue.set(this.invalidConnections, connectionId, reason);
+        },
         removeConnection(this: State, terminal: InputTerminal | OutputTerminal | Connection["id"]) {
             const stepStore = useWorkflowStepStore();
             this.connections = this.connections.filter((connection) => {
                 if (typeof terminal === "string") {
                     if (connection.id == terminal) {
                         stepStore.removeConnection(connection);
+                        Vue.delete(this.invalidConnections, connection.id);
                         return false;
                     } else {
                         return true;
@@ -125,6 +137,7 @@ export const useConnectionStore = defineStore("workflowConnectionStore", {
                 } else if (terminal.connectorType === "input") {
                     if (connection.input.stepId == terminal.stepId && connection.input.name == terminal.name) {
                         stepStore.removeConnection(connection);
+                        Vue.delete(this.invalidConnections, connection.id);
                         return false;
                     } else {
                         return true;
@@ -132,6 +145,7 @@ export const useConnectionStore = defineStore("workflowConnectionStore", {
                 } else {
                     if (connection.output.stepId == terminal.stepId && connection.output.name == terminal.name) {
                         stepStore.removeConnection(connection);
+                        Vue.delete(this.invalidConnections, connection.id);
                         return false;
                     } else {
                         return true;

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -105,6 +105,7 @@ export interface NewStep {
     tooltip?: string;
     type: "tool" | "data_input" | "data_collection_input" | "subworkflow" | "parameter_input" | "pause";
     uuid?: string;
+    when?: string;
     workflow_outputs?: WorkflowOutput[];
 }
 

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -244,7 +244,7 @@ export function stepToConnections(step: Step): Connection[] {
     if (step.input_connections) {
         Object.entries(step?.input_connections).forEach(([input_name, outputArray]) => {
             if (outputArray === undefined) {
-                return
+                return;
             }
             if (!Array.isArray(outputArray)) {
                 outputArray = [outputArray];

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -118,7 +118,7 @@ export interface Steps {
 }
 
 export interface StepInputConnection {
-    [index: string]: ConnectionOutputLink | ConnectionOutputLink[];
+    [index: string]: ConnectionOutputLink | ConnectionOutputLink[] | undefined;
 }
 
 export interface ConnectionOutputLink {
@@ -144,6 +144,32 @@ export const useWorkflowStepStore = defineStore("workflowStepStore", {
             return (stepId: number): Step => {
                 return state.steps[stepId.toString()];
             };
+        },
+        getStepExtraInputs(state: State) {
+            const extraInputs: { [index: number]: InputTerminalSource[] } = {};
+            Object.values(state.steps).forEach((step) => {
+                if (step?.when !== undefined) {
+                    Object.keys(step.input_connections).forEach((inputName) => {
+                        if (!step.inputs.find((input) => input.name === inputName) && step.when?.includes(inputName)) {
+                            const terminalSource = {
+                                name: inputName,
+                                optional: false,
+                                input_type: "parameter" as const,
+                                type: "boolean" as const,
+                                multiple: false,
+                                label: inputName,
+                                extensions: [],
+                            };
+                            if (extraInputs[step.id]) {
+                                extraInputs[step.id].push(terminalSource);
+                            } else {
+                                extraInputs[step.id] = [terminalSource];
+                            }
+                        }
+                    });
+                }
+            });
+            return (stepId: number) => extraInputs[stepId] || [];
         },
         getStepIndex(state: State) {
             return Math.max(...Object.values(state.steps).map((step) => step.id), state.stepIndex);
@@ -217,6 +243,9 @@ export function stepToConnections(step: Step): Connection[] {
     const connections: Connection[] = [];
     if (step.input_connections) {
         Object.entries(step?.input_connections).forEach(([input_name, outputArray]) => {
+            if (outputArray === undefined) {
+                return
+            }
             if (!Array.isArray(outputArray)) {
                 outputArray = [outputArray];
             }

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -78,8 +78,8 @@ export interface ParameterStepInput extends Omit<BaseStepInput, "input_type"> {
     type: typeof ParameterTypes;
 }
 
-type InputTerminalSource = DataStepInput | DataCollectionStepInput | ParameterStepInput;
-type OutputTerminalSource = DataOutput | CollectionOutput | ParameterOutput;
+export type InputTerminalSource = DataStepInput | DataCollectionStepInput | ParameterStepInput;
+export type OutputTerminalSource = DataOutput | CollectionOutput | ParameterOutput;
 export type TerminalSource = InputTerminalSource | OutputTerminalSource;
 
 interface WorkflowOutput {

--- a/client/src/style/scss/workflow.scss
+++ b/client/src/style/scss/workflow.scss
@@ -117,6 +117,9 @@
                 .ribbon-inner-invalid {
                     stroke: $brand-warning;
                 }
+                &.dashed {
+                    stroke-dasharray: 5, 3;
+                }
                 &:hover .ribbon-outer {
                     stroke: $brand-success;
                 }

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -643,6 +643,7 @@ workflow_editor:
         //div[@data-label='Remove Tags']//input
     tool_version_button: ".tool-versions"
     connector_for: "#connection-${sink_id}-${source_id}"
+    connector_invalid_for: "#connection-${sink_id}-${source_id} .ribbon-inner-invalid"
     connector_destroy_callout: '.delete-terminal'
     save_button: '.editor-button-save'
     state_modal_body: '.state-upgrade-modal'

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -937,6 +937,7 @@ class WorkflowContentsManager(UsesAnnotations):
             else:
                 inputs = step.module.get_runtime_inputs(connections=step.output_connections)
                 step_model = {"inputs": [input.to_dict(trans) for input in inputs.values()]}
+            step_model["when"] = step.when_expression
             step_model["replacement_parameters"] = step.module.get_replacement_parameters(step)
             step_model["step_type"] = step.type
             step_model["step_label"] = step.label
@@ -1131,6 +1132,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 "annotation": annotation_str,
                 "post_job_actions": module.get_post_job_actions({}),
                 "uuid": str(step.uuid) if step.uuid else None,
+                "when": step.when_expression,
                 "workflow_outputs": [],
             }
             if tooltip:
@@ -1363,6 +1365,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 "uuid": str(step.uuid),
                 "label": step.label or None,
                 "annotation": annotation_str,
+                "when": step.when_expression,
             }
             if step.type == "tool":
                 step_dict["tool_id"] = content_id if allow_upgrade else step.tool_id
@@ -1550,6 +1553,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 "annotation": self.get_item_annotation_str(sa_session, stored.user, step),
                 "tool_inputs": step.tool_inputs,
                 "input_steps": {},
+                "when": step.when_expression,
             }
 
             if step_type == "subworkflow":

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -557,7 +557,7 @@ steps:
         editor.select_datatype_text_search.wait_for_and_send_keys("bam")
         editor.select_datatype(datatype="bam").wait_for_and_click()
         editor.node.output_data_row(output_name="out_file1", extension="bam").wait_for_visible()
-        self.assert_not_connected("create_2#out_file1", "checksum#input")
+        self.assert_connection_invalid("create_2#out_file1", "checksum#input")
 
     @selenium_test
     def test_change_datatype_post_job_action_lost_regression(self):
@@ -861,6 +861,10 @@ steps:
     def assert_connected(self, source, sink):
         source_id, sink_id = self.workflow_editor_source_sink_terminal_ids(source, sink)
         self.components.workflow_editor.connector_for(source_id=source_id, sink_id=sink_id).wait_for_visible()
+
+    def assert_connection_invalid(self, source, sink):
+        source_id, sink_id = self.workflow_editor_source_sink_terminal_ids(source, sink)
+        self.components.workflow_editor.connector_invalid_for(source_id=source_id, sink_id=sink_id).wait_for_present()
 
     def assert_not_connected(self, source, sink):
         source_id, sink_id = self.workflow_editor_source_sink_terminal_ids(source, sink)


### PR DESCRIPTION
This adds editor support for conditional workflow steps:

![creating a conditional workflow step](https://user-images.githubusercontent.com/6804901/213717362-18e6d9db-af8e-47d2-aa6e-2326a8ebea0f.gif)


This also changes how we deal with invalid connections (like when you make a step conditional, or change a steps's output datatype, or when the tool is not installed ...) 
This makes it so much easier to replace invalid connections without missing something:

<img width="803" alt="Screenshot 2023-01-18 at 11 57 39" src="https://user-images.githubusercontent.com/6804901/213154216-7ee56040-e1a7-4b13-854b-8e1818686703.png">

Fixes https://github.com/galaxyproject/galaxy/issues/13527.


It'd also be the basis for transitively changing e.g the input collection type ... if we can just show that a connection is now invalid we can let the user evaluate if they really want to do it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
