### PR TITLE
[23.0] Clarify info messages for Collection Edit tabs

### DIFF
--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -10,7 +10,7 @@
             </b-alert>
         </div>
         <b-tabs content-class="mt-3">
-            <b-tab @click="updateInfoMessage(newCollectionMessage + noQuotaIncreaseMessage)">
+            <b-tab @click="updateInfoMessage(newCollectionMessage + ' ' + noQuotaIncreaseMessage)">
                 <template v-slot:title> <font-awesome-icon icon="table" /> &nbsp; {{ l("Database/Build") }}</template>
                 <db-key-provider v-slot="{ item, loading }">
                     <div v-if="loading"><b-spinner label="Loading Database/Builds..."></b-spinner></div>

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -2,15 +2,15 @@
     <div aria-labelledby="collection-edit-view-heading">
         <h1 id="collection-edit-view-heading" class="h-lg">{{ l("Edit Collection Attributes") }}</h1>
         <b-alert show variant="info" dismissible>
-            {{ l(newCollectionInfoMessage) }}
+            {{ l(infoMessage) }}
         </b-alert>
         <div v-if="jobError">
             <b-alert show variant="danger" dismissible>
-                {{ errorMessage }}
+                {{ l(errorMessage) }}
             </b-alert>
         </div>
         <b-tabs content-class="mt-3">
-            <b-tab @click="noQuotaIncrease = true">
+            <b-tab @click="updateInfoMessage(newCollectionMessage + noQuotaIncreaseMessage)">
                 <template v-slot:title> <font-awesome-icon icon="table" /> &nbsp; {{ l("Database/Build") }}</template>
                 <db-key-provider v-slot="{ item, loading }">
                     <div v-if="loading"><b-spinner label="Loading Database/Builds..."></b-spinner></div>
@@ -24,13 +24,13 @@
                 </db-key-provider>
             </b-tab>
             <SuitableConvertersProvider :id="collection_id" v-slot="{ item }">
-                <b-tab v-if="item && item.length" @click="noQuotaIncrease = false">
+                <b-tab v-if="item && item.length" @click="updateInfoMessage(newCollectionMessage)">
                     <template v-slot:title> <font-awesome-icon icon="cog" /> &nbsp; {{ l("Convert") }}</template>
                     <suitable-converters-tab :suitable-converters="item" @clicked-convert="clickedConvert" />
                 </b-tab>
             </SuitableConvertersProvider>
             <ConfigProvider v-slot="{ config }">
-                <b-tab v-if="config.enable_celery_tasks">
+                <b-tab v-if="config.enable_celery_tasks" @click="updateInfoMessage(expectWaitTimeMessage)">
                     <template v-slot:title>
                         <font-awesome-icon icon="database" /> &nbsp; {{ l("Datatypes") }}
                     </template>
@@ -94,6 +94,10 @@ export default {
             jobError: null,
             noQuotaIncrease: true,
             loadingString: "Loading Datatypes",
+            infoMessage: "This will create a new collection in your History. Your quota will not increase.", //initialmessage on first/database tab
+            newCollectionMessage: "This will create a new collection in your History.",
+            noQuotaIncreaseMessage: "Your quota will not increase.",
+            expectWaitTimeMessage: "This operation might take a short while, depending on the size of your collection.",
         };
     },
     computed: {
@@ -103,13 +107,6 @@ export default {
         datatypeFromElements: function () {
             return this.attributesData.extension;
         },
-        newCollectionInfoMessage: function () {
-            let newCollectionMessage = "This will create a new collection in your History.";
-            if (this.noQuotaIncrease) {
-                newCollectionMessage += " Your quota usage will not increase.";
-            }
-            return newCollectionMessage;
-        },
         historyId: function () {
             return this.$store.getters["history/currentHistoryId"];
         },
@@ -118,6 +115,9 @@ export default {
         this.getCollectionDataAndAttributes();
     },
     methods: {
+        updateInfoMessage: function (strMessage) {
+            this.infoMessage = strMessage;
+        },
         getCollectionDataAndAttributes: async function () {
             let attributesGet = this.$store.getters.getCollectionAttributes(this.collection_id);
             if (attributesGet == null) {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -309,6 +309,7 @@ edit_dataset_attributes:
 
 edit_collection_attributes:
   selectors:
+    alert_info: 'div.alert-info'
     database_genome_tab:
       type: xpath
       selector: '//a[contains(text(), "Database/Build")]'

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -13,10 +13,10 @@ class TestCollectionEdit(SeleniumTestCase):
         self.create_simple_list_collection()
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
-        self.components.edit_collection_attributes.alert_info.wait_for_visible()
+        alert_element = self.components.edit_collection_attributes.alert_info.wait_for_visible()
         assert (
             "This will create a new collection in your History. Your quota will not increase."
-            in self.find_element_by_selector("div.alert-info").text
+            in alert_element.text
         )
         dataValue = "unspecified"
         self.check_current_data_value(dataValue)

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -30,10 +30,9 @@ class TestCollectionEdit(SeleniumTestCase):
         self.open_collection_edit_view()
         self.navigate_to_datatype_tab()
         alert_element = self.components.edit_collection_attributes.alert_info.wait_for_visible()
-        
+
         assert (
-            "This operation might take a short while, depending on the size of your collection."
-            in alert_element.text
+            "This operation might take a short while, depending on the size of your collection." in alert_element.text
         )
         dataValue = "txt"
         self.check_current_data_value(dataValue)

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -29,10 +29,11 @@ class TestCollectionEdit(SeleniumTestCase):
         self.create_simple_list_collection_txt()
         self.open_collection_edit_view()
         self.navigate_to_datatype_tab()
-        self.components.edit_collection_attributes.alert_info.wait_for_visible()
+        alert_element = self.components.edit_collection_attributes.alert_info.wait_for_visible()
+        
         assert (
             "This operation might take a short while, depending on the size of your collection."
-            in self.find_element_by_selector("div.alert-info").text
+            in alert_element.text
         )
         dataValue = "txt"
         self.check_current_data_value(dataValue)

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -13,6 +13,7 @@ class TestCollectionEdit(SeleniumTestCase):
         self.create_simple_list_collection()
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
+        self.components.edit_collection_attributes.alert_info.wait_for_visible()
         assert (
             "This will create a new collection in your History. Your quota will not increase."
             in self.find_element_by_selector("div.alert-info").text
@@ -31,6 +32,7 @@ class TestCollectionEdit(SeleniumTestCase):
         self.create_simple_list_collection_txt()
         self.open_collection_edit_view()
         self.navigate_to_datatype_tab()
+        self.components.edit_collection_attributes.alert_info.wait_for_visible()
         assert (
             "This operation might take a short while, depending on the size of your collection."
             in self.find_element_by_selector("div.alert-info").text

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -14,10 +14,7 @@ class TestCollectionEdit(SeleniumTestCase):
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
         alert_element = self.components.edit_collection_attributes.alert_info.wait_for_visible()
-        assert (
-            "This will create a new collection in your History. Your quota will not increase."
-            in alert_element.text
-        )
+        assert "This will create a new collection in your History. Your quota will not increase." in alert_element.text
         dataValue = "unspecified"
         self.check_current_data_value(dataValue)
         dataNew = "hg17"

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -13,6 +13,7 @@ class TestCollectionEdit(SeleniumTestCase):
         self.create_simple_list_collection()
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
+        assert "This will create a new collection in your History. Your quota will not increase." in self.find_element_by_selector("div.alert-info").text
         dataValue = "unspecified"
         self.check_current_data_value(dataValue)
         dataNew = "hg17"
@@ -27,6 +28,7 @@ class TestCollectionEdit(SeleniumTestCase):
         self.create_simple_list_collection_txt()
         self.open_collection_edit_view()
         self.navigate_to_datatype_tab()
+        assert "This operation might take a short while, depending on the size of your collection." in self.find_element_by_selector("div.alert-info").text
         dataValue = "txt"
         self.check_current_data_value(dataValue)
         dataNew = "tabular"

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -13,7 +13,10 @@ class TestCollectionEdit(SeleniumTestCase):
         self.create_simple_list_collection()
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
-        assert "This will create a new collection in your History. Your quota will not increase." in self.find_element_by_selector("div.alert-info").text
+        assert (
+            "This will create a new collection in your History. Your quota will not increase."
+            in self.find_element_by_selector("div.alert-info").text
+        )
         dataValue = "unspecified"
         self.check_current_data_value(dataValue)
         dataNew = "hg17"
@@ -28,7 +31,10 @@ class TestCollectionEdit(SeleniumTestCase):
         self.create_simple_list_collection_txt()
         self.open_collection_edit_view()
         self.navigate_to_datatype_tab()
-        assert "This operation might take a short while, depending on the size of your collection." in self.find_element_by_selector("div.alert-info").text
+        assert (
+            "This operation might take a short while, depending on the size of your collection."
+            in self.find_element_by_selector("div.alert-info").text
+        )
         dataValue = "txt"
         self.check_current_data_value(dataValue)
         dataNew = "tabular"


### PR DESCRIPTION
Fix for #15416
Ensures info message changes as you switch between tabs in the Collection Edit view 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Edit a Collection
  2. Note how the info message changes as you switch tabs

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
