### PR TITLE
doc accept_default as deprecated

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3459,7 +3459,11 @@ or ``select``.
         </xs:attribute>
         <xs:attribute name="accept_default" type="PermissiveBoolean">
           <xs:annotation>
-            <xs:documentation xml:lang="en"></xs:documentation>
+            <xs:documentation xml:lang="en"><![CDATA[
+Deprecated. Take the value given by ``default_value`` (or ``value``) and ``1``
+if no ``value`` is given. Applies to ``data_column`` and ``group_tag``
+parameters.
+            ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="refresh_on_change" type="PermissiveBoolean">


### PR DESCRIPTION
when `default_value` was deprecated this rendered the semantics of this attribute pretty nonsensical. So I'm documenting it and marking it as deprecated (i.e. do not use it anymore).

- before it might have been: take `default_value` if no `value` is given and 1 if no `default_value` is set
- now it is take `value` if no `value` is given and 1 if no `value` is set which is equiv to take 1 of no `value` is given. There are better ways to do this, e.g. just set a default of 1 for the `value` also the implicit default of 1 is also intransparent to the user...

Edit: BUT can one set a default for for data column parameters...? 

Edit: Looks really ugly on 22.01 ![Screenshot from 2023-01-19 17-28-56](https://user-images.githubusercontent.com/25689525/213499213-2ca07085-8e12-4d96-b695-87eaa7332f08.png) .. shown here for the built in sort tool

For 22.05 it looks like a standard select. Noticed that column 1 is selected automatically (is this a consequence of the implementation?), but one can still unselect the parameter because it is optional by definition.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
