### PR TITLE
[23.0] Add Database filter to HistoryFilters

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.test.js
@@ -38,6 +38,8 @@ describe("HistoryFilters", () => {
             "[placeholder='any extension']": "ext-filter",
             "[placeholder='any tag']": "tag filter",
             "[placeholder='any state']": "state-filter",
+            "[placeholder='any database']": "db-filter",
+            "[placeholder='index equals']": "hid-related",
             "[placeholder='index greater']": "hid-greater",
             "[placeholder='index lower']": "hid-lower",
             "[placeholder='created after']": "January 1, 2022",
@@ -79,7 +81,7 @@ describe("HistoryFilters", () => {
         await expectCorrectEmits(
             wrapper,
             false,
-            "create_time>'January 1, 2022' create_time<'January 1, 2023' extension:ext-filter hid>hid-greater hid<hid-lower name:name-filter state:state-filter tag:'tag filter'"
+            "create_time>'January 1, 2022' create_time<'January 1, 2023' extension:ext-filter genome_build:db-filter related:hid-related hid>hid-greater hid<hid-lower name:name-filter state:state-filter tag:'tag filter'"
         );
 
         // -------- Test esc key:  ---------

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -46,6 +46,8 @@
             <small class="mt-1">Filter by state:</small>
             <b-form-input v-model="filterSettings['state:']" size="sm" placeholder="any state" list="stateSelect" />
             <b-form-datalist id="stateSelect" :options="states"></b-form-datalist>
+            <small>Filter by database:</small>
+            <b-form-input v-model="filterSettings['genome_build:']" size="sm" placeholder="any database" />
             <small class="mt-1">Filter by related to item index:</small>
             <b-form-input v-model="filterSettings['related:']" size="sm" placeholder="index equals" />
             <small class="mt-1">Filter by item index:</small>

--- a/client/src/components/History/HistoryFilters.js
+++ b/client/src/components/History/HistoryFilters.js
@@ -5,6 +5,7 @@ export const validFilters = {
     state: equals("state"),
     name: contains("name"),
     extension: equals("extension"),
+    genome_build: contains("genome_build"),
     hid_ge: compare("hid", "ge"),
     hid_gt: compare("hid", "gt"),
     hid_le: compare("hid", "le"),

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -337,6 +337,7 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                 "hid",
                 "history_content_type",
                 "dataset_id",
+                "genome_build",
                 "state",
                 "extension",
                 "deleted",

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1248,7 +1248,7 @@ class TestHistoryContentsApiBulkOperation(ApiTestCase):
         with self.dataset_populator.test_history() as history_id:
             self._create_test_history_contents(history_id)
 
-            invalid_filter_keys_with_stats = ["genome_build", "data_type", "annotation"]
+            invalid_filter_keys_with_stats = ["data_type", "annotation"]
 
             for filter_key in invalid_filter_keys_with_stats:
                 response = self._get_contents_with_stats(


### PR DESCRIPTION
Added Database (`genome_build`) filter to `HistoryFilters`. Fixes https://github.com/galaxyproject/galaxy/issues/15470

https://user-images.githubusercontent.com/78516064/216724380-bf6c89be-471b-4d81-87f3-4f78c9a552c6.mov



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
