### PR TITLE
Update prettier

### DIFF
--- a/.pre-commit-config.yaml.sample
+++ b/.pre-commit-config.yaml.sample
@@ -8,11 +8,13 @@ repos:
     hooks:
     - id: flake8
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.0 # Use the sha or tag you want to point at
+    rev: v2.7.1 # Use the sha or tag you want to point at
     hooks:
       - id: prettier
         types: [file]
         types_or: [javascript, jsx, ts, tsx, vue]
+        additional_dependencies:
+          - prettier@2.8.3 # Workaround. See https://github.com/pre-commit/mirrors-prettier/issues/29
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0  # Use the ref you want to point at
     hooks:

--- a/client/package.json
+++ b/client/package.json
@@ -173,7 +173,7 @@
     "karma-webpack": "^5.0.0",
     "mini-css-extract-plugin": "^2.5.3",
     "postcss-loader": "^7.0.1",
-    "prettier": "^2.7.1",
+    "prettier": "^2.8.3",
     "process": "^0.11.10",
     "qunit": "^2.17.2",
     "raw-loader": "^4.0.2",

--- a/client/src/mvc/ui/ui-modal.js
+++ b/client/src/mvc/ui/ui-modal.js
@@ -108,10 +108,7 @@ export var View = Backbone.View.extend({
         if (this.options.buttons) {
             var counter = 0;
             $.each(this.options.buttons, (name, callback) => {
-                var $button = $("<button/>")
-                    .attr("id", `button-${counter++}`)
-                    .text(name)
-                    .click(callback);
+                var $button = $("<button/>").attr("id", `button-${counter++}`).text(name).click(callback);
                 self.$buttons.append($button).append("&nbsp;");
                 self.buttonList[name] = $button;
             });

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8972,10 +8972,15 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
-"prettier@^1.18.2 || ^2.0.0", prettier@^2.7.1:
+"prettier@^1.18.2 || ^2.0.0":
   version "2.7.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
+prettier@^2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
+  integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
 
 pretty-bytes@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Update prettier to 2.8.3 to support current typescript features (namely `satisfies`).
Make sure to update your local pre-commit-config from the new sample.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
