### PR TITLE
[23.0] Fix webhook backbone view

### DIFF
--- a/client/src/utils/webhooks.js
+++ b/client/src/utils/webhooks.js
@@ -29,11 +29,9 @@ const WebhookView = Backbone.View.extend({
         this.$el.attr("tool_version", toolVersion);
 
         getWebHookData().then((data) => {
-            if (options.type) {
-                data.reset(filterType(data, options.type));
-            }
-            if (data.length > 0) {
-                this.render(weightedRandomPick(data));
+            const filteredData = filterData(data, options);
+            if (filteredData.length > 0) {
+                this.render(weightedRandomPick(filteredData));
             }
         });
     },
@@ -46,13 +44,17 @@ const WebhookView = Backbone.View.extend({
     },
 });
 
+function filterData(data, options) {
+    let filteredData = data;
+    if (options.type) {
+        filteredData = filterType(data, options.type);
+    }
+    return filteredData;
+}
+
 const load = (options) => {
     getWebHookData().then((data) => {
-        let filteredData = data;
-        if (options.type) {
-            filteredData = filterType(data, options.type);
-        }
-        options.callback(filteredData);
+        options.callback(filterData(data, options));
     });
 };
 


### PR DESCRIPTION
Fixes:

```
TypeError: data.reset is not a function. (In 'data.reset(filterType(data, options.type))', 'data.reset' is undefined)
  at promiseReactionJob([native code])
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
