### PR TITLE
[23.0] Format Python code with black 23.1.0

### DIFF
--- a/config/plugins/webhooks/demo/tool_list/__init__.py
+++ b/config/plugins/webhooks/demo/tool_list/__init__.py
@@ -9,7 +9,6 @@ def main(trans, webhook, params):
     tools = trans.app.toolbox.tools()
 
     for tool in tools:
-
         try:
             ts_data = tool[1].tool_shed_repository.to_dict()
             panel = tool[1].get_panel_section()
@@ -17,7 +16,6 @@ def main(trans, webhook, params):
             continue
 
         if ts_data["name"] + ts_data["installed_changeset_revision"] not in unique_tools:
-
             unique_tools.append(ts_data["name"] + ts_data["installed_changeset_revision"])
 
             data["tools"].append(

--- a/contrib/galaxy_config_merger.py
+++ b/contrib/galaxy_config_merger.py
@@ -47,7 +47,7 @@ def main():
         if not config_sample.has_section(section):
             logging.warning("-MISSING- section [%s] not found in sample file. It will be ignored.", section)
         else:
-            for (name, value) in config.items(section):
+            for name, value in config.items(section):
                 if not config_sample.has_option(section, name):
                     if f"#{name}" not in config_sample_content:
                         logging.warning(

--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -213,7 +213,7 @@ class LibraryActions:
         (files_and_folders, _response_code, _message) = self._get_path_files_and_folders(params, preserve_dirs)
         if _response_code:
             return (uploaded_datasets, _response_code, _message)
-        for (path, name, folder) in files_and_folders:
+        for path, name, folder in files_and_folders:
             uploaded_datasets.append(
                 self._make_library_uploaded_dataset(trans, params, name, path, "path_paste", library_bunch, folder)
             )
@@ -224,7 +224,7 @@ class LibraryActions:
         if problem_response:
             return problem_response
         files_and_folders = []
-        for (line, path) in self._paths_list(params):
+        for line, path in self._paths_list(params):
             line_files_and_folders = self._get_single_path_files_and_folders(line, path, preserve_dirs)
             files_and_folders.extend(line_files_and_folders)
         return files_and_folders, None, None
@@ -257,7 +257,7 @@ class LibraryActions:
             response_code = 400
             return None, response_code, message
         bad_paths = []
-        for (_, path) in self._paths_list(params):
+        for _, path in self._paths_list(params):
             if not os.path.exists(path):
                 bad_paths.append(path)
         if bad_paths:

--- a/lib/galaxy/auth/providers/pam_auth.py
+++ b/lib/galaxy/auth/providers/pam_auth.py
@@ -55,7 +55,6 @@ Configuration example (for internal authentication, use email for user details):
 
 
 class PAM(AuthProvider):
-
     plugin_type = "PAM"
 
     def authenticate(self, email, username, password, options, request):

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -264,7 +264,6 @@ class CustosAuthnz(IdentityProvider):
         return session
 
     def _fetch_token(self, oauth2_session, trans):
-
         if self.config.get("iam_client_secret"):
             # Custos uses the Keycloak client secret to get the token
             client_secret = self.config["iam_client_secret"]

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -147,7 +147,6 @@ def galaxy_task(*args, action=None, **celery_task_kwd):
         @shared_task(**celery_task_kwd)
         @wraps(func)
         def wrapper(*args, **kwds):
-
             app = get_galaxy_app()
             assert app
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -412,7 +412,6 @@ class BaseAppConfiguration(HasDynamicProperties):
                     return path
 
     def _update_raw_config_from_kwargs(self, kwargs):
-
         type_converters: Dict[str, Callable[[Any], Union[bool, int, float, str]]] = {
             "bool": string_as_bool,
             "int": int,

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -327,7 +327,6 @@ class Bref3(Binary):
 
 
 class DynamicCompressedArchive(CompressedArchive):
-
     compressed_format: str
     uncompressed_datatype_instance: Data
 

--- a/lib/galaxy/datatypes/converters/fasta_to_len.py
+++ b/lib/galaxy/datatypes/converters/fasta_to_len.py
@@ -10,7 +10,6 @@ assert sys.version_info[:2] >= (2, 4)
 
 
 def compute_fasta_length(fasta_file, out_file, keep_first_char, keep_first_word=False):
-
     infile = fasta_file
     keep_first_char = int(keep_first_char)
 

--- a/lib/galaxy/datatypes/converters/interval_to_bed_converter.py
+++ b/lib/galaxy/datatypes/converters/interval_to_bed_converter.py
@@ -65,7 +65,6 @@ def __main__():
             except Exception:
                 name = "region_%i" % count
             try:
-
                 out.write("%s\t%i\t%i\t%s\t%i\t%s\n" % (region.chrom, region.start, region.end, name, 0, region.strand))
             except Exception:
                 skipped_lines += 1

--- a/lib/galaxy/datatypes/converters/interval_to_interval_index_converter.py
+++ b/lib/galaxy/datatypes/converters/interval_to_interval_index_converter.py
@@ -15,7 +15,6 @@ from bx.interval_index_file import Indexes
 
 
 def main():
-
     # Read options, args.
     parser = optparse.OptionParser()
     parser.add_option("-c", "--chr-col", type="int", dest="chrom_col", default=1)

--- a/lib/galaxy/datatypes/converters/pileup_to_interval_index_converter.py
+++ b/lib/galaxy/datatypes/converters/pileup_to_interval_index_converter.py
@@ -12,7 +12,6 @@ from bx.interval_index_file import Indexes
 
 
 def main():
-
     # Read options, args.
     parser = optparse.OptionParser()
     (options, args) = parser.parse_args()

--- a/lib/galaxy/datatypes/dataproviders/decorators.py
+++ b/lib/galaxy/datatypes/dataproviders/decorators.py
@@ -94,6 +94,7 @@ def dataprovider_factory(name, settings=None):
         to __init__ arguments
     :type settings: dictionary
     """
+
     # TODO:?? use *args for settings allowing mulitple dictionaries
     # make a function available through the name->provider dispatch to parse query strings
     #   callable like:
@@ -123,6 +124,7 @@ def _parse_query_string_settings(query_kwargs, settings=None):
     Parse the values in `query_kwargs` from strings to the proper types
     listed in the same key in `settings`.
     """
+
     # TODO: this was a relatively late addition: review and re-think
     def list_from_query_string(s):
         # assume csv

--- a/lib/galaxy/datatypes/goldenpath.py
+++ b/lib/galaxy/datatypes/goldenpath.py
@@ -125,7 +125,6 @@ class AGPFile:
     """
 
     def __init__(self, in_file):
-
         self._agp_version = "2.1"
         self._fname = os.path.abspath(in_file)
 
@@ -193,7 +192,6 @@ class AGPFile:
     def _add_line(self, agp_line):
         # Perform validity checks if this is a new object
         if agp_line.obj != self._current_obj:
-
             # Check if we have already seen this object before
             if agp_line.obj in self._seen_objs:
                 raise AGPError(self.fname, agp_line.line_number, "object identifier out of order")

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -108,7 +108,6 @@ class _Isa(Data):
         isa_folder = self._get_isa_folder_path(dataset)
 
         if os.path.exists(isa_folder):
-
             # Get ISA archive older
             isa_files = os.listdir(isa_folder)
 
@@ -350,7 +349,6 @@ class IsaTab(_Isa):
     ################################################################
 
     def _make_investigation_instance(self, filename: str) -> "Investigation":
-
         # Parse ISA-Tab investigation file
         parser = isatab_meta.InvestigationParser()
         isa_dir = os.path.dirname(filename)
@@ -384,7 +382,6 @@ class IsaJson(_Isa):
     ################################################################
 
     def _make_investigation_instance(self, filename: str) -> "Investigation":
-
         # Parse JSON file
         with open(filename, newline="", encoding="utf8") as fp:
             isa = isajson.load(fp)

--- a/lib/galaxy/datatypes/media.py
+++ b/lib/galaxy/datatypes/media.py
@@ -35,7 +35,6 @@ def ffprobe(path):
 
 
 class Audio(Binary):
-
     MetadataElement(
         name="duration",
         default=0,
@@ -90,7 +89,6 @@ class Audio(Binary):
 
 
 class Video(Binary):
-
     MetadataElement(
         name="resolution_w",
         default=0,

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -246,7 +246,6 @@ class Stockholm_1_0(Text):
                 part_file.writelines(accumulated_lines)
 
         try:
-
             stockholm_records = _read_stockholm_records(input_files[0])
             stockholm_lines_accumulated = []
             for counter, stockholm_record in enumerate(stockholm_records, start=1):

--- a/lib/galaxy/datatypes/speech.py
+++ b/lib/galaxy/datatypes/speech.py
@@ -41,7 +41,6 @@ class TextGrid(Text):
     )
 
     def sniff(self, filename: str) -> bool:
-
         with open(filename) as fd:
             text = fd.read(len(self.header))
             return text == self.header

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -1813,9 +1813,7 @@ class CMAP(TabularData):
                 for i, line in enumerate(dataset_fh):
                     line = line.strip("\n")
                     if line.startswith("#"):
-
                         if line.startswith("#h"):
-
                             column_headers = line.split("\t")[1:]
                         elif line.startswith("#f"):
                             cleaned_column_types = []

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -443,7 +443,7 @@ class Biom1(Json):
                     return []
 
                 b_transform = {"rows": _transform_dict_list_ids, "columns": _transform_dict_list_ids}
-                for (m_name, b_name) in [
+                for m_name, b_name in [
                     ("table_rows", "rows"),
                     ("table_matrix_element_type", "matrix_element_type"),
                     ("table_format", "format"),

--- a/lib/galaxy/datatypes/util/maf_utilities.py
+++ b/lib/galaxy/datatypes/util/maf_utilities.py
@@ -134,7 +134,6 @@ class TempFileHandler:
 
 # an object corresponding to a reference layered alignment
 class RegionAlignment:
-
     DNA_COMPLEMENT = maketrans("ACGTacgt", "TGCAtgca")
     MAX_SEQUENCE_SIZE = sys.maxsize  # Maximum length of sequence allowed
 
@@ -226,7 +225,6 @@ class GenomicRegionAlignment(RegionAlignment):
 
 
 class SplicedAlignment:
-
     DNA_COMPLEMENT = maketrans("ACGTacgt", "TGCAtgca")
 
     def __init__(self, exon_starts, exon_ends, species=None, temp_file_handler=None):

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -44,7 +44,7 @@ class PosixFilesSource(BaseFilesSource):
         if recursive:
             res: List[Dict[str, Any]] = []
             effective_root = self._effective_root(user_context)
-            for (p, dirs, files) in safe_walk(dir_path, allowlist=self._allowlist):
+            for p, dirs, files in safe_walk(dir_path, allowlist=self._allowlist):
                 rel_dir = os.path.relpath(p, effective_root)
                 to_dict = functools.partial(self._resource_info_to_dict, rel_dir, user_context=user_context)
                 res.extend(map(to_dict, dirs))

--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -402,7 +402,7 @@ class DeleteIntermediatesAction(DefaultJobAction):
                         )
                     else:
                         creating_jobs.append((input_dataset, input_dataset.dataset.creating_job))
-                for (input_dataset, creating_job) in creating_jobs:
+                for input_dataset, creating_job in creating_jobs:
                     sa_session.refresh(creating_job)
                     sa_session.refresh(input_dataset)
                 for input_dataset in [
@@ -497,7 +497,6 @@ class RemoveTagDatasetAction(TagDatasetAction):
 
 
 class ActionBox:
-
     actions = {
         "RenameDatasetAction": RenameDatasetAction,
         "HideDatasetAction": HideDatasetAction,

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -189,7 +189,6 @@ def collect_dynamic_outputs(
 
 
 class BaseJobContext(ModelPersistenceContext):
-
     max_discovered_files: Union[int, float]
     tool_provided_metadata: BaseToolProvidedMetadata
     job_working_directory: str
@@ -575,7 +574,7 @@ def discover_files(output_name, tool_provided_metadata, extra_file_collectors, j
                 JsonCollectedDatasetMatch(dataset, extra_file_collector, filename, path=path),
             )
     else:
-        for (match, collector) in walk_over_file_collectors(extra_file_collectors, job_working_directory, matchable):
+        for match, collector in walk_over_file_collectors(extra_file_collectors, job_working_directory, matchable):
             yield DiscoveredFile(match.path, collector, match)
 
 

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -222,7 +222,7 @@ class JobIO(Dictifiable):
         if getattr(dataset, "fake_dataset_association", False):
             return dataset.file_name
         assert dataset.id is not None, f"{dataset} needs to be flushed to find output path"
-        for (hda, dataset_path) in self.output_hdas_and_paths.values():
+        for hda, dataset_path in self.output_hdas_and_paths.values():
             if hda.id == dataset.id:
                 return dataset_path
         raise KeyError(f"Couldn't find job output for [{dataset}] in [{self.output_hdas_and_paths.values()}]")

--- a/lib/galaxy/jobs/dynamic_tool_destination.py
+++ b/lib/galaxy/jobs/dynamic_tool_destination.py
@@ -416,7 +416,6 @@ class RuleValidator:
                         valid_rule = False
             elif isinstance(rule["destination"], dict):
                 if "priority" in rule["destination"] and isinstance(rule["destination"]["priority"], dict):
-
                     for priority in rule["destination"]["priority"]:
                         if priority not in priority_list:
                             error = "Invalid priority '"
@@ -530,7 +529,6 @@ class RuleValidator:
                 upper_bound = -1
 
             if upper_bound != -1 and lower_bound > upper_bound:
-
                 error = f"lower_bound exceeds upper_bound for rule {str(counter)}"
                 error += f" in '{str(tool)}'."
                 if not return_bool:
@@ -850,11 +848,9 @@ def validate_config(obj: dict, app=None, return_bool: bool = False):
                     valid_config = False
 
             elif isinstance(obj["default_destination"], dict):
-
                 if "priority" in obj["default_destination"] and isinstance(
                     obj["default_destination"]["priority"], dict
                 ):
-
                     for priority in obj["default_destination"]["priority"]:
                         if isinstance(obj["default_destination"]["priority"][priority], str):
                             priority_list.add(priority)
@@ -936,7 +932,6 @@ def validate_config(obj: dict, app=None, return_bool: bool = False):
 
                     if isinstance(curr, dict):
                         if "priority" in curr and isinstance(curr["priority"], str):
-
                             if curr["priority"] in priority_list:
                                 new_config["users"][user]["priority"] = curr["priority"]
                             else:
@@ -980,7 +975,6 @@ def validate_config(obj: dict, app=None, return_bool: bool = False):
                     curr_tool_rules = []
 
                     if curr is not None:
-
                         # in each tool, there should always be only 2 sub-categories:
                         # default_destination (not mandatory) and rules (mandatory)
                         if "default_destination" in curr:
@@ -998,16 +992,13 @@ def validate_config(obj: dict, app=None, return_bool: bool = False):
                                 else:
                                     valid_config = False
                             elif isinstance(curr["default_destination"], dict):
-
                                 if "priority" in curr["default_destination"] and isinstance(
                                     curr["default_destination"]["priority"], dict
                                 ):
-
                                     for priority in curr["default_destination"]["priority"]:
                                         destination = curr["default_destination"]["priority"][priority]
                                         if priority in priority_list:
                                             if isinstance(destination, str):
-
                                                 is_valid = validate_destination(
                                                     app,
                                                     destination,
@@ -1401,7 +1392,6 @@ def map_tool_to_destination(job, app, tool, user_email, test=False, path=None, j
     if fail_message is not None:
         destination = "fail"
     elif config is not None:
-
         # Get the default priority from the config if necessary.
         # If there isn't one, choose an arbitrary one as a fallback
         if "default_destination" in config:
@@ -1477,7 +1467,6 @@ def map_tool_to_destination(job, app, tool, user_email, test=False, path=None, j
                         if user_authorized:
                             matched = False
                             if rule["rule_type"] == "file_size":
-
                                 # bounds comparisons
                                 upper_bound = str_to_bytes(rule["upper_bound"])
                                 lower_bound = str_to_bytes(rule["lower_bound"])
@@ -1491,7 +1480,6 @@ def map_tool_to_destination(job, app, tool, user_email, test=False, path=None, j
                                         matched = True
 
                             elif rule["rule_type"] == "num_input_datasets":
-
                                 # bounds comparisons
                                 upper_bound = rule["upper_bound"]
                                 lower_bound = rule["lower_bound"]
@@ -1504,7 +1492,6 @@ def map_tool_to_destination(job, app, tool, user_email, test=False, path=None, j
                                         matched = True
 
                             elif rule["rule_type"] == "records":
-
                                 # bounds comparisons
                                 upper_bound = str_to_bytes(rule["upper_bound"])
                                 lower_bound = str_to_bytes(rule["lower_bound"])

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -613,7 +613,7 @@ class JobHandlerQueue(Monitors):
         jobs_to_pause = defaultdict(list)
         jobs_to_fail = defaultdict(list)
         jobs_to_ignore = defaultdict(list)
-        for (job_id, hda_deleted, hda_state, hda_name, dataset_deleted, dataset_purged, dataset_state) in queries:
+        for job_id, hda_deleted, hda_state, hda_name, dataset_deleted, dataset_purged, dataset_state in queries:
             if hda_deleted or dataset_deleted:
                 if dataset_purged:
                     # If the dataset has been purged we can't resume the job by undeleting the input

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -82,7 +82,6 @@ class RunnerParams(ParamsWithSpecs):
 
 
 class BaseJobRunner:
-
     runner_name = "BaseJobRunner"
 
     start_methods = ["_init_monitor_thread", "_init_worker_threads"]
@@ -343,7 +342,7 @@ class BaseJobRunner:
         # Walk job's output associations to find and use from_work_dir attributes.
         job = job_wrapper.get_job()
         job_tool = job_wrapper.tool
-        for (joda, dataset) in self._walk_dataset_outputs(job):
+        for joda, dataset in self._walk_dataset_outputs(job):
             if joda and job_tool:
                 hda_tool_output = job_tool.find_output_def(joda.name)
                 if hda_tool_output and hda_tool_output.from_work_dir:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -314,7 +314,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
     def __get_k8s_job_spec(self, ajs):
         """Creates the k8s Job spec. For a Job spec, the only requirement is to have a .spec.template.
-        If the job hangs around unlimited it will be ended after k8s wall time limit, which sets activeDeadlineSeconds"""
+        If the job hangs around unlimited it will be ended after k8s wall time limit, which sets activeDeadlineSeconds
+        """
         k8s_job_spec = {
             "template": self.__get_k8s_job_spec_template(ajs),
             "activeDeadlineSeconds": int(self.runner_params["k8s_walltime_limit"]),

--- a/lib/galaxy/jobs/runners/util/cli/job/__init__.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/__init__.py
@@ -12,7 +12,6 @@ try:
 
     job_states = Job.states
 except ImportError:
-
     # Not in Galaxy, map Galaxy job states to Pulsar ones.
     class job_states(str, Enum):  # type: ignore[no-redef]
         RUNNING = "running"

--- a/lib/galaxy/jobs/runners/util/cli/job/pbs.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/pbs.py
@@ -7,7 +7,6 @@ log = getLogger(__name__)
 
 
 class OpenPBS(Torque):
-
     ERROR_MESSAGE_UNRECOGNIZED_ARG = "Unrecognized long argument passed to OpenPBS CLI plugin: %s"
 
     def get_status(self, job_ids=None):

--- a/lib/galaxy/jobs/runners/util/cli/job/torque.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/torque.py
@@ -34,7 +34,6 @@ argmap = {
 
 
 class Torque(BaseJobExec):
-
     ERROR_MESSAGE_UNRECOGNIZED_ARG = "Unrecognized long argument passed to Torque CLI plugin: %s"
 
     def job_script_kwargs(self, ofile, efile, job_name):

--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -144,7 +144,6 @@ def write_script(path: str, contents, job_io: DescribesScriptIntegrityChecks, mo
 def _handle_script_integrity(
     path: str, check_job_script_integrity_count: int, check_job_script_integrity_sleep: float
 ) -> None:
-
     script_integrity_verified = False
     for _ in range(check_job_script_integrity_count):
         try:

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -1082,7 +1082,7 @@ class ModelFilterParser(HasAModelManager):
         """
         # TODO: allow defining the default filter op in this class (and not 'eq' in base/controller.py)
         parsed = []
-        for (attr, op, val) in filter_tuple_list:
+        for attr, op, val in filter_tuple_list:
             filter_ = self.parse_filter(attr, op, val)
             parsed.append(filter_)
         return parsed

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -47,7 +47,6 @@ SINGED_URL_TTL = 3600
 
 
 class CloudManager(sharable.SharableModelManager):
-
     # This manager does not manage a history; however,
     # some of its functions require operations
     # on history objects using methods from the base

--- a/lib/galaxy/managers/cloudauthzs.py
+++ b/lib/galaxy/managers/cloudauthzs.py
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 
 
 class CloudAuthzManager(sharable.SharableModelManager):
-
     model_class = model.CloudAuthz
     foreign_key_name = "cloudauthz"
 

--- a/lib/galaxy/managers/datatypes.py
+++ b/lib/galaxy/managers/datatypes.py
@@ -78,7 +78,7 @@ def view_sniffers(datatypes_registry: Registry) -> List[str]:
 
 def view_converters(datatypes_registry: Registry) -> DatatypeConverterList:
     converters = []
-    for (source_type, targets) in datatypes_registry.datatype_converters.items():
+    for source_type, targets in datatypes_registry.datatype_converters.items():
         for target_type in targets:
             converters.append(
                 {
@@ -92,7 +92,7 @@ def view_converters(datatypes_registry: Registry) -> DatatypeConverterList:
 
 def _get_edam_details(datatypes_registry: Registry, edam_ids: Dict[str, str]) -> Dict[str, Dict]:
     details_dict = {}
-    for (format, edam_iri) in edam_ids.items():
+    for format, edam_iri in edam_ids.items():
         edam_details = datatypes_registry.edam.get(edam_iri, {})
 
         details_dict[format] = {

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -482,7 +482,6 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
         hda = item
         display_apps: List[Dict[str, Any]] = []
         for display_app in hda.get_display_applications(trans).values():
-
             app_links = []
             for link_app in display_app.links.values():
                 app_links.append(

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -50,7 +50,6 @@ log = logging.getLogger(__name__)
 
 
 class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMixin, SortableManager):
-
     model_class = model.History
     foreign_key_name = "history"
     user_share_model = model.HistoryUserShareAssociation

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -57,7 +57,6 @@ log = logging.getLogger(__name__)
 # into its own class to have it's own filters, etc.
 # TODO: but can't inherit from model manager (which assumes only one model)
 class HistoryContentsManager(base.SortableManager):
-
     root_container_class = model.History
 
     contained_class = model.HistoryDatasetAssociation
@@ -553,7 +552,6 @@ class HistoryContentsFilters(
         return super().parse_query_filters(query_filters)
 
     def _parse_orm_filter(self, attr, op, val):
-
         # we need to use some manual/text/column fu here since some where clauses on the union don't work
         # using the model_class defined above - they need to be wrapped in their own .column()
         # (and some of these are *not* a normal columns (especially 'state') anyway)

--- a/lib/galaxy/managers/licenses.py
+++ b/lib/galaxy/managers/licenses.py
@@ -78,7 +78,6 @@ class LicensesManager:
     def __init__(self):
         by_index = {}
         for spdx_license in self.index():
-
             by_index[spdx_license["licenseId"]] = spdx_license
             by_index[spdx_license["detailsUrl"]] = spdx_license
             for seeAlso in spdx_license.get("seeAlso", []):

--- a/lib/galaxy/managers/markdown_parse.py
+++ b/lib/galaxy/managers/markdown_parse.py
@@ -80,7 +80,7 @@ def validate_galaxy_markdown(galaxy_markdown, internal=True):
     expecting_container_close_for = None
     last_line_no = 0
     function_calls = 0
-    for (line, fenced, open_fence, line_no) in _split_markdown_lines(galaxy_markdown):
+    for line, fenced, open_fence, line_no in _split_markdown_lines(galaxy_markdown):
         last_line_no = line_no
 
         expecting_container_close = expecting_container_close_for is not None

--- a/lib/galaxy/managers/ratable.py
+++ b/lib/galaxy/managers/ratable.py
@@ -13,7 +13,6 @@ log = logging.getLogger(__name__)
 
 
 class RatableManagerMixin:
-
     rating_assoc: Type[ItemRatingAssociation]
 
     def rating(self, item, user, as_int=True):

--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -108,7 +108,6 @@ class TaggableDeserializerMixin:
 
 
 class TaggableFilterMixin:
-
     valid_ops = ("eq", "contains", "has")
 
     def create_tag_filter(self, attr, op, val):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -377,7 +377,6 @@ class HasName:
 
 
 class UsesCreateAndUpdateTime:
-
     update_time: DateTime
 
     @property
@@ -2840,7 +2839,6 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         return [hda for hda in self.datasets if not hda.dataset.deleted]
 
     def _serialize(self, id_encoder, serialization_options):
-
         history_attrs = dict_for(
             self,
             create_time=self.create_time.__str__(),
@@ -2855,7 +2853,6 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         return history_attrs
 
     def to_dict(self, view="collection", value_mapper=None):
-
         # Get basic value.
         rval = super().to_dict(view=view, value_mapper=value_mapper)
 

--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -63,7 +63,6 @@ def _sniffnfix_pg9_hex(value):
 
 
 class GalaxyLargeBinary(LargeBinary):
-
     # This hack is necessary because the LargeBinary result processor
     # does not specify an encoding in the `bytes` call ,
     # likely because `result` should be binary.

--- a/lib/galaxy/model/dataset_collections/structure.py
+++ b/lib/galaxy/model/dataset_collections/structure.py
@@ -131,7 +131,7 @@ class Tree(BaseTree):
 
         new_collection_type = self.collection_type_description.multiply(other_structure.collection_type_description)
         new_children = []
-        for (identifier, structure) in self.children:
+        for identifier, structure in self.children:
             new_children.append((identifier, structure.multiply(other_structure)))
 
         return Tree(new_children, new_collection_type)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/c39f1de47a04_add_skipped_state_to_collection_job_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/c39f1de47a04_add_skipped_state_to_collection_job_.py
@@ -70,7 +70,6 @@ class SqlitePGView(PGView):
 
 
 def get_view_instance(definition: str):
-
     try:
         url = make_url(context.config.get_main_option("sqlalchemy.url"))
         dialect = url.get_dialect().name

--- a/lib/galaxy/model/migrations/scripts.py
+++ b/lib/galaxy/model/migrations/scripts.py
@@ -93,7 +93,6 @@ def get_configuration(argv: List[str], cwd: str) -> Tuple[DatabaseConfig, Databa
 def get_configuration_from_file(
     cwd: str, config_file: Optional[str] = None
 ) -> Tuple[DatabaseConfig, DatabaseConfig, bool]:
-
     if config_file is None:
         cwds = [cwd, os.path.join(cwd, CONFIG_DIR_NAME)]
         config_file = find_config_file(DEFAULT_CONFIG_NAMES, dirs=cwds)
@@ -163,7 +162,6 @@ class LegacyScriptsException(Exception):
 
 
 class LegacyManageDb:
-
     LEGACY_CONFIG_FILE_ARG_NAMES = ["-c", "--config", "--config-file"]
 
     def __init__(self):

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2258,7 +2258,6 @@ class DirectoryModelExportStore(ModelExportStore):
             jobs_attrs.append({"id": job_id, "output_dataset_mapping": output_dataset_mapping})
 
         if self.serialize_jobs:
-
             #
             # Write jobs attributes file.
             #

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -358,9 +358,7 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
             element_datasets["paths"].append(filename)
 
         self.add_tags_to_datasets(datasets=element_datasets["datasets"], tag_lists=element_datasets["tag_lists"])
-        for (element_identifiers, dataset) in zip(
-            element_datasets["element_identifiers"], element_datasets["datasets"]
-        ):
+        for element_identifiers, dataset in zip(element_datasets["element_identifiers"], element_datasets["datasets"]):
             current_builder = root_collection_builder
             for element_identifier in element_identifiers[:-1]:
                 current_builder = current_builder.get_level(element_identifier)

--- a/lib/galaxy/model/triggers/history_update_time_field.py
+++ b/lib/galaxy/model/triggers/history_update_time_field.py
@@ -44,7 +44,6 @@ def get_timestamp_install_sql(variant):
         # is not necessarily reusable with a function
 
         for operation in ["INSERT", "UPDATE", "DELETE"]:
-
             # change hda -> update history
             sql.append(
                 build_timestamp_trigger(operation, "history_dataset_association", "history", source_key="history_id")

--- a/lib/galaxy/model/triggers/update_audit_table.py
+++ b/lib/galaxy/model/triggers/update_audit_table.py
@@ -146,7 +146,6 @@ def _sqlite_install():
     sql = _sqlite_remove()
 
     def trigger_def(source_table, id_field, operation, when="AFTER"):
-
         # only one trigger per operation/table in simple databases, so
         # trigger name is less descriptive
         trigger_name = get_trigger_name(source_table, operation, when)

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -400,9 +400,7 @@ class AzureBlobObjectStore(ConcreteObjectStore):
         return False
 
     def _create(self, obj, **kwargs):
-
         if not self._exists(obj, **kwargs):
-
             # Pull out locally used fields
             extra_dir = kwargs.get("extra_dir", None)
             extra_dir_at_root = kwargs.get("extra_dir_at_root", False)

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -583,7 +583,6 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
 
     def _create(self, obj, **kwargs):
         if not self._exists(obj, **kwargs):
-
             # Pull out locally used fields
             extra_dir = kwargs.get("extra_dir", None)
             extra_dir_at_root = kwargs.get("extra_dir_at_root", False)

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -593,7 +593,6 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
 
     def _create(self, obj, **kwargs):
         if not self._exists(obj, **kwargs):
-
             # Pull out locally used fields
             extra_dir = kwargs.get("extra_dir", None)
             extra_dir_at_root = kwargs.get("extra_dir_at_root", False)

--- a/lib/galaxy/objectstore/s3_multipart_upload.py
+++ b/lib/galaxy/objectstore/s3_multipart_upload.py
@@ -69,7 +69,7 @@ def multipart_upload(s3server, bucket, s3_key_name, tarball, mb_size):
 
     mp = bucket.initiate_multipart_upload(s3_key_name, reduced_redundancy=s3server["use_rr"])
 
-    for (i, part) in enumerate(split_file(tarball, mb_size)):
+    for i, part in enumerate(split_file(tarball, mb_size)):
         t = threading.Thread(target=transfer_part, args=(s3server, mp.id, mp.key_name, mp.bucket_name, i, part))
         t.start()
         t.join()

--- a/lib/galaxy/schema/fetch_data.py
+++ b/lib/galaxy/schema/fetch_data.py
@@ -274,10 +274,8 @@ Targets = List[
 
 
 class FetchDataPayload(BaseDataPayload):
-
     targets: Targets
 
 
 class FetchDataFormPayload(BaseDataPayload):
-
     targets: Union[Json[Targets], Targets]  # type: ignore[type-arg]  # https://github.com/samuelcolvin/pydantic/issues/2990

--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -48,7 +48,6 @@ DatabaseIdT = TypeVar("DatabaseIdT")
 
 class StepOrderIndexGetter(GetterDict):
     def get(self, key: Any, default: Any = None) -> Any:
-
         # Fetch the order_index when serializing for the API,
         # which makes much more sense when pointing to steps.
         if key == "workflow_step_id":

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -882,7 +882,6 @@ class NavigatesGalaxy(HasDriver):
         rule_builder = self.components.rule_builder
         rule_builder.menu_button_column.wait_for_and_click()
         with self.rule_builder_rule_editor("add-column-regex") as editor_element:
-
             column_elem = editor_element.find_element(By.CSS_SELECTOR, ".rule-column-selector")
             self.select2_set_value(column_elem, column_label)
 
@@ -903,7 +902,6 @@ class NavigatesGalaxy(HasDriver):
         rule_builder = self.components.rule_builder
         rule_builder.menu_button_column.wait_for_and_click()
         with self.rule_builder_rule_editor("add-column-regex") as editor_element:
-
             column_elem = editor_element.find_element(By.CSS_SELECTOR, ".rule-column-selector")
             self.select2_set_value(column_elem, column_label)
 
@@ -1309,7 +1307,6 @@ class NavigatesGalaxy(HasDriver):
         self.wait_for_and_click_selector("input[name='make_accessible_and_publish']")
 
     def tagging_add(self, tags, auto_closes=True, parent_selector=""):
-
         for i, tag in enumerate(tags):
             if auto_closes or i == 0:
                 tag_area = f"{parent_selector}.tags-input input[type='text']"
@@ -1824,7 +1821,6 @@ class NavigatesGalaxy(HasDriver):
 
     def assert_message(self, element, contains=None):
         if contains is not None:
-
             if type(element) == list:
                 assert any(
                     contains in el.text for el in element

--- a/lib/galaxy/tool_util/cwl/parser.py
+++ b/lib/galaxy/tool_util/cwl/parser.py
@@ -106,7 +106,6 @@ class InputInstanceArrayDict(TypedDict):
 
 
 class ToolProxy(metaclass=ABCMeta):
-
     _class: str
 
     def __init__(self, tool, uuid, raw_process_reference=None, tool_path=None):
@@ -610,7 +609,7 @@ class WorkflowProxy:
                 cwl_source_id = input_proxy.cwl_source_id
                 input_name = input_proxy.input_name
                 # Consider only allow multiple if MultipleInputFeatureRequirement is enabled
-                for (output_step_name, output_name) in split_step_references(cwl_source_id, workflow_id=self.cwl_id):
+                for output_step_name, output_name in split_step_references(cwl_source_id, workflow_id=self.cwl_id):
                     if "#" in self.cwl_id:
                         sep_on = "/"
                     else:
@@ -1188,7 +1187,6 @@ class ConditionalInstance:
         self.whens = whens
 
     def to_dict(self):
-
         as_dict = dict(
             name=self.name,
             type=INPUT_TYPE.CONDITIONAL,

--- a/lib/galaxy/tool_util/cwl/runtime_actions.py
+++ b/lib/galaxy/tool_util/cwl/runtime_actions.py
@@ -120,7 +120,6 @@ def handle_outputs(job_directory=None):
 
         secondary_files = output.get("secondaryFiles", [])
         if secondary_files:
-
             order = []
             index_contents = {"order": order}
 

--- a/lib/galaxy/tool_util/data/__init__.py
+++ b/lib/galaxy/tool_util/data/__init__.py
@@ -266,7 +266,7 @@ class ToolDataTable(Dictifiable):
         merged_info = self._merged_load_info
         self.__init__(*self._load_info[0], **self._load_info[1])  # type: ignore[misc]
         self._update_version(version=new_version)
-        for (tool_data_table_class, load_info) in merged_info:
+        for tool_data_table_class, load_info in merged_info:
             self.merge_tool_data_table(tool_data_table_class(*load_info[0], **load_info[1]), allow_duplicates=False)
         return self._update_version()
 
@@ -709,10 +709,8 @@ class TabularToolDataTable(ToolDataTable):
                 data_table_fh.write(fields_collapsed.encode("utf-8"))
 
     def _remove_entry(self, values):
-
         # update every file
         for filename in self.filenames:
-
             if os.path.exists(filename):
                 values = self._replace_field_separators(values)
                 self.filter_file_fields(filename, values)
@@ -792,7 +790,6 @@ class TabularToolDataTable(ToolDataTable):
 
 
 class TabularToolDataField(Dictifiable):
-
     dict_collection_visible_keys: List[str] = []
 
     def __init__(self, data: Dict):

--- a/lib/galaxy/tool_util/deps/__init__.py
+++ b/lib/galaxy/tool_util/deps/__init__.py
@@ -241,7 +241,6 @@ class DependencyManager:
         tool_info = ToolInfo(**tool_info_kwds)
 
         for i, resolver in enumerate(self.dependency_resolvers):
-
             if index is not None and i != index:
                 continue
 
@@ -304,7 +303,6 @@ class DependencyManager:
                     break
 
             if not isinstance(resolver, ContainerResolver):
-
                 # Check individual requirements
                 for requirement in resolvable_requirements:
                     if requirement in _requirement_to_dependency:

--- a/lib/galaxy/tool_util/deps/brew_exts.py
+++ b/lib/galaxy/tool_util/deps/brew_exts.py
@@ -324,7 +324,6 @@ def build_env_statements(cellar_root, cellar_path, relaxed=None, custom_only=Fal
 
 
 def build_env_actions(deps, cellar_root, cellar_path, relaxed=None, custom_only=False):
-
     path_appends = []
     ld_path_appends = []
     actions = []

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -271,7 +271,6 @@ class HasDockerLikeVolumes:
 
 
 class DockerContainer(Container, HasDockerLikeVolumes):
-
     container_type = DOCKER_CONTAINER_TYPE
 
     @property
@@ -383,7 +382,6 @@ def docker_cache_path(cache_directory, container_id):
 
 
 class SingularityContainer(Container, HasDockerLikeVolumes):
-
     container_type = SINGULARITY_CONTAINER_TYPE
 
     def get_singularity_target_kwds(self):
@@ -411,7 +409,6 @@ class SingularityContainer(Container, HasDockerLikeVolumes):
         )
 
     def containerize_command(self, command):
-
         env = []
         for pass_through_var in self.tool_info.env_pass_through:
             env.append((pass_through_var, f"${pass_through_var}"))

--- a/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
@@ -34,7 +34,6 @@ class ExplicitContainerResolver(ContainerResolver):
 
 
 class ExplicitSingularityContainerResolver(ExplicitContainerResolver):
-
     resolver_type = "explicit_singularity"
     container_type = "singularity"
 
@@ -160,7 +159,6 @@ class FallbackSingularityContainerResolver(FallbackContainerResolver):
 
 
 class FallbackNoRequirementsContainerResolver(FallbackContainerResolver):
-
     resolver_type = "fallback_no_requirements"
 
     def _match(self, enabled_container_types, tool_info, container_description):
@@ -169,13 +167,11 @@ class FallbackNoRequirementsContainerResolver(FallbackContainerResolver):
 
 
 class FallbackNoRequirementsSingularityContainerResolver(FallbackNoRequirementsContainerResolver):
-
     resolver_type = "fallback_no_requirements_singularity"
     container_type = "singularity"
 
 
 class RequiresGalaxyEnvironmentContainerResolver(FallbackContainerResolver):
-
     resolver_type = "requires_galaxy_environment"
 
     def _match(self, enabled_container_types, tool_info, container_description):
@@ -184,7 +180,6 @@ class RequiresGalaxyEnvironmentContainerResolver(FallbackContainerResolver):
 
 
 class RequiresGalaxyEnvironmentSingularityContainerResolver(RequiresGalaxyEnvironmentContainerResolver):
-
     resolver_type = "requires_galaxy_environment_singularity"
     container_type = "singularity"
 

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -423,7 +423,6 @@ def targets_to_mulled_name(
 
 
 class CliContainerResolver(ContainerResolver):
-
     container_type = "docker"
     cli = "docker"
 
@@ -445,7 +444,6 @@ class CliContainerResolver(ContainerResolver):
 
 
 class SingularityCliContainerResolver(CliContainerResolver):
-
     container_type = "singularity"
     cli = "singularity"
 
@@ -465,7 +463,6 @@ class SingularityCliContainerResolver(CliContainerResolver):
 
 
 class CachedMulledDockerContainerResolver(CliContainerResolver):
-
     resolver_type = "cached_mulled"
     shell = "/bin/bash"
 
@@ -494,7 +491,6 @@ class CachedMulledDockerContainerResolver(CliContainerResolver):
 
 
 class CachedMulledSingularityContainerResolver(SingularityCliContainerResolver):
-
     resolver_type = "cached_mulled_singularity"
     shell = "/bin/bash"
 
@@ -611,7 +607,6 @@ class MulledDockerContainerResolver(CliContainerResolver):
 
 
 class MulledSingularityContainerResolver(SingularityCliContainerResolver, MulledDockerContainerResolver):
-
     resolver_type = "mulled_singularity"
     protocol = "docker://"
 

--- a/lib/galaxy/tool_util/deps/container_volumes.py
+++ b/lib/galaxy/tool_util/deps/container_volumes.py
@@ -6,7 +6,6 @@ from abc import (
 
 
 class ContainerVolume(metaclass=ABCMeta):
-
     valid_modes = frozenset({"ro", "rw"})
 
     def __init__(self, path, host_path=None, mode=None):

--- a/lib/galaxy/tool_util/deps/dockerfiles.py
+++ b/lib/galaxy/tool_util/deps/dockerfiles.py
@@ -22,7 +22,7 @@ def docker_host_args(**kwds):
 def dockerfile_build(path, dockerfile=None, error=log.error, **kwds):
     expected_container_names = set()
     tool_directories = set()
-    for (tool_path, tool_xml) in load_tool_elements_from_path(path):
+    for tool_path, tool_xml in load_tool_elements_from_path(path):
         requirements, containers = parse_requirements_from_xml(tool_xml)
         for container in containers:
             if container.type == "docker":

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -379,7 +379,6 @@ class CondaInDockerContext(CondaContext):
 
 
 class InvolucroContext(installable.InstallableContext):
-
     installable_description = "Involucro"
 
     def __init__(self, involucro_bin=None, shell_exec=None, verbose="3"):

--- a/lib/galaxy/tool_util/deps/mulled/mulled_search.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_search.py
@@ -233,7 +233,6 @@ def singularity_search(search_string):
 
 
 def readable_output(json, organization="biocontainers", channel="bioconda"):
-
     # if json is empty:
     if sum(len(json[destination][results]) for destination in json for results in json[destination]) == 0:
         sys.stdout.write("No results found for that query.\n")

--- a/lib/galaxy/tool_util/deps/resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/resolvers/__init__.py
@@ -285,7 +285,6 @@ class Dependency(Dictifiable, metaclass=ABCMeta):
 
 
 class ContainerDependency(Dependency):
-
     dict_collection_visible_keys = Dependency.dict_collection_visible_keys + [
         "environment_path",
         "container_description",

--- a/lib/galaxy/tool_util/deps/singularity_util.py
+++ b/lib/galaxy/tool_util/deps/singularity_util.py
@@ -66,7 +66,7 @@ def build_singularity_run_command(
     command_parts = []
     # http://singularity.lbl.gov/docs-environment-metadata
     home = None
-    for (key, value) in env:
+    for key, value in env:
         if key == "HOME":
             home = value
         command_parts.extend([f"SINGULARITYENV_{key}={value}"])

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -327,7 +327,7 @@ def lint_tool_source_with(lint_context, tool_source, extra_modules=None) -> Lint
         if not ("*" in lint_tool_types or tool_type in lint_tool_types):
             continue
 
-        for (name, value) in inspect.getmembers(module):
+        for name, value in inspect.getmembers(module):
             if callable(value) and name.startswith("lint_"):
                 # Look at the first argument to the linter to decide
                 # if we should lint the XML description or the abstract

--- a/lib/galaxy/tool_util/locations/dockstore.py
+++ b/lib/galaxy/tool_util/locations/dockstore.py
@@ -8,7 +8,6 @@ from . import ToolLocationResolver
 
 
 class DockStoreResolver(ToolLocationResolver):
-
     scheme = "dockstore"
 
     def get_tool_source_path(self, uri_like: str) -> str:

--- a/lib/galaxy/tool_util/locations/file.py
+++ b/lib/galaxy/tool_util/locations/file.py
@@ -2,7 +2,6 @@ from . import ToolLocationResolver
 
 
 class HttpToolResolver(ToolLocationResolver):
-
     scheme = "file"
 
     def get_tool_source_path(self, uri_like: str) -> str:

--- a/lib/galaxy/tool_util/locations/http.py
+++ b/lib/galaxy/tool_util/locations/http.py
@@ -3,7 +3,6 @@ from . import ToolLocationResolver
 
 
 class HttpToolResolver(ToolLocationResolver):
-
     scheme = "http"
 
     def __init__(self, **kwds):
@@ -16,7 +15,6 @@ class HttpToolResolver(ToolLocationResolver):
 
 
 class HttpsToolResolver(HttpToolResolver):
-
     scheme = "https"
 
 

--- a/lib/galaxy/tool_util/parser/cwl.py
+++ b/lib/galaxy/tool_util/parser/cwl.py
@@ -27,7 +27,6 @@ log = logging.getLogger(__name__)
 
 
 class CwlToolSource(ToolSource):
-
     language = "yaml"
 
     def __init__(self, tool_file=None, strict_cwl_validation=True, tool_proxy: Optional[ToolProxy] = None):

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -544,7 +544,7 @@ class RequiredFiles:
             excludes.append({"path": ".hg", "path_type": "prefix"})
 
         files: List[str] = []
-        for (dirpath, _, filenames) in safe_walk(tool_directory):
+        for dirpath, _, filenames in safe_walk(tool_directory):
             for filename in filenames:
                 rel_path = join(dirpath, filename).replace(tool_directory + os.path.sep, "")
                 if matches(self.includes, rel_path) and not matches(self.excludes, rel_path):

--- a/lib/galaxy/tool_util/parser/output_collection_def.py
+++ b/lib/galaxy/tool_util/parser/output_collection_def.py
@@ -104,12 +104,10 @@ class DatasetCollectionDescription:
 
 
 class ToolProvidedMetadataDatasetCollection(DatasetCollectionDescription):
-
     discover_via = "tool_provided_metadata"
 
 
 class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
-
     discover_via = "pattern"
 
     def __init__(self, **kwargs):

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -32,7 +32,6 @@ from .util import is_dict
 
 
 class YamlToolSource(ToolSource):
-
     language = "yaml"
 
     def __init__(self, root_dict: Dict, source_path=None):

--- a/lib/galaxy/tool_util/toolbox/panel.py
+++ b/lib/galaxy/tool_util/toolbox/panel.py
@@ -230,11 +230,11 @@ class ToolPanelElements(odict, HasPanelItems):
                 yield (key, item)
 
     def closest_section(self, target_section_id: Optional[str], target_section_name: Optional[str]):
-        for (section_id, section) in self.walk_sections():
+        for section_id, section in self.walk_sections():
             if section_id == target_section_id:
                 return section
 
-        for (_, section) in self.walk_sections():
+        for _, section in self.walk_sections():
             if section.name == target_section_name:
                 return section
 

--- a/lib/galaxy/tool_util/toolbox/views/edam.py
+++ b/lib/galaxy/tool_util/toolbox/views/edam.py
@@ -123,7 +123,7 @@ class EdamToolPanelView(ToolPanelView):
                 populate_section(*tuple_)
 
         section = new_panel.get_or_create_section("uncategorized", "Uncategorized")
-        for (tool_id, key, val, val_name) in uncategorized:
+        for tool_id, key, val, val_name in uncategorized:
             toolbox_registry.add_tool_to_tool_panel_view(val, section)
             new_panel.record_section_for_tool_id(tool_id, key, val_name)
         log.debug("Loading EDAM tool panel finished %s", execution_timer)

--- a/lib/galaxy/tool_util/toolbox/views/static.py
+++ b/lib/galaxy/tool_util/toolbox/views/static.py
@@ -169,7 +169,7 @@ class StaticToolPanelView(ToolPanelView):
         if root_items is None:
             root_items = []
             # No items found, use base tool panel and apply filters to that...
-            for (_, panel_type, panel_value) in base_tool_panel.panel_items_iter():
+            for _, panel_type, panel_value in base_tool_panel.panel_items_iter():
                 item: Optional[ExpandedRootContent] = None
                 if panel_type == panel_item_types.TOOL:
                     item = Tool(

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -709,7 +709,6 @@ class GalaxyInteractorApi:
             return
 
         for history_content in history_contents:
-
             dataset = history_content
 
             print(ERROR_MESSAGE_DATASET_SEP)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1461,7 +1461,7 @@ class Tool(Dictifiable):
                     # Must refresh when test_param changes
                     group_c.test_param.refresh_on_change = True
                     # And a set of possible cases
-                    for (value, case_inputs_source) in input_source.parse_when_input_sources():
+                    for value, case_inputs_source in input_source.parse_when_input_sources():
                         case = ConditionalWhen()
                         case.value = value
                         case.inputs = self.parse_input_elem(case_inputs_source, enctypes, context)
@@ -2808,7 +2808,6 @@ class ExpressionTool(Tool):
                 # Skip filtered outputs
                 continue
             if val.output_type == "data":
-
                 with open(out_data[key].file_name) as f:
                     src = json.load(f)
                 assert isinstance(src, dict), f"Expected dataset 'src' to be a dictionary - actual type is {type(src)}"

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -752,7 +752,7 @@ class DefaultToolAction(ToolAction):
                     current_job.parameters.append(p.copy())
             remapped_hdas = self.__remap_data_inputs(old_job=old_job, current_job=current_job)
             for jtod in old_job.output_datasets:
-                for (job_to_remap, jtid) in [(jtid.job, jtid) for jtid in jtod.dataset.dependent_jobs]:
+                for job_to_remap, jtid in [(jtid.job, jtid) for jtid in jtod.dataset.dependent_jobs]:
                     if (trans.user is not None and job_to_remap.user_id == trans.user.id) or (
                         trans.user is None and job_to_remap.session_id == galaxy_session.id
                     ):
@@ -838,7 +838,7 @@ class DefaultToolAction(ToolAction):
         #        parameters to the command as a special case.
         reductions: Dict[str, List[str]] = {}
         for name, dataset_collection_info_pairs in inp_dataset_collections.items():
-            for (dataset_collection, reduced) in dataset_collection_info_pairs:
+            for dataset_collection, reduced in dataset_collection_info_pairs:
                 if reduced:
                     if name not in reductions:
                         reductions[name] = []
@@ -1193,7 +1193,8 @@ def determine_output_format(
                             check, context=parameter_context, python_template_version=python_template_version
                         ) == when_elem.get("value", None):
                             ext = when_elem.get("format", ext)
-                    except Exception:  # bad tag input value; possibly referencing a param within a different conditional when block or other nonexistent grouping construct
+                    except Exception:
+                        # bad tag input value; possibly referencing a param within a different conditional when block or other nonexistent grouping construct
                         continue
                 else:
                     check = when_elem.get("input_dataset", None)

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -172,7 +172,6 @@ class RefgenieToolDataTable(TabularToolDataTable):
         return rval
 
     def _remove_entry(self, values):
-
         log.warning(
             "Deletion from refgenie-backed '%s' data table is not supported, will only try to delete from .loc files",
             self.name,

--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -54,7 +54,6 @@ class GithubPlugin(BaseGitPlugin):
         log.info(self.github)
 
         if self.github:
-
             # Determine the ToolShed url, initially we connect with HTTP and if redirect to HTTPS is set up,
             # this will be detected by requests and used further down the line. Also cache this so everything is
             # as fast as possible

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -398,7 +398,6 @@ class ExecutionTracker:
         # walk through and optional replace runtime values with None, assume they
         # would have been replaced by now if they were going to be set.
         def replace_optional_runtime_values(path, key, value):
-
             if is_runtime_value(value):
                 return key, None
             return key, value

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -67,7 +67,6 @@ class JobImportHistoryArchiveWrapper:
             )
             job = jiha.job
             with model_store.target_history(default_history=job.history) as new_history:
-
                 jiha.history = new_history
                 self.sa_session.flush()
                 model_store.perform_import(new_history, job=job, new_history=True)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -360,7 +360,7 @@ class TextToolParameter(SimpleTextToolParameter):
         input_source = ensure_input_source(input_source)
         super().__init__(tool, input_source)
         self.datalist = []
-        for (title, value, _) in input_source.parse_static_options():
+        for title, value, _ in input_source.parse_static_options():
             self.datalist.append({"label": title, "value": value})
         self.value = input_source.get("value")
         self.area = input_source.get_bool("area", False)
@@ -905,7 +905,7 @@ class SelectToolParameter(ToolParameter):
                 self.validators.append(validator)
         if self.dynamic_options is None and self.options is None:
             self.static_options = input_source.parse_static_options()
-            for (_, value, _) in self.static_options:
+            for _, value, _ in self.static_options:
                 self.legal_values.add(value)
         self.is_dynamic = (self.dynamic_options is not None) or (self.options is not None)
 
@@ -1794,7 +1794,6 @@ class DrillDownSelectToolParameter(SelectToolParameter):
 
 
 class BaseDataToolParameter(ToolParameter):
-
     multiple: bool
 
     def __init__(self, tool, input_source, trans):

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -40,7 +40,6 @@ URI_PREFIXES = [f"{x}://" for x in ["http", "https", "ftp", "file", "gxfiles", "
 
 
 class Group(Dictifiable):
-
     dict_collection_visible_keys = ["name", "type"]
     type: str
 
@@ -77,7 +76,6 @@ class Group(Dictifiable):
 
 
 class Repeat(Group):
-
     dict_collection_visible_keys = ["name", "type", "title", "help", "default", "min", "max"]
     type = "repeat"
 
@@ -169,7 +167,6 @@ class Repeat(Group):
 
 
 class Section(Group):
-
     dict_collection_visible_keys = ["name", "type", "title", "help", "expanded"]
     type = "section"
 

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -216,7 +216,7 @@ def _process_simple_value(param, param_value, required_data_tables, required_loc
         def process_param_value(param_value):
             found_value = False
             value_for_text = None
-            for (text, opt_value, _) in getattr(param, "static_options", []):
+            for text, opt_value, _ in getattr(param, "static_options", []):
                 if param_value == opt_value:
                     found_value = True
                 if value_for_text is None and param_value == text:
@@ -270,7 +270,7 @@ def _matching_case_for_value(tool, cond, declared_value):
             # No explicit value in test case, not much to do if options are dynamic but
             # if static options are available can find the one specified as default or
             # fallback on top most option (like GUI).
-            for (name, _, selected) in test_param.static_options:
+            for name, _, selected in test_param.static_options:
                 if selected:
                     default_option = name
             else:

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -516,7 +516,6 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
 
 
 class HasDatasets:
-
     job_working_directory: Optional[str]
 
     @abc.abstractmethod

--- a/lib/galaxy/util/compression_utils.py
+++ b/lib/galaxy/util/compression_utils.py
@@ -167,7 +167,6 @@ def decompress_path_to_directory(path: str) -> str:
 
 
 class CompressedFile:
-
     archive: Union[tarfile.TarFile, zipfile.ZipFile]
 
     @staticmethod

--- a/lib/galaxy/util/odict.py
+++ b/lib/galaxy/util/odict.py
@@ -30,7 +30,7 @@ class odict(UserDict):
         else:
             UserDict.__init__(self, None)
         if isinstance(item, list):
-            for (key, value) in item:
+            for key, value in item:
                 self[key] = value
 
     def __delitem__(self, key):
@@ -72,7 +72,7 @@ class odict(UserDict):
         return UserDict.setdefault(self, key, failobj)
 
     def update(self, dict):
-        for (key, val) in dict.items():
+        for key, val in dict.items():
             self.__setitem__(key, val)
 
     def values(self):

--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -451,7 +451,7 @@ class SortRuleDefinition(BaseRuleDefinition):
         new_data = []
         new_sources = []
 
-        for (row, source) in sorted_data:
+        for row, source in sorted_data:
             new_data.append(row)
             new_sources.append(source)
 

--- a/lib/galaxy/util/template.py
+++ b/lib/galaxy/util/template.py
@@ -19,7 +19,6 @@ refactoring_tool = RefactoringTool(myfixes, {"print_function": True})
 
 
 class FixedModuleCodeCompiler(Compiler):
-
     module_code = None
 
     def getModuleCode(self):

--- a/lib/galaxy/visualization/data_providers/basic.py
+++ b/lib/galaxy/visualization/data_providers/basic.py
@@ -147,7 +147,6 @@ class ColumnDataProvider(BaseDataProvider):
         f = open(self.original_dataset.file_name)
         # TODO: add f.seek if given fptr in kwargs
         for count, line in enumerate(f):
-
             # check line v. desired start, end
             if count < start_val:
                 continue
@@ -165,7 +164,6 @@ class ColumnDataProvider(BaseDataProvider):
                 if column < fields_len:
                     column_val = cast_val(fields[column], column_type)
                     if column_val is not None:
-
                         # if numeric, maintain min, max, sum
                         if column_type == "float" or column_type == "int":
                             if (meta[index]["min"] is None) or (column_val < meta[index]["min"]):

--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -1141,7 +1141,6 @@ class BamDataProvider(GenomeDataProvider, FilterableMixin):
 
 
 class SamDataProvider(BamDataProvider):
-
     dataset_type = "bai"
 
     def __init__(self, converted_dataset=None, original_dataset=None, dependencies=None):

--- a/lib/galaxy/visualization/data_providers/phyloviz/__init__.py
+++ b/lib/galaxy/visualization/data_providers/phyloviz/__init__.py
@@ -11,7 +11,6 @@ from galaxy.visualization.data_providers.phyloviz.phyloxmlparser import Phyloxml
 
 
 class PhylovizDataProvider(BaseDataProvider):
-
     dataset_type = "phylo"
 
     def __init__(self, original_dataset=None):

--- a/lib/galaxy/visualization/data_providers/phyloviz/newickparser.py
+++ b/lib/galaxy/visualization/data_providers/phyloviz/newickparser.py
@@ -137,7 +137,6 @@ class Newick_Parser(Base_Parser):
                 i = bracketStack.pop()
 
                 if len(bracketStack) == 0:  # is child of current node
-
                     InternalNode = None
 
                     # First flat call to make nodes of the same depth but from the preceeding string.

--- a/lib/galaxy/visualization/data_providers/phyloviz/nexusparser.py
+++ b/lib/galaxy/visualization/data_providers/phyloviz/nexusparser.py
@@ -48,7 +48,6 @@ class Nexus_Parser(Newick_Parser):
                 continue
 
             if inTreeBlock:
-
                 if "title" in lline:  # Adding title to the tree
                     continue
 

--- a/lib/galaxy/web/proxy/__init__.py
+++ b/lib/galaxy/web/proxy/__init__.py
@@ -27,7 +27,6 @@ SECURE_COOKIE = "galaxysession"
 
 
 class ProxyManager:
-
     valid_update_keys = (
         "host",
         "port",
@@ -49,7 +48,6 @@ class ProxyManager:
             "dynamic_proxy_golang_docker_address",
             "dynamic_proxy_golang_api_key",
         ]:
-
             setattr(self, option, getattr(config, option))
 
         if self.manage_dynamic_proxy:

--- a/lib/galaxy/web/short_term_storage/__init__.py
+++ b/lib/galaxy/web/short_term_storage/__init__.py
@@ -105,7 +105,6 @@ ShortTermStorageServeInformation = Union[
 
 
 class ShortTermStorageAllocator(metaclass=abc.ABCMeta):
-
     # TODO: Implement upstream_mod_zip=False, upstream_gzip=False - in initial request and serving...
     @abc.abstractmethod
     def new_target(

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -392,7 +392,6 @@ class SharableItemSecurityMixin:
 
 
 class UsesLibraryMixinItems(SharableItemSecurityMixin):
-
     get_object: Callable
 
     def get_library_folder(self, trans, id: int, check_ownership=False, check_accessible=True):

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -291,7 +291,6 @@ class Router(InferringRouter):
         include_in_schema = kwd.pop("include_in_schema", True)
 
         def decorate_route(route, include_in_schema=include_in_schema):
-
             # Decorator solely exists to allow passing `route_class_override` to add_api_route
             def decorated_route(func):
                 self.add_api_route(

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -62,12 +62,10 @@ SEARCH_RESERVED_TERMS_FAVORITES = ["#favs", "#favorites", "#favourites"]
 
 
 class FormDataApiRoute(APIContentTypeRoute):
-
     match_content_type = "multipart/form-data"
 
 
 class JsonApiRoute(APIContentTypeRoute):
-
     match_content_type = "application/json"
 
 
@@ -419,6 +417,7 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         Return diagnostic information to help debug panel
         and dependency related problems.
         """
+
         # TODO: Move this into tool.
         def to_dict(x):
             return x.to_dict()

--- a/lib/galaxy/webapps/galaxy/api/uploads.py
+++ b/lib/galaxy/webapps/galaxy/api/uploads.py
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 
 
 class UploadsAPIController(BaseGalaxyAPIController):
-
     READ_CHUNK_SIZE = 2**16
 
     @expose_api_raw_anonymous

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -972,7 +972,7 @@ class WorkflowsAPIController(
         decoded_invocation_id = self.decode_id(invocation_id)
         ids = []
         types = []
-        for (job_source_type, job_source_id, _) in invocation_job_source_iter(trans.sa_session, decoded_invocation_id):
+        for job_source_type, job_source_id, _ in invocation_job_source_iter(trans.sa_session, decoded_invocation_id):
             ids.append(job_source_id)
             types.append(job_source_type)
         return [self.encode_all_ids(trans, s) for s in fetch_job_states(trans.sa_session, ids, types)]

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -547,7 +547,6 @@ class DatatypesEntryT(TypedDict):
 
 
 class AdminGalaxy(controller.JSAppLauncher):
-
     user_list_grid = UserListGrid()
     role_list_grid = RoleListGrid()
     group_list_grid = GroupListGrid()

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -51,7 +51,6 @@ class NameColumn(grids.TextColumn):
 
 
 class HistoryListGrid(grids.Grid):
-
     # Custom column types
     class ItemCountColumn(grids.GridColumn):
         def get_value(self, trans, grid, history):
@@ -175,7 +174,6 @@ class HistoryListGrid(grids.Grid):
 
 
 class SharedHistoryListGrid(grids.Grid):
-
     # Custom column types
     class DatasetsByStateColumn(grids.GridColumn):
         def get_value(self, trans, grid, history):

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -347,7 +347,6 @@ class VisualizationSelectionGrid(ItemSelectionGrid):
 
 # Adapted from the _BaseHTMLProcessor class of https://github.com/kurtmckee/feedparser
 class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, UsesVisualizationMixin, UsesItemRatings):
-
     _page_list = PageListGrid()
     _all_published_list = PageAllPublishedGrid()
     _history_selection_grid = HistorySelectionGrid()

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -18,7 +18,6 @@ log = logging.getLogger(__name__)
 
 
 class ToolRunner(BaseUIController):
-
     # Hack to get biomart to work, ideally, we could pass tool_id to biomart and receive it back
     @web.expose
     def biomart(self, trans, tool_id="biomart", **kwd):

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -121,7 +121,6 @@ def add_galaxy_middleware(app: FastAPI, gx_app):
             max_age=600,
         )
     else:
-
         # handle CORS preflight requests - synchronize with wsgi behavior.
         @app.options("/api/{rest_of_path:path}")
         async def preflight_handler(request: Request, rest_of_path: str) -> Response:

--- a/lib/galaxy/webapps/galaxy/services/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/services/_fetch_util.py
@@ -59,7 +59,6 @@ def validate_and_normalize_targets(trans, payload):
     payload["check_content"] = trans.app.config.check_upload_content
 
     def check_src(item):
-
         validate_datatype_extension(datatypes_registry=trans.app.datatypes_registry, ext=item.get("ext"))
 
         # Normalize file:// URLs into paths.
@@ -107,7 +106,7 @@ def validate_and_normalize_targets(trans, payload):
             is_directory = False
 
             assert not os.path.islink(user_ftp_dir), "User FTP directory cannot be a symbolic link"
-            for (dirpath, dirnames, filenames) in os.walk(user_ftp_dir):
+            for dirpath, dirnames, filenames in os.walk(user_ftp_dir):
                 for filename in filenames:
                     if ftp_path == filename:
                         path = relpath(os.path.join(dirpath, filename), user_ftp_dir)
@@ -125,7 +124,7 @@ def validate_and_normalize_targets(trans, payload):
 
             if is_directory:
                 # If the target is a directory - make sure no files under it are symbolic links
-                for (dirpath, dirnames, filenames) in os.walk(full_path):
+                for dirpath, dirnames, filenames in os.walk(full_path):
                     for filename in filenames:
                         if ftp_path == filename:
                             path = relpath(os.path.join(dirpath, filename), full_path)

--- a/lib/galaxy/webapps/galaxy/services/libraries.py
+++ b/lib/galaxy/webapps/galaxy/services/libraries.py
@@ -232,7 +232,6 @@ class LibrariesService(ServiceBase, ConsumesModelStores):
             if not is_public:
                 raise exceptions.InternalServerError("An error occurred while making library public.")
         elif action == "set_permissions":
-
             # ACCESS LIBRARY ROLES
             valid_access_roles = []
             invalid_access_roles_names = []

--- a/lib/galaxy/webapps/galaxy/services/library_folders.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folders.py
@@ -168,7 +168,6 @@ class LibraryFoldersService(ServiceBase):
         if action is None:
             raise RequestParameterMissingException('The mandatory parameter "action" is missing.')
         elif action == "set_permissions":
-
             # ADD TO LIBRARY ROLES
             valid_add_roles = []
             invalid_add_roles_names = []

--- a/lib/galaxy/webapps/openapi/utils.py
+++ b/lib/galaxy/webapps/openapi/utils.py
@@ -245,7 +245,7 @@ def get_openapi_path(
                 callbacks = {}
                 for callback in route.callbacks:
                     if isinstance(callback, routing.APIRoute):
-                        (cb_path, cb_security_schemes, cb_definitions,) = get_openapi_path(
+                        cb_path, cb_security_schemes, cb_definitions = get_openapi_path(
                             route=callback,
                             model_name_map=model_name_map,
                             operation_ids=operation_ids,
@@ -480,7 +480,7 @@ def merge_parameters(params_by_id: Dict[str, Optional[List[Dict[str, Any]]]]) ->
     if len(with_params) == 1:
         return with_params[0][1]
     param_by_id_by_name: Dict[str, Any] = {}
-    for (param_id, params) in with_params:
+    for param_id, params in with_params:
         for param in params:
             param_by_id_by_name.setdefault(param["name"], {})[param_id] = param
 

--- a/lib/galaxy/webapps/reports/controllers/workflows.py
+++ b/lib/galaxy/webapps/reports/controllers/workflows.py
@@ -126,7 +126,6 @@ class SpecifiedDateListGrid(grids.Grid):
 
 
 class Workflows(BaseUIController, ReportQueryBuilder):
-
     specified_date_list_grid = SpecifiedDateListGrid()
 
     @web.expose

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -239,7 +239,6 @@ def evaluate_value_from_expressions(progress, step, execution_state, extra_step_
 
 
 class WorkflowModule:
-
     label: str
     type: str
     name: str
@@ -754,7 +753,7 @@ class SubWorkflowModule(WorkflowModule):
 
         when_values = []
         if step.when_expression:
-            for (iteration_elements, when_value) in iteration_elements_iter:
+            for iteration_elements, when_value in iteration_elements_iter:
                 if when_value is False:
                     when_values.append(when_value)
                     continue
@@ -1657,7 +1656,6 @@ class PauseModule(WorkflowModule):
 
 
 class ToolModule(WorkflowModule):
-
     type = "tool"
     name = "Tool"
 
@@ -2130,7 +2128,7 @@ class ToolModule(WorkflowModule):
             iteration_elements_iter = [(None, progress.when_values[0] if progress.when_values else None)]
 
         resource_parameters = invocation.resource_parameters
-        for (iteration_elements, when_value) in iteration_elements_iter:
+        for iteration_elements, when_value in iteration_elements_iter:
             execution_state = tool_state.copy()
             # TODO: Move next step into copy()
             execution_state.inputs = make_dict_copy(execution_state.inputs)

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -208,7 +208,7 @@ class WorkflowInvoker:
         remaining_steps = self.progress.remaining_steps()
         delayed_steps = False
         max_jobs_per_iteration_reached = False
-        for (step, workflow_invocation_step) in remaining_steps:
+        for step, workflow_invocation_step in remaining_steps:
             max_jobs_to_schedule = self.progress.maximum_jobs_to_schedule_or_none
             if max_jobs_to_schedule is not None and max_jobs_to_schedule <= 0:
                 max_jobs_per_iteration_reached = True

--- a/lib/galaxy/workflow/trs_proxy.py
+++ b/lib/galaxy/workflow/trs_proxy.py
@@ -47,7 +47,7 @@ def parse_search_kwds(search_query):
         query_kwd["description"] = (description_term,)
 
     if keyed_terms is not None:
-        for (key, value, _) in keyed_terms:
+        for key, value, _ in keyed_terms:
             query_kwd[key] = value
     return query_kwd
 

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -590,7 +590,7 @@ class TestDatasetCollectionsApi(ApiTestCase):
     def _compare_collection_contents_elements(self, contents_elements, hdca_elements):
         # compare collection api results to existing hdca element contents
         fields = ["element_identifier", "element_index", "element_type", "id", "model_class"]
-        for (content_element, hdca_element) in zip(contents_elements, hdca_elements):
+        for content_element, hdca_element in zip(contents_elements, hdca_elements):
             for f in fields:
                 assert content_element[f] == hdca_element[f]
 

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -504,7 +504,6 @@ class ImportExportTests(BaseHistories):
         )
 
     def _import_history_and_wait(self, import_data, history_name, wait_on_history_length=None):
-
         imported_history_id = self.dataset_populator.import_history_and_wait_for_name(import_data, history_name)
 
         if wait_on_history_length:

--- a/lib/galaxy_test/api/test_pages.py
+++ b/lib/galaxy_test/api/test_pages.py
@@ -44,7 +44,6 @@ class BasePagesApiTestCase(ApiTestCase):
 
 
 class TestPagesApi(BasePagesApiTestCase, SharingApiTests):
-
     api_name = "pages"
 
     def create(self, name: str) -> str:

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -2194,7 +2194,7 @@ class TestToolsApi(ApiTestCase, TestsTools):
             (element10, "456\n789\n"),
             (element11, "456\n0ab\n"),
         ]
-        for (element, expected_contents) in expected_contents_list:
+        for element, expected_contents in expected_contents_list:
             dataset_id = element["object"]["id"]
             contents = self.dataset_populator.get_history_dataset_content(history_id, dataset_id=dataset_id)
             assert expected_contents == contents

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -47,7 +47,6 @@ class TestUsersApi(ApiTestCase):
         user = self._setup_user(TEST_USER_EMAIL)
         not_the_user = self._setup_user("email@example.com")
         with self._different_user(email=TEST_USER_EMAIL):
-
             # working
             update_response = self.__update(user, username=new_name)
             self._assert_status_code_is(update_response, 200)

--- a/lib/galaxy_test/api/test_visualizations.py
+++ b/lib/galaxy_test/api/test_visualizations.py
@@ -13,7 +13,6 @@ REVISION_KEYS = ["id", "title", "visualization_id", "dbkey", "model_class", "con
 
 
 class TestVisualizationsApi(ApiTestCase, SharingApiTests):
-
     api_name = "visualizations"
 
     def create(self, _: str) -> str:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -277,7 +277,6 @@ input1:
 
 
 class TestWorkflowSharingApi(ApiTestCase, SharingApiTests):
-
     api_name = "workflows"
 
     def create(self, name: str) -> str:
@@ -6596,7 +6595,6 @@ input_c:
 
 
 class TestAdminWorkflowsApi(BaseWorkflowsApiTestCase):
-
     require_admin_user = True
 
     def test_import_export_dynamic_tools(self, history_id):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -335,7 +335,6 @@ class CwlWorkflowRun(CwlRun):
 
 
 class BasePopulator(metaclass=ABCMeta):
-
     galaxy_interactor: ApiTestInteractor
 
     @abstractmethod

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -7,7 +7,6 @@ from .framework import (
 
 
 class TestAdminApp(SeleniumTestCase):
-
     run_as_admin = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_collection_builders.py
+++ b/lib/galaxy_test/selenium/test_collection_builders.py
@@ -5,7 +5,6 @@ from .framework import (
 
 
 class TestCollectionBuilders(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -5,7 +5,6 @@ from .framework import (
 
 
 class TestCollectionEdit(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_data_source_tools.py
+++ b/lib/galaxy_test/selenium/test_data_source_tools.py
@@ -8,7 +8,6 @@ from .framework import (
 
 
 class TestDataSource(SeleniumTestCase, UsesHistoryItemAssertions):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_history_copy_elements.py
+++ b/lib/galaxy_test/selenium/test_history_copy_elements.py
@@ -5,7 +5,6 @@ from .framework import (
 
 
 class TestHistoryCopyElements(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -5,7 +5,6 @@ from .framework import (
 
 
 class TestHistoryMultiView(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_history_panel.py
+++ b/lib/galaxy_test/selenium/test_history_panel.py
@@ -9,7 +9,6 @@ NEW_HISTORY_NAME = "New History Name"
 
 
 class TestHistoryPanel(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test
@@ -46,7 +45,6 @@ class TestHistoryPanel(SeleniumTestCase):
 
         @retry_assertion_during_transitions
         def assert_current_annotation(expected, error_message="History annotation", is_equal=True):
-
             text_component = history_panel.annotation_editable_text
             current_annotation = text_component.wait_for_visible()
             error_message += " given: [%s] expected [%s] "

--- a/lib/galaxy_test/selenium/test_history_panel_collections.py
+++ b/lib/galaxy_test/selenium/test_history_panel_collections.py
@@ -11,7 +11,6 @@ from .framework import (
 
 
 class TestHistoryPanelCollections(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_history_sharing.py
+++ b/lib/galaxy_test/selenium/test_history_sharing.py
@@ -121,7 +121,6 @@ class TestHistorySharing(SeleniumTestCase):
 
 
 class TestHistoryRequiresLoginSelenium(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_invocation_grid.py
+++ b/lib/galaxy_test/selenium/test_invocation_grid.py
@@ -8,7 +8,6 @@ from .framework import (
 
 
 class TestInvocationGridSelenium(SeleniumTestCase, TestsGalaxyPagers):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -13,7 +13,6 @@ from .framework import (
 
 
 class TestLibraryContents(SeleniumTestCase, UsesLibraryAssertions):
-
     run_as_admin = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_library_landing.py
+++ b/lib/galaxy_test/selenium/test_library_landing.py
@@ -6,7 +6,6 @@ from .framework import (
 
 
 class TestLibraryLanding(SeleniumTestCase):
-
     requires_admin = True
 
     def setup_with_driver(self):

--- a/lib/galaxy_test/selenium/test_library_to_collections.py
+++ b/lib/galaxy_test/selenium/test_library_to_collections.py
@@ -6,7 +6,6 @@ from .framework import (
 
 
 class TestLibraryToCollections(SeleniumTestCase, UsesLibraryAssertions):
-
     requires_admin = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_pages.py
+++ b/lib/galaxy_test/selenium/test_pages.py
@@ -6,7 +6,6 @@ from .framework import (
 
 
 class TestPages(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -181,7 +181,6 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
 
 
 class TestLoggedInToolForm(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -28,7 +28,6 @@ from .framework import (
 
 
 class TestWorkflowEditor(SeleniumTestCase, RunsWorkflows):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_workflow_invocation_details.py
+++ b/lib/galaxy_test/selenium/test_workflow_invocation_details.py
@@ -7,7 +7,6 @@ from .framework import (
 
 
 class TestWorkflowInvocationDetails(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_workflow_management.py
+++ b/lib/galaxy_test/selenium/test_workflow_management.py
@@ -11,7 +11,6 @@ from .framework import (
 
 
 class TestWorkflowManagement(SeleniumTestCase, TestsGalaxyPagers, UsesWorkflowAssertions):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -25,7 +25,6 @@ from .framework import (
 
 
 class TestWorkflowRun(SeleniumTestCase, UsesHistoryItemAssertions, RunsWorkflows):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_workflow_sharing.py
+++ b/lib/galaxy_test/selenium/test_workflow_sharing.py
@@ -7,7 +7,6 @@ from .framework import (
 
 
 class TestWorkflowSharingRedirect(SeleniumTestCase):
-
     ensure_registered = True
 
     @selenium_test

--- a/lib/tool_shed/webapp/controllers/admin.py
+++ b/lib/tool_shed/webapp/controllers/admin.py
@@ -21,7 +21,6 @@ log = logging.getLogger(__name__)
 
 
 class AdminController(BaseUIController, Admin):
-
     user_list_grid = admin_grids.UserGrid()
     role_list_grid = admin_grids.RoleGrid()
     group_list_grid = admin_grids.GroupGrid()

--- a/lib/tool_shed/webapp/controllers/repository.py
+++ b/lib/tool_shed/webapp/controllers/repository.py
@@ -73,7 +73,6 @@ def get_mercurial_default_options_dict(command):
 
 
 class RepositoryController(BaseUIController, ratings_util.ItemRatings):
-
     category_grid = repository_grids.CategoryGrid()
     datatypes_grid = repository_grids.DatatypesGrid()
     deprecated_repositories_i_own_grid = repository_grids.DeprecatedRepositoriesIOwnGrid()

--- a/scripts/api/library_upload_dir.py
+++ b/scripts/api/library_upload_dir.py
@@ -83,7 +83,7 @@ class Uploader:
         ids = self.recursively_build_path(path_parts, base_folder)
 
         # These are then associated with the paths.
-        for (key, fid) in zip(nfk, ids):
+        for key, fid in zip(nfk, ids):
             self.memo_path[key] = fid
         return ids[-1]
 

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -255,7 +255,7 @@ def administrative_delete_datasets(
                 app.sa_session.flush()
 
     emailtemplate = Template(filename=template_file)
-    for (email, dataset_list) in user_notifications.items():
+    for email, dataset_list in user_notifications.items():
         msgtext = emailtemplate.render(email=email, datasets=dataset_list, cutoff=cutoff_days)
         subject = "Galaxy Server Cleanup " "- %d datasets DELETED" % len(dataset_list)
         fromaddr = config.email_from

--- a/scripts/grt/export.py
+++ b/scripts/grt/export.py
@@ -263,7 +263,6 @@ def main(argv):
             datasets = {i[0]: i[1:] for i in datasets}
 
             for job_to_hda in job_to_hda_ids:
-
                 job = job_to_hda[0]  # job_id, hda_id, name
                 filetype = job_to_hda[1]  # input|output
 

--- a/scripts/microbes/util.py
+++ b/scripts/microbes/util.py
@@ -258,7 +258,7 @@ def get_bed_from_glimmer3(glimmer3_filename, chr):
     if min_score < 0:
         delta = min_score * -1
     regions = []
-    for (chr, start, end, name, score, strand) in orfs:
+    for chr, start, end, name, score, strand in orfs:
         # need to cast to str because was having the case where 1000.0 was rounded to 999 by int, some sort of precision bug?
         my_score = int(float(str(((score + delta) * (1000 - 0 - (min_score + delta))) / ((max_score + delta) + 0))))
 

--- a/scripts/runtime_stats.py
+++ b/scripts/runtime_stats.py
@@ -120,7 +120,6 @@ def parse_arguments():
 def query(
     tool_id=None, user=None, like=None, source="metrics", connect_args=None, debug=False, min=-1, max=-1, **kwargs
 ):
-
     connect_arg_str = ""
     for k, v in connect_args.items():
         connect_arg_str += f"{k}={v}"

--- a/scripts/set_user_disk_usage.py
+++ b/scripts/set_user_disk_usage.py
@@ -32,7 +32,6 @@ args = parser.parse_args()
 
 
 def init():
-
     if args.username == "all":
         args.username = None
     if args.email == "all":

--- a/test/functional/test_toolbox_pytest.py
+++ b/test/functional/test_toolbox_pytest.py
@@ -59,7 +59,6 @@ def idfn(val: ToolTest):
 
 
 class TestFrameworkTools(ApiTestCase):
-
     conda_auto_init = True
     conda_auto_install = True
 

--- a/test/integration/cloudauthz/test_cloudauthz.py
+++ b/test/integration/cloudauthz/test_cloudauthz.py
@@ -22,7 +22,6 @@ class TestDefineCloudAuthz(integration_util.IntegrationTestCase):
         client_id = "def"
         client_secret = "ghi"
         with self._different_user("vahid@test.com"):
-
             # The payload for the POST API.
             payload = {
                 "provider": provider,

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -50,7 +50,6 @@ def stop_minio(container_name):
 
 
 class BaseObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase):
-
     dataset_populator: DatasetPopulator
     framework_tool_and_types = True
 
@@ -81,7 +80,6 @@ def files_count(directory):
 
 @integration_util.skip_unless_docker()
 class BaseSwiftObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
-
     object_store_cache_path: str
 
     @classmethod

--- a/test/integration/objectstore/test_objectstore_datatype_upload.py
+++ b/test/integration/objectstore/test_objectstore_datatype_upload.py
@@ -118,7 +118,6 @@ def stop_irods(container_name):
 
 
 class BaseObjectstoreUploadTest(UploadTestDatatypeDataTestCase):
-
     object_store_template: Optional[string.Template] = None
 
     @classmethod
@@ -140,7 +139,6 @@ class BaseObjectstoreUploadTest(UploadTestDatatypeDataTestCase):
 
 
 class IrodsUploadTestDatatypeDataTestCase(BaseObjectstoreUploadTest):
-
     object_store_template = IRODS_OBJECT_STORE_CONFIG
 
     @classmethod
@@ -171,12 +169,10 @@ class IrodsUploadTestDatatypeDataTestCase(BaseObjectstoreUploadTest):
 
 
 class IrodsIdleConnectionUploadTestCase(IrodsUploadTestDatatypeDataTestCase):
-
     object_store_template = IRODS_OBJECT_STORE_CONFIG
 
 
 class UploadTestDosDiskAndDiskTestCase(BaseObjectstoreUploadTest):
-
     object_store_template = DISTRIBUTED_OBJECT_STORE_CONFIG
 
     @classmethod
@@ -185,7 +181,6 @@ class UploadTestDosDiskAndDiskTestCase(BaseObjectstoreUploadTest):
 
 
 class UploadTestDosIrodsAndDiskTestCase(IrodsUploadTestDatatypeDataTestCase):
-
     object_store_template = DISTRIBUTED_IRODS_OBJECT_STORE_CONFIG
 
 

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -261,7 +261,6 @@ class TestInlineJobEnvironmentContainerResolver(integration_util.IntegrationTest
 # TMPDIR can fix this.
 # TMPDIR=/home/vagrant/tmp/ pytest test/integration/test_containerized_jobs.py::TestSingularityJobsIntegration
 class TestSingularityJobsIntegration(TestDockerizedJobsIntegration):
-
     job_config_file = SINGULARITY_JOB_CONFIG_FILE
     build_mulled_resolver = "build_mulled_singularity"
     container_type = "singularity"

--- a/test/integration/test_edam_toolbox.py
+++ b/test/integration/test_edam_toolbox.py
@@ -2,7 +2,6 @@ from galaxy_test.driver import integration_util
 
 
 class TestEdamToolboxIntegration(integration_util.IntegrationTestCase):
-
     framework_tool_and_types = True
 
     @classmethod
@@ -32,7 +31,6 @@ class TestEdamToolboxIntegration(integration_util.IntegrationTestCase):
 
 
 class TestEdamToolboxDefaultIntegration(integration_util.IntegrationTestCase):
-
     framework_tool_and_types = True
 
     @classmethod

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -128,7 +128,6 @@ class TestExtendedMetadataDeferredIntegration(integration_util.IntegrationTestCa
 
 
 class ExtendedMetadataIntegrationInstance(integration_util.IntegrationInstance):
-
     framework_tool_and_types = True
 
     @classmethod

--- a/test/integration/test_galaxy_interactor.py
+++ b/test/integration/test_galaxy_interactor.py
@@ -6,7 +6,6 @@ from galaxy_test.driver import integration_util
 
 
 class TestGalaxyInteractor(integration_util.IntegrationTestCase):
-
     framework_tool_and_types = True
 
     def test_local_test_data_download(self):

--- a/test/integration/test_handler_assignment_methods.py
+++ b/test/integration/test_handler_assignment_methods.py
@@ -33,7 +33,6 @@ class WritesConfig:
 
 
 class BaseHandlerAssignmentMethodIntegrationTestCase(integration_util.IntegrationTestCase, WritesConfig):
-
     framework_tool_and_types = True
 
     @classmethod

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -43,7 +43,6 @@ class _BaseResubmissionIntegrationTestCase(integration_util.IntegrationTestCase)
 
 
 class TestJobResubmissionIntegration(_BaseResubmissionIntegrationTestCase):
-
     framework_tool_and_types = True
 
     @classmethod
@@ -176,7 +175,6 @@ class TestJobResubmissionIntegration(_BaseResubmissionIntegrationTestCase):
 
 
 class TestJobResubmissionDefaultIntegration(_BaseResubmissionIntegrationTestCase):
-
     framework_tool_and_types = True
 
     @classmethod
@@ -191,7 +189,6 @@ class TestJobResubmissionDefaultIntegration(_BaseResubmissionIntegrationTestCase
 
 
 class TestJobResubmissionDynamicIntegration(_BaseResubmissionIntegrationTestCase):
-
     framework_tool_and_types = True
 
     @classmethod

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -207,7 +207,7 @@ class TestKubernetesIntegration(BaseJobEnvironmentIntegrationTestCase, MulledJob
         ]
         cls.persistent_volumes = []
         cls.persistent_volume_claims = []
-        for (path, volume, claim) in volumes:
+        for path, volume, claim in volumes:
             volume_obj = persistent_volume(path, volume)
             volume_obj.setup()
             cls.persistent_volumes.append(volume_obj)

--- a/test/integration/test_local_job_cancellation.py
+++ b/test/integration/test_local_job_cancellation.py
@@ -32,7 +32,6 @@ class CancelsJob:
 
 
 class TestLocalJobCancellation(CancelsJob, integration_util.IntegrationTestCase):
-
     framework_tool_and_types = True
 
     def setUp(self):

--- a/test/integration/test_panel_views.py
+++ b/test/integration/test_panel_views.py
@@ -7,7 +7,6 @@ PANEL_VIEWS_DIR_1 = os.path.join(THIS_DIR, "panel_views_1")
 
 
 class TestPanelViewsFromDirectoryIntegration(integration_util.IntegrationTestCase):
-
     framework_tool_and_types = True
     allow_tool_conf_override = False
 
@@ -113,7 +112,6 @@ class TestPanelViewsFromDirectoryIntegration(integration_util.IntegrationTestCas
 
 
 class TestPanelViewsFromConfigIntegration(integration_util.IntegrationTestCase):
-
     framework_tool_and_types = True
 
     @classmethod

--- a/test/integration/test_purge_datasets.py
+++ b/test/integration/test_purge_datasets.py
@@ -9,7 +9,6 @@ from galaxy_test.driver import integration_util
 
 
 class TestPurgeDatasetsIntegration(integration_util.IntegrationTestCase):
-
     dataset_populator: DatasetPopulator
 
     def setUp(self):

--- a/test/integration/test_remote_files_histories.py
+++ b/test/integration/test_remote_files_histories.py
@@ -5,7 +5,6 @@ from .test_remote_files import ConfiguresRemoteFilesIntegrationTestCase
 
 
 class TestRemoteFilesHistoryImportExportIntegration(ConfiguresRemoteFilesIntegrationTestCase):
-
     framework_tool_and_types = True
 
     def test_history_import_from_library_dir(self):

--- a/test/integration/test_tool_data_delete.py
+++ b/test/integration/test_tool_data_delete.py
@@ -18,7 +18,6 @@ SOURCE_TOOL_DATA_DIRECTORY = os.path.join(THIS_DIR, os.pardir, "functional", "to
 
 
 class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase):
-
     require_admin_user = True
     dataset_populator: DatasetPopulator
 

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -191,7 +191,6 @@ class TestNonAdminsCannotPasteFilePath(BaseUploadContentConfigurationTestCase):
 
 
 class TestAdminsCanPasteFilePaths(BaseUploadContentConfigurationTestCase):
-
     require_admin_user = True
 
     @classmethod
@@ -261,7 +260,6 @@ class TestAdminsCanPasteFilePaths(BaseUploadContentConfigurationTestCase):
 
 
 class TestDefaultBinaryContentFilters(BaseUploadContentConfigurationTestCase):
-
     require_admin_user = True
 
     @classmethod
@@ -285,7 +283,6 @@ class TestDefaultBinaryContentFilters(BaseUploadContentConfigurationTestCase):
 
 
 class TestDisableContentChecking(BaseUploadContentConfigurationTestCase):
-
     require_admin_user = True
 
     @classmethod
@@ -304,7 +301,6 @@ class TestDisableContentChecking(BaseUploadContentConfigurationTestCase):
 
 
 class TestAutoDecompress(BaseUploadContentConfigurationTestCase):
-
     require_admin_user = True
 
     @classmethod
@@ -675,7 +671,6 @@ class TestUploadOptionsFtpUploadConfiguration(BaseFtpUploadConfigurationTestCase
 
 
 class TestServerDirectoryOffByDefault(BaseUploadContentConfigurationTestCase):
-
     require_admin_user = True
 
     @classmethod
@@ -795,7 +790,6 @@ class TestUserServerDirectoryValidUsage(BaseUploadContentConfigurationTestCase):
 
 
 class TestFetchByPath(BaseUploadContentConfigurationTestCase):
-
     require_admin_user = True
 
     @classmethod
@@ -931,7 +925,6 @@ class TestFetchByPath(BaseUploadContentConfigurationTestCase):
 
 
 class TestDirectoryAndCompressedTypes(BaseUploadContentConfigurationTestCase):
-
     require_admin_user = True
 
     @classmethod

--- a/test/integration/test_workflow_handler_configuration.py
+++ b/test/integration/test_workflow_handler_configuration.py
@@ -138,7 +138,6 @@ class BaseWorkflowHandlerConfigurationTestCase(integration_util.IntegrationTestC
 
 
 class TestHistoryRestrictionConfiguration(BaseWorkflowHandlerConfigurationTestCase):
-
     # Assign with db-preassign. Would also work with grabbing assignment, but we don't start grabber.
     assign_with = "db-preassign"
 
@@ -155,7 +154,6 @@ class TestHistoryRestrictionConfiguration(BaseWorkflowHandlerConfigurationTestCa
 
 
 class TestHistoryParallelConfiguration(BaseWorkflowHandlerConfigurationTestCase):
-
     # Assign with db-preassign. Would also work with grabbing assignment, but we don't start grabber.
     assign_with = "db-preassign"
 
@@ -179,7 +177,6 @@ class TestHistoryParallelConfiguration(BaseWorkflowHandlerConfigurationTestCase)
 
 # Setup an explicit workflow handler and make sure this is assigned to that.
 class TestWorkflowSchedulerHandlerAssignment(BaseWorkflowHandlerConfigurationTestCase):
-
     # Assign with db-preassign. Would also work with grabbing assignment, but we don't start grabber.
     assign_with = "db-preassign"
 
@@ -226,7 +223,6 @@ class TestDefaultWorkflowHandlerIfJobHandlerOn(BaseWorkflowHandlerConfigurationT
 
 
 class TestJobHandlerAsWorkflowHandlerWithDbSkipLocked(BaseWorkflowHandlerConfigurationTestCase):
-
     assign_with = "db-skip-locked"
 
     @classmethod
@@ -263,7 +259,6 @@ class TestDefaultWorkflowHandlerIfJobHandlerOff(BaseWorkflowHandlerConfiguration
 
 
 class TestExplicitWorkflowHandlersOn(BaseWorkflowHandlerConfigurationTestCase):
-
     assign_with = ""
 
     @classmethod
@@ -280,7 +275,6 @@ class TestExplicitWorkflowHandlersOn(BaseWorkflowHandlerConfigurationTestCase):
 
 @integration_util.skip_unless_postgres()
 class TestWorkflowSchedulerHandlerAssignmentDbSkipLocked(TestExplicitWorkflowHandlersOn):
-
     assign_with = "db-skip-locked"
 
     def test_handler_assignment(self, history_id: str):
@@ -292,7 +286,6 @@ class TestWorkflowSchedulerHandlerAssignmentDbSkipLocked(TestExplicitWorkflowHan
 
 @integration_util.skip_unless_postgres()
 class TestWorkflowSchedulerHandlerAssignmentDbTransactionIsolation(TestWorkflowSchedulerHandlerAssignmentDbSkipLocked):
-
     assign_with = "db-transaction-isolation"
 
 

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -48,7 +48,6 @@ ActionsJson = List[ActionJson]
 
 
 class TestWorkflowRefactoringIntegration(integration_util.IntegrationTestCase, UsesShedApi):
-
     framework_tool_and_types = True
 
     def setUp(self):

--- a/test/integration/test_workflow_sync.py
+++ b/test/integration/test_workflow_sync.py
@@ -14,7 +14,6 @@ from galaxy_test.driver import integration_util
 
 
 class TestWorkflowSync(integration_util.IntegrationTestCase):
-
     framework_tool_and_types = True
     require_admin_user = True
 

--- a/test/integration_selenium/test_edam_tool_panel_views.py
+++ b/test/integration_selenium/test_edam_tool_panel_views.py
@@ -6,7 +6,6 @@ from .framework import (
 
 
 class TestEdamToolPanelViewsSeleniumIntegration(SeleniumIntegrationTestCase):
-
     ensure_registered = True  # to test workflow editor
 
     @selenium_test

--- a/test/unit/app/authnz/test_custos_authnz.py
+++ b/test/unit/app/authnz/test_custos_authnz.py
@@ -27,7 +27,6 @@ from galaxy.util.unittest import TestCase
 
 
 class TestCustosAuthnz(TestCase):
-
     _create_oauth2_session_called = False
     _fetch_token_called = False
     _get_userinfo_called = False
@@ -605,7 +604,6 @@ class TestCustosAuthnz(TestCase):
         assert redirect_uri is None
 
     def test_logout_with_redirect(self):
-
         logout_redirect_url = "http://localhost:8080/post-logout"
         redirect_url = self.custos_authnz.logout(self.trans, logout_redirect_url)
 

--- a/test/unit/app/jobs/test_command_factory.py
+++ b/test/unit/app/jobs/test_command_factory.py
@@ -25,7 +25,6 @@ CP_WORK_DIR_OUTPUTS = '; \nif [ -f "foo" ] ; then cp "foo" "bar" ; fi'
 
 
 class TestCommandFactory(TestCase):
-
     maxDiff = None
     stream_stdout_stderr = False
     TEE_LOG = " "
@@ -199,7 +198,6 @@ class TestCommandFactory(TestCase):
 
 
 class TestCommandFactoryStreamStdoutStderr(TestCommandFactory):
-
     stream_stdout_stderr = True
     TEE_LOG = """ __out="${TMPDIR:-.}/out.$$" __err="${TMPDIR:-.}/err.$$"
 mkfifo "$__out" "$__err"

--- a/test/unit/app/tools/test_actions.py
+++ b/test/unit/app/tools/test_actions.py
@@ -134,7 +134,7 @@ class TestDefaultToolAction(TestCase, tools_support.UsesTools):
         if incoming is None:
             incoming = dict(param1="moo")
         self._init_tool(contents)
-        job, out_data, _, = self.action.execute(
+        job, out_data, _ = self.action.execute(
             tool=self.tool,
             trans=self.trans,
             history=self.history,

--- a/test/unit/app/tools/test_history_imp_exp.py
+++ b/test/unit/app/tools/test_history_imp_exp.py
@@ -747,7 +747,6 @@ def test_history_import_relpath_in_archive():
     """
     dest_parent = tempfile.mkdtemp()
     with HistoryArchive(arcname_prefix="../insecure") as history_archive:
-
         history_archive.write_metafiles()
         history_archive.write_file("datasets/Pasted_Entry_1.txt", "foo")
         history_archive.finalize()

--- a/test/unit/app/tools/test_tool_deserialization.py
+++ b/test/unit/app/tools/test_tool_deserialization.py
@@ -56,7 +56,6 @@ def _deserialize(app, tool_source_class, raw_tool_source):
 
 
 def test_deserialize_xml_tool(tool_app):
-
     tool = _deserialize(tool_app, tool_source_class="XmlToolSource", raw_tool_source=XML_TOOL)
     assert tool.id == "tool_id"
     assert tool.name == "xml tool"

--- a/test/unit/data/model/mapping/test_gxy_model_mapping.py
+++ b/test/unit/data/model/mapping/test_gxy_model_mapping.py
@@ -1099,7 +1099,6 @@ class TestGalaxySession(BaseTest):
         assert cls_.__tablename__ == "galaxy_session"
 
     def test_columns(self, session, cls_, user, history, galaxy_session):
-
         create_time = now()
         update_time = create_time + timedelta(hours=1)
         remote_host = "a"
@@ -3191,7 +3190,6 @@ class TestLibraryDatasetCollectionAssociation(BaseTest):
         library_dataset_collection_rating_association,
         library_dataset_collection_tag_association,
     ):
-
         obj = cls_()
         obj.collection = dataset_collection
         obj.folder = library_folder
@@ -6400,6 +6398,7 @@ class TestWorkflowStepTagAssociation(BaseTest):
 
 
 # Misc. helper fixtures.
+
 
 # When enabled, this fixture auto-runs before each test and any unscoped fixtures
 # (except session and model on which it depends) and verifies that all model

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -263,7 +263,6 @@ backends:
 def test_hierarchical_store():
     for config_str in [HIERARCHICAL_TEST_CONFIG, HIERARCHICAL_TEST_CONFIG_YAML]:
         with TestConfig(config_str) as (directory, object_store):
-
             # Test no dataset with id 1 exists.
             assert not object_store.exists(MockDataset(1))
 
@@ -683,7 +682,6 @@ def test_config_parse_cloud():
             open(path, "w").write("some_gcp_config")
             config_str = config_str.replace("gcp.config", path)
         with TestConfig(config_str, clazz=UnitializedCloudObjectStore) as (directory, object_store):
-
             assert object_store.bucket_name == "unique_bucket_name_all_lowercase"
             assert object_store.use_rr is False
 
@@ -750,7 +748,6 @@ CLOUD_AWS_NO_AUTH_TEST_CONFIG = """<object_store type="cloud" provider="aws">
 def test_config_parse_cloud_noauth_for_aws():
     for config_str in [CLOUD_AWS_NO_AUTH_TEST_CONFIG]:
         with TestConfig(config_str, clazz=UnitializedCloudObjectStore) as (directory, object_store):
-
             assert object_store.bucket_name == "unique_bucket_name_all_lowercase"
             assert object_store.use_rr is False
 

--- a/test/unit/shed_unit/model/test_mapping.py
+++ b/test/unit/shed_unit/model/test_mapping.py
@@ -99,7 +99,6 @@ class TestGalaxySession(BaseTest):
         assert cls_.__tablename__ == "galaxy_session"
 
     def test_columns(self, session, cls_, user, galaxy_session):
-
         create_time = datetime.now()
         update_time = create_time + timedelta(hours=1)
         remote_host = "a"
@@ -416,7 +415,6 @@ class TestRepositoryMetadata(BaseTest):
         repository,
         user,
     ):
-
         obj = cls_()
         obj.repository = repository
         obj.changeset_revision = "nonempty"

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -319,7 +319,7 @@ def _construct_steps_for_map_over() -> List[MapOverTestCase]:
         ("list:list", ["list", "pair"], "list:list", "list:list:list"),
     ]
     test_cases = []
-    for (data_input, step_input_def, step_output_def, expected_collection_type) in test_case_args:
+    for data_input, step_input_def, step_output_def, expected_collection_type in test_case_args:
         steps: Dict[int, Dict[str, Any]] = {
             0: _input_step(collection_type=data_input),
             1: _output_step(step_input_def=step_input_def, step_output_def=step_output_def),

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -315,7 +315,6 @@ def output_adjacent_tmpdir(output_path):
 
 
 def __main__():
-
     if len(sys.argv) < 4:
         print("usage: upload.py <root> <datatypes_conf> <json paramfile> <output spec> ...", file=sys.stderr)
         sys.exit(1)

--- a/tools/solid_tools/solid_qual_stats.py
+++ b/tools/solid_tools/solid_qual_stats.py
@@ -27,7 +27,6 @@ def unzip(filename):
 def __main__():
     infile_score_name = sys.argv[1].strip()
     with open(sys.argv[2].strip(), "w") as fout:
-
         if zipfile.is_zipfile(infile_score_name):
             infile_name = unzip(infile_score_name)
         else:

--- a/tools/stats/aggregate_scores_in_intervals.py
+++ b/tools/stats/aggregate_scores_in_intervals.py
@@ -148,7 +148,6 @@ def load_scores_ba_dir(dir):
 
 
 def main():
-
     # Parse command line
     options, args = doc_optparse.parse(__doc__)
 

--- a/tools/stats/grouping.py
+++ b/tools/stats/grouping.py
@@ -127,7 +127,6 @@ def main():
         return item
 
     with open(sys.argv[1], "w") as fout:
-
         for key, line_list in groupby(tmpfile, key=is_new_item):
             op_vals = [[] for _ in ops]
             out_str = key


### PR DESCRIPTION
with manual fixes to 3 files to make them compatible with black 22.12.0 .

We need to keep black pinned at `<23` until we vendorise `packaging`, since the new version of black depends on `packaging >=22.0` which is the version where `LegacyVersion` (which we use for tool lineages) was removed.

This fixes the Python linting GitHub workflow tests which use the `psf/black` action without pinning a black version.
Targeting the `release_23.0` to make it easier to merge forward/backward in the future.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
