### PR TITLE
Increase memory limit of dev server

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -111,7 +111,7 @@
   },
   "scripts": {
     "watch": "gulp && yarn run save-build-hash && yarn run webpack-watch",
-    "serve": "NODE_ENV=development gulp && webpack serve",
+    "serve": "NODE_OPTIONS=--max-old-space-size=4096 && NODE_ENV=development gulp && webpack serve",
     "build": "NODE_ENV=development gulp && webpack && yarn run save-build-hash",
     "build-production": "NODE_ENV=production gulp && yarn run webpack-production && yarn run save-build-hash",
     "build-production-maps": "NODE_ENV=production gulp && yarn run webpack-production-maps && yarn run save-build-hash",


### PR DESCRIPTION
With typescript added, I regulary experience extreme slowdowns, and crashes of the dev server due to hitting the memory limit. Especially when running into multiple type errors at once. This drastically slows down development.

This PR changes nodes memory limit from the default 2gb, to 4gb, when running `yarn serve` (and consequently also `make client-dev-server`)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
