### PR TITLE
[23.0] Fix leftover reference to old sample_tool_conf.xml

### DIFF
--- a/.vscode/.test.env
+++ b/.vscode/.test.env
@@ -1,1 +1,1 @@
-GALAXY_TEST_TOOL_CONF="lib/galaxy/config/sample/tool_conf.xml.sample,test/functional/tools/samples_tool_conf.xml"
+GALAXY_TEST_TOOL_CONF="lib/galaxy/config/sample/tool_conf.xml.sample,test/functional/tools/sample_tool_conf.xml"

--- a/.vscode/launch_gitpod.json
+++ b/.vscode/launch_gitpod.json
@@ -10,7 +10,7 @@
             "env": {
                 "GALAXY_CONFIG_FILE": "${workspaceFolder}/config/galaxy.yml",
                 "GALAXY_CONDA_AUTO_INIT": "false",
-                "GALAXY_CONFIG_TOOL_CONFIG_FILE": "lib/galaxy/config/sample/tool_conf.xml.sample,test/functional/tools/samples_tool_conf.xml",
+                "GALAXY_CONFIG_TOOL_CONFIG_FILE": "lib/galaxy/config/sample/tool_conf.xml.sample,test/functional/tools/sample_tool_conf.xml",
                 "GALAXY_CONFIG_DATABASE_CONNECTION": "postgresql://localhost/galaxy"
             }
         },


### PR DESCRIPTION
Follow up on #14035

Minor inconsistency issue detected while debugging tests with VSCode or in Gitpod.

Error message:
```
Failed with Error: [undefined]failed on setup with "galaxy.exceptions.ConfigurationError: Tool config file not found: /home/davelopez/dev/galaxy/test/functional/tools/samples_tool_conf.xml"
```

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
