### PR TITLE
[23.0] Enable conversion of bz2 files to gz in converter

### DIFF
--- a/lib/galaxy/datatypes/converters/uncompressed_to_gz.xml
+++ b/lib/galaxy/datatypes/converters/uncompressed_to_gz.xml
@@ -1,19 +1,27 @@
 <tool id="CONVERTER_uncompressed_to_gz" name="Convert uncompressed file to compressed" hidden="true" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.01">
     <macros>
-        <token name="@TOOL_VERSION@">1.15.1</token>
+        <token name="@TOOL_VERSION@">1.16</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">htslib</requirement>
+        <requirement type="package" version="1.0.8">bzip2</requirement>
     </requirements>
     <command><![CDATA[
 cp '$ext_config' galaxy.json &&
-bgzip -@ "\${GALAXY_SLOTS:-1}" -c '$input1' > '$output1'
+#if $input1.ext.endswith(".bz2"):
+    bzcat '$input1' | bgzip -@ "\${GALAXY_SLOTS:-1}" -c > '$output1'
+#else:
+    bgzip -@ "\${GALAXY_SLOTS:-1}" -c '$input1' > '$output1'
+#end if
     ]]></command>
     <configfiles>
-        <configfile name="ext_config">{"output1": {
-  "name": "${input1.name + '.gz' if not $input1.name.endswith('.vcf') else $input1.name + '.bgzip'} compressed",
-  "ext": "${input1.ext + '.gz' if $input1.ext != 'vcf' else 'vcf_bgzip'}"
+        <configfile name="ext_config">
+#silent ext = $input1.ext[:-4] if $input1.ext.endswith(".bz2") else $input1.ext
+#silent ext = ext + '.gz' if ext != 'vcf' else 'vcf_bgzip'
+{"output1": {
+  "name": "${input1.name} compressed",
+  "ext": "${ext}"
 }}</configfile>
     </configfiles>
     <inputs>
@@ -31,6 +39,10 @@ bgzip -@ "\${GALAXY_SLOTS:-1}" -c '$input1' > '$output1'
         <test>
             <param name="input1" value="1.fasta" ftype="fasta"/>
             <output name="output1" file="1.fasta.gz" ftype="fasta.gz" decompress="true"/>
+        </test>
+        <test>
+            <param name="input1" value="1.fastqsanger.bz2" ftype="fastqsanger.bz2"/>
+            <output name="output1" file="1.fastqsanger.gz" ftype="fastqsanger.gz" decompress="true"/>
         </test>
     </tests>
     <help>


### PR DESCRIPTION
We'd previously just produce invalid, double-compressed data.
Fixes https://github.com/galaxyproject/galaxy/issues/14361
and
https://sentry.galaxyproject.org/share/issue/fab8c5f18d1149598c98899f07107f0f/:
```
NotFound: cannot find 'fq1'
  File "galaxy/jobs/runners/pulsar.py", line 480, in __prepare_job
    job_wrapper.prepare(**prepare_kwds)
  File "galaxy/jobs/__init__.py", line 1253, in prepare
    ) = tool_evaluator.build()
  File "galaxy/tools/evaluation.py", line 558, in build
    global_tool_logs(self._build_command_line, config_file, "Building Command Line")
  File "galaxy/tools/evaluation.py", line 90, in global_tool_logs
    raise e
  File "galaxy/tools/evaluation.py", line 86, in global_tool_logs
    return func()
  File "galaxy/tools/evaluation.py", line 575, in _build_command_line
    command_line = fill_template(
  File "galaxy/util/template.py", line 110, in fill_template
    raise first_exception or e
  File "galaxy/util/template.py", line 82, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1184, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1675947468_485589_65108.py", line 102, in respond
```

which happens when the implicit converter forces fastqsanger.bz2.gz files into unicycler,
because unicycler does:
```
    #set $uncompressed = ('fastqsanger','fastq')
    #set $compressed = ('fastqsanger.gz','fastq.gz')
    #if $paired_unpaired.fastq_input1.file_ext in $uncompressed
        #set fq1 = "fq1.fastq"
    #elif $paired_unpaired.fastq_input1.file_ext in $compressed
        #set fq1 = "fq1.fastq.gz"
    #end if
```

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
