### PR TITLE
[WIP] Disable Related items filter for Imported histories and Copied datasets

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -24,7 +24,7 @@
                 <DatasetActions
                     :item="result"
                     :writable="writable"
-                    :show-highlight="showHighlight"
+                    :show-highlight="showHighlight && !result.copied_from_hda_id"
                     :item-urls="itemUrls"
                     @toggleHighlights="toggleHighlights" />
                 <pre v-if="result.peek" class="dataset-peek p-1" v-html="result.peek" />

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -359,6 +359,7 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                 # why include if model_class is there?
                 "hda_ldda",
                 "copied_from_ldda_id",
+                "copied_from_hda_id",
                 # TODO: accessible needs to go away
                 "accessible",
                 # remapped
@@ -411,10 +412,18 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
 
     def serialize_copied_from_ldda_id(self, item, key, **context):
         """
-        Serialize an id attribute of `item`.
+        Serialize the copied from ldda id attribute of `item`.
         """
         if item.copied_from_library_dataset_dataset_association is not None:
             return self.app.security.encode_id(item.copied_from_library_dataset_dataset_association.id)
+        return None
+
+    def serialize_copied_from_hda_id(self, item, key, **context):
+        """
+        Serialize the copied from hda id attribute of `item`.
+        """
+        if item.copied_from_history_dataset_association is not None:
+            return self.app.security.encode_id(item.copied_from_history_dataset_association.id)
         return None
 
     def add_serializers(self):
@@ -428,6 +437,7 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
             "hda_ldda": lambda item, key, **context: "hda",
             "type_id": self.serialize_type_id,
             "copied_from_ldda_id": self.serialize_copied_from_ldda_id,
+            "copied_from_hda_id": self.serialize_copied_from_hda_id,
             "history_id": self.serialize_id,
             # remapped
             "misc_info": self._remap_from("info"),


### PR DESCRIPTION
## WIP for 23.1
Fixes https://github.com/galaxyproject/galaxy/issues/15515
This is a fix for 23.0 to reduce confusion for users, who might try to find related items for an item in an Imported history by clicking the `Show Inputs for this item` button. The button will now not be available on items with the `item.copied_from_hda_id != null`
**Adding a proper implementation for 23.1 that takes into account the relations within items in an imported history, or even for copied datasets.**

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
