### PR TITLE
[23.0] Reduce workflow tool form request frequency

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormTool.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.test.js
@@ -11,9 +11,7 @@ import { createTestingPinia } from "@pinia/testing";
 const localVue = getLocalVue();
 
 describe("FormTool", () => {
-    let wrapper;
-
-    beforeEach(() => {
+    function mountTarget() {
         const store = new Vuex.Store({
             modules: {
                 user: mockModule(userStore),
@@ -21,7 +19,7 @@ describe("FormTool", () => {
             },
         });
 
-        wrapper = mount(FormTool, {
+        return mount(FormTool, {
             propsData: {
                 id: "input",
                 datatypes: [],
@@ -32,7 +30,7 @@ describe("FormTool", () => {
                         name: "tool_name",
                         version: "1.0",
                         description: "description",
-                        inputs: [],
+                        inputs: [{ name: "input", label: "input", type: "text", value: "value" }],
                         help: "help_text",
                         versions: ["1.0", "2.0", "3.0"],
                         citations: false,
@@ -46,15 +44,16 @@ describe("FormTool", () => {
             stubs: {
                 CurrentUser: MockCurrentUser({ id: "fakeuser" }),
                 ConfigProvider: MockConfigProvider({ id: "fakeconfig" }),
-                FormElement: { template: "<div>form-element</div>" },
                 ToolFooter: { template: "<div>tool-footer</div>" },
             },
             pinia: createTestingPinia(),
             provide: { store },
         });
-    });
+    }
 
     it("changes between different versions", async () => {
+        const wrapper = mountTarget();
+
         const dropdowns = wrapper.findAll(".tool-versions .dropdown-item");
         let version = dropdowns.at(1);
         expect(version.text()).toBe("Switch to 2.0");

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -163,9 +163,16 @@ export default {
         onLabel(newLabel) {
             this.$emit("onLabel", this.stepId, newLabel);
         },
+        /**
+         * Change event is triggered on component creation and input changes.
+         * @param { Object } values contains flat key-value pairs `prefixed-name=value`
+         */
         onChange(values) {
+            const initialRequest = Object.keys(this.mainValues).length === 0;
             this.mainValues = values;
-            this.postChanges();
+            if (!initialRequest) {
+                this.postChanges();
+            }
         },
         onChangePostJobActions(postJobActions) {
             this.$emit("onChangePostJobActions", this.stepId, postJobActions);

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -108,6 +108,7 @@
                             <div>
                                 <FormTool
                                     v-if="hasActiveNodeTool"
+                                    :key="activeStep.id"
                                     :step="activeStep"
                                     :datatypes="datatypes"
                                     @onChangePostJobActions="onChangePostJobActions"

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -490,10 +490,10 @@ export class InputParameterTerminal extends BaseInputTerminal {
         const effectiveThisType = this.effectiveType(this.type);
         const otherType = ("type" in other && other.type) || "data";
         const effectiveOtherType = this.effectiveType(otherType);
-        const canAccept = effectiveThisType === effectiveOtherType
+        const canAccept = effectiveThisType === effectiveOtherType;
         return new ConnectionAcceptable(
             canAccept,
-            canAccept ? null: `Cannot attach a ${effectiveOtherType} parameter to a ${effectiveThisType} input`
+            canAccept ? null : `Cannot attach a ${effectiveOtherType} parameter to a ${effectiveThisType} input`
         );
     }
 }


### PR DESCRIPTION
This PR ensure that an initial tool form loading and changing the active node in the workflow editor does not trigger a change request in the parent component. Related to: #15423.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
