### PR TITLE
[23.0] Mark disconnected required inputs in editor

### DIFF
--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -17,6 +17,13 @@
             @click="onRemove"
             @keyup.delete="onRemove" />
         {{ label }}
+        <span
+            v-if="!input.optional && !hasTerminals"
+            v-b-tooltip.hover
+            class="input-required"
+            title="Input is required">
+            *
+        </span>
     </div>
 </template>
 
@@ -214,3 +221,16 @@ export default {
     },
 };
 </script>
+
+<style lang="scss" scoped>
+@import "theme/blue.scss";
+@import "~@fortawesome/fontawesome-free/scss/_variables";
+
+.input-required {
+    margin-top: $margin-v * 0.25;
+    margin-bottom: $margin-v * 0.25;
+    color: $brand-danger;
+    font-weight: 300;
+    cursor: default;
+}
+</style>

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -252,7 +252,11 @@ export const useWorkflowStepStore = defineStore("workflowStepStore", {
         },
         removeConnection(connection: Connection) {
             const inputStep = this.getStep(connection.input.stepId);
-            Vue.delete(inputStep.input_connections, connection.input.name);
+            if (this.getStepExtraInputs(inputStep.id).find((input) => connection.input.name === input.name)) {
+                inputStep.input_connections[connection.input.name] = undefined;
+            } else {
+                Vue.delete(inputStep.input_connections, connection.input.name);
+            }
             this.updateStep(inputStep);
         },
         removeStep(this: State, stepId: number) {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -615,6 +615,11 @@ workflow_editor:
       type: xpath
       selector: >
         //div[@id='form-element-__annotation']//textarea
+    step_when:
+      type: xpath
+      selector: >
+       //div[@id='form-element-__conditional']//input
+    param_type_form: '#parameter_definition\|parameter_type'
     configure_output:
       type: xpath
       selector: >


### PR DESCRIPTION
and keep the injected extra step input when removing a connection to a when.

![input_required](https://user-images.githubusercontent.com/6804901/214118593-b20b20e0-77de-4b52-8542-e003d7815ccf.gif)

Inspired by #14861 

WIP, we'll also want to prevent saving a workflow whose expression is just `${inputs.when}`, but `when` is not connected and not a regular input.

@dannon had the cool idea to add another button next to the save button with the "state summary" of the best practice state. That let's us disable the save button and direct the user to exactly what needs to happen. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
