### PR TITLE
[23.0] Fix wrong tool converter names

### DIFF
--- a/lib/galaxy/datatypes/converters/bam_to_bai.xml
+++ b/lib/galaxy/datatypes/converters/bam_to_bai.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_Bam_Bai_0" name="Bam to Bai" version="1.0.0" hidden="true" profile="16.04">
+<tool id="CONVERTER_Bam_Bai_0" name="Convert Bam to Bai" version="1.0.0" hidden="true" profile="16.04">
     <requirements>
         <requirement type="package" version="1.10">samtools</requirement>
     </requirements>

--- a/lib/galaxy/datatypes/converters/bcf_bcf_uncompressed_converter.xml
+++ b/lib/galaxy/datatypes/converters/bcf_bcf_uncompressed_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_bcf_uncompressed_to_bcf" name="Converter for BCF and uncompressed BCF" version="0.0.1" hidden="false" profile="21.09">
+<tool id="CONVERTER_bcf_uncompressed_to_bcf" name="Convert compressed and uncompressed BCF files" version="0.0.1" hidden="false" profile="21.09">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <requirements>
         <requirement type="package" version="1.12">bcftools</requirement>

--- a/lib/galaxy/datatypes/converters/bigwig_to_wig_converter.xml
+++ b/lib/galaxy/datatypes/converters/bigwig_to_wig_converter.xml
@@ -1,4 +1,4 @@
-<tool id="bigwigtowig" name="bigWigToWig" version="@TOOL_VERSION@+galaxy@SUFFIX_VERSION@" profile="20.01">
+<tool id="bigwigtowig" name="Convert BigWig to Wiggle" version="@TOOL_VERSION@+galaxy@SUFFIX_VERSION@" profile="20.01">
     <description>Convert bigWig to wig</description>
     <macros>
         <token name="@TOOL_VERSION@">377</token>

--- a/lib/galaxy/datatypes/converters/cml_to_smi_converter.xml
+++ b/lib/galaxy/datatypes/converters/cml_to_smi_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_cml_to_smiles" name="CML to SMILES" version="2.4.1">
+<tool id="CONVERTER_cml_to_smiles" name="Convert CML to SMILES" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>

--- a/lib/galaxy/datatypes/converters/gro_to_pdb.xml
+++ b/lib/galaxy/datatypes/converters/gro_to_pdb.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_Gro_to_Pdb_0" name="GRO to PDB" version="1.0.0" hidden="true" profile="20.09">
+<tool id="CONVERTER_Gro_to_Pdb_0" name="Convert GRO to PDB" version="1.0.0" hidden="true" profile="20.09">
     <requirements>
         <requirement type="package" version="2020.4">gromacs</requirement>
     </requirements>

--- a/lib/galaxy/datatypes/converters/inchi_to_mol_converter.xml
+++ b/lib/galaxy/datatypes/converters/inchi_to_mol_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_inchi_to_mol" name="InChI to MOL" version="2.4.1">
+<tool id="CONVERTER_inchi_to_mol" name="Convert InChI to MOL" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>

--- a/lib/galaxy/datatypes/converters/mdconvert.xml
+++ b/lib/galaxy/datatypes/converters/mdconvert.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_mdconvert" name="Converter for XTC, DCD, and TRR" version="1.0.0" hidden="true" profile="21.09">
+<tool id="CONVERTER_mdconvert" name="Convert XTC, DCD, and TRR" version="1.0.0" hidden="true" profile="21.09">
     <requirements>
         <requirement type="package" version="1.9.4">mdtraj</requirement>
     </requirements>

--- a/lib/galaxy/datatypes/converters/mol2_to_mol_converter.xml
+++ b/lib/galaxy/datatypes/converters/mol2_to_mol_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_mol2_to_mol" name="MOL2 to MOL" version="2.4.1">
+<tool id="CONVERTER_mol2_to_mol" name="Convert MOL2 to MOL" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>

--- a/lib/galaxy/datatypes/converters/pdb_to_gro.xml
+++ b/lib/galaxy/datatypes/converters/pdb_to_gro.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_Pdb_to_Gro_0" name="PDB to GRO" version="1.0.0" hidden="true" profile="20.09">
+<tool id="CONVERTER_Pdb_to_Gro_0" name="Convert PDB to GRO" version="1.0.0" hidden="true" profile="20.09">
     <requirements>
         <requirement type="package" version="2020.4">gromacs</requirement>
     </requirements>

--- a/lib/galaxy/datatypes/converters/smi_to_mol_converter.xml
+++ b/lib/galaxy/datatypes/converters/smi_to_mol_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_SMILES_to_MOL" name="SMILES to MOL" version="2.4.1">
+<tool id="CONVERTER_SMILES_to_MOL" name="Convert SMILES to MOL" version="2.4.1">
     <description></description>
     <parallelism method="multi" split_inputs="input" split_mode="to_size" split_size="10000" shared_inputs="" merge_outputs="output"></parallelism>
     <requirements>

--- a/lib/galaxy/datatypes/converters/wiggle_to_simple_converter.xml
+++ b/lib/galaxy/datatypes/converters/wiggle_to_simple_converter.xml
@@ -1,4 +1,4 @@
-<tool id="CONVERTER_wiggle_to_interval_0" name="Wiggle to Interval" version="1.0.1" profile="16.04">
+<tool id="CONVERTER_wiggle_to_interval_0" name="Convert Wiggle to Interval" version="1.0.1" profile="16.04">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <!-- Used on the metadata edit page. -->
     <requirements>

--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -1472,10 +1472,9 @@ class BaseGalaxyToolBox(AbstractToolBox):
         section = ToolSection({"name": "Built-in Converters", "id": id})
         self._tool_panel[id] = section
 
-        converters = self.app.datatypes_registry.datatype_converters
-        for source, targets in converters.items():
-            for target, tool in targets.items():
-                tool.name = f"{source}-to-{target}"
-                tool.description = "converter"
-                tool.hidden = False
-                section.elems.append_tool(tool)
+        converters = {
+            tool for target in self.app.datatypes_registry.datatype_converters.values() for tool in target.values()
+        }
+        for tool in converters:
+            tool.hidden = False
+            section.elems.append_tool(tool)


### PR DESCRIPTION
And give some of the converters a more consistent name.

Fixes https://github.com/galaxyproject/galaxy/issues/15495

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
