### PR TITLE
[23.0] Fix runtime type checking for toolbox sorting

### DIFF
--- a/client/src/components/Panels/ToolBoxWorkflow.vue
+++ b/client/src/components/Panels/ToolBoxWorkflow.vue
@@ -59,7 +59,7 @@
                     :key="workflowSection.name"
                     :category="workflowSection"
                     section-name="workflows"
-                    sort-items="false"
+                    :sort-items="false"
                     operation-icon="fa fa-files-o"
                     operation-title="Insert individual steps."
                     :query-filter="query"


### PR DESCRIPTION
Incidentally worked fine `(!== true)`, but it throws a runtime warning.  This is a boolean, not a string.

Followup to https://github.com/galaxyproject/galaxy/pull/15455

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
