### PR TITLE
[23.0] Sync ToolForm and WorkflowRun with history changes

### DIFF
--- a/client/src/components/Tool/ToolForm.test.js
+++ b/client/src/components/Tool/ToolForm.test.js
@@ -10,6 +10,7 @@ import Vue from "vue";
 import Vuex from "vuex";
 import { createPinia } from "pinia";
 import { userStore } from "store/userStore";
+import { historyStore } from "store/historyStore";
 import { configStore } from "store/configStore";
 
 const localVue = getLocalVue();
@@ -39,6 +40,7 @@ describe("ToolForm", () => {
             modules: {
                 user: mockModule(userStore),
                 config: mockModule(configStore),
+                history: mockModule(historyStore, { currentHistoryId: "fakehistory", histories: { fakehistory: {} } }),
             },
         });
 
@@ -54,6 +56,7 @@ describe("ToolForm", () => {
                 ConfigProvider: MockConfigProvider({ id: "fakeconfig" }),
                 FormDisplay: true,
             },
+            store,
             provide: { store },
             pinia,
         });

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -104,6 +104,7 @@ import { getGalaxyInstance } from "app";
 import { useHistoryItemsStore } from "stores/history/historyItemsStore";
 import { useJobStore } from "stores/jobStore";
 import { mapState, mapActions } from "pinia";
+import { mapGetters } from "vuex";
 import { getToolFormData, updateToolFormData, submitJob } from "./services";
 import { allowCachedJobs } from "./utilities";
 import { refreshContentsWrapper } from "utils/data";
@@ -182,7 +183,8 @@ export default {
         };
     },
     computed: {
-        ...mapState(useHistoryItemsStore, ["getLatestCreateTime"]),
+        ...mapState(useHistoryItemsStore, ["getLastUpdateTime"]),
+        ...mapGetters("history", ["currentHistoryId"]),
         toolName() {
             return this.formConfig.name;
         },
@@ -214,12 +216,11 @@ export default {
         },
     },
     watch: {
-        getLatestCreateTime() {
-            const Galaxy = getGalaxyInstance();
-            if (this.initialized && Galaxy && Galaxy.currHistoryPanel) {
-                console.debug("History change watcher detected a change.");
-                this.onHistoryChange();
-            }
+        currentHistoryId() {
+            this.onHistoryChange();
+        },
+        getLastUpdateTime() {
+            this.onHistoryChange();
         },
     },
     created() {
@@ -237,8 +238,11 @@ export default {
             return allowCachedJobs(user.preferences);
         },
         onHistoryChange() {
-            console.debug(`ToolForm::created - Loading history changes. [${this.id}]`);
-            this.onUpdate();
+            const Galaxy = getGalaxyInstance();
+            if (this.initialized && Galaxy && Galaxy.currHistoryPanel) {
+                console.debug(`ToolForm::onHistoryChange - Loading history changes. [${this.id}]`);
+                this.onUpdate();
+            }
         },
         onValidation(validationInternal) {
             this.validationInternal = validationInternal;

--- a/client/src/components/Workflow/Run/WorkflowRun.test.js
+++ b/client/src/components/Workflow/Run/WorkflowRun.test.js
@@ -1,6 +1,10 @@
 import WorkflowRun from "./WorkflowRun.vue";
 import { shallowMount, createLocalVue } from "@vue/test-utils";
-import { watchForChange } from "tests/jest/helpers";
+import { mockModule, watchForChange } from "tests/jest/helpers";
+import Vuex from "vuex";
+import { historyStore } from "store/historyStore";
+import { createTestingPinia } from "@pinia/testing";
+import { PiniaVuePlugin } from "pinia";
 
 import sampleRunData1 from "./testdata/run1.json";
 
@@ -31,9 +35,17 @@ describe("WorkflowRun.vue", () => {
     beforeEach(() => {
         const propsData = { workflowId: run1WorkflowId };
         localVue = createLocalVue();
+        localVue.use(PiniaVuePlugin);
+        const store = new Vuex.Store({
+            modules: {
+                history: mockModule(historyStore, { currentHistoryId: "fakehistory", histories: { fakehistory: {} } }),
+            },
+        });
         wrapper = shallowMount(WorkflowRun, {
+            store,
             propsData: propsData,
             localVue,
+            pinia: createTestingPinia(),
         });
     });
 

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -97,14 +97,15 @@ export default {
     computed: {
         ...mapState(useHistoryItemsStore, ["getLastUpdateTime"]),
         ...mapGetters("history", ["currentHistoryId"]),
-        rerenderKey() {
+        historyStatusKey() {
             return `${this.currentHistoryId}_${this.getLastUpdateTime}`;
         },
     },
     watch: {
-        rerenderKey() {
-            this.loading = true;
-            this.loadRun();
+        historyStatusKey() {
+            if (!this.invocations) {
+                this.loadRun();
+            }
         },
     },
     created() {

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -45,6 +45,9 @@
 </template>
 
 <script>
+import { useHistoryItemsStore } from "stores/history/historyItemsStore";
+import { mapState } from "pinia";
+import { mapGetters } from "vuex";
 import { getRunData } from "./services";
 import LoadingSpan from "components/LoadingSpan";
 import WorkflowRunSuccess from "./WorkflowRunSuccess";
@@ -91,47 +94,21 @@ export default {
             model: null,
         };
     },
+    computed: {
+        ...mapState(useHistoryItemsStore, ["getLastUpdateTime"]),
+        ...mapGetters("history", ["currentHistoryId"]),
+        rerenderKey() {
+            return `${this.currentHistoryId}_${this.getLastUpdateTime}`;
+        },
+    },
+    watch: {
+        rerenderKey() {
+            this.loading = true;
+            this.loadRun();
+        },
+    },
     created() {
-        getRunData(this.workflowId)
-            .then((runData) => {
-                this.loading = false;
-                const model = new WorkflowRunModel(runData);
-                let simpleForm = this.preferSimpleForm;
-                if (simpleForm) {
-                    // These only work with PJA - the API doesn't evaluate them at
-                    // all outside that context currently. The main workflow form renders
-                    // these dynamically and takes care of all the validation and setup details
-                    // on the frontend. If these are implemented on the backend at some
-                    // point this restriction can be lifted.
-                    if (model.hasReplacementParametersInToolForm) {
-                        console.log("cannot render simple workflow form - has ${} values in tool steps");
-                        simpleForm = false;
-                    }
-                    // If there are required parameters in a tool form (a disconnected runtime
-                    // input), we have to render the tool form steps and cannot use the
-                    // simplified tool form.
-                    if (model.hasOpenToolSteps) {
-                        console.log(
-                            "cannot render simple workflow form - one or more tools have disconnected runtime inputs"
-                        );
-                        simpleForm = false;
-                    }
-                    // Just render the whole form for resource request parameters (kind of
-                    // niche - I'm not sure anyone is using these currently anyway).
-                    if (model.hasWorkflowResourceParameters) {
-                        console.log(`Cannot render simple workflow form - workflow resource parameters are configured`);
-                        simpleForm = false;
-                    }
-                }
-                this.simpleForm = simpleForm;
-                this.model = model;
-                this.hasUpgradeMessages = model.hasUpgradeMessages;
-                this.hasStepVersionChanges = model.hasStepVersionChanges;
-                this.workflowName = this.model.name;
-            })
-            .catch((response) => {
-                this.error = errorMessageAsString(response);
-            });
+        this.loadRun();
     },
     methods: {
         handleInvocations(invocations) {
@@ -139,6 +116,50 @@ export default {
         },
         handleSubmissionError(error) {
             this.submissionError = errorMessageAsString(error);
+        },
+        loadRun() {
+            getRunData(this.workflowId)
+                .then((runData) => {
+                    this.loading = false;
+                    const model = new WorkflowRunModel(runData);
+                    let simpleForm = this.preferSimpleForm;
+                    if (simpleForm) {
+                        // These only work with PJA - the API doesn't evaluate them at
+                        // all outside that context currently. The main workflow form renders
+                        // these dynamically and takes care of all the validation and setup details
+                        // on the frontend. If these are implemented on the backend at some
+                        // point this restriction can be lifted.
+                        if (model.hasReplacementParametersInToolForm) {
+                            console.log("cannot render simple workflow form - has ${} values in tool steps");
+                            simpleForm = false;
+                        }
+                        // If there are required parameters in a tool form (a disconnected runtime
+                        // input), we have to render the tool form steps and cannot use the
+                        // simplified tool form.
+                        if (model.hasOpenToolSteps) {
+                            console.log(
+                                "cannot render simple workflow form - one or more tools have disconnected runtime inputs"
+                            );
+                            simpleForm = false;
+                        }
+                        // Just render the whole form for resource request parameters (kind of
+                        // niche - I'm not sure anyone is using these currently anyway).
+                        if (model.hasWorkflowResourceParameters) {
+                            console.log(
+                                `Cannot render simple workflow form - workflow resource parameters are configured`
+                            );
+                            simpleForm = false;
+                        }
+                    }
+                    this.simpleForm = simpleForm;
+                    this.model = model;
+                    this.hasUpgradeMessages = model.hasUpgradeMessages;
+                    this.hasStepVersionChanges = model.hasStepVersionChanges;
+                    this.workflowName = this.model.name;
+                })
+                .catch((response) => {
+                    this.error = errorMessageAsString(response);
+                });
         },
         showAdvanced() {
             this.simpleForm = false;

--- a/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunDefaultStep.vue
@@ -21,6 +21,9 @@
 </template>
 
 <script>
+import { getGalaxyInstance } from "app";
+import { useHistoryItemsStore } from "stores/history/historyItemsStore";
+import { mapState } from "pinia";
 import WorkflowIcons from "components/Workflow/icons";
 import FormDisplay from "components/Form/FormDisplay";
 import FormMessage from "components/Form/FormMessage";
@@ -60,13 +63,18 @@ export default {
         return {
             expanded: this.model.expanded,
             errorText: null,
+            modelData: {},
             modelIndex: {},
             modelInputs: this.model.inputs,
         };
     },
     computed: {
+        ...mapState(useHistoryItemsStore, ["getLastUpdateTime"]),
         icon() {
             return WorkflowIcons[this.model.step_type];
+        },
+        historyStatusKey() {
+            return `${this.historyId}_${this.getLastUpdateTime}`;
         },
     },
     watch: {
@@ -74,6 +82,9 @@ export default {
             if (this.validationScrollTo.length > 0) {
                 this.expanded = true;
             }
+        },
+        historyStatusKey() {
+            this.onHistoryChange();
         },
     },
     methods: {
@@ -83,24 +94,34 @@ export default {
                 this.modelIndex[name] = input;
             });
         },
+        onHistoryChange() {
+            const Galaxy = getGalaxyInstance();
+            if (Galaxy && Galaxy.currHistoryPanel) {
+                this.onUpdate();
+            }
+        },
         onChange(data, refreshRequest) {
+            this.modelData = data;
             if (refreshRequest) {
-                getTool(this.model.id, this.model.version, data, this.historyId).then(
-                    (newModel) => {
-                        this.onCreateIndex();
-                        visitInputs(newModel.inputs, (newInput, name) => {
-                            const input = this.modelIndex[name];
-                            input.options = newInput.options;
-                            input.textable = newInput.textable;
-                        });
-                        this.modelInputs = JSON.parse(JSON.stringify(this.modelInputs));
-                    },
-                    (errorText) => {
-                        this.errorText = errorText;
-                    }
-                );
+                this.onUpdate();
             }
             this.$emit("onChange", this.model.index, data);
+        },
+        onUpdate() {
+            getTool(this.model.id, this.model.version, this.modelData, this.historyId).then(
+                (newModel) => {
+                    this.onCreateIndex();
+                    visitInputs(newModel.inputs, (newInput, name) => {
+                        const input = this.modelIndex[name];
+                        input.options = newInput.options;
+                        input.textable = newInput.textable;
+                    });
+                    this.modelInputs = JSON.parse(JSON.stringify(this.modelInputs));
+                },
+                (errorText) => {
+                    this.errorText = errorText;
+                }
+            );
         },
         onValidation(validation) {
             this.$emit("onValidation", this.model.index, validation);

--- a/client/src/store/historyStore/model/watchHistory.js
+++ b/client/src/store/historyStore/model/watchHistory.js
@@ -53,6 +53,7 @@ export async function watchHistoryOnce(store) {
     if (!lastUpdateTime || lastUpdateTime < history.update_time) {
         const historyId = history.id;
         lastUpdateTime = history.update_time;
+        historyItemsStore.setLastUpdateTime();
         // execute request to obtain recently changed items
         const params = {
             v: "dev",

--- a/client/src/stores/history/historyItemsStore.js
+++ b/client/src/stores/history/historyItemsStore.js
@@ -18,9 +18,10 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
     state: () => ({
         items: {},
         itemKey: "hid",
-        latestCreateTime: new Date(),
+        latestCreateTime: undefined,
         totalMatchesCount: undefined,
         lastCheckedTime: new Date(),
+        lastUpdateTime: new Date(),
         relatedItems: {},
         isWatching: false,
     }),
@@ -55,6 +56,9 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
         getLastCheckedTime: (state) => {
             return state.lastCheckedTime;
         },
+        getLastUpdateTime: (state) => {
+            return state.lastUpdateTime;
+        },
         getWatchingVisibility: (state) => {
             return state.isWatching;
         },
@@ -82,8 +86,10 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
                 payload.forEach((item) => {
                     if (item.state == "ok") {
                         const itemCreateTime = new Date(item.create_time);
-                        if (itemCreateTime > state.latestCreateTime) {
+                        if (!state.latestCreateTime || itemCreateTime > state.latestCreateTime) {
                             state.latestCreateTime = itemCreateTime;
+                        } else if (itemCreateTime > state.lastUpdateTime) {
+                            state.lastUpdateTime = itemCreateTime;
                         }
                     }
                     if (relatedHid) {
@@ -95,6 +101,9 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
         },
         setLastCheckedTime(checkForUpdate) {
             this.lastCheckedTime = checkForUpdate;
+        },
+        setLastUpdateTime(lastUpdateTime = new Date()) {
+            this.lastUpdateTime = lastUpdateTime;
         },
         setWatchingVisibility(watchingVisibility) {
             this.isWatching = watchingVisibility;

--- a/client/src/stores/history/historyItemsStore.js
+++ b/client/src/stores/history/historyItemsStore.js
@@ -18,7 +18,6 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
     state: () => ({
         items: {},
         itemKey: "hid",
-        latestCreateTime: undefined,
         totalMatchesCount: undefined,
         lastCheckedTime: new Date(),
         lastUpdateTime: new Date(),
@@ -46,9 +45,6 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
                 });
                 return reverse(filtered);
             };
-        },
-        getLatestCreateTime: (state) => {
-            return state.latestCreateTime;
         },
         getTotalMatchesCount: (state) => {
             return state.totalMatchesCount;
@@ -84,14 +80,6 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
                 mergeArray(historyId, payload, state.items, state.itemKey);
                 // keep track of latest create time for items
                 payload.forEach((item) => {
-                    if (item.state == "ok") {
-                        const itemCreateTime = new Date(item.create_time);
-                        if (!state.latestCreateTime || itemCreateTime > state.latestCreateTime) {
-                            state.latestCreateTime = itemCreateTime;
-                        } else if (itemCreateTime > state.lastUpdateTime) {
-                            state.lastUpdateTime = itemCreateTime;
-                        }
-                    }
                     if (relatedHid) {
                         const relationKey = `${historyId}-${relatedHid}-${item.hid}`;
                         Vue.set(state.relatedItems, relationKey, true);

--- a/client/src/stores/history/historyItemsStore.js
+++ b/client/src/stores/history/historyItemsStore.js
@@ -78,13 +78,13 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
             this.$patch((state) => {
                 // merges incoming payload into existing state
                 mergeArray(historyId, payload, state.items, state.itemKey);
-                // keep track of latest create time for items
-                payload.forEach((item) => {
-                    if (relatedHid) {
+                // if related filter is included, set keys in state
+                if (relatedHid) {
+                    payload.forEach((item) => {
                         const relationKey = `${historyId}-${relatedHid}-${item.hid}`;
                         Vue.set(state.relatedItems, relationKey, true);
-                    }
-                });
+                    });
+                }
             });
         },
         setLastCheckedTime(checkForUpdate) {


### PR DESCRIPTION
The `ToolForm` and `WorkflowRun` forms were not in sync with history changes. 

Added a `lastUpdateTime` val to the `historyItemsStore` that ensures every change in the current history is recorded. 

`historyItemsStore.lastUpdateTime` + `historyStore/currentHistoryId` are watched and used to rerender these forms.

Fixes https://github.com/galaxyproject/galaxy/issues/15427
Closes https://github.com/galaxyproject/galaxy/issues/15427

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
