### PR TITLE
Fix jest tests run on CI

### DIFF
--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -31,5 +31,5 @@ jobs:
         run: yarn run gulp client
         working-directory: client
       - name: Run Unit Tests
-      - run: yarn jest
+        run: yarn jest
         working-directory: client


### PR DESCRIPTION
This should fix: https://github.com/galaxyproject/galaxy/actions/runs/4186186498
```
[Error: .github#L1]
every step must define a `uses` or `run` key
```
Sorry I should have catched this on the review of #15452

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
