### PR TITLE
[23.0] Switch to official setup-node action for cache

### DIFF
--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -48,9 +48,11 @@ jobs:
         with:
           path: .tox
           key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-first-startup
-      - uses: mvdbeek/gha-yarn-cache@master
+      - uses: actions/setup-node@v3
         with:
-          yarn-lock-file: 'galaxy root/client/yarn.lock'
+          node-version: '18.12.1'
+          cache: 'yarn'
+          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - name: Install tox
         run: pip install tox
       - name: run tests

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -63,9 +63,11 @@ jobs:
         with:
           path: 'galaxy root/.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-integration-selenium
-      - uses: mvdbeek/gha-yarn-cache@master
+      - uses: actions/setup-node@v3
         with:
-          yarn-lock-file: 'galaxy root/client/yarn.lock'
+          node-version: '18.12.1'
+          cache: 'yarn'
+          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: nanasess/setup-chromedriver@v1
       - name: Run tests
         run: ./run_tests.sh --coverage -integration test/integration_selenium

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16]
+        node: [18]
     steps:
       - uses: actions/checkout@v3
       - name: Setup node

--- a/.github/workflows/js_lint.yaml
+++ b/.github/workflows/js_lint.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [16]
+        node: [18]
     steps:
       - uses: actions/checkout@v3
       - name: Setup node

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -45,9 +45,11 @@ jobs:
         with:
           path: 'galaxy root/.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-reports-startup
-      - uses: mvdbeek/gha-yarn-cache@master
+      - uses: actions/setup-node@v3
         with:
-          yarn-lock-file: 'galaxy root/client/yarn.lock'
+          node-version: '18.12.1'
+          cache: 'yarn'
+          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - name: Install tox
         run: pip install tox
       - name: Run tests

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -63,9 +63,11 @@ jobs:
         with:
           path: 'galaxy root/.venv'
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-selenium
-      - uses: mvdbeek/gha-yarn-cache@master
+      - uses: actions/setup-node@v3
         with:
-          yarn-lock-file: 'galaxy root/client/yarn.lock'
+          node-version: '18.12.1'
+          cache: 'yarn'
+          cache-dependency-path: 'galaxy root/client/yarn.lock'
       - uses: nanasess/setup-chromedriver@v1
       - name: Run tests
         run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}


### PR DESCRIPTION
The old action often fails, this should be a little more stable. Should also bypass the node installation via nodeenv, which is rate-limited and can also fail. Also updates lint and unit tests to use node 18.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
