### PR TITLE
[23.0] Fix duplicated Copy History dialog in Shared Histories

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -69,7 +69,7 @@
                     <b-dropdown-divider></b-dropdown-divider>
 
                     <b-dropdown-item
-                        v-b-modal:copy-history-modal
+                        v-b-modal:copy-current-history-modal
                         :disabled="currentUser.isAnonymous"
                         :title="userTitle('Copy History to a New History')">
                         <Icon fixed-width icon="copy" class="mr-1" />
@@ -140,7 +140,7 @@
             :current-history-id="history.id"
             @selectHistory="$emit('setCurrentHistory', $event)" />
 
-        <CopyModal id="copy-history-modal" :history="history" />
+        <CopyModal id="copy-current-history-modal" :history="history" />
 
         <b-modal
             id="history-privacy-modal"


### PR DESCRIPTION
Addresses `Import this History case 1` in #15608

While on the Shared Histories page, there were two `CopyModal` dialogs in the DOM with the same ID (one in HistoryView.vue and the other in HistoryNavigation.vue), so triggering the opening of one of them would open both.


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow the steps on #15608
  - Only the correct dialog will be shown.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
