### PR TITLE
[23.0] Move workflow node loading indicator

### DIFF
--- a/client/src/components/LoadingSpan.vue
+++ b/client/src/components/LoadingSpan.vue
@@ -1,7 +1,7 @@
 <template>
     <span>
-        <span :class="spinnerClasses"></span>
-        <span class="loading-message">{{ message }}.<span class="blinking">..</span></span>
+        <span :class="spinnerClasses" title="loading"></span>
+        <span v-if="!spinnerOnly" class="loading-message">{{ message }}.<span class="blinking">..</span></span>
     </span>
 </template>
 <script>
@@ -15,6 +15,11 @@ export default {
         message: {
             type: String,
             default: "Loading",
+        },
+        spinnerOnly: {
+            type: Boolean,
+            required: false,
+            default: false,
         },
     },
     computed: {

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -175,9 +175,7 @@ const workflowOutputs = computed(() => props.step.workflow_outputs || []);
 const connectionStore = useConnectionStore();
 const stateStore = useWorkflowStateStore();
 const stepStore = useWorkflowStepStore();
-const isLoading = computed(() =>
-    Boolean(stateStore.getStepLoadingState(props.id)?.loading)
-);
+const isLoading = computed(() => Boolean(stateStore.getStepLoadingState(props.id)?.loading));
 useNodePosition(el, props.id, stateStore);
 const title = computed(() => props.step.label || props.step.name);
 const idString = computed(() => `wf-node-step-${props.id}`);

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -176,7 +176,7 @@ const connectionStore = useConnectionStore();
 const stateStore = useWorkflowStateStore();
 const stepStore = useWorkflowStepStore();
 const isLoading = computed(() =>
-    Boolean(stateStore.getStepLoadingState(props.id)?.loading && props.step.outputs.length === 0)
+    Boolean(stateStore.getStepLoadingState(props.id)?.loading)
 );
 useNodePosition(el, props.id, stateStore);
 const title = computed(() => props.step.label || props.step.name);

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -11,8 +11,8 @@
         @move="onMoveTo"
         @pan-by="onPanBy">
         <div class="node-header unselectable clearfix" @click="makeActive" @keyup.enter="makeActive">
-            <loading-span v-if="isLoading" message="Loading details" />
             <b-button-group class="float-right">
+                <loading-span v-if="isLoading" spinner-only />
                 <b-button
                     v-if="canClone"
                     v-b-tooltip.hover
@@ -175,7 +175,9 @@ const workflowOutputs = computed(() => props.step.workflow_outputs || []);
 const connectionStore = useConnectionStore();
 const stateStore = useWorkflowStateStore();
 const stepStore = useWorkflowStepStore();
-const isLoading = computed(() => Boolean(stateStore.getStepLoadingState(props.id)?.loading));
+const isLoading = computed(() =>
+    Boolean(stateStore.getStepLoadingState(props.id)?.loading && props.step.outputs.length === 0)
+);
 useNodePosition(el, props.id, stateStore);
 const title = computed(() => props.step.label || props.step.name);
 const idString = computed(() => `wf-node-step-${props.id}`);


### PR DESCRIPTION
this is a presumably harmless way to close #15323

- It drops the mandatory text for the loading span component to allow for less intrusive indicator
- It ties the computed property that indicates loading to the initial load only (assuming that every step has at least one output, seems safe?)

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
