### PR TITLE
Update database_heartbeat for SA 2.0 compatibility

### DIFF
--- a/lib/galaxy/model/database_heartbeat.py
+++ b/lib/galaxy/model/database_heartbeat.py
@@ -4,6 +4,12 @@ import os
 import socket
 import threading
 
+from sqlalchemy import (
+    and_,
+    delete,
+    select,
+)
+
 from galaxy.model import WorkerProcess
 from galaxy.model.orm.now import now
 
@@ -15,6 +21,7 @@ class DatabaseHeartbeat:
         self.application_stack = application_stack
         self.heartbeat_interval = heartbeat_interval
         self.hostname = socket.gethostname()
+        self._engine = application_stack.app.model.engine
         self._is_config_watcher = False
         self._observers = []
         self.exit = threading.Event()
@@ -46,18 +53,17 @@ class DatabaseHeartbeat:
         self.exit.set()
         if self.thread:
             self.thread.join()
-        worker_process = self.worker_process
-        if worker_process:
-            self.sa_session.delete(worker_process)
-            self.sa_session.flush()
-            self.application_stack.app.queue_worker.send_control_task("reconfigure_watcher", noop_self=True)
+        self._delete_worker_process()
+        self.application_stack.app.queue_worker.send_control_task("reconfigure_watcher", noop_self=True)
 
     def get_active_processes(self, last_seen_seconds=None):
         """Return all processes seen in ``last_seen_seconds`` seconds."""
         if last_seen_seconds is None:
             last_seen_seconds = self.heartbeat_interval
         seconds_ago = now() - datetime.timedelta(seconds=last_seen_seconds)
-        return self.sa_session.query(WorkerProcess).filter(WorkerProcess.update_time > seconds_ago).all()
+        stmt = select(WorkerProcess).filter(WorkerProcess.update_time > seconds_ago)
+        with self.sa_session() as session:
+            return session.scalars(stmt).all()
 
     def add_change_callback(self, callback):
         self._observers.append(callback)
@@ -73,26 +79,17 @@ class DatabaseHeartbeat:
         for callback in self._observers:
             callback(self._is_config_watcher)
 
-    @property
-    def worker_process(self):
-        return (
-            self.sa_session.query(WorkerProcess)
-            .with_for_update(of=WorkerProcess)
-            .filter_by(
-                server_name=self.server_name,
-                hostname=self.hostname,
-            )
-            .first()
-        )
-
     def update_watcher_designation(self):
-        worker_process = self.worker_process
-        if not worker_process:
-            worker_process = WorkerProcess(server_name=self.server_name, hostname=self.hostname)
-        worker_process.update_time = now()
-        worker_process.pid = self.pid
-        self.sa_session.add(worker_process)
-        self.sa_session.flush()
+        expression = self._worker_process_identifying_clause()
+        stmt = select(WorkerProcess).with_for_update(of=WorkerProcess).where(expression)
+        with self.sa_session() as session:
+            with session.begin():
+                worker_process = session.scalars(stmt).first()
+                if not worker_process:
+                    worker_process = WorkerProcess(server_name=self.server_name, hostname=self.hostname)
+                worker_process.update_time = now()
+                worker_process.pid = self.pid
+                session.add(worker_process)
         # We only want a single process watching the various config files on the file system.
         # We just pick the max server name for simplicity
         is_config_watcher = self.server_name == max(
@@ -106,3 +103,12 @@ class DatabaseHeartbeat:
             while not self.exit.is_set():
                 self.update_watcher_designation()
                 self.exit.wait(self.heartbeat_interval)
+
+    def _delete_worker_process(self):
+        expression = self._worker_process_identifying_clause()
+        stmt = delete(WorkerProcess).where(expression)
+        with self._engine.begin() as conn:
+            conn.execute(stmt)
+
+    def _worker_process_identifying_clause(self):
+        return and_(WorkerProcess.server_name == self.server_name, WorkerProcess.hostname == self.hostname)

--- a/test/unit/app/queue_worker/test_database_heartbeat.py
+++ b/test/unit/app/queue_worker/test_database_heartbeat.py
@@ -46,7 +46,9 @@ def test_database_heartbeat(heartbeat_app):
     update_time = process.update_time
 
     def process_updated():
-        heartbeat_app.model.context.refresh(process)
+        session = heartbeat_app.model.context()
+        session.add(process)
+        session.refresh(process)
         next_update_time = process.update_time
         assert update_time < next_update_time
 


### PR DESCRIPTION
Ref. #12541

When we set `autocommit=False` (requirement for SA 2.0), each SQL statement will be in transactional mode. That means that a `BEGIN` statement will precede any other statement if the current dbapi connection is not in a transaction. A transaction must be explicitly ended, via `ROLLBACK` or `COMMIT`, otherwise, it will remain open (the state of the connection will be  "idle in transaction"). And that's bad: all locks created by statements executed within the context of the transaction will remain present, the connection won't return to the engine's connection pool, and so new connections will be created each time the database is accessed, and they will create the same locks, etc.; very soon the pool will be exhausted and the "too many clients already" psycopg2 error will be raised. 

This PR updates database_heartbeat by: (1) starting and ending transactions explicitly in a 1.4/2.0 cross-compatible way (via context managers); and (2) bypassing the ORM where possible by using a Connection instead of a Session where session state is not needed.

Here's what I've observed experimentally. Starting up Galaxy with `autocommit=False` (with `job_manager` and `workflow_scheduling_manager` disabled) resulted in 1 connection stuck in `idle in transaction` and 14 additional locks:

```
rivendell$ psql -f activity_galaxy.sql 
 datid  | datname |  pid   | client_port |         backend_start         |          xact_start           |          query_start          |         state_change          | wait_event_type | wait_event |        state        |              left              
--------+---------+--------+-------------+-------------------------------+-------------------------------+-------------------------------+-------------------------------+-----------------+------------+---------------------+--------------------------------
 363460 | galaxy2 | 568224 |       48454 | 2023-02-16 20:52:26.779987-05 | 2023-02-16 20:52:27.821876-05 | 2023-02-16 20:52:27.830929-05 | 2023-02-16 20:52:27.831009-05 | Client          | ClientRead | idle in transaction | SELECT worker_process.id AS wo
 363460 | galaxy2 | 568251 |       48456 | 2023-02-16 20:52:27.457237-05 |                               | 2023-02-16 20:52:31.893796-05 | 2023-02-16 20:52:31.893812-05 | Client          | ClientRead | idle                | COMMIT
 363460 | galaxy2 | 568252 |       48458 | 2023-02-16 20:52:27.829115-05 |                               | 2023-02-16 20:52:31.895459-05 | 2023-02-16 20:52:31.895469-05 | Client          | ClientRead | idle                | COMMIT
(3 rows)

rivendell$ psql -c 'select * from pg_locks'
   locktype    | database | relation | page | tuple | virtualxid | transactionid | classid | objid | objsubid | virtualtransaction |  pid   |       mode       | granted | fastpath 
---------------+----------+----------+------+-------+------------+---------------+---------+-------+----------+--------------------+--------+------------------+---------+----------
 relation      |   363460 |   363603 |      |       |            |               |         |       |          | 3/182420           | 568224 | AccessShareLock  | t       | t
 relation      |   363460 |   363603 |      |       |            |               |         |       |          | 3/182420           | 568224 | RowShareLock     | t       | t
 relation      |   363460 |   363603 |      |       |            |               |         |       |          | 3/182420           | 568224 | RowExclusiveLock | t       | t
 relation      |   363460 |   363601 |      |       |            |               |         |       |          | 3/182420           | 568224 | AccessShareLock  | t       | t
 relation      |   363460 |   363601 |      |       |            |               |         |       |          | 3/182420           | 568224 | RowShareLock     | t       | t
 relation      |   363460 |   363601 |      |       |            |               |         |       |          | 3/182420           | 568224 | RowExclusiveLock | t       | t
 relation      |   363460 |   363599 |      |       |            |               |         |       |          | 3/182420           | 568224 | AccessShareLock  | t       | t
 relation      |   363460 |   363599 |      |       |            |               |         |       |          | 3/182420           | 568224 | RowShareLock     | t       | t
 relation      |   363460 |   363599 |      |       |            |               |         |       |          | 3/182420           | 568224 | RowExclusiveLock | t       | t
 relation      |   363460 |   363592 |      |       |            |               |         |       |          | 3/182420           | 568224 | AccessShareLock  | t       | t
 relation      |   363460 |   363592 |      |       |            |               |         |       |          | 3/182420           | 568224 | RowShareLock     | t       | t
 relation      |   363460 |   363592 |      |       |            |               |         |       |          | 3/182420           | 568224 | RowExclusiveLock | t       | t
 virtualxid    |          |          |      |       | 3/182420   |               |         |       |          | 3/182420           | 568224 | ExclusiveLock    | t       | t
 relation      |    16389 |    12141 |      |       |            |               |         |       |          | 6/2545             | 568323 | AccessShareLock  | t       | t
 virtualxid    |          |          |      |       | 6/2545     |               |         |       |          | 6/2545             | 568323 | ExclusiveLock    | t       | t
 transactionid |          |          |      |       |            |        358641 |         |       |          | 3/182420           | 568224 | ExclusiveLock    | t       | f
(16 rows)
```

This particular issue was caused by `get_active_processes`. The edits in this PR removed all the new locks (the remaining 2 are normal) and switched the connection back to "idle" state (which is normal):

```
rivendell$ psql -f activity_galaxy.sql 
 datid  | datname |  pid   | client_port |         backend_start         | xact_start |          query_start          |         state_change          | wait_event_type | wait_event | state |   left   
--------+---------+--------+-------------+-------------------------------+------------+-------------------------------+-------------------------------+-----------------+------------+-------+----------
 363460 | galaxy2 | 578795 |       48704 | 2023-02-16 22:47:39.324124-05 |            | 2023-02-16 22:47:40.680126-05 | 2023-02-16 22:47:40.680135-05 | Client          | ClientRead | idle  | ROLLBACK
 363460 | galaxy2 | 578822 |       48706 | 2023-02-16 22:47:40.305585-05 |            | 2023-02-16 22:47:41.70292-05  | 2023-02-16 22:47:41.702931-05 | Client          | ClientRead | idle  | COMMIT
 363460 | galaxy2 | 578823 |       48708 | 2023-02-16 22:47:40.666345-05 |            | 2023-02-16 22:47:41.7009-05   | 2023-02-16 22:47:41.700991-05 | Client          | ClientRead | idle  | COMMIT
(3 rows)

rivendell$ psql -c 'select * from pg_locks'
  locktype  | database | relation | page | tuple | virtualxid | transactionid | classid | objid | objsubid | virtualtransaction |  pid   |      mode       | granted | fastpath 
------------+----------+----------+------+-------+------------+---------------+---------+-------+----------+--------------------+--------+-----------------+---------+----------
 relation   |    16389 |    12141 |      |       |            |               |         |       |          | 6/2724             | 578840 | AccessShareLock | t       | t
 virtualxid |          |          |      |       | 6/2724     |               |         |       |          | 6/2724             | 578840 | ExclusiveLock   | t       | t
(2 rows)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
