### PR TITLE
Global drag and drop followup

### DIFF
--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -7,6 +7,7 @@ import { getAppRoot } from "onload";
 import { useCurrentUser } from "composables/user";
 import { useUserHistories } from "composables/userHistories";
 import { useConfig } from "composables/config";
+import { wait } from "@/utils/wait";
 
 const { currentUser } = useCurrentUser();
 const { currentHistoryId } = useUserHistories(currentUser);
@@ -49,12 +50,6 @@ function dismiss(result) {
     }
 
     showModal.value = false;
-}
-
-function wait(milliseconds) {
-    return new Promise((resolve) => {
-        setTimeout(() => resolve(), milliseconds);
-    });
 }
 
 async function open(overrideOptions) {

--- a/client/src/components/Upload/UploadModalContent.vue
+++ b/client/src/components/Upload/UploadModalContent.vue
@@ -218,7 +218,6 @@ export default {
         },
         immediateUpload: function (files) {
             this.$refs.regular?.addFiles(files);
-            this.$refs.regular?._eventStart();
         },
     },
 };

--- a/client/src/composables/fileDrop.ts
+++ b/client/src/composables/fileDrop.ts
@@ -1,5 +1,6 @@
 import { ref, unref } from "vue";
-import { useEventListener } from "@vueuse/core";
+import { useEventListener, type MaybeComputedRef } from "@vueuse/core";
+import { wait } from "@/utils/wait";
 
 /**
  * Custom File-Drop composable
@@ -7,18 +8,26 @@ import { useEventListener } from "@vueuse/core";
  * @param onDrop callback function called when drop occurs
  * @param solo when true, only reacts if no modal is open
  */
-export function useFileDrop(dropZone, onDrop, solo) {
+export function useFileDrop(
+    dropZone: MaybeComputedRef<EventTarget | null | undefined>,
+    onDrop: (event: DragEvent) => void,
+    solo: MaybeComputedRef<boolean>
+) {
     const isFileOverDocument = ref(false);
     const isFileOverDropZone = ref(false);
 
-    const dragBlocked = ref(false);
+    // blocks drag events in this composable, to avoid drag events in unwanted situations
+    let dragBlocked = false;
+
+    // keeps track if the drag has exited, to avoid premature drag canceling
+    let hasExited = true;
 
     // Don't react to page-internal drag events
     useEventListener(
         document.body,
         "dragstart",
         () => {
-            dragBlocked.value = true;
+            dragBlocked = true;
         },
         true
     );
@@ -27,9 +36,10 @@ export function useFileDrop(dropZone, onDrop, solo) {
         document.body,
         "dragover",
         (event) => {
-            if (!dragBlocked.value) {
+            if (!dragBlocked) {
                 // prevent the browser from opening the file
                 event.preventDefault();
+                hasExited = false;
             }
         },
         true
@@ -39,40 +49,53 @@ export function useFileDrop(dropZone, onDrop, solo) {
         document.body,
         "drop",
         (event) => {
-            if (!dragBlocked.value) {
+            if (!dragBlocked) {
                 // prevent the browser from opening the file
                 event.preventDefault();
 
                 if (isFileOverDropZone.value && isFileOverDocument.value) {
-                    unref(onDrop)(event);
+                    unref(onDrop)(event as DragEvent);
                 }
             }
             isFileOverDocument.value = false;
-            dragBlocked.value = false;
+            dragBlocked = false;
+            hasExited = true;
         },
         true
     );
 
-    useEventListener(
-        document.body,
-        "dragend",
-        () => {
-            // reset on drag end
-            isFileOverDocument.value = false;
-            isFileOverDropZone.value = false;
-            dragBlocked.value = false;
-        },
-        true
-    );
+    /** Reset all variables */
+    const reset = () => {
+        isFileOverDocument.value = false;
+        isFileOverDropZone.value = false;
+        dragBlocked = false;
+        hasExited = true;
+    };
+
+    useEventListener(document.body, "dragend", reset, true);
+
+    useEventListener(document.body, "dragleave", async () => {
+        hasExited = true;
+
+        // This event may have been triggered by components
+        // which have not been properly childed to the body yet.
+        // Wait a bit, and check if hasExited is still true.
+        await wait(100);
+
+        if (hasExited) {
+            reset();
+        }
+    });
 
     useEventListener(
         document.body,
         "dragenter",
         (event) => {
             // init values if drag is possible
-            if (!dragBlocked.value && !(unref(solo) && isAnyModalOpen())) {
+            if (!dragBlocked && !(unref(solo) && isAnyModalOpen())) {
                 isFileOverDocument.value = true;
                 isFileOverDropZone.value = false;
+                hasExited = false;
 
                 event.preventDefault();
             }
@@ -90,6 +113,7 @@ export function useFileDrop(dropZone, onDrop, solo) {
         "dragenter",
         () => {
             isFileOverDropZone.value = true;
+            hasExited = false;
         },
         true
     );
@@ -99,6 +123,7 @@ export function useFileDrop(dropZone, onDrop, solo) {
         "dragleave",
         () => {
             isFileOverDropZone.value = false;
+            hasExited = false;
         },
         true
     );

--- a/client/src/composables/fileDrop.ts
+++ b/client/src/composables/fileDrop.ts
@@ -1,6 +1,8 @@
-import { ref, unref } from "vue";
+import { ref, unref, type Ref } from "vue";
 import { useEventListener, type MaybeComputedRef } from "@vueuse/core";
 import { wait } from "@/utils/wait";
+
+export type FileDropHandler = (event: DragEvent) => void;
 
 /**
  * Custom File-Drop composable
@@ -10,7 +12,7 @@ import { wait } from "@/utils/wait";
  */
 export function useFileDrop(
     dropZone: MaybeComputedRef<EventTarget | null | undefined>,
-    onDrop: (event: DragEvent) => void,
+    onDrop: Ref<FileDropHandler> | FileDropHandler,
     solo: MaybeComputedRef<boolean>
 ) {
     const isFileOverDocument = ref(false);
@@ -54,7 +56,8 @@ export function useFileDrop(
                 event.preventDefault();
 
                 if (isFileOverDropZone.value && isFileOverDocument.value) {
-                    unref(onDrop)(event as DragEvent);
+                    const dropHandler = unref(onDrop);
+                    dropHandler(event as DragEvent);
                 }
             }
             isFileOverDocument.value = false;

--- a/client/src/utils/wait.ts
+++ b/client/src/utils/wait.ts
@@ -1,0 +1,5 @@
+export function wait(milliseconds: number) {
+    return new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), milliseconds);
+    });
+}


### PR DESCRIPTION
Followup for #14905
Closes #15314
Fixes #15319

Dragleave did previously not work due to a quirk with dragleave events and vue bootstrap. This followup introduces a work-around for this issue.
It also removes the upload immediately starting.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
