### PR TITLE
[23.0] Update default GALAXY_URL for webpack-dev-server.

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -28,9 +28,6 @@ const modulesExcludedFromLibs = [
 
 const buildDate = new Date();
 
-const dns = require('node:dns');
-dns.setDefaultResultOrder('ipv4first');
-
 module.exports = (env = {}, argv = {}) => {
     // environment name based on -d, -p, webpack flag
     const targetEnv = process.env.NODE_ENV == "production" || argv.mode == "production" ? "production" : "development";
@@ -262,7 +259,10 @@ module.exports = (env = {}, argv = {}) => {
             // can be a more limited set -- e.g. `/api`, `/auth`
             proxy: {
                 "**": {
-                    target: process.env.GALAXY_URL || "http://localhost:8080",
+                    // We explicitly use ipv4 loopback instead of localhost to
+                    // avoid ipv6/ipv4 resolution order issues; this should
+                    // align with Galaxy's default.
+                    target: process.env.GALAXY_URL || "http://127.0.0.1:8080",
                     secure: process.env.CHANGE_ORIGIN ? !process.env.CHANGE_ORIGIN : true,
                     changeOrigin: !!process.env.CHANGE_ORIGIN,
                     logLevel: "debug",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -28,6 +28,9 @@ const modulesExcludedFromLibs = [
 
 const buildDate = new Date();
 
+const dns = require('node:dns');
+dns.setDefaultResultOrder('ipv4first');
+
 module.exports = (env = {}, argv = {}) => {
     // environment name based on -d, -p, webpack flag
     const targetEnv = process.env.NODE_ENV == "production" || argv.mode == "production" ? "production" : "development";


### PR DESCRIPTION
Similar issue to xref #15060, this popped up after the node 18 upgrade when trying to use the webpack dev server.

@guerler This should fix what you saw.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `yarn develop` on a machine with ipv6 localhost defined, I guess, see that devserver works.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
