### PR TITLE
Remove one redundant `cached_mulled_singularity` from default container resolvers

### DIFF
--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -283,8 +283,7 @@ class ContainerRegistry:
                 [
                     CachedMulledDockerContainerResolver(self.app_info, namespace="biocontainers"),
                     CachedMulledDockerContainerResolver(self.app_info, namespace="local"),
-                    CachedMulledSingularityContainerResolver(self.app_info, namespace="biocontainers"),
-                    CachedMulledSingularityContainerResolver(self.app_info, namespace="local"),
+                    CachedMulledSingularityContainerResolver(self.app_info),
                     MulledDockerContainerResolver(self.app_info, namespace="biocontainers"),
                     MulledSingularityContainerResolver(self.app_info, namespace="biocontainers"),
                 ]


### PR DESCRIPTION
The `cached_mulled_singularity` does not use the `namespace` argument.

Edit: The `cached_mulled_singularity` is added twice to the list of default container resolvers .. with different, but unused arguments.

This is probably untested. Suggestion are welcome if you think its necessary. 

I would like to use this opportunity to ask what `namespace` is used for. In particular I would like to know what `namespace="local"` is used for?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
