### PR TITLE
[23.0] fix hostname parsing for newer Docker versions

### DIFF
--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -198,6 +198,11 @@ def parse_port_text(port_text):
     >>> slurm_ports[8888]['host']
     '0.0.0.0'
     >>> ports = parse_port_text("5432/tcp -> :::5432")
+    >>> len(ports)
+    0
+    >>> ports_new = parse_port_text("5432/tcp -> [::]:5432")
+    >>> len(ports_new)
+    0
     """
     ports = None
     if port_text is not None:
@@ -207,7 +212,7 @@ def parse_port_text(port_text):
                 raise Exception(f"Cannot parse host and port from line [{line}]")
             tool, host = line.split(" -> ", 1)
             hostname, port = host.rsplit(":", 1)
-            if hostname == "::":
+            if hostname in ["::", "[::]"]:
                 # Skip unspecified IPv6 address, which is also specified as 0:0:0:0 in another line.
                 # This is brittle of course, but so is parsing the container ports like this.
                 continue


### PR DESCRIPTION
_same PR, against release_23.0 branch now_

We were getting errors in interactive tools with the newer Docker version (23.0). The problem was that Docker seemed to return "[::]" instead of "::" for the IPv6 hostname, which was not filtered, and then gie-proxy could not redirect to the container.

So, I fixed that here. Also fixed the existing test and added a new one.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
