### PR TITLE
[22.05] Fix visible handling for exisiting datasets on discovery

### DIFF
--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -100,7 +100,6 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
 
         if primary_data is not None:
             primary_data.extension = ext
-            primary_data.visible = visible
             primary_data.dbkey = dbkey
         else:
             if not library_folder:
@@ -798,12 +797,13 @@ def persist_hdas(elements, model_persistence_context, final_job_state="ok"):
                 hashes = fields_match.hashes
                 created_from_basename = fields_match.created_from_basename
                 extra_files = fields_match.extra_files
+                visible = fields_match.visible
 
                 info, state = discovered_file.discovered_state(element, final_job_state)
                 dataset = model_persistence_context.create_dataset(
                     ext=ext,
                     designation=designation,
-                    visible=True,
+                    visible=visible,
                     dbkey=dbkey,
                     name=name,
                     filename=discovered_file.path,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -418,7 +418,7 @@ class FastAPIHistoryContents:
     @router.get(
         "/api/histories/{history_id}/contents/{id}",
         name="history_content",
-        summary="Return detailed information about an HDA within a history.",
+        summary="Return detailed information about an HDA within a history. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.",
         response_model_exclude_unset=True,
         deprecated=True,
     )
@@ -675,7 +675,7 @@ class FastAPIHistoryContents:
     )
     @router.put(
         "/api/histories/{history_id}/contents/{id}",
-        summary="Updates the values for the history content item with the given ``ID``.",
+        summary="Updates the values for the history content item with the given ``ID``. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.",
         response_model_exclude_unset=True,
         deprecated=True,
     )

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -810,6 +810,23 @@ class ToolsTestCase(ApiTestCase, TestsTools):
     def test_apply_rules_6(self):
         self._apply_rules_and_check(rules_test_data.EXAMPLE_6)
 
+    @skip_without_tool("galaxy_json_sleep")
+    def test_dataset_hidden_after_job_finish(self):
+        with self.dataset_populator.test_history() as history_id:
+            inputs = {
+                "sleep_time": 5,
+            }
+            response = self._run("galaxy_json_sleep", history_id, inputs, assert_ok=True)
+            output = response["outputs"][0]
+            response = self._put(
+                f"histories/{history_id}/contents/datasets/{output['id']}", data={"visible": False}, json=True
+            )
+            response.raise_for_status()
+            output_details = self.dataset_populator.get_history_dataset_details(history_id, dataset=output, wait=False)
+            assert not output_details["visible"]
+            output_details = self.dataset_populator.get_history_dataset_details(history_id, dataset=output, wait=True)
+            assert not output_details["visible"]
+
     @skip_without_tool("multi_select")
     def test_multi_select_as_list(self):
         with self.dataset_populator.test_history() as history_id:

--- a/test/functional/tools/galaxy_json_discover_and_sleep.xml
+++ b/test/functional/tools/galaxy_json_discover_and_sleep.xml
@@ -1,0 +1,28 @@
+<tool id="galaxy_json_sleep" name="galaxy_json_sleep" version="1.0.0" profile="22.05">
+    <command><![CDATA[ 
+        touch out &&
+        sleep $sleep_time &&
+        cp '$c1' galaxy.json
+    ]]></command>
+    <configfiles>
+        <configfile name="c1">{"output_tool_supplied_metadata": {
+            "name": "my dynamic name",
+            "ext": "txt",
+            "info": "my dynamic info"
+            }}
+</configfile>
+    </configfiles>
+    <inputs>
+        <param name="sleep_time" type="integer" value="0" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" from_work_dir="out" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="7" />
+            <output name="output" md5="d41d8cd98f00b204e9800998ecf8427e">
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <toolbox tool_path="${tool_conf_dir}" is_shed_conf="false">
-  <tool file="upload.xml"/>
-  <tool file="export_remote.xml"/>
+  <tool file="upload.xml" />
+  <tool file="export_remote.xml" />
   <section id="test" name="Test Section">
     <tool file="multi_data_optional.xml" />
     <tool file="paths_as_file.xml" />
     <tool file="param_text_option.xml" />
     <tool file="column_param.xml" />
   </section>
-  <tool file="ucsc_tablebrowser.xml"/>
-  <tool file="test_data_source.xml"/>
+  <tool file="ucsc_tablebrowser.xml" />
+  <tool file="test_data_source.xml" />
   <tool file="simple_constructs.xml" />
   <tool file="color_param.xml" />
   <tool file="inheritance_simple.xml" />
@@ -19,10 +19,10 @@
   <tool file="environment_variables_inject.xml" />
   <tool file="code_file.xml" />
   <tool file="disambiguate_cond.xml" />
-  <tool file="multi_repeats.xml"/>
-  <tool file="library_data.xml"/>
-  <tool file="remove_value.xml"/>
-  <tool file="bibtex.xml"/>
+  <tool file="multi_repeats.xml" />
+  <tool file="library_data.xml" />
+  <tool file="remove_value.xml" />
+  <tool file="bibtex.xml" />
   <tool file="multi_select.xml" />
   <tool file="multi_output.xml" />
   <tool file="multi_output_configured.xml" />
@@ -30,6 +30,7 @@
   <tool file="multi_output_assign_primary_ext_dbkey.xml" />
   <tool file="multi_output_recurse.xml" />
   <tool file="multi_output_recurse_collection.xml" />
+  <tool file="galaxy_json_discover_and_sleep.xml" />
   <tool file="tool_provided_metadata_1.xml" />
   <tool file="tool_provided_metadata_2.xml" />
   <tool file="tool_provided_metadata_3.xml" />


### PR DESCRIPTION
Fixes the flaky selenium upload tests and prevents fetch_data uploads from reverting from hidden to visible on job finish.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
