### PR TITLE
Require selecting a test mode in ``run_tests.sh``

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -304,10 +304,10 @@ do
           ;;
       -id|--id)
           if [ $# -gt 1 ]; then
-              test_id=$2;
+              test_id=$2
               shift 2
           else
-              echo "--id requires an argument" 1>&2
+              echo "ERROR: --id requires an argument" 1>&2
               exit 1
           fi
           ;;
@@ -388,20 +388,20 @@ do
           GALAXY_TEST_TOOL_CONF="test/functional/tools/sample_tool_conf.xml"
           marker="tool"
           report_file="run_framework_tests.html"
-          framework_test=1;
+          framework_test=1
           shift 1
           ;;
       -d|-data_managers|--data_managers)
           marker="data_manager"
           report_file="run_data_managers_tests.html"
-          data_managers_test=1;
+          data_managers_test=1
           shift 1
           ;;
       -main|-main_tools|--main_tools)
           GALAXY_TEST_TOOL_CONF="lib/galaxy/config/sample/tool_conf.xml.sample"
           marker="tool"
           report_file="run_framework_tests.html"
-          framework_test=1;
+          framework_test=1
           shift 1
           ;;
       -r|--report_file)
@@ -409,7 +409,7 @@ do
               report_file=$2
               shift 2
           else
-              echo "--report_file requires an argument" 1>&2
+              echo "ERROR: --report_file requires an argument" 1>&2
               exit 1
           fi
           ;;
@@ -418,7 +418,7 @@ do
               xunit_report_file=$2
               shift 2
           else
-              echo "--xunit_report_file requires an argument" 1>&2
+              echo "ERROR: --xunit_report_file requires an argument" 1>&2
               exit 1
           fi
           ;;
@@ -427,7 +427,7 @@ do
               structured_data_report_file=$2
               shift 2
           else
-              echo "--structured_data_report_file requires an argument" 1>&2
+              echo "ERROR: --structured_data_report_file requires an argument" 1>&2
               exit 1
           fi
           ;;
@@ -523,7 +523,7 @@ do
           break
           ;;
       -*)
-          echo "invalid option: $1" 1>&2;
+          echo "ERROR: Invalid option $1" 1>&2
           show_help
           exit 1
           ;;
@@ -572,7 +572,9 @@ elif [ -n "$integration_extra" ]; then
 elif [ -n "$test_target" ] ; then
     extra_args="$test_target"
 else
-    extra_args=""
+    echo "ERROR: No testing mode selected!" 1>&2
+    show_help
+    exit 1
 fi
 
 if [ -n "$xunit_report_file" ]; then


### PR DESCRIPTION
We have recently removed from this script the possibility to test installed tools, which was the default when no test mode was selected.

xref. https://github.com/galaxyproject/galaxy/pull/15326

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. ./run_tests.sh

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
