### PR TITLE
Make serving address more visible in console

### DIFF
--- a/lib/galaxy/web_stack/__init__.py
+++ b/lib/galaxy/web_stack/__init__.py
@@ -229,7 +229,8 @@ class GunicornApplicationStack(ApplicationStack):
     def log_startup(self):
         msg = [f"Galaxy server instance '{self.config.server_name}' is running"]
         if "GUNICORN_LISTENERS" in os.environ:
-            msg.append(f'serving on {os.environ["GUNICORN_LISTENERS"]}')
+            message = f'\nServing on {os.environ["GUNICORN_LISTENERS"]}\n'
+            msg.append(f"\033[92m{message}\033[0m")  # Highlight in green
         log.info("\n".join(msg))
 
 


### PR DESCRIPTION
This just makes the serving address easier to tell apart from the rest of the log in the console. Sometimes it takes me 2 seconds instead of 0.5 to notice if the server is already running :stuck_out_tongue: 

Feel free to directly close this one as it may render uglier in the actual log files.

## Before

![Screenshot from 2023-02-01 10-26-37](https://user-images.githubusercontent.com/46503462/216003594-f78356c0-a2df-40f7-929f-5752f1bd6d51.png)


## After :sparkles: 

![Screenshot from 2023-02-01 10-18-29](https://user-images.githubusercontent.com/46503462/216003366-d7aacaeb-d49b-4eb6-b432-9c19f8851da2.png)


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
