### PR TITLE
Drop defineEmits import from FormUpload

### DIFF
--- a/client/src/components/Form/Elements/FormUpload.vue
+++ b/client/src/components/Form/Elements/FormUpload.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, defineEmits, computed } from "vue";
+import { ref, computed } from "vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 const props = defineProps({
     value: {


### PR DESCRIPTION
 `defineEmits` is a compiler macro and no longer needs to be imported

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
