### PR TITLE
[23.0] Fixes for Pulsar 0.15.0 discovered on usegalaxy.org

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -117,7 +117,7 @@ pkgutil-resolve-name==1.3.10 ; python_version >= "3.7" and python_version < "3.9
 prompt-toolkit==3.0.36 ; python_version >= "3.7" and python_version < "3.12"
 prov==1.5.1 ; python_version >= "3.7" and python_version < "3.12"
 psutil==5.9.4 ; python_version >= "3.7" and python_version < "3.12"
-pulsar-galaxy-lib==0.15.0.dev0 ; python_version >= "3.7" and python_version < "3.12"
+pulsar-galaxy-lib==0.15.0.dev1 ; python_version >= "3.7" and python_version < "3.12"
 pyasn1==0.4.8 ; python_version >= "3.7" and python_version < "3.12"
 pycparser==2.21 ; python_version >= "3.7" and python_version < "3.12"
 pycryptodome==3.16.0 ; python_version >= "3.7" and python_version < "3.12"

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -99,6 +99,10 @@ PULSAR_PARAM_SPECS = dict(
         map=specs.to_str_or_none,
         default=None,
     ),
+    amqp_key_prefix=dict(
+        map=specs.to_str_or_none,
+        default=None,
+    ),
     galaxy_url=dict(
         map=specs.to_str_or_none,
         default=None,
@@ -968,7 +972,7 @@ class PulsarMQJobRunner(PulsarJobRunner):
     )
 
 
-DEFAULT_PULSAR_CONTAINER = "galaxy/pulsar-pod-staging:0.15.0.1"
+DEFAULT_PULSAR_CONTAINER = "galaxy/pulsar-pod-staging:0.15.0.2"
 COEXECUTION_DESTENTATION_DEFAULTS = {
     "default_file_action": "remote_transfer",
     "rewrite_parameters": "true",


### PR DESCRIPTION
Requires new unreleased Pulsar changes in https://github.com/galaxyproject/pulsar/pull/315

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Abandon all hope ye who read this.
  2. Use brew to setup rabbitmq and Docker Desktop to setup Kubernetes and install the Pulsar PR as pulsar-galaxy-lib into Galaxy's environment.
  3. GALAXY_TEST_AMQP_URL=amqp://guest:guest@localhost:5672 FUNNEL_SERVER_TARGET=http://localhost:8000 GALAXY_TEST_PORT=9234 pytest -s test/integration/test_coexecution.py


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
