### PR TITLE
[23.0] Resolve ``collection_type_source`` in workflow editor

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -409,6 +409,7 @@ export default {
             hide_modal(); // hide other modals created in utilities also...
         },
         async onRefactor(response) {
+            this.resetStores();
             await fromSimple(response.workflow);
             this._loadEditorData(response.workflow);
         },

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -254,6 +254,10 @@ export default {
         const hasChanges = ref(false);
         const hasInvalidConnections = computed(() => Object.keys(connectionsStore.invalidConnections).length > 0);
 
+        stepStore.$subscribe((mutation, state) => {
+            hasChanges.value = true;
+        });
+
         function resetStores() {
             connectionsStore.$reset();
             stepStore.$reset();
@@ -342,9 +346,6 @@ export default {
                 this.hasChanges = true;
             }
         },
-        steps(newSteps, oldSteps) {
-            this.hasChanges = true;
-        },
         hasChanges() {
             this.$emit("update:confirmation", this.hasChanges);
         },
@@ -357,7 +358,6 @@ export default {
     methods: {
         onUpdateStep(step) {
             this.stepStore.updateStep(step);
-            this.hasChanges = true;
         },
         onUpdateStepPosition(stepId, position) {
             const step = { ...this.steps[stepId], position };

--- a/client/src/components/Workflow/Editor/composables/useUniqueLabelError.ts
+++ b/client/src/components/Workflow/Editor/composables/useUniqueLabelError.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 
 export function useUniqueLabelError(
     workflowStateStore: ReturnType<typeof useWorkflowStepStore>,
-    label: string | undefined
+    label: string | null | undefined
 ) {
     const error = ref("");
     if (label && workflowStateStore.workflowOutputs[label]) {

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -402,7 +402,9 @@ describe("canAccept", () => {
         const collectionOut = terminals["list:list input"]["output"] as OutputCollectionTerminal;
         const collectionIn = terminals["list collection input"]["input1"] as InputCollectionTerminal;
         expect(collectionIn.canAccept(collectionOut).canAccept).toBe(true);
+        expect(collectionIn.isMappedOver()).toBe(false);
         collectionIn.connect(collectionOut);
+        expect(collectionIn.isMappedOver()).toBe(true);
         expect(collectionIn.mapOver).toEqual({ collectionType: "list", isCollection: true, rank: 1 });
         const intermediateOut = terminals["list collection input"]["out_file1"] as OutputCollectionTerminal;
         const otherListIn = terminals["list collection input 2"]["input1"] as InputCollectionTerminal;

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -1,6 +1,6 @@
 import { setActivePinia, createPinia } from "pinia";
 
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { useWorkflowStepStore, type TerminalSource } from "@/stores/workflowStepStore";
 import {
     terminalFactory,
     InputCollectionTerminal,
@@ -15,7 +15,11 @@ import {
 import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import type { DataOutput, Steps } from "@/stores/workflowStepStore";
-import { NULL_COLLECTION_TYPE_DESCRIPTION } from "./collectionTypeDescription";
+import {
+    ANY_COLLECTION_TYPE_DESCRIPTION,
+    CollectionTypeDescription,
+    NULL_COLLECTION_TYPE_DESCRIPTION,
+} from "./collectionTypeDescription";
 import { simpleSteps, advancedSteps } from "../test_fixtures";
 
 function setupAdvanced() {
@@ -33,6 +37,17 @@ function setupAdvanced() {
         }
     });
     return terminals;
+}
+
+function rebuildTerminal<T extends ReturnType<typeof terminalFactory>>(terminal: T): T {
+    let terminalSource: TerminalSource;
+    const step = terminal.stepStore.getStep(terminal.stepId);
+    if (terminal.terminalType === "input") {
+        terminalSource = step.inputs.find((input) => input.name == terminal.name)!;
+    } else {
+        terminalSource = step.outputs.find((output) => output.name == terminal.name)!;
+    }
+    return terminalFactory(terminal.stepId, terminalSource, testDatatypesMapper) as T;
 }
 
 describe("terminalFactory", () => {
@@ -64,6 +79,8 @@ describe("terminalFactory", () => {
         expect(terminals["any collection"]["output"]).toBeInstanceOf(OutputCollectionTerminal);
         expect(terminals["multi data"]["advanced|advanced_threshold"]).toBeInstanceOf(InputParameterTerminal);
         expect(terminals["list collection input"]["input1"]).toBeInstanceOf(InputCollectionTerminal);
+        expect(terminals["filter_failed"]["input"]).toBeInstanceOf(InputCollectionTerminal);
+        expect(terminals["filter_failed"]["output"]).toBeInstanceOf(OutputCollectionTerminal);
     });
     it("throws error on invalid terminalSource", () => {
         const invalidFactory = () => terminalFactory(1, {} as any, testDatatypesMapper);
@@ -281,11 +298,7 @@ describe("canAccept", () => {
         dataInTwo.disconnect(dataOut);
         // terminal isn't a reactive class in any way (worth a thought doing, but difficult!), the following happens when a new terminal is built
         // in useTerminal.ts
-        const rebuiltDataIn = terminalFactory(
-            dataIn.stepId,
-            advancedSteps[dataIn.stepId].inputs[0],
-            testDatatypesMapper
-        );
+        const rebuiltDataIn = rebuildTerminal(dataIn);
         expect(rebuiltDataIn.localMapOver.isCollection).toBe(false);
         expect(rebuiltDataIn.canAccept(simpleDataOut).canAccept).toBe(true);
     });
@@ -457,6 +470,20 @@ describe("canAccept", () => {
         expect(dataIn.canAccept(dataOut).canAccept).toBe(false);
         expect(dataIn.canAccept(dataOut).reason).toBe(
             "Effective output data type(s) [tabular] do not appear to match input type(s) [ab1]."
+        );
+    });
+    it("resolves collection type source", () => {
+        const filterFailedInput = terminals["filter_failed"]["input"] as InputCollectionTerminal;
+        const filterFailedOutput = terminals["filter_failed"]["output"] as OutputCollectionTerminal;
+        expect(filterFailedOutput.collectionType).toBe(ANY_COLLECTION_TYPE_DESCRIPTION);
+        const collectionOut = terminals["list input"]["output"] as OutputCollectionTerminal;
+        filterFailedInput.connect(collectionOut);
+        expect(rebuildTerminal(filterFailedOutput).collectionType).toStrictEqual(new CollectionTypeDescription("list"));
+        filterFailedInput.disconnect(collectionOut);
+        const listPairedOutput = terminals["list:paired input"]["output"] as OutputCollectionTerminal;
+        filterFailedInput.connect(listPairedOutput);
+        expect(rebuildTerminal(filterFailedOutput).collectionType).toStrictEqual(
+            new CollectionTypeDescription("list:paired")
         );
     });
 });

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -274,7 +274,7 @@ describe("canAccept", () => {
             "Can't map over this input with output collection type - this step has outputs defined constraining the mapping of this tool. Disconnect outputs and retry."
         );
     });
-    it("rejects attaching non-collection outputs to mapper over inputs", () => {
+    it("rejects attaching non-collection outputs to mapped-over inputs", () => {
         const collectionOut = terminals["list input"]["output"] as OutputCollectionTerminal;
         const simpleDataOut = terminals["data input"]["output"] as OutputTerminal;
         const dataIn = terminals["simple data"]["input"] as InputTerminal;

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -248,6 +248,11 @@ class BaseInputTerminal extends Terminal {
         }
         return null;
     }
+
+    isMappedOver(): boolean {
+        return Boolean(this.localMapOver.isCollection);
+    }
+
     connected() {
         return Boolean(this._getFirstOutputTerminal());
     }
@@ -404,10 +409,6 @@ export class InputTerminal extends BaseInputTerminal {
         super(attr);
         this.collection = false;
         this.getStepMapOver();
-    }
-
-    isMappedOver(): boolean {
-        return Boolean(this.localMapOver.isCollection);
     }
 
     attachable(other: BaseOutputTerminal) {

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -115,9 +115,8 @@ class Terminal extends EventEmitter {
         }
         if (
             !this.mapOver.equal(effectiveMapOver) &&
-            Object.values(this.stepStore.stepInputMapOver[this.stepId]).some((mapOver) =>
-                mapOver.equal(effectiveMapOver)
-            )
+            (effectiveMapOver.isCollection ||
+                !Object.values(this.stepStore.stepInputMapOver[this.stepId]).find((mapOver) => mapOver.isCollection))
         ) {
             this.stepStore.changeStepMapOver(this.stepId, effectiveMapOver);
         }

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -97,6 +97,7 @@ class Terminal extends EventEmitter {
         this.resetMappingIfNeeded(connection);
     }
     setMapOver(val: CollectionTypeDescriptor) {
+        // we use this method to determine the map over status based on all terminals connected to this step
         let outputVal = val;
         if (this.multiple) {
             // emulate list input
@@ -112,7 +113,12 @@ class Terminal extends EventEmitter {
             this.stepStore.changeStepInputMapOver(this.stepId, this.name, effectiveMapOver);
             this.localMapOver = effectiveMapOver;
         }
-        if (!this.mapOver.equal(effectiveMapOver)) {
+        if (
+            !this.mapOver.equal(effectiveMapOver) &&
+            Object.values(this.stepStore.stepInputMapOver[this.stepId]).some((mapOver) =>
+                mapOver.equal(effectiveMapOver)
+            )
+        ) {
             this.stepStore.changeStepMapOver(this.stepId, effectiveMapOver);
         }
     }
@@ -672,18 +678,55 @@ interface OutputCollectionTerminalArgs extends BaseOutputTerminalArgs {
 }
 
 export class OutputCollectionTerminal extends BaseOutputTerminal {
+    collectionTypeSource: string | null;
+
     constructor(attr: OutputCollectionTerminalArgs) {
         super(attr);
+        this.collectionTypeSource = null;
         if (attr.collection_type) {
             this.collectionType = new CollectionTypeDescription(attr.collection_type);
         } else {
-            const collectionTypeSource = attr.collection_type_source;
-            if (!collectionTypeSource) {
+            this.collectionTypeSource = attr.collection_type_source;
+            if (!this.collectionTypeSource) {
                 console.log("Warning: No collection type or collection type source defined.");
             }
-            this.collectionType = ANY_COLLECTION_TYPE_DESCRIPTION;
+            this.collectionType = this.getCollectionTypeFromInput() || ANY_COLLECTION_TYPE_DESCRIPTION;
         }
         this.isCollection = true;
+    }
+
+    getCollectionTypeFromInput() {
+        const connection = this.connectionStore.connections.find(
+            (connection) =>
+                connection.input.name === this.collectionTypeSource && connection.input.stepId === this.stepId
+        );
+        if (connection) {
+            const outputStep = this.stepStore.getStep(connection.output.stepId);
+            const inputStep = this.stepStore.getStep(this.stepId);
+            if (outputStep) {
+                const stepOutput = outputStep.outputs.find((output) => output.name == connection.output.name);
+                const stepInput = inputStep.inputs.find((input) => input.name === this.collectionTypeSource);
+                if (stepInput && stepOutput) {
+                    const outputTerminal = terminalFactory(connection.output.stepId, stepOutput, this.datatypesMapper);
+                    const inputTerminal = terminalFactory(connection.output.stepId, stepInput, this.datatypesMapper);
+                    // otherCollectionType is the mapped over output collection as it would appear at the input terminal
+                    const otherCollectionType = inputTerminal._otherCollectionType(outputTerminal);
+                    // we need to find which of the possible input collection types is connected
+                    if ("collectionTypes" in inputTerminal) {
+                        // collection_type_source must point at input collection terminal
+                        const connectedCollectionType = inputTerminal.collectionTypes.find(
+                            (collectionType) =>
+                                otherCollectionType.canMatch(collectionType) ||
+                                otherCollectionType.canMapOver(collectionType)
+                        );
+                        if (connectedCollectionType) {
+                            return connectedCollectionType;
+                        }
+                    }
+                }
+            }
+        }
+        return ANY_COLLECTION_TYPE_DESCRIPTION;
     }
 }
 

--- a/client/src/components/Workflow/Editor/test-data/parameter_steps.json
+++ b/client/src/components/Workflow/Editor/test-data/parameter_steps.json
@@ -812,5 +812,99 @@
       "left": 70.45245361328125,
       "top": 316.3525695800781
     }
+  },
+  "17": {
+    "id": 17,
+    "type": "tool",
+    "label": "filter_failed",
+    "content_id": "__FILTER_FAILED_DATASETS__",
+    "name": "Filter failed datasets",
+    "tool_state": {
+      "input": "{\"__class__\": \"RuntimeValue\"}",
+      "__page__": null,
+      "__rerun_remap_job_id__": null
+    },
+    "errors": null,
+    "inputs": [
+      {
+        "name": "input",
+        "label": "Input Collection",
+        "multiple": false,
+        "input_type": "dataset_collection",
+        "collection_types": [
+          "list",
+          "list:paired"
+        ],
+        "optional": false,
+        "extensions": [
+          "data"
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "output",
+        "extensions": [
+          "input"
+        ],
+        "type": "collection",
+        "optional": false,
+        "collection": true,
+        "collection_type": null,
+        "collection_type_source": "input",
+        "label": "input dataset(s) (filtered failed datasets)"
+      }
+    ],
+    "annotation": "",
+    "post_job_actions": {},
+    "uuid": "f5de18b9-b08e-4160-b71b-54768a4e5208",
+    "when": null,
+    "workflow_outputs": [
+      {
+        "output_name": "output",
+        "uuid": "3774e554-b7d1-41ba-9acd-ee82ba9fbf54",
+        "label": null
+      }
+    ],
+    "input_connections": {},
+    "position": {
+      "left": 0,
+      "top": 0
+    }
+  },
+  "18": {
+    "id": 18,
+    "type": "data_collection_input",
+    "label": "list:paired input",
+    "content_id": null,
+    "name": "Input dataset collection",
+    "tool_state": {
+      "collection_type": "\"list:paired\"",
+      "optional": "\"false\"",
+      "tag": "\"\"",
+      "__page__": null,
+      "__rerun_remap_job_id__": null
+    },
+    "errors": null,
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "output",
+        "extensions": [
+          "input"
+        ],
+        "collection": true,
+        "collection_type": "list:paired",
+        "optional": false
+      }
+    ],
+    "annotation": "",
+    "post_job_actions": {},
+    "workflow_outputs": [],
+    "input_connections": {},
+    "position": {
+      "left": 12.8729248046875,
+      "top": 501.7839660644531
+    }
   }
 }

--- a/client/src/stores/workflowConnectionStore.ts
+++ b/client/src/stores/workflowConnectionStore.ts
@@ -34,6 +34,7 @@ export interface BaseTerminal {
 
 export interface InputTerminal extends BaseTerminal {
     connectorType: "input";
+    input_subworkflow_step_id?: number;
 }
 
 export interface OutputTerminal extends BaseTerminal {

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -85,8 +85,8 @@ export type TerminalSource = InputTerminalSource | OutputTerminalSource;
 
 interface WorkflowOutput {
     output_name: string;
-    label?: string;
-    uuid?: string;
+    label?: string | null;
+    uuid?: string | null;
 }
 
 export interface NewStep {
@@ -97,7 +97,7 @@ export interface NewStep {
     errors?: string[] | null;
     input_connections: StepInputConnection;
     inputs: Array<InputTerminalSource>;
-    label?: string;
+    label?: string | null;
     name: string;
     outputs: Array<OutputTerminalSource>;
     position?: StepPosition;
@@ -106,7 +106,7 @@ export interface NewStep {
     tooltip?: string;
     type: "tool" | "data_input" | "data_collection_input" | "subworkflow" | "parameter_input" | "pause";
     uuid?: string;
-    when?: string;
+    when?: string | null;
     workflow_outputs?: WorkflowOutput[];
 }
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2051,6 +2051,8 @@ steps:
       inputs:
         some_file:
           type: data
+        should_run:
+          type: boolean
       steps:
         a_tool_step:
           tool_id: cat1
@@ -2154,6 +2156,7 @@ steps:
       class: GalaxyWorkflow
       inputs:
         boolean_input_file: data
+        should_run: boolean
       steps:
         consume_expression_parameter:
           tool_id: cat1

--- a/lib/galaxy_test/base/workflow_fixtures.py
+++ b/lib/galaxy_test/base/workflow_fixtures.py
@@ -1012,6 +1012,7 @@ steps:
       class: GalaxyWorkflow
       inputs:
         boolean_input_file: data
+        should_run: boolean
       steps:
         create_more_inputs:
           tool_id: collection_creates_dynamic_nested

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -697,7 +697,10 @@ steps:
         workflow_populator.upload_yaml_workflow(WORKFLOW_OPTIONAL_TRUE_INPUT_COLLECTION, name=child_workflow_name)
         parent_workflow_id = workflow_populator.upload_yaml_workflow(
             """class: GalaxyWorkflow
-inputs: []
+inputs:
+  input_collection:
+    type: collection
+    collection_type: "list"
 steps:
   - tool_id: multiple_versions
     tool_version: 0.1
@@ -716,10 +719,16 @@ steps:
         self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_workflow_has_changes_and_save()
         workflow = self.workflow_populator.download_workflow(parent_workflow_id)
-        subworkflow_step = workflow["steps"]["1"]
+        subworkflow_step = workflow["steps"]["2"]
         assert subworkflow_step["name"] == child_workflow_name
         assert subworkflow_step["type"] == "subworkflow"
         assert subworkflow_step["subworkflow"]["a_galaxy_workflow"] == "true"
+        self.workflow_editor_connect("input_collection#output", f"{child_workflow_name}#input1")
+        self.assert_connected("input_collection#output", f"{child_workflow_name}#input1")
+        self.assert_workflow_has_changes_and_save()
+        workflow = self.workflow_populator.download_workflow(parent_workflow_id)
+        subworkflow_step = workflow["steps"]["2"]
+        assert subworkflow_step["input_connections"]["input1"]["input_subworkflow_step_id"] == 0
 
     @selenium_test
     def test_editor_insert_steps(self):


### PR DESCRIPTION
And make dealing with any as the `collection_type_source` more robust.
Fixes an infinite loop when opening https://usegalaxy.org/published/workflow?id=f18c0f5f632ea3d5

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
