### PR TITLE
[23.0] Hide metadata auto-detection option if dataset is in improper state

### DIFF
--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -20,12 +20,12 @@
                                 @click="submit('attribute', 'attributes')">
                                 <font-awesome-icon icon="save" class="mr-1" />{{ "Save" | l }}
                             </b-button>
-                            <b-button @click="submit('attribute', 'autodetect')">
+                            <b-button v-if="!result['metadata_disable']" @click="submit('attribute', 'autodetect')">
                                 <font-awesome-icon icon="redo" class="mr-1" />{{ "Auto-detect" | l }}
                             </b-button>
                         </div>
                     </b-tab>
-                    <b-tab v-if="!result['conversion_disable'] || !result['datatype_disable']">
+                    <b-tab v-if="(!result['conversion_disable'] || !result['datatype_disable']) && !result['metadata_disable']">
                         <template v-slot:title>
                             <span v-if="!result['conversion_disable']">
                                 <font-awesome-icon icon="cog" class="mr-1" />{{ "Convert" | l }}

--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -25,7 +25,11 @@
                             </b-button>
                         </div>
                     </b-tab>
-                    <b-tab v-if="(!result['conversion_disable'] || !result['datatype_disable']) && !result['metadata_disable']">
+                    <b-tab
+                        v-if="
+                            (!result['conversion_disable'] || !result['datatype_disable']) &&
+                            !result['metadata_disable']
+                        ">
                         <template v-slot:title>
                             <span v-if="!result['conversion_disable']">
                                 <font-awesome-icon icon="cog" class="mr-1" />{{ "Convert" | l }}

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -490,10 +490,10 @@ export class InputParameterTerminal extends BaseInputTerminal {
         const effectiveThisType = this.effectiveType(this.type);
         const otherType = ("type" in other && other.type) || "data";
         const effectiveOtherType = this.effectiveType(otherType);
-        const canAccept = effectiveThisType === effectiveOtherType
+        const canAccept = effectiveThisType === effectiveOtherType;
         return new ConnectionAcceptable(
             canAccept,
-            canAccept ? null: `Cannot attach a ${effectiveOtherType} parameter to a ${effectiveThisType} input`
+            canAccept ? null : `Cannot attach a ${effectiveOtherType} parameter to a ${effectiveThisType} input`
         );
     }
 }

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -291,6 +291,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             if data.missing_meta():
                 message = 'Required metadata values are missing. Some of these values may not be editable by the user. Selecting "Auto-detect" will attempt to fix these values.'
                 status = "warning"
+            metadata_disable = data.state not in [trans.model.Dataset.states.OK, trans.model.Dataset.states.FAILED_METADATA]
             # datatype conversion
             conversion_options = [
                 (f"{convert_id} (using '{convert_name}')", convert_id)
@@ -369,6 +370,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                 "message": message,
                 "status": status,
                 "dataset_id": dataset_id,
+                "metadata_disable": metadata_disable,
                 "attribute_inputs": attribute_inputs,
                 "conversion_inputs": conversion_inputs,
                 "conversion_disable": conversion_disable,

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -295,7 +295,6 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                 trans.model.Dataset.states.OK,
                 trans.model.Dataset.states.FAILED_METADATA,
             ]
-            metadata_disable = data.state not in [trans.model.Dataset.states.OK, trans.model.Dataset.states.FAILED_METADATA]
             # datatype conversion
             conversion_options = [
                 (f"{convert_id} (using '{convert_name}')", convert_id)

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -291,6 +291,10 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             if data.missing_meta():
                 message = 'Required metadata values are missing. Some of these values may not be editable by the user. Selecting "Auto-detect" will attempt to fix these values.'
                 status = "warning"
+            metadata_disable = data.state not in [
+                trans.model.Dataset.states.OK,
+                trans.model.Dataset.states.FAILED_METADATA,
+            ]
             metadata_disable = data.state not in [trans.model.Dataset.states.OK, trans.model.Dataset.states.FAILED_METADATA]
             # datatype conversion
             conversion_options = [


### PR DESCRIPTION
Fixes #15360. As of right now the dataset attributes form is build and specified in the corresponding controller endpoint. This PR adds an additional flag to that controller attribute, verifying that the auto-detect and data conversion options are only shown if the dataset is in `OK` or `FAILED_METADATA` states.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
