### PR TITLE
[23.0] Fix node input map over status 

### DIFF
--- a/client/src/components/Workflow/Editor/TerminalConnector.vue
+++ b/client/src/components/Workflow/Editor/TerminalConnector.vue
@@ -23,7 +23,11 @@ const props = defineProps<{
 const stepStore = useWorkflowStepStore();
 const connectionStore = useConnectionStore();
 const outputIsMappedOver = computed(() => stepStore.stepMapOver[props.connection.output.stepId]?.isCollection);
-const inputIsMappedOver = computed(() => stepStore.stepMapOver[props.connection.input.stepId]?.isCollection);
+const inputIsMappedOver = computed(
+    () =>
+        stepStore.stepInputMapOver[props.connection.input.stepId] &&
+        stepStore.stepInputMapOver[props.connection.input.stepId][props.connection.input.name]?.isCollection
+);
 const outputIsOptional = computed(() => {
     return Boolean(
         stepStore.getStep(props.connection.output.stepId)?.when ||

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -102,7 +102,9 @@ describe("canAccept", () => {
         dataIn.connect(collectionOut);
         expect(dataIn.mapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
         expect(dataIn.canAccept(collectionOut).canAccept).toBe(false);
-        expect(dataIn.canAccept(collectionOut).reason).toBe("Input already filled with another connection, delete it before connecting another output.");
+        expect(dataIn.canAccept(collectionOut).reason).toBe(
+            "Input already filled with another connection, delete it before connecting another output."
+        );
         dataIn.disconnect(collectionOut);
         expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
         expect(dataIn.mapOver).toEqual(NULL_COLLECTION_TYPE_DESCRIPTION);
@@ -262,14 +264,16 @@ describe("canAccept", () => {
         dataIn.connect(collectionOut);
         dataInTwo.connect(dataOut);
         expect(dataIn.mapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
+        expect(dataIn.localMapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
         //
         dataIn.disconnect(collectionOut);
         // this is weird and not particularly robust, if you save and reload this will most likely not be constrained
         // TODO: avoid this if possible ...
         expect(dataIn.mapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
+        expect(dataIn.localMapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
         expect(dataIn.canAccept(simpleDataOut).canAccept).toBe(false);
         expect(dataIn.canAccept(simpleDataOut).reason).toBe(
-            "Cannot attach non-collection outputs to mapped over inputs, consider disconnecting inputs and outputs to reset this input's mapping."
+            "Cannot attach non-collection output to mapped over input, consider disconnecting inputs and outputs to reset this input's mapping."
         );
     });
     // TODO: test mapOver reset when constraint removed

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -315,23 +315,23 @@ describe("canAccept", () => {
         expect(multiSimpleInputOne.canAccept(simpleDataOut).reason).toBe(
             "Cannot attach non-collection output to mapped over input, consider disconnecting inputs and outputs to reset this input's mapping."
         );
-    }),
-        it("resets mapOver when constraint is lifted", () => {
-            const collectionOut = terminals["list input"]["output"] as OutputCollectionTerminal;
-            const dataIn = terminals["simple data"]["input"] as InputTerminal;
-            const dataOut = terminals["simple data"]["out_file1"] as OutputTerminal;
-            const dataInTwo = terminals["simple data 2"]["input"] as InputTerminal;
-            dataIn.connect(collectionOut);
-            dataInTwo.connect(dataOut);
-            expect(dataIn.mapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
-            //
-            dataIn.disconnect(collectionOut);
-            // this is weird and not particularly robust, if you save and reload this will most likely not be constrained
-            // TODO: avoid this if possible ...
-            expect(dataIn.mapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
-            dataInTwo.disconnect(dataOut);
-            expect(dataIn.mapOver).toEqual(NULL_COLLECTION_TYPE_DESCRIPTION);
-        });
+    });
+    it("resets mapOver when constraint is lifted", () => {
+        const collectionOut = terminals["list input"]["output"] as OutputCollectionTerminal;
+        const dataIn = terminals["simple data"]["input"] as InputTerminal;
+        const dataOut = terminals["simple data"]["out_file1"] as OutputTerminal;
+        const dataInTwo = terminals["simple data 2"]["input"] as InputTerminal;
+        dataIn.connect(collectionOut);
+        dataInTwo.connect(dataOut);
+        expect(dataIn.mapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
+        //
+        dataIn.disconnect(collectionOut);
+        // this is weird and not particularly robust, if you save and reload this will most likely not be constrained
+        // TODO: avoid this if possible ...
+        expect(dataIn.mapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
+        dataInTwo.disconnect(dataOut);
+        expect(dataIn.mapOver).toEqual(NULL_COLLECTION_TYPE_DESCRIPTION);
+    });
     it("rejects connecting incompatible connection types", () => {
         const pairedOut = terminals["paired input"]["output"] as OutputCollectionTerminal;
         const collectionIn = terminals["list collection input"]["input1"] as InputCollectionTerminal;

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -102,6 +102,7 @@ describe("canAccept", () => {
         dataIn.connect(collectionOut);
         expect(dataIn.mapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
         expect(dataIn.canAccept(collectionOut).canAccept).toBe(false);
+        expect(dataIn.canAccept(collectionOut).reason).toBe("Input already filled with another connection, delete it before connecting another output.");
         dataIn.disconnect(collectionOut);
         expect(dataIn.canAccept(collectionOut).canAccept).toBe(true);
         expect(dataIn.mapOver).toEqual(NULL_COLLECTION_TYPE_DESCRIPTION);

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -8,6 +8,7 @@ interface State {
     steps: { [index: string]: Step };
     stepIndex: number;
     stepMapOver: { [index: number]: CollectionTypeDescriptor };
+    stepInputMapOver: StepInputMapOver;
 }
 
 interface StepPosition {
@@ -133,10 +134,15 @@ interface WorkflowOutputs {
     };
 }
 
+interface StepInputMapOver {
+    [index: number]: { [index: string]: CollectionTypeDescriptor };
+}
+
 export const useWorkflowStepStore = defineStore("workflowStepStore", {
     state: (): State => ({
         steps: {} as Steps,
         stepMapOver: {} as { [index: number]: CollectionTypeDescriptor },
+        stepInputMapOver: {} as StepInputMapOver,
         stepIndex: -1,
     }),
     getters: {
@@ -211,7 +217,17 @@ export const useWorkflowStepStore = defineStore("workflowStepStore", {
             this.steps[step.id.toString()] = step;
         },
         changeStepMapOver(stepId: number, mapOver: CollectionTypeDescriptor) {
-            this.stepMapOver[stepId] = mapOver;
+            Vue.set(this.stepMapOver, stepId, mapOver);
+        },
+        resetStepInputMapOver(stepId: number) {
+            Vue.set(this.stepInputMapOver, stepId, {});
+        },
+        changeStepInputMapOver(stepId: number, inputName: string, mapOver: CollectionTypeDescriptor) {
+            if (this.stepInputMapOver[stepId]) {
+                Vue.set(this.stepInputMapOver[stepId], inputName, mapOver);
+            } else {
+                Vue.set(this.stepInputMapOver, stepId, { [inputName]: mapOver });
+            }
         },
         addConnection(connection: Connection) {
             const inputStep = this.getStep(connection.input.stepId);


### PR DESCRIPTION
I had just lumped everything together, but we do need to keep track of which input terminals are mapped over due to a downstream constraint.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
