### PR TITLE
Display beginning of non-text files as text instead of triggering a download

### DIFF
--- a/templates/webapps/galaxy/dataset/binary_file.mako
+++ b/templates/webapps/galaxy/dataset/binary_file.mako
@@ -1,0 +1,17 @@
+<%inherit file="/base.mako"/>
+<%namespace file="/dataset/display.mako" import="render_deleted_data_message" />
+
+${ render_deleted_data_message( data ) }
+
+<div class="warningmessagelarge">
+    This is a binary (or unknown to Galaxy) dataset of size ${ file_size }. Preview is not implemented for this filetype. Displaying
+    %if truncated:
+first 100KB
+    %endif
+ as ASCII text<br/>
+    <a href="${h.url_for( controller='dataset', action='display', dataset_id=trans.security.encode_id( data.id ), to_ext=data.ext )}">Download</a>
+</div>
+
+<pre>
+${ util.unicodify( file_contents ) | h }
+</pre>


### PR DESCRIPTION
display the first 100K of a binary file or a file whose type is unknown to Galaxy as ASCII text instead of downloading this file.

If a user clicks on the "eye" button for a binary dataset (or a dataset with an unknown type), Galaxy downloads the whole file. This is probably not what a user wants, especially for large files. Even worse, when using an object store, the file will be fetched from that store and then sent to the web client. So, we implemented displaying a warning and first 100K as an ASCII text, which in many cases still gives an idea of what is inside the file.

<img width="1492" alt="image" src="https://user-images.githubusercontent.com/17157816/215515421-9480e251-ccee-4d70-89c8-fbb657e608e1.png">



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Upload a binary file to Galaxy
  2. Click on the "eye" button to display the file.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
