### PR TITLE
[23.0] Reset confirmation state when unmounting workflow editor

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -236,7 +236,7 @@ export default {
             required: true,
         },
     },
-    setup() {
+    setup(props, { emit }) {
         const { datatypes, datatypesMapper, datatypesMapperLoading } = useDatatypesMapper();
         const connectionsStore = useConnectionStore();
         const stepStore = useWorkflowStepStore();
@@ -260,6 +260,7 @@ export default {
         }
         onUnmounted(() => {
             resetStores();
+            emit("update:confirmation", false);
         });
         return {
             connectionsStore,


### PR DESCRIPTION
Should fix https://github.com/galaxyproject/galaxy/issues/15366

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

See https://github.com/galaxyproject/galaxy/issues/15366

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
