### PR TITLE
[23.0] check only first 64 chars of the activation token

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -305,7 +305,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
                 return trans.show_ok_message(
                     "Your account is already active. Nothing has changed. <br><a href='%s'>Go to login page.</a>"
                 ) % web.url_for(controller="root", action="index")
-            if user.activation_token == activation_token:
+            if user.activation_token == activation_token[:64]:
                 user.activation_token = None
                 self.user_manager.activate(user)
                 return trans.show_ok_message(


### PR DESCRIPTION
Our database only stores 64 chars of the token but we generate 128 length hash. This is a *hotfix* to allow people to activate their accounts with the URLs they have.

partially addresses  https://github.com/galaxyproject/galaxy/issues/15604

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
