### PR TITLE
[23.0] Fix multi-input connection handling in workflow editor

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -646,6 +646,7 @@ export default {
             const stepData = {
                 name: name,
                 content_id: contentId,
+                input_connections: {},
                 type: type,
                 outputs: [],
                 position: defaultPosition(this.graphOffset, this.transform),

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -152,6 +152,38 @@ describe("canAccept", () => {
         multiDataIn.connect(collectionOut);
         expect(multiDataIn.mapOver).toBe(NULL_COLLECTION_TYPE_DESCRIPTION);
     });
+    it("accepts multiple simple data inputs on multi-data input", () => {
+        const multiDataIn = terminals["multi data"]!["f1"] as InputTerminal;
+        const dataOutOne = terminals["data input"]!["output"] as OutputTerminal;
+        const dataOutTwo = terminals["simple data"]!["out_file1"] as OutputTerminal;
+        let step = stepStore.getStep(multiDataIn.stepId)!;
+        expect(step.input_connections["f1"]).toBe(undefined);
+        multiDataIn.connect(dataOutOne);
+        step = stepStore.getStep(multiDataIn.stepId)!;
+        expect(step.input_connections["f1"]).toStrictEqual([{ id: dataOutOne.stepId, output_name: dataOutOne.name }]);
+        multiDataIn.connect(dataOutTwo);
+        step = stepStore.getStep(multiDataIn.stepId)!;
+        expect(step.input_connections["f1"]).toStrictEqual([
+            { id: dataOutOne.stepId, output_name: dataOutOne.name },
+            { id: dataOutTwo.stepId, output_name: dataOutTwo.name },
+        ]);
+        multiDataIn.disconnect(dataOutTwo);
+        step = stepStore.getStep(multiDataIn.stepId)!;
+        expect(step.input_connections["f1"]).toStrictEqual([{ id: dataOutOne.stepId, output_name: dataOutOne.name }]);
+        multiDataIn.disconnect(dataOutOne);
+        step = stepStore.getStep(multiDataIn.stepId)!;
+        expect(step.input_connections["f1"]).toStrictEqual([]);
+        multiDataIn.connect(dataOutOne);
+        multiDataIn.connect(dataOutTwo);
+        step = stepStore.getStep(multiDataIn.stepId)!;
+        expect(step.input_connections["f1"]).toStrictEqual([
+            { id: dataOutOne.stepId, output_name: dataOutOne.name },
+            { id: dataOutTwo.stepId, output_name: dataOutTwo.name },
+        ]);
+        stepStore.removeStep(dataOutTwo.stepId);
+        step = stepStore.getStep(multiDataIn.stepId)!;
+        expect(step.input_connections["f1"]).toStrictEqual([{ id: dataOutOne.stepId, output_name: dataOutOne.name }]);
+    });
     it("accepts separate list:list inputs on separate multi-data inputs of same tool", () => {
         const collectionOut = terminals["list:list input"]["output"] as OutputCollectionTerminal;
         const multiDataInOne = terminals["multi data"]["f1"] as InputTerminal;

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -18,7 +18,6 @@ import type {
     TerminalSource,
 } from "@/stores/workflowStepStore";
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
-import Vue from "vue";
 
 export class ConnectionAcceptable {
     reason: string | null;

--- a/client/src/components/Workflow/Editor/test-data/simple_steps.json
+++ b/client/src/components/Workflow/Editor/test-data/simple_steps.json
@@ -73,10 +73,12 @@
     "uuid": "16626ff6-6484-4db2-bffc-71b69ff05b80",
     "workflow_outputs": [],
     "input_connections": {
-      "input": {
-        "output_name": "output",
-        "id": 0
-      }
+      "input": [
+        {
+          "output_name": "output",
+          "id": 0
+        }
+      ]
     },
     "position": {
       "left": 231.74591064453125,

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -241,21 +241,44 @@ export const useWorkflowStepStore = defineStore("workflowStepStore", {
             if (input && "input_subworkflow_step_id" in input && input.input_subworkflow_step_id !== undefined) {
                 connectionLink["input_subworkflow_step_id"] = input.input_subworkflow_step_id;
             }
+            let connectionLinks: ConnectionOutputLink[] = [connectionLink];
+            let inputConnection = inputStep.input_connections[connection.input.name];
+            if (inputConnection) {
+                if (!Array.isArray(inputConnection)) {
+                    inputConnection = [inputConnection];
+                }
+                inputConnection = inputConnection.filter(
+                    (connection) =>
+                        !(connection.id === connectionLink.id && connection.output_name === connectionLink.output_name)
+                );
+                connectionLinks = [...connectionLinks, ...inputConnection];
+            }
             const updatedStep = {
                 ...inputStep,
                 input_connections: {
                     ...inputStep.input_connections,
-                    [connection.input.name]: connectionLink,
+                    [connection.input.name]: connectionLinks.sort((a, b) =>
+                        a.id === b.id ? a.output_name.localeCompare(b.output_name) : a.id - b.id
+                    ),
                 },
             };
             this.updateStep(updatedStep);
         },
         removeConnection(connection: Connection) {
             const inputStep = this.getStep(connection.input.stepId);
+            const inputConnections = inputStep.input_connections[connection.input.name];
             if (this.getStepExtraInputs(inputStep.id).find((input) => connection.input.name === input.name)) {
                 inputStep.input_connections[connection.input.name] = undefined;
             } else {
-                Vue.delete(inputStep.input_connections, connection.input.name);
+                if (Array.isArray(inputConnections)) {
+                    inputStep.input_connections[connection.input.name] = inputConnections.filter(
+                        (outputLink) =>
+                            !(outputLink.id === connection.output.stepId,
+                            outputLink.output_name === connection.output.name)
+                    );
+                } else {
+                    Vue.delete(inputStep.input_connections, connection.input.name);
+                }
             }
             this.updateStep(inputStep);
         },
@@ -263,7 +286,7 @@ export const useWorkflowStepStore = defineStore("workflowStepStore", {
             const connectionStore = useConnectionStore();
             connectionStore
                 .getConnectionsForStep(stepId)
-                .map((connection) => connectionStore.removeConnection(connection.input));
+                .map((connection) => connectionStore.removeConnection(connection.id));
             Vue.delete(this.steps, stepId.toString());
         },
     },

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -286,7 +286,7 @@ export const useWorkflowStepStore = defineStore("workflowStepStore", {
             const connectionStore = useConnectionStore();
             connectionStore
                 .getConnectionsForStep(stepId)
-                .map((connection) => connectionStore.removeConnection(connection.id));
+                .forEach((connection) => connectionStore.removeConnection(connection.id));
             Vue.delete(this.steps, stepId.toString());
         },
     },


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15458, and also
fixes all input connections to a connected multi-input being removed when deleting a node that
connect to a multi-input.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
