### PR TITLE
[23.0] Fix inserting inputs through repeats

### DIFF
--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -128,13 +128,18 @@ export default {
     created() {
         this.onCloneInputs();
         // build flat formData that is ready to be submitted
-        Object.entries(this.formIndex).forEach(([key, input]) => {
-            this.formData[key] = input.value;
-        });
+        this.formData = this.buildFormData();
         // emit back to parent, so that parent has submittable data
         this.$emit("onChange", this.formData);
     },
     methods: {
+        buildFormData() {
+            const params = {};
+            Object.entries(this.formIndex).forEach(([key, input]) => {
+                params[key] = input.value;
+            });
+            return params;
+        },
         onReplaceParams() {
             let refreshOnChange = false;
             Object.entries(this.replaceParams).forEach(([key, value]) => {
@@ -165,10 +170,7 @@ export default {
         },
         onChange(refreshOnChange) {
             this.onCreateIndex();
-            const params = {};
-            Object.entries(this.formIndex).forEach(([key, input]) => {
-                params[key] = input.value;
-            });
+            const params = this.buildFormData();
             if (JSON.stringify(params) != JSON.stringify(this.formData)) {
                 this.formData = params;
                 this.resetError();

--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -127,6 +127,12 @@ export default {
     },
     created() {
         this.onCloneInputs();
+        // build flat formData that is ready to be submitted
+        Object.entries(this.formIndex).forEach(([key, input]) => {
+            this.formData[key] = input.value;
+        });
+        // emit back to parent, so that parent has submittable data
+        this.$emit("onChange", this.formData);
     },
     methods: {
         onReplaceParams() {

--- a/client/src/components/Form/FormElement.test.js
+++ b/client/src/components/Form/FormElement.test.js
@@ -49,11 +49,10 @@ describe("FormElement", () => {
         });
         expect(wrapper.find(".ui-form-title-text").text()).toEqual("title_text");
         expect(wrapper.findAll("button[title='Disable']").length).toEqual(1);
-        expect(wrapper.emitted().input[0][0]).toEqual("initial_value");
 
         await wrapper.find(".ui-form-collapsible-icon").trigger("click");
-        expect(wrapper.emitted().input[1][0]).toEqual("collapsible_value");
-        expect(wrapper.emitted().input[1][1]).toEqual("input");
+        expect(wrapper.emitted().input[0][0]).toEqual("collapsible_value");
+        expect(wrapper.emitted().input[0][1]).toEqual("input");
 
         await wrapper.setProps({
             collapsedEnableText: "Enable Collapsible",
@@ -63,7 +62,7 @@ describe("FormElement", () => {
         expect(wrapper.findAll("button[title='Disable Collapsible']").length).toEqual(0);
 
         await wrapper.find(".ui-form-collapsible-icon").trigger("click");
-        expect(wrapper.emitted().input[2][0]).toEqual("default_value");
+        expect(wrapper.emitted().input[1][0]).toEqual("default_value");
         expect(wrapper.findAll("button[title='Disable Collapsible']").length).toEqual(1);
         expect(wrapper.findAll("button[title='Enable Collapsible']").length).toEqual(0);
     });

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -81,9 +81,8 @@ const collapsed = ref(false);
 const collapsible = computed(() => !props.disabled && collapsibleValue.value !== undefined);
 const connectable = computed(() => collapsible.value && Boolean(attrs.value["connectable"]));
 
-// Determines to wether expand or collapse the input
+// Determines whether to expand or collapse the input
 {
-    setValue(props.value);
     const valueJson = JSON.stringify(props.value);
     connected.value = valueJson === JSON.stringify(connectedValue);
     collapsed.value =

--- a/client/src/components/Masthead/_webhooks.js
+++ b/client/src/components/Masthead/_webhooks.js
@@ -5,8 +5,7 @@ export function loadWebhookMenuItems(items) {
     Webhooks.load({
         type: "masthead",
         callback: function (webhooks) {
-            webhooks.each((model) => {
-                const webhook = model.toJSON();
+            webhooks.forEach((webhook) => {
                 if (webhook.activate) {
                     const obj = {
                         id: webhook.id,

--- a/client/src/components/Tool/Buttons/ToolOptionsButton.vue
+++ b/client/src/components/Tool/Buttons/ToolOptionsButton.vue
@@ -28,9 +28,7 @@ const webhookDetails = ref([]);
 Webhooks.load({
     type: "tool-menu",
     callback: (webhooks) => {
-        webhooks.each((model) => {
-            const webhook = model.toJSON();
-
+        webhooks.forEach((webhook) => {
             if (webhook.activate && webhook.config.function) {
                 webhookDetails.value.push({
                     icon: `fa ${webhook.config.icon}`,

--- a/client/src/components/Tool/Buttons/ToolOptionsButton.vue
+++ b/client/src/components/Tool/Buttons/ToolOptionsButton.vue
@@ -6,7 +6,7 @@ import Webhooks from "utils/webhooks";
 import ToolSourceMenuItem from "components/Tool/ToolSourceMenuItem";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
-const { currentUser: user } = useCurrentUser();
+const { currentUser: user } = useCurrentUser(false, true);
 
 const props = defineProps({
     id: {

--- a/client/src/components/Tool/ToolCard.test.js
+++ b/client/src/components/Tool/ToolCard.test.js
@@ -1,5 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { getLocalVue, mockModule } from "tests/jest/helpers";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
 import ToolCard from "./ToolCard";
 import Vuex from "vuex";
 import { userStore } from "store/userStore";
@@ -18,8 +20,12 @@ const createStore = (currentUser) => {
 
 describe("ToolCard", () => {
     let wrapper;
+    let axiosMock;
 
     beforeEach(() => {
+        axiosMock = new MockAdapter(axios);
+        axiosMock.onGet(`/api/webhooks`).reply(200, []);
+
         const store = createStore({
             id: "user.id",
             email: "user.email",

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -66,7 +66,7 @@ function onSetError(e) {
     errorText.value = e;
 }
 
-const { currentUser: user } = useCurrentUser();
+const { currentUser: user } = useCurrentUser(false, true);
 const hasUser = computed(() => !user.value.isAnonymous);
 
 const versions = computed(() => props.options.versions);

--- a/client/src/components/Tool/ToolForm.test.js
+++ b/client/src/components/Tool/ToolForm.test.js
@@ -30,6 +30,7 @@ describe("ToolForm", () => {
             help: "help_text",
         };
         axiosMock.onGet(`/api/tools/tool_id/build?tool_version=version`).reply(200, toolData);
+        axiosMock.onGet(`/api/webhooks`).reply(200, []);
 
         const citations = [];
         axiosMock.onGet(`/api/tools/tool_id/citations`).reply(200, citations);

--- a/client/src/components/Tool/ToolSourceMenuItem.vue
+++ b/client/src/components/Tool/ToolSourceMenuItem.vue
@@ -5,7 +5,7 @@ import { useCurrentUser } from "composables/user";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 const { config } = useConfig();
-const { currentUser } = useCurrentUser();
+const { currentUser } = useCurrentUser(false, true);
 
 const props = defineProps({
     toolId: {

--- a/client/src/components/Tool/ToolSourceMenuItem.vue
+++ b/client/src/components/Tool/ToolSourceMenuItem.vue
@@ -4,7 +4,7 @@ import { useConfig } from "composables/config";
 import { useCurrentUser } from "composables/user";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
-const { config } = useConfig();
+const { config } = useConfig(true);
 const { currentUser } = useCurrentUser(false, true);
 
 const props = defineProps({

--- a/client/src/components/Workflow/Editor/Forms/FormTool.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.test.js
@@ -1,5 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { getLocalVue, mockModule } from "tests/jest/helpers";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 import FormTool from "./FormTool";
 import MockCurrentUser from "components/providers/MockCurrentUser";
 import MockConfigProvider from "components/providers/MockConfigProvider";
@@ -11,6 +13,9 @@ import { createTestingPinia } from "@pinia/testing";
 const localVue = getLocalVue();
 
 describe("FormTool", () => {
+    const axiosMock = new MockAdapter(axios);
+    axiosMock.onGet(`/api/webhooks`).reply(200, []);
+
     function mountTarget() {
         const store = new Vuex.Store({
             modules: {

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -110,7 +110,7 @@ export default {
     },
     data() {
         return {
-            mainValues: {},
+            mainValues: null,
             messageText: "",
             messageVariant: "success",
         };
@@ -168,7 +168,7 @@ export default {
          * @param { Object } values contains flat key-value pairs `prefixed-name=value`
          */
         onChange(values) {
-            const initialRequest = Object.keys(this.mainValues).length === 0;
+            const initialRequest = this.mainValues === null;
             this.mainValues = values;
             if (!initialRequest) {
                 this.postChanges();

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -1,62 +1,58 @@
 <template>
-    <CurrentUser v-slot="{ user }">
-        <ToolCard
-            v-if="hasData"
-            :id="configForm.id"
-            :user="user"
-            :version="configForm.version"
-            :title="configForm.name"
-            :description="configForm.description"
-            :options="configForm"
-            :message-text="messageText"
-            :message-variant="messageVariant"
-            @onChangeVersion="onChangeVersion"
-            @onUpdateFavorites="onUpdateFavorites">
-            <template v-slot:body>
-                <FormElement
-                    id="__label"
-                    :value="label"
-                    title="Label"
-                    help="Add a step label."
-                    :error="uniqueErrorLabel"
-                    @input="onLabel" />
-                <FormElement
-                    id="__annotation"
-                    :value="annotation"
-                    title="Step Annotation"
-                    :area="true"
-                    help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
-                    @input="onAnnotation" />
-                <FormConditional :step="step" v-on="$listeners" />
-                <div class="mt-2 mb-4">
-                    <Heading h2 separator bold size="sm"> Tool Parameters </Heading>
-                    <FormDisplay
-                        :id="id"
-                        :inputs="inputs"
-                        :errors="errors"
-                        text-enable="Set in Advance"
-                        text-disable="Set at Runtime"
-                        :workflow-building-mode="true"
-                        @onChange="onChange" />
-                </div>
-                <div class="mt-2 mb-4">
-                    <Heading h2 separator bold size="sm"> Additional Options </Heading>
-                    <FormSection
-                        :id="stepId"
-                        :node-inputs="stepInputs"
-                        :node-outputs="stepOutputs"
-                        :step="step"
-                        :datatypes="datatypes"
-                        :post-job-actions="postJobActions"
-                        @onChange="onChangePostJobActions" />
-                </div>
-            </template>
-        </ToolCard>
-    </CurrentUser>
+    <ToolCard
+        v-if="hasData"
+        :id="configForm.id"
+        :version="configForm.version"
+        :title="configForm.name"
+        :description="configForm.description"
+        :options="configForm"
+        :message-text="messageText"
+        :message-variant="messageVariant"
+        @onChangeVersion="onChangeVersion"
+        @onUpdateFavorites="onUpdateFavorites">
+        <template v-slot:body>
+            <FormElement
+                id="__label"
+                :value="label"
+                title="Label"
+                help="Add a step label."
+                :error="uniqueErrorLabel"
+                @input="onLabel" />
+            <FormElement
+                id="__annotation"
+                :value="annotation"
+                title="Step Annotation"
+                :area="true"
+                help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
+                @input="onAnnotation" />
+            <FormConditional :step="step" v-on="$listeners" />
+            <div class="mt-2 mb-4">
+                <Heading h2 separator bold size="sm"> Tool Parameters </Heading>
+                <FormDisplay
+                    :id="id"
+                    :inputs="inputs"
+                    :errors="errors"
+                    text-enable="Set in Advance"
+                    text-disable="Set at Runtime"
+                    :workflow-building-mode="true"
+                    @onChange="onChange" />
+            </div>
+            <div class="mt-2 mb-4">
+                <Heading h2 separator bold size="sm"> Additional Options </Heading>
+                <FormSection
+                    :id="stepId"
+                    :node-inputs="stepInputs"
+                    :node-outputs="stepOutputs"
+                    :step="step"
+                    :datatypes="datatypes"
+                    :post-job-actions="postJobActions"
+                    @onChange="onChangePostJobActions" />
+            </div>
+        </template>
+    </ToolCard>
 </template>
 
 <script>
-import CurrentUser from "@/components/providers/CurrentUser";
 import FormDisplay from "@/components/Form/FormDisplay.vue";
 import ToolCard from "@/components/Tool/ToolCard.vue";
 import FormSection from "./FormSection.vue";
@@ -71,7 +67,6 @@ import { toRef } from "vue";
 
 export default {
     components: {
-        CurrentUser,
         FormDisplay,
         ToolCard,
         FormElement,

--- a/client/src/composables/config.js
+++ b/client/src/composables/config.js
@@ -1,7 +1,7 @@
 import { computed, onMounted, inject } from "vue";
 
 /* composable config wrapper */
-export function useConfig() {
+export function useConfig(fetchOnce = false) {
     const store = inject("store");
 
     const config = computed(() => store.getters["config/config"]);
@@ -9,7 +9,9 @@ export function useConfig() {
 
     // Anytime we mount this (for now), make sure to load.
     onMounted(() => {
-        store.dispatch("config/loadConfigs");
+        if (!(fetchOnce && isLoaded)) {
+            store.dispatch("config/loadConfigs");
+        }
     });
 
     return { config, isLoaded };

--- a/client/src/composables/user.ts
+++ b/client/src/composables/user.ts
@@ -6,15 +6,16 @@ import type { Store } from "vuex";
 /**
  * composable user store wrapper
  * @param noFetch when true, the user will not be fetched from the server
+ * @param fetchOnce when true, the user will only be fetched from the server if it is not already in the store
  * @returns currentUser computed
  */
-export function useCurrentUser(noFetch: boolean | Ref<boolean> = false) {
+export function useCurrentUser(noFetch: boolean | Ref<boolean> = false, fetchOnce: boolean | Ref<boolean> = false) {
     // TODO: add store typing
     const store = inject("store") as Store<unknown>;
     const currentUser = computed(() => store.getters["user/currentUser"]);
     const currentFavorites = computed(() => store.getters["user/currentFavorites"]);
     onMounted(() => {
-        if (!unref(noFetch)) {
+        if (!unref(noFetch) && !(Object.keys(currentUser).length > 0) && unref(fetchOnce)) {
             store.dispatch("user/loadUser");
         }
     });

--- a/client/src/onload/globalInits/onloadWebhooks.js
+++ b/client/src/onload/globalInits/onloadWebhooks.js
@@ -2,14 +2,11 @@ import Webhooks from "utils/webhooks";
 import Utils from "utils/utils";
 
 export function onloadWebhooks(Galaxy) {
-    console.log("onloadWebhooks");
-
     if (Galaxy.config.enable_webhooks) {
         Webhooks.load({
             type: "onload",
             callback: function (webhooks) {
-                webhooks.each((model) => {
-                    var webhook = model.toJSON();
+                webhooks.forEach((webhook) => {
                     if (webhook.activate && webhook.script) {
                         Utils.appendScriptStyle(webhook);
                     }

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -490,6 +490,7 @@ tool_form:
     parameter_checkbox: 'div.ui-form-element[id="form-element-${parameter}"] .ui-switch'
     parameter_input: 'div.ui-form-element[id="form-element-${parameter}"] .ui-input'
     parameter_textarea: 'div.ui-form-element[id="form-element-${parameter}"] textarea'
+    repeat_insert: '[data-description="repeat insert"]'
     reference: '.formatted-reference'
     about: '.tool-footer'
 

--- a/client/src/utils/webhooks.js
+++ b/client/src/utils/webhooks.js
@@ -1,12 +1,22 @@
+import axios from "axios";
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
+import { rethrowSimple } from "@/utils/simple-error";
 import Utils from "utils/utils";
 
-const Webhooks = Backbone.Collection.extend({
-    url: function () {
-        return `${getAppRoot()}api/webhooks`;
-    },
-});
+let webhookData = undefined;
+
+async function getWebHookData() {
+    if (webhookData === undefined) {
+        try {
+            const { data } = await axios.get(`${getAppRoot()}api/webhooks`);
+            webhookData = data;
+        } catch (e) {
+            rethrowSimple(e);
+        }
+    }
+    return webhookData;
+}
 
 const WebhookView = Backbone.View.extend({
     el: "#webhook-view",
@@ -18,16 +28,13 @@ const WebhookView = Backbone.View.extend({
         this.$el.attr("tool_id", toolId);
         this.$el.attr("tool_version", toolVersion);
 
-        const webhooks = new Webhooks();
-        webhooks.fetch({
-            success: (data) => {
-                if (options.type) {
-                    data.reset(filterType(data, options.type));
-                }
-                if (data.length > 0) {
-                    this.render(weightedRandomPick(data));
-                }
-            },
+        getWebHookData().then((data) => {
+            if (options.type) {
+                data.reset(filterType(data, options.type));
+            }
+            if (data.length > 0) {
+                this.render(weightedRandomPick(data));
+            }
         });
     },
 
@@ -40,21 +47,18 @@ const WebhookView = Backbone.View.extend({
 });
 
 const load = (options) => {
-    const webhooks = new Webhooks();
-    webhooks.fetch({
-        async: options.async !== undefined ? options.async : true,
-        success: (data) => {
-            if (options.type) {
-                data.reset(filterType(data, options.type));
-            }
-            options.callback(data);
-        },
+    getWebHookData().then((data) => {
+        let filteredData = data;
+        if (options.type) {
+            filteredData = filterType(data, options.type);
+        }
+        options.callback(filteredData);
     });
 };
 
 function filterType(data, type) {
-    return data.models.filter((item) => {
-        const itype = item.get("type");
+    return data.filter((item) => {
+        const itype = item.type;
         if (itype) {
             return itype.indexOf(type) !== -1;
         } else {

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -919,6 +919,26 @@ steps:
         assert self.driver.switch_to.active_element.text == "No compatible input found in workflow"
 
     @selenium_test
+    def test_insert_input_handling(self):
+        self.open_in_workflow_editor(
+            """class: GalaxyWorkflow
+inputs: []
+steps:
+  build_list:
+    tool_id: __BUILD_LIST__
+        """
+        )
+        editor = self.components.workflow_editor
+        node = editor.node._(label="build_list")
+        node.wait_for_and_click()
+        assert not node.has_class("input-terminal")
+        self.components.tool_form.repeat_insert.wait_for_and_click()
+        node.input_terminal(name="datasets_0|input").wait_for_present()
+        self.components.tool_form.repeat_insert.wait_for_and_click()
+        node.input_terminal(name="datasets_1|input").wait_for_present()
+        self.assert_workflow_has_changes_and_save()
+
+    @selenium_test
     def test_workflow_output_handling(self):
         self.open_in_workflow_editor(
             """


### PR DESCRIPTION
Skips emitting `change` event in the `FormElement` setup section,
since we already have the necessary data that were passed in via the prop.
Instead we emit the current form state once in the FormDisplay
component's `created` hook.  That works reliably, also if there is no
acutal parameter value.

To handle the no parameter value case in the workflow editor (as happens in the
`__BUILD_LIST__` tool) I've changed the initial empty Object value to null,
so that when we determine whether or not we have to update the module
we're not thrown off by the empty Object value.

Also eliminates some unnecessary repeated requests for webhooks, user and config objects.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
