### PR TITLE
[23.0] Sort tool sections in a way that works for both Chrome and Firefox...

### DIFF
--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -137,9 +137,19 @@ export default {
                 this.config.toolbox_auto_sort === true &&
                 !this.category.elems.some((el) => el.text !== undefined && el.text !== "")
             ) {
-                return Object.entries(
-                    [...this.category.elems].sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase())
-                );
+                const elements = [...this.category.elems];
+                const sorted = elements.sort((a, b) => {
+                    const aNameLower = a.name.toLowerCase();
+                    const bNameLower = b.name.toLowerCase();
+                    if (aNameLower > bNameLower) {
+                        return 1;
+                    } else if (aNameLower < bNameLower) {
+                        return -1;
+                    } else {
+                        return 0;
+                    }
+                });
+                return Object.entries(sorted);
             } else {
                 return Object.entries(this.category.elems);
             }


### PR DESCRIPTION
Fixes #15413 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Check default 'Text Manipulation' section in chrome, observe sorting.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
