### PR TITLE
[23.0] Make options text clear for datasets list

### DIFF
--- a/client/src/components/Dataset/DatasetName.vue
+++ b/client/src/components/Dataset/DatasetName.vue
@@ -22,11 +22,11 @@
         <div class="dropdown-menu" aria-labelledby="dataset-dropdown">
             <a class="dropdown-item" href="#" @click.prevent="showDataset">
                 <span class="fa fa-eye fa-fw mr-1" />
-                <span>Show in History</span>
+                <span>Switch to History containing dataset</span>
             </a>
             <a class="dropdown-item" href="#" @click.prevent="copyDataset">
                 <span class="fa fa-copy fa-fw mr-1" />
-                <span>Copy to History</span>
+                <span>Copy to current History</span>
             </a>
         </div>
     </div>


### PR DESCRIPTION
Closes #15397

I'm assuming the intention here is to just switch to the associated history so I just changed the texts. Switching to the history and then actually jumping to or highlighting the target dataset would be a nice feature but not a simple fix for the release.

- On show: explicitly state that we will be switching to the associated History to avoid confusion.
- On copy: explicitly state that it will be copied to the **current** history.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow the steps on #15397
  - Check that the intention of the action is clearer

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
