### PR TITLE
[22.05] Fix unbound local error in sort collection tool

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3408,7 +3408,7 @@ class SortTool(DatabaseOperationTool):
         sorttype = incoming["sort_type"]["sort_type"]
         new_elements = {}
         elements = hdca.collection.elements
-        presort_elements = []
+        presort_elements = None
         if sorttype == "alpha":
             presort_elements = [(dce.element_identifier, dce) for dce in elements]
         elif sorttype == "numeric":
@@ -3433,7 +3433,7 @@ class SortTool(DatabaseOperationTool):
         else:
             raise Exception(f"Unknown sort_type '{sorttype}'")
 
-        if presort_elements:
+        if presort_elements is not None:
             sorted_elements = [x[1] for x in sorted(presort_elements, key=lambda x: x[0])]
 
         for dce in sorted_elements:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5155,6 +5155,43 @@ input:
         put_response = self._update_workflow(workflow_id, workflow_object)
         assert put_response.status_code == 200
 
+    def test_empty_collection_sort(self):
+        self._run_workflow(
+            """class: GalaxyWorkflow
+inputs:
+  input: collection
+  filter_file: data
+steps:
+  filter_collection:
+    tool_id: __FILTER_FROM_FILE__
+    in:
+       input: input
+       how|filter_source: filter_file
+  sort_collection_1:
+    tool_id: __SORTLIST__
+    in:
+      input: filter_collection/output_filtered
+  sort_collection_2:
+    tool_id: __SORTLIST__
+    in:
+      input: filter_collection/output_discarded
+  merge_collection:
+    tool_id: __MERGE_COLLECTION__
+    in:
+      inputs_0|input: sort_collection_1/output
+      inputs_1|input: sort_collection_2/output
+test_data:
+  input:
+    collection_type: list
+    elements:
+      - identifier: i1
+        content: "0"
+  filter_file: i1
+""",
+            wait=True,
+            assert_ok=True,
+        )
+
     @skip_without_tool("random_lines1")
     def test_run_replace_params_over_default_delayed(self):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
Fixes
```
UnboundLocalError: local variable 'sorted_elements' referenced before assignment
  File "galaxy/tools/__init__.py", line 1909, in handle_single_execution
    rval = self.execute(
  File "galaxy/tools/__init__.py", line 2005, in execute
    return self.tool_action.execute(
  File "galaxy/tools/actions/model_operations.py", line 83, in execute
    self._produce_outputs(
  File "galaxy/tools/actions/model_operations.py", line 108, in _produce_outputs
    tool.produce_outputs(
  File "galaxy/tools/__init__.py", line 3490, in produce_outputs
    for dce in sorted_elements:
```
in https://sentry.galaxyproject.org/share/issue/264aea1fd3994e5ba67ab80fcbd2c577/

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
