### PR TITLE
Explore remote tool test data

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -556,7 +556,7 @@ class GalaxyInteractorApi:
             file_name_exists = False
             location: Optional[str] = test_data.get("location")
             has_valid_location = location and util.is_url(location)
-            if not has_valid_location:
+            if location and not has_valid_location:
                 raise ValueError(f"Invalid `location` URL: `{location}`")
             if fname:
                 file_name = self.test_data_path(tool_id, fname, tool_version=tool_version)

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -445,7 +445,10 @@ class GalaxyInteractorApi:
     def test_data_path(self, tool_id, filename, tool_version=None):
         version_fragment = f"&tool_version={tool_version}" if tool_version else ""
         response = self._get(f"tools/{tool_id}/test_data_path?filename={filename}{version_fragment}", admin=True)
-        return response.json()
+        result = response.json()
+        if response.status_code in [200, 404]:
+            return result
+        raise Exception(result["err_msg"])
 
     def test_data_download(self, tool_id, filename, mode="file", is_output=True, tool_version=None):
         result = None

--- a/lib/galaxy/tool_util/verify/test_data.py
+++ b/lib/galaxy/tool_util/verify/test_data.py
@@ -202,6 +202,6 @@ class RemoteLocationDataResolver(FileDataResolver):
                 f"Failed to validate test data '{filename}' with [{hash_function}] - expected [{expected_hash_value}] got [{calculated_hash_value}]"
             )
 
-    def _is_direct_url_paste_upload(self, filename: str, location: str):
+    def _is_direct_url_paste_upload(self, filename: str, location: Optional[str]):
         """Checks if the test data file is an URL and will be directly url_pasted to Galaxy."""
-        return filename == location and is_url(location)
+        return location and filename == location and is_url(location)

--- a/lib/galaxy/tool_util/verify/test_data.py
+++ b/lib/galaxy/tool_util/verify/test_data.py
@@ -173,6 +173,8 @@ class RemoteLocationDataResolver(FileDataResolver):
     def _try_download_from_location(self, context: TestDataContext):
         filename = context.get("value")
         location = context.get("location")
+        if location is None:
+            return
         if not is_url(location):
             raise ValueError(f"Invalid 'location' URL for remote test data provided: {location}")
         if filename:

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1498,6 +1498,14 @@ select an option for a test.
       <xs:element name="composite_data" type="TestCompositeData" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="metadata" type="TestParamMetadata" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
+    <xs:attribute name="location" type="xs:anyURI">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">URL that points to a remote input file that will be directly uploaded to Galaxy.
+Please use this option only when is not possible to include the files in the `test-data` folder, since
+this is more error prone due to external factors like remote availability.
+You don't need to specify the `value` attribute in this case.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
         <xs:documentation xml:lang="en">This value must match the name of the

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1498,14 +1498,6 @@ select an option for a test.
       <xs:element name="composite_data" type="TestCompositeData" minOccurs="0" maxOccurs="unbounded" />
       <xs:element name="metadata" type="TestParamMetadata" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
-    <xs:attribute name="location" type="xs:anyURI">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">URL that points to a remote input file that will be directly uploaded to Galaxy.
-Please use this option only when is not possible to include the files in the `test-data` folder, since
-this is more error prone due to external factors like remote availability.
-You don't need to specify the `value` attribute in this case.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
         <xs:documentation xml:lang="en">This value must match the name of the
@@ -1543,6 +1535,20 @@ of ``type`` ``data``.</xs:documentation>
     <xs:attribute name="tags" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">Comma separated list of tags to apply to the dataset (only works for elements of collections - e.g. ``element`` XML tags).</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="location" type="xs:anyURI">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">URL that points to a remote input file that will be directly uploaded to Galaxy.
+Please use this option only when is not possible to include the files in the `test-data` folder, since
+this is more error prone due to external factors like remote availability.
+You don't need to specify the `value` attribute in this case.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="checksum" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">If specified in combination with `location`, after downloading the test input file, the checksum should match the value specified
+here. This value should have the form ``hash_type$hash_value`` (e.g. ``sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1349,10 +1349,22 @@ class Tool(Dictifiable):
             # under development, and some older ToolShed published tools that
             # used stock test data.
             try:
-                test_data = self.app.test_data_resolver.get_filename(filename)
+                test_data_context = self._find_required_file_context(filename)
+                test_data = self.app.test_data_resolver.get_filename(filename, test_data_context)
             except ValueError:
                 test_data = None
         return test_data
+
+    def _find_required_file_context(self, filename: str):
+        """Returns the attributes (context) associated with a required file."""
+        for test in self.tests:
+            for required_file in test.required_files:
+                # We are returning the first that matches the filename
+                # Could there be multiple different required files with the same filename
+                # and different attributes? I hope not...
+                if len(required_file) > 1 and required_file[0] == filename:
+                    return required_file[1]
+        return None
 
     def __walk_test_data(self, dir, filename):
         for root, dirs, _ in os.walk(dir):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -78,6 +78,7 @@ from galaxy.tool_util.toolbox import (
     ToolSection,
 )
 from galaxy.tool_util.toolbox.views.sources import StaticToolBoxViewSources
+from galaxy.tool_util.verify.test_data import TestDataNotFoundError
 from galaxy.tools import expressions
 from galaxy.tools.actions import (
     DefaultToolAction,
@@ -1347,11 +1348,11 @@ class Tool(Dictifiable):
         if not test_data:
             # Fallback to Galaxy test data directory for builtin tools, tools
             # under development, and some older ToolShed published tools that
-            # used stock test data.
+            # used stock test data. Also possible remote test data using `location`.
             try:
                 test_data_context = self._find_required_file_context(filename)
                 test_data = self.app.test_data_resolver.get_filename(filename, test_data_context)
-            except ValueError:
+            except TestDataNotFoundError:
                 test_data = None
         return test_data
 

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -182,6 +182,10 @@ def _process_raw_inputs(
                 name = raw_input_dict["name"]
                 param_value = raw_input_dict["value"]
                 param_extra = raw_input_dict["attributes"]
+                location = param_extra.get("location")
+                if param_value is None and location:
+                    # TODO: I bet there is a better way of signaling that we are going to use the location and not the value...
+                    param_value = location
                 if not value.type == "text":
                     param_value = _split_if_str(param_value)
                 if isinstance(value, galaxy.tools.parameters.basic.DataToolParameter):

--- a/lib/galaxy/util/hash_util.py
+++ b/lib/galaxy/util/hash_util.py
@@ -142,7 +142,7 @@ def is_hashable(value: Any) -> bool:
     return True
 
 
-def parse_checksum_hash(checksum: str) -> Tuple[str, str]:
+def parse_checksum_hash(checksum: str) -> Tuple[HashFunctionNameEnum, str]:
     """Parses checksum strings in the form of `hash_type$hash_value` considering possible aliases."""
     hash_name, hash_value = checksum.split("$", 1)
     hash_name = hash_name.upper()
@@ -150,7 +150,7 @@ def parse_checksum_hash(checksum: str) -> Tuple[str, str]:
         hash_name = HASH_NAME_ALIAS[hash_name]
     if hash_name not in HASH_NAMES:
         raise ValueError(f"Unsupported hash function '{hash_name}'. Supported functions: [{','.join(HASH_NAMES)}]")
-    return hash_name, hash_value
+    return HashFunctionNameEnum(hash_name), hash_value
 
 
 __all__ = (

--- a/lib/galaxy/util/hash_util.py
+++ b/lib/galaxy/util/hash_util.py
@@ -14,6 +14,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Union,
 )
 
@@ -40,6 +41,12 @@ class HashFunctionNameEnum(str, Enum):
     sha256 = "SHA-256"
     sha512 = "SHA-512"
 
+
+HASH_NAME_ALIAS: Dict[str, str] = {
+    "SHA1": "SHA-1",
+    "SHA256": "SHA-256",
+    "SHA512": "SHA-512",
+}
 
 HASH_NAME_MAP: Dict[HashFunctionNameEnum, HashFunctionT] = {
     HashFunctionNameEnum.md5: md5,
@@ -135,4 +142,25 @@ def is_hashable(value: Any) -> bool:
     return True
 
 
-__all__ = ("md5", "hashlib", "sha1", "sha", "new_insecure_hash", "new_secure_hash_v2", "hmac_new", "is_hashable")
+def parse_checksum_hash(checksum: str) -> Tuple[str, str]:
+    """Parses checksum strings in the form of `hash_type$hash_value` considering possible aliases."""
+    hash_name, hash_value = checksum.split("$", 1)
+    hash_name = hash_name.upper()
+    if hash_name in HASH_NAME_ALIAS:
+        hash_name = HASH_NAME_ALIAS[hash_name]
+    if hash_name not in HASH_NAMES:
+        raise ValueError(f"Unsupported hash function '{hash_name}'. Supported functions: [{','.join(HASH_NAMES)}]")
+    return hash_name, hash_value
+
+
+__all__ = (
+    "md5",
+    "hashlib",
+    "sha1",
+    "sha",
+    "new_insecure_hash",
+    "new_secure_hash_v2",
+    "hmac_new",
+    "is_hashable",
+    "parse_checksum_hash",
+)

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -223,7 +223,10 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         kwd = _kwd_or_payload(kwd)
         tool_version = kwd.get("tool_version", None)
         tool = self.service._get_tool(trans, id, tool_version=tool_version, user=trans.user)
-        path = tool.test_data_path(kwd.get("filename"))
+        try:
+            path = tool.test_data_path(kwd.get("filename"))
+        except ValueError as e:
+            raise exceptions.MessageException(str(e))
         if path:
             return path
         else:

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -56,7 +56,7 @@ from .test_logging import logging_config_file
 galaxy_root = galaxy_directory()
 DEFAULT_CONFIG_PREFIX = "GALAXY"
 GALAXY_TEST_DIRECTORY = os.path.join(galaxy_root, "test")
-GALAXY_TEST_FILE_DIR = "test-data,https://github.com/galaxyproject/galaxy-test-data.git"
+GALAXY_TEST_FILE_DIR = "test-data,url-location,https://github.com/galaxyproject/galaxy-test-data.git"
 TOOL_SHED_TEST_DATA = os.path.join(galaxy_root, "lib", "tool_shed", "test", "test_data")
 TEST_WEBHOOKS_DIR = os.path.join(galaxy_root, "test", "functional", "webhooks")
 FRAMEWORK_TOOLS_DIR = os.path.join(GALAXY_TEST_DIRECTORY, "functional", "tools")

--- a/test/functional/tools/remote_test_data_location.xml
+++ b/test/functional/tools/remote_test_data_location.xml
@@ -1,0 +1,40 @@
+<tool id="remote_test_data_location" name="Remote test data location" version="1.0.0" profile="22.01">
+    <command><![CDATA[
+        cat '$input' > '$output'
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" format="txt" label="Input"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <!-- When only the `location` is defined, it will be directly URL pasted to Galaxy -->
+            <param name="input" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="Hello World!"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <!-- When the `value` and the `location` are defined, if the local file is not present, the location will be used as a fallback and directly URL pasted to Galaxy. -->
+            <param name="input" value="does_not_exists.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="Hello World!"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <!-- When the `value` and the `location` are defined, if the local file is present, the location will be ignored. -->
+            <param name="input" value="simple_line.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="This is a line of text."/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/remote_test_data_location.xml
+++ b/test/functional/tools/remote_test_data_location.xml
@@ -19,8 +19,10 @@
             </output>
         </test>
         <test>
-            <!-- When the `value` and the `location` are defined, if the local file is not present, the location will be used as a fallback and directly URL pasted to Galaxy. -->
-            <param name="input" value="does_not_exists.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
+            <!-- When the `value` and the `location` are defined, if the local file is missing, the remote file pointed by location will be pre-downloaded
+                to the test data cache directory (GALAXY_TEST_DATA_REPO_CACHE) and then uploaded to Galaxy as usual.
+                Additional download integrity checks can be done by specifying a `checksum`. -->
+            <param name="input" value="missing_file_1.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
             <output name="output">
                 <assert_contents>
                     <has_line line="Hello World!"/>
@@ -28,7 +30,16 @@
             </output>
         </test>
         <test>
-            <!-- When the `value` and the `location` are defined, if the local file is present, the location will be ignored. -->
+            <!-- Additional download integrity checks can be done by specifying a `checksum`. -->
+            <param name="input" value="missing_file_2.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt" checksum="sha1$2ef7bde608ce5404e97d5f042f95f89f1c232871"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="Hello World!"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <!-- When the `value` and the `location` are defined, if the local file already exists, the location will be ignored. -->
             <param name="input" value="simple_line.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
             <output name="output">
                 <assert_contents>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -85,6 +85,7 @@
   <tool file="is_valid_xml.xml" />
   <tool file="expression_tools/parse_values_from_file.xml"/>
   <tool file="expression_tools/pick_value.xml" />
+  <tool file="remote_test_data_location.xml" />
   <!--
   TODO: Figure out why this transiently fails on Jenkins.
   <tool file="maxseconds.xml" />


### PR DESCRIPTION
xref: https://github.com/galaxyproject/galaxy/issues/7900 https://github.com/galaxyproject/galaxy/issues/3714 https://github.com/galaxyproject/galaxy/pull/13495

First attempt at allowing URLs as input data in tool tests.

This is probably not the ideal solution and there might be something already implemented that goes in the right direction but I couldn't find it. Opening the PR for discussion and getting feedback.

The idea is to be able to specify a remote URL to retrieve the input data for tool testing. Although we should always try to keep the test data as tiny as possible and always available to the tool, there are some situations where this is not possible. This tries to alleviate those situations.

## How it works
Just use the `location` attribute in a test `param` in the following way:

- without `value`: It will directly upload the input file from the `location` as a pasted URL to Galaxy
  ```xml
  <test>
      <param name="input" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
      <output name="output">
          <assert_contents>
              <has_line line="Hello World!"/>
          </assert_contents>
      </output>
  </test>
  ```
- with `value` defined but the file is not present on disk: It will behave exactly as the previous case
  ```xml
  <test>
      <param name="input" value="does_not_exists.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
      <output name="output">
          <assert_contents>
              <has_line line="Hello World!"/>
          </assert_contents>
      </output>
  </test>
  ```
- with `value` defined and the file is present: It will just ignore the location and use the input file as always
  ```xml
  <test>
      <param name="input" value="simple_line.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
      <output name="output">
          <assert_contents>
              <has_line line="This is a line of text."/>
          </assert_contents>
      </output>
  </test>
  ```

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Run `./run_tests.sh -framework -id remote_test_data_location`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
