### PR TITLE
[23.0] Fix job completion email from tool form

### DIFF
--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -55,11 +55,13 @@ class EmailAction(DefaultJobAction):
         try:
             frm = app.config.email_from
             history_id_encoded = app.security.encode_id(job.history_id)
-            invocation_id_encoded = app.security.encode_id(job.workflow_invocation_step.workflow_invocation_id)
+            link_invocation = None
+            if job.workflow_invocation_step:
+                invocation_id_encoded = app.security.encode_id(job.workflow_invocation_step.workflow_invocation_id)
+                link_invocation = (
+                    f"{app.config.galaxy_infrastructure_url}/workflows/invocations/report?id={invocation_id_encoded}"
+                )
             link = f"{app.config.galaxy_infrastructure_url}/histories/view?id={history_id_encoded}"
-            link_invocation = (
-                f"{app.config.galaxy_infrastructure_url}/workflows/invocations/report?id={invocation_id_encoded}"
-            )
             if frm is None:
                 if action.action_arguments and "host" in action.action_arguments:
                     host = action.action_arguments["host"]
@@ -70,7 +72,8 @@ class EmailAction(DefaultJobAction):
             subject = f"Galaxy job completion notification from history '{job.history.name}'"
             outdata = ",\n".join(ds.dataset.display_name() for ds in job.output_datasets)
             body = f"Your Galaxy job generating dataset(s):\n\n{outdata}\n\nis complete as of {datetime.datetime.now().strftime('%I:%M')}. Click the link below to access your data: \n{link}"
-            body += f"\n\nWorkflow Invocation Report:\n{link_invocation}"
+            if link_invocation:
+                body += f"\n\nWorkflow Invocation Report:\n{link_invocation}"
             send_mail(frm, to, subject, body, app.config)
         except Exception as e:
             log.error("EmailAction PJA Failed, exception: %s", unicodify(e))


### PR DESCRIPTION
PJAs can be attached to regular, non-workflow-invocation jobs, which fails without this fix.

Fixes
```
EmailAction PJA Failed, exception: 'NoneType' object has no attribute 'workflow_invocation_id'

```
in https://sentry.galaxyproject.org/share/issue/14d7ac0d63974f689bb58c178fdf76d8/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
