### PR TITLE
[22.05] fix looks_like_yaml_or_cwl_with_class

### DIFF
--- a/lib/galaxy/tool_util/loader_directory.py
+++ b/lib/galaxy/tool_util/loader_directory.py
@@ -190,7 +190,7 @@ def looks_like_a_data_manager_xml(path):
 
 def as_dict_if_looks_like_yaml_or_cwl_with_class(path, classes):
     """
-    get a dict from yaml file if it contains `class: CLASS`, where CLASS is
+    get a dict from yaml file if it contains a line `class: CLASS`, where CLASS is
     any string given in CLASSES. must appear in the first 5k and also load
     properly in total.
     """
@@ -199,7 +199,7 @@ def as_dict_if_looks_like_yaml_or_cwl_with_class(path, classes):
             start_contents = f.read(5 * 1024)
         except UnicodeDecodeError:
             return False, None
-        if re.search(rf"\nclass:\s+({'|'.join(classes)})\s*\n", start_contents) is None:
+        if re.search(rf"^class:\s+{'|'.join(classes)}\s*$", start_contents, re.MULTILINE) is None:
             return False, None
 
     with open(path) as f:

--- a/test/unit/tool_util/test_loader_directory.py
+++ b/test/unit/tool_util/test_loader_directory.py
@@ -3,6 +3,7 @@ import tempfile
 
 from galaxy.tool_util.loader_directory import is_a_yaml_with_class
 
+
 def test_is_a_yaml_with_class():
     with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
         fname = tf.name

--- a/test/unit/tool_util/test_loader_directory.py
+++ b/test/unit/tool_util/test_loader_directory.py
@@ -1,11 +1,10 @@
-import os
 import tempfile
 
 from galaxy.tool_util.loader_directory import is_a_yaml_with_class
 
 
 def test_is_a_yaml_with_class():
-    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml") as tf:
         fname = tf.name
         tf.write(
             """class: GalaxyWorkflow
@@ -21,6 +20,5 @@ steps:
     in:
       input1: input1"""
         )
-
-    assert is_a_yaml_with_class(fname, ["GalaxyWorkflow"])
-    os.unlink(fname)
+        tf.flush()
+        assert is_a_yaml_with_class(fname, ["GalaxyWorkflow"])

--- a/test/unit/tool_util/test_loader_directory.py
+++ b/test/unit/tool_util/test_loader_directory.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+
+from galaxy.tool_util.loader_directory import is_a_yaml_with_class
+
+def test_is_a_yaml_with_class():
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
+        fname = tf.name
+        tf.write("""class: GalaxyWorkflow
+name: "Test Workflow"
+inputs:
+  - id: input1
+outputs:
+  - id: wf_output_1
+    outputSource: first_cat/out_file1
+steps:
+  - tool_id: cat
+    label: first_cat
+    in:
+      input1: input1""")
+
+    assert is_a_yaml_with_class(fname, ["GalaxyWorkflow"])
+    os.unlink(fname)

--- a/test/unit/tool_util/test_loader_directory.py
+++ b/test/unit/tool_util/test_loader_directory.py
@@ -7,7 +7,8 @@ from galaxy.tool_util.loader_directory import is_a_yaml_with_class
 def test_is_a_yaml_with_class():
     with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as tf:
         fname = tf.name
-        tf.write("""class: GalaxyWorkflow
+        tf.write(
+            """class: GalaxyWorkflow
 name: "Test Workflow"
 inputs:
   - id: input1
@@ -18,7 +19,8 @@ steps:
   - tool_id: cat
     label: first_cat
     in:
-      input1: input1""")
+      input1: input1"""
+        )
 
     assert is_a_yaml_with_class(fname, ["GalaxyWorkflow"])
     os.unlink(fname)


### PR DESCRIPTION
the string `class: ...` might appear on the first line hence the leading `\n` was wrong

I guess its better to use `^` and `$` and add the MULTILINE flag

Bug has been introduced here: https://github.com/galaxyproject/galaxy/pull/12604

Suggestions for tests welcome

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
