### PR TITLE
Fix Workflow Editor Zoom

### DIFF
--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -48,9 +48,10 @@ import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
 import type { TerminalPosition } from "@/stores/workflowEditorStateStore";
 import { DatatypesMapperModel } from "@/components/Datatypes/model";
 import { useWorkflowStepStore, type Step } from "@/stores/workflowStepStore";
-import { useZoom } from "./composables/useZoom";
+import { useD3Zoom } from "./composables/d3Zoom";
 import type { XYPosition } from "@/stores/workflowEditorStateStore";
 import type { OutputTerminals } from "./modules/terminals";
+import { minZoom, maxZoom } from "./modules/zoomLevels";
 
 const emit = defineEmits(["transform", "graph-offset", "onRemove", "scrollTo"]);
 const props = defineProps({
@@ -67,7 +68,7 @@ const canvas: Ref<HTMLElement | null> = ref(null);
 
 const elementBounding = useElementBounding(canvas, { windowResize: false, windowScroll: false });
 const scroll = useScroll(canvas);
-const { transform, panBy, setZoom, moveTo } = useZoom(1, 0.2, 5, canvas, scroll);
+const { transform, panBy, setZoom, moveTo } = useD3Zoom(1, minZoom, maxZoom, canvas, scroll);
 
 const isDragging = ref(false);
 provide("isDragging", isDragging);

--- a/client/src/components/Workflow/Editor/ZoomControl.vue
+++ b/client/src/components/Workflow/Editor/ZoomControl.vue
@@ -1,8 +1,38 @@
+<script lang="ts" setup>
+import Vue, { computed } from "vue";
+import BootstrapVue from "bootstrap-vue";
+import { getZoomInLevel, getZoomOutLevel, isMinZoom, isMaxZoom } from "./modules/zoomLevels";
+
+Vue.use(BootstrapVue);
+
+const props = defineProps({
+    zoomLevel: { type: Number, default: 1 },
+});
+
+const emit = defineEmits<{
+    (e: "onZoom", zoom: number): void;
+}>();
+
+const zoomDefault = 1;
+const zoomPercentage = computed(() => Math.round(props.zoomLevel * 100));
+
+function onZoomIn() {
+    emit("onZoom", getZoomInLevel(props.zoomLevel));
+}
+
+function onZoomOut() {
+    emit("onZoom", getZoomOutLevel(props.zoomLevel));
+}
+
+function onZoomReset() {
+    emit("onZoom", zoomDefault);
+}
+</script>
+
 <template>
     <span class="zoom-control float-right btn-group-horizontal">
         <b-button
-            v-b-tooltip.hover
-            :disabled="isMin"
+            :disabled="isMinZoom(props.zoomLevel)"
             role="button"
             class="fa fa-minus"
             title="Zoom Out"
@@ -21,8 +51,7 @@
             {{ zoomPercentage }}%
         </b-button>
         <b-button
-            v-b-tooltip.hover
-            :disabled="isMax"
+            :disabled="isMaxZoom(props.zoomLevel)"
             role="button"
             class="fa fa-plus"
             title="Zoom In"
@@ -31,54 +60,6 @@
             @click="onZoomIn" />
     </span>
 </template>
-
-<script lang="ts" setup>
-import Vue, { computed } from "vue";
-import BootstrapVue from "bootstrap-vue";
-
-Vue.use(BootstrapVue);
-
-const props = withDefaults(
-    defineProps<{
-        zoomLevel: number;
-    }>(),
-    {
-        zoomLevel: 1,
-    }
-);
-const emit = defineEmits(["onZoom"]);
-
-const zoomDefault = 1;
-const zoomLevels = [0.1, 0.2, 0.25, 0.33, 0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.33, 1.5, 2, 2.5, 3, 4, 5];
-const isMin = computed(() => Math.round(props.zoomLevel * 100) == Math.round(zoomLevels[0] * 100));
-const isMax = computed(() => Math.round(props.zoomLevel * 100) == Math.round(zoomLevels.at(-1)! * 100));
-const zoomPercentage = computed(() => Math.round(props.zoomLevel * 100));
-const index = computed(() => {
-    let index = zoomLevels.indexOf(props.zoomLevel);
-    if (index < 0) {
-        const closest = zoomLevels.reduce((prev, curr) => {
-            return Math.abs(curr - props.zoomLevel) < Math.abs(prev - props.zoomLevel) ? curr : prev;
-        });
-        index = zoomLevels.indexOf(closest);
-    }
-    return index;
-});
-function onZoomIn() {
-    const zoomLevel = zoomLevels[index.value + 1];
-    if (zoomLevel) {
-        emit("onZoom", zoomLevel);
-    }
-}
-function onZoomOut() {
-    const zoomLevel = zoomLevels[index.value - 1];
-    if (zoomLevel) {
-        emit("onZoom", zoomLevel);
-    }
-}
-function onZoomReset() {
-    emit("onZoom", zoomDefault);
-}
-</script>
 
 <style scoped>
 .zoom-reset {

--- a/client/src/components/Workflow/Editor/composables/d3Zoom.ts
+++ b/client/src/components/Workflow/Editor/composables/d3Zoom.ts
@@ -1,6 +1,6 @@
 import { zoom, zoomIdentity, type D3ZoomEvent } from "d3-zoom";
 import { ref, watch } from "vue";
-import { pointer, select } from "d3-selection";
+import { select } from "d3-selection";
 import type { Ref } from "vue";
 import type { XYPosition } from "@/stores/workflowEditorStateStore";
 import type { UseScrollReturn } from "@vueuse/core";
@@ -12,7 +12,7 @@ const filter = (event: any) => {
     return !preventZoom;
 };
 
-export function useZoom(
+export function useD3Zoom(
     k: number,
     minZoom: number,
     maxZoom: number,
@@ -29,20 +29,6 @@ export function useZoom(
                 .translate(transform.value.x, transform.value.y)
                 .scale(transform.value.k);
             d3Zoom.transform(d3Selection, updatedTransform);
-
-            d3Selection
-                .on("wheel", (event) => {
-                    const currentZoom = d3Selection.property("__zoom").k || 1;
-
-                    const pinchDelta =
-                        -event.deltaY * (event.deltaMode === 1 ? 0.05 : event.deltaMode ? 1 : 0.002) * 10;
-                    const point = pointer(event);
-                    point[0] += scroll.x.value;
-                    point[1] += scroll.y.value;
-                    const zoom = currentZoom * 2 ** pinchDelta;
-                    d3Zoom.scaleTo(d3Selection, zoom, point);
-                })
-                .on("wheel.zoom", null);
         }
 
         d3Zoom.on("zoom", (event: D3ZoomEvent<HTMLElement, unknown>) => {

--- a/client/src/components/Workflow/Editor/modules/zoomLevels.ts
+++ b/client/src/components/Workflow/Editor/modules/zoomLevels.ts
@@ -1,0 +1,59 @@
+export const zoomLevels = [
+    0.1, 0.2, 0.25, 0.33, 0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.33, 1.5, 2, 2.5, 3, 4, 5,
+] as const;
+
+export type ZoomLevel = (typeof zoomLevels)[number];
+
+export const minZoom = zoomLevels[0];
+export const maxZoom = zoomLevels[zoomLevels.length - 1];
+
+/**
+ * Finds the closest snapped zoom level
+ * @param zoom decimal number indicating current zoom multiplier
+ * @returns snapped zoom level
+ */
+export function getSnappedZoom(zoom: number): ZoomLevel {
+    return zoomLevels.reduce((a, b) => {
+        return Math.abs(b - zoom) < Math.abs(a - zoom) ? b : a;
+    });
+}
+
+/**
+ * Gets the next largest zoom level
+ * @param zoom decimal number indicating current zoom multiplier
+ * @returns snapped zoom level
+ */
+export function getZoomInLevel(zoom: number): ZoomLevel {
+    const snapped = getSnappedZoom(zoom);
+    const index = zoomLevels.indexOf(snapped);
+
+    if (index === zoomLevels.length - 1) {
+        return snapped;
+    } else {
+        return zoomLevels[index + 1];
+    }
+}
+
+/**
+ * Get the next smaller zoom level
+ * @param zoom decimal number indicating current zoom multiplier
+ * @returns snapped zoom level
+ */
+export function getZoomOutLevel(zoom: number): ZoomLevel {
+    const snapped = getSnappedZoom(zoom);
+    const index = zoomLevels.indexOf(snapped);
+
+    if (index === 0) {
+        return snapped;
+    } else {
+        return zoomLevels[index - 1];
+    }
+}
+
+export function isMinZoom(zoom: number): boolean {
+    return zoom === minZoom;
+}
+
+export function isMaxZoom(zoom: number): boolean {
+    return zoom === maxZoom;
+}


### PR DESCRIPTION
Fixes #15370

Fixes coarse zoom by using default zoom behavior. Please let me know if this works with pinch-zoom, as my touch-pad does not support pinch-zooming on website content. If it does not, I have another solution in mind.

Also fixes an issue with stuck tooltips, by using default tooltips instead of bootstrap vue ones.
Since bootstrap vue tooltips do not work on disabled buttons. Since the zoom button get's disabled on highest zoom, the label got stuck, even when zooming back out.

Also does some minor refactoring.