### PR TITLE
[23.0] ToolBox remove Expression Tools section

### DIFF
--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -74,7 +74,7 @@ import { UploadButton } from "components/Upload";
 import { useGlobalUploadModal } from "composables/globalUploadModal";
 import FavoritesButton from "./Buttons/FavoritesButton";
 import PanelViewButton from "./Buttons/PanelViewButton";
-import { filterToolSections, filterTools, hasResults } from "./utilities";
+import { filterToolSections, filterTools, hasResults, hideToolsSection } from "./utilities";
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload";
 import _l from "utils/localization";
@@ -135,7 +135,9 @@ export default {
             if (this.showSections) {
                 return filterToolSections(this.toolbox, this.results);
             } else {
-                return hasResults(this.results) ? filterTools(this.toolbox, this.results) : this.toolbox;
+                return hasResults(this.results)
+                    ? filterTools(this.toolbox, this.results)
+                    : hideToolsSection(this.toolbox);
             }
         },
         isUser() {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -114,6 +114,10 @@ export function normalizeTools(tools) {
     return tools;
 }
 
+export function hideToolsSection(tools) {
+    return tools.filter((section) => !TOOLS_RESULTS_SECTIONS_HIDE.includes(section.name));
+}
+
 export function removeDisabledTools(tools) {
     return tools.filter((section) => {
         if (section.model_class === "ToolSectionLabel") {
@@ -191,10 +195,6 @@ function deleteEmptyToolsSections(tools, results) {
         });
 
     return tools;
-}
-
-function hideToolsSection(tools) {
-    return tools.filter((section) => !TOOLS_RESULTS_SECTIONS_HIDE.includes(section.name));
 }
 
 function flattenTools(tools) {


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15481. Expression Tools are used in workflows and do not render a `ToolForm`, hence removed them from the main `ToolBox`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
