### PR TITLE
[23.0] Update client API schema

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -520,7 +520,7 @@ export interface paths {
     };
     "/api/histories/{history_id}/contents/{id}": {
         /**
-         * Return detailed information about an HDA within a history.
+         * Return detailed information about an HDA within a history. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
          * @deprecated
          * @description Return detailed information about an `HDA` or `HDCA` within a history.
          *
@@ -528,7 +528,7 @@ export interface paths {
          */
         get: operations["history_content_api_histories__history_id__contents__id__get"];
         /**
-         * Updates the values for the history content item with the given ``ID``.
+         * Updates the values for the history content item with the given ``ID``. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
          * @deprecated
          * @description Updates the values for the history content item with the given ``ID``.
          */
@@ -10605,7 +10605,7 @@ export interface operations {
     };
     history_content_api_histories__history_id__contents__id__get: {
         /**
-         * Return detailed information about an HDA within a history.
+         * Return detailed information about an HDA within a history. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
          * @deprecated
          * @description Return detailed information about an `HDA` or `HDCA` within a history.
          *
@@ -10658,7 +10658,7 @@ export interface operations {
     };
     update_api_histories__history_id__contents__id__put: {
         /**
-         * Updates the values for the history content item with the given ``ID``.
+         * Updates the values for the history content item with the given ``ID``. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
          * @deprecated
          * @description Updates the values for the history content item with the given ``ID``.
          */


### PR DESCRIPTION
Follow up to https://github.com/galaxyproject/galaxy/pull/15525/commits/69d2decf8137dcff205abcf0b7fdf2221a3ea4ce. Fixes client API schema linting after merging forward.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
