### PR TITLE
Add framework test for profile behavior of `format="input"`

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -558,8 +558,11 @@ def lint_inputs(tool_source: "ToolSource", lint_ctx: "LintContext"):
                 )
 
 
-def lint_repeats(tool_xml, lint_ctx):
+def lint_repeats(tool_source: "ToolSource", lint_ctx):
     """Lint repeat blocks in tool inputs."""
+    tool_xml = getattr(tool_source, "xml_tree", None)
+    if tool_xml is None:
+        return
     repeats = tool_xml.findall("./inputs//repeat")
     for repeat in repeats:
         if "name" not in repeat.attrib:

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -116,16 +116,11 @@ def __check_format(node, lint_ctx, profile: str, allow_ext=False):
     if fmt is None:
         fmt = node.attrib.get("format")
     if fmt == "input":
+        message = f"Using format='input' on {node.tag} is deprecated. Use the format_source attribute."
         if profile <= "16.01":
-            lint_ctx.warn(
-                f"Using format='input' on {node.tag}: format_source attribute is less ambiguous and should be used instead (with a non-legacy tool profile).",
-                node=node,
-            )
+            lint_ctx.warn(message, node=node)
         else:
-            lint_ctx.error(
-                f"Using format='input' on {node.tag} is deprecated. Use the format_source attribute.",
-                node=node,
-            )
+            lint_ctx.error(message, node=node)
 
     return fmt is not None
 

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -1,6 +1,8 @@
 """This module contains a linting functions for tool outputs."""
 from typing import TYPE_CHECKING
 
+from packaging.version import Version
+
 from galaxy.util import (
     etree,
     string_as_bool,
@@ -117,7 +119,7 @@ def __check_format(node, lint_ctx, profile: str, allow_ext=False):
         fmt = node.attrib.get("format")
     if fmt == "input":
         message = f"Using format='input' on {node.tag} is deprecated. Use the format_source attribute."
-        if profile <= "16.01":
+        if Version(str(profile)) <= Version("16.01"):
             lint_ctx.warn(message, node=node)
         else:
             lint_ctx.error(message, node=node)

--- a/test/functional/tools/output_format_input.xml
+++ b/test/functional/tools/output_format_input.xml
@@ -1,0 +1,26 @@
+<tool id="output_format_input" name="output_format_input" version="1.0" profile="21.01">
+  <!-- test format="input" for the profile version where the format is set to "input"
+       (for legacy tools, i.e. profile <16.04, the format of a ramdom input is used) -->
+  <description></description>
+  <command>
+    cat '$input' > '$output'
+  </command>
+  <inputs>
+    <param format="tabular" name="input" type="data" label="Select cells from"/>
+  </inputs>
+  <outputs>
+    <data format="input" name="output" metadata_source="input" />
+  </outputs>
+  <tests>
+    <test>
+      <param name="input" value="simple_line.txt" ftype="txt" />
+      <output name="output" file="simple_line.txt" ftype="input"/>
+    </test>
+    <test>
+      <param name="input" value="simple_line.txt" ftype="tabular" />
+      <output name="output" file="simple_line.txt" ftype="input"/>
+    </test>
+  </tests>
+  <help>
+  </help>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -8,8 +8,9 @@
     <tool file="param_text_option.xml" />
     <tool file="column_param.xml" />
   </section>
-  <tool file="ucsc_tablebrowser.xml" />
-  <tool file="test_data_source.xml" />
+  <tool file="output_format_input.xml"/>
+  <tool file="ucsc_tablebrowser.xml"/>
+  <tool file="test_data_source.xml"/>
   <tool file="simple_constructs.xml" />
   <tool file="color_param.xml" />
   <tool file="inheritance_simple.xml" />

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1527,8 +1527,8 @@ def test_outputs_format_input_legacy(lint_ctx):
 
 
 def test_outputs_format_input(lint_ctx):
-    tool_xml_tree = get_xml_tree(OUTPUTS_FORMAT_INPUT)
-    run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
+    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_INPUT)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "1 outputs found." in lint_ctx.info_messages
     assert "Using format='input' on data is deprecated. Use the format_source attribute." in lint_ctx.error_messages
     assert len(lint_ctx.info_messages) == 1

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1115,8 +1115,8 @@ def test_help_invalid_rst(lint_ctx):
 
 
 def test_inputs_no_inputs(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_NO_INPUTS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_NO_INPUTS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found no input parameters." in lint_ctx.warn_messages
     assert not lint_ctx.info_messages
     assert not lint_ctx.valid_messages
@@ -1125,8 +1125,8 @@ def test_inputs_no_inputs(lint_ctx):
 
 
 def test_inputs_no_inputs_datasource(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_NO_INPUTS_DATASOURCE)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_NO_INPUTS_DATASOURCE)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "No input parameters, OK for data sources" in lint_ctx.info_messages
     assert "display tag usually present in data sources" in lint_ctx.info_messages
     assert "uihints tag usually present in data sources" in lint_ctx.info_messages
@@ -1137,8 +1137,8 @@ def test_inputs_no_inputs_datasource(lint_ctx):
 
 
 def test_inputs_valid(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_VALID)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_VALID)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 2 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
@@ -1147,8 +1147,8 @@ def test_inputs_valid(lint_ctx):
 
 
 def test_inputs_param_name(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_PARAM_NAME)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_PARAM_NAME)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 5 input parameters." in lint_ctx.info_messages
     assert "Param input [2] is not a valid Cheetah placeholder." in lint_ctx.warn_messages
     assert "Found param input with no name specified." in lint_ctx.error_messages
@@ -1164,8 +1164,8 @@ def test_inputs_param_name(lint_ctx):
 
 
 def test_inputs_param_type(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_PARAM_TYPE)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_PARAM_TYPE)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 2 input parameters." in lint_ctx.info_messages
     assert "Param input [valid_name] input with no type specified." in lint_ctx.error_messages
     assert "Param input [another_valid_name] with empty type specified." in lint_ctx.error_messages
@@ -1176,8 +1176,8 @@ def test_inputs_param_type(lint_ctx):
 
 
 def test_inputs_data_param(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_DATA_PARAM)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert (
         "Param input [valid_name] with no format specified - 'data' format will be assumed." in lint_ctx.warn_messages
@@ -1199,8 +1199,8 @@ def test_inputs_boolean_param(lint_ctx):
 
 
 def test_inputs_data_param_options(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_DATA_PARAM_OPTIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_OPTIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert not lint_ctx.valid_messages
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
@@ -1209,8 +1209,8 @@ def test_inputs_data_param_options(lint_ctx):
 
 
 def test_inputs_data_param_options_filter_attribute(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_DATA_PARAM_OPTIONS_FILTER_ATTRIBUTE)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_OPTIONS_FILTER_ATTRIBUTE)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert not lint_ctx.valid_messages
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
@@ -1219,8 +1219,8 @@ def test_inputs_data_param_options_filter_attribute(lint_ctx):
 
 
 def test_inputs_data_param_invalid_options(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_DATA_PARAM_INVALIDOPTIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_INVALIDOPTIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert not lint_ctx.valid_messages
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
@@ -1235,8 +1235,8 @@ def test_inputs_data_param_invalid_options(lint_ctx):
 
 
 def test_inputs_conditional(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_CONDITIONAL)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_CONDITIONAL)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 10 input parameters." in lint_ctx.info_messages
     assert "Conditional without a name" in lint_ctx.error_messages
     assert (
@@ -1262,8 +1262,8 @@ def test_inputs_conditional(lint_ctx):
 
 
 def test_inputs_select_incompatible_display(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_SELECT_INCOMPATIBLE_DISPLAY)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_SELECT_INCOMPATIBLE_DISPLAY)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 3 input parameters." in lint_ctx.info_messages
     assert 'Select [radio_select] display="radio" is incompatible with optional="true"' in lint_ctx.error_messages
     assert 'Select [radio_select] display="radio" is incompatible with multiple="true"' in lint_ctx.error_messages
@@ -1282,8 +1282,8 @@ def test_inputs_select_incompatible_display(lint_ctx):
 
 
 def test_inputs_duplicated_options(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_SELECT_DUPLICATED_OPTIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_SELECT_DUPLICATED_OPTIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert "Select parameter [select] has multiple options with the same text content" in lint_ctx.error_messages
     assert "Select parameter [select] has multiple options with the same value" in lint_ctx.error_messages
@@ -1294,15 +1294,15 @@ def test_inputs_duplicated_options(lint_ctx):
 
 
 def test_inputs_duplicated_options_with_different_select(lint_ctx):
-    tool_xml_tree = get_xml_tree(SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert not lint_ctx.warn_messages
     assert not lint_ctx.error_messages
 
 
 def test_inputs_select_deprections(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_SELECT_DEPRECATIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_SELECT_DEPRECATIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 3 input parameters." in lint_ctx.info_messages
     assert "Select parameter [select_do] uses deprecated 'dynamic_options' attribute." in lint_ctx.warn_messages
     assert "Select parameter [select_ff] options uses deprecated 'from_file' attribute." in lint_ctx.warn_messages
@@ -1319,8 +1319,8 @@ def test_inputs_select_deprections(lint_ctx):
 
 
 def test_inputs_select_option_definitions(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_SELECT_OPTION_DEFINITIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_SELECT_OPTION_DEFINITIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 6 input parameters." in lint_ctx.info_messages
     assert (
         "Select parameter [select_noopt] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute."
@@ -1352,8 +1352,8 @@ def test_inputs_select_option_definitions(lint_ctx):
 
 
 def test_inputs_select_filter(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_SELECT_FILTER)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_SELECT_FILTER)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert "Select parameter [select_filter_types] contains filter without type." in lint_ctx.error_messages
     assert (
@@ -1367,8 +1367,8 @@ def test_inputs_select_filter(lint_ctx):
 
 
 def test_inputs_validator_incompatibilities(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_VALIDATOR_INCOMPATIBILITIES)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_VALIDATOR_INCOMPATIBILITIES)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 2 input parameters." in lint_ctx.info_messages
     assert (
         "Parameter [param_name]: 'in_range' validators are not expected to contain text (found 'TEXT')"
@@ -1411,8 +1411,8 @@ def test_inputs_validator_incompatibilities(lint_ctx):
 
 
 def test_inputs_validator_correct(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_VALIDATOR_CORRECT)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_VALIDATOR_CORRECT)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert "Found 5 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
@@ -1421,8 +1421,8 @@ def test_inputs_validator_correct(lint_ctx):
 
 
 def test_inputs_type_child_combinations(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_TYPE_CHILD_COMBINATIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_TYPE_CHILD_COMBINATIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert not lint_ctx.warn_messages
@@ -1442,8 +1442,8 @@ def test_inputs_type_child_combinations(lint_ctx):
 
 
 def test_inputs_duplicate_names(lint_ctx):
-    tool_xml_tree = get_xml_tree(INPUTS_DUPLICATE_NAMES)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
+    tool_source = get_xml_tool_source(INPUTS_DUPLICATE_NAMES)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert not lint_ctx.warn_messages
@@ -1455,8 +1455,8 @@ def test_inputs_duplicate_names(lint_ctx):
 
 
 def test_inputs_repeats(lint_ctx):
-    tool_xml_tree = get_xml_tree(REPEATS)
-    run_lint(lint_ctx, inputs.lint_repeats, tool_xml_tree)
+    tool_source = get_xml_tool_source(REPEATS)
+    run_lint(lint_ctx, inputs.lint_repeats, tool_source)
     assert "Repeat does not specify name attribute." in lint_ctx.error_messages
     assert "Repeat does not specify title attribute." in lint_ctx.error_messages
     assert not lint_ctx.info_messages
@@ -1466,8 +1466,8 @@ def test_inputs_repeats(lint_ctx):
 
 
 def test_outputs_missing(lint_ctx):
-    tool_xml_tree = get_xml_tree(OUTPUTS_MISSING)
-    run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
+    tool_source = get_xml_tool_source(OUTPUTS_MISSING)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "Tool contains no outputs section, most tools should produce outputs." in lint_ctx.warn_messages
     assert not lint_ctx.info_messages
     assert not lint_ctx.valid_messages
@@ -1476,8 +1476,8 @@ def test_outputs_missing(lint_ctx):
 
 
 def test_outputs_multiple(lint_ctx):
-    tool_xml_tree = get_xml_tree(OUTPUTS_MULTIPLE)
-    run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
+    tool_source = get_xml_tool_source(OUTPUTS_MULTIPLE)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "0 outputs found." in lint_ctx.info_messages
     assert "Tool contains multiple output sections, behavior undefined." in lint_ctx.warn_messages
     assert len(lint_ctx.info_messages) == 1
@@ -1487,8 +1487,8 @@ def test_outputs_multiple(lint_ctx):
 
 
 def test_outputs_unknown_tag(lint_ctx):
-    tool_xml_tree = get_xml_tree(OUTPUTS_UNKNOWN_TAG)
-    run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
+    tool_source = get_xml_tool_source(OUTPUTS_UNKNOWN_TAG)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "0 outputs found." in lint_ctx.info_messages
     assert "Unknown element found in outputs [output]" in lint_ctx.warn_messages
     assert len(lint_ctx.info_messages) == 1
@@ -1498,8 +1498,8 @@ def test_outputs_unknown_tag(lint_ctx):
 
 
 def test_outputs_unnamed_invalid_name(lint_ctx):
-    tool_xml_tree = get_xml_tree(OUTPUTS_UNNAMED_INVALID_NAME)
-    run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
+    tool_source = get_xml_tool_source(OUTPUTS_UNNAMED_INVALID_NAME)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "2 outputs found." in lint_ctx.info_messages
     assert "Tool output doesn't define a name - this is likely a problem." in lint_ctx.warn_messages
     assert "Tool data output with missing name doesn't define an output format." in lint_ctx.warn_messages
@@ -1538,8 +1538,8 @@ def test_outputs_format_input(lint_ctx):
 
 
 def test_outputs_collection_format_source(lint_ctx):
-    tool_xml_tree = get_xml_tree(OUTPUTS_COLLECTION_FORMAT_SOURCE)
-    run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
+    tool_source = get_xml_tool_source(OUTPUTS_COLLECTION_FORMAT_SOURCE)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "Tool data output 'reverse' should use either format_source or format/ext" in lint_ctx.warn_messages
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
@@ -1548,8 +1548,8 @@ def test_outputs_collection_format_source(lint_ctx):
 
 
 def test_outputs_format_action(lint_ctx):
-    tool_xml_tree = get_xml_tree(OUTPUTS_FORMAT_ACTION)
-    run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
+    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_ACTION)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert not lint_ctx.warn_messages
@@ -1557,8 +1557,8 @@ def test_outputs_format_action(lint_ctx):
 
 
 def test_outputs_discover_tool_provided_metadata(lint_ctx):
-    tool_xml_tree = get_xml_tree(OUTPUTS_DISCOVER_TOOL_PROVIDED_METADATA)
-    run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
+    tool_source = get_xml_tool_source(OUTPUTS_DISCOVER_TOOL_PROVIDED_METADATA)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "1 outputs found." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
@@ -1567,8 +1567,8 @@ def test_outputs_discover_tool_provided_metadata(lint_ctx):
 
 
 def test_outputs_duplicated_name_label(lint_ctx):
-    tool_xml_tree = get_xml_tree(OUTPUTS_DUPLICATED_NAME_LABEL)
-    run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
+    tool_source = get_xml_tool_source(OUTPUTS_DUPLICATED_NAME_LABEL)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "4 outputs found." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1516,10 +1516,7 @@ def test_outputs_format_input_legacy(lint_ctx):
     tool_source = get_xml_tool_source(OUTPUTS_FORMAT_INPUT_LEGACY)
     run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "1 outputs found." in lint_ctx.info_messages
-    assert (
-        "Using format='input' on data: format_source attribute is less ambiguous and should be used instead (with a non-legacy tool profile)."
-        in lint_ctx.warn_messages
-    )
+    assert "Using format='input' on data is deprecated. Use the format_source attribute." in lint_ctx.warn_messages
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert len(lint_ctx.warn_messages) == 1

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -538,8 +538,15 @@ OUTPUTS_UNNAMED_INVALID_NAME = """
     </outputs>
 </tool>
 """
-OUTPUTS_FORMAT_INPUT = """
+OUTPUTS_FORMAT_INPUT_LEGACY = """
 <tool>
+    <outputs>
+        <data name="valid_name" format="input"/>
+    </outputs>
+</tool>
+"""
+OUTPUTS_FORMAT_INPUT = """
+<tool profile="16.04">
     <outputs>
         <data name="valid_name" format="input"/>
     </outputs>
@@ -911,15 +918,6 @@ def get_tool_xml_exact(xml_string: str):
         return parse_xml(tool_path, strip_whitespace=False, remove_comments=False)
 
 
-def failed_assert_print(lint_ctx):
-    return (
-        f"Valid: {lint_ctx.valid_messages}\n"
-        f"Info: {lint_ctx.info_messages}\n"
-        f"Warnings: {lint_ctx.warn_messages}\n"
-        f"Errors: {lint_ctx.error_messages}"
-    )
-
-
 def run_lint(lint_ctx, lint_func, lint_target):
     lint_ctx.lint(name="test_lint", lint_func=lint_func, lint_target=lint_target)
     # check if the lint messages have the line
@@ -1117,8 +1115,8 @@ def test_help_invalid_rst(lint_ctx):
 
 
 def test_inputs_no_inputs(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_NO_INPUTS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_NO_INPUTS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found no input parameters." in lint_ctx.warn_messages
     assert not lint_ctx.info_messages
     assert not lint_ctx.valid_messages
@@ -1127,8 +1125,8 @@ def test_inputs_no_inputs(lint_ctx):
 
 
 def test_inputs_no_inputs_datasource(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_NO_INPUTS_DATASOURCE)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_NO_INPUTS_DATASOURCE)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "No input parameters, OK for data sources" in lint_ctx.info_messages
     assert "display tag usually present in data sources" in lint_ctx.info_messages
     assert "uihints tag usually present in data sources" in lint_ctx.info_messages
@@ -1139,8 +1137,8 @@ def test_inputs_no_inputs_datasource(lint_ctx):
 
 
 def test_inputs_valid(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_VALID)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_VALID)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 2 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
@@ -1149,8 +1147,8 @@ def test_inputs_valid(lint_ctx):
 
 
 def test_inputs_param_name(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_PARAM_NAME)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_PARAM_NAME)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 5 input parameters." in lint_ctx.info_messages
     assert "Param input [2] is not a valid Cheetah placeholder." in lint_ctx.warn_messages
     assert "Found param input with no name specified." in lint_ctx.error_messages
@@ -1166,8 +1164,8 @@ def test_inputs_param_name(lint_ctx):
 
 
 def test_inputs_param_type(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_PARAM_TYPE)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_PARAM_TYPE)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 2 input parameters." in lint_ctx.info_messages
     assert "Param input [valid_name] input with no type specified." in lint_ctx.error_messages
     assert "Param input [another_valid_name] with empty type specified." in lint_ctx.error_messages
@@ -1178,8 +1176,8 @@ def test_inputs_param_type(lint_ctx):
 
 
 def test_inputs_data_param(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_DATA_PARAM)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert (
         "Param input [valid_name] with no format specified - 'data' format will be assumed." in lint_ctx.warn_messages
@@ -1201,8 +1199,8 @@ def test_inputs_boolean_param(lint_ctx):
 
 
 def test_inputs_data_param_options(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_OPTIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_DATA_PARAM_OPTIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert not lint_ctx.valid_messages
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
@@ -1211,8 +1209,8 @@ def test_inputs_data_param_options(lint_ctx):
 
 
 def test_inputs_data_param_options_filter_attribute(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_OPTIONS_FILTER_ATTRIBUTE)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_DATA_PARAM_OPTIONS_FILTER_ATTRIBUTE)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert not lint_ctx.valid_messages
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
@@ -1221,8 +1219,8 @@ def test_inputs_data_param_options_filter_attribute(lint_ctx):
 
 
 def test_inputs_data_param_invalid_options(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_DATA_PARAM_INVALIDOPTIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_DATA_PARAM_INVALIDOPTIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert not lint_ctx.valid_messages
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
@@ -1237,8 +1235,8 @@ def test_inputs_data_param_invalid_options(lint_ctx):
 
 
 def test_inputs_conditional(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_CONDITIONAL)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_CONDITIONAL)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 10 input parameters." in lint_ctx.info_messages
     assert "Conditional without a name" in lint_ctx.error_messages
     assert (
@@ -1264,8 +1262,8 @@ def test_inputs_conditional(lint_ctx):
 
 
 def test_inputs_select_incompatible_display(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_SELECT_INCOMPATIBLE_DISPLAY)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_SELECT_INCOMPATIBLE_DISPLAY)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 3 input parameters." in lint_ctx.info_messages
     assert 'Select [radio_select] display="radio" is incompatible with optional="true"' in lint_ctx.error_messages
     assert 'Select [radio_select] display="radio" is incompatible with multiple="true"' in lint_ctx.error_messages
@@ -1284,8 +1282,8 @@ def test_inputs_select_incompatible_display(lint_ctx):
 
 
 def test_inputs_duplicated_options(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_SELECT_DUPLICATED_OPTIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_SELECT_DUPLICATED_OPTIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert "Select parameter [select] has multiple options with the same text content" in lint_ctx.error_messages
     assert "Select parameter [select] has multiple options with the same value" in lint_ctx.error_messages
@@ -1296,15 +1294,15 @@ def test_inputs_duplicated_options(lint_ctx):
 
 
 def test_inputs_duplicated_options_with_different_select(lint_ctx):
-    tool_source = get_xml_tool_source(SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert not lint_ctx.warn_messages
     assert not lint_ctx.error_messages
 
 
 def test_inputs_select_deprections(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_SELECT_DEPRECATIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_SELECT_DEPRECATIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 3 input parameters." in lint_ctx.info_messages
     assert "Select parameter [select_do] uses deprecated 'dynamic_options' attribute." in lint_ctx.warn_messages
     assert "Select parameter [select_ff] options uses deprecated 'from_file' attribute." in lint_ctx.warn_messages
@@ -1321,8 +1319,8 @@ def test_inputs_select_deprections(lint_ctx):
 
 
 def test_inputs_select_option_definitions(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_SELECT_OPTION_DEFINITIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_SELECT_OPTION_DEFINITIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 6 input parameters." in lint_ctx.info_messages
     assert (
         "Select parameter [select_noopt] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute."
@@ -1354,8 +1352,8 @@ def test_inputs_select_option_definitions(lint_ctx):
 
 
 def test_inputs_select_filter(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_SELECT_FILTER)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_SELECT_FILTER)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 1 input parameters." in lint_ctx.info_messages
     assert "Select parameter [select_filter_types] contains filter without type." in lint_ctx.error_messages
     assert (
@@ -1369,8 +1367,8 @@ def test_inputs_select_filter(lint_ctx):
 
 
 def test_inputs_validator_incompatibilities(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_VALIDATOR_INCOMPATIBILITIES)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_VALIDATOR_INCOMPATIBILITIES)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 2 input parameters." in lint_ctx.info_messages
     assert (
         "Parameter [param_name]: 'in_range' validators are not expected to contain text (found 'TEXT')"
@@ -1413,8 +1411,8 @@ def test_inputs_validator_incompatibilities(lint_ctx):
 
 
 def test_inputs_validator_correct(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_VALIDATOR_CORRECT)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_VALIDATOR_CORRECT)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert "Found 5 input parameters." in lint_ctx.info_messages
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
@@ -1423,8 +1421,8 @@ def test_inputs_validator_correct(lint_ctx):
 
 
 def test_inputs_type_child_combinations(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_TYPE_CHILD_COMBINATIONS)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_TYPE_CHILD_COMBINATIONS)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert not lint_ctx.warn_messages
@@ -1444,8 +1442,8 @@ def test_inputs_type_child_combinations(lint_ctx):
 
 
 def test_inputs_duplicate_names(lint_ctx):
-    tool_source = get_xml_tool_source(INPUTS_DUPLICATE_NAMES)
-    run_lint(lint_ctx, inputs.lint_inputs, tool_source)
+    tool_xml_tree = get_xml_tree(INPUTS_DUPLICATE_NAMES)
+    run_lint(lint_ctx, inputs.lint_inputs, tool_xml_tree)
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert not lint_ctx.warn_messages
@@ -1514,14 +1512,25 @@ def test_outputs_unnamed_invalid_name(lint_ctx):
     assert not lint_ctx.error_messages
 
 
+def test_outputs_format_input_legacy(lint_ctx):
+    tool_source = get_xml_tool_source(OUTPUTS_FORMAT_INPUT_LEGACY)
+    run_lint(lint_ctx, outputs.lint_output, tool_source)
+    assert "1 outputs found." in lint_ctx.info_messages
+    assert (
+        "Using format='input' on data: format_source attribute is less ambiguous and should be used instead (with a non-legacy tool profile)."
+        in lint_ctx.warn_messages
+    )
+    assert len(lint_ctx.info_messages) == 1
+    assert not lint_ctx.valid_messages
+    assert len(lint_ctx.warn_messages) == 1
+    assert not lint_ctx.error_messages
+
+
 def test_outputs_format_input(lint_ctx):
     tool_xml_tree = get_xml_tree(OUTPUTS_FORMAT_INPUT)
     run_lint(lint_ctx, outputs.lint_output, tool_xml_tree)
     assert "1 outputs found." in lint_ctx.info_messages
-    assert (
-        "Using format='input' on data, format_source attribute is less ambiguous and should be used instead."
-        in lint_ctx.error_messages
-    )
+    assert "Using format='input' on data is deprecated. Use the format_source attribute." in lint_ctx.error_messages
     assert len(lint_ctx.info_messages) == 1
     assert not lint_ctx.valid_messages
     assert not lint_ctx.warn_messages


### PR DESCRIPTION
stumbled over this here: https://github.com/galaxyproteomics/tools-galaxyp/pull/679 could not find a test.

Wondering if we can/should be a bit more strict .. in the sense that some of the tool testing / linting would lead to an error that is easily recognized, e.g. by adding a linter rule or fail the tests if a unknown format is used (`"input"` in this case)

In the original implementation of the profile behavior (https://github.com/galaxyproject/galaxy/pull/1688/commits/b92074e6ff87a19133b4d973577779c4ee6286d7) it is stated "_Disable format="input" - require explicit metadata targets (metadata_source, format_source)_.". Currently "disable" means that just the format is set to the invalid datatype "input". Wondering if we want to change this to really disable this, e.g. by just failing tool execution.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
