### PR TITLE
[23.0] Change Field Method for Tool Table Columns to a Map

### DIFF
--- a/client/src/components/admin/DataManager/DataManagerTable.vue
+++ b/client/src/components/admin/DataManager/DataManagerTable.vue
@@ -98,9 +98,7 @@ export default {
     },
     methods: {
         fields(columns) {
-            // Columns and data are given as arrays. Use each column index as field
-            // key for the table and the column values as labels
-            return columns.reduce((acc, c, i) => Object.assign(acc, { [i]: { label: c } }), {});
+            return columns.map((elem, index) => ({ key: index.toString(), label: elem }));
         },
         reload() {
             axios


### PR DESCRIPTION
Fix for #15162 
Replaced logic to build column headers with a map that uses the index (converted to a String) and a label (which is displayed as column header)

![Screenshot from 2023-02-07 17-13-48](https://user-images.githubusercontent.com/26912553/217394276-d94438b5-5c5a-4f5e-a3c8-e930bc147359.png)

## How to test the changes?
(Select all options that apply)
- [X] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Open the Admin Tool Table View with a Data Manager loaded
  2. Notice that the column headers are not indexes, but are instead descriptive strings.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
