### PR TITLE
Fixes for two framework test tools

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4862,7 +4862,7 @@ only used if ``multiple`` is set to ``true``.]]></xs:documentation>
       <xs:annotation>
         <xs:documentation xml:lang="en">If ``true``, keep columns matching the
 value, if ``false`` discard columns matching the value. Used when ``type`` is
-either ``static_value``, ``regexp`` or ``param_value``.</xs:documentation>
+either ``static_value``, ``regexp`` or ``param_value``. Default: true</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="value" type="xs:string">

--- a/test/functional/tools/expression_pick_larger_file.xml
+++ b/test/functional/tools/expression_pick_larger_file.xml
@@ -35,7 +35,7 @@
         </test>
         <test>
             <param name="input1" value_json="null" />
-            <param name="input2" value_json="simple_line.txt" />
+            <param name="input2" value_json="&quot;simple_line.txt&quot;" />
             <output name="larger_file" file="simple_line.txt"/>
         </test>
     </tests>

--- a/test/functional/tools/filter_static_regexp.xml
+++ b/test/functional/tools/filter_static_regexp.xml
@@ -5,13 +5,13 @@
     echo index_static $index_static > '$output' &&
 #end if
 #if $index_static_keep
-echo index_static_keep $index_static_keep >> '$output' &&
+    echo index_static_keep $index_static_keep >> '$output' &&
 #end if
 #if $index_regexp
-echo index_regexp $index_regexp >> '$output' &&
+    echo index_regexp $index_regexp >> '$output' &&
 #end if
 #if $index_regexp_keep
-echo index_regexp_keep $index_regexp_keep >> '$output'
+    echo index_regexp_keep $index_regexp_keep >> '$output'
 #end if
     ]]></command>
     <inputs>

--- a/test/functional/tools/filter_static_regexp.xml
+++ b/test/functional/tools/filter_static_regexp.xml
@@ -1,38 +1,46 @@
 <tool id="filter_static_regexp" name="filter_static_regexp" version="0.1.0">
     <description>Filter by static value and regexp</description>
     <command><![CDATA[
-echo $index_static > '$output' &&
-echo $index_static_keep >> '$output' &&
-echo $index_regexp >> '$output' &&
-echo $index_regexp_keep >> '$output' &&
+#if $index_static
+    echo index_static $index_static > '$output' &&
+#end if
+#if $index_static_keep
+echo index_static_keep $index_static_keep >> '$output' &&
+#end if
+#if $index_regexp
+echo index_regexp $index_regexp >> '$output' &&
+#end if
+#if $index_regexp_keep
+echo index_regexp_keep $index_regexp_keep >> '$output'
+#end if
     ]]></command>
     <inputs>
         <!-- tests for static_value filter: remove hp18 from the options by 
              a) removing it explicitly (due to keep="false") 
              b) keeping only the other option, i.e. hg19 -->
-        <param name="index_static" type="select" label="Using reference genome">
+        <param name="index_static" type="select" optional="true" label="Using reference genome">
             <options from_data_table="test_fasta_indexes">
                 <filter type="static_value" column="dbkey" value="hg18" />
                 <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
             </options>
         </param>
-        <param name="index_static_keep" type="select" label="Using reference genome">
+        <param name="index_static_keep" type="select" optional="true" label="Using reference genome">
             <options from_data_table="test_fasta_indexes">
-                <filter type="static_value" column="dbkey" value="hg19" keep="true" />
+                <filter type="static_value" column="dbkey" value="hg18" keep="false" />
                 <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
             </options>
         </param>
         <!-- tests for regexp filter: remove hp18 from the options 
              essentially the same as for the static value filter, just using a simple regexp -->
-        <param name="index_regexp" type="select" label="Using reference genome">
+        <param name="index_regexp" type="select" optional="true" label="Using reference genome">
             <options from_data_table="test_fasta_indexes">
                 <filter type="regexp" column="dbkey" value="hg.8" />
                 <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
             </options>
         </param>
-        <param name="index_regexp_keep" type="select" label="Using reference genome">
+        <param name="index_regexp_keep" type="select" optional="true" label="Using reference genome">
             <options from_data_table="test_fasta_indexes">
-                <filter type="regexp" column="dbkey" value="hg.9" keep="true" />
+                <filter type="regexp" column="dbkey" value="hg.8" keep="false" />
                 <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
             </options>
         </param>
@@ -43,45 +51,44 @@ echo $index_regexp_keep >> '$output' &&
     </outputs>
 
     <tests>
-        <!-- can choose a dbkey if it matches input -->
+        <!-- check that non filtered values can be chosen -->
         <test>
-            <param name="index_static" value="hg19_value" />
-            <param name="index_static_keep" value="hg19_value" />
-            <param name="index_regexp" value="hg19_value" />
-            <param name="index_regexp_keep" value="hg19_value" />
-            <output name="output">
-                <assert_contents>
-                    <has_text text="hg19" />    
-                    <not_has_text text="hg18" />
-                </assert_contents>
-            </output>
-        </test>
-        <!-- cannot pick index otherwise -->
-        <!-- Does this make sense - if no dbkey is defined there is no option
-             available? -->
-        <test expect_failure="true">
             <param name="index_static" value="hg18_value" />
-            <param name="index_static_keep" value="hg19_value" />
-            <param name="index_regexp" value="hg19_value" />
-            <param name="index_regexp_keep" value="hg19_value" />
-        </test>
-        <test expect_failure="true">
-            <param name="index_static" value="hg19_value" />
-            <param name="index_static_keep" value="hg18_value" />
-            <param name="index_regexp" value="hg19_value" />
-            <param name="index_regexp_keep" value="hg19_value" />
-        </test>
-        <test expect_failure="true">
-            <param name="index_static" value="hg19_value" />
             <param name="index_static_keep" value="hg19_value" />
             <param name="index_regexp" value="hg18_value" />
             <param name="index_regexp_keep" value="hg19_value" />
+            <output name="output">
+                <assert_contents>
+                    <has_text text="index_static hg18_value" />    
+                    <has_text text="index_static_keep hg19_value" />    
+                    <has_text text="index_regexp hg18_value" />    
+                    <has_text text="index_regexp_keep hg19_value" />    
+                </assert_contents>
+            </output>
+        </test>
+        <!-- ... all of them -->
+        <test>
+            <param name="index_static_keep" value="mm10_value" />
+            <param name="index_regexp_keep" value="mm10_value" />
+            <output name="output">
+                <assert_contents>
+                    <has_text text="index_static_keep mm10_value" />    
+                    <has_text text="index_regexp_keep mm10_value" />    
+                </assert_contents>
+            </output>
+        </test>
+        <!-- cannot pick filtered options -->
+        <test expect_failure="true">
+            <param name="index_static" value="hg19_value" />
         </test>
         <test expect_failure="true">
-            <param name="index_static" value="hg19" />
-            <param name="index_static_keep" value="hg19" />
-            <param name="index_regexp" value="hg19" />
-            <param name="index_regexp_keep" value="hg18" />
+            <param name="index_static_keep" value="hg18_value" />
+        </test>
+        <test expect_failure="true">
+            <param name="index_regexp" value="hg19_value" />
+        </test>
+        <test expect_failure="true">
+            <param name="index_regexp_keep" value="hg18_value" />
         </test>
     </tests>
     <help>

--- a/test/functional/tools/filter_static_regexp.xml
+++ b/test/functional/tools/filter_static_regexp.xml
@@ -10,13 +10,13 @@ echo $index_regexp_keep >> '$output' &&
         <!-- tests for static_value filter: remove hp18 from the options by 
              a) removing it explicitly (due to keep="false") 
              b) keeping only the other option, i.e. hg19 -->
-        <param name="index" type="select" label="Using reference genome">
+        <param name="index_static" type="select" label="Using reference genome">
             <options from_data_table="test_fasta_indexes">
                 <filter type="static_value" column="dbkey" value="hg18" />
                 <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
             </options>
         </param>
-        <param name="index2" type="select" label="Using reference genome">
+        <param name="index_static_keep" type="select" label="Using reference genome">
             <options from_data_table="test_fasta_indexes">
                 <filter type="static_value" column="dbkey" value="hg19" keep="true" />
                 <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
@@ -64,28 +64,24 @@ echo $index_regexp_keep >> '$output' &&
             <param name="index_static_keep" value="hg19_value" />
             <param name="index_regexp" value="hg19_value" />
             <param name="index_regexp_keep" value="hg19_value" />
-            <output name="output"/>
         </test>
         <test expect_failure="true">
             <param name="index_static" value="hg19_value" />
             <param name="index_static_keep" value="hg18_value" />
             <param name="index_regexp" value="hg19_value" />
             <param name="index_regexp_keep" value="hg19_value" />
-            <output name="output"/>
         </test>
         <test expect_failure="true">
             <param name="index_static" value="hg19_value" />
             <param name="index_static_keep" value="hg19_value" />
             <param name="index_regexp" value="hg18_value" />
             <param name="index_regexp_keep" value="hg19_value" />
-            <output name="output"/>
         </test>
         <test expect_failure="true">
             <param name="index_static" value="hg19" />
             <param name="index_static_keep" value="hg19" />
             <param name="index_regexp" value="hg19" />
             <param name="index_regexp_keep" value="hg18" />
-            <output name="output"/>
         </test>
     </tests>
     <help>


### PR DESCRIPTION
While working on https://github.com/galaxyproject/galaxy/pull/15482 I noticed Tracebacks while loading some of the test tools. Lets see what fails.

Would be cool if the framework tests fail in such a case. 

Same is for `planemo test` if tools fail to load the test turns out successful. So if no one checks the detailed output this may be accepted. 

My suggestion would be to make testing / galaxy startup fail if tools fail to load. I understand that this **may** not be useful on production instance .. but what is the use of tools that do not load and only produce errors. 



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
