### PR TITLE
[23.0] Allow configuring webpack devserver port

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -252,7 +252,7 @@ module.exports = (env = {}, argv = {}) => {
                 publicPath: "/static/dist",
             },
             hot: true,
-            port: 8081,
+            port: process.env.WEBPACK_PORT || 8081,
             host: "0.0.0.0",
             // proxy *everything* to the galaxy server.
             // someday, when we have a fully API-driven independent client, this


### PR DESCRIPTION
Should be useful when you're debugging against a live server and a local instance.

Using it for debugging 23.0, so targeting this for convenience.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
