### PR TITLE
[23.0] More comfortable initial pan for workflow editor

### DIFF
--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -68,7 +68,7 @@ const canvas: Ref<HTMLElement | null> = ref(null);
 
 const elementBounding = useElementBounding(canvas, { windowResize: false, windowScroll: false });
 const scroll = useScroll(canvas);
-const { transform, panBy, setZoom, moveTo } = useD3Zoom(1, minZoom, maxZoom, canvas, scroll);
+const { transform, panBy, setZoom, moveTo } = useD3Zoom(1, minZoom, maxZoom, canvas, scroll, { x: 20, y: 20 });
 
 const isDragging = ref(false);
 provide("isDragging", isDragging);

--- a/client/src/components/Workflow/Editor/composables/d3Zoom.ts
+++ b/client/src/components/Workflow/Editor/composables/d3Zoom.ts
@@ -17,9 +17,10 @@ export function useD3Zoom(
     minZoom: number,
     maxZoom: number,
     targetRef: Ref<HTMLElement | null>,
-    scroll: UseScrollReturn
+    scroll: UseScrollReturn,
+    initialPan: XYPosition = { x: 0, y: 0 }
 ) {
-    const transform = ref({ x: 0, y: 0, k: k });
+    const transform = ref({ x: initialPan.x, y: initialPan.y, k: k });
     const d3Zoom = zoom<HTMLElement, unknown>().filter(filter).scaleExtent([minZoom, maxZoom]);
 
     watch(targetRef, () => {


### PR DESCRIPTION
Just adds a bit of an initial pan, to avoid the nodes being so snug to the topleft, like this:

![image](https://user-images.githubusercontent.com/155398/215873757-6f2e48ce-a5ce-4d7a-a75d-40a869fdb024.png)

The 20px here looks like this:

![image](https://user-images.githubusercontent.com/155398/215873936-db07c895-8ae5-4a04-b7e7-485a2c435225.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
