### PR TITLE
[23.0] Fix selecting directory on safari

### DIFF
--- a/client/src/components/Form/Elements/FormDirectory.vue
+++ b/client/src/components/Form/Elements/FormDirectory.vue
@@ -95,9 +95,9 @@ export default {
         setUrl({ url }) {
             this.url = new URL(url);
             // split path and keep only valid entries
-            this.pathChunks = this.url.pathname
-                .split("/")
-                .filter((pathChunk) => pathChunk)
+            this.pathChunks = this.url.href
+                .split(/[/\\]/)
+                .splice(2)
                 .map((x) => ({ pathChunk: x, editable: false }));
 
             if (url) {


### PR DESCRIPTION
Fixes #15057
On Safari, the `new URL` creates an array that `host` part is not included in the `pathname` field.

e.g. `gxfiles://test-posix-source/level1/level2`
On edge, chrome, firefox: `pathname: "//posix-source/level1/level2"`
On Safari: `pathname: "//level1/level2"`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
