### PR TITLE
[23.0] Vue proptype fixes

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormOutput.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutput.vue
@@ -84,7 +84,6 @@
 import FormCard from "@/components/Form/FormCard";
 import FormElement from "@/components/Form/FormElement";
 import FormOutputLabel from "@/components/Workflow/Editor/Forms/FormOutputLabel";
-import { Step } from "@/stores/workflowStepStore";
 
 const actions = [
     "RenameDatasetAction__newname",
@@ -129,7 +128,8 @@ export default {
             required: true,
         },
         step: {
-            type: Step,
+            // type  Step from "@/stores/workflowStepStore";
+            type: Object,
             required: true,
         },
     },

--- a/client/src/components/Workflow/Editor/Forms/FormSection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormSection.vue
@@ -30,7 +30,6 @@
 <script>
 import FormElement from "@/components/Form/FormElement";
 import FormOutput from "@/components/Workflow/Editor/Forms/FormOutput";
-import { Step } from "@/stores/workflowStepStore";
 
 export default {
     components: {
@@ -51,7 +50,8 @@ export default {
             required: true,
         },
         step: {
-            type: Step,
+            // type Step from "@/stores/workflowStepStore";
+            type: Object,
             required: true,
         },
         datatypes: {

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -32,7 +32,6 @@ import { useCoordinatePosition } from "./composables/useCoordinatePosition";
 import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import { computed } from "vue";
 import { inject, ref, toRefs, watchEffect } from "vue";
-import { UseElementBoundingReturn } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { useTerminal } from "./composables/useTerminal";
 import { DatatypesMapperModel } from "@/components/Datatypes/model";
@@ -58,7 +57,8 @@ export default {
             required: true,
         },
         rootOffset: {
-            type: UseElementBoundingReturn,
+            // type UseElementBoundingReturn from "@vueuse/core";
+            type: Object,
             required: true,
         },
         scale: {

--- a/client/src/components/Workflow/Editor/WorkflowMinimap.vue
+++ b/client/src/components/Workflow/Editor/WorkflowMinimap.vue
@@ -22,7 +22,7 @@
 <script>
 import MinimapNode from "./MinimapNode.vue";
 import { computed, reactive, ref } from "vue";
-import { useDraggable, UseElementBoundingReturn } from "@vueuse/core";
+import { useDraggable } from "@vueuse/core";
 import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
 
 export default {
@@ -53,7 +53,8 @@ export default {
             },
         },
         rootOffset: {
-            type: UseElementBoundingReturn,
+            // type UseElementBoundingReturn from "@vueuse/core";
+            type: Object,
             required: true,
         },
     },


### PR DESCRIPTION
A couple of these are also addressed in https://github.com/galaxyproject/galaxy/pull/15311/files, which we will want to apply to dev, but this PR targets 23.0 with a few more instances of this same issue.

These actually seemed to all work in usage, but this resolves the warning as seen at build time:

```
WARNING in ./src/components/Workflow/Editor/WorkflowMinimap.vue?vue&type=script&lang=js& (./node_modules/vue-loader/lib/index.js??vue-loader-options!./src/components/Workflow/Editor/WorkflowMinimap.vue?vue&type=script&lang=js&) 35:18-42
export 'UseElementBoundingReturn' (imported as 'UseElementBoundingReturn') was not found in '@vueuse/core'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
