### PR TITLE
[23.0] Fix history modal selection highlight

### DIFF
--- a/client/src/components/History/Modals/SelectorModal.test.js
+++ b/client/src/components/History/Modals/SelectorModal.test.js
@@ -27,8 +27,7 @@ const PROPS_WITH_10_HISTORY_MULTIPLE_SELECT = {
     multiple: true,
 };
 
-const CURRENT_HISTORY_HIGHLIGHT_CLASS = ".table-info";
-const SELECTED_HISTORY_HIGHLIGHT_CLASS = ".table-success";
+const CURRENT_HISTORY_INDICATION_TEXT = "(Current)";
 
 describe("History SelectorModal.vue", () => {
     let wrapper;
@@ -41,12 +40,11 @@ describe("History SelectorModal.vue", () => {
         await flushPromises();
     }
 
-    it("should highlight the currently selected history", async () => {
+    it("should indicate the currently selected history", async () => {
         await mountWith(PROPS_WITH_10_HISTORIES);
 
-        const selectedRows = wrapper.findAll(CURRENT_HISTORY_HIGHLIGHT_CLASS);
-        expect(selectedRows.length).toBe(1);
-        expect(selectedRows.at(0).attributes("data-pk")).toBe(CURRENT_HISTORY_ID);
+        const currentHistoryRow = wrapper.find(`[data-pk="${CURRENT_HISTORY_ID}"]`);
+        expect(currentHistoryRow.html()).toContain(CURRENT_HISTORY_INDICATION_TEXT);
     });
 
     it("paginates the histories", async () => {
@@ -93,25 +91,6 @@ describe("History SelectorModal.vue", () => {
             expect(wrapper.emitted()["selectHistories"][0][0][0].id).toBe(targetHistoryId1);
 
             console.debug(wrapper.html());
-        });
-
-        it("should highlight the current history differently by default but equally when selected", async () => {
-            await mountWith(PROPS_WITH_10_HISTORY_MULTIPLE_SELECT);
-
-            let selectedRows = wrapper.findAll(CURRENT_HISTORY_HIGHLIGHT_CLASS);
-            expect(selectedRows.length).toBe(1);
-            expect(selectedRows.at(0).attributes("data-pk")).toBe(CURRENT_HISTORY_ID);
-
-            const targetRow = wrapper.find(`[data-pk="${CURRENT_HISTORY_ID}"]`);
-            await targetRow.trigger("click");
-
-            // No longer highlighted as current
-            selectedRows = wrapper.findAll(CURRENT_HISTORY_HIGHLIGHT_CLASS);
-            expect(selectedRows.length).toBe(0);
-
-            // Highlighted as normal selection
-            selectedRows = wrapper.findAll(SELECTED_HISTORY_HIGHLIGHT_CLASS);
-            expect(selectedRows.length).toBe(1);
         });
     });
 });

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -11,7 +11,7 @@
             primary-key="id"
             :fields="fields"
             :filter="filter"
-            :items="formattedItems"
+            :items="histories"
             :per-page="perPage"
             :current-page="currentPage"
             :selectable="true"
@@ -22,6 +22,9 @@
             selected-variant="success"
             @row-selected="rowSelected"
             @filtered="onFiltered">
+            <template v-slot:cell(name)="row">
+                {{ row.item.name }} <i v-if="row.item.id === currentHistoryId"><b>(Current)</b></i>
+            </template>
             <template v-slot:cell(tags)="row">
                 <stateless-tags :value="row.item.tags" :disabled="true" />
             </template>
@@ -71,17 +74,6 @@ export default {
         };
     },
     computed: {
-        formattedItems() {
-            return this.histories.map((item) => {
-                if (item.id === this.currentHistoryId) {
-                    const isCurrentSelected = this.selectedHistories.some(
-                        (history) => history.id === this.currentHistoryId
-                    );
-                    item._rowVariant = isCurrentSelected ? "success" : "info";
-                }
-                return item;
-            });
-        },
         isEmptySelection() {
             return this.selectedHistories.length === 0;
         },

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -31,7 +31,9 @@
         </b-table>
         <template v-slot:modal-footer>
             <b-pagination v-model="currentPage" :total-rows="totalRows" :per-page="perPage" />
-            <b-button v-if="multiple" variant="primary" @click="addSelected">Add Selected</b-button>
+            <b-button v-if="multiple" :disabled="isEmptySelection" variant="primary" @click="addSelected">
+                Add Selected
+            </b-button>
         </template>
     </b-modal>
 </template>
@@ -76,6 +78,9 @@ export default {
                 }
                 return item;
             });
+        },
+        isEmptySelection() {
+            return this.selectedHistories.length === 0;
         },
     },
     watch: {

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -74,7 +74,10 @@ export default {
         formattedItems() {
             return this.histories.map((item) => {
                 if (item.id === this.currentHistoryId) {
-                    item._rowVariant = "info";
+                    const isCurrentSelected = this.selectedHistories.some(
+                        (history) => history.id === this.currentHistoryId
+                    );
+                    item._rowVariant = isCurrentSelected ? "success" : "info";
                 }
                 return item;
             });


### PR DESCRIPTION
Fixes #15373

The current history will be highlighted in the same way as the others when selected.
Also, the `Add selected` button will remain disabled if there is nothing selected to make it more obvious.

![fix_history_selection](https://user-images.githubusercontent.com/46503462/214313975-4214741b-226c-4423-bd88-4432f1400c56.gif)

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
