### PR TITLE
[23.0] Use ``galaxy.util.download_to_file`` instead of wget/curl

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -24,6 +24,7 @@ import packaging.version
 
 from galaxy.util import (
     commands,
+    download_to_file,
     listify,
     shlex_join,
     smart_str,
@@ -483,16 +484,13 @@ def hash_conda_packages(conda_packages: Iterable[CondaTarget]) -> str:
 def install_conda(conda_context: CondaContext, force_conda_build: bool = False) -> int:
     with tempfile.NamedTemporaryFile(suffix=".sh", prefix="conda_install", delete=False) as temp:
         script_path = temp.name
-    download_cmd = commands.download_command(conda_link(), to=script_path)
     install_cmd = ["bash", script_path, "-b", "-p", conda_context.conda_prefix]
     package_targets = list(CONDA_PACKAGE_SPECS)
     if force_conda_build or conda_context.use_local:
         package_targets.extend(CONDA_BUILD_SPECS)
     log.info("Installing conda, this may take several minutes.")
     try:
-        exit_code = conda_context.shell_exec(download_cmd)
-        if exit_code:
-            return exit_code
+        download_to_file(conda_link(), script_path)
         exit_code = conda_context.shell_exec(install_cmd)
     except Exception:
         log.exception("Failed to install conda")

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -29,6 +29,7 @@ from galaxy.tool_util.deps.conda_util import (
 from galaxy.tool_util.deps.docker_util import command_list as docker_command_list
 from galaxy.util import (
     commands,
+    download_to_file,
     safe_makedirs,
     shlex_join,
     unicodify,
@@ -428,10 +429,12 @@ def ensure_installed(involucro_context, auto_init):
 def install_involucro(involucro_context):
     install_path = os.path.abspath(involucro_context.involucro_bin)
     involucro_context.involucro_bin = install_path
-    download_cmd = commands.download_command(involucro_link(), to=install_path)
-    exit_code = involucro_context.shell_exec(download_cmd)
-    if exit_code:
-        return exit_code
+
+    try:
+        download_to_file(involucro_link(), install_path)
+    except Exception:
+        log.exception(f"Failed to download involucro from url '{involucro_link()}'")
+        return 1
     try:
         os.chmod(install_path, os.stat(install_path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         return 0


### PR DESCRIPTION
for installing conda/involucro (on startup)

Fixes https://github.com/galaxyproject/galaxy/issues/15355

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
