### PR TITLE
[23.0] More responsive clientside search

### DIFF
--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -4,6 +4,7 @@
         <DelayedInput
             :class="!showAdvanced && 'mb-3'"
             :query="query"
+            :delay="100"
             :show-advanced="showAdvanced"
             :enable-advanced="enableAdvanced"
             :placeholder="showAdvanced ? 'any name' : placeholder"


### PR DESCRIPTION
Calling this a bug since we're currently delaying a full second after input.  I don't know about dropping the delay completely, but this feels a lot better to me at 100ms.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
