### PR TITLE
[23.0] Fix masthead/ribbon alerts to use Alert component, update variant.

### DIFF
--- a/client/src/entry/analysis/App.vue
+++ b/client/src/entry/analysis/App.vue
@@ -12,25 +12,25 @@
                 :tabs="tabs"
                 :window-tab="windowTab"
                 @open-url="openUrl" />
-            <alert
+            <Alert
                 v-if="config.message_box_visible && config.message_box_content"
                 id="messagebox"
                 class="rounded-0 m-0 p-2"
                 :variant="config.message_box_class || 'info'">
                 <span class="fa fa-fw mr-1 fa-exclamation" />
                 <span>{{ config.message_box_content }}</span>
-            </alert>
-            <alert
+            </Alert>
+            <Alert
                 v-if="config.show_inactivity_warning && config.inactivity_box_content"
                 id="inactivebox"
                 class="rounded-0 m-0 p-2"
-                variant="alert-warning">
+                variant="warning">
                 <span class="fa fa-fw mr-1 fa-exclamation-triangle" />
                 <span>{{ config.inactivity_box_content }}</span>
                 <span>
                     <a class="ml-1" :href="resendUrl">Resend Verification</a>
                 </span>
-            </alert>
+            </Alert>
             <router-view @update:confirmation="confirmation = $event" />
         </div>
         <div id="dd-helper" />
@@ -40,6 +40,7 @@
     </div>
 </template>
 <script>
+import Alert from "@/components/Alert.vue";
 import Modal from "mvc/ui/ui-modal";
 import Masthead from "components/Masthead/Masthead.vue";
 import { getGalaxyInstance } from "app";
@@ -59,6 +60,7 @@ import { useCurrentTheme } from "@/composables/user";
 
 export default {
     components: {
+        Alert,
         Masthead,
         Toast,
         ConfirmDialog,


### PR DESCRIPTION
Should fix #15601 

![image](https://user-images.githubusercontent.com/155398/219465638-7cc79e53-f317-4ad5-b5f5-9e6ee577f44d.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
