### PR TITLE
[22.05] Drop SentryWSGIMiddleware

### DIFF
--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -171,6 +171,11 @@ def add_empty_response_middleware(app: FastAPI) -> None:
     app.add_middleware(SuppressNoResponseReturnedMiddleware)
 
 
+def add_sentry_middleware(app: FastAPI) -> None:
+    from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+    app.add_middleware(SentryAsgiMiddleware)
+
+
 def add_exception_handler(app: FastAPI) -> None:
     @app.exception_handler(RequestValidationError)
     async def validate_exception_middleware(request: Request, exc: RequestValidationError) -> Response:

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1366,13 +1366,7 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         from paste import recursive
 
         app = wrap_if_allowed(app, stack, recursive.RecursiveMiddleware, args=(conf,))
-    # If sentry logging is enabled, log here before propogating up to
-    # the error middleware
-    sentry_dsn = conf.get("sentry_dsn", None)
-    if sentry_dsn:
-        from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
-        app = wrap_if_allowed(app, stack, SentryWsgiMiddleware)
     # Various debug middleware that can only be turned on if the debug
     # flag is set, either because they are insecure or greatly hurt
     # performance

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -263,14 +263,7 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         from paste.translogger import TransLogger
 
         app = wrap_if_allowed(app, stack, TransLogger)
-    # If sentry logging is enabled, log here before propogating up to
-    # the error middleware
-    # TODO sentry config is duplicated between tool_shed/galaxy, refactor this.
-    sentry_dsn = conf.get("sentry_dsn", None)
-    if sentry_dsn:
-        from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
-        app = wrap_if_allowed(app, stack, SentryWsgiMiddleware)
     # X-Forwarded-Host handling
     from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
 

--- a/lib/tool_shed/webapp/fast_app.py
+++ b/lib/tool_shed/webapp/fast_app.py
@@ -5,6 +5,7 @@ from galaxy.webapps.base.api import (
     add_empty_response_middleware,
     add_exception_handler,
     add_request_id_middleware,
+    add_sentry_middleware,
     include_all_package_routers,
 )
 
@@ -22,6 +23,8 @@ def initialize_fast_app(gx_webapp, tool_shed_app):
     tool_shed_app.haltables.append(("WSGI Middleware threadpool", wsgi_handler.executor.shutdown))
     app.mount("/", wsgi_handler)
     add_empty_response_middleware(app)
+    if tool_shed_app.config.sentry_dsn:
+        add_sentry_middleware(app=app)
     return app
 
 


### PR DESCRIPTION
It appears that we can't combine the WSGI middleware with the ASGI middleware in the same app. We're currently not sending events that occur in the WSGI portion of the app. With this change they're logged again, though we do lose the WSGI request context (which contains, browser, route, etc.) It's usually pretty clear from the traceback what went wrong though, so I think this is much better than what's happening now.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
