### PR TITLE
[23.0] History scroller fixes

### DIFF
--- a/client/src/components/History/Layout/ListingLayout.vue
+++ b/client/src/components/History/Layout/ListingLayout.vue
@@ -8,6 +8,8 @@
             :offset="offset"
             :data-sources="items"
             :data-component="{}"
+            :estimate-size="estimatedItemHeight"
+            :keeps="estimatedItemCount"
             @scroll="onScroll">
             <template v-slot:item="{ item }">
                 <slot name="item" :item="item" :current-offset="getOffset()" />
@@ -21,6 +23,8 @@
 <script>
 import VirtualList from "vue-virtual-scroll-list";
 import LoadingSpan from "components/LoadingSpan";
+import { useElementBounding } from "@vueuse/core";
+import { computed, ref } from "vue";
 
 export default {
     components: {
@@ -33,6 +37,18 @@ export default {
         items: { type: Array, default: null },
         queryKey: { type: String, default: null },
     },
+    setup() {
+        const listing = ref(null);
+        const { height } = useElementBounding(listing);
+
+        const estimatedItemHeight = 40;
+        const estimatedItemCount = computed(() => {
+            const baseCount = Math.ceil(height.value / estimatedItemHeight);
+            return baseCount + 20;
+        });
+
+        return { listing, estimatedItemHeight, estimatedItemCount };
+    },
     data() {
         return {
             previousStart: undefined,
@@ -40,19 +56,19 @@ export default {
     },
     watch: {
         queryKey() {
-            this.$refs.listing.scrollToOffset(0);
+            this.listing.scrollToOffset(0);
         },
     },
     methods: {
         onScroll() {
-            const rangeStart = this.$refs.listing.range.start;
+            const rangeStart = this.listing.range.start;
             if (this.previousStart !== rangeStart) {
                 this.previousStart = rangeStart;
                 this.$emit("scroll", rangeStart);
             }
         },
         getOffset() {
-            return this.$refs.listing?.getOffset() || 0;
+            return this.listing?.getOffset() || 0;
         },
     },
 };


### PR DESCRIPTION
This PR does not replace the scroller component, but passes in an estimated buffer size based on the components height, to make the history usable on large screens.

Replacing the component has been pushed to the next release.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
