### PR TITLE
Towards SQLAlchemy 2.0: drop session autocommit setting

### DIFF
--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -31,6 +31,7 @@ from galaxy.model import tags
 from galaxy.model.base import (
     ModelMapping,
     SharedModelMapping,
+    transaction,
 )
 from galaxy.model.mapping import GalaxyModelMapping
 from galaxy.model.scoped_session import galaxy_scoped_session
@@ -314,7 +315,8 @@ class MockTrans:
         if self.galaxy_session:
             self.galaxy_session.user = user
             self.sa_session.add(self.galaxy_session)
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
         self.__user = user
 
     user = property(get_user, set_user)

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -19,6 +19,7 @@ from galaxy.model import (
     CustosAuthnzToken,
     User,
 )
+from galaxy.model.base import transaction
 from galaxy.model.orm.util import add_object_to_object_session
 from . import IdentityProvider
 
@@ -199,7 +200,8 @@ class CustosAuthnz(IdentityProvider):
             redirect_url = "/"
 
         trans.sa_session.add(custos_authnz_token)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
         return redirect_url, custos_authnz_token.user
 
@@ -247,7 +249,8 @@ class CustosAuthnz(IdentityProvider):
 
         trans.sa_session.add(user)
         trans.sa_session.add(custos_authnz_token)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return login_redirect_url, user
 
     def disconnect(self, provider, trans, email=None, disconnect_redirect_url=None):
@@ -264,7 +267,8 @@ class CustosAuthnz(IdentityProvider):
                     if id_token_decoded["email"] == email:
                         index = idx
             trans.sa_session.delete(provider_tokens[index])
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             return True, "", disconnect_redirect_url
         except Exception as e:
             return False, f"Failed to disconnect provider {provider}: {util.unicodify(e)}", None

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -22,6 +22,7 @@ from galaxy.model import (
     PSAPartial,
     UserAuthnzToken,
 )
+from galaxy.model.base import transaction
 from galaxy.util import DEFAULT_SOCKET_TIMEOUT
 from . import IdentityProvider
 
@@ -438,4 +439,5 @@ def disconnect(
     sa_session.delete(user_authnz)
     # option B
     # user_authnz.extra_data = None
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -33,6 +33,7 @@ from galaxy.managers.markdown_util import generate_branded_pdf
 from galaxy.managers.model_stores import ModelStoreManager
 from galaxy.managers.tool_data import ToolDataImportManager
 from galaxy.metadata.set_metadata import set_metadata_portable
+from galaxy.model.base import transaction
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.objectstore import BaseObjectStore
 from galaxy.schema.tasks import (
@@ -137,7 +138,8 @@ def change_datatype(
         path = dataset_instance.dataset.file_name
         datatype = sniff.guess_ext(path, datatypes_registry.sniff_order)
     datatypes_registry.change_datatype(dataset_instance, datatype)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     set_metadata(hda_manager, ldda_manager, sa_session, dataset_id, model_class)
 
 
@@ -147,7 +149,8 @@ def touch(sa_session: galaxy_scoped_session, item_id: int, model_class: str = "H
         raise NotImplementedError(f"touch method not implemented for '{model_class}'")
     item = sa_session.query(model.HistoryDatasetCollectionAssociation).filter_by(id=item_id).one()
     item.touch()
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
 
 @galaxy_task(action="set dataset association metadata")
@@ -174,7 +177,8 @@ def set_metadata(
     except Exception as e:
         log.info(f"Setting metadata failed on {model_class} {dataset_instance.id}: {str(e)}")
         dataset_instance.dataset.state = dataset_instance.dataset.states.FAILED_METADATA
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
 
 def _get_dataset_manager(

--- a/lib/galaxy/datatypes/display_applications/parameters.py
+++ b/lib/galaxy/datatypes/display_applications/parameters.py
@@ -3,6 +3,7 @@ import mimetypes
 from typing import Optional
 from urllib.parse import quote_plus
 
+from galaxy.model.base import transaction
 from galaxy.util import string_as_bool
 from galaxy.util.bunch import Bunch
 from galaxy.util.template import fill_template
@@ -151,7 +152,8 @@ class DisplayApplicationDataParameter(DisplayApplicationParameter):
                         parent=data, file_type=target_ext, dataset=new_data, metadata_safe=False
                     )
                     trans.sa_session.add(assoc)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                 elif converted_dataset and converted_dataset.state == converted_dataset.states.ERROR:
                     raise Exception(f"Dataset conversion failed for data parameter: {self.name}")
         return self.get_value(other_values, dataset_hash, user_hash, trans)

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -795,8 +795,8 @@ class Sam(Tabular, _BamOrSam):
         >>> from galaxy.model.mapping import init
         >>> sa_session = init("/tmp", "sqlite:///:memory:", create_tables=True).session
         >>> hist = History()
-        >>> sa_session.add(hist)
-        >>> sa_session.flush()
+        >>> with sa_session.begin():
+        ...     sa_session.add(hist)
         >>> set_datatypes_registry(example_datatype_registry_for_sample())
         >>> fname = get_test_fname( 'sam_with_header.sam' )
         >>> samds = Dataset(external_filename=fname)

--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -6,6 +6,7 @@ import datetime
 
 from markupsafe import escape
 
+from galaxy.model.base import transaction
 from galaxy.util import (
     send_mail,
     unicodify,
@@ -366,7 +367,8 @@ class DeleteIntermediatesAction(DefaultJobAction):
         # POTENTIAL ISSUES:  When many outputs are being finish()ed
         # concurrently, sometimes non-terminal steps won't be cleaned up
         # because of the lag in job state updates.
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         if not job.workflow_invocation_step:
             log.debug("This job is not part of a workflow invocation, delete intermediates aborted.")
             return

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -22,6 +22,7 @@ from galaxy.model import (
     JobToOutputDatasetAssociation,
     LibraryDatasetDatasetAssociation,
 )
+from galaxy.model.base import transaction
 from galaxy.model.dataset_collections import builder
 from galaxy.model.dataset_collections.structure import UninitializedTree
 from galaxy.model.dataset_collections.type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
@@ -292,7 +293,8 @@ class JobContext(BaseJobContext):
         self.sa_session.add(obj)
 
     def flush(self):
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
     def get_library_folder(self, destination):
         app = self.app
@@ -332,7 +334,8 @@ class JobContext(BaseJobContext):
         trans = self.work_context
         trans.app.security_agent.copy_library_permissions(trans, library_folder, ld)
         trans.sa_session.add(ld)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
         # Permissions must be the same on the LibraryDatasetDatasetAssociation and the associated LibraryDataset
         trans.app.security_agent.copy_library_permissions(trans, ld, ldda)
@@ -342,10 +345,12 @@ class JobContext(BaseJobContext):
         )
         library_folder.add_library_dataset(ld, genome_build=ldda.dbkey)
         trans.sa_session.add(library_folder)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
         trans.sa_session.add(ld)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
     def add_datasets_to_history(self, datasets, for_output_dataset=None):
         sa_session = self.sa_session

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -34,6 +34,7 @@ from galaxy.jobs import (
     TaskWrapper,
 )
 from galaxy.jobs.mapper import JobNotReadyException
+from galaxy.model.base import transaction
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.util import unicodify
 from galaxy.util.custom_logging import get_logger
@@ -570,8 +571,10 @@ class JobHandlerQueue(BaseJobHandlerQueue):
         # Remove cached wrappers for any jobs that are no longer being tracked
         for id in set(self.job_wrappers.keys()) - set(new_waiting_jobs):
             del self.job_wrappers[id]
-        # Flush, if we updated the state
-        self.sa_session.flush()
+        # Commit updated state
+        with transaction(self.sa_session):
+            self.sa_session.commit()
+
         # Done with the session
         self.sa_session.remove()
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -30,6 +30,7 @@ from galaxy.jobs.runners.util.job_script import (
     job_script,
     write_script,
 )
+from galaxy.model.base import transaction
 from galaxy.tool_util.deps.dependencies import (
     JobInfo,
     ToolInfo,
@@ -613,7 +614,8 @@ class BaseJobRunner:
 
             # Flush with streams...
             self.sa_session.add(job)
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
 
             if not job_ok:
                 job_runner_state = JobState.runner_states.TOOL_DETECT_ERROR

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -134,41 +134,42 @@ class BaseJobRunner:
     def run_next(self):
         """Run the next item in the work queue (a job waiting to run)"""
         while self._should_stop is False:
-            try:
-                (method, arg) = self.work_queue.get(timeout=1)
-            except Empty:
-                continue
-            if method is STOP_SIGNAL:
-                return
-            # id and name are collected first so that the call of method() is the last exception.
-            try:
-                if isinstance(arg, AsynchronousJobState):
-                    job_id = arg.job_wrapper.get_id_tag()
-                else:
-                    # arg should be a JobWrapper/TaskWrapper
-                    job_id = arg.get_id_tag()
-            except Exception:
-                job_id = UNKNOWN
-            try:
-                name = method.__name__
-            except Exception:
-                name = UNKNOWN
-            try:
-                action_str = f"galaxy.jobs.runners.{self.__class__.__name__.lower()}.{name}"
-                action_timer = self.app.execution_timer_factory.get_timer(
-                    f"internals.{action_str}", "job runner action %s for job ${job_id} executed" % (action_str)
-                )
-                method(arg)
-                log.trace(action_timer.to_str(job_id=job_id))
-            except Exception:
-                log.exception(f"({job_id}) Unhandled exception calling {name}")
-                if not isinstance(arg, JobState):
-                    job_state = JobState(job_wrapper=arg, job_destination={})
-                else:
-                    job_state = arg
-                if method != self.fail_job:
-                    # Prevent fail_job cycle in the work_queue
-                    self.work_queue.put((self.fail_job, job_state))
+            with self.app.model.session():  # Create a Session instance and ensure it's closed.
+                try:
+                    (method, arg) = self.work_queue.get(timeout=1)
+                except Empty:
+                    continue
+                if method is STOP_SIGNAL:
+                    return
+                # id and name are collected first so that the call of method() is the last exception.
+                try:
+                    if isinstance(arg, AsynchronousJobState):
+                        job_id = arg.job_wrapper.get_id_tag()
+                    else:
+                        # arg should be a JobWrapper/TaskWrapper
+                        job_id = arg.get_id_tag()
+                except Exception:
+                    job_id = UNKNOWN
+                try:
+                    name = method.__name__
+                except Exception:
+                    name = UNKNOWN
+                try:
+                    action_str = f"galaxy.jobs.runners.{self.__class__.__name__.lower()}.{name}"
+                    action_timer = self.app.execution_timer_factory.get_timer(
+                        f"internals.{action_str}", "job runner action %s for job ${job_id} executed" % (action_str)
+                    )
+                    method(arg)
+                    log.trace(action_timer.to_str(job_id=job_id))
+                except Exception:
+                    log.exception(f"({job_id}) Unhandled exception calling {name}")
+                    if not isinstance(arg, JobState):
+                        job_state = JobState(job_wrapper=arg, job_destination={})
+                    else:
+                        job_state = arg
+                    if method != self.fail_job:
+                        # Prevent fail_job cycle in the work_queue
+                        self.work_queue.put((self.fail_job, job_state))
 
     # Causes a runner's `queue_job` method to be called from a worker thread
     def put(self, job_wrapper: "MinimalJobWrapper"):

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from galaxy import model
 from galaxy.jobs.runners import JobState
+from galaxy.model.base import transaction
 from ._safe_eval import safe_eval
 
 __all__ = ("failure",)
@@ -83,7 +84,8 @@ def _handle_resubmit_definitions(resubmit_definitions, app, job_runner, job_stat
             job.set_handler(resubmit["handler"])
             job_runner.sa_session.add(job)
             # Is this safe to do here?
-            job_runner.sa_session.flush()
+            with transaction(job_runner.sa_session):
+                job_runner.sa_session.commit()
         # Cache the destination to prevent rerunning dynamic after
         # resubmit
         job_state.job_wrapper.job_runner_mapper.cached_job_destination = new_destination

--- a/lib/galaxy/managers/annotatable.py
+++ b/lib/galaxy/managers/annotatable.py
@@ -11,6 +11,7 @@ from typing import (
 
 from sqlalchemy.orm import scoped_session
 
+from galaxy.model.base import transaction
 from .base import (
     Deserializer,
     FunctionFilterParsersType,
@@ -63,7 +64,9 @@ class AnnotatableManagerMixin:
 
         annotation_obj = item.add_item_annotation(self.session(), user, item, annotation)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return annotation_obj
 
     def _user_annotation(self, item, user):
@@ -72,7 +75,9 @@ class AnnotatableManagerMixin:
     def _delete_annotation(self, item, user, flush=True):
         returned = item.delete_item_annotation(self.session(), user, item)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return returned
 
 

--- a/lib/galaxy/managers/api_keys.py
+++ b/lib/galaxy/managers/api_keys.py
@@ -4,6 +4,7 @@ from typing import (
 )
 
 from galaxy.model import User
+from galaxy.model.base import transaction
 from galaxy.structured_app import BasicSharedApp
 
 if TYPE_CHECKING:
@@ -31,7 +32,8 @@ class ApiKeyManager:
         new_key.key = guid
         sa_session = self.app.model.context
         sa_session.add(new_key)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         return new_key
 
     def get_or_create_api_key(self, user: User) -> str:
@@ -51,4 +53,5 @@ class ApiKeyManager:
         for api_key in api_keys:
             api_key.deleted = True
             sa_session.add(api_key)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -54,6 +54,7 @@ from galaxy import (
     model,
 )
 from galaxy.model import tool_shed_install
+from galaxy.model.base import transaction
 from galaxy.schema import ValueFilterQueryParams
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.storage_cleaner import (
@@ -238,7 +239,9 @@ class ModelManager(Generic[U]):
 
         self.session().add(item)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return item
 
     # .... query foundation wrapper
@@ -524,7 +527,9 @@ class ModelManager(Generic[U]):
         item = self.model_class(*args, **kwargs)
         self.session().add(item)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return item
 
     def copy(self, item, **kwargs):
@@ -544,7 +549,9 @@ class ModelManager(Generic[U]):
             if hasattr(item, key):
                 setattr(item, key, value)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return item
 
     def associate(self, associate_with, item, foreign_key_name=None):
@@ -955,7 +962,8 @@ class ModelDeserializer(HasAModelManager[T]):
         # TODO:?? add and flush here or in manager?
         if flush and len(new_dict):
             sa_session.add(item)
-            sa_session.flush()
+            with transaction(sa_session):
+                sa_session.commit()
 
         return new_dict
 

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -53,7 +53,10 @@ from galaxy.model import (
     HistoryDatasetAssociation,
     Role,
 )
-from galaxy.model.base import ModelMapping
+from galaxy.model.base import (
+    ModelMapping,
+    transaction,
+)
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.tasks import RequestUser
 from galaxy.security.idencoding import IdEncodingHelper
@@ -109,7 +112,8 @@ class ProvidesAppContext:
             except Exception:
                 action.session_id = None
             self.sa_session.add(action)
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
 
     def log_event(self, message, tool_id=None, **kwargs):
         """
@@ -140,7 +144,8 @@ class ProvidesAppContext:
             except Exception:
                 event.session_id = None
             self.sa_session.add(event)
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
 
     @property
     def sa_session(self) -> galaxy_scoped_session:

--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -25,6 +25,7 @@ from galaxy.managers import (
     secured,
     users,
 )
+from galaxy.model.base import transaction
 from galaxy.schema.tasks import (
     ComputeDatasetHashTaskRequest,
     PurgeDatasetsTaskRequest,
@@ -66,7 +67,9 @@ class DatasetManager(base.ModelManager[model.Dataset], secured.AccessibleManager
         self.permissions.set(dataset, manage_roles, access_roles, flush=False)
 
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return dataset
 
     def copy(self, dataset, **kwargs):
@@ -85,7 +88,9 @@ class DatasetManager(base.ModelManager[model.Dataset], secured.AccessibleManager
         dataset.full_delete()
         self.session().add(dataset)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return dataset
 
     def purge_datasets(self, request: PurgeDatasetsTaskRequest):
@@ -164,7 +169,8 @@ class DatasetManager(base.ModelManager[model.Dataset], secured.AccessibleManager
         )
         if hash is None:
             sa_session.add(dataset_hash)
-            sa_session.flush()
+            with transaction(sa_session):
+                sa_session.commit()
         else:
             old_hash_value = hash.hash_value
             if old_hash_value != calculated_hash_value:
@@ -399,7 +405,9 @@ class DatasetAssociationManager(
                     if not track_jobs_in_database:
                         self.app.job_manager.stop(job)
                     if flush:
-                        self.session().flush()
+                        session = self.session()
+                        with transaction(session):
+                            session.commit()
                     return True
         return False
 
@@ -475,7 +483,8 @@ class DatasetAssociationManager(
         path = data.dataset.file_name
         datatype = sniff.guess_ext(path, trans.app.datatypes_registry.sniff_order)
         trans.app.datatypes_registry.change_datatype(data, datatype)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         self.set_metadata(trans, dataset_assoc)
 
     def set_metadata(self, trans, dataset_assoc, overwrite=False, validate=True):
@@ -532,7 +541,8 @@ class DatasetAssociationManager(
                     trans.app.security_agent.permitted_actions.DATASET_ACCESS.action, dataset, private_role
                 )
                 trans.sa_session.add(dp)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
             if not trans.app.security_agent.dataset_is_private_to_user(trans, dataset):
                 # Check again and inform the user if dataset is not private.
                 raise exceptions.InternalServerError("An error occurred and the dataset is NOT private.")
@@ -813,7 +823,8 @@ class DatasetAssociationDeserializer(base.ModelDeserializer, deletable.PurgableD
             )
         item.change_datatype(val)
         sa_session = self.app.model.context
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         trans = context.get("trans")
         assert (
             trans

--- a/lib/galaxy/managers/export_tracker.py
+++ b/lib/galaxy/managers/export_tracker.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm.scoping import scoped_session
 
 from galaxy.exceptions import ObjectNotFound
 from galaxy.model import StoreExportAssociation
+from galaxy.model.base import transaction
 from galaxy.schema.schema import ExportObjectType
 from galaxy.structured_app import MinimalManagerApp
 
@@ -33,7 +34,8 @@ class StoreExportTracker:
     def create_export_association(self, object_id: int, object_type: ExportObjectType) -> StoreExportAssociation:
         export_association = StoreExportAssociation(object_id=object_id, object_type=object_type)
         self.session.add(export_association)
-        self.session.flush()
+        with transaction(self.session):
+            self.session.commit()
         return export_association
 
     def set_export_association_metadata(self, export_association_id: int, export_metadata: BaseModel):
@@ -43,7 +45,8 @@ class StoreExportTracker:
         except NoResultFound:
             raise ObjectNotFound("Cannot set export metadata. Reason: Export association not found")
         export_association.export_metadata = export_metadata.json()
-        self.session.flush()
+        with transaction(self.session):
+            self.session.commit()
 
     def get_object_exports(
         self, object_id: int, object_type: ExportObjectType, limit: Optional[int] = None, offset: Optional[int] = None

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -36,6 +36,7 @@ from galaxy.exceptions import (
     MalformedId,
     RequestParameterInvalidException,
 )
+from galaxy.model.base import transaction
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.fields import LibraryFolderDatabaseIdField
 from galaxy.schema.schema import LibraryFolderContentsIndexQueryPayload
@@ -216,7 +217,8 @@ class FolderManager:
         new_folder.genome_build = trans.app.genome_builds.default_value
         parent_folder.add_folder(new_folder)
         trans.sa_session.add(new_folder)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         # New folders default to having the same permissions as their parent folder
         trans.app.security_agent.copy_library_permissions(trans, parent_folder, new_folder)
         return new_folder
@@ -250,7 +252,8 @@ class FolderManager:
             changed = True
         if changed:
             trans.sa_session.add(folder)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         return folder
 
     def delete(self, trans, folder, undelete=False):
@@ -274,7 +277,8 @@ class FolderManager:
         else:
             folder.deleted = True
         trans.sa_session.add(folder)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return folder
 
     def get_current_roles(self, trans, folder):

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -7,6 +7,7 @@ from typing import (
 from galaxy import model
 from galaxy.exceptions import ObjectNotFound
 from galaxy.managers.context import ProvidesAppContext
+from galaxy.model.base import transaction
 from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
@@ -83,8 +84,10 @@ class GroupRolesManager:
     def _add_role_to_group(self, trans: ProvidesAppContext, group: model.Group, role: model.Role):
         gra = model.GroupRoleAssociation(group, role)
         trans.sa_session.add(gra)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
     def _remove_role_from_group(self, trans: ProvidesAppContext, group_role: model.GroupRoleAssociation):
         trans.sa_session.delete(group_role)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()

--- a/lib/galaxy/managers/group_users.py
+++ b/lib/galaxy/managers/group_users.py
@@ -7,6 +7,7 @@ from typing import (
 from galaxy import model
 from galaxy.exceptions import ObjectNotFound
 from galaxy.managers.context import ProvidesAppContext
+from galaxy.model.base import transaction
 from galaxy.structured_app import MinimalManagerApp
 
 log = logging.getLogger(__name__)
@@ -83,8 +84,10 @@ class GroupUsersManager:
     def _add_user_to_group(self, trans: ProvidesAppContext, group: model.Group, user: model.User):
         gra = model.UserGroupAssociation(user, group)
         trans.sa_session.add(gra)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
     def _remove_user_from_group(self, trans: ProvidesAppContext, group_user: model.UserGroupAssociation):
         trans.sa_session.delete(group_user)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -43,6 +43,7 @@ from galaxy.managers.base import (
     StorageCleanerManager,
 )
 from galaxy.managers.export_tracker import StoreExportTracker
+from galaxy.model.base import transaction
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     ExportObjectMetadata,
@@ -417,15 +418,19 @@ class HistoryStorageCleanerManager(StorageCleanerManager):
         total_free_bytes = 0
         errors: List[StorageItemCleanupError] = []
 
-        with self.history_manager.session().begin():
-            for history_id in item_ids:
-                try:
-                    history = self.history_manager.get_owned(history_id, user)
-                    self.history_manager.purge(history, flush=False)
-                    success_item_count += 1
-                    total_free_bytes += int(history.disk_size)
-                except BaseException as e:
-                    errors.append(StorageItemCleanupError(item_id=history_id, error=str(e)))
+        for history_id in item_ids:
+            try:
+                history = self.history_manager.get_owned(history_id, user)
+                self.history_manager.purge(history, flush=False)
+                success_item_count += 1
+                total_free_bytes += int(history.disk_size)
+            except BaseException as e:
+                errors.append(StorageItemCleanupError(item_id=history_id, error=str(e)))
+
+        if success_item_count:
+            session = self.history_manager.session()
+            with transaction(session):
+                session.commit()
 
         return StorageItemsCleanupResult(
             total_item_count=len(item_ids),

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -35,6 +35,7 @@ from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
+from galaxy.model.base import transaction
 from galaxy.model.index_filter_util import (
     raw_text_column_filter,
     text_column_filter,
@@ -241,7 +242,9 @@ class JobManager:
     def stop(self, job, message=None):
         if not job.finished:
             job.mark_deleted(self.app.config.track_jobs_in_database)
-            self.app.model.session.flush()
+            session = self.app.model.session
+            with transaction(session):
+                session.commit()
             self.app.job_manager.stop(job, message=message)
             return True
         else:

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -28,6 +28,7 @@ from galaxy.model import (
     Library,
     Role,
 )
+from galaxy.model.base import transaction
 from galaxy.util import (
     pretty_print_time_interval,
     unicodify,
@@ -80,7 +81,8 @@ class LibraryManager:
             root_folder = trans.app.model.LibraryFolder(name=name, description="")
             library.root_folder = root_folder
             trans.sa_session.add_all((library, root_folder))
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             return library
 
     def update(
@@ -117,7 +119,8 @@ class LibraryManager:
             changed = True
         if changed:
             trans.sa_session.add(library)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         return library
 
     def delete(self, trans, library: Library, undelete: Optional[bool] = False) -> Library:
@@ -131,7 +134,8 @@ class LibraryManager:
         else:
             library.deleted = True
         trans.sa_session.add(library)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return library
 
     def list(self, trans, deleted: Optional[bool] = False) -> Tuple[Query, Dict[str, Set]]:

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -13,6 +13,7 @@ from galaxy.exceptions import (
 )
 from galaxy.managers import datasets
 from galaxy.model import tags
+from galaxy.model.base import transaction
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.util import validation
 
@@ -116,7 +117,8 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         if changed:
             ldda.update_parent_folder_update_times()
             trans.sa_session.add(ldda)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         return changed
 
     def _validate_and_parse_update_payload(self, payload):

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -10,6 +10,7 @@ from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.export_tracker import StoreExportTracker
 from galaxy.managers.histories import HistoryManager
 from galaxy.managers.users import UserManager
+from galaxy.model.base import transaction
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.model.store import (
     DirectoryModelExportStore,
@@ -100,7 +101,8 @@ class ModelStoreManager:
             export_store.export_history(history, include_hidden=include_hidden, include_deleted=include_deleted)
         job = self._sa_session.query(model.Job).get(job_id)
         job.state = model.Job.states.NEW
-        self._sa_session.flush()
+        with transaction(self._sa_session):
+            self._sa_session.commit()
         self._job_manager.enqueue(job)
 
     def prepare_history_download(self, request: GenerateHistoryDownload):

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -37,6 +37,7 @@ from galaxy.managers.markdown_util import (
     ready_galaxy_markdown_for_export,
     ready_galaxy_markdown_for_import,
 )
+from galaxy.model.base import transaction
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.schema.schema import (
     CreatePagePayload,
@@ -181,7 +182,8 @@ class PageManager(sharable.SharableModelManager, UsesAnnotations):
         # Persist
         session = trans.sa_session
         session.add(page)
-        session.flush()
+        with transaction(session):
+            session.commit()
         return page
 
     def save_new_revision(self, trans, page, payload):
@@ -213,7 +215,8 @@ class PageManager(sharable.SharableModelManager, UsesAnnotations):
 
         # Persist
         session = trans.sa_session
-        session.flush()
+        with transaction(session):
+            session.commit()
         return page_revision
 
     def rewrite_content_for_import(self, trans, content, content_format: str):

--- a/lib/galaxy/managers/ratable.py
+++ b/lib/galaxy/managers/ratable.py
@@ -7,6 +7,7 @@ from typing import Type
 from sqlalchemy.sql.expression import func
 
 from galaxy.model import ItemRatingAssociation
+from galaxy.model.base import transaction
 from . import base
 
 log = logging.getLogger(__name__)
@@ -54,7 +55,9 @@ class RatableManagerMixin:
 
         self.session().add(rating)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return rating
 
     # TODO?: all ratings for a user

--- a/lib/galaxy/managers/rbac_secured.py
+++ b/lib/galaxy/managers/rbac_secured.py
@@ -6,6 +6,7 @@ from galaxy import (
     security,
 )
 from galaxy.managers import users
+from galaxy.model.base import transaction
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +111,9 @@ class DatasetRBACPermission(RBACPermission):
         for role in roles:
             permissions.append(self._create(dataset, role, flush=False))
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return permissions
 
     def clear(self, dataset, flush=True):
@@ -122,7 +125,9 @@ class DatasetRBACPermission(RBACPermission):
         permission = self.permissions_class(self.action_name, dataset, role)
         self.session().add(permission)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return permission
 
     def _roles(self, dataset):
@@ -142,7 +147,9 @@ class DatasetRBACPermission(RBACPermission):
             else:
                 self.session().delete(permission)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
 
     def _revoke_role(self, dataset, role, flush=True):
         role_permissions = self.by_roles(dataset, [role])

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -13,6 +13,7 @@ from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.managers import base
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import Role
+from galaxy.model.base import transaction
 from galaxy.schema.schema import RoleDefinitionModel
 from galaxy.util import unicodify
 
@@ -87,5 +88,6 @@ class RoleManager(base.ModelManager[model.Role]):
         for group in groups:
             trans.app.security_agent.associate_group_role(group, role)
 
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return role

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -38,6 +38,7 @@ from galaxy.model import (
     User,
     UserShareAssociation,
 )
+from galaxy.model.base import transaction
 from galaxy.model.tags import GalaxyTagHandler
 from galaxy.schema.schema import (
     ShareWithExtra,
@@ -203,7 +204,9 @@ class SharableModelManager(
             self.create_unique_slug(item)
 
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return user_share_assoc
 
     def unshare_with(self, item, user: User, flush: bool = True):
@@ -214,7 +217,9 @@ class SharableModelManager(
         user_share_assoc = self.get_share_assocs(item, user=user)[0]
         self.session().delete(user_share_assoc)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return user_share_assoc
 
     def _query_shared_with(self, user, eagerloads=True, **kwargs):
@@ -279,7 +284,9 @@ class SharableModelManager(
             current_shares.remove(self.unshare_with(item, user, flush=False))
 
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return current_shares
 
     # .... slugs
@@ -302,7 +309,9 @@ class SharableModelManager(
 
         item.slug = new_slug
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return item
 
     def is_valid_slug(self, slug):
@@ -366,7 +375,9 @@ class SharableModelManager(
         item.slug = self.get_unique_slug(item)
         self.session().add(item)
         if flush:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
         return item
 
     # TODO: def by_slug( self, user, **kwargs ):

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -5,6 +5,7 @@ from pydantic import Field
 
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import ItemTagAssociation
+from galaxy.model.base import transaction
 from galaxy.model.tags import GalaxyTagHandlerSession
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -50,7 +51,8 @@ class TagsManager:
         item = self._get_item(tag_handler, payload)
         tag_handler.delete_item_tags(user, item)
         tag_handler.apply_item_tags(user, item, new_tags)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
 
     def _get_item(self, tag_handler: GalaxyTagHandlerSession, payload: ItemTagsPayload):
         """

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -35,6 +35,7 @@ from galaxy.managers import (
     deletable,
 )
 from galaxy.model import UserQuotaUsage
+from galaxy.model.base import transaction
 from galaxy.security.validate_user_input import (
     VALID_EMAIL_RE,
     validate_email,
@@ -135,7 +136,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             user.active = True
         self.session().add(user)
         try:
-            self.session().flush()
+            session = self.session()
+            with transaction(session):
+                session.commit()
             # TODO:?? flush needed for permissions below? If not, make optional
         except exc.IntegrityError as db_err:
             raise exceptions.Conflict(str(db_err))
@@ -477,7 +480,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                         other_galaxy_session.is_valid = False
                         trans.sa_session.add(other_galaxy_session)
                 trans.sa_session.add(user)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 trans.log_event("User change password")
         else:
             return "Failed to determine user, access denied."
@@ -524,7 +528,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             activation_token = util.hash_util.new_secure_hash_v2(str(random.getrandbits(256)))
             user.activation_token = activation_token
             trans.sa_session.add(user)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         return activation_token
 
     def send_reset_email(self, trans, payload, **kwd):
@@ -551,7 +556,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                 try:
                     util.send_mail(trans.app.config.email_from, email, subject, body, self.app.config)
                     trans.sa_session.add(reset_user)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                     trans.log_event(f"User reset password: {email}")
                 except Exception as e:
                     log.debug(body)
@@ -572,7 +578,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         if reset_user:
             prt = self.app.model.PasswordResetToken(reset_user)
             trans.sa_session.add(prt)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             return reset_user, prt
         return None, None
 
@@ -593,7 +600,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
     def activate(self, user):
         user.active = True
         self.session().add(user)
-        self.session().flush()
+        session = self.session()
+        with transaction(session):
+            session.commit()
 
 
 class UserSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5730,7 +5730,10 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
                     WHERE library_folder.id = parent_folders_of.folder_id)
             """
         ).execution_options(autocommit=True)
-        ret = object_session(self).execute(sql, {"library_dataset_id": ldda.library_dataset_id, "ldda_id": ldda.id})
+
+        with object_session(self).bind.connect() as conn, conn.begin():
+            ret = conn.execute(sql, {"library_dataset_id": ldda.library_dataset_id, "ldda_id": ldda.id})
+
         if ret.rowcount < 1:
             log.warning(f"Attempt to updated parent folder times failed: {ret.rowcount} records updated.")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -929,6 +929,7 @@ ON CONFLICT
     ON constraint uqsu_unique_label_per_user
     DO UPDATE SET disk_usage = user_quota_source_usage.disk_usage + :amount
 """
+                statement = text(statement)
                 params = {
                     "user_id": self.id,
                     "amount": int(amount),

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -117,6 +117,7 @@ import galaxy.model.metadata
 import galaxy.model.tags
 import galaxy.security.passwords
 import galaxy.util
+from galaxy.model.base import transaction
 from galaxy.model.custom_types import (
     JSONType,
     MetadataType,
@@ -993,7 +994,8 @@ ON CONFLICT
             # the existing value - we're setting it in raw SQL for
             # performance reasons and bypassing object properties.
             sa_session.expire(self, ["disk_usage"])
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
 
     @staticmethod
     def user_template_environment(user):
@@ -1055,7 +1057,8 @@ ON CONFLICT
         role = Role(name=role_name, description=role_desc, type=role_type)
         assoc = UserRoleAssociation(self, role)
         session.add(assoc)
-        session.flush()
+        with transaction(session):
+            session.commit()
 
     def dictify_usage(self, object_store=None) -> List[UserQuotaBasicUsage]:
         """Include object_store to include empty/unused usage info."""
@@ -1674,7 +1677,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
             for job in jobs_to_resume:
                 job.resume(flush=False)
             if flush:
-                object_session(self).flush()
+                session = object_session(self)
+                with transaction(session):
+                    session.commit()
 
     def _serialize(self, id_encoder, serialization_options):
         job_attrs = dict_for(self)
@@ -1957,7 +1962,9 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, Serializable):
         for output_association in self.output_datasets + self.output_dataset_collection_instances:
             output_association.item.visible = False
         if flush:
-            object_session(self).flush()
+            session = object_session(self)
+            with transaction(session):
+                session.commit()
 
 
 class Task(Base, JobLike, RepresentById):
@@ -2521,7 +2528,10 @@ class JobExportHistoryArchive(Base, RepresentById):
         # Create dataset that will serve as archive.
         archive_dataset = Dataset()
         sa_session.add(archive_dataset)
-        sa_session.flush()  # ensure job.id and archive_dataset.id are available
+
+        with transaction(sa_session):
+            sa_session.commit()  # ensure job.id and archive_dataset.id are available
+
         object_store.create(archive_dataset)  # set the object store id, create dataset (if applicable)
         # Add association for keeping track of job, history, archive relationship.
         jeha = JobExportHistoryArchive(job=job, history=history, dataset=archive_dataset, compressed=compressed)
@@ -2943,7 +2953,11 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         if isinstance(dataset, Dataset):
             dataset = HistoryDatasetAssociation(dataset=dataset)
             object_session(self).add(dataset)
-            object_session(self).flush()
+
+            session = object_session(self)
+            with transaction(session):
+                session.commit()
+
         elif not isinstance(dataset, (HistoryDatasetAssociation, HistoryDatasetCollectionAssociation)):
             raise TypeError(
                 "You can only add Dataset and HistoryDatasetAssociation instances to a history"
@@ -2989,13 +3003,15 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
                         self.user.adjust_total_disk_usage(disk_usage, quota_source_info.label)
             sa_session.add_all(datasets)
             if flush:
-                sa_session.flush()
+                with transaction(sa_session):
+                    sa_session.commit()
         else:
             for dataset in datasets:
                 self.add_dataset(dataset, parent_id=parent_id, genome_build=genome_build, set_hid=set_hid, quota=quota)
                 sa_session.add(dataset)
                 if flush:
-                    sa_session.flush()
+                    with transaction(sa_session):
+                        sa_session.commit()
 
     def __add_datasets_optimized(self, datasets, genome_build=None):
         """Optimized version of add_dataset above that minimizes database
@@ -3074,7 +3090,8 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
                 new_hdca.copy_tags_from(target_user, hdca)
 
         new_history.hid_counter = self.hid_counter
-        db_session.flush()
+        with transaction(db_session):
+            db_session.commit()
 
         return new_history
 
@@ -3130,7 +3147,9 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
             job.resume(flush=False)
         if job is not None:
             # We'll flush once if there was a paused job
-            object_session(job).flush()
+            session = object_session(job)
+            with transaction(session):
+                session.commit()
 
     @property
     def paused_jobs(self):
@@ -3670,7 +3689,8 @@ class StorableObject:
     def flush(self):
         sa_session = object_session(self)
         if sa_session:
-            sa_session.flush()
+            with transaction(sa_session):
+                sa_session.commit()
 
 
 class Dataset(Base, StorableObject, Serializable):
@@ -3946,7 +3966,8 @@ class Dataset(Base, StorableObject, Serializable):
         # for backwards compatibility, set if unset
         self.set_total_size()
         db_session = object_session(self)
-        db_session.flush()
+        with transaction(db_session):
+            db_session.commit()
         return self.total_size
 
     def set_total_size(self):
@@ -4219,7 +4240,8 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
             dataset.job_id = creating_job_id
             if flush:
                 sa_session.add(dataset)
-                sa_session.flush()
+                with transaction(sa_session):
+                    sa_session.commit()
         elif dataset:
             add_object_to_object_session(self, dataset)
         self.dataset = dataset
@@ -4260,7 +4282,9 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
             sa_session = object_session(self)
             if sa_session:
                 object_session(self).add(self.dataset)
-                object_session(self).flush()  # flush here, because hda.flush() won't flush the Dataset object
+                session = object_session(self)
+                with transaction(session):
+                    session.commit()  # flush here, because hda.flush() won't flush the Dataset object
 
     state = property(get_dataset_state, set_dataset_state)
 
@@ -4516,7 +4540,8 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
         session = trans.sa_session
         session.add(new_dataset)
         session.add(assoc)
-        session.flush()
+        with transaction(session):
+            session.commit()
         return new_dataset
 
     def copy_attributes(self, new_dataset):
@@ -4867,7 +4892,9 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         object_session(self).add(hda)
         hda.metadata = self.metadata
         if flush:
-            object_session(self).flush()
+            session = object_session(self)
+            with transaction(session):
+                session.commit()
         return hda
 
     def copy_tags_to(self, copy_tags=None):
@@ -4934,7 +4961,9 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
             trans.sa_session.add(dp)
         # Must set metadata after ldda flushed, as MetadataFiles require ldda.id
         if self.set_metadata_requires_flush:
-            object_session(self).flush()
+            session = object_session(self)
+            with transaction(session):
+                session.commit()
         ldda.metadata = self.metadata
         # TODO: copy #tags from history
         if ldda_message:
@@ -4943,7 +4972,11 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
             target_folder.add_library_dataset(library_dataset, genome_build=ldda.dbkey)
             object_session(self).add(target_folder)
         object_session(self).add(library_dataset)
-        object_session(self).flush()
+
+        session = object_session(self)
+        with transaction(session):
+            session.commit()
+
         return ldda
 
     def clear_associated_files(self, metadata_safe=False, purge=False):
@@ -5566,13 +5599,14 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         tag_manager = galaxy.model.tags.GalaxyTagHandler(sa_session)
         src_ldda_tags = tag_manager.get_tags_str(self.tags)
         tag_manager.apply_item_tags(user=self.user, item=hda, tags_str=src_ldda_tags)
-
         sa_session.add(hda)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         hda.metadata = self.metadata  # need to set after flushed, as MetadataFiles require dataset.id
         if add_to_history and target_history:
             target_history.add_dataset(hda)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         return hda
 
     def copy(self, parent_id=None, target_folder=None):
@@ -5598,10 +5632,12 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, Serializable):
         tag_manager.apply_item_tags(user=self.user, item=ldda, tags_str=src_ldda_tags)
 
         sa_session.add(ldda)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         # Need to set after flushed, as MetadataFiles require dataset.id
         ldda.metadata = self.metadata
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         return ldda
 
     def clear_associated_files(self, metadata_safe=False, purge=False):
@@ -6262,7 +6298,9 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
             )
         object_session(self).add(new_collection)
         if flush:
-            object_session(self).flush()
+            session = object_session(self)
+            with transaction(session):
+                session.commit()
         return new_collection
 
     def replace_failed_elements(self, replacements):
@@ -6686,7 +6724,9 @@ class HistoryDatasetCollectionAssociation(
             element_destination.stage_addition(hdca)
             element_destination.add_pending_items()
         if flush:
-            object_session(self).flush()
+            session = object_session(self)
+            with transaction(session):
+                session.commit()
         return hdca
 
     @property
@@ -9128,7 +9168,8 @@ class PSAAssociation(Base, AssociationMixin, RepresentById):
 
     def save(self):
         self.sa_session.add(self)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
     @classmethod
     def store(cls, server_url, association):
@@ -9141,7 +9182,8 @@ class PSAAssociation(Base, AssociationMixin, RepresentById):
         assoc.lifetime = association.lifetime
         assoc.assoc_type = association.assoc_type
         cls.sa_session.add(assoc)
-        cls.sa_session.flush()
+        with transaction(cls.sa_session):
+            cls.sa_session.commit()
 
     @classmethod
     def get(cls, *args, **kwargs):
@@ -9169,7 +9211,8 @@ class PSACode(Base, CodeMixin, RepresentById):
 
     def save(self):
         self.sa_session.add(self)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
     @classmethod
     def get_code(cls, code):
@@ -9194,7 +9237,8 @@ class PSANonce(Base, NonceMixin, RepresentById):
 
     def save(self):
         self.sa_session.add(self)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
     @classmethod
     def use(cls, server_url, timestamp, salt):
@@ -9203,7 +9247,8 @@ class PSANonce(Base, NonceMixin, RepresentById):
         except IndexError:
             instance = cls(server_url=server_url, timestamp=timestamp, salt=salt)
             cls.sa_session.add(instance)
-            cls.sa_session.flush()
+            with transaction(cls.sa_session):
+                cls.sa_session.commit()
             return instance
 
 
@@ -9227,7 +9272,8 @@ class PSAPartial(Base, PartialMixin, RepresentById):
 
     def save(self):
         self.sa_session.add(self)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
     @classmethod
     def load(cls, token):
@@ -9274,11 +9320,13 @@ class UserAuthnzToken(Base, UserMixin, RepresentById):
     def set_extra_data(self, extra_data=None):
         if super().set_extra_data(extra_data):
             self.sa_session.add(self)
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
 
     def save(self):
         self.sa_session.add(self)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
     @classmethod
     def username_max_length(cls):
@@ -9293,7 +9341,8 @@ class UserAuthnzToken(Base, UserMixin, RepresentById):
     @classmethod
     def changed(cls, user):
         cls.sa_session.add(user)
-        cls.sa_session.flush()
+        with transaction(cls.sa_session):
+            cls.sa_session.commit()
 
     @classmethod
     def user_query(cls):
@@ -9319,7 +9368,8 @@ class UserAuthnzToken(Base, UserMixin, RepresentById):
             raise Exception(f"User with this email '{instance.email}' already exists.")
         instance.set_random_password()
         cls.sa_session.add(instance)
-        cls.sa_session.flush()
+        with transaction(cls.sa_session):
+            cls.sa_session.commit()
         return instance
 
     @classmethod
@@ -9352,7 +9402,8 @@ class UserAuthnzToken(Base, UserMixin, RepresentById):
         uid = str(uid)
         instance = cls(user=user, uid=uid, provider=provider)
         cls.sa_session.add(instance)
-        cls.sa_session.flush()
+        with transaction(cls.sa_session):
+            cls.sa_session.commit()
         return instance
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2749,7 +2749,8 @@ class HistoryAudit(Base, RepresentById):
             .subquery()
         )
         q = cls.__table__.delete().where(tuple_(cls.history_id, cls.update_time).in_(select(not_latest_query)))
-        sa_session.execute(q)
+        with sa_session() as session, session.begin():
+            session.execute(q)
 
 
 class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable):

--- a/lib/galaxy/model/base.py
+++ b/lib/galaxy/model/base.py
@@ -54,7 +54,7 @@ def transaction(session):
 class ModelMapping(Bunch):
     def __init__(self, model_modules, engine):
         self.engine = engine
-        self._SessionLocal = sessionmaker(autoflush=False, autocommit=True)
+        self._SessionLocal = sessionmaker(autoflush=False, autocommit=False)
         versioned_session(self._SessionLocal)
         context = scoped_session(self._SessionLocal, scopefunc=self.request_scopefunc)
         # For backward compatibility with "context.current"

--- a/lib/galaxy/model/base.py
+++ b/lib/galaxy/model/base.py
@@ -2,6 +2,7 @@
 Shared model and mapping code between Galaxy and Tool Shed, trying to
 generalize to generic database connections.
 """
+import contextlib
 import os
 import threading
 from contextvars import ContextVar
@@ -17,6 +18,7 @@ from typing import (
 from sqlalchemy import event
 from sqlalchemy.orm import (
     scoped_session,
+    Session,
     sessionmaker,
 )
 
@@ -28,6 +30,24 @@ from galaxy.util.bunch import Bunch
 # for details
 _request_state: Dict[str, str] = {}
 REQUEST_ID = ContextVar("request_id", default=_request_state.copy())
+
+
+@contextlib.contextmanager
+def transaction(session):
+    """Start a new transaction only if one is not present."""
+    # temporary hack; need to fix access to scoped_session callable, not proxy
+    if isinstance(session, scoped_session):
+        session = session()
+    # hack: this could be model.store.SessionlessContext; then we don't need to do anything
+    elif not isinstance(session, Session):
+        yield
+        return  # exit: can't use as a Session
+
+    if not session.in_transaction():
+        with session.begin():
+            yield
+    else:
+        yield
 
 
 # TODO: Refactor this to be a proper class, not a bunch.

--- a/lib/galaxy/model/base.py
+++ b/lib/galaxy/model/base.py
@@ -13,6 +13,8 @@ from inspect import (
 from typing import (
     Dict,
     Type,
+    TYPE_CHECKING,
+    Union,
 )
 
 from sqlalchemy import event
@@ -24,6 +26,9 @@ from sqlalchemy.orm import (
 
 from galaxy.util.bunch import Bunch
 
+if TYPE_CHECKING:
+    from galaxy.model.store import SessionlessContext
+
 # Create a ContextVar with mutable state, this allows sync tasks in the context
 # of a request (which run within a threadpool) to see changes to the ContextVar
 # state. See https://github.com/tiangolo/fastapi/issues/953#issuecomment-586006249
@@ -33,7 +38,7 @@ REQUEST_ID = ContextVar("request_id", default=_request_state.copy())
 
 
 @contextlib.contextmanager
-def transaction(session):
+def transaction(session: Union[scoped_session, Session, "SessionlessContext"]):
     """Start a new transaction only if one is not present."""
     # temporary hack; need to fix access to scoped_session callable, not proxy
     if isinstance(session, scoped_session):

--- a/lib/galaxy/model/deferred.py
+++ b/lib/galaxy/model/deferred.py
@@ -29,6 +29,7 @@ from galaxy.model import (
     HistoryDatasetCollectionAssociation,
     LibraryDatasetDatasetAssociation,
 )
+from galaxy.model.base import transaction
 from galaxy.objectstore import (
     ObjectStore,
     ObjectStorePopulator,
@@ -123,7 +124,8 @@ class DatasetInstanceMaterializer:
                 if sa_session is None:
                     sa_session = object_session(dataset_instance)
                 sa_session.add(materialized_dataset)
-                sa_session.flush()
+                with transaction(sa_session):
+                    sa_session.commit()
             object_store_populator.set_dataset_object_store_id(materialized_dataset)
             path = self._stream_source(target_source, datatype=dataset_instance.datatype)
             object_store.update_from_file(materialized_dataset, file_name=path)

--- a/lib/galaxy/model/item_attrs.py
+++ b/lib/galaxy/model/item_attrs.py
@@ -4,6 +4,7 @@ from sqlalchemy.sql.expression import func
 
 # Cannot import galaxy.model b/c it creates a circular import graph.
 import galaxy
+from galaxy.model.base import transaction
 
 log = logging.getLogger(__name__)
 
@@ -45,11 +46,13 @@ class UsesItemRatings:
             item_rating_assoc_class = self._get_item_rating_assoc_class(item, webapp_model=webapp_model)
             item_rating = item_rating_assoc_class(user, item, rating)
             db_session.add(item_rating)
-            db_session.flush()
+            with transaction(db_session):
+                db_session.commit()
         elif item_rating.rating != rating:
             # User has rated item; update rating.
             item_rating.rating = rating
-            db_session.flush()
+            with transaction(db_session):
+                db_session.commit()
         return item_rating
 
     def get_user_item_rating(self, db_session, user, item, webapp_model=None):
@@ -93,7 +96,8 @@ class UsesAnnotations:
         annotation_assoc = get_item_annotation_obj(db_session, user, item)
         if annotation_assoc:
             db_session.delete(annotation_assoc)
-            db_session.flush()
+            with transaction(db_session):
+                db_session.commit()
 
     def copy_item_annotation(self, db_session, source_user, source_item, target_user, target_item):
         """Copy an annotation from a user/item source to a user/item target."""

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -198,6 +198,9 @@ class SessionlessContext:
     def __init__(self) -> None:
         self.objects: Dict[Type, Dict] = defaultdict(dict)
 
+    def commit(self) -> None:
+        pass
+
     def flush(self) -> None:
         pass
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -55,6 +55,7 @@ from galaxy.files import (
     ProvidesUserFileSourcesUserContext,
 )
 from galaxy.files.uris import stream_url_to_file
+from galaxy.model.base import transaction
 from galaxy.model.mapping import GalaxyModelMapping
 from galaxy.model.metadata import MetadataCollection
 from galaxy.model.orm.util import (
@@ -759,7 +760,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                     ld.library_dataset_dataset_association = ldda
                 self._session_add(ld)
 
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
             return library_folder
 
         libraries_attrs = self.library_properties()
@@ -1271,7 +1273,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
         self.sa_session.add(obj)
 
     def _flush(self) -> None:
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
 
 def _copied_from_object_key(

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -266,7 +266,6 @@ class TagHandler:
         with Session() as separate_session:
             separate_session.add(tag)
             try:
-                separate_session.commit()
                 with transaction(separate_session):
                     separate_session.commit()
             except IntegrityError:

--- a/lib/galaxy/quota/__init__.py
+++ b/lib/galaxy/quota/__init__.py
@@ -5,6 +5,7 @@ from typing import Optional
 from sqlalchemy.sql import text
 
 import galaxy.util
+from galaxy.model.base import transaction
 
 log = logging.getLogger(__name__)
 
@@ -223,7 +224,8 @@ WHERE default_quota_association.type = :default_type
         else:
             target_default = self.model.DefaultQuotaAssociation(default_type, quota)
         self.sa_session.add(target_default)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
     def get_percent(
         self, trans=None, user=False, history=False, usage=False, quota=False, quota_source_label=None
@@ -263,14 +265,16 @@ WHERE default_quota_association.type = :default_type
                     self.sa_session.delete(a)
                     flush_needed = True
                 if flush_needed:
-                    self.sa_session.flush()
+                    with transaction(self.sa_session):
+                        self.sa_session.commit()
             for user in users:
                 uqa = self.model.UserQuotaAssociation(user, quota)
                 self.sa_session.add(uqa)
             for group in groups:
                 gqa = self.model.GroupQuotaAssociation(group, quota)
                 self.sa_session.add(gqa)
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
 
     def is_over_quota(self, app, job, job_destination):
         # Doesn't work because job.object_store_id until inside handler :_(

--- a/lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 from galaxy import util
+from galaxy.model.base import transaction
 from galaxy.model.tool_shed_install import (
     ToolDependency,
     ToolShedRepository,
@@ -144,7 +145,8 @@ class InstalledRepositoryManager:
                     repository_tools_tups,
                 )
         self.context.add(repository)
-        self.context.flush()
+        with transaction(self.context):
+            self.context.commit()
 
     def add_entry_to_installed_repository_dependencies_of_installed_repositories(
         self, repository: ToolShedRepository
@@ -699,7 +701,8 @@ class InstalledRepositoryManager:
         else:
             repository.status = ToolShedRepository.installation_status.DEACTIVATED
         self.context.add(repository)
-        self.context.flush()
+        with transaction(self.context):
+            self.context.commit()
         return errors
 
     def remove_entry_from_installed_repository_dependencies_of_installed_repositories(
@@ -887,7 +890,8 @@ class InstalledRepositoryManager:
                     tool_dependency.status = ToolDependency.installation_status.UNINSTALLED
                     tool_dependency.error_message = None
                     context.add(tool_dependency)
-                    context.flush()
+                    with transaction(context):
+                        context.commit()
                     new_tool_dependency = tool_dependency
                 else:
                     # We have no new tool dependency definition based on a matching dependency name, so remove
@@ -899,5 +903,6 @@ class InstalledRepositoryManager:
                         tool_dependency.name,
                     )
                     context.delete(tool_dependency)
-                    context.flush()
+                    with transaction(context):
+                        context.commit()
         return new_tool_dependency

--- a/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
@@ -5,6 +5,7 @@ from typing import Optional
 from sqlalchemy import false
 
 from galaxy import util
+from galaxy.model.base import transaction
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.tool_shed.galaxy_install.tools import tool_panel_manager
 from galaxy.tool_shed.metadata.metadata_generator import MetadataGenerator
@@ -124,8 +125,12 @@ class InstalledRepositoryMetadataManager(MetadataGenerator):
             if self.metadata_dict != original_metadata_dict:
                 self.repository.metadata_ = self.metadata_dict
                 self.update_in_shed_tool_config()
-                self.app.install_model.context.add(self.repository)
-                self.app.install_model.context.flush()
+
+                session = self.app.install_model.context
+                session.add(self.repository)
+                with transaction(session):
+                    session.commit()
+
                 log.debug(f"Metadata has been reset on repository {self.repository.name}.")
             else:
                 log.debug(f"Metadata did not need to be reset on repository {self.repository.name}.")

--- a/lib/galaxy/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
@@ -15,6 +15,7 @@ from urllib.request import (
     urlopen,
 )
 
+from galaxy.model.base import transaction
 from galaxy.tool_shed.galaxy_install.tools import tool_panel_manager
 from galaxy.tool_shed.util import repository_util
 from galaxy.tool_shed.util.container_util import get_components_from_key
@@ -133,15 +134,20 @@ class RepositoryDependencyInstallManager:
                                     repository_dependency = install_model.RepositoryDependency(
                                         tool_shed_repository_id=required_repository.id
                                     )
-                                    install_model.context.add(repository_dependency)
-                                    install_model.context.flush()
+                                    session = install_model.context
+                                    session.add(repository_dependency)
+                                    with transaction(session):
+                                        session.commit()
+
                                 # Build the relationship between the d_repository and the required_repository.
                                 rrda = install_model.RepositoryRepositoryDependencyAssociation(
                                     tool_shed_repository_id=d_repository.id,
                                     repository_dependency_id=repository_dependency.id,
                                 )
-                                install_model.context.add(rrda)
-                                install_model.context.flush()
+                                session = install_model.context
+                                session.add(rrda)
+                                with transaction(session):
+                                    session.commit()
 
     def create_repository_dependency_objects(
         self,
@@ -571,8 +577,11 @@ class RepositoryDependencyInstallManager:
         repository.uninstalled = False
         repository.status = self.app.install_model.ToolShedRepository.installation_status.NEW
         repository.error_message = None
-        self.app.install_model.context.add(repository)
-        self.app.install_model.context.flush()
+
+        session = self.app.install_model.context
+        session.add(repository)
+        with transaction(session):
+            session.commit()
 
 
 def _urlopen(url, data=None):

--- a/lib/galaxy/tool_shed/util/repository_util.py
+++ b/lib/galaxy/tool_shed/util/repository_util.py
@@ -25,6 +25,7 @@ from galaxy import (
     util,
     web,
 )
+from galaxy.model.base import transaction
 from galaxy.model.scoped_session import install_model_scoped_session
 from galaxy.model.tool_shed_install import ToolShedRepository
 from galaxy.tool_shed.util import basic_util
@@ -96,8 +97,11 @@ def _check_or_update_tool_shed_status_for_installed_repository(
         ok = True
         if tool_shed_status_dict != repository.tool_shed_status:
             repository.tool_shed_status = tool_shed_status_dict
-            install_model_context.add(repository)
-            install_model_context.flush()
+            session = install_model_context
+            session.add(repository)
+            with transaction(session):
+                session.commit()
+
             updated = True
     else:
         ok = False
@@ -180,7 +184,8 @@ def create_or_update_tool_shed_repository(
             status=status,
         )
     context.add(tool_shed_repository)
-    context.flush()
+    with transaction(context):
+        context.commit()
     return tool_shed_repository
 
 
@@ -766,8 +771,11 @@ def set_repository_attributes(app, repository, status, error_message, deleted, u
     repository.status = status
     repository.deleted = deleted
     repository.uninstalled = uninstalled
-    app.install_model.context.add(repository)
-    app.install_model.context.flush()
+
+    session = app.install_model.context
+    session.add(repository)
+    with transaction(session):
+        session.commit()
 
 
 __all__ = (

--- a/lib/galaxy/tool_shed/util/shed_util_common.py
+++ b/lib/galaxy/tool_shed/util/shed_util_common.py
@@ -2,6 +2,7 @@ import logging
 import re
 
 from galaxy import util
+from galaxy.model.base import transaction
 from galaxy.tool_shed.util import repository_util
 from galaxy.util.tool_shed import common_util
 from galaxy.web import url_for
@@ -44,8 +45,10 @@ def clean_dependency_relationships(trans, metadata_dict, tool_shed_repository, t
             message = "Repository dependency %s by owner %s is not required by repository %s, owner %s, "
             message += "removing from list of repository dependencies."
             log.debug(message % (r.name, r.owner, tool_shed_repository.name, tool_shed_repository.owner))
-            trans.install_model.context.delete(rrda)
-            trans.install_model.context.flush()
+            session = trans.install_model.context
+            session.delete(rrda)
+            with transaction(session):
+                session.commit()
 
 
 def generate_tool_guid(repository_clone_url, tool):

--- a/lib/galaxy/tool_shed/util/tool_dependency_util.py
+++ b/lib/galaxy/tool_shed/util/tool_dependency_util.py
@@ -5,6 +5,7 @@ import shutil
 from sqlalchemy import and_
 
 from galaxy import util
+from galaxy.model.base import transaction
 
 log = logging.getLogger(__name__)
 
@@ -215,7 +216,8 @@ def remove_tool_dependency(app, tool_dependency):
         tool_dependency.status = app.install_model.ToolDependency.installation_status.UNINSTALLED
         tool_dependency.error_message = None
         context.add(tool_dependency)
-        context.flush()
+        with transaction(context):
+            context.commit()
         # Since the received tool_dependency is in an error state, nothing will need to be changed in any
         # of the in-memory dictionaries in the installed_repository_manager because changing the state from
         # error to uninstalled requires no in-memory changes..

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -38,6 +38,7 @@ from galaxy import (
 from galaxy.exceptions import ToolInputsNotReadyException
 from galaxy.job_execution import output_collect
 from galaxy.metadata import get_metadata_compute_strategy
+from galaxy.model.base import transaction
 from galaxy.tool_shed.util.repository_util import get_installed_repository
 from galaxy.tool_shed.util.shed_util_common import set_image_paths
 from galaxy.tool_util.deps import (
@@ -348,7 +349,8 @@ class PersistentToolTagManager(AbstractToolTagManager):
             f"removing all tool tag associations ({str(self.sa_session.query(self.app.model.ToolTagAssociation).count())})"
         )
         self.sa_session.query(self.app.model.ToolTagAssociation).delete()
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
     def handle_tags(self, tool_id, tool_definition_source):
         elem = tool_definition_source
@@ -361,10 +363,12 @@ class PersistentToolTagManager(AbstractToolTagManager):
                 if not tag:
                     tag = self.app.model.Tag(name=tag_name)
                     self.sa_session.add(tag)
-                    self.sa_session.flush()
+                    with transaction(self.sa_session):
+                        self.sa_session.commit()
                     tta = self.app.model.ToolTagAssociation(tool_id=tool_id, tag_id=tag.id)
                     self.sa_session.add(tta)
-                    self.sa_session.flush()
+                    with transaction(self.sa_session):
+                        self.sa_session.commit()
                 else:
                     for tagged_tool in tag.tagged_tools:
                         if tagged_tool.tool_id == tool_id:
@@ -372,7 +376,8 @@ class PersistentToolTagManager(AbstractToolTagManager):
                     else:
                         tta = self.app.model.ToolTagAssociation(tool_id=tool_id, tag_id=tag.id)
                         self.sa_session.add(tta)
-                        self.sa_session.flush()
+                        with transaction(self.sa_session):
+                            self.sa_session.commit()
 
 
 class ToolBox(AbstractToolBox):
@@ -3110,7 +3115,8 @@ class SetMetadataTool(Tool):
             if not metadata_set_successfully:
                 dataset._state = model.Dataset.states.FAILED_METADATA
                 self.sa_session.add(dataset)
-                self.sa_session.flush()
+                with transaction(self.sa_session):
+                    self.sa_session.commit()
                 return
             # If setting external metadata has failed, how can we inform the
             # user? For now, we'll leave the default metadata and set the state
@@ -3129,7 +3135,8 @@ class SetMetadataTool(Tool):
             except Exception:
                 log.exception("Exception occured while setting dataset peek")
             self.sa_session.add(dataset)
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
 
     def job_failed(self, job_wrapper, message, exception=False):
         job = job_wrapper.sa_session.query(model.Job).get(job_wrapper.job_id)
@@ -3220,7 +3227,8 @@ class DataManagerTool(OutputParameterJSONTool):
             history = trans.app.model.History(name="Data Manager History (automatically created)", user=user)
             data_manager_association = trans.app.model.DataManagerHistoryAssociation(user=user, history=history)
             trans.sa_session.add_all((history, data_manager_association))
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             return history
 
         user = trans.user

--- a/lib/galaxy/tools/actions/data_manager.py
+++ b/lib/galaxy/tools/actions/data_manager.py
@@ -1,5 +1,6 @@
 import logging
 
+from galaxy.model.base import transaction
 from . import DefaultToolAction
 
 log = logging.getLogger(__name__)
@@ -13,7 +14,8 @@ class DataManagerToolAction(DefaultToolAction):
         if isinstance(rval, tuple) and len(rval) >= 2 and isinstance(rval[0], trans.app.model.Job):
             assoc = trans.app.model.DataManagerJobAssociation(job=rval[0], data_manager_id=tool.data_manager_id)
             trans.sa_session.add(assoc)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         else:
             log.error(f"Got bad return value from DefaultToolAction.execute(): {rval}")
         return rval

--- a/lib/galaxy/tools/actions/upload.py
+++ b/lib/galaxy/tools/actions/upload.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from galaxy.exceptions import RequestParameterMissingException
+from galaxy.model.base import transaction
 from galaxy.model.dataset_collections.structure import UninitializedTree
 from galaxy.tools.actions import upload_common
 from galaxy.util import ExecutionTimer
@@ -150,5 +151,6 @@ def _precreate_fetched_collection_instance(trans, history, target, outputs):
     )
     outputs.append(hdca)
     # Following flushed needed for an ID.
-    trans.sa_session.flush()
+    with transaction(trans.sa_session):
+        trans.sa_session.commit()
     target["destination"]["object_id"] = hdca.id

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -29,6 +29,7 @@ from galaxy.model import (
     Role,
     tags,
 )
+from galaxy.model.base import transaction
 from galaxy.util import is_url
 from galaxy.util.path import external_chown
 
@@ -137,11 +138,13 @@ def __new_history_upload(trans, uploaded_dataset, history=None, state=None):
         hda.state = state
     else:
         hda.state = hda.states.QUEUED
-    trans.sa_session.flush()
+    with transaction(trans.sa_session):
+        trans.sa_session.commit()
     history.add_dataset(hda, genome_build=uploaded_dataset.dbkey, quota=False)
     permissions = trans.app.security_agent.history_get_default_permissions(history)
     trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions, new=True, flush=False)
-    trans.sa_session.flush()
+    with transaction(trans.sa_session):
+        trans.sa_session.commit()
     return hda
 
 
@@ -166,7 +169,8 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
                 new_folder.genome_build = trans.app.genome_builds.default_value
                 folder.add_folder(new_folder)
                 trans.sa_session.add(new_folder)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 trans.app.security_agent.copy_library_permissions(trans, folder, new_folder)
                 folder = new_folder
     if library_bunch.replace_dataset:
@@ -174,7 +178,8 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
     else:
         ld = trans.app.model.LibraryDataset(folder=folder, name=uploaded_dataset.name)
         trans.sa_session.add(ld)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         trans.app.security_agent.copy_library_permissions(trans, folder, ld)
     ldda = trans.app.model.LibraryDatasetDatasetAssociation(
         name=uploaded_dataset.name,
@@ -200,7 +205,8 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
     else:
         ldda.state = ldda.states.QUEUED
     ldda.message = library_bunch.message
-    trans.sa_session.flush()
+    with transaction(trans.sa_session):
+        trans.sa_session.commit()
     # Permissions must be the same on the LibraryDatasetDatasetAssociation and the associated LibraryDataset
     trans.app.security_agent.copy_library_permissions(trans, ld, ldda)
     if library_bunch.replace_dataset:
@@ -215,10 +221,12 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
         )
         folder.add_library_dataset(ld, genome_build=uploaded_dataset.dbkey)
         trans.sa_session.add(folder)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
     ld.library_dataset_dataset_association_id = ldda.id
     trans.sa_session.add(ld)
-    trans.sa_session.flush()
+    with transaction(trans.sa_session):
+        trans.sa_session.commit()
     # Handle template included in the upload form, if any.  If the upload is not asynchronous ( e.g., URL paste ),
     # then the template and contents will be included in the library_bunch at this point.  If the upload is
     # asynchronous ( e.g., uploading a file ), then the template and contents will be included in the library_bunch
@@ -230,7 +238,8 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
         # Create a new FormValues object, using the template we previously retrieved
         form_values = trans.app.model.FormValues(library_bunch.template, library_bunch.template_field_contents)
         trans.sa_session.add(form_values)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         # Create a new info_association between the current ldda and form_values
         # TODO: Currently info_associations at the ldda level are not inheritable to the associated LibraryDataset,
         # we need to figure out if this is optimal
@@ -238,7 +247,8 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
             ldda, library_bunch.template, form_values
         )
         trans.sa_session.add(info_association)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
     # If roles were selected upon upload, restrict access to the Dataset to those roles
     if library_bunch.roles:
         for role in library_bunch.roles:
@@ -246,7 +256,8 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
                 trans.app.security_agent.permitted_actions.DATASET_ACCESS.action, ldda.dataset, role
             )
             trans.sa_session.add(dp)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
     return ldda
 
 
@@ -295,7 +306,8 @@ def create_paramfile(trans, uploaded_datasets):
             for meta_name, meta_value in uploaded_dataset.metadata.items():
                 setattr(data.metadata, meta_name, meta_value)
             trans.sa_session.add(data)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             params = dict(
                 file_type=uploaded_dataset.file_type,
                 dataset_id=data.dataset.id,

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -19,6 +19,7 @@ from typing import (
 from boltons.iterutils import remap
 
 from galaxy import model
+from galaxy.model.base import transaction
 from galaxy.model.dataset_collections.matching import MatchingCollections
 from galaxy.model.dataset_collections.structure import (
     get_structure,
@@ -177,7 +178,8 @@ def execute(
     if execution_slice:
         history.add_pending_items()
     # Make sure collections, implicit jobs etc are flushed even if there are no precreated output datasets
-    trans.sa_session.flush()
+    with transaction(trans.sa_session):
+        trans.sa_session.commit()
 
     tool_id = tool.id
     for job2 in execution_tracker.successful_jobs:
@@ -205,7 +207,8 @@ def execute(
             continue
         tool.app.job_manager.enqueue(job2, tool=tool, flush=False)
         trans.log_event(f"Added job to the job queue, id: {str(job2.id)}", tool_id=tool_id)
-    trans.sa_session.flush()
+    with transaction(trans.sa_session):
+        trans.sa_session.commit()
 
     if has_remaining_jobs:
         raise PartialJobExecution(execution_tracker)
@@ -425,7 +428,8 @@ class ExecutionTracker:
             trans.sa_session.add(collection_instance)
         # Needed to flush the association created just above with
         # job.add_output_dataset_collection.
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         self.implicit_collections = collection_instances
 
     @property
@@ -462,7 +466,8 @@ class ExecutionTracker:
                     collection_type_description=self.collection_info.structure.collection_type_description
                 )
                 trans.sa_session.add(implicit_collection.collection)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
     @property
     def implicit_inputs(self):

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1323,8 +1323,8 @@ class ColumnListParameter(SelectToolParameter):
     >>> from galaxy.model.mapping import init
     >>> sa_session = init("/tmp", "sqlite:///:memory:", create_tables=True).session
     >>> hist = History()
-    >>> sa_session.add(hist)
-    >>> sa_session.flush()
+    >>> with sa_session.begin():
+    ...     sa_session.add(hist)
     >>> hda = hist.add_dataset(HistoryDatasetAssociation(id=1, extension='interval', create_dataset=True, sa_session=sa_session))
     >>> dtp =  DataToolParameter(None, XML('<param name="blah" type="data" format="interval"/>'))
     >>> print(dtp.name)

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -312,8 +312,8 @@ class DatasetOkValidator(Validator):
     >>>
     >>> sa_session = init("/tmp", "sqlite:///:memory:", create_tables=True).session
     >>> hist = History()
-    >>> sa_session.add(hist)
-    >>> sa_session.flush()
+    >>> with sa_session.begin():
+    ...     sa_session.add(hist)
     >>> set_datatypes_registry(example_datatype_registry_for_sample())
     >>> ok_hda = hist.add_dataset(HistoryDatasetAssociation(id=1, extension='interval', create_dataset=True, sa_session=sa_session))
     >>> ok_hda.set_dataset_state(model.Dataset.states.OK)
@@ -371,8 +371,8 @@ class DatasetEmptyValidator(Validator):
     >>>
     >>> sa_session = init("/tmp", "sqlite:///:memory:", create_tables=True).session
     >>> hist = History()
-    >>> sa_session.add(hist)
-    >>> sa_session.flush()
+    >>> with sa_session.begin():
+    ...     sa_session.add(hist)
     >>> set_datatypes_registry(example_datatype_registry_for_sample())
     >>> empty_dataset = Dataset(external_filename=get_test_fname("empty.txt"))
     >>> empty_hda = hist.add_dataset(HistoryDatasetAssociation(id=1, extension='interval', dataset=empty_dataset, sa_session=sa_session))
@@ -427,8 +427,8 @@ class DatasetExtraFilesPathEmptyValidator(Validator):
     >>>
     >>> sa_session = init("/tmp", "sqlite:///:memory:", create_tables=True).session
     >>> hist = History()
-    >>> sa_session.add(hist)
-    >>> sa_session.flush()
+    >>> with sa_session.begin():
+    ...     sa_session.add(hist)
     >>> set_datatypes_registry(example_datatype_registry_for_sample())
     >>> has_extra_hda = hist.add_dataset(HistoryDatasetAssociation(id=1, extension='interval', create_dataset=True, sa_session=sa_session))
     >>> has_extra_hda.dataset.file_size = 10
@@ -485,8 +485,8 @@ class MetadataValidator(Validator):
     >>>
     >>> sa_session = init("/tmp", "sqlite:///:memory:", create_tables=True).session
     >>> hist = History()
-    >>> sa_session.add(hist)
-    >>> sa_session.flush()
+    >>> with sa_session.begin():
+    ...     sa_session.add(hist)
     >>> set_datatypes_registry(example_datatype_registry_for_sample())
     >>> fname = get_test_fname('1.bed')
     >>> bedds = Dataset(external_filename=fname)
@@ -571,8 +571,8 @@ class UnspecifiedBuildValidator(Validator):
     >>>
     >>> sa_session = init("/tmp", "sqlite:///:memory:", create_tables=True).session
     >>> hist = History()
-    >>> sa_session.add(hist)
-    >>> sa_session.flush()
+    >>> with sa_session.begin():
+    ...     sa_session.add(hist)
     >>> set_datatypes_registry(example_datatype_registry_for_sample())
     >>> has_dbkey_hda = hist.add_dataset(HistoryDatasetAssociation(id=1, extension='interval', create_dataset=True, sa_session=sa_session))
     >>> has_dbkey_hda.set_dataset_state(model.Dataset.states.OK)

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -13,6 +13,7 @@ from typing import Tuple
 from sqlalchemy.orm import object_session
 
 from galaxy.exceptions import HandlerAssignmentError
+from galaxy.model.base import transaction
 from galaxy.util import (
     ExecutionTimer,
     listify,
@@ -461,5 +462,6 @@ class ConfiguresHandlers:
 def _timed_flush_obj(obj):
     obj_flush_timer = ExecutionTimer()
     sa_session = object_session(obj)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     log.info(f"Flushed transaction for {obj.log_str()} {obj_flush_timer}")

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -37,6 +37,7 @@ from galaxy.exceptions import (
 from galaxy.managers import context
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.users import UserManager
+from galaxy.model.base import transaction
 from galaxy.structured_app import (
     BasicSharedApp,
     MinimalApp,
@@ -352,7 +353,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                     expiration_time = now
                     self.galaxy_session.last_action = now - datetime.timedelta(seconds=1)
                     self.sa_session.add(self.galaxy_session)
-                    self.sa_session.flush()
+                    with transaction(self.sa_session):
+                        self.sa_session.commit()
                 if expiration_time < now:
                     # Expiration time has passed.
                     self.handle_user_logout()
@@ -373,7 +375,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                 else:
                     self.galaxy_session.last_action = now
                     self.sa_session.add(self.galaxy_session)
-                    self.sa_session.flush()
+                    with transaction(self.sa_session):
+                        self.sa_session.commit()
 
     @property
     def app(self):
@@ -447,7 +450,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
             if user and not user.bootstrap_admin_user:
                 self.galaxy_session.user = user
                 self.sa_session.add(self.galaxy_session)
-                self.sa_session.flush()
+                with transaction(self.sa_session):
+                    self.sa_session.commit()
         self.__user = user
 
     user = property(get_user, set_user)
@@ -641,7 +645,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
             #        be needed.
             if prev_galaxy_session:
                 self.sa_session.add(prev_galaxy_session)
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
         # If the old session was invalid, get a new (or existing default,
         # unused) history with our new session
         if invalidate_existing_session:
@@ -772,7 +777,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                 username += f"-{str(i)}"
             user.username = username
             self.sa_session.add(user)
-            self.sa_session.flush()
+            with transaction(self.sa_session):
+                self.sa_session.commit()
             self.app.security_agent.create_private_user_role(user)
             # We set default user permissions, before we log in and set the default history permissions
             if "webapp" not in self.environ or self.environ["webapp"] != "tool_shed":
@@ -877,7 +883,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         else:
             cookie_name = "galaxycommunitysession"
             self.sa_session.add_all((prev_galaxy_session, self.galaxy_session))
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
         # This method is not called from the Galaxy reports, so the cookie will always be galaxysession
         self.__update_session_cookie(name=cookie_name)
 
@@ -902,7 +909,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
             ):
                 other_galaxy_session.is_valid = False
                 self.sa_session.add(other_galaxy_session)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
         if self.webapp.name == "galaxy":
             # This method is not called from the Galaxy reports, so the cookie will always be galaxysession
             self.__update_session_cookie(name="galaxysession")
@@ -939,7 +947,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         if history and not history.deleted:
             self.galaxy_session.current_history = history
         self.sa_session.add(self.galaxy_session)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
     @property
     def history(self):
@@ -1020,7 +1029,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         self.app.security_agent.history_set_default_permissions(history)
         # Save
         self.sa_session.add_all((self.galaxy_session, history))
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
         return history
 
     @base.lazy_property

--- a/lib/galaxy/webapps/galaxy/api/annotations.py
+++ b/lib/galaxy/webapps/galaxy/api/annotations.py
@@ -9,6 +9,7 @@ from galaxy import (
     managers,
 )
 from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.model.base import transaction
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.web import expose_api
@@ -43,7 +44,8 @@ class BaseAnnotationsController(BaseGalaxyAPIController, UsesStoredWorkflowMixin
             new_annotation = sanitize_html(new_annotation)
 
             self.add_item_annotation(trans.sa_session, trans.user, item, new_annotation)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             return new_annotation
         return ""
 

--- a/lib/galaxy/webapps/galaxy/api/cloudauthz.py
+++ b/lib/galaxy/webapps/galaxy/api/cloudauthz.py
@@ -18,6 +18,7 @@ from galaxy.exceptions import (
     RequestParameterMissingException,
 )
 from galaxy.managers import cloudauthzs
+from galaxy.model.base import transaction
 from galaxy.structured_app import StructuredApp
 from galaxy.util import unicodify
 from galaxy.web import expose_api
@@ -190,7 +191,8 @@ class CloudAuthzController(BaseGalaxyAPIController):
         try:
             cloudauthz = trans.app.authnz_manager.try_get_authz_config(trans.sa_session, trans.user.id, authz_id)
             trans.sa_session.delete(cloudauthz)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             log.debug(f"Deleted a cloudauthz record with id `{authz_id}` for the user id `{str(trans.user.id)}` ")
             view = self.cloudauthz_serializer.serialize_to_view(
                 cloudauthz, trans=trans, **self._parse_serialization_params(kwargs, "summary")

--- a/lib/galaxy/webapps/galaxy/api/forms.py
+++ b/lib/galaxy/webapps/galaxy/api/forms.py
@@ -5,6 +5,7 @@ import logging
 
 from galaxy import web
 from galaxy.forms.forms import form_factory
+from galaxy.model.base import transaction
 from galaxy.util import XML
 from galaxy.webapps.base.controller import url_for
 from . import BaseGalaxyAPIController
@@ -74,7 +75,8 @@ class FormDefinitionAPIController(BaseGalaxyAPIController):
             # enhance to allow creating from more than just xml
         form_definition = form_factory.from_elem(XML(xml_text))
         trans.sa_session.add(form_definition)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         encoded_id = trans.security.encode_id(form_definition.id)
         item = form_definition.to_dict(
             view="element",

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -28,6 +28,7 @@ from galaxy.model import (
     LibraryDataset,
     tags,
 )
+from galaxy.model.base import transaction
 from galaxy.structured_app import StructuredApp
 from galaxy.web import expose_api
 from galaxy.webapps.base.controller import (
@@ -317,11 +318,13 @@ class LibraryContentsController(
                     trans.sa_session.add(ex_meta)
                     v.extended_metadata = ex_meta
                     trans.sa_session.add(v)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                     for path, value in self._scan_json_block(ex_meta_payload):
                         meta_i = ExtendedMetadataIndex(ex_meta, path, value)
                         trans.sa_session.add(meta_i)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                 if type(v) == trans.app.model.LibraryDatasetDatasetAssociation:
                     v = v.library_dataset
                 encoded_id = trans.security.encode_id(v.id)
@@ -432,7 +435,8 @@ class LibraryContentsController(
                 metadata_safe=True,
             )
             trans.sa_session.add(assoc)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
 
     def _decode_library_content_id(self, content_id):
         if len(content_id) % 16 == 0:
@@ -482,7 +486,8 @@ class LibraryContentsController(
             if purge:
                 ld.purged = True
                 trans.sa_session.add(ld)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
 
                 # TODO: had to change this up a bit from Dataset.user_can_purge
                 dataset = ld.library_dataset_dataset_association.dataset
@@ -497,9 +502,11 @@ class LibraryContentsController(
                     except Exception:
                         pass
                     # flush now to preserve deleted state in case of later interruption
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                 rval["purged"] = True
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             rval["deleted"] = True
 
         except exceptions.httpexceptions.HTTPInternalServerError:

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -25,6 +25,7 @@ from galaxy.managers import (
     library_datasets,
     roles,
 )
+from galaxy.model.base import transaction
 from galaxy.structured_app import StructuredApp
 from galaxy.tools.actions import upload_common
 from galaxy.tools.parameters import populate_state
@@ -261,7 +262,8 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
                     trans.app.security_agent.permitted_actions.DATASET_ACCESS.action, dataset, private_role
                 )
                 trans.sa_session.add(dp)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
             if not trans.app.security_agent.dataset_is_private_to_user(trans, dataset):
                 # Check again and inform the user if dataset is not private.
                 raise exceptions.InternalServerError("An error occurred and the dataset is NOT private.")
@@ -354,7 +356,8 @@ class LibraryDatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin,
             library_dataset.deleted = True
 
         trans.sa_session.add(library_dataset)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
         rval = trans.security.encode_all_ids(library_dataset.to_dict())
         nice_size = util.nice_size(

--- a/lib/galaxy/webapps/galaxy/api/visualizations.py
+++ b/lib/galaxy/webapps/galaxy/api/visualizations.py
@@ -20,6 +20,7 @@ from galaxy import (
     web,
 )
 from galaxy.managers.context import ProvidesUserContext
+from galaxy.model.base import transaction
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -273,7 +274,8 @@ class VisualizationsController(BaseGalaxyAPIController, UsesVisualizationMixin, 
 
         # allow updating vis title
         visualization.title = title
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
         return rval
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -45,6 +45,7 @@ from galaxy.managers.workflows import (
     WorkflowCreateOptions,
     WorkflowUpdateOptions,
 )
+from galaxy.model.base import transaction
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.model.store import BcoExportOptions
 from galaxy.schema.fields import DecodedDatabaseIdField
@@ -172,7 +173,8 @@ class WorkflowsAPIController(
             m = model.StoredWorkflowMenuEntry()
             m.stored_workflow = q.get(wf_id)
             user.stored_workflow_menu_entries.append(m)
-        sess.flush()
+        with transaction(sess):
+            sess.commit()
         message = "Menu updated."
         trans.set_message(message)
         return {"message": message, "status": "done"}
@@ -527,7 +529,8 @@ class WorkflowsAPIController(
                 )
 
             if require_flush:
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
 
             if "steps" in workflow_dict:
                 try:
@@ -765,7 +768,8 @@ class WorkflowsAPIController(
             )
             invocations.append(workflow_invocation)
 
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         encoded_invocations = []
         for invocation in invocations:
             as_dict = workflow_invocation.to_dict()
@@ -1048,7 +1052,8 @@ class WorkflowsAPIController(
         )
         if importable:
             self._make_item_accessible(trans.sa_session, created_workflow.stored_workflow)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
 
         self._import_tools_if_needed(trans, workflow_create_options, raw_workflow_description)
         return created_workflow.stored_workflow, created_workflow.missing_tools

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -18,6 +18,7 @@ from galaxy.exceptions import (
 )
 from galaxy.managers.quotas import QuotaManager
 from galaxy.model import tool_shed_install as install_model
+from galaxy.model.base import transaction
 from galaxy.security.validate_user_input import validate_password
 from galaxy.structured_app import StructuredApp
 from galaxy.util import (
@@ -1035,7 +1036,8 @@ class AdminGalaxy(controller.JSAppLauncher):
                     num_in_groups = len(in_groups) + 1
                 else:
                     num_in_groups = len(in_groups)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 message = f"Role '{role.name}' has been created with {len(in_users)} associated users and {num_in_groups} associated groups."
                 if auto_create_checked:
                     message += (
@@ -1075,7 +1077,8 @@ class AdminGalaxy(controller.JSAppLauncher):
                         role.name = new_name
                         role.description = new_description
                         trans.sa_session.add(role)
-                        trans.sa_session.flush()
+                        with transaction(trans.sa_session):
+                            trans.sa_session.commit()
             return {"message": f"Role '{old_name}' has been renamed to '{new_name}'."}
 
     @web.legacy_expose_api
@@ -1139,7 +1142,8 @@ class AdminGalaxy(controller.JSAppLauncher):
                         for dhp in history.default_permissions:
                             if role == dhp.role:
                                 trans.sa_session.delete(dhp)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
             trans.app.security_agent.set_entity_role_associations(roles=[role], users=in_users, groups=in_groups)
             trans.sa_session.refresh(role)
             return {
@@ -1152,7 +1156,8 @@ class AdminGalaxy(controller.JSAppLauncher):
             role = get_role(trans, role_id)
             role.deleted = True
             trans.sa_session.add(role)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             message += f" {role.name} "
         return (message, "done")
 
@@ -1165,7 +1170,8 @@ class AdminGalaxy(controller.JSAppLauncher):
                 return (f"Role '{role.name}' has not been deleted, so it cannot be undeleted.", "error")
             role.deleted = False
             trans.sa_session.add(role)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             count += 1
             undeleted_roles += f" {role.name}"
         return ("Undeleted %d roles: %s" % (count, undeleted_roles), "done")
@@ -1202,7 +1208,8 @@ class AdminGalaxy(controller.JSAppLauncher):
             # Delete DatasetPermissionss
             for dp in role.dataset_actions:
                 trans.sa_session.delete(dp)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             message += f" {role.name} "
         return (message, "done")
 
@@ -1255,7 +1262,8 @@ class AdminGalaxy(controller.JSAppLauncher):
                     if not (group.name == new_name):
                         group.name = new_name
                         trans.sa_session.add(group)
-                        trans.sa_session.flush()
+                        with transaction(trans.sa_session):
+                            trans.sa_session.commit()
             return {"message": f"Group '{old_name}' has been renamed to '{new_name}'."}
 
     @web.legacy_expose_api
@@ -1394,7 +1402,8 @@ class AdminGalaxy(controller.JSAppLauncher):
                     num_in_roles = len(in_roles) + 1
                 else:
                     num_in_roles = len(in_roles)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 message = "Group '%s' has been created with %d associated users and %d associated roles." % (
                     group.name,
                     len(in_users),
@@ -1412,7 +1421,8 @@ class AdminGalaxy(controller.JSAppLauncher):
             group = get_group(trans, group_id)
             group.deleted = True
             trans.sa_session.add(group)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             message += f" {group.name} "
         return (message, "done")
 
@@ -1425,7 +1435,8 @@ class AdminGalaxy(controller.JSAppLauncher):
                 return (f"Group '{group.name}' has not been deleted, so it cannot be undeleted.", "error")
             group.deleted = False
             trans.sa_session.add(group)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             count += 1
             undeleted_groups += f" {group.name}"
         return ("Undeleted %d groups: %s" % (count, undeleted_groups), "done")
@@ -1442,7 +1453,8 @@ class AdminGalaxy(controller.JSAppLauncher):
             # Delete GroupRoleAssociations
             for gra in group.roles:
                 trans.sa_session.delete(gra)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             message += f" {group.name} "
         return (message, "done")
 
@@ -1474,7 +1486,8 @@ class AdminGalaxy(controller.JSAppLauncher):
                 for user in users.values():
                     user.set_password_cleartext(password)
                     trans.sa_session.add(user)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                 return {"message": "Passwords reset for %d user(s)." % len(users)}
         else:
             return self.message_exception(trans, "Please specify user ids.")
@@ -1542,7 +1555,8 @@ class AdminGalaxy(controller.JSAppLauncher):
             user_id=trans.security.decode_id(user_id), key=trans.app.security.get_new_guid()
         )
         trans.sa_session.add(new_key)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return (f"New key '{new_key.key}' generated for requested user '{user.email}'.", "done")
 
     def _activate_user(self, trans, user_id):

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -8,6 +8,7 @@ from galaxy import (
     web,
 )
 from galaxy.exceptions import ConfigDoesNotAllowException
+from galaxy.model.base import transaction
 from galaxy.tool_shed.util import dependency_display
 from galaxy.tool_shed.util.repository_util import (
     get_absolute_path_to_file_in_repository,
@@ -149,7 +150,8 @@ class AdminToolshed(AdminGalaxy):
             if description != repository.description:
                 repository.description = description
                 trans.install_model.context.add(repository)
-                trans.install_model.context.flush()
+                with transaction(trans.install_model.context):
+                    trans.install_model.context.commit()
             message = "The repository information has been updated."
         dd = dependency_display.DependencyDisplayer(trans.app)
         containers_dict = dd.populate_containers_dict_from_repository_metadata(

--- a/lib/galaxy/webapps/galaxy/controllers/forms.py
+++ b/lib/galaxy/webapps/galaxy/controllers/forms.py
@@ -9,6 +9,7 @@ from galaxy import (
     model,
     util,
 )
+from galaxy.model.base import transaction
 from galaxy.web.framework.helpers import (
     grids,
     iff,
@@ -298,7 +299,8 @@ class Forms(BaseUIController):
         form_definition.form_definition_current = form_definition_current
         form_definition_current.latest_form = form_definition
         trans.sa_session.add(form_definition_current)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return form_definition, None
 
     @web.expose
@@ -308,7 +310,8 @@ class Forms(BaseUIController):
             form = get_form(trans, form_id)
             form.deleted = True
             trans.sa_session.add(form)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         return ("Deleted %i form(s)." % len(ids), "done")
 
     @web.expose
@@ -318,7 +321,8 @@ class Forms(BaseUIController):
             form = get_form(trans, form_id)
             form.deleted = False
             trans.sa_session.add(form)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         return ("Undeleted %i form(s)." % len(ids), "done")
 
 

--- a/lib/galaxy/webapps/galaxy/controllers/tag.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tag.py
@@ -11,6 +11,7 @@ from sqlalchemy.sql.expression import (
 )
 
 from galaxy import web
+from galaxy.model.base import transaction
 from galaxy.webapps.base.controller import (
     BaseUIController,
     UsesTagsMixin,
@@ -49,7 +50,8 @@ class TagsController(BaseUIController, UsesTagsMixin):
         item = self._get_item(trans, item_class, trans.security.decode_id(item_id))
         user = trans.user
         self.get_tag_handler(trans).apply_item_tags(user, item, new_tag)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         # Log.
         params = dict(item_id=item.id, item_class=item_class, tag=new_tag)
         trans.log_action(user, "tag", context, params)
@@ -64,7 +66,8 @@ class TagsController(BaseUIController, UsesTagsMixin):
         item = self._get_item(trans, item_class, trans.security.decode_id(item_id))
         user = trans.user
         self.get_tag_handler(trans).remove_item_tag(user, item, tag_name)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         # Log.
         params = dict(item_id=item.id, item_class=item_class, tag=tag_name)
         trans.log_action(user, "untag", context, params)
@@ -81,7 +84,8 @@ class TagsController(BaseUIController, UsesTagsMixin):
         user = trans.user
         self.get_tag_handler(trans).delete_item_tags(user, item)
         self.get_tag_handler(trans).apply_item_tags(user, item, new_tags)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
     @web.expose
     @web.require_login("get autocomplete data for an item's tags")

--- a/lib/galaxy/webapps/galaxy/controllers/userskeys.py
+++ b/lib/galaxy/webapps/galaxy/controllers/userskeys.py
@@ -8,6 +8,7 @@ from galaxy import (
     util,
     web,
 )
+from galaxy.model.base import transaction
 from galaxy.webapps.base.controller import (
     BaseUIController,
     UsesFormDefinitionsMixin,
@@ -31,7 +32,8 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
         new_key.user_id = trans.security.decode_id(uid)
         new_key.key = trans.app.security.get_new_guid()
         trans.sa_session.add(new_key)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return self.get_all_users(trans)
 
     @web.expose

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -20,6 +20,7 @@ from galaxy.managers.workflows import (
     MissingToolsException,
     WorkflowUpdateOptions,
 )
+from galaxy.model.base import transaction
 from galaxy.model.item_attrs import UsesItemRatings
 from galaxy.tools.parameters.basic import workflow_building_modes
 from galaxy.util import FILENAME_VALID_CHARS
@@ -314,7 +315,8 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             san_new_name = sanitize_html(new_name)
             stored.name = san_new_name
             stored.latest_workflow.name = san_new_name
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             return stored.name
 
     @web.expose
@@ -325,7 +327,8 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             # Sanitize annotation before adding it.
             new_annotation = sanitize_html(new_annotation)
             self.add_item_annotation(trans.sa_session, trans.get_user(), stored, new_annotation)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             return new_annotation
 
     @web.expose
@@ -405,7 +408,8 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             # Persist
             session = trans.sa_session
             session.add(stored_workflow)
-            session.flush()
+            with transaction(session):
+                session.commit()
             return {
                 "id": trans.security.encode_id(stored_workflow.id),
                 "message": f"Workflow {workflow_name} has been created.",
@@ -435,7 +439,8 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             # Persist
             session = trans.sa_session
             session.add(stored_workflow)
-            session.flush()
+            with transaction(session):
+                session.commit()
             workflow_update_options = WorkflowUpdateOptions(
                 update_stored_workflow_attributes=False,  # taken care of above
                 from_tool_form=from_tool_form,

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -39,6 +39,7 @@ from galaxy.managers.history_contents import (
     HistoryContentsManager,
 )
 from galaxy.managers.lddas import LDDAManager
+from galaxy.model.base import transaction
 from galaxy.schema import (
     FilterQueryParams,
     SerializationParams,
@@ -712,7 +713,8 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                 )
 
         if success_count:
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         return DeleteDatasetBatchResult.construct(success_count=success_count, errors=errors)
 
     def get_structured_content(

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -39,6 +39,7 @@ from galaxy.managers.histories import (
     HistorySerializer,
 )
 from galaxy.managers.users import UserManager
+from galaxy.model.base import transaction
 from galaxy.model.store import payload_to_source_uri
 from galaxy.schema import (
     FilterQueryParams,
@@ -249,7 +250,8 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
 
         trans.app.security_agent.history_set_default_permissions(new_history)
         trans.sa_session.add(new_history)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
         # an anonymous user can only have one history
         if self.user_manager.is_anonymous(trans.user):
@@ -347,7 +349,8 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         result = prepare_history_download.delay(request=request)
         task_summary = async_task_summary(result)
         export_association.task_uuid = task_summary.id
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return AsyncFile(storage_request_id=short_term_storage_target.request_id, task=task_summary)
 
     def write_store(
@@ -364,7 +367,8 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         result = write_history_to.delay(request=request)
         task_summary = async_task_summary(result)
         export_association.task_uuid = task_summary.id
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return task_summary
 
     def update(

--- a/lib/galaxy/webapps/galaxy/services/pages.py
+++ b/lib/galaxy/webapps/galaxy/services/pages.py
@@ -11,6 +11,7 @@ from galaxy.managers.pages import (
     PageManager,
     PageSerializer,
 )
+from galaxy.model.base import transaction
 from galaxy.schema import PdfDocumentType
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -91,7 +92,8 @@ class PagesService(ServiceBase):
 
         # Mark a page as deleted
         page.deleted = True
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
     def show(self, trans, id: DecodedDatabaseIdField) -> PageDetails:
         """View a page summary and the content of the latest revision

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -24,6 +24,7 @@ from galaxy.managers.context import (
 )
 from galaxy.managers.histories import HistoryManager
 from galaxy.model import PostJobAction
+from galaxy.model.base import transaction
 from galaxy.schema.fetch_data import (
     FetchDataFormPayload,
     FetchDataPayload,
@@ -187,7 +188,8 @@ class ToolsService(ServiceBase):
                     new_pja_flush = True
 
         if new_pja_flush:
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
 
         return self._handle_inputs_output_to_api_response(trans, tool, target_history, vars)
 

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.model import History
+from galaxy.model.base import transaction
 
 
 class WorkRequestContext(ProvidesHistoryContext):
@@ -114,7 +115,8 @@ class SessionRequestContext(WorkRequestContext):
         if history and not history.deleted:
             self.galaxy_session.current_history = history
         self.sa_session.add(self.galaxy_session)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
 
 
 def proxy_work_context_for_history(

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -8,6 +8,7 @@ from galaxy import (
     exceptions,
     model,
 )
+from galaxy.model.base import transaction
 from galaxy.tool_util.parser import ToolOutputCollectionPart
 from galaxy.tools.parameters.basic import (
     DataCollectionToolParameter,
@@ -70,7 +71,8 @@ def extract_workflow(
     workflow.stored_workflow = stored
     stored.latest_workflow = workflow
     trans.sa_session.add(stored)
-    trans.sa_session.flush()
+    with transaction(trans.sa_session):
+        trans.sa_session.commit()
     return stored
 
 

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -18,6 +18,7 @@ from galaxy.model import (
     WorkflowInvocation,
     WorkflowInvocationStep,
 )
+from galaxy.model.base import transaction
 from galaxy.schema.invocation import (
     CancelReason,
     FailureReason,
@@ -111,7 +112,8 @@ def __invoke(
 
     # Be sure to update state of workflow_invocation.
     trans.sa_session.add(workflow_invocation)
-    trans.sa_session.flush()
+    with transaction(trans.sa_session):
+        trans.sa_session.commit()
 
     return outputs, workflow_invocation
 

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -20,6 +20,7 @@ from galaxy.model import (
     WorkflowRequestInputParameter,
     WorkflowRequestStepState,
 )
+from galaxy.model.base import transaction
 from galaxy.tools.parameters.meta import expand_workflow_inputs
 from galaxy.workflow.resources import get_resource_mapper_function
 
@@ -271,7 +272,8 @@ def _get_target_history(
             nh_name = f"{nh_name} on {', '.join(ids[0:-1])} and {ids[-1]}"
         new_history = History(user=trans.user, name=nh_name)
         trans.sa_session.add(new_history)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         target_history = new_history
     return target_history
 

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -5,6 +5,7 @@ import galaxy.workflow.schedulers
 from galaxy import model
 from galaxy.exceptions import HandlerAssignmentError
 from galaxy.jobs.handler import ItemGrabber
+from galaxy.model.base import transaction
 from galaxy.util import plugin_config
 from galaxy.util.custom_logging import get_logger
 from galaxy.util.monitors import Monitors
@@ -87,7 +88,8 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         if workflow_invocation.handler is None:
             workflow_invocation.handler = self.app.config.server_name
             sa_session.add(workflow_invocation)
-            sa_session.flush()
+            with transaction(sa_session):
+                sa_session.commit()
         else:
             log.warning(
                 "(%s) Handler '%s' received setup message for workflow invocation but handler '%s' is"
@@ -111,7 +113,8 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         workflow_invocation.handler = self.app.config.server_name
         sa_session = self.app.model.context
         sa_session.add(workflow_invocation)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
 
     def _message_callback(self, workflow_invocation):
         return WorkflowSchedulingMessage(task="setup", workflow_invocation_id=workflow_invocation.id)

--- a/lib/galaxy_test/driver/uses_shed.py
+++ b/lib/galaxy_test/driver/uses_shed.py
@@ -6,6 +6,7 @@ import tempfile
 from typing import ClassVar
 
 from galaxy.app import UniverseApplication
+from galaxy.model.base import transaction
 from galaxy_test.base.populators import DEFAULT_TIMEOUT
 from galaxy_test.base.uses_shed_api import UsesShedApi
 from galaxy_test.driver.driver_util import (
@@ -97,4 +98,5 @@ class UsesShed(UsesShedApi):
         ]
         for item in models_to_delete:
             model.context.query(item).delete()
-        model.context.flush()
+        with transaction(model.context):
+            model.context.commit()

--- a/lib/tool_shed/managers/groups.py
+++ b/lib/tool_shed/managers/groups.py
@@ -20,6 +20,7 @@ from galaxy.exceptions import (
     ObjectNotFound,
     RequestParameterInvalidException,
 )
+from galaxy.model.base import transaction
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +74,8 @@ class GroupManager:
             # TODO add description field to the model
             group = trans.app.model.Group(name=name)
             trans.sa_session.add(group)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             return group
 
     def update(self, trans, group, name=None, description=None):
@@ -93,7 +95,8 @@ class GroupManager:
             changed = True
         if changed:
             trans.sa_session.add(group)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         return group
 
     def delete(self, trans, group, undelete=False):
@@ -107,7 +110,8 @@ class GroupManager:
         else:
             group.deleted = True
         trans.sa_session.add(group)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         return group
 
     def list(self, trans, deleted=False):

--- a/lib/tool_shed/metadata/repository_metadata_manager.py
+++ b/lib/tool_shed/metadata/repository_metadata_manager.py
@@ -7,6 +7,7 @@ from sqlalchemy import (
 )
 
 from galaxy import util
+from galaxy.model.base import transaction
 from galaxy.util import inflector
 from galaxy.web.form_builder import SelectField
 from tool_shed.metadata import metadata_generator
@@ -78,7 +79,9 @@ class RepositoryMetadataManager(metadata_generator.MetadataGenerator):
         if tool_versions_dict:
             repository_metadata.tool_versions = tool_versions_dict
             self.sa_session.add(repository_metadata)
-            self.sa_session.flush()
+            session = self.sa_session()
+            with transaction(session):
+                session.commit()
 
     def build_repository_ids_select_field(
         self, name="repository_ids", multiple=True, display="checkboxes", my_writable=False
@@ -111,7 +114,9 @@ class RepositoryMetadataManager(metadata_generator.MetadataGenerator):
             changeset_revision = repository_metadata.changeset_revision
             if changeset_revision in changeset_revisions_checked or changeset_revision not in changeset_revisions:
                 self.sa_session.delete(repository_metadata)
-                self.sa_session.flush()
+                session = self.sa_session()
+                with transaction(session):
+                    session.commit()
 
     def compare_changeset_revisions(self, ancestor_changeset_revision, ancestor_metadata_dict):
         """
@@ -450,7 +455,9 @@ class RepositoryMetadataManager(metadata_generator.MetadataGenerator):
         # on a repository this will reset the values.
         repository_metadata.missing_test_components = False
         self.sa_session.add(repository_metadata)
-        self.sa_session.flush()
+        session = self.sa_session()
+        with transaction(session):
+            session.commit()
 
         return repository_metadata
 
@@ -951,7 +958,9 @@ class RepositoryMetadataManager(metadata_generator.MetadataGenerator):
             if tool_versions_dict:
                 repository_metadata.tool_versions = tool_versions_dict
                 self.sa_session.add(repository_metadata)
-                self.sa_session.flush()
+                session = self.sa_session()
+                with transaction(session):
+                    session.commit()
 
     def reset_metadata_on_selected_repositories(self, **kwd):
         """
@@ -1060,7 +1069,9 @@ class RepositoryMetadataManager(metadata_generator.MetadataGenerator):
                     repository_metadata.includes_workflows = False
                     repository_metadata.missing_test_components = False
                     self.sa_session.add(repository_metadata)
-                    self.sa_session.flush()
+                    session = self.sa_session()
+                    with transaction(session):
+                        session.commit()
                 else:
                     # There are no metadata records associated with the repository.
                     repository_metadata = self.create_or_update_repository_metadata(

--- a/lib/tool_shed/util/metadata_util.py
+++ b/lib/tool_shed/util/metadata_util.py
@@ -7,6 +7,7 @@ from typing import (
 
 from sqlalchemy import and_
 
+from galaxy.model.base import transaction
 from galaxy.tool_shed.util.hg_util import (
     INITIAL_CHANGELOG_HASH,
     reversed_lower_upper_bounded_changelog,
@@ -146,7 +147,9 @@ def get_metadata_revisions(app, repository, sort_revisions=True, reverse=False, 
                 rev = changeset2rev(repo_path, repository_metadata.changeset_revision)
                 repository_metadata.numeric_revision = rev
                 sa_session.add(repository_metadata)
-                sa_session.flush()
+                session = sa_session()
+                with transaction(session):
+                    session.commit()
             except Exception:
                 rev = -1
         else:
@@ -269,7 +272,9 @@ def repository_metadata_by_changeset_revision(
         # Delete all records older than the last one updated.
         for repository_metadata in all_metadata_records[1:]:
             sa_session.delete(repository_metadata)
-            sa_session.flush()
+            session = sa_session()
+            with transaction(session):
+                session.commit()
         return all_metadata_records[0]
     elif all_metadata_records:
         return all_metadata_records[0]

--- a/lib/tool_shed/webapp/api/categories.py
+++ b/lib/tool_shed/webapp/api/categories.py
@@ -11,6 +11,7 @@ from galaxy import (
     util,
     web,
 )
+from galaxy.model.base import transaction
 from galaxy.web import (
     expose_api,
     expose_api_anonymous_and_sessionless,
@@ -57,7 +58,8 @@ class CategoriesController(BaseAPIController):
                 # Create the category
                 category = self.app.model.Category(name=name, description=description)
                 trans.sa_session.add(category)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 category_dict = category.to_dict(view="element", value_mapper=self.__get_value_mapper(trans))
                 category_dict["message"] = f"Category '{str(category.name)}' has been created"
                 category_dict["url"] = web.url_for(

--- a/lib/tool_shed/webapp/api/repository_revisions.py
+++ b/lib/tool_shed/webapp/api/repository_revisions.py
@@ -10,6 +10,7 @@ from galaxy import (
     util,
     web,
 )
+from galaxy.model.base import transaction
 from galaxy.webapps.base.controller import (
     BaseAPIController,
     HTTPBadRequest,
@@ -213,7 +214,8 @@ class RepositoryRevisionsController(BaseAPIController):
                 repository_metadata.changeset_revision,
             )
             trans.sa_session.add(repository_metadata)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
             trans.sa_session.refresh(repository_metadata)
         repository_metadata_dict = repository_metadata.to_dict(
             view="element", value_mapper=self.__get_value_mapper(trans)

--- a/lib/tool_shed/webapp/api/users.py
+++ b/lib/tool_shed/webapp/api/users.py
@@ -6,6 +6,7 @@ from galaxy import (
     util,
     web,
 )
+from galaxy.model.base import transaction
 from galaxy.security.validate_user_input import (
     validate_email,
     validate_password,
@@ -57,7 +58,8 @@ class UsersController(BaseAPIController):
         else:
             user.active = True  # Activation is off, every new user is active by default.
         trans.sa_session.add(user)
-        trans.sa_session.flush()
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
         trans.app.security_agent.create_private_user_role(user)
         return user
 

--- a/lib/tool_shed/webapp/controllers/admin.py
+++ b/lib/tool_shed/webapp/controllers/admin.py
@@ -5,6 +5,7 @@ from galaxy import (
     util,
     web,
 )
+from galaxy.model.base import transaction
 from galaxy.util import inflector
 from galaxy.web.legacy_framework import grids
 from galaxy.webapps.base.controller import BaseUIController
@@ -150,7 +151,8 @@ class AdminController(BaseUIController, Admin):
                 # Create the category
                 category = trans.app.model.Category(name=name, description=description)
                 trans.sa_session.add(category)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 # Update the Tool Shed's repository registry.
                 trans.app.repository_registry.add_category_entry(category)
                 message = f"Category '{escape(category.name)}' has been created"
@@ -192,7 +194,8 @@ class AdminController(BaseUIController, Admin):
                             trans.sa_session.add(repository_admin_role)
                         repository.deleted = True
                         trans.sa_session.add(repository)
-                        trans.sa_session.flush()
+                        with transaction(trans.sa_session):
+                            trans.sa_session.commit()
                         # Update the repository registry.
                         trans.app.repository_registry.remove_entry(repository)
                         count += 1
@@ -226,7 +229,8 @@ class AdminController(BaseUIController, Admin):
             for repository_metadata_id in ids:
                 repository_metadata = metadata_util.get_repository_metadata_by_id(trans.app, repository_metadata_id)
                 trans.sa_session.delete(repository_metadata)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 count += 1
             if count:
                 message = "Deleted %d repository metadata %s" % (count, inflector.cond_plural(len(ids), "record"))
@@ -277,7 +281,8 @@ class AdminController(BaseUIController, Admin):
                     flush_needed = True
             if flush_needed:
                 trans.sa_session.add(category)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 if original_category_name != new_name:
                     # Update the Tool Shed's repository registry.
                     trans.app.repository_registry.edit_category_entry(original_category_name, new_name)
@@ -402,7 +407,8 @@ class AdminController(BaseUIController, Admin):
                             trans.sa_session.add(repository_admin_role)
                         repository.deleted = False
                         trans.sa_session.add(repository)
-                        trans.sa_session.flush()
+                        with transaction(trans.sa_session):
+                            trans.sa_session.commit()
                         if not repository.deprecated:
                             # Update the repository registry.
                             trans.app.repository_registry.add_entry(repository)
@@ -439,7 +445,8 @@ class AdminController(BaseUIController, Admin):
                 category = suc.get_category(trans.app, category_id)
                 category.deleted = True
                 trans.sa_session.add(category)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 # Update the Tool Shed's repository registry.
                 trans.app.repository_registry.remove_category_entry(category)
                 message += f" {escape(category.name)} "
@@ -470,7 +477,8 @@ class AdminController(BaseUIController, Admin):
                     # Delete RepositoryCategoryAssociations
                     for rca in category.repositories:
                         trans.sa_session.delete(rca)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                     purged_categories += f" {category.name} "
             message = "Purged %d categories: %s" % (count, escape(purged_categories))
         else:
@@ -495,7 +503,8 @@ class AdminController(BaseUIController, Admin):
                 if category.deleted:
                     category.deleted = False
                     trans.sa_session.add(category)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                     # Update the Tool Shed's repository registry.
                     trans.app.repository_registry.add_category_entry(category)
                     count += 1

--- a/lib/tool_shed/webapp/controllers/hg.py
+++ b/lib/tool_shed/webapp/controllers/hg.py
@@ -4,6 +4,7 @@ from mercurial.hgweb.hgwebdir_mod import hgwebdir
 
 from galaxy import web
 from galaxy.exceptions import ObjectNotFound
+from galaxy.model.base import transaction
 from galaxy.webapps.base.controller import BaseUIController
 from tool_shed.util.repository_util import get_repository_by_name_and_owner
 
@@ -45,5 +46,6 @@ class HgController(BaseUIController):
                 times_downloaded += 1
                 repository.times_downloaded = times_downloaded
                 trans.sa_session.add(repository)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
         return PortAsStringMiddleware(wsgi_app)

--- a/lib/tool_shed/webapp/controllers/user.py
+++ b/lib/tool_shed/webapp/controllers/user.py
@@ -9,6 +9,7 @@ from galaxy import (
     web,
 )
 from galaxy.managers.api_keys import ApiKeyManager
+from galaxy.model.base import transaction
 from galaxy.security.validate_user_input import (
     validate_email,
     validate_password,
@@ -261,7 +262,8 @@ class User(BaseUser):
                 if reset_user:
                     prt = trans.app.model.PasswordResetToken(reset_user)
                     trans.sa_session.add(prt)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                     host = trans.request.host.split(":")[0]
                     if host in ["localhost", "127.0.0.1", "0.0.0.0"]:
                         host = socket.getfqdn()
@@ -276,7 +278,8 @@ class User(BaseUser):
                     try:
                         util.send_mail(frm, email, subject, body, trans.app.config)
                         trans.sa_session.add(reset_user)
-                        trans.sa_session.flush()
+                        with transaction(trans.sa_session):
+                            trans.sa_session.commit()
                         trans.log_event(f"User reset password: {email}")
                     except Exception:
                         log.exception("Unable to reset password.")
@@ -345,7 +348,8 @@ class User(BaseUser):
             else:
                 user.username = username
                 trans.sa_session.add(user)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
                 message = "The username has been updated with the changes."
         return trans.fill_template(
             "/webapps/tool_shed/user/username.mako",
@@ -394,11 +398,13 @@ class User(BaseUser):
                     # Change the email itself
                     user.email = email
                     trans.sa_session.add_all((user, private_role))
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                     if trans.webapp.name == "galaxy" and trans.app.config.user_activation_on:
                         user.active = False
                         trans.sa_session.add(user)
-                        trans.sa_session.flush()
+                        with transaction(trans.sa_session):
+                            trans.sa_session.commit()
                         is_activation_sent = self.user_manager.send_activation_email(trans, user.email, user.username)
                         if is_activation_sent:
                             message = "The login information has been updated with the changes.<br>Verification email has been sent to your new email address. Please verify it by clicking the activation link in the email.<br>Please check your spam/trash folder in case you cannot find the message."
@@ -409,7 +415,8 @@ class User(BaseUser):
                 if user.username != username:
                     user.username = username
                     trans.sa_session.add(user)
-                    trans.sa_session.flush()
+                    with transaction(trans.sa_session):
+                        trans.sa_session.commit()
                 message = "The login information has been updated with the changes."
         elif user and params.get("edit_user_info_button", False):
             # Edit user information - webapp MUST BE 'galaxy'
@@ -440,7 +447,8 @@ class User(BaseUser):
                 flush_needed = True
             if flush_needed:
                 trans.sa_session.add(user)
-                trans.sa_session.flush()
+                with transaction(trans.sa_session):
+                    trans.sa_session.commit()
             message = "The user information has been updated with the changes."
         if user and trans.webapp.name == "galaxy" and is_admin:
             kwd["user_id"] = trans.security.encode_id(user.id)

--- a/lib/tool_shed/webapp/util/ratings_util.py
+++ b/lib/tool_shed/webapp/util/ratings_util.py
@@ -1,5 +1,6 @@
 import logging
 
+from galaxy.model.base import transaction
 from galaxy.model.item_attrs import UsesItemRatings
 
 log = logging.getLogger(__name__)
@@ -20,11 +21,13 @@ class ItemRatings(UsesItemRatings):
             item_rating.rating = rating
             item_rating.comment = comment
             trans.sa_session.add(item_rating)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         elif item_rating.rating != rating or item_rating.comment != comment:
             # User has previously rated item; update rating.
             item_rating.rating = rating
             item_rating.comment = comment
             trans.sa_session.add(item_rating)
-            trans.sa_session.flush()
+            with transaction(trans.sa_session):
+                trans.sa_session.commit()
         return item_rating

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -64,6 +64,7 @@ from cleanup_datasets import CleanupDatasetsApplication  # noqa: I100
 import galaxy.config
 import galaxy.model.mapping
 import galaxy.util
+from galaxy.model.base import transaction
 from galaxy.util.script import (
     app_properties_from_args,
     populate_config_args,
@@ -255,7 +256,9 @@ def administrative_delete_datasets(
                     hda.deleted = True
                     app.sa_session.add(hda)
                     print("Marked HistoryDatasetAssociation id %d as " "deleted" % hda.id)
-                app.sa_session.flush()
+                session = app.sa_session()
+                with transaction(session):
+                    session.commit()
 
     emailtemplate = Template(filename=template_file)
     for email, dataset_list in user_notifications.items():

--- a/scripts/pages_identifier_conversion.py
+++ b/scripts/pages_identifier_conversion.py
@@ -13,6 +13,7 @@ from galaxy.managers.pages import (
     PageContentProcessor,
     placeholderRenderForSave,
 )
+from galaxy.model.base import transaction
 from galaxy.model.mapping import init_models_from_config
 from galaxy.objectstore import build_object_store_from_config
 from galaxy.security.idencoding import IdEncodingHelper
@@ -53,7 +54,9 @@ def main(argv):
                 if not args.dry_run:
                     p.content = unicodify(processor.output(), "utf-8")
                     session.add(p)
-                    session.flush()
+                    session = session()
+                    with transaction(session):
+                        session.commit()
                 else:
                     print("Modifying revision %s." % p.id)
                     print(difflib.unified_diff(p.content, newcontent))

--- a/scripts/tool_shed/deprecate_repositories_without_metadata.py
+++ b/scripts/tool_shed/deprecate_repositories_without_metadata.py
@@ -26,6 +26,7 @@ sys.path.insert(1, os.path.join(os.path.dirname(__file__), os.pardir, os.pardir,
 
 import tool_shed.webapp.config as tool_shed_config
 import tool_shed.webapp.model.mapping
+from galaxy.model.base import transaction
 from galaxy.util import (
     build_url,
     send_mail as galaxy_send_mail,
@@ -180,7 +181,9 @@ def deprecate_repositories(app, cutoff_time, days=14, info_only=False, verbose=F
         for repository in repositories_by_owner[repository_owner]["repositories"]:
             repository.deprecated = True
             app.sa_session.add(repository)
-            app.sa_session.flush()
+            session = app.sa_session()
+            with transaction(session):
+                session.commit()
         owner = repositories_by_owner[repository_owner]["owner"]
         send_mail_to_owner(
             app, owner.username, owner.email, repositories_by_owner[repository_owner]["repositories"], days

--- a/scripts/update_shed_config_path.py
+++ b/scripts/update_shed_config_path.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import (
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "lib")))
 
 import galaxy.model.tool_shed_install.mapping as mapping
+from galaxy.model.base import transaction
 
 
 def main(opts, session, model):
@@ -26,7 +27,8 @@ def main(opts, session, model):
             if row.metadata_["shed_config_filename"] == opts.bad_filename:
                 row.metadata_["shed_config_filename"] = opts.good_filename
                 session.add(row)
-                session.flush()
+                with transaction(session):
+                    session.commit()
     return 0
 
 

--- a/test/integration/test_job_files.py
+++ b/test/integration/test_job_files.py
@@ -21,6 +21,7 @@ import tempfile
 import requests
 
 from galaxy import model
+from galaxy.model.base import transaction
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
@@ -127,7 +128,8 @@ class TestJobFilesIntegration(integration_util.IntegrationTestCase):
         output_hda = model.HistoryDatasetAssociation(history=history, create_dataset=True, flush=False)
         output_hda.hid = 2
         sa_session.add(output_hda)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         job = model.Job()
         job.history = history
         job.user = user
@@ -136,7 +138,8 @@ class TestJobFilesIntegration(integration_util.IntegrationTestCase):
         sa_session.add(job)
         job.add_input_dataset("input1", hda)
         job.add_output_dataset("output1", output_hda)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         self._app.object_store.create(output_hda.dataset)
         self._app.object_store.create(job, base_dir="job_work", dir_only=True, obj_dir=True)
         working_directory = self._app.object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
@@ -152,7 +155,8 @@ class TestJobFilesIntegration(integration_util.IntegrationTestCase):
         job.state = state
         sa_session = self.sa_session
         sa_session.add(job)
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
 
 
 def _assert_insufficient_permissions(response):

--- a/test/integration/test_local_job_cancellation.py
+++ b/test/integration/test_local_job_cancellation.py
@@ -4,6 +4,7 @@ import time
 
 import psutil
 
+from galaxy.model.base import transaction
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 
@@ -50,7 +51,8 @@ class TestLocalJobCancellation(CancelsJob, integration_util.IntegrationTestCase)
             job.job_stderr = "admin cancelled job"
             job.set_state(app.model.Job.states.DELETING)
             sa_session.add(job)
-            sa_session.flush()
+            with transaction(sa_session):
+                sa_session.commit()
             self.galaxy_interactor.wait_for(
                 lambda: self._get(f"jobs/{job_id}").json()["state"] != "error",
                 what="Wait for job to end in error",

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -1,6 +1,7 @@
 import os
 from collections import namedtuple
 
+from galaxy.model.base import transaction
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
 from galaxy_test.driver.uses_shed import UsesShed
@@ -92,7 +93,9 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         tsr.ctx_rev = "3"
         tsr.installed_changeset_revision = REVISION_3
         tsr.changeset_revision = REVISION_3
-        model.context.flush()
+        session = model.context
+        with transaction(session):
+            session.commit()
         # update shed_tool_conf.xml to look like revision 3 was the installed_changeset_revision
         with open(self._app.config.shed_tool_config_file) as shed_config:
             shed_text = shed_config.read().replace(latest_revision, REVISION_3)

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -18,6 +18,7 @@ from galaxy.model import (
     WorkflowStep,
     WorkflowStepConnection,
 )
+from galaxy.model.base import transaction
 from galaxy.tools.parameters.basic import workflow_building_modes
 from galaxy.workflow.refactor.schema import RefactorActionExecutionMessageTypeEnum
 from galaxy_test.base.populators import WorkflowPopulator
@@ -789,7 +790,8 @@ steps:
         # Do a bunch of checks to ensure nothing workflow related was written to the database
         # or even added to the sa_session.
         sa_session = self._app.model.session
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
 
         sw_update_time = self._model_last_time(StoredWorkflow)
         assert sw_update_time
@@ -803,8 +805,8 @@ steps:
         wo_last_id = self._model_last_id(WorkflowOutput)
 
         response = self._refactor(actions, stored_workflow=stored_workflow, dry_run=True)
-        sa_session.flush()
-        sa_session.expunge_all()
+        with transaction(sa_session):
+            sa_session.commit()
         assert sw_update_time == self._model_last_time(StoredWorkflow)
         assert w_update_time == self._model_last_time(Workflow)
         assert ws_last_id == self._model_last_id(WorkflowStep)

--- a/test/unit/app/authnz/test_custos_authnz.py
+++ b/test/unit/app/authnz/test_custos_authnz.py
@@ -207,7 +207,7 @@ class TestCustosAuthnz(TestCase):
 
         class Session:
             items = []
-            flush_called = False
+            commit_called = False
             _query = Query()
             deleted = []
 
@@ -217,8 +217,8 @@ class TestCustosAuthnz(TestCase):
             def delete(self, item):
                 self.deleted.append(item)
 
-            def flush(self):
-                self.flush_called = True
+            def commit(self):
+                self.commit_called = True
 
             def query(self, cls):
                 return self._query
@@ -469,7 +469,7 @@ class TestCustosAuthnz(TestCase):
         )
         assert refresh_expiration_timedelta.total_seconds() < 1
         assert self.custos_authnz.config["provider"] == added_custos_authnz_token.provider
-        assert self.trans.sa_session.flush_called
+        assert self.trans.sa_session.commit_called
 
     def test_callback_galaxy_user_not_created_when_user_logged_in_and_no_custos_authnz_token_exists(self):
         """
@@ -499,7 +499,7 @@ class TestCustosAuthnz(TestCase):
         assert isinstance(added_custos_authnz_token, CustosAuthnzToken)
         assert user is added_custos_authnz_token.user
         assert user is self.trans.user
-        assert self.trans.sa_session.flush_called
+        assert self.trans.sa_session.commit_called
 
     def test_callback_galaxy_user_not_created_when_custos_authnz_token_exists(self):
         self.trans.set_cookie(value=self.test_state, name=custos_authnz.STATE_COOKIE_NAME)
@@ -560,7 +560,7 @@ class TestCustosAuthnz(TestCase):
         )
         assert refresh_expiration_timedelta.total_seconds() < 1
         assert old_refresh_expiration_time != session_custos_authnz_token.refresh_expiration_time
-        assert self.trans.sa_session.flush_called
+        assert self.trans.sa_session.commit_called
 
     def test_galaxy_oidc_login_when_account_matching_oidc_email_exists(self):
         """
@@ -632,7 +632,7 @@ class TestCustosAuthnz(TestCase):
         assert 1 == len(self.trans.sa_session.deleted)
         deleted_token = self.trans.sa_session.deleted[0]
         assert custos_authnz_token is deleted_token
-        assert self.trans.sa_session.flush_called
+        assert self.trans.sa_session.commit_called
         assert success
         assert "" == message
         assert "/" == redirect_uri
@@ -641,7 +641,7 @@ class TestCustosAuthnz(TestCase):
         self.trans.user = User()
         success, message, redirect_uri = self.custos_authnz.disconnect("Custos", self.trans, "/")
         assert 0 == len(self.trans.sa_session.deleted)
-        assert not self.trans.sa_session.flush_called
+        assert not self.trans.sa_session.commit_called
         assert not success
         assert "" != message
         assert redirect_uri is None
@@ -673,7 +673,7 @@ class TestCustosAuthnz(TestCase):
         success, message, redirect_uri = self.custos_authnz.disconnect("Custos", self.trans, "/")
 
         assert 0 == len(self.trans.sa_session.deleted)
-        assert not self.trans.sa_session.flush_called
+        assert not self.trans.sa_session.commit_called
         assert not success
         assert "" != message
         assert redirect_uri is None

--- a/test/unit/app/jobs/test_job_wrapper.py
+++ b/test/unit/app/jobs/test_job_wrapper.py
@@ -137,7 +137,6 @@ class MockJobDispatcher:
 class MockContext:
     def __init__(self, model_objects):
         self.expunged_all = False
-        self.flushed = False
         self.model_objects = model_objects
         self.created_objects = []
 
@@ -148,7 +147,10 @@ class MockContext:
         return MockQuery(self.model_objects.get(clazz))
 
     def flush(self):
-        self.flushed = True
+        pass
+
+    def commit(self):
+        pass
 
     def add(self, object):
         self.created_objects.append(object)

--- a/test/unit/app/jobs/test_rule_helper.py
+++ b/test/unit/app/jobs/test_rule_helper.py
@@ -3,6 +3,7 @@ import uuid
 from galaxy import model
 from galaxy.jobs.rule_helper import RuleHelper
 from galaxy.model import mapping
+from galaxy.model.base import transaction
 from galaxy.util import bunch
 
 USER_EMAIL_1 = "u1@example.com"
@@ -200,4 +201,6 @@ class MockApp:
     def add(self, *args):
         for arg in args:
             self.model.context.add(arg)
-        self.model.context.flush()
+        session = self.model.context
+        with transaction(session):
+            session.commit()

--- a/test/unit/app/managers/test_JobConnectionsManager.py
+++ b/test/unit/app/managers/test_JobConnectionsManager.py
@@ -7,6 +7,7 @@ from galaxy.model import (
     HistoryDatasetCollectionAssociation,
     Job,
 )
+from galaxy.model.base import transaction
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.model.unittest_utils import GalaxyDataTestApp
 
@@ -38,7 +39,8 @@ def setup_connected_dataset(sa_session: galaxy_scoped_session):
     output_job.add_output_dataset("output_hda", output_hda)
     output_job.add_output_dataset_collection("output_hdca", output_hdca)
     sa_session.add_all([center_hda, input_hda, input_hdca, output_hdca, input_job, output_job])
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     expected_graph = {
         "inputs": [
             {"src": "HistoryDatasetAssociation", "id": input_hda.id},
@@ -69,7 +71,8 @@ def setup_connected_dataset_collection(sa_session: galaxy_scoped_session):
     output_job.add_output_dataset("output_hda", output_hda)
     output_job.add_output_dataset_collection("output_hdca", output_hdca)
     sa_session.add_all([center_hdca, input_hda1, input_hda2, input_hdca, output_hdca, input_job, output_job])
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     expected_graph = {
         "inputs": [
             {"src": "HistoryDatasetAssociation", "id": input_hda1.id},

--- a/test/unit/app/tools/conftest.py
+++ b/test/unit/app/tools/conftest.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from galaxy.model import tool_shed_install
+from galaxy.model.base import transaction
 from galaxy.model.tool_shed_install import mapping
 from galaxy.tool_shed.cache import ToolShedRepositoryCache
 from galaxy.tool_util.toolbox.base import ToolConfRepository
@@ -27,7 +28,9 @@ def repos(mock_app):
     repositories = [
         create_repo(mock_app.install_model.context, changeset=i + 1, installed_changeset=i) for i in range(10)
     ]
-    mock_app.install_model.context.flush()
+    session = mock_app.install_model.context
+    with transaction(session):
+        session.commit()
     return repositories
 
 
@@ -69,7 +72,8 @@ def create_repo(session, changeset, installed_changeset, config_filename=None):
     repository.deleted = False
     repository.uninstalled = False
     session.add(repository)
-    session.flush()
+    with transaction(session):
+        session.commit()
     tool_dependency = tool_shed_install.ToolDependency(
         name="Name",
         version="100",

--- a/test/unit/app/tools/test_actions.py
+++ b/test/unit/app/tools/test_actions.py
@@ -7,6 +7,7 @@ from typing import (
 from galaxy import model
 from galaxy.app_unittest_utils import tools_support
 from galaxy.exceptions import UserActivationRequiredException
+from galaxy.model.base import transaction
 from galaxy.objectstore import BaseObjectStore
 from galaxy.tool_util.parser.output_objects import ToolOutput
 from galaxy.tools.actions import (
@@ -68,7 +69,9 @@ class TestDefaultToolAction(TestCase, tools_support.UsesTools):
         self.history = history
         self.trans = MockTrans(self.app, self.history)
         self.app.model.context.add(history)
-        self.app.model.context.flush()
+        session = self.app.model.context
+        with transaction(session):
+            session.commit()
         self.action = DefaultToolAction()
         self.app.config.len_file_path = "moocow"
         self.app.object_store = cast(BaseObjectStore, MockObjectStore())
@@ -125,7 +128,9 @@ class TestDefaultToolAction(TestCase, tools_support.UsesTools):
         hda.dataset.state = "ok"
         hda.dataset.external_filename = "/tmp/datasets/dataset_001.dat"
         self.history.add_dataset(hda)
-        self.app.model.context.flush()
+        session = self.app.model.context
+        with transaction(session):
+            session.commit()
         return hda
 
     def _simple_execute(self, contents=None, incoming=None):

--- a/test/unit/app/tools/test_collect_primary_datasets.py
+++ b/test/unit/app/tools/test_collect_primary_datasets.py
@@ -7,6 +7,7 @@ from galaxy import (
     util,
 )
 from galaxy.app_unittest_utils import tools_support
+from galaxy.model.base import transaction
 from galaxy.objectstore import BaseObjectStore
 from galaxy.tool_util.parser import output_collection_def
 from galaxy.tool_util.provided_metadata import (
@@ -436,7 +437,9 @@ class TestCollectPrimaryDatasets(TestCase, tools_support.UsesTools):
         self.app.model.context.add(history)
         for hda in hdas:
             history.add_dataset(hda, set_hid=False)
-        self.app.model.context.flush()
+        session = self.app.model.context
+        with transaction(session):
+            session.commit()
         return history
 
 

--- a/test/unit/app/tools/test_column_parameters.py
+++ b/test/unit/app/tools/test_column_parameters.py
@@ -3,6 +3,7 @@ test_select_parameters.py.
 """
 from galaxy import model
 from galaxy.app_unittest_utils.tools_support import datatypes_registry
+from galaxy.model.base import transaction
 from galaxy.util import bunch
 from .util import BaseParameterTestCase
 
@@ -60,7 +61,9 @@ class TestDataColumnParameter(BaseParameterTestCase):
         super().setUp()
         self.test_history = model.History()
         self.app.model.context.add(self.test_history)
-        self.app.model.context.flush()
+        session = self.app.model.context
+        with transaction(session):
+            session.commit()
         self.trans = bunch.Bunch(
             app=self.app,
             get_history=lambda: self.test_history,

--- a/test/unit/app/tools/test_data_parameters.py
+++ b/test/unit/app/tools/test_data_parameters.py
@@ -6,6 +6,7 @@ from typing import (
 
 from galaxy import model
 from galaxy.app_unittest_utils import galaxy_mock
+from galaxy.model.base import transaction
 from .util import BaseParameterTestCase
 
 
@@ -147,14 +148,18 @@ class TestDataToolParameter(BaseParameterTestCase):
         hda.visible = True
         hda.dataset = model.Dataset()
         self.app.model.context.add(hda)
-        self.app.model.context.flush()
+        session = self.app.model.context
+        with transaction(session):
+            session.commit()
         return hda
 
     def setUp(self):
         super().setUp()
         self.test_history = model.History()
         self.app.model.context.add(self.test_history)
-        self.app.model.context.flush()
+        session = self.app.model.context
+        with transaction(session):
+            session.commit()
         self.trans = galaxy_mock.MockTrans(history=self.test_history)
         self.multiple = False
         self.optional = False

--- a/test/unit/app/tools/test_execution.py
+++ b/test/unit/app/tools/test_execution.py
@@ -8,6 +8,7 @@ import webob.exc
 import galaxy.model
 from galaxy.app_unittest_utils import tools_support
 from galaxy.managers.collections import DatasetCollectionManager
+from galaxy.model.base import transaction
 from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.util.bunch import Bunch
 from galaxy.util.unittest import TestCase
@@ -131,7 +132,9 @@ class TestToolExecution(TestCase, tools_support.UsesTools):
         self.trans.sa_session.add(hda)
         add_object_to_object_session(self.history, hda)
         self.history.datasets.append(hda)
-        self.trans.sa_session.flush()
+        session = self.trans.sa_session
+        with transaction(session):
+            session.commit()
         return hda
 
     def __add_collection_dataset(self, id, collection_type="paired", *hdas):

--- a/test/unit/app/tools/test_history_imp_exp.py
+++ b/test/unit/app/tools/test_history_imp_exp.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 from galaxy import model
 from galaxy.app_unittest_utils.galaxy_mock import MockApp
 from galaxy.exceptions import MalformedContents
+from galaxy.model.base import transaction
 from galaxy.model.orm.util import add_object_to_object_session
 from galaxy.objectstore.unittest_utils import Config as TestConfig
 from galaxy.tools.imp_exp import (
@@ -37,7 +38,9 @@ def _run_jihaw_cleanup(archive_dir, app=None):
     job.tool_stderr = ""
     jiha = model.JobImportHistoryArchive(job=job, archive_dir=archive_dir)
     app.model.context.current.add_all([job, jiha])
-    app.model.context.flush()
+    session = app.model.context
+    with transaction(session):
+        session.commit()
     jihaw = JobImportHistoryArchiveWrapper(app, job.id)  # yeehaw!
     return app, jihaw.cleanup_after_job()
 
@@ -137,7 +140,8 @@ def test_export_dataset():
     sa_session.add(d2)
     sa_session.add(h)
     sa_session.add(j)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     app.object_store.update_from_file(d1, file_name=t_data_path("1.txt"), create=True)
     app.object_store.update_from_file(d2, file_name=t_data_path("2.bed"), create=True)
@@ -203,7 +207,8 @@ def test_export_dataset_with_deleted_and_purged():
     sa_session.add(j1)
     sa_session.add(j2)
     sa_session.add(h)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     assert d1.deleted
 
@@ -241,7 +246,8 @@ def test_multi_inputs():
     sa_session.add(d3)
     sa_session.add(h)
     sa_session.add(j)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     app.object_store.update_from_file(d1, file_name=t_data_path("1.txt"), create=True)
     app.object_store.update_from_file(d2, file_name=t_data_path("2.bed"), create=True)
@@ -311,7 +317,8 @@ def test_export_collection_history():
     sa_session.add(hc1)
     sa_session.add(hc2)
     sa_session.add(j)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     imported_history = _import_export(app, h)
 
@@ -381,7 +388,8 @@ def test_export_collection_with_mapping_history():
     sa_session.add(hc2)
     sa_session.add(j1)
     sa_session.add(j2)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     implicit_collection_jobs = model.ImplicitCollectionJobs()
     j1.add_output_dataset_collection("out_file1", hc2)  # really?
@@ -401,7 +409,8 @@ def test_export_collection_with_mapping_history():
     sa_session.add(implicit_collection_jobs)
     sa_session.add(ija1)
     sa_session.add(ija2)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     imported_history = _import_export(app, h)
     assert len(imported_history.jobs) == 2
@@ -430,7 +439,8 @@ def test_export_collection_with_datasets_from_other_history():
     sa_session.add(d1)
     sa_session.add(d2)
     sa_session.add(hc1)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     imported_history = _import_export(app, h)
 
@@ -454,7 +464,8 @@ def test_export_collection_with_copied_datasets_and_overlapping_hids():
     sa_session.add(d1)
     sa_session.add(d2)
     sa_session.add(dataset_history)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     app.object_store.update_from_file(d1, file_name=t_data_path("1.txt"), create=True)
     app.object_store.update_from_file(d2, file_name=t_data_path("2.bed"), create=True)
@@ -476,7 +487,8 @@ def test_export_collection_with_copied_datasets_and_overlapping_hids():
     sa_session.add(d1_copy)
     sa_session.add(d2_copy)
     sa_session.add(hc1)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     _import_export(app, h)
     # Currently d1 and d1_copy would have conflicting paths in the tar file... this test verifies at least
@@ -497,14 +509,16 @@ def test_export_copied_collection():
     dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
 
     sa_session.add_all((dce1, dce2, d1, d2, hc1))
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     hc2 = hc1.copy(element_destination=h)
     h.add_pending_items()
     assert h.hid_counter == 7
 
     sa_session.add(hc2)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     assert hc2.copied_from_history_dataset_collection_association == hc1
 
@@ -533,7 +547,8 @@ def test_export_copied_objects_copied_outside_history():
     dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
 
     sa_session.add_all((dce1, dce2, d1, d2, hc1))
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     hc2 = hc1.copy(element_destination=h)
 
@@ -541,7 +556,8 @@ def test_export_copied_objects_copied_outside_history():
 
     other_h = model.History(name=h.name + "-other", user=h.user)
     sa_session.add(other_h)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     hc3 = hc2.copy(element_destination=other_h)
     other_h.add_pending_items()
@@ -549,7 +565,8 @@ def test_export_copied_objects_copied_outside_history():
     hc4 = hc3.copy(element_destination=h)
     sa_session.add(hc4)
     h.add_pending_items()
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     assert h.hid_counter == 10
 
@@ -591,7 +608,8 @@ def test_export_collection_hids():
     sa_session.add(d1)
     sa_session.add(d2)
     sa_session.add(hc1)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     imported_history = _import_export(app, h)
 
@@ -654,7 +672,9 @@ def _import_export(app, h, dest_export=None):
 
     job = model.Job()
     app.model.session.add(job, h)
-    app.model.session.flush()
+    session = app.model.session
+    with transaction(session):
+        session.commit()
     jeha = model.JobExportHistoryArchive.create_for_history(
         h, job, app.model.context, app.object_store, compressed=True
     )

--- a/test/unit/app/tools/test_metadata.py
+++ b/test/unit/app/tools/test_metadata.py
@@ -5,6 +5,7 @@ from galaxy import model
 from galaxy.app_unittest_utils import tools_support
 from galaxy.job_execution.datasets import DatasetPath
 from galaxy.metadata import get_metadata_compute_strategy
+from galaxy.model.base import transaction
 from galaxy.objectstore import ObjectStorePopulator
 from galaxy.util import (
     galaxy_directory,
@@ -23,7 +24,8 @@ class TestMetadata(TestCase, tools_support.UsesTools):
         sa_session.add(job)
         history = model.History()
         job.history = history
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         self.job = job
         self.history = history
         self.job_working_directory = os.path.join(self.test_directory, "job_working")
@@ -50,7 +52,8 @@ class TestMetadata(TestCase, tools_support.UsesTools):
             extension="fasta",
         )
         sa_session = self.app.model.session
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         output_datasets = {
             "out_file1": output_dataset,
         }
@@ -82,7 +85,8 @@ class TestMetadata(TestCase, tools_support.UsesTools):
             extension="auto",
         )
         sa_session = self.app.model.session
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         output_datasets = {
             "out_file1": output_dataset,
         }
@@ -120,7 +124,8 @@ class TestMetadata(TestCase, tools_support.UsesTools):
             extension="auto",
         )
         sa_session = self.app.model.session
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         output_datasets = {
             "out_file1": output_dataset,
         }
@@ -165,7 +170,9 @@ class TestMetadata(TestCase, tools_support.UsesTools):
         self.history.add_dataset_collection(output_dataset_collection)
         assert output_dataset_collection.collection
         self.app.model.session.add(output_dataset_collection)
-        self.app.model.session.flush()
+        session = self.app.model.session
+        with transaction(session):
+            session.commit()
         return output_dataset_collection
 
     def _create_output_dataset(self, **kwd):

--- a/test/unit/app/tools/test_select_parameters.py
+++ b/test/unit/app/tools/test_select_parameters.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from galaxy import model
+from galaxy.model.base import transaction
 from galaxy.tools.parameters import basic
 from .util import BaseParameterTestCase
 
@@ -57,7 +58,9 @@ class TestSelectToolParameter(BaseParameterTestCase):
         super().setUp()
         self.test_history = model.History()
         self.app.model.context.add(self.test_history)
-        self.app.model.context.flush()
+        session = self.app.model.context
+        with transaction(session):
+            session.commit()
         self.app.tool_data_tables["test_table"] = MockToolDataTable()
         self.trans = Mock(
             app=self.app,

--- a/test/unit/app/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/app/tools/test_tool_shed_repository_cache.py
@@ -1,5 +1,6 @@
 import pytest
 
+from galaxy.model.base import transaction
 from .conftest import create_repo
 
 
@@ -24,7 +25,9 @@ def test_add_repository_and_tool_conf_repository_to_repository_cache(
     assert len(tool_shed_repository_cache.repositories) == 10
     assert len(tool_shed_repository_cache.local_repositories) == 10
     create_repo(tool_shed_repository_cache.session, "21", "20")
-    tool_shed_repository_cache.session.flush()
+    session = tool_shed_repository_cache.session
+    with transaction(session):
+        session.commit()
     tool_shed_repository_cache._build()
     assert len(tool_shed_repository_cache.repositories) == 11
     assert len(tool_shed_repository_cache.local_repositories) == 10

--- a/test/unit/data/model/test_model_discovery.py
+++ b/test/unit/data/model/test_model_discovery.py
@@ -3,6 +3,7 @@ from tempfile import mkdtemp
 
 from galaxy import model
 from galaxy.model import store
+from galaxy.model.base import transaction
 from galaxy.model.store.discover import persist_target_to_export_store
 from galaxy.model.unittest_utils import GalaxyDataTestApp
 
@@ -242,7 +243,8 @@ def _import_directory_to_history(app, target, work_directory):
 
     sa_session = app.model.context
     sa_session.add_all([u, import_history])
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     assert len(import_history.datasets) == 0
 

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm.scoping import scoped_session
 
 from galaxy import model
 from galaxy.model import store
+from galaxy.model.base import transaction
 from galaxy.model.metadata import MetadataTempFile
 from galaxy.model.orm.now import now
 from galaxy.model.unittest_utils import GalaxyDataTestApp
@@ -71,7 +72,9 @@ def test_import_export_history_hidden_false_with_hidden_dataset():
 
     u, h, d1, d2, j = _setup_simple_cat_job(app)
     d2.visible = False
-    app.model.session.flush()
+    session = app.model.session
+    with transaction(session):
+        session.commit()
 
     imported_history = _import_export_history(app, h, export_files="copy", include_hidden=False)
     assert d1.dataset.get_size() == imported_history.datasets[0].get_size()
@@ -83,7 +86,9 @@ def test_import_export_history_hidden_true_with_hidden_dataset():
 
     u, h, d1, d2, j = _setup_simple_cat_job(app)
     d2.visible = False
-    app.model.session.flush()
+    session = app.model.session
+    with transaction(session):
+        session.commit()
 
     imported_history = _import_export_history(app, h, export_files="copy", include_hidden=True)
     assert d1.dataset.get_size() == imported_history.datasets[0].get_size()
@@ -245,7 +250,8 @@ def test_import_library_require_permissions():
     root_folder = model.LibraryFolder(name="my library 1", description="folder description")
     library.root_folder = root_folder
     sa_session.add_all((library, root_folder))
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     temp_directory = mkdtemp()
     with store.DirectoryModelExportStore(temp_directory, app=app) as export_store:
@@ -273,7 +279,8 @@ def test_import_export_library():
     root_folder = model.LibraryFolder(name="my library 1", description="folder description")
     library.root_folder = root_folder
     sa_session.add_all((library, root_folder))
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     subfolder = model.LibraryFolder(name="sub folder 1", description="sub folder")
     root_folder.add_folder(subfolder)
@@ -287,7 +294,8 @@ def test_import_export_library():
     sa_session.add(ld)
     sa_session.add(ldda)
 
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     assert len(root_folder.datasets) == 1
     assert len(root_folder.folders) == 1
 
@@ -329,7 +337,8 @@ def test_import_export_invocation():
     sa_session = app.model.context
     h2 = model.History(user=workflow_invocation.user)
     sa_session.add(h2)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     import_model_store = store.get_import_model_store_for_directory(
         temp_directory, app=app, user=workflow_invocation.user, import_options=store.ImportOptions()
@@ -606,7 +615,8 @@ def test_import_export_edit_collection():
     sa_session.add(h)
     import_history = model.History(name="Test History for Import", user=u)
     sa_session.add(import_history)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     temp_directory = mkdtemp()
     with store.DirectoryModelExportStore(temp_directory, app=app, for_edit=True) as export_store:
@@ -680,7 +690,8 @@ def test_import_export_composite_datasets():
     d1 = _create_datasets(sa_session, h, 1, extension="html")[0]
     d1.dataset.create_extra_files_path()
     sa_session.add_all((h, d1))
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     primary = NamedTemporaryFile("w")
     primary.write("cool primary file")
@@ -706,7 +717,8 @@ def test_import_export_composite_datasets():
 
     import_history = model.History(name="Test History for Import", user=u)
     sa_session.add(import_history)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     _perform_import_from_directory(temp_directory, app, u, import_history)
     assert len(import_history.datasets) == 1
     import_dataset = import_history.datasets[0]
@@ -730,7 +742,8 @@ def test_edit_metadata_files():
 
     d1 = _create_datasets(sa_session, h, 1, extension="bam")[0]
     sa_session.add_all((h, d1))
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     index = NamedTemporaryFile("w")
     index.write("cool bam index")
     metadata_dict = {"bam_index": MetadataTempFile.from_JSON({"kwds": {}, "filename": index.name})}
@@ -746,7 +759,8 @@ def test_edit_metadata_files():
 
     import_history = model.History(name="Test History for Import", user=u)
     sa_session.add(import_history)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     _perform_import_from_directory(temp_directory, app, u, import_history, store.ImportOptions(allow_edit=True))
 
 
@@ -787,7 +801,8 @@ def _setup_simple_export(export_kwds):
 
     import_history = model.History(name="Test History for Import", user=u)
     sa_session.add(import_history)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     temp_directory = mkdtemp()
     with store.DirectoryModelExportStore(temp_directory, app=app, **export_kwds) as export_store:
@@ -836,7 +851,8 @@ def _setup_simple_cat_job(app, state="ok"):
     j.add_output_dataset("out_file1", d2)
 
     sa_session.add_all((d1, d2, h, j))
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     app.object_store.update_from_file(d1, file_name=TEST_PATH_1, create=True)
     app.object_store.update_from_file(d2, file_name=TEST_PATH_2, create=True)
@@ -872,7 +888,8 @@ def _setup_invocation(app):
     wf_output = model.WorkflowOutput(workflow_step_1, label="output_label")
     workflow_invocation.add_output(wf_output, workflow_step_1, d2)
     sa_session.add(workflow_invocation)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     return workflow_invocation
 
 
@@ -918,7 +935,8 @@ def _setup_simple_collection_job(app, state="ok"):
     sa_session.add(hc2)
     sa_session.add(hc3)
     sa_session.add(j)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     return u, h, c1, c2, c3, hc1, hc2, hc3, j
 
@@ -945,7 +963,8 @@ def _setup_collection_invocation(app):
     workflow_invocation.add_output(wf_output, workflow_step_1, hc3)
 
     sa_session.add(workflow_invocation)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     return workflow_invocation
 
 
@@ -1026,7 +1045,8 @@ class MockWorkflowContentsManager:
         stored_workflow.latest_workflow = workflow
         sa_session = app.model.context
         sa_session.add_all((stored_workflow, workflow))
-        sa_session.flush()
+        with transaction(sa_session):
+            sa_session.commit()
         return workflow
 
 
@@ -1070,7 +1090,8 @@ def setup_fixture_context_with_history(
     app, sa_session, user = setup_fixture_context_with_user(**kwd)
     history = model.History(name=history_name, user=user)
     sa_session.add(history)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     return StoreFixtureContextWithHistory(app, sa_session, user, history)
 
 

--- a/test/unit/data/test_dataset_materialization.py
+++ b/test/unit/data/test_dataset_materialization.py
@@ -9,6 +9,7 @@ from galaxy.model import (
     LibraryDatasetDatasetAssociation,
     store,
 )
+from galaxy.model.base import transaction
 from galaxy.model.deferred import (
     materialize_collection_instance,
     materializer_factory,
@@ -32,7 +33,8 @@ def test_undeferred_hdas_untouched(tmpdir):
     hda_fh = tmpdir.join("file.txt")
     hda_fh.write("Moo Cow")
     hda = _create_hda(sa_session, app.object_store, history, hda_fh, include_metadata_file=False)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
 
     materializer = materializer_factory(True, object_store=app.object_store)
     assert materializer.ensure_materialized(hda) == hda
@@ -299,7 +301,8 @@ def _test_hdca(
     )
     sa_session.add(hdca)
     sa_session.add(collection)
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     return hdca
 
 

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -726,6 +726,8 @@ class TestMappings(BaseModelTestCase):
         # However, flushing anything non-empty - even unrelated object will invalidate
         # the session ID.
         self._non_empty_flush()
+        if session().in_transaction():
+            session.commit()
         assert "id" in inspect(galaxy_model_object).unloaded
 
         # Fetch the ID loads the value from the database
@@ -734,6 +736,8 @@ class TestMappings(BaseModelTestCase):
 
         # Using cached_id instead does not exhibit this behavior.
         self._non_empty_flush()
+        if session().in_transaction():
+            session.commit()
         assert expected_id == galaxy.model.cached_id(galaxy_model_object)
         assert "id" in inspect(galaxy_model_object).unloaded
 
@@ -760,6 +764,8 @@ class TestMappings(BaseModelTestCase):
         galaxy_model_object_new = model.GalaxySession()
         session.add(galaxy_model_object_new)
         session.flush()
+        if session().in_transaction():
+            session.commit()
         assert galaxy.model.cached_id(galaxy_model_object_new)
         assert "id" in inspect(galaxy_model_object_new).unloaded
 

--- a/test/unit/data/test_metadata_limit.py
+++ b/test/unit/data/test_metadata_limit.py
@@ -7,6 +7,7 @@ from galaxy.model import (
     HistoryDatasetAssociation,
     set_datatypes_registry,
 )
+from galaxy.model.base import transaction
 
 METADATA_LIMIT = 500
 
@@ -30,7 +31,8 @@ def create_bed_data(sa_session, string_size):
     sa_session.add(hda)
     hda.metadata.column_names = [big_string]
     assert hda.metadata.column_names
-    sa_session.flush()
+    with transaction(sa_session):
+        sa_session.commit()
     return hda
 
 

--- a/test/unit/data/test_mutable_json_column.py
+++ b/test/unit/data/test_mutable_json_column.py
@@ -1,20 +1,25 @@
 import copy
 
 from galaxy import model
+from galaxy.model.base import transaction
 from .test_galaxy_mapping import BaseModelTestCase
 
 
 class TestMutableColumn(BaseModelTestCase):
     def persist_and_reload(self, item):
         item_id = item.id
-        self.model.session.flush()
+        session = self.model.session
+        with transaction(session):
+            session.commit()
         self.model.session.expunge_all()
         return self.model.session.query(model.DynamicTool).get(item_id)
 
     def test_metadata_mutable_column(self):
         w = model.DynamicTool()
         self.model.session.add(w)
-        self.model.session.flush()
+        session = self.model.session
+        with transaction(session):
+            session.commit()
         w.value = {"x": "z"}
         persisted = self.persist_and_reload(w)
         assert persisted.value == {"x": "z"}

--- a/test/unit/job_execution/test_job_io.py
+++ b/test/unit/job_execution/test_job_io.py
@@ -9,6 +9,7 @@ from galaxy.files import (
 )
 from galaxy.job_execution.setup import JobIO
 from galaxy.model import Job
+from galaxy.model.base import transaction
 from galaxy.model.unittest_utils import GalaxyDataTestApp
 
 WORKING_DIRECTORY = "/tmp"
@@ -40,7 +41,9 @@ def app() -> FileSourcesMockApp:
 def job(app: FileSourcesMockApp) -> Job:
     job = Job()
     app.model.session.add(job)
-    app.model.session.flush()
+    session = app.model.session
+    with transaction(session):
+        session.commit()
     return job
 
 

--- a/test/unit/workflows/test_run_parameters.py
+++ b/test/unit/workflows/test_run_parameters.py
@@ -1,4 +1,5 @@
 from galaxy import model
+from galaxy.model.base import transaction
 from galaxy.workflow.run_request import (
     _normalize_inputs,
     _normalize_step_parameters,
@@ -116,7 +117,9 @@ def __workflow_fixure(trans):
         tool_id="cat1",
         order_index=4,
     )
-    trans.app.model.context.flush()
+    session = trans.app.model.context
+    with transaction(session):
+        session.commit()
     # Expunge and reload to ensure step state is as expected from database.
     workflow_id = workflow.id
     trans.app.model.context.expunge_all()

--- a/test/unit/workflows/test_workflow_progress.py
+++ b/test/unit/workflows/test_workflow_progress.py
@@ -1,4 +1,5 @@
 from galaxy import model
+from galaxy.model.base import transaction
 from galaxy.util.unittest import TestCase
 from galaxy.workflow.run import WorkflowProgress
 from .workflow_support import (
@@ -189,7 +190,9 @@ class TestWorkflowProgress(TestCase):
             self.invocation.workflow.step_by_index(1)
         )
         self.app.model.session.add(subworkflow_invocation)
-        self.app.model.session.flush()
+        session = self.app.model.session
+        with transaction(session):
+            session.commit()
         progress = self._new_workflow_progress()
         remaining_steps = progress.remaining_steps()
         (subworkflow_step, subworkflow_invocation_step) = remaining_steps[0]

--- a/test/unit/workflows/workflow_support.py
+++ b/test/unit/workflows/workflow_support.py
@@ -5,6 +5,7 @@ import yaml
 from galaxy import model
 from galaxy.app_unittest_utils import galaxy_mock
 from galaxy.managers.workflows import WorkflowsManager
+from galaxy.model.base import transaction
 from galaxy.workflow.modules import module_factory
 
 
@@ -20,7 +21,8 @@ class MockTrans:
         workflow.stored_workflow = stored_workflow
         stored_workflow.user = self.user
         self.sa_session.add(stored_workflow)
-        self.sa_session.flush()
+        with transaction(self.sa_session):
+            self.sa_session.commit()
         return stored_workflow
 
     @property


### PR DESCRIPTION
Ref. #12541

Incremental approach to switch to `autocommit=False`. (This setting is, likely, responsible for the vast majority of the 485K+ RemovedIn20Warning messages that prevent migration to SA 2.0)

Synopsis of approach:
1. Wrap relevant statements in a context manager that works the same for both autocommit setting
2. Set `autocommit=False`
3. Resolve issues handled (for now) by the hacky parts of the context manager

Note: in autocommit mode, a flush creates a new transaction and commits it. With autocommit turned off, a transaction may or may not exist; a flush does not create one, and neither does it issue a commit. Therefore, for our purposes, a flush with autocommit is equivalent to a commit (provided a transaction exists). That's the core of what the context manager takes care of. (This does not cover the case of a flush with arguments, which limits the flush to a subset of objects currently in the session)

Ref. SA docs [Library-level (but not driver level) “Autocommit” removed from both Core and ORM](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#library-level-but-not-driver-level-autocommit-removed-from-both-core-and-orm)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
