### PR TITLE
[23.0] Adjust to bleach.ALLOWED_PROTOCOLS being frozenset

### DIFF
--- a/lib/galaxy/util/sanitize_html.py
+++ b/lib/galaxy/util/sanitize_html.py
@@ -252,5 +252,5 @@ _acceptable_attributes = [
 def sanitize_html(htmlSource, allow_data_urls=False):
     kwd = dict(tags=_acceptable_elements, attributes=_acceptable_attributes, strip=True)
     if allow_data_urls:
-        kwd["protocols"] = bleach.ALLOWED_PROTOCOLS + ["data"]
+        kwd["protocols"] = list(bleach.ALLOWED_PROTOCOLS) + ["data"]
     return bleach.clean(unicodify(htmlSource), **kwd)


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/actions/runs/4042668405/jobs/6950651177#step:7:6788 and works with lists (bleach < 6) and sets (bleach >= 6).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
