### PR TITLE
[23.0] Remove "required" indicator from tool interface Radio select elements

### DIFF
--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -148,6 +148,7 @@ const isHiddenType = computed(
         ["hidden", "hidden_data", "baseurl"].includes(props.type ?? "") ||
         (props.attributes && props.attributes.titleonly)
 );
+const isRadioSelectionType = computed(() => props.type === "select" && attrs.value["display"] == "radio");
 
 const collapseText = computed(() => (collapsed.value ? props.collapsedEnableText : props.collapsedDisableText));
 const connectText = computed(() => (connected.value ? props.connectedEnableText : props.connectedDisableText));
@@ -203,7 +204,7 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
             <span v-else-if="props.title" class="ui-form-title-text">{{ props.title }}</span>
 
             <span
-                v-if="isRequired && isRequiredType && props.title"
+                v-if="isRequired && isRequiredType && props.title && !isRadioSelectionType"
                 v-b-tooltip.hover
                 class="ui-form-title-star"
                 title="required"


### PR DESCRIPTION
I have removed the * required indicator from radio `FormSelect`s, like the one below. Fixes https://github.com/galaxyproject/galaxy/issues/15368

<img width="531" alt="image" src="https://user-images.githubusercontent.com/78516064/219973334-20bc1d02-dcca-4c71-8722-fd0ae86573e4.png">

There is ambiguity on whether the same should be done for some drop-down fields that have a "blank" default value, as discussed here: https://github.com/galaxyproject/galaxy/issues/15368#issuecomment-1401647824

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
