### PR TITLE
[23.0] Redirect anonymous users on histories/list

### DIFF
--- a/client/src/components/Grid/GridHistory.vue
+++ b/client/src/components/Grid/GridHistory.vue
@@ -5,16 +5,8 @@
 <script>
 import HistoryList from "./history-list";
 export default {
-    props: {
-        actionId: {
-            type: String,
-            default: null,
-        },
-    },
     mounted() {
-        new HistoryList.View({
-            action_id: this.actionId,
-        }).$el.appendTo(this.$refs.target);
+        new HistoryList.View().$el.appendTo(this.$refs.target);
     },
 };
 </script>

--- a/client/src/components/Grid/history-list.js
+++ b/client/src/components/Grid/history-list.js
@@ -62,15 +62,10 @@ var View = Backbone.View.extend({
     initialize: function (options) {
         const Galaxy = getGalaxyInstance();
         LoadingIndicator.markViewAsLoading(this);
-
-        if (options.action_id == "list_published") {
-            this.active_tab = "shared";
-        } else if (options.action_id == "list") {
-            this.active_tab = "user";
-        }
+        this.active_tab = "user";
         this.model = new Backbone.Model();
         Utils.get({
-            url: `${getAppRoot()}history/${options.action_id}?${$.param(Galaxy.params)}`,
+            url: `${getAppRoot()}history/list?${$.param(Galaxy.params)}`,
             success: (response) => {
                 this.model.set(response);
                 this.render();

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -236,15 +236,16 @@ export function getRouter(Galaxy) {
                         props: true,
                     },
                     {
+                        path: "histories/list",
+                        component: GridHistory,
+                        props: true,
+                        redirect: redirectAnon(),
+                    },
+                    {
                         path: "histories/:historyId/export",
                         get component() {
                             return Galaxy.config.enable_celery_tasks ? HistoryExportTasks : HistoryExport;
                         },
-                        props: true,
-                    },
-                    {
-                        path: "histories/:actionId",
-                        component: GridHistory,
                         props: true,
                     },
                     {


### PR DESCRIPTION
Fixes #15389

Returning 403 is the expected outcome for requesting histories for anonymous users since they can only have one single History.

Since the `histories/list_published` is now in Vue thanks to @itisAliRH, I've just removed the `actionId` for branching to the published or the user's histories list and redirecting anonymous users when trying to access `histories/list` as we do in other resources like workflows.

I hope this is the proper fix.

Thank you @neoformit for finding this.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - As an anonymous user, try to go to `histories/list`
  - You should get redirected to the main page

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
