### PR TITLE
Outline Deployment Tests

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,0 +1,71 @@
+name: Deployment Tests
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Galaxy Deployment to target'
+        required: true
+        default: 'usegalaxymain'
+        type: choice
+        options:
+        - usegalaxytest
+        - usegalaxymain
+        - usegalaxyeu
+      type:
+        description: 'Test type'
+        required: true
+        default: 'all'
+        type: choice
+        options:
+        - all
+        - api
+        - selenium
+      branch:
+        description: 'Branch of code to run from'
+        default: 'dev'
+        type: string        
+      debug:
+        required: true
+        description: 'Run deployment tests with debug mode on'
+        type: boolean
+jobs:
+  testdeployment:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip dir
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+      - uses: nanasess/setup-chromedriver@v1
+      - name: Run tests
+        run: bash ./test/deployment/usegalaxystar.bash
+        env:
+          GALAXY_TEST_DEPLOYMENT_TARGET: ${{ inputs.target }}
+          GALAXY_TEST_DEPLOYMENT_DEBUG: ${{ inputs.debug }}
+          GALAXY_TEST_DEPLOYMENT_TEST_TYPE: ${{ inputs.type }}
+          GALAXY_TEST_USEGALAXYMAIN_USER_EMAIL: "jmchilton+test@gmail.com"
+          GALAXY_TEST_USEGALAXYMAIN_USER_PASSWORD: ${{ secrets.USEGALAXYMAIN_USER_PASSWORD }}
+          GALAXY_TEST_USEGALAXYMAIN_USER_KEY: ${{ secrets.USEGALAXYMAIN_USER_KEY }}
+          GALAXY_TEST_USEGALAXYTEST_USER_EMAIL: "jmchilton+test@gmail.com"
+          GALAXY_TEST_USEGALAXYTEST_USER_PASSWORD: ${{ secrets.USEGALAXYTEST_USER_PASSWORD }}
+          GALAXY_TEST_USEGALAXYTEST_USER_KEY: ${{ secrets.USEGALAXYTEST_USER_KEY }}
+          GALAXY_TEST_USEGALAXYEU_USER_EMAIL: "jmchilton+test@gmail.com"
+          GALAXY_TEST_USEGALAXYEU_USER_PASSWORD: ${{ secrets.USEGALAXYEU_USER_PASSWORD }}
+          GALAXY_TEST_USEGALAXYEU_USER_KEY: ${{ secrets.USEGALAXYEU_USER_KEY }}
+          GALAXY_TEST_TIMEOUT_MULTIPLIER: 10
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Deployment test results (${{ inputs.target }}, ${{ inputs.type }})
+          path: 'deployment_tests.html'

--- a/lib/galaxy_test/api/test_authenticate.py
+++ b/lib/galaxy_test/api/test_authenticate.py
@@ -4,6 +4,7 @@ from requests import get
 
 from galaxy_test.base.api_util import baseauth_headers
 from galaxy_test.base.decorators import requires_new_user
+from galaxy_test.base.populators import skip_without_tool
 from ._framework import ApiTestCase
 
 TEST_USER_EMAIL = "auth_user_test@bx.psu.edu"
@@ -26,6 +27,7 @@ class TestAuthenticateApi(ApiTestCase):
         random_api_response = get(random_api_url, params=dict(key=auth_dict["api_key"]))
         self._assert_status_code_is(random_api_response, 200)
 
+    @skip_without_tool("test_data_source")
     def test_tool_runner_session_cookie_handling(self):
         response = get(self.url)
         tool_runner_session_cookie = response.cookies["galaxytoolrunnersession"]

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -4,6 +4,7 @@ from typing import List
 
 from galaxy.util.unittest_utils import skip_if_github_down
 from galaxy_test.base.api_asserts import assert_object_id_error
+from galaxy_test.base.decorators import requires_new_user
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
@@ -181,6 +182,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
             namelist = archive.namelist()
             assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
 
+    @requires_new_user
     def test_hda_security(self):
         with self.dataset_populator.test_history(require_new=False) as history_id:
             element_identifiers = self.dataset_collection_populator.pair_identifiers(history_id)
@@ -374,6 +376,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
     def _download_dataset_collection(self, history_id: str, hdca_id: str):
         return self._get(f"histories/{history_id}/contents/dataset_collections/{hdca_id}/download")
 
+    @requires_new_user
     def test_collection_contents_security(self, history_id):
         # request contents on an hdca that doesn't belong to user
         hdca, contents_url = self._create_collection_contents_pair(history_id)

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -11,6 +11,10 @@ from galaxy.model.unittest_utils.store_fixtures import (
 )
 from galaxy_test.api.sharable import SharingApiTests
 from galaxy_test.base.api_asserts import assert_has_keys
+from galaxy_test.base.decorators import (
+    requires_admin,
+    requires_new_user,
+)
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
@@ -249,6 +253,7 @@ class TestHistoriesApi(ApiTestCase, BaseHistories):
         create_response = self._post("histories", data=post_data, anon=True)
         self._assert_status_code_is(create_response, 403)
 
+    @requires_admin
     def test_create_without_session_fails(self):
         post_data = dict(name="SessionNeeded")
         # Using admin=True will boostrap an Admin user without session
@@ -581,6 +586,7 @@ class TestSharingHistory(ApiTestCase, BaseHistories, SharingApiTests):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
+    @requires_new_user
     def test_sharing_with_private_datasets(self):
         history_id = self.dataset_populator.new_history()
         hda = self.dataset_populator.new_dataset(history_id)
@@ -607,6 +613,8 @@ class TestSharingHistory(ApiTestCase, BaseHistories, SharingApiTests):
         assert sharing_response["users_shared_with"]
         assert sharing_response["users_shared_with"][0]["id"] == target_user_id
 
+    @requires_admin
+    @requires_new_user
     def test_sharing_without_manage_permissions(self):
         history_id = self.dataset_populator.new_history()
         hda = self.dataset_populator.new_dataset(history_id)
@@ -649,6 +657,7 @@ class TestSharingHistory(ApiTestCase, BaseHistories, SharingApiTests):
         assert sharing_response["users_shared_with"]
         assert sharing_response["users_shared_with"][0]["id"] == target_user_id
 
+    @requires_new_user
     def test_sharing_empty_not_allowed(self):
         history_id = self.dataset_populator.new_history()
 
@@ -661,6 +670,7 @@ class TestSharingHistory(ApiTestCase, BaseHistories, SharingApiTests):
         assert sharing_response["errors"]
         assert "empty" in sharing_response["errors"][0]
 
+    @requires_new_user
     def test_sharing_with_duplicated_users(self):
         history_id = self.create("HistoryToShareWithDuplicatedUser")
 
@@ -674,6 +684,7 @@ class TestSharingHistory(ApiTestCase, BaseHistories, SharingApiTests):
         assert len(sharing_response["users_shared_with"]) == 1
         assert sharing_response["users_shared_with"][0]["id"] == target_user_id
 
+    @requires_new_user
     def test_sharing_private_history_makes_datasets_public(self):
         history_id = self.dataset_populator.new_history()
         hda = self.dataset_populator.new_dataset(history_id)

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -7,6 +7,12 @@ from typing import (
 )
 
 from galaxy_test.api._framework import ApiTestCase
+from galaxy_test.base.decorators import (
+    requires_admin,
+    requires_celery,
+    requires_new_library,
+    requires_new_user,
+)
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
@@ -35,6 +41,7 @@ class TestHistoryContentsApi(ApiTestCase):
         hda_summary = self.__check_for_hda(contents_response, hda1)
         assert "display_types" not in hda_summary  # Quick summary, not full details
 
+    @requires_admin
     def test_make_private_and_public(self, history_id):
         hda1 = self._wait_for_new_hda(history_id)
         update_url = f"histories/{history_id}/contents/{hda1['id']}/permissions"
@@ -64,9 +71,11 @@ class TestHistoryContentsApi(ApiTestCase):
         self._assert_status_code_is(update_response, 200)
         self._assert_other_user_can_access(history_id, hda1["id"])
 
+    @requires_new_user
     def test_set_permissions_add_admin_history_contents(self, history_id):
         self._verify_dataset_permissions(history_id, "history_contents")
 
+    @requires_new_user
     def test_set_permissions_add_admin_datasets(self, history_id):
         self._verify_dataset_permissions(history_id, "dataset")
 
@@ -204,6 +213,7 @@ class TestHistoryContentsApi(ApiTestCase):
         inheritance_chain = inheritance_chain_response.json()
         assert len(inheritance_chain) == 1
 
+    @requires_new_library
     def test_library_copy(self, history_id):
         ld = self.library_populator.new_library_dataset("lda_test_library")
         create_data = dict(
@@ -591,6 +601,7 @@ class TestHistoryContentsApi(ApiTestCase):
 
         return element0["object"], element1["object"]
 
+    @requires_new_library
     def test_hdca_from_library_datasets(self, history_id):
         ld = self.library_populator.new_library_dataset("el1")
         ldda_id = ld["ldda_id"]
@@ -612,6 +623,7 @@ class TestHistoryContentsApi(ApiTestCase):
         assert hda["copied_from_ldda_id"] == ldda_id
         assert hda["history_id"] == history_id
 
+    @requires_new_library
     def test_hdca_from_inaccessible_library_datasets(self, history_id):
         library, library_dataset = self.library_populator.new_library_dataset_in_private_library(
             "HDCACreateInaccesibleLibrary"
@@ -943,6 +955,7 @@ class TestHistoryContentsApiBulkOperation(ApiTestCase):
                 if item["history_content_type"] == "dataset":
                     self.dataset_populator.wait_for_purge(history_id=history_id, content_id=item["id"])
 
+    @requires_new_user
     def test_only_owner_can_apply_bulk_operations(self):
         with self.dataset_populator.test_history() as history_id:
             self._create_test_history_contents(history_id)
@@ -993,6 +1006,7 @@ class TestHistoryContentsApiBulkOperation(ApiTestCase):
                     for expected_tag in expected_tags:
                         assert expected_tag in item["tags"]
 
+    @requires_celery
     def test_bulk_dbkey_change(self):
         with self.dataset_populator.test_history() as history_id:
             _, _, history_contents = self._create_test_history_contents(history_id)
@@ -1015,6 +1029,7 @@ class TestHistoryContentsApiBulkOperation(ApiTestCase):
                 if item["history_content_type"] == "dataset":
                     assert item["dbkey"] == expected_dbkey
 
+    @requires_celery
     def test_bulk_dbkey_change_dataset_collection(self):
         with self.dataset_populator.test_history() as history_id:
             _, collection_ids, history_contents = self._create_test_history_contents(history_id)

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -8,6 +8,10 @@ from requests import (
 
 from galaxy_test.api._framework import ApiTestCase
 from galaxy_test.base.api_asserts import assert_object_id_error
+from galaxy_test.base.decorators import (
+    requires_admin,
+    requires_new_user,
+)
 from galaxy_test.base.populators import skip_without_tool
 
 TEST_USER_EMAIL = "user_for_users_index_test@bx.psu.edu"
@@ -17,6 +21,8 @@ TEST_USER_EMAIL_UNDELETE = "user_for_undelete_test@bx.psu.edu"
 
 
 class TestUsersApi(ApiTestCase):
+    @requires_admin
+    @requires_new_user
     def test_index(self):
         self._setup_user(TEST_USER_EMAIL)
         all_users_response = self._get("users", admin=True)
@@ -28,6 +34,7 @@ class TestUsersApi(ApiTestCase):
         # new user.
         assert len(all_users) > 1
 
+    @requires_new_user
     def test_index_only_self_for_nonadmins(self):
         self._setup_user(TEST_USER_EMAIL)
         with self._different_user():
@@ -35,6 +42,7 @@ class TestUsersApi(ApiTestCase):
             # Non admin users can only see themselves
             assert len(all_users_response.json()) == 1
 
+    @requires_new_user
     def test_show(self):
         user = self._setup_user(TEST_USER_EMAIL)
         with self._different_user(email=TEST_USER_EMAIL):
@@ -42,6 +50,7 @@ class TestUsersApi(ApiTestCase):
             self._assert_status_code_is(show_response, 200)
             self.__assert_matches_user(user, show_response.json())
 
+    @requires_new_user
     def test_update(self):
         new_name = "linnaeus"
         user = self._setup_user(TEST_USER_EMAIL)
@@ -68,6 +77,8 @@ class TestUsersApi(ApiTestCase):
             update_response = put(update_url, data=json.dumps(dict(username=new_name)))
             assert_object_id_error(update_response)
 
+    @requires_admin
+    @requires_new_user
     def test_admin_update(self):
         new_name = "flexo"
         user = self._setup_user(TEST_USER_EMAIL)
@@ -77,12 +88,16 @@ class TestUsersApi(ApiTestCase):
         update_json = update_response.json()
         assert update_json["username"] == new_name
 
+    @requires_admin
+    @requires_new_user
     def test_delete_user(self):
         user = self._setup_user(TEST_USER_EMAIL_DELETE)
         self._delete(f"users/{user['id']}", admin=True)
         updated_user = self._get(f"users/deleted/{user['id']}", admin=True).json()
         assert updated_user["deleted"] is True, updated_user
 
+    @requires_admin
+    @requires_new_user
     def test_purge_user(self):
         """Delete user and then purge them."""
         user = self._setup_user(TEST_USER_EMAIL_PURGE)
@@ -96,6 +111,8 @@ class TestUsersApi(ApiTestCase):
         assert purged_user["deleted"] is True, purged_user
         assert purged_user["purged"] is True, purged_user
 
+    @requires_admin
+    @requires_new_user
     def test_undelete_user(self):
         """Delete user and then undelete them."""
         user = self._setup_user(TEST_USER_EMAIL_UNDELETE)
@@ -107,6 +124,7 @@ class TestUsersApi(ApiTestCase):
         undeleted_user = self._get(f"users/{user['id']}", admin=True).json()
         assert undeleted_user["deleted"] is False, undeleted_user
 
+    @requires_new_user
     def test_information(self):
         user = self._setup_user(TEST_USER_EMAIL)
         url = self.__url("information/inputs", user)
@@ -126,6 +144,7 @@ class TestUsersApi(ApiTestCase):
         assert len(response["addresses"]) == 1
         assert response["addresses"][0]["desc"] == "_desc"
 
+    @requires_new_user
     def test_manage_api_key(self):
         with self._different_user("manage-api-key-test@user.com"):
             user_id = self._get_current_user_id()
@@ -150,6 +169,7 @@ class TestUsersApi(ApiTestCase):
             assert new_api_key
             assert new_api_key != user_api_key
 
+    @requires_new_user
     def test_only_admin_can_manage_other_users_api_key(self):
         with self._different_user():
             other_user_id = self._get_current_user_id()
@@ -171,6 +191,8 @@ class TestUsersApi(ApiTestCase):
         response = self._delete(f"users/{other_user_id}/api_key", admin=True)
         self._assert_status_code_is_ok(response)
 
+    @requires_admin
+    @requires_new_user
     @skip_without_tool("cat1")
     def test_favorites(self):
         user = self._setup_user(TEST_USER_EMAIL)

--- a/lib/galaxy_test/base/decorators.py
+++ b/lib/galaxy_test/base/decorators.py
@@ -18,6 +18,7 @@ from typing_extensions import Literal
 
 KnownRequirementT = Union[
     Literal["admin"],
+    Literal["celery"],
     Literal["new_history"],
     Literal["new_library"],
     Literal["new_published_objects"],
@@ -92,9 +93,14 @@ def requires_admin(method):
     return _wrap_method_with_galaxy_requirement(method, "admin")
 
 
+def requires_celery(method):
+    return _wrap_method_with_galaxy_requirement(method, "celery")
+
+
 __all__ = (
     "has_requirement",
     "requires_admin",
+    "requires_celery",
     "requires_new_history",
     "requires_new_library",
     "requires_new_published_objects",

--- a/lib/galaxy_test/selenium/test_anon_history.py
+++ b/lib/galaxy_test/selenium/test_anon_history.py
@@ -1,3 +1,4 @@
+from galaxy_test.base.decorators import requires_new_user
 from .framework import (
     selenium_test,
     SeleniumTestCase,
@@ -25,12 +26,14 @@ class TestAnonymousHistories(SeleniumTestCase):
         self.components.history_panel.empty_message.assert_absent_or_hidden()
 
     @selenium_test
+    @requires_new_user
     def test_anon_history_after_registration(self):
         self._upload_file_anonymous_then_register_user()
         self.home()
         self.history_panel_wait_for_hid_state(1, "ok")
 
     @selenium_test
+    @requires_new_user
     def test_clean_anon_history_after_logout(self):
         self._upload_file_anonymous_then_register_user()
         self.logout_if_needed()

--- a/lib/galaxy_test/selenium/test_collection_builders.py
+++ b/lib/galaxy_test/selenium/test_collection_builders.py
@@ -1,4 +1,5 @@
 from .framework import (
+    managed_history,
     selenium_test,
     SeleniumTestCase,
 )
@@ -9,6 +10,7 @@ class TestCollectionBuilders(SeleniumTestCase):
     ensure_registered = True
 
     @selenium_test
+    @managed_history
     def test_build_list_simple_hidden(self):
         self.perform_upload(self.get_filename("1.fasta"))
         self._wait_for_and_select([1])
@@ -19,6 +21,7 @@ class TestCollectionBuilders(SeleniumTestCase):
         self._wait_for_hid_visible(2)
 
     @selenium_test
+    @managed_history
     def test_build_list_and_show_items(self):
         self.perform_upload(self.get_filename("1.fasta"))
         self._wait_for_and_select([1])
@@ -32,6 +35,7 @@ class TestCollectionBuilders(SeleniumTestCase):
         self._wait_for_hid_visible(3)
 
     @selenium_test
+    @managed_history
     def test_build_pair_simple_hidden(self):
         self.perform_upload(self.get_filename("1.tabular"))
         self.perform_upload(self.get_filename("2.tabular"))
@@ -43,6 +47,7 @@ class TestCollectionBuilders(SeleniumTestCase):
         self._wait_for_hid_visible(3)
 
     @selenium_test
+    @managed_history
     def test_build_paired_list_simple(self):
         self.perform_upload(self.get_filename("1.tabular"))
         self.perform_upload(self.get_filename("2.tabular"))
@@ -61,6 +66,7 @@ class TestCollectionBuilders(SeleniumTestCase):
         self._wait_for_hid_visible(2)
 
     @selenium_test
+    @managed_history
     def test_build_paired_list_show_original(self):
         self.perform_upload(self.get_filename("1.tabular"))
         self.perform_upload(self.get_filename("2.tabular"))
@@ -85,6 +91,7 @@ class TestCollectionBuilders(SeleniumTestCase):
         self._wait_for_hid_visible(4)
 
     @selenium_test
+    @managed_history
     def test_build_simple_list_via_rules_hidden(self):
         self.perform_upload(self.get_filename("1.fasta"))
         self._wait_for_and_select([1])

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -1,4 +1,5 @@
 from .framework import (
+    managed_history,
     selenium_test,
     SeleniumTestCase,
 )
@@ -9,6 +10,7 @@ class TestCollectionEdit(SeleniumTestCase):
     ensure_registered = True
 
     @selenium_test
+    @managed_history
     def test_change_dbkey_simple_list(self):
         self.create_simple_list_collection()
         self.open_collection_edit_view()
@@ -23,6 +25,7 @@ class TestCollectionEdit(SeleniumTestCase):
         self.check_current_data_value(dataNew)
 
     @selenium_test
+    @managed_history
     def test_change_datatype_simple_list(self):
         self.create_simple_list_collection_txt()
         self.open_collection_edit_view()

--- a/lib/galaxy_test/selenium/test_dataset_metadata_download.py
+++ b/lib/galaxy_test/selenium/test_dataset_metadata_download.py
@@ -1,4 +1,5 @@
 from .framework import (
+    managed_history,
     selenium_test,
     SeleniumTestCase,
     UsesHistoryItemAssertions,
@@ -11,6 +12,7 @@ class TestHistoryDatasetState(SeleniumTestCase, UsesHistoryItemAssertions):
     ensure_registered = True
 
     @selenium_test
+    @managed_history
     def test_dataset_metadata_download(self):
         self._prepare_dataset()
         item = self.history_panel_item_component(hid=FIRST_HID)

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -4,6 +4,7 @@ from galaxy.model.unittest_utils.store_fixtures import (
     TEST_SOURCE_URI,
 )
 from .framework import (
+    managed_history,
     selenium_test,
     SeleniumTestCase,
     UsesHistoryItemAssertions,
@@ -26,6 +27,7 @@ class TestHistoryDatasetState(SeleniumTestCase, UsesHistoryItemAssertions):
     ensure_registered = True
 
     @selenium_test
+    @managed_history
     def test_dataset_state(self):
         self._prepare_dataset()
         self.history_panel_item_body_component(FIRST_HID, wait=True)
@@ -40,6 +42,7 @@ class TestHistoryDatasetState(SeleniumTestCase, UsesHistoryItemAssertions):
         self.screenshot("dataset_details_ok")
 
     @selenium_test
+    @managed_history
     def test_dataset_change_dbkey(self):
         item = self._prepare_dataset()
         self.assert_item_dbkey_displayed_as(FIRST_HID, "?")
@@ -57,6 +60,7 @@ class TestHistoryDatasetState(SeleniumTestCase, UsesHistoryItemAssertions):
         self.assert_item_dbkey_displayed_as(FIRST_HID, "apiMel3")
 
     @selenium_test
+    @managed_history
     def test_dataset_state_discarded(self):
         self.history_panel_create_new()
         history_id = self.current_history_id()
@@ -77,6 +81,7 @@ class TestHistoryDatasetState(SeleniumTestCase, UsesHistoryItemAssertions):
         self.screenshot("dataset_details_discarded")
 
     @selenium_test
+    @managed_history
     def test_dataset_state_deferred(self):
         self.history_panel_create_new()
         history_id = self.current_history_id()

--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -1,4 +1,5 @@
 from .framework import (
+    managed_history,
     selenium_test,
     SeleniumTestCase,
 )
@@ -22,6 +23,7 @@ class TestHistoryMultiView(SeleniumTestCase):
         self.screenshot("multi_history_collection")
 
     @selenium_test
+    @managed_history
     def test_list_list_display(self):
         history_id = self.current_history_id()
         method = self.dataset_collection_populator.create_list_of_list_in_history(history_id, wait=True).json

--- a/test/deployment/usegalaxystar.bash
+++ b/test/deployment/usegalaxystar.bash
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Once-a-release deployment tests for usegalaxy*
+# This script is designed for use with .github/workflows/deployment.yaml,
+# a manually triggered GitHub Actions workflow.
+# The variables this script consumes include:
+# - GALAXY_TEST_DEPLOYMENT_TARGET
+#    target Galaxy deployment to test against - this should be
+#    usegalaxymain or usegalaxytest currently.
+# - GALAXY_TEST_DEPLOYMENT_DEBUG
+#    should be the string "true" to enable additional debugging
+# - GALAXY_TEST_USEGALAXYMAIN_USER_KEY
+#   GALAXY_TEST_USEGALAXYTEST_USER_KEY
+#    API key to select for given target.
+
+set -e
+
+echo "Deployment target is $GALAXY_TEST_DEPLOYMENT_TARGET"
+
+# Setup dependencies and activate resulting Python environment.
+./scripts/common_startup.sh --skip-client-build --skip-node
+. .venv/bin/activate
+
+if [ $GALAXY_TEST_DEPLOYMENT_DEBUG = "true" ];
+then
+    PYTEST_DEBUG_ARGS="-s -v"
+else
+    PYTEST_DEBUG_ARGS=""
+fi
+
+if [ "$GALAXY_TEST_DEPLOYMENT_TARGET" = "usegalaxymain" ];
+then
+    GALAXY_TEST_EXTERNAL="https://usegalaxy.org"
+    GALAXY_TEST_USER_API_KEY="$GALAXY_TEST_USEGALAXYMAIN_USER_KEY"
+    GALAXY_TEST_USER_EMAIL="$GALAXY_TEST_USEGALAXYMAIN_USER_EMAIL"
+    GALAXY_TEST_SELENIUM_USER_PASSWORD="$GALAXY_TEST_USEGALAXYMAIN_USER_PASSWORD"
+elif [ "$GALAXY_TEST_DEPLOYMENT_TARGET" = "usegalaxytest" ];
+then
+    GALAXY_TEST_EXTERNAL="https://test.galaxyproject.org"
+    GALAXY_TEST_USER_API_KEY="$GALAXY_TEST_USEGALAXYTEST_USER_KEY"
+    GALAXY_TEST_USER_EMAIL="$GALAXY_TEST_USEGALAXYTEST_USER_EMAIL"
+    GALAXY_TEST_SELENIUM_USER_PASSWORD="$GALAXY_TEST_USEGALAXYTEST_USER_PASSWORD"
+elif [ "$GALAXY_TEST_DEPLOYMENT_TARGET" = "usegalaxyeu" ];
+then
+    GALAXY_TEST_EXTERNAL="https://usegalaxy.eu"
+    GALAXY_TEST_USER_API_KEY="$GALAXY_TEST_USEGALAXYEU_USER_KEY"
+    GALAXY_TEST_USER_EMAIL="$GALAXY_TEST_USEGALAXYEU_USER_EMAIL"
+    GALAXY_TEST_SELENIUM_USER_PASSWORD="$GALAXY_TEST_USEGALAXYEU_USER_PASSWORD"
+else
+    echo "ERROR: Unknown deployment test target ${GALAXY_TEST_DEPLOYMENT_TARGET}"
+    exit 1
+fi
+export GALAXY_TEST_EXTERNAL
+export GALAXY_TEST_USER_API_KEY
+export GALAXY_TEST_USER_EMAIL
+GALAXY_TEST_SELENIUM_USER_EMAIL="$GALAXY_TEST_USER_EMAIL"
+export GALAXY_TEST_SELENIUM_USER_EMAIL
+export GALAXY_TEST_SELENIUM_USER_PASSWORD
+
+api_tests=(
+    lib/galaxy_test/api/test_datatypes.py
+    lib/galaxy_test/api/test_workflow_extraction.py
+    lib/galaxy_test/api/test_users.py
+    lib/galaxy_test/api/test_roles.py
+    lib/galaxy_test/api/test_authenticate.py
+    lib/galaxy_test/api/test_configuration.py
+    lib/galaxy_test/api/test_dataset_collections.py
+    lib/galaxy_test/api/test_display_applications.py
+    lib/galaxy_test/api/test_drs.py
+    lib/galaxy_test/api/test_folders.py
+    lib/galaxy_test/api/test_folder_contents.py
+    lib/galaxy_test/api/test_framework.py
+    lib/galaxy_test/api/test_histories.py
+    lib/galaxy_test/api/test_history_contents.py
+)
+selenium_tests=(
+    lib/galaxy_test/selenium/test_anon_history.py
+    lib/galaxy_test/selenium/test_collection_builders.py
+    lib/galaxy_test/selenium/test_dataset_metadata_download.py
+    lib/galaxy_test/selenium/test_collection_edit.py
+    lib/galaxy_test/selenium/test_history_copy_elements.py
+    lib/galaxy_test/selenium/test_history_dataset_state.py
+    lib/galaxy_test/selenium/test_history_multi_view.py
+)
+if [ "$GALAXY_TEST_DEPLOYMENT_TEST_TYPE" = "all" ];
+then
+    tests=("${api_tests[@]}" "${selenium_tests[@]}")
+elif [ "$GALAXY_TEST_DEPLOYMENT_TEST_TYPE" = "api" ];
+then
+    tests=("${api_tests[@]}")
+elif [ "$GALAXY_TEST_DEPLOYMENT_TEST_TYPE" = "selenium" ];
+then
+    tests=("${selenium_tests[@]}")
+else
+    echo "Unknown GALAXY_TEST_DEPLOYMENT_TEST_TYPE encountered ${GALAXY_TEST_DEPLOYMENT_TEST_TYPE}"
+    exit 1
+fi
+
+echo "Running tests: ${tests[@]}"
+# pytest markers to select against. In order to not cause an explosion of
+# semi-permanent artifacts that are difficult to manage tests which require
+# new libraries or users are disabled. Tests which require admin keys are
+# also disabled for security/simplicity reasons.
+PYTEST_MARKER_EXPRESSION="not requires_admin and not requires_new_library and not requires_new_user and not requires_celery"
+PYTEST_HTML_REPORT="deployment_tests.html"
+pytest \
+    $PYTEST_DEBUG_ARGS \
+    --html "$PYTEST_HTML_REPORT" \
+    -m "${PYTEST_MARKER_EXPRESSION}" \
+    "${tests[@]}"


### PR DESCRIPTION
Manually triggered tests that run API and/or Selenium tests against public servers that can be refined and eventually included in the release process.

Passwords and Galaxy API keys are stored as Github Action secrets.

Some screenshots:

<img width="1564" alt="Screen Shot 2023-01-26 at 1 47 25 PM" src="https://user-images.githubusercontent.com/216771/214923574-d1205398-3347-4183-aff9-1398ee1debad.png">

<img width="1023" alt="Screen Shot 2023-01-26 at 1 47 06 PM" src="https://user-images.githubusercontent.com/216771/214923624-0cf9e12b-eed5-4b69-a935-df171ad228c7.png">

This continues the work of annotating the tests with requirements more completely and fixes some bugs in the newer test_drs test case.

It will take a lot of work to get all the tests properly annotated and to adapt a bunch of the tests to work with different tool panels and small pools of users and such... but I think this is a good first step. I'll try to do a bit more work in this direction each release and include updates in the release testing reports.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Add relevant keys and such to the project's repo.
  2. Run the deployment tests according to the screenshots above after the work is merged.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
