### PR TITLE
[23.0] Fix re-enabling save button when invalid connections are resolved

### DIFF
--- a/client/src/stores/workflowConnectionStore.ts
+++ b/client/src/stores/workflowConnectionStore.ts
@@ -124,7 +124,7 @@ export const useConnectionStore = defineStore("workflowConnectionStore", {
             Vue.set(this.invalidConnections, connectionId, reason);
         },
         dropFromInvalidConnections(this: State, connectionId: string) {
-            this.invalidConnections[connectionId] = undefined;
+            Vue.delete(this.invalidConnections, connectionId);
         },
         removeConnection(this: State, terminal: InputTerminal | OutputTerminal | Connection["id"]) {
             const stepStore = useWorkflowStepStore();

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -558,6 +558,17 @@ steps:
         editor.select_datatype(datatype="bam").wait_for_and_click()
         editor.node.output_data_row(output_name="out_file1", extension="bam").wait_for_visible()
         self.assert_connection_invalid("create_2#out_file1", "checksum#input")
+        save_button = self.components.workflow_editor.save_button
+        # Assert save button is disabled
+        assert save_button.has_class("disabled")
+        # Make connection valid again
+        editor.change_datatype.wait_for_and_click()
+        editor.select_datatype_text_search.wait_for_and_send_keys("tabular")
+        editor.select_datatype(datatype="tabular").wait_for_and_click()
+        # Assert connection is valid
+        self.assert_connected("create_2#out_file1", "checksum#input")
+        # Assert save button is enabled
+        assert not save_button.has_class("disabled")
 
     @selenium_test
     def test_change_datatype_post_job_action_lost_regression(self):


### PR DESCRIPTION
@dannon noticed this:


https://user-images.githubusercontent.com/6804901/213913739-9d424a3e-4f37-42c8-afe7-ed04ca5b6e5a.mp4

that fixes it.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
