### PR TITLE
[23.0] Add failed metadata info

### DIFF
--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -33,7 +33,7 @@ export const STATES = {
     /** metadata discovery/setting failed or errored (but otherwise ok) */
     failed_metadata: {
         status: "danger",
-        text: "Metadata generation failed.",
+        text: "Metadata generation failed. Please retry.",
         icon: "exclamation-triangle",
     },
     /** was created without a tool */

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -33,6 +33,7 @@ export const STATES = {
     /** metadata discovery/setting failed or errored (but otherwise ok) */
     failed_metadata: {
         status: "danger",
+        text: "Metadata generation failed.",
         icon: "exclamation-triangle",
     },
     /** was created without a tool */


### PR DESCRIPTION
Fixes #15358. While working on this I noticed, that the metadata set operation can get stuck, e.g. when running auto-detect on failed datasets. We might want to follow-up and improve the resilience of the dataset metadata setting operation.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
