### PR TITLE
[23.0] Adding more directive to the Invalid Input tooltip

### DIFF
--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -367,7 +367,7 @@ export class InvalidInputTerminal extends BaseInputTerminal {
     }
 
     attachable(terminal: BaseOutputTerminal) {
-        return new ConnectionAcceptable(false, "Cannot attach to invalid input.");
+        return new ConnectionAcceptable(false, "Cannot attach to invalid input. Disconnect this input.");
     }
 }
 


### PR DESCRIPTION
In response to #15374, I've added a directive to the invalid input tooltip that says that the user must disconnect the input to move forward.

[Screencast from 01-25-2023 12:45:21 PM.webm](https://user-images.githubusercontent.com/26912553/214644208-b889a8eb-0a14-42ec-8c03-0a4f8fe95ef0.webm)

## How to test the changes?
(Select all options that apply)
- [X] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Create Workflow with conditionals
  2. Change the tool to not use conditional
  3. Notice change in the tooltip that tells user how to fix error

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
