### PR TITLE
[23.0] Disable invocation export when Celery is disabled

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
@@ -3,6 +3,15 @@ import { shallowMount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
 import Vuex from "vuex";
 import invocationData from "../Workflow/test/json/invocation.json";
+import { useConfig } from "composables/config";
+
+jest.mock("composables/config");
+useConfig.mockReturnValue({
+    config: {
+        enable_celery_tasks: true,
+    },
+    isLoaded: true,
+});
 
 const invocationJobsSummaryById = {
     id: "d9833097445452b0",

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -17,7 +17,7 @@
         <!-- <b-tab title="Workflow Overview">
             <p>TODO: Insert readonly version of workflow editor here</p>
         </b-tab> -->
-        <b-tab title="Export">
+        <b-tab v-if="canExecuteTasks" title="Export">
             <div v-if="invocationAndJobTerminal">
                 <workflow-invocation-export-options :invocation-id="invocation.id" />
             </div>
@@ -39,6 +39,7 @@ import WorkflowInvocationExportOptions from "./WorkflowInvocationExportOptions.v
 import JOB_STATES_MODEL from "utils/job-states-model";
 import mixin from "components/JobStates/mixin";
 import { mapGetters, mapActions } from "vuex";
+import { useConfig } from "composables/config";
 
 export default {
     components: {
@@ -58,6 +59,13 @@ export default {
             required: false,
             default: null,
         },
+    },
+    setup() {
+        const { config, isLoaded: isConfigLoaded } = useConfig();
+        return {
+            config,
+            isConfigLoaded,
+        };
     },
     data() {
         return {
@@ -93,6 +101,9 @@ export default {
         jobStatesSummary() {
             const jobsSummary = this.getInvocationJobsSummaryById(this.invocationId);
             return !jobsSummary ? null : new JOB_STATES_MODEL.JobStatesSummary(jobsSummary);
+        },
+        canExecuteTasks() {
+            return this.isConfigLoaded && this.config.enable_celery_tasks;
         },
     },
     created: function () {


### PR DESCRIPTION
Fixes #15552

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Set `enable_celery_tasks: false` in your Galaxy config file. 
  2. Go to `User -> Workflow Invocations`
  3. Expand an invocation and observe the `Export` tab no longer appear.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
