### PR TITLE
[23.0] Add name+description ToolSearch

### DIFF
--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -109,7 +109,7 @@ export default {
                     this.$emit("onResults", this.favoritesResults);
                 } else {
                     // keys with sorting order
-                    const keys = { exact: 2, name: 1, description: 0 };
+                    const keys = { exact: 3, name: 2, description: 1, combined: 0 };
                     this.$emit("onResults", searchToolsByKeys(this.toolsList, keys, q));
                 }
             } else {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -89,7 +89,12 @@ export function searchToolsByKeys(tools, keys, query) {
     const returnedTools = [];
     for (const tool of tools) {
         for (const key of Object.keys(keys)) {
-            const actualValue = tool[key] ? tool[key].toLowerCase() : "";
+            let actualValue = "";
+            if (key === "combined") {
+                actualValue = tool.name.toLowerCase() + " " + tool.description.toLowerCase();
+            } else {
+                actualValue = tool[key] ? tool[key].toLowerCase() : "";
+            }
             const queryLowerCase = query.toLowerCase();
             if (actualValue.match(queryLowerCase)) {
                 // do we care for exact matches && is it an exact match ?

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -17,7 +17,7 @@ describe("test helpers in tool searching utilities", () => {
     });
 
     it("test tool search helper that searches for tools given keys", async () => {
-        const q = "collection";
+        let q = "collection";
         let expectedResults = [
             "__FILTER_FAILED_DATASETS__",
             "__FILTER_EMPTY_DATASETS__",

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -37,6 +37,12 @@ describe("test helpers in tool searching utilities", () => {
         keys = { description: 0, name: 1 };
         results = searchToolsByKeys(normalizeTools(toolsList), keys, q);
         expect(results).toEqual(expectedResults);
+
+        q = "filter empty datasets";
+        expectedResults = ["__FILTER_EMPTY_DATASETS__"];
+        keys = { description: 1, name: 2, combined: 0 };
+        results = searchToolsByKeys(normalizeTools(toolsList), keys, q);
+        expect(results).toEqual(expectedResults);
     });
 
     it("test tool filtering helpers on toolsList given list of ids", async () => {


### PR DESCRIPTION
Make tool searchable by full name (`name+description`) in `ToolSearch`. Fixes https://github.com/galaxyproject/galaxy/issues/15382

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
