### PR TITLE
[23.0] Fix workflow toolbox sorting of workflows

### DIFF
--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -97,6 +97,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        sortItems: {
+            type: Boolean,
+            default: true,
+        },
     },
     setup() {
         const { config, isLoaded } = useConfig();
@@ -135,6 +139,7 @@ export default {
             if (
                 this.isLoaded &&
                 this.config.toolbox_auto_sort === true &&
+                this.sortItems === true &&
                 !this.category.elems.some((el) => el.text !== undefined && el.text !== "")
             ) {
                 const elements = [...this.category.elems];

--- a/client/src/components/Panels/ToolBoxWorkflow.vue
+++ b/client/src/components/Panels/ToolBoxWorkflow.vue
@@ -59,6 +59,7 @@
                     :key="workflowSection.name"
                     :category="workflowSection"
                     section-name="workflows"
+                    sort-items="false"
                     operation-icon="fa fa-files-o"
                     operation-title="Insert individual steps."
                     :query-filter="query"


### PR DESCRIPTION
 Prevent tool panel from sorting workflows list -- it was noted that this is, unlike the tool sections, actually a chronologically ordered list that is more useful that way.

fixes #15454 


The two toolboxes (standard and workflow) could use some refactoring to reduce duplication and handle this the same way, but in the interest of a minimal fix this should do the trick for 23.0.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
