### PR TITLE
[23.0] Test validators for optional parameters

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -59,6 +59,11 @@ List of behavior changes associated with profile versions:
 
 - Do not strip leading and trailing whitespaces in `from_work_dir` attribute.
 
+### 23.0
+
+- Text parameters that are inferred to be optional (i.e the `optional` tag is not set, but the tool parameter accepts an empty string)
+  are set to `None` for templating in Cheetah. Older tools receive the empty string `""` as the templated value.
+
 ### Examples
 
 A normal tool:

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -356,7 +356,9 @@ class ToolEvaluator:
                     input, value, other_values=param_dict, compute_environment=self.compute_environment
                 )
             else:
-                input_values[input.name] = InputValueWrapper(input, value, param_dict)
+                input_values[input.name] = InputValueWrapper(
+                    input, value, param_dict, profile=self.tool and self.tool.profile
+                )
 
         # HACK: only wrap if check_values is not false, this deals with external
         #       tools where the inputs don't even get passed through. These

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -328,7 +328,7 @@ class SimpleTextToolParameter(ToolParameter):
         super().__init__(tool, input_source)
         self.optional = input_source.get_bool("optional", False)
 
-        if not self.optional:
+        if not self.optional and self.type == "text":
             try:
                 for validator in self.validators:
                     validator.validate("")

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -327,6 +327,15 @@ class SimpleTextToolParameter(ToolParameter):
         input_source = ensure_input_source(input_source)
         super().__init__(tool, input_source)
         self.optional = input_source.get_bool("optional", False)
+
+        if not self.optional:
+            try:
+                for validator in self.validators:
+                    validator.validate("")
+                self.optional = True
+            except ValueError:
+                self.optional = False
+
         if self.optional:
             self.value = None
         else:

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -362,7 +362,7 @@ class TextToolParameter(SimpleTextToolParameter):
     >>> p = TextToolParameter(None, XML('<param name="_name" type="text" value="default" />'))
     >>> print(p.name)
     _name
-    >>> assert sorted(p.to_dict(trans).items()) == [('area', False), ('argument', None), ('datalist', []), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'TextToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'text'), ('value', u'default')]
+    >>> assert sorted(p.to_dict(trans).items()) == [('area', False), ('argument', None), ('datalist', []), ('help', ''), ('hidden', False), ('is_dynamic', False), ('label', ''), ('model_class', 'TextToolParameter'), ('name', '_name'), ('optional', True), ('refresh_on_change', False), ('type', 'text'), ('value', u'default')]
     """
 
     def __init__(self, tool, input_source):

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -98,7 +98,7 @@ class WrappedParameters:
                     name=input.name,
                 )
             else:
-                input_values[input.name] = InputValueWrapper(input, value, incoming)
+                input_values[input.name] = InputValueWrapper(input, value, incoming, tool.profile)
 
 
 def make_dict_copy(from_dict):

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -66,7 +66,7 @@ class ToolParameterValueWrapper:
     Base class for object that Wraps a Tool Parameter and Value.
     """
 
-    value: Union[str, List[str]]
+    value: Optional[Union[str, List[str]]]
     input: "ToolParameter"
 
     def __bool__(self) -> bool:
@@ -246,7 +246,7 @@ class SelectToolParameterWrapper(ToolParameterValueWrapper):
         compute_environment: Optional["ComputeEnvironment"] = None,
     ):
         self.input = input
-        self.value = value
+        self.value: Union[str, List[str]] = value
         self.input.value_label = input.value_to_display_text(value)
         self._other_values = other_values or {}
         self.compute_environment = compute_environment

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -120,10 +120,20 @@ class InputValueWrapper(ToolParameterValueWrapper):
     def __init__(
         self,
         input: "ToolParameter",
-        value: str,
+        value: Optional[str],
         other_values: Optional[Dict[str, str]] = None,
+        profile: Optional[float] = None,
     ) -> None:
         self.input = input
+        if (
+            value is None
+            and input.type == "text"
+            and input.optional
+            and input.optionality_inferred
+            and (profile is None or profile < 23.0)
+        ):
+            # Tools with old profile versions may treat an optional text parameter as `""`
+            value = ""
         self.value = value
         self._other_values: Dict[str, str] = other_values or {}
 

--- a/test/functional/tools/cheetah_casting.xml
+++ b/test/functional/tools/cheetah_casting.xml
@@ -3,13 +3,16 @@
         #set $int_val_inc = int($inttest) + 1
         #set $int_flot_val_inc = int($floattest) + 1
         #set $float_val_inc = float($floattest) + 1
-        echo $int_val_inc   >> '$out_file1';
+        #set $text_val = $texttest.strip()
+        echo $int_val_inc >> '$out_file1';
         echo $int_flot_val_inc >> '$out_file1';
         echo $float_val_inc >> '$out_file1';
+        echo $text_val >> '#out_file1'
     </command>
     <inputs>
         <param name="inttest" value="1" type="integer" />
         <param name="floattest" value="1.0" type="float" />
+        <param name="texttest" type="text" />
     </inputs>
     <outputs>
         <data name="out_file1" format="txt" />

--- a/test/unit/app/tools/test_parameter_parsing.py
+++ b/test/unit/app/tools/test_parameter_parsing.py
@@ -91,7 +91,9 @@ class TestParameterParsing(BaseParameterTestCase):
     def test_parse_optional(self):
         param = self._parameter_for(
             xml="""
-            <param type="text" name="texti" value="mydefault" />
+            <param type="text" name="texti" value="mydefault">
+                <validator type="empty_field" />
+            </param>
         """
         )
         assert param.optional is False


### PR DESCRIPTION
Potential fix for optional text parameters not marked as optional.

From the UI/UX working group chat:

> Unlike other types of parameters, `type="text"` parameters are always optional, and tool author need to restrict the input with validator elements

![image](https://user-images.githubusercontent.com/44241786/216291427-1c04bb89-bcc3-410f-9ef5-29ef006cb212.png)

https://github.com/galaxyproject/tools-iuc/blob/main/tools/bcftools/bcftools_isec.xml#L55-L58

-> nfiles allows empty values, but is displayed as required.

Draft PR to check how the tool tests react to this

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
