### PR TITLE
Fix call to `docker_cached_container_description`

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -528,7 +528,7 @@ class MulledDockerContainerResolver(CliContainerResolver):
 
     def cached_container_description(self, targets, namespace, hash_func, resolution_cache):
         try:
-            return docker_cached_container_description(targets, namespace, hash_func, resolution_cache)
+            return docker_cached_container_description(targets, namespace, hash_func=hash_func, resolution_cache=resolution_cache)
         except subprocess.CalledProcessError:
             # We should only get here if a docker binary is available, but command quits with a non-zero exit code,
             # e.g if the docker daemon is not available

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -295,7 +295,6 @@ def docker_cached_container_description(
     shell: str = DEFAULT_CONTAINER_SHELL,
     resolution_cache: Optional[ResolutionCache] = None,
 ):
-    log.error(f"{targets}")
     if len(targets) == 0:
         return None
 

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -8,6 +8,7 @@ from abc import (
     abstractmethod,
 )
 from typing import (
+    List,
     NamedTuple,
     Optional,
     TYPE_CHECKING,
@@ -37,6 +38,7 @@ from ..mulled.util import (
     default_mulled_conda_channels_from_env,
     mulled_tags_for,
     split_tag,
+    Target,
     v1_image_name,
     v2_image_name,
     version_sorted,
@@ -287,8 +289,13 @@ def find_best_matching_cached_image(targets, cached_images, hash_func):
 
 
 def docker_cached_container_description(
-    targets, namespace, hash_func="v2", shell=DEFAULT_CONTAINER_SHELL, resolution_cache=None
+    targets: List[Target],
+    namespace: str,
+    hash_func: str = "v2",
+    shell: str = DEFAULT_CONTAINER_SHELL,
+    resolution_cache: Optional[ResolutionCache] = None,
 ):
+    log.error(f"{targets}")
     if len(targets) == 0:
         return None
 
@@ -528,7 +535,9 @@ class MulledDockerContainerResolver(CliContainerResolver):
 
     def cached_container_description(self, targets, namespace, hash_func, resolution_cache):
         try:
-            return docker_cached_container_description(targets, namespace, hash_func=hash_func, resolution_cache=resolution_cache)
+            return docker_cached_container_description(
+                targets, namespace, hash_func=hash_func, resolution_cache=resolution_cache
+            )
         except subprocess.CalledProcessError:
             # We should only get here if a docker binary is available, but command quits with a non-zero exit code,
             # e.g if the docker daemon is not available

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -10,8 +10,8 @@ import tarfile
 import threading
 from io import BytesIO
 from typing import (
-    NamedTuple,
     List,
+    NamedTuple,
     Optional,
     TYPE_CHECKING,
 )

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -10,7 +10,9 @@ import tarfile
 import threading
 from io import BytesIO
 from typing import (
+    NamedTuple,
     List,
+    Optional,
     TYPE_CHECKING,
 )
 
@@ -199,7 +201,11 @@ def version_sorted(elements):
     return [e.tag for e in elements]
 
 
-Target = collections.namedtuple("Target", ["package_name", "version", "build", "package"])
+class Target(NamedTuple):
+    package_name: str
+    version: Optional[str]
+    build: Optional[str]
+    package: Optional[str]
 
 
 def build_target(package_name, version=None, build=None, tag=None):


### PR DESCRIPTION
otherwise `resolution_cache` is assigned to `shell` which leads to an exception

Should affect `MulledDockerContainerResolver` and should be triggered if `install=True` or `auto_install=False`. 

Not sure if needs to be backported. Seems that only a few people use this resolver, because the exception should be triggered when `install=True` or `auto_intstall=False` ... 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
