### PR TITLE
[23.0] Fix workflow output activiting on activating node

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
@@ -44,9 +44,26 @@ const label = computed(() => {
     return null;
 });
 
-function onInput(newLabel: string) {
+function onInput(newLabel: string | undefined | null) {
+    if (newLabel === undefined || newLabel === null) {
+        // form got activated or we set a workflow output through the checkbox
+        // shouldn't change status of error label or result in deleting the label
+        return;
+    }
+
+    if (newLabel === "") {
+        // user deleted existing label, we inactivate this as output
+        const strippedWorkflowOutputs = (props.step.workflow_outputs || []).filter(
+            (workflowOutput) => workflowOutput.output_name !== props.name
+        );
+        stepStore.updateStep({ ...props.step, workflow_outputs: strippedWorkflowOutputs });
+        error.value = undefined;
+        return;
+    }
+
     const existingWorkflowOutput = stepStore.workflowOutputs[newLabel];
     if (!existingWorkflowOutput) {
+        // got a new label that isn't in use yet
         const newWorkflowOutputs = [...(props.step.workflow_outputs || [])].filter(
             (workflowOutput) => workflowOutput.output_name !== props.name
         );

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -587,6 +587,8 @@ workflow_editor:
       output_terminal: "${_} [output-name='${name}']"
       input_terminal: "${_} [input-name='${name}']"
       input_mapping_icon: "${_} [input-name='${name}'].multiple"
+      workflow_output_toggle: "${_} .callout-terminal.${name}"
+      workflow_output_toggle_active: "${_} .callout-terminal.${name} .mark-terminal-active"
   selectors:
     canvas_body: '#workflow-canvas'
     edit_annotation: '#workflow-annotation'
@@ -628,6 +630,10 @@ workflow_editor:
       type: xpath
       selector: >
         //div[@id='form-element-__label__${output}']//input
+    duplicate_label_error:
+      type: xpath
+      selector: >
+        //div[@id='form-element-__label__${output}']//span[contains(text(), 'Duplicate output label')]
     rename_output:
       type: xpath
       selector: >

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -919,6 +919,77 @@ steps:
         output_connector.send_keys(Keys.SPACE)
         assert self.driver.switch_to.active_element.text == "No compatible input found in workflow"
 
+    @selenium_test
+    def test_workflow_output_handling(self):
+        self.open_in_workflow_editor(
+            """
+class: GalaxyWorkflow
+inputs: []
+outputs:
+  first_out:
+    outputSource: first/out_file1
+  second_out:
+    outputSource: second/out_file1
+steps:
+  first:
+    tool_id: create_2
+  second:
+    tool_id: create_2
+""",
+            auto_layout=True,
+        )
+        editor = self.components.workflow_editor
+        # assert both steps have one workflow output each
+        first = editor.node._(label="first")
+        first.workflow_output_toggle_active(name="out_file1").wait_for_visible()
+        first.workflow_output_toggle_active(name="out_file2").wait_for_absent()
+        second = editor.node._(label="second")
+        second.workflow_output_toggle_active(name="out_file1").wait_for_visible()
+        second.workflow_output_toggle_active(name="out_file2").wait_for_absent()
+        # toggle out_file1 on second step, both outputs not active
+        second.workflow_output_toggle(name="out_file1").wait_for_and_click()
+        # just toggling outputs doesn't set a label
+        second.workflow_output_toggle_active(name="out_file1").wait_for_absent()
+        second.workflow_output_toggle_active(name="out_file2").wait_for_absent()
+        # switch to first node
+        editor.node._(label="first").wait_for_and_click()
+        # toggle out_file1 on first step
+        first.workflow_output_toggle(name="out_file1").wait_for_and_click()
+        first.workflow_output_toggle_active(name="out_file1").wait_for_absent()
+        # turn out_file1 back on
+        first.workflow_output_toggle(name="out_file1").wait_for_and_click()
+        first.workflow_output_toggle_active(name="out_file1").wait_for_visible()
+        # turn out_file1 off
+        first.workflow_output_toggle(name="out_file1").wait_for_and_click()
+        first.workflow_output_toggle_active(name="out_file1").wait_for_absent()
+        editor.node._(label="second").wait_for_and_click()
+        editor.node._(label="first").wait_for_and_click()
+        # make sure workflow outputs are both off for second step
+        first.workflow_output_toggle_active(name="out_file1").wait_for_absent()
+        first.workflow_output_toggle_active(name="out_file2").wait_for_absent()
+        # add an output label
+        editor.configure_output(output="out_file1").wait_for_and_click()
+        output_label = editor.label_output(output="out_file1")
+        self.set_text_element(output_label, "workflow output label")
+        # should indicate active workflow output
+        first.workflow_output_toggle_active(name="out_file1").wait_for_visible()
+        self.set_text_element(output_label, "")
+        # deleting label also deletes active output
+        first.workflow_output_toggle_active(name="out_file1").wait_for_absent()
+        # set duplicate label
+        output_label = editor.label_output(output="out_file1")
+        self.set_text_element(output_label, "workflow output label")
+        editor.node._(label="second").wait_for_and_click()
+        editor.configure_output(output="out_file1").wait_for_and_click()
+        output_label = editor.label_output(output="out_file1")
+        self.set_text_element(output_label, "workflow output label")
+        # should show error
+        editor.duplicate_label_error(output="out_file1").wait_for_visible()
+        # make label unique
+        self.set_text_element(output_label, "workflow output label2")
+        # should not show error
+        editor.duplicate_label_error(output="out_file1").wait_for_absent()
+
     def workflow_editor_maximize_center_pane(self, collapse_left=True, collapse_right=True):
         if collapse_left:
             self.components._.left_panel_collapse.wait_for_and_click()


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15365

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
