### PR TITLE
read job_conf directly from `config_dir` instead of computing it again from `config_file`

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -366,8 +366,9 @@ class JobConfiguration(ConfiguresHandlers):
             else:
                 job_config_file = self.app.config.job_config_file
                 if not self.app.config.is_set("job_config_file") and not os.path.exists(job_config_file):
-                    job_config_file = os.path.join(self.app.config.config_dir, "job_conf.xml")
-                    if os.path.exists(job_config_file):
+                    old_default_job_config_file = os.path.join(self.app.config.config_dir, "job_conf.xml")
+                    if os.path.exists(old_default_job_config_file):
+                        job_config_file = old_default_job_config_file
                         log.warning(
                             "Implicit loading of job_conf.xml has been deprecated and will be removed in a future"
                             f" release of Galaxy. Please convert to YAML at {self.app.config.job_config_file} or"

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -366,7 +366,7 @@ class JobConfiguration(ConfiguresHandlers):
             else:
                 job_config_file = self.app.config.job_config_file
                 if not self.app.config.is_set("job_config_file") and not os.path.exists(job_config_file):
-                    job_config_file = os.path.join(os.path.dirname(self.app.config.config_file), "job_conf.xml")
+                    job_config_file = os.path.join(self.app.config.config_dir, "job_conf.xml")
                     if os.path.exists(job_config_file):
                         log.warning(
                             "Implicit loading of job_conf.xml has been deprecated and will be removed in a future"


### PR DESCRIPTION
`config_dir` should be the same as `os.path.dirname(self.app.config.config_file)` but `config_dir` is computed anyway in the config module

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
