### PR TITLE
[23.0] Fix Filter history inputs and outputs server error

### DIFF
--- a/lib/galaxy/managers/job_connections.py
+++ b/lib/galaxy/managers/job_connections.py
@@ -78,7 +78,7 @@ class JobConnectionsManager:
             )
             .where(
                 expression.and_(
-                    model.JobToInputDatasetAssociation.dataset_id != None,
+                    model.JobToInputDatasetAssociation.dataset_id is not None,
                     model.JobToInputDatasetAssociation.dataset_id == input_hda_id,
                 )
             )
@@ -96,7 +96,7 @@ class JobConnectionsManager:
             )
             .where(
                 expression.and_(
-                    model.JobToInputDatasetAssociation.dataset_id != None,
+                    model.JobToInputDatasetAssociation.dataset_id is not None,
                     model.JobToInputDatasetAssociation.dataset_id == input_hda_id,
                 )
             )
@@ -117,7 +117,7 @@ class JobConnectionsManager:
             )
             .where(
                 expression.and_(
-                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id != None,
+                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id is not None,
                     model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
                 )
             )
@@ -136,7 +136,7 @@ class JobConnectionsManager:
             )
             .where(
                 expression.and_(
-                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id != None,
+                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id is not None,
                     model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
                 )
             )
@@ -157,7 +157,7 @@ class JobConnectionsManager:
             )
             .where(
                 expression.and_(
-                    model.JobToOutputDatasetAssociation.dataset_id != None,
+                    model.JobToOutputDatasetAssociation.dataset_id is not None,
                     model.JobToOutputDatasetAssociation.dataset_id == input_hda_id,
                 )
             )
@@ -175,7 +175,7 @@ class JobConnectionsManager:
             )
             .where(
                 expression.and_(
-                    model.JobToOutputDatasetAssociation.dataset_id != None,
+                    model.JobToOutputDatasetAssociation.dataset_id is not None,
                     model.JobToOutputDatasetAssociation.dataset_id == input_hda_id,
                 )
             )
@@ -196,7 +196,7 @@ class JobConnectionsManager:
             )
             .where(
                 expression.and_(
-                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id != None,
+                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id is not None,
                     model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
                 )
             )
@@ -215,7 +215,7 @@ class JobConnectionsManager:
             )
             .where(
                 expression.and_(
-                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id != None,
+                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id is not None,
                     model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
                 )
             )

--- a/lib/galaxy/managers/job_connections.py
+++ b/lib/galaxy/managers/job_connections.py
@@ -54,7 +54,8 @@ class JobConnectionsManager:
             for val in graph["outputs"] + graph["inputs"]:
                 item_class = get_class(val["src"])
                 item = self.sa_session.query(item_class).get(val["id"])
-                result.append(item.hid)
+                if item:
+                    result.append(item.hid)
         return result
 
     def _get_union_results(self, *selects):

--- a/lib/galaxy/managers/job_connections.py
+++ b/lib/galaxy/managers/job_connections.py
@@ -53,9 +53,9 @@ class JobConnectionsManager:
             # Add found related items' hids to result list
             for val in graph["outputs"] + graph["inputs"]:
                 item_class = get_class(val["src"])
-                item = self.sa_session.query(item_class).get(val["id"])
-                if item:
-                    result.append(item.hid)
+                item_hid = self.sa_session.execute(select(item_class.hid).where(item_class.id == val["id"])).scalar()
+                if item_hid:
+                    result.append(item_hid)
         return result
 
     def _get_union_results(self, *selects):
@@ -76,7 +76,12 @@ class JobConnectionsManager:
                 model.JobToInputDatasetAssociation,
                 model.JobToInputDatasetAssociation.job_id == model.JobToOutputDatasetAssociation.job_id,
             )
-            .where(model.JobToInputDatasetAssociation.dataset_id == input_hda_id)
+            .where(
+                expression.and_(
+                    model.JobToInputDatasetAssociation.dataset_id != None,
+                    model.JobToInputDatasetAssociation.dataset_id == input_hda_id,
+                )
+            )
         )
         hdca_select = (
             select(
@@ -89,7 +94,12 @@ class JobConnectionsManager:
                 model.JobToInputDatasetAssociation,
                 model.JobToInputDatasetAssociation.job_id == model.JobToOutputDatasetCollectionAssociation.job_id,
             )
-            .where(model.JobToInputDatasetAssociation.dataset_id == input_hda_id)
+            .where(
+                expression.and_(
+                    model.JobToInputDatasetAssociation.dataset_id != None,
+                    model.JobToInputDatasetAssociation.dataset_id == input_hda_id,
+                )
+            )
         )
         return hda_select, hdca_select
 
@@ -105,7 +115,12 @@ class JobConnectionsManager:
                 model.JobToInputDatasetCollectionAssociation,
                 model.JobToInputDatasetCollectionAssociation.job_id == model.JobToOutputDatasetAssociation.job_id,
             )
-            .where(model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id)
+            .where(
+                expression.and_(
+                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id != None,
+                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
+                )
+            )
         )
         hdca_select = (
             select(
@@ -119,7 +134,12 @@ class JobConnectionsManager:
                 model.JobToInputDatasetCollectionAssociation.job_id
                 == model.JobToOutputDatasetCollectionAssociation.job_id,
             )
-            .where(model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id)
+            .where(
+                expression.and_(
+                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id != None,
+                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
+                )
+            )
         )
         return hda_select, hdca_select
 
@@ -135,7 +155,12 @@ class JobConnectionsManager:
                 model.JobToOutputDatasetAssociation,
                 model.JobToOutputDatasetAssociation.job_id == model.JobToInputDatasetAssociation.job_id,
             )
-            .where(model.JobToOutputDatasetAssociation.dataset_id == input_hda_id)
+            .where(
+                expression.and_(
+                    model.JobToOutputDatasetAssociation.dataset_id != None,
+                    model.JobToOutputDatasetAssociation.dataset_id == input_hda_id,
+                )
+            )
         )
         input_hdcas = (
             select(
@@ -148,7 +173,12 @@ class JobConnectionsManager:
                 model.JobToOutputDatasetAssociation,
                 model.JobToOutputDatasetAssociation.job_id == model.JobToInputDatasetCollectionAssociation.job_id,
             )
-            .where(model.JobToOutputDatasetAssociation.dataset_id == input_hda_id)
+            .where(
+                expression.and_(
+                    model.JobToOutputDatasetAssociation.dataset_id != None,
+                    model.JobToOutputDatasetAssociation.dataset_id == input_hda_id,
+                )
+            )
         )
         return input_hdas, input_hdcas
 
@@ -164,7 +194,12 @@ class JobConnectionsManager:
                 model.JobToOutputDatasetCollectionAssociation,
                 model.JobToOutputDatasetCollectionAssociation.job_id == model.JobToInputDatasetAssociation.job_id,
             )
-            .where(model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id)
+            .where(
+                expression.and_(
+                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id != None,
+                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
+                )
+            )
         )
         input_hdcas = (
             select(
@@ -178,6 +213,11 @@ class JobConnectionsManager:
                 model.JobToOutputDatasetCollectionAssociation.job_id
                 == model.JobToInputDatasetCollectionAssociation.job_id,
             )
-            .where(model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id)
+            .where(
+                expression.and_(
+                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id != None,
+                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
+                )
+            )
         )
         return input_hdas, input_hdcas

--- a/lib/galaxy/managers/job_connections.py
+++ b/lib/galaxy/managers/job_connections.py
@@ -54,8 +54,7 @@ class JobConnectionsManager:
             for val in graph["outputs"] + graph["inputs"]:
                 item_class = get_class(val["src"])
                 item_hid = self.sa_session.execute(select(item_class.hid).where(item_class.id == val["id"])).scalar()
-                if item_hid:
-                    result.append(item_hid)
+                result.append(item_hid)
         return result
 
     def _get_union_results(self, *selects):
@@ -76,12 +75,8 @@ class JobConnectionsManager:
                 model.JobToInputDatasetAssociation,
                 model.JobToInputDatasetAssociation.job_id == model.JobToOutputDatasetAssociation.job_id,
             )
-            .where(
-                expression.and_(
-                    model.JobToInputDatasetAssociation.dataset_id is not None,
-                    model.JobToInputDatasetAssociation.dataset_id == input_hda_id,
-                )
-            )
+            .where(model.JobToOutputDatasetAssociation.dataset_id.is_not(None))
+            .where(model.JobToInputDatasetAssociation.dataset_id == input_hda_id)
         )
         hdca_select = (
             select(
@@ -94,12 +89,8 @@ class JobConnectionsManager:
                 model.JobToInputDatasetAssociation,
                 model.JobToInputDatasetAssociation.job_id == model.JobToOutputDatasetCollectionAssociation.job_id,
             )
-            .where(
-                expression.and_(
-                    model.JobToInputDatasetAssociation.dataset_id is not None,
-                    model.JobToInputDatasetAssociation.dataset_id == input_hda_id,
-                )
-            )
+            .where(model.JobToOutputDatasetCollectionAssociation.dataset_collection_id.is_not(None))
+            .where(model.JobToInputDatasetAssociation.dataset_id == input_hda_id)
         )
         return hda_select, hdca_select
 
@@ -115,12 +106,8 @@ class JobConnectionsManager:
                 model.JobToInputDatasetCollectionAssociation,
                 model.JobToInputDatasetCollectionAssociation.job_id == model.JobToOutputDatasetAssociation.job_id,
             )
-            .where(
-                expression.and_(
-                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id is not None,
-                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
-                )
-            )
+            .where(model.JobToOutputDatasetAssociation.dataset_id.is_not(None))
+            .where(model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id)
         )
         hdca_select = (
             select(
@@ -134,12 +121,8 @@ class JobConnectionsManager:
                 model.JobToInputDatasetCollectionAssociation.job_id
                 == model.JobToOutputDatasetCollectionAssociation.job_id,
             )
-            .where(
-                expression.and_(
-                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id is not None,
-                    model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
-                )
-            )
+            .where(model.JobToOutputDatasetCollectionAssociation.dataset_collection_id.is_not(None))
+            .where(model.JobToInputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id)
         )
         return hda_select, hdca_select
 
@@ -155,12 +138,8 @@ class JobConnectionsManager:
                 model.JobToOutputDatasetAssociation,
                 model.JobToOutputDatasetAssociation.job_id == model.JobToInputDatasetAssociation.job_id,
             )
-            .where(
-                expression.and_(
-                    model.JobToOutputDatasetAssociation.dataset_id is not None,
-                    model.JobToOutputDatasetAssociation.dataset_id == input_hda_id,
-                )
-            )
+            .where(model.JobToInputDatasetAssociation.dataset_id.is_not(None))
+            .where(model.JobToOutputDatasetAssociation.dataset_id == input_hda_id)
         )
         input_hdcas = (
             select(
@@ -173,12 +152,8 @@ class JobConnectionsManager:
                 model.JobToOutputDatasetAssociation,
                 model.JobToOutputDatasetAssociation.job_id == model.JobToInputDatasetCollectionAssociation.job_id,
             )
-            .where(
-                expression.and_(
-                    model.JobToOutputDatasetAssociation.dataset_id is not None,
-                    model.JobToOutputDatasetAssociation.dataset_id == input_hda_id,
-                )
-            )
+            .where(model.JobToInputDatasetCollectionAssociation.dataset_collection_id.is_not(None))
+            .where(model.JobToOutputDatasetAssociation.dataset_id == input_hda_id)
         )
         return input_hdas, input_hdcas
 
@@ -194,12 +169,8 @@ class JobConnectionsManager:
                 model.JobToOutputDatasetCollectionAssociation,
                 model.JobToOutputDatasetCollectionAssociation.job_id == model.JobToInputDatasetAssociation.job_id,
             )
-            .where(
-                expression.and_(
-                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id is not None,
-                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
-                )
-            )
+            .where(model.JobToInputDatasetAssociation.dataset_id.is_not(None))
+            .where(model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id)
         )
         input_hdcas = (
             select(
@@ -213,11 +184,7 @@ class JobConnectionsManager:
                 model.JobToOutputDatasetCollectionAssociation.job_id
                 == model.JobToInputDatasetCollectionAssociation.job_id,
             )
-            .where(
-                expression.and_(
-                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id is not None,
-                    model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id,
-                )
-            )
+            .where(model.JobToInputDatasetCollectionAssociation.dataset_collection_id.is_not(None))
+            .where(model.JobToOutputDatasetCollectionAssociation.dataset_collection_id == input_hdca_id)
         )
         return input_hdas, input_hdcas


### PR DESCRIPTION
Optional inputs caused the `JobToInputDatasetAssociation` to have `None` as the `dataset_id`
Fixed so that we make sure we query items with existing id
Fixes https://github.com/galaxyproject/galaxy/issues/15514

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
