### PR TITLE
Towards SQLAlchemy 2.0: use model attributes instead of strings

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -829,7 +829,9 @@ class DatasetCollectionManager:
         DCE = model.DatasetCollectionElement
         qry = Query(DCE).filter(DCE.dataset_collection_id == parent_id)
         qry = qry.order_by(DCE.element_index)
-        qry = qry.options(joinedload("child_collection"), joinedload("hda"))
+        qry = qry.options(
+            joinedload(model.DatasetCollectionElement.child_collection), joinedload(model.DatasetCollectionElement.hda)
+        )
         if limit is not None:
             qry = qry.limit(int(limit))
         if offset is not None:

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -438,7 +438,7 @@ class HistoryContentsManager(base.SortableManager):
             .query(component_class)
             .filter(component_class.id.in_(id_list))
             .options(undefer(component_class._metadata))
-            .options(joinedload("dataset.actions"))  # TODO: use class attr after moving Dataset to declarative mapping.
+            .options(joinedload(component_class.dataset).joinedload(model.Dataset.actions))
             .options(joinedload(component_class.tags))
             .options(joinedload(component_class.annotations))  # type: ignore[attr-defined]
         )

--- a/lib/galaxy/managers/session.py
+++ b/lib/galaxy/managers/session.py
@@ -30,7 +30,7 @@ class GalaxySessionManager:
                     self.model.GalaxySession.table.c.is_valid == true(),
                 )
             )
-            .options(joinedload("user"))
+            .options(joinedload(self.model.GalaxySession.user))
             .first()
         )
         return galaxy_session

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -222,7 +222,7 @@ class SharableModelManager(
         Return a query for this model already filtered to models shared
         with a particular user.
         """
-        query = self.session().query(self.model_class).join("users_shared_with")
+        query = self.session().query(self.model_class).join(self.model_class.users_shared_with)
         if eagerloads is False:
             query = query.enable_eagerloads(False)
         # TODO: as filter in FilterParser also

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2962,10 +2962,10 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
             .filter(not_(HistoryDatasetAssociation.deleted))
             .order_by(HistoryDatasetAssociation.table.c.hid.asc())
             .options(
-                joinedload("dataset"),
-                joinedload("dataset.actions"),
-                joinedload("dataset.actions.role"),
-                joinedload("tags"),
+                joinedload(HistoryDatasetAssociation.dataset)
+                .joinedload(Dataset.actions)
+                .joinedload(DatasetPermissions.role),
+                joinedload(HistoryDatasetAssociation.tags),
             )
         )
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2993,7 +2993,10 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
                 .filter(not_(HistoryDatasetCollectionAssociation.deleted))
                 .filter(HistoryDatasetCollectionAssociation.visible)
                 .order_by(HistoryDatasetCollectionAssociation.table.c.hid.asc())
-                .options(joinedload("collection"), joinedload("tags"))
+                .options(
+                    joinedload(HistoryDatasetCollectionAssociation.collection),
+                    joinedload(HistoryDatasetCollectionAssociation.tags),
+                )
             )
             self._active_visible_dataset_collections = query.all()
         return self._active_visible_dataset_collections

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1507,12 +1507,15 @@ class GalaxyRBACAgent(RBACAgent):
             return True, ""
         action = self.permitted_actions.DATASET_ACCESS
 
+        raise
         lddas = (
             self.sa_session.query(self.model.LibraryDatasetDatasetAssociation)
             .join("library_dataset")
             .filter(self.model.LibraryDataset.folder == folder)
             .join("dataset")
-            .options(joinedload("dataset").joinedload("actions"))
+            .options(
+                joinedload(self.model.LibraryDatasetDatasetAssociation.dataset).joinedload(self.model.Dataset.actions)
+            )
             .all()
         )
 

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -422,10 +422,11 @@ def active_folders(trans, folder):
     # Stolen from galaxy.web.controllers.library_common (importing from which causes a circular issues).
     # Much faster way of retrieving all active sub-folders within a given folder than the
     # performance of the mapper.  This query also eagerloads the permissions on each folder.
+    raise
     return (
         trans.sa_session.query(LibraryFolder)
         .filter_by(parent=folder, deleted=False)
-        .options(joinedload("actions"))
+        .options(joinedload(LibraryFolder.actions))
         .order_by(LibraryFolder.table.c.name)
         .all()
     )

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -208,7 +208,7 @@ class SharedHistoryListGrid(grids.Grid):
     ]
 
     def build_initial_query(self, trans, **kwargs):
-        return trans.sa_session.query(self.model_class).join("users_shared_with")
+        return trans.sa_session.query(self.model_class).join(self.model_class.users_shared_with)
 
     def apply_query_filter(self, trans, query, **kwargs):
         return query.filter(model.HistoryUserShareAssociation.user == trans.user)

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -161,7 +161,11 @@ class PageAllPublishedGrid(grids.Grid):
             trans.sa_session.query(self.model_class)
             .join("user")
             .filter(model.User.deleted == false())
-            .options(joinedload("user").load_only("username"), joinedload("annotations"), undefer("average_rating"))
+            .options(
+                joinedload(self.model_class.user).load_only("username"),
+                joinedload(self.model_class.annotations),
+                undefer("average_rating"),
+            )
         )
 
     def apply_query_filter(self, trans, query, **kwargs):

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -287,8 +287,12 @@ class VisualizationAllPublishedGrid(grids.Grid):
         # See optimization description comments and TODO for tags in matching public histories query.
         return (
             trans.sa_session.query(self.model_class)
-            .join("user")
-            .options(joinedload("user").load_only("username"), joinedload("annotations"), undefer("average_rating"))
+            .join(self.model_class.user)
+            .options(
+                joinedload(self.model_class.user).load_only("username"),
+                joinedload(self.model_class.annotations),
+                undefer("average_rating"),
+            )
         )
 
     def apply_query_filter(self, trans, query, **kwargs):

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -163,12 +163,12 @@ class StoredWorkflowAllPublishedGrid(grids.Grid):
         # of its steps to be eagerly loaded.
         return (
             trans.sa_session.query(self.model_class)
-            .join("user")
+            .join(self.model_class.user)
             .options(
-                lazyload("latest_workflow"),
-                joinedload("user").load_only("username"),
-                joinedload("annotations"),
-                undefer("average_rating"),
+                lazyload(self.model_class.latest_workflow),
+                joinedload(self.model_class.user).load_only(model.User.username),
+                joinedload(self.model_class.annotations),
+                undefer(self.model_class.average_rating),
             )
         )
 
@@ -487,7 +487,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             trans.sa_session.query(model.StoredWorkflow)
             .filter_by(user=trans.user, deleted=False, hidden=False)
             .order_by(desc(model.StoredWorkflow.table.c.update_time))
-            .options(joinedload("latest_workflow").joinedload("steps"))
+            .options(joinedload(model.StoredWorkflow.latest_workflow).joinedload(model.Workflow.steps))
             .all()
         )
         if version is None:

--- a/lib/galaxy/webapps/reports/controllers/system.py
+++ b/lib/galaxy/webapps/reports/controllers/system.py
@@ -115,7 +115,7 @@ class System(BaseUIController):
                         model.History.update_time < cutoff_time,
                     )
                 )
-                .options(joinedload("datasets"))
+                .options(joinedload(model.History.datasets))
             )
 
             for history in histories:

--- a/lib/tool_shed/webapp/api/repositories.py
+++ b/lib/tool_shed/webapp/api/repositories.py
@@ -38,7 +38,6 @@ from galaxy.webapps.base.controller import (
     BaseAPIController,
     HTTPBadRequest,
 )
-from tool_shed.webapp import model
 from tool_shed.dependencies import attribute_handlers
 from tool_shed.metadata import repository_metadata_manager
 from tool_shed.repository_types import util as rt_util
@@ -51,6 +50,7 @@ from tool_shed.util import (
     repository_util,
     tool_util,
 )
+from tool_shed.webapp import model
 from tool_shed.webapp.search.repo_search import RepoSearch
 
 log = logging.getLogger(__name__)

--- a/lib/tool_shed/webapp/api/repositories.py
+++ b/lib/tool_shed/webapp/api/repositories.py
@@ -38,6 +38,7 @@ from galaxy.webapps.base.controller import (
     BaseAPIController,
     HTTPBadRequest,
 )
+from tool_shed.webapp import model
 from tool_shed.dependencies import attribute_handlers
 from tool_shed.metadata import repository_metadata_manager
 from tool_shed.repository_types import util as rt_util
@@ -118,7 +119,7 @@ class RepositoriesController(BaseAPIController):
         if owner is None:
             owner = kwd.get("owner", None)
         tsr_id = kwd.get("tsr_id", None)
-        eagerload_columns = ["downloadable_revisions"]
+        eagerload_columns = [model.Repository.downloadable_revisions]
         if None not in [name, owner]:
             # Get the repository information.
             repository = repository_util.get_repository_by_name_and_owner(
@@ -217,7 +218,7 @@ class RepositoriesController(BaseAPIController):
         if name and owner and changeset_revision:
             # Get the repository information.
             repository = repository_util.get_repository_by_name_and_owner(
-                self.app, name, owner, eagerload_columns=["downloadable_revisions"]
+                self.app, name, owner, eagerload_columns=[model.Repository.downloadable_revisions]
             )
             if repository is None:
                 log.debug(f"Cannot locate repository {name} owned by {owner}")
@@ -284,7 +285,7 @@ class RepositoriesController(BaseAPIController):
         tsr_id = kwd.get("tsr_id", None)
         if tsr_id is not None:
             repository = repository_util.get_repository_in_tool_shed(
-                self.app, tsr_id, eagerload_columns=["downloadable_revisions"]
+                self.app, tsr_id, eagerload_columns=[model.Repository.downloadable_revisions]
             )
         else:
             error_message = "Error in the Tool Shed repositories API in get_ordered_installable_revisions: "
@@ -737,7 +738,7 @@ class RepositoriesController(BaseAPIController):
         changeset_revision = kwd.get("changeset_revision", None)
         hexlify_this = util.asbool(kwd.get("hexlify", True))
         repository = repository_util.get_repository_by_name_and_owner(
-            trans.app, name, owner, eagerload_columns=["downloadable_revisions"]
+            trans.app, name, owner, eagerload_columns=[model.Repository.downloadable_revisions]
         )
         if repository and repository.downloadable_revisions:
             repository_metadata = metadata_util.get_repository_metadata_by_changeset_revision(
@@ -837,7 +838,7 @@ class RepositoriesController(BaseAPIController):
         downloadable_only = util.asbool(kwd.get("downloadable_only", "True"))
         all_metadata = {}
         repository = repository_util.get_repository_in_tool_shed(
-            self.app, id, eagerload_columns=["downloadable_revisions"]
+            self.app, id, eagerload_columns=[model.Repository.downloadable_revisions]
         )
         for changeset, changehash in metadata_util.get_metadata_revisions(
             self.app, repository, sort_revisions=True, downloadable=downloadable_only


### PR DESCRIPTION
Ref. #12541

Ref. SA docs:  [ORM Query - Joining / loading on relationships uses attributes, not strings](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#orm-query-joining-loading-on-relationships-uses-attributes-not-strings)

This is done. I did not do any additional refactoring intentionally: there will be more updates to the Query objects in follow-up PRs.
~~NOTE: There are more relevant cases of this type in the code base; I'll try to group them all (or most of them) in one PR before moving this out of WIP status.~~

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
