### PR TITLE
[23.0] Fix incorrect warning for workflow output duplicate label

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.test.js
@@ -52,9 +52,13 @@ describe("FormOutputLabel", () => {
         const inputOther = wrapperOther.find("input");
         await input.setValue("new-label");
         expect(wrapper.find(".ui-form-error").exists()).toBe(false);
+        expect(wrapperOther.find(".ui-form-error").exists()).toBe(false);
         await inputOther.setValue("other-label");
+        expect(wrapper.find(".ui-form-error").exists()).toBe(false);
+        expect(wrapperOther.find(".ui-form-error").exists()).toBe(false);
         await input.setValue("other-label");
         expect(wrapper.find(".ui-form-error").text()).toBe("Duplicate output label 'other-label' will be ignored.");
+        expect(wrapperOther.find(".ui-form-error").exists()).toBe(false);
         expect(stepStore.workflowOutputs["new-label"].outputName).toBe("output-name");
     });
 });

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
@@ -45,7 +45,8 @@ const label = computed(() => {
 });
 
 function onInput(newLabel: string) {
-    if (!stepStore.workflowOutputs[newLabel]) {
+    const existingWorkflowOutput = stepStore.workflowOutputs[newLabel];
+    if (!existingWorkflowOutput) {
         const newWorkflowOutputs = [...(props.step.workflow_outputs || [])].filter(
             (workflowOutput) => workflowOutput.output_name !== props.name
         );
@@ -55,7 +56,7 @@ function onInput(newLabel: string) {
         });
         stepStore.updateStep({ ...props.step, workflow_outputs: newWorkflowOutputs });
         error.value = undefined;
-    } else {
+    } else if (existingWorkflowOutput.stepId !== props.step.id) {
         error.value = `Duplicate output label '${newLabel}' will be ignored.`;
     }
 }


### PR DESCRIPTION
Fixes #15456

There is a side effect though. Since we update the output label while typing, the output will have the last "valid" label applied.

![fix_wf_output_dup_label](https://user-images.githubusercontent.com/46503462/216049560-f5be2bf1-309a-4566-b643-e0662949875d.gif)

If we consider this undesired then we need to update the output label only on hitting enter or losing focus. Although the warning message clearly states that the duplicated label will be ignored.


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
