### PR TITLE
Fix button alignment and change external icon in Tools List

### DIFF
--- a/client/src/components/ToolsList/ToolsListItem.vue
+++ b/client/src/components/ToolsList/ToolsListItem.vue
@@ -34,7 +34,7 @@ const formattedToolHelp = computed(() => {
 import { library } from "@fortawesome/fontawesome-svg-core";
 import {
     faWrench,
-    faGlobe,
+    faExternalLinkAlt,
     faCheck,
     faTimes,
     faAngleDown,
@@ -42,7 +42,7 @@ import {
     faExclamationTriangle,
 } from "@fortawesome/free-solid-svg-icons";
 
-library.add(faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp, faExclamationTriangle);
+library.add(faWrench, faExternalLinkAlt, faCheck, faTimes, faAngleDown, faAngleUp, faExclamationTriangle);
 </script>
 
 <template>
@@ -51,7 +51,7 @@ library.add(faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp, faExcla
             <div class="py-1 d-flex flex-wrap flex-gapx-1">
                 <span>
                     <FontAwesomeIcon v-if="props.local" icon="fa-wrench" fixed-width />
-                    <FontAwesomeIcon v-else icon="fa-globe" fixed-width />
+                    <FontAwesomeIcon v-else icon="fa-external-link-alt" fixed-width />
 
                     <b-button v-if="props.local" class="ui-link text-dark" @click="() => emit('open')">
                         <b>{{ props.name }}</b>
@@ -64,16 +64,23 @@ library.add(faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp, faExcla
                 <span>(Galaxy Version {{ props.version }})</span>
             </div>
             <div>
-                <ToolFavoriteButton :id="props.id" />
+                <b-button-group>
+                    <ToolFavoriteButton :id="props.id" />
 
-                <b-button v-if="props.local" variant="primary" size="sm" @click="() => emit('open')">
-                    <FontAwesomeIcon icon="fa-wrench" fixed-width />
-                    Open
-                </b-button>
-                <b-button v-else variant="primary" size="sm" :href="props.link">
-                    <FontAwesomeIcon icon="fa-globe" fixed-width />
-                    Open
-                </b-button>
+                    <b-button
+                        v-if="props.local"
+                        class="text-nowrap"
+                        variant="primary"
+                        size="sm"
+                        @click="() => emit('open')">
+                        <FontAwesomeIcon icon="fa-wrench" fixed-width />
+                        Open
+                    </b-button>
+                    <b-button v-else class="text-nowrap" variant="primary" size="sm" :href="props.link">
+                        <FontAwesomeIcon icon="fa-external-link-alt" fixed-width />
+                        Open
+                    </b-button>
+                </b-button-group>
             </div>
         </div>
 
@@ -84,7 +91,7 @@ library.add(faWrench, faGlobe, faCheck, faTimes, faAngleDown, faAngleUp, faExcla
                 </span>
 
                 <span v-if="!props.local" class="info px-1 rounded">
-                    <FontAwesomeIcon icon="fa-globe" fixed-width />
+                    <FontAwesomeIcon icon="fa-external-link-alt" fixed-width />
                     External
                 </span>
 


### PR DESCRIPTION
Changes made to the Tools List/Results page (Fixes #15258):

### Changed External button icon
| **Before** | **After** |
| ----------- | ----------- |
| ![Screen Shot 2023-01-19 at 1 00 20 AM](https://user-images.githubusercontent.com/78516064/213286459-e0bfac98-06ac-4776-b3ab-58a1f81cf853.png) | ![Screen Shot 2023-01-19 at 1 01 40 AM](https://user-images.githubusercontent.com/78516064/213286473-f7cb3b4a-37b9-455e-8ad0-3828e0ba40b4.png) |

## Fixed button alignment

| **Before** | **After** |
| ----------- | ----------- |
| ![tool_results_button_wrap_Before](https://user-images.githubusercontent.com/78516064/213288433-81091efb-23e0-440b-ba4a-39c8e86a6525.gif) | ![tool_results_button_wrap_After](https://user-images.githubusercontent.com/78516064/213288690-94bd7ac0-894e-4c58-8682-2c31a41830eb.gif) |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
