### PR TITLE
Attempt 2 at fixing development ram issues

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -113,7 +113,7 @@
     "xml-beautifier": "^0.5.0"
   },
   "scripts": {
-    "develop": "export NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=development gulp && webpack-dev-server",
+    "develop": "export NODE_OPTIONS=--max_old_space_size=4096 && NODE_ENV=development gulp && webpack-dev-server",
     "build": "NODE_ENV=development gulp && webpack && yarn run stage-build",
     "build-production": "NODE_ENV=production gulp && yarn run webpack-production && yarn run stage-build",
     "build-production-maps": "NODE_ENV=production gulp && yarn run webpack-production-maps && yarn run stage-build",

--- a/client/package.json
+++ b/client/package.json
@@ -113,7 +113,7 @@
     "xml-beautifier": "^0.5.0"
   },
   "scripts": {
-    "develop": "NODE_OPTIONS=--max-old-space-size=4096 NODE_ENV=development gulp && webpack-dev-server",
+    "develop": "export NODE_OPTIONS=--max_old_space_size=4096 NODE_ENV=development gulp && webpack-dev-server",
     "build": "NODE_ENV=development gulp && webpack && yarn run stage-build",
     "build-production": "NODE_ENV=production gulp && yarn run webpack-production && yarn run stage-build",
     "build-production-maps": "NODE_ENV=production gulp && yarn run webpack-production-maps && yarn run stage-build",


### PR DESCRIPTION
I've previously attempted to increase the available memory by setting "max-old-space-size".
The issue has since resurfaced, again at 2GB ram, so the setting does not seem to have been properly applied to the node process.

I found several possible reasons for this:
 - 32 bit node is used. Unlikely, since my node install reports to be 64 bit.
 - Snake case vs kebab case when setting this option via env variables. Reports of this are mixed, though most examples for setting via the env variable seem to use snake case, so I switched it.
 - Env variable does not propagate to sub-processes. Should be addressed by adding `export`

This is nearly impossible to test reliably, so this PR is yet another shot in the dark. I'd like to try these new settings for a while, and check if the issue pops up again.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
