### PR TITLE
[23.0] ToolSearch trim whitespace in query

### DIFF
--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -95,7 +95,7 @@ export function searchToolsByKeys(tools, keys, query) {
             } else {
                 actualValue = tool[key] ? tool[key].toLowerCase() : "";
             }
-            const queryLowerCase = query.toLowerCase();
+            const queryLowerCase = query.trim().toLowerCase();
             if (actualValue.match(queryLowerCase)) {
                 // do we care for exact matches && is it an exact match ?
                 const order = keys.exact && actualValue === queryLowerCase ? keys.exact : keys[key];

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -38,7 +38,8 @@ describe("test helpers in tool searching utilities", () => {
         results = searchToolsByKeys(normalizeTools(toolsList), keys, q);
         expect(results).toEqual(expectedResults);
 
-        q = "filter empty datasets";
+        // whitespace precedes to ensure query.trim() works
+        q = " filter empty datasets";
         expectedResults = ["__FILTER_EMPTY_DATASETS__"];
         keys = { description: 1, name: 2, combined: 0 };
         results = searchToolsByKeys(normalizeTools(toolsList), keys, q);


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15448. Takes care of any whitespace surrounding query using `trim()`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
