### PR TITLE
Use sentry-fastapi integration, expose sampling rate

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2914,6 +2914,19 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``sentry_traces_sample_rate``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Set to a number between 0 and 1. With this option set, every
+    transaction created will have that percentage chance of being sent
+    to Sentry. A value higher than 0 is required to analyze
+    performance.
+:Default: ``0.0``
+:Type: float
+
+
 ~~~~~~~~~~~~~~~
 ``statsd_host``
 ~~~~~~~~~~~~~~~
@@ -5076,14 +5089,15 @@
 :Type: str
 
 
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``enable_beacon_integration``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Enables user preferences and api endpoint for the beacon integration.
+    Enables user preferences and api endpoint for the beacon
+    integration.
 :Default: ``false``
 :Type: bool
+
 
 

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -202,6 +202,7 @@ class SentryClientMixin:
                     self.config.sentry_dsn,
                     release=f"{self.config.version_major}.{self.config.version_minor}",
                     integrations=[sentry_logging],
+                    traces_sample_rate=self.config.sentry_traces_sample_rate,
                 )
 
             self.application_stack.register_postfork_function(postfork_sentry_client)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1667,6 +1667,11 @@ galaxy:
   # Sentry. Possible values are DEBUG, INFO, WARNING, ERROR or CRITICAL.
   #sentry_event_level: ERROR
 
+  # Set to a number between 0 and 1. With this option set, every
+  # transaction created will have that percentage chance of being sent
+  # to Sentry. A value higher than 0 is required to analyze performance.
+  #sentry_traces_sample_rate: 0.0
+
   # Log to statsd Statsd is an external statistics aggregator
   # (https://github.com/etsy/statsd) Enabling the following options will
   # cause galaxy to log request timing and other statistics to the

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -311,6 +311,11 @@ tool_shed:
   # Sentry. Possible values are DEBUG, INFO, WARNING, ERROR or CRITICAL.
   #sentry_event_level: ERROR
 
+  # Set to a number between 0 and 1. With this option set, every
+  # transaction created will have that percentage chance of being sent
+  # to Sentry. A value higher than 0 is required to analyze performance.
+  #sentry_traces_sample_rate: 0.0
+
   # Galaxy Session Timeout This provides a timeout (in minutes) after
   # which a user will have to log back in. A duration of 0 disables this
   # feature.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2108,6 +2108,15 @@ mapping:
           Determines the minimum log level that will be sent as an event to Sentry.
           Possible values are DEBUG, INFO, WARNING, ERROR or CRITICAL.
 
+      sentry_traces_sample_rate:
+        type: float
+        default: 0.0
+        required: false
+        desc: |
+          Set to a number between 0 and 1. With this option set, every transaction created
+          will have that percentage chance of being sent to Sentry. A value higher than 0
+          is required to analyze performance.
+
       statsd_host:
         type: str
         required: false

--- a/lib/galaxy/config/schemas/tool_shed_config_schema.yml
+++ b/lib/galaxy/config/schemas/tool_shed_config_schema.yml
@@ -557,6 +557,15 @@ mapping:
           Determines the minimum log level that will be sent as an event to Sentry.
           Possible values are DEBUG, INFO, WARNING, ERROR or CRITICAL.
 
+      sentry_traces_sample_rate:
+        type: float
+        default: 0.0
+        required: false
+        desc: |
+          Set to a number between 0 and 1. With this option set, every transaction created
+          will have that percentage chance of being sent to Sentry. A value higher than 0
+          is required to analyze performance.
+
       session_duration:
         type: int
         default: 0

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -2,7 +2,7 @@
 psycopg2-binary==2.9.5
 mysqlclient
 fluent-logger
-sentry-sdk
+sentry-sdk[fastapi]
 pbs_python
 drmaa
 statsd

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -66,6 +66,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
         # Call app's shutdown method when the interpeter exits, this cleanly stops
         # the various Galaxy application daemon threads
         app.application_stack.register_postfork_function(atexit.register, app.shutdown)
+
     # Create the universe WSGI application
     webapp = GalaxyWebApplication(app, session_cookie="galaxysession", name="galaxy")
 
@@ -1304,13 +1305,7 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         from paste import recursive
 
         app = wrap_if_allowed(app, stack, recursive.RecursiveMiddleware, args=(conf,))
-    # If sentry logging is enabled, log here before propogating up to
-    # the error middleware
-    sentry_dsn = conf.get("sentry_dsn", None)
-    if sentry_dsn:
-        from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
-        app = wrap_if_allowed(app, stack, SentryWsgiMiddleware)
     # Error middleware
     app = wrap_if_allowed(app, stack, ErrorMiddleware, args=(conf,))
     # Transaction logging (apache access.log style)

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -107,11 +107,6 @@ def add_galaxy_middleware(app: FastAPI, gx_app):
     GalaxyFileResponse.nginx_x_accel_redirect_base = gx_app.config.nginx_x_accel_redirect_base
     GalaxyFileResponse.apache_xsendfile = gx_app.config.apache_xsendfile
 
-    if gx_app.config.sentry_dsn:
-        from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
-
-        app.add_middleware(SentryAsgiMiddleware)
-
     if gx_app.config.get("allowed_origin_hostnames", None):
         app.add_middleware(
             GalaxyCORSMiddleware,

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -267,14 +267,7 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         from paste.translogger import TransLogger
 
         app = wrap_if_allowed(app, stack, TransLogger)
-    # If sentry logging is enabled, log here before propogating up to
-    # the error middleware
-    # TODO sentry config is duplicated between tool_shed/galaxy, refactor this.
-    sentry_dsn = conf.get("sentry_dsn", None)
-    if sentry_dsn:
-        from sentry_sdk.integrations.wsgi import SentryWsgiMiddleware
 
-        app = wrap_if_allowed(app, stack, SentryWsgiMiddleware)
     # X-Forwarded-Host handling
     from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
 


### PR DESCRIPTION
That's the recommended way for FastAPI apps (https://docs.sentry.io/platforms/python/guides/quart/configuration/integrations/asgi/, https://docs.sentry.io/platforms/python/guides/fastapi/). Like #15548 it only adds extra information on ASGI routes.
Also exposes the traces_sample_rate setting for potential performance measurement details:

<img width="1882" alt="sentry" src="https://user-images.githubusercontent.com/6804901/218087329-617417b6-37aa-41d6-bb4c-9ea189d44217.png">

<img width="1461" alt="perf" src="https://user-images.githubusercontent.com/6804901/218088344-a7d27ca6-9337-44b3-8e1a-a720ff1378f7.png">


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
