### PR TITLE
[23.0] Fix large_file.mako arguments

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -542,7 +542,7 @@ class Data(metaclass=DataMeta):
                 trans.fill_template_mako(
                     "/dataset/large_file.mako",
                     truncated_data=open(dataset.file_name, "rb").read(max_peek_size),
-                    dataset=dataset,
+                    data=dataset,
                 ),
                 headers,
             )


### PR DESCRIPTION
Broke in https://github.com/galaxyproject/galaxy/commit/4a638398fa89b3edd2c84bf2bf25f7d588968d30

Fixes displaying large files such as the asn files in https://usegalaxy.org/u/abernier/h/mbio4603

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
