### PR TITLE
Add suggested Training material to Tool Form

### DIFF
--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -166,13 +166,7 @@ function onUpdatePreferredObjectStoreId(selectedToolPreferredObjectStoreId) {
         <slot name="buttons" />
 
         <div>
-            <ToolTutorialRecommendations
-                :id="props.options.id"
-                :name="props.options.name"
-                :version="props.options.version"
-                :owner="props.options.tool_shed_repository?.owner" />
-
-            <div class="mt-2 mb-4">
+            <div v-if="props.options.help" class="mt-2 mb-4">
                 <Heading h2 separator bold size="sm"> Help </Heading>
                 <ToolHelp :content="props.options.help" />
             </div>
@@ -184,6 +178,12 @@ function onUpdatePreferredObjectStoreId(selectedToolPreferredObjectStoreId) {
                 :license="props.options.license"
                 :creators="props.options.creators"
                 :requirements="props.options.requirements" />
+
+            <ToolTutorialRecommendations
+                :id="props.options.id"
+                :name="props.options.name"
+                :version="props.options.version"
+                :owner="props.options.tool_shed_repository?.owner" />
         </div>
     </div>
 </template>

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -171,6 +171,12 @@ function onUpdatePreferredObjectStoreId(selectedToolPreferredObjectStoreId) {
                 <ToolHelp :content="props.options.help" />
             </div>
 
+            <ToolTutorialRecommendations
+                :id="props.options.id"
+                :name="props.options.name"
+                :version="props.options.version"
+                :owner="props.options.tool_shed_repository?.owner" />
+
             <ToolFooter
                 :id="props.id"
                 :has-citations="props.options.citations"
@@ -178,12 +184,6 @@ function onUpdatePreferredObjectStoreId(selectedToolPreferredObjectStoreId) {
                 :license="props.options.license"
                 :creators="props.options.creators"
                 :requirements="props.options.requirements" />
-
-            <ToolTutorialRecommendations
-                :id="props.options.id"
-                :name="props.options.name"
-                :version="props.options.version"
-                :owner="props.options.tool_shed_repository?.owner" />
         </div>
     </div>
 </template>

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -9,6 +9,7 @@ import Heading from "components/Common/Heading";
 import ToolSelectPreferredObjectStore from "./ToolSelectPreferredObjectStore";
 import ToolTargetPreferredObjectStorePopover from "./ToolTargetPreferredObjectStorePopover";
 import { getAppRoot } from "onload/loadConfig";
+import ToolTutorialRecommendations from "./ToolTutorialRecommendations.vue";
 
 import { computed, ref, watch } from "vue";
 import { useCurrentUser } from "composables/user";
@@ -165,6 +166,12 @@ function onUpdatePreferredObjectStoreId(selectedToolPreferredObjectStoreId) {
         <slot name="buttons" />
 
         <div>
+            <ToolTutorialRecommendations
+                :id="props.options.id"
+                :name="props.options.name"
+                :version="props.options.version"
+                :repository="props.options.tool_shed_repository?.owner" />
+
             <div class="mt-2 mb-4">
                 <Heading h2 separator bold size="sm"> Help </Heading>
                 <ToolHelp :content="props.options.help" />

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -170,7 +170,7 @@ function onUpdatePreferredObjectStoreId(selectedToolPreferredObjectStoreId) {
                 :id="props.options.id"
                 :name="props.options.name"
                 :version="props.options.version"
-                :repository="props.options.tool_shed_repository?.owner" />
+                :owner="props.options.tool_shed_repository?.owner" />
 
             <div class="mt-2 mb-4">
                 <Heading h2 separator bold size="sm"> Help </Heading>

--- a/client/src/components/Tool/ToolTutorialRecommendations.vue
+++ b/client/src/components/Tool/ToolTutorialRecommendations.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import Heading from "@/components/Common/Heading.vue";
+import { useToolTrainingMaterial } from "@/composables/toolTrainingMaterial";
+import ExternalLink from "../ExternalLink.vue";
+import { BCollapse, BButton } from "bootstrap-vue";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
+import { useUid } from "@/composables/utils/uid";
+import slugify from "slugify";
+
+const props = defineProps<{
+    name: string;
+    id: string;
+    version: string;
+    repository?: string;
+}>();
+
+//@ts-ignore: bad library types
+library.add(faCaretDown);
+
+const { trainingAvailable, trainingCategories, tutorialDetails, allTutorialsUrl, versionAvailable } =
+    useToolTrainingMaterial(props.id, props.name, props.version, props.repository);
+
+const collapseId = useUid("collapse-");
+
+function idForCategory(category: string) {
+    return `${collapseId.value}-${slugify(category)}`;
+}
+
+function tutorialsInCategory(category: string) {
+    return tutorialDetails.value.filter((tut) => tut.category === category);
+}
+</script>
+
+<template>
+    <div v-if="trainingAvailable" class="mt-2 mb-4">
+        <Heading h2 separator bold size="sm">Tutorials</Heading>
+
+        <p>
+            There are {{ tutorialDetails.length }} tutorials available which use this tool.
+            <span v-if="versionAvailable"> These tutorials include training for the current version of the tool. </span>
+
+            <ExternalLink v-if="allTutorialsUrl" :href="allTutorialsUrl">
+                View all tutorials referencing this tool.
+            </ExternalLink>
+        </p>
+
+        <BButton v-b-toggle="collapseId" class="ui-link">
+            <b>
+                Tutorials available in {{ trainingCategories.length }}
+                {{ trainingCategories.length > 1 ? "categories" : "category" }}
+            </b>
+            <FontAwesomeIcon icon="caret-down" />
+        </BButton>
+        <BCollapse :id="collapseId">
+            <div v-for="category in trainingCategories" :key="category">
+                <BButton v-b-toggle="idForCategory(category)" class="ui-link ml-3">
+                    {{ category }} ({{ tutorialsInCategory(category).length }})
+                    <FontAwesomeIcon icon="caret-down" />
+                </BButton>
+                <BCollapse :id="idForCategory(category)">
+                    <ul class="d-flex flex-column my-1">
+                        <li v-for="tutorial in tutorialsInCategory(category)" :key="tutorial.title">
+                            <ExternalLink :href="tutorial.url.toString()" class="ml-2">
+                                {{ tutorial.title }}
+                            </ExternalLink>
+                        </li>
+                    </ul>
+                </BCollapse>
+            </div>
+        </BCollapse>
+    </div>
+</template>

--- a/client/src/components/Tool/ToolTutorialRecommendations.vue
+++ b/client/src/components/Tool/ToolTutorialRecommendations.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import Heading from "@/components/Common/Heading.vue";
 import { useToolTrainingMaterial } from "@/composables/toolTrainingMaterial";
-import ExternalLink from "../ExternalLink.vue";
+import ExternalLink from "@/components/ExternalLink.vue";
 import { BCollapse, BButton } from "bootstrap-vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";

--- a/client/src/components/Tool/ToolTutorialRecommendations.vue
+++ b/client/src/components/Tool/ToolTutorialRecommendations.vue
@@ -8,6 +8,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { useUid } from "@/composables/utils/uid";
 import slugify from "slugify";
+import { computed } from "vue";
 
 const props = defineProps<{
     name: string;
@@ -31,6 +32,14 @@ function idForCategory(category: string) {
 function tutorialsInCategory(category: string) {
     return tutorialDetails.value.filter((tut) => tut.category === category);
 }
+
+const tutorialText = computed(() => {
+    if (tutorialDetails.value.length > 1) {
+        return `There are ${tutorialDetails.value.length} tutorials available which use this tool.`;
+    } else {
+        return "There is 1 tutorial available which uses this tool.";
+    }
+});
 </script>
 
 <template>
@@ -38,7 +47,7 @@ function tutorialsInCategory(category: string) {
         <Heading h2 separator bold size="sm">Tutorials</Heading>
 
         <p>
-            There are {{ tutorialDetails.length }} tutorials available which use this tool.
+            {{ tutorialText }}
             <span v-if="versionAvailable"> These tutorials include training for the current version of the tool. </span>
 
             <ExternalLink v-if="allTutorialsUrl" :href="allTutorialsUrl">

--- a/client/src/components/Tool/ToolTutorialRecommendations.vue
+++ b/client/src/components/Tool/ToolTutorialRecommendations.vue
@@ -14,14 +14,14 @@ const props = defineProps<{
     name: string;
     id: string;
     version: string;
-    repository?: string;
+    owner?: string;
 }>();
 
 //@ts-ignore: bad library types
 library.add(faCaretDown);
 
 const { trainingAvailable, trainingCategories, tutorialDetails, allTutorialsUrl, versionAvailable } =
-    useToolTrainingMaterial(props.id, props.name, props.version, props.repository);
+    useToolTrainingMaterial(props.id, props.name, props.version, props.owner);
 
 const collapseId = useUid("collapse-");
 

--- a/client/src/composables/toolTrainingMaterial.ts
+++ b/client/src/composables/toolTrainingMaterial.ts
@@ -59,7 +59,7 @@ export function useToolTrainingMaterial(id: ID, name: Name, version: string, rep
                 return;
             }
 
-            if (apiEnabled.value) {
+            if (apiEnabled.value && !cachedResponse.value) {
                 const res = await fetch(config.value.tool_training_recommendations_api_url);
 
                 if (res.ok) {

--- a/client/src/composables/toolTrainingMaterial.ts
+++ b/client/src/composables/toolTrainingMaterial.ts
@@ -1,0 +1,168 @@
+import { useConfig } from "./config";
+import { computed, ref, watch, type Ref } from "vue";
+
+type Name = string;
+type Repo = string;
+type ID = string;
+
+type TrainingId = `${Repo}/${Name}` | ID;
+
+type TrainingDetails = {
+    tool_id: Array<
+        [
+            string, // ID (unused)
+            string // Version
+        ]
+    >;
+    tutorials: Array<
+        [
+            string, // tutorial ID (unused)
+            string, // Title
+            string, // Category
+            string // URL
+        ]
+    >;
+};
+
+type TrainingMaterialResponse = {
+    [id: TrainingId]: TrainingDetails;
+};
+
+type Config = {
+    tool_training_recommendations: boolean;
+    tool_training_recommendations_api_url: string;
+    tool_training_recommendations_link: string;
+};
+
+export type TutorialDetails = {
+    category: string;
+    title: string;
+    url: URL;
+};
+
+const cachedResponse: Ref<TrainingMaterialResponse | null> = ref(null);
+
+export function useToolTrainingMaterial(id: ID, name: Name, version: string, repo?: Repo) {
+    const { config, isLoaded }: { config: Ref<Config>; isLoaded: Ref<boolean> } = useConfig();
+    const apiEnabled = computed(() => {
+        return Boolean(
+            isLoaded.value &&
+                config.value.tool_training_recommendations &&
+                config.value.tool_training_recommendations_api_url
+        );
+    });
+
+    watch(
+        () => isLoaded.value,
+        async () => {
+            if (!isLoaded.value) {
+                return;
+            }
+
+            if (apiEnabled.value) {
+                const res = await fetch(config.value.tool_training_recommendations_api_url);
+
+                if (res.ok) {
+                    cachedResponse.value = await res.json();
+                }
+            }
+        },
+        { immediate: true }
+    );
+
+    const identifier = computed(() => {
+        if (repo) {
+            return `${repo}/${name.toLowerCase()}`;
+        } else {
+            return id;
+        }
+    });
+
+    const trainingAvailable = computed(() => {
+        if (!apiEnabled.value || !cachedResponse.value) {
+            return false;
+        }
+
+        return Object.keys(cachedResponse.value).includes(identifier.value);
+    });
+
+    const trainingDetails = computed(() => {
+        if (!trainingAvailable.value) {
+            return null;
+        }
+
+        return cachedResponse.value?.[identifier.value] ?? null;
+    });
+
+    const trainingCategories = computed<string[]>(() => {
+        if (!trainingDetails.value) {
+            return [];
+        }
+
+        const categories = new Set<string>();
+
+        trainingDetails.value.tutorials.forEach((tutorial) => {
+            categories.add(tutorial[2]);
+        });
+
+        return Array.from(categories);
+    });
+
+    const tutorialDetails = computed<TutorialDetails[]>(() => {
+        if (!trainingDetails.value) {
+            return [];
+        }
+
+        const details: TutorialDetails[] = [];
+
+        trainingDetails.value.tutorials.forEach((tutorial) => {
+            details.push({
+                title: tutorial[1],
+                category: tutorial[2],
+                url: new URL(tutorial[3], config.value.tool_training_recommendations_api_url),
+            });
+        });
+
+        return details;
+    });
+
+    const allTutorialsUrl = computed<string | undefined>(() => {
+        if (!isLoaded.value || !config.value.tool_training_recommendations_link) {
+            return;
+        }
+
+        let url = config.value.tool_training_recommendations_link;
+
+        url = url.replace("{training_tool_identifier}", identifier.value);
+        url = url.replace("{tool_id}", id);
+        url = url.replace("{name}", name);
+        url = url.replace("{repository}", repo ?? "");
+        url = url.replace("{version}", version);
+
+        return url;
+    });
+
+    const versionAvailable = computed<boolean>(() => {
+        if (!trainingDetails.value) {
+            return false;
+        }
+
+        for (let i = 0; i < trainingDetails.value.tool_id.length; i++) {
+            const element = trainingDetails.value.tool_id[i]!;
+
+            if (element[1] === version) {
+                return true;
+            }
+        }
+
+        return false;
+    });
+
+    return {
+        trainingAvailable,
+        trainingCategories,
+        tutorialDetails,
+        allTutorialsUrl,
+        versionAvailable,
+    };
+}

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -382,6 +382,10 @@ $ui-margin-horizontal-large: $margin-v * 2;
     column-gap: 0.25rem;
 }
 
+.flex-gapy-1 {
+    row-gap: 0.25rem;
+}
+
 /* Heading Sizes */
 .h-xl {
     font-size: $h1-font-size;

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -416,6 +416,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
     display: inline;
     line-height: unset;
     vertical-align: unset;
+    user-select: text;
 
     &:hover {
         text-decoration: underline;

--- a/client/src/utils/regExp.ts
+++ b/client/src/utils/regExp.ts
@@ -1,0 +1,10 @@
+/**
+ * Escapes all RegExp control characters from a string, so it can be matched literally
+ * @param string input string
+ * @returns string with all control characters escaped
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+ */
+export function escapeRegExp(string: string) {
+    return string.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+}

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5087,7 +5087,8 @@
 :Description:
     Displays a link to training material, if any includes the current
     tool. When activated the following options also need to be set:
-    - tool_training_recommendations_link
+    tool_training_recommendations_link,
+    tool_training_recommendations_api_url
 :Default: ``true``
 :Type: bool
 
@@ -5098,9 +5099,9 @@
 
 :Description:
     Template URL to display all tutorials containing current tool.
-    Valid template inputs are:   {repository}   {name}   {id}
-    {version}
-:Default: ``https://training.galaxyproject.org/training-material/by-tool/{repository}/{name}.html``
+    Valid template inputs are:   {repository}   {name}   {tool_id}
+    {training_tool_identifier}   {version}
+:Default: ``https://training.galaxyproject.org/training-material/by-tool/{training_tool_identifier}.html``
 :Type: str
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5080,4 +5080,36 @@
 :Type: bool
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``tool_training_recommendations``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+:Description:
+    Displays a link to training material, if any includes the current
+    tool. When activated the following options also need to be set:
+    - tool_training_recommendations_link
+:Default: ``true``
+:Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``tool_training_recommendations_link``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Template URL to display all tutorials containing current tool.
+    Valid template inputs are:   {repository}   {name}   {id}
+    {version}
+:Default: ``https://training.galaxyproject.org/training-material/by-tool/{repository}/{name}.html``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``tool_training_recommendations_api_url``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    URL to API describing tutorials containing specific tools. When
+    CORS is used, make sure to add this host.
+:Default: ``https://training.galaxyproject.org/training-material/api/top-tools.json``
+:Type: str

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5099,8 +5099,8 @@
 
 :Description:
     Template URL to display all tutorials containing current tool.
-    Valid template inputs are:   {repository}   {name}   {tool_id}
-    {training_tool_identifier}   {version}
+    Valid template inputs are:   {repository_owner}   {name}
+    {tool_id}   {training_tool_identifier}   {version}
 :Default: ``https://training.galaxyproject.org/training-material/by-tool/{training_tool_identifier}.html``
 :Type: str
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2717,7 +2717,7 @@ galaxy:
   #tool_training_recommendations: true
 
   # Template URL to display all tutorials containing current tool. Valid
-  # template inputs are:   {repository}   {name}   {tool_id}
+  # template inputs are:   {repository_owner}   {name}   {tool_id}
   # {training_tool_identifier}   {version}
   #tool_training_recommendations_link: https://training.galaxyproject.org/training-material/by-tool/{training_tool_identifier}.html
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2711,13 +2711,15 @@ galaxy:
   #enable_beacon_integration: false
 
   # Displays a link to training material, if any includes the current
-  # tool. When activated the following options also need to be set:   -
-  # tool_training_recommendations_link
+  # tool. When activated the following options also need to be set:
+  # tool_training_recommendations_link,
+  # tool_training_recommendations_api_url
   #tool_training_recommendations: true
 
   # Template URL to display all tutorials containing current tool. Valid
-  # template inputs are:   {repository}   {name}   {id}   {version}
-  #tool_training_recommendations_link: https://training.galaxyproject.org/training-material/by-tool/{repository}/{name}.html
+  # template inputs are:   {repository}   {name}   {tool_id}
+  # {training_tool_identifier}   {version}
+  #tool_training_recommendations_link: https://training.galaxyproject.org/training-material/by-tool/{training_tool_identifier}.html
 
   # URL to API describing tutorials containing specific tools. When CORS
   # is used, make sure to add this host.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1,21 +1,21 @@
 # Galaxy is configured by default to be usable in a single-user development
 # environment.  To tune the application for a multi-user production
 # environment, see the documentation at:
-# 
+#
 #  https://docs.galaxyproject.org/en/master/admin/production.html
-# 
+#
 # Throughout this sample configuration file, except where stated otherwise,
 # uncommented values override the default if left unset, whereas commented
 # values are set to the default value.  Relative paths are relative to the root
 # Galaxy directory.
-# 
+#
 # Examples of many of these options are explained in more detail in the Galaxy
 # Community Hub.
-# 
+#
 #   https://galaxyproject.org/admin/config
-# 
+#
 # Config hackers are encouraged to check there before asking for help.
-# 
+#
 # Configuration for Gravity process manager.
 # ``uwsgi:`` section will be ignored if Galaxy is started via Gravity commands (e.g ``./run.sh``, ``galaxy`` or ``galaxyctl``).
 gravity:
@@ -2710,3 +2710,15 @@ galaxy:
   # integration.
   #enable_beacon_integration: false
 
+  # Displays a link to training material, if any includes the current
+  # tool. When activated the following options also need to be set:   -
+  # tool_training_recommendations_link
+  #tool_training_recommendations: true
+
+  # Template URL to display all tutorials containing current tool. Valid
+  # template inputs are:   {repository}   {name}   {id}   {version}
+  #tool_training_recommendations_link: https://training.galaxyproject.org/training-material/by-tool/{repository}/{name}.html
+
+  # URL to API describing tutorials containing specific tools. When CORS
+  # is used, make sure to add this host.
+  #tool_training_recommendations_api_url: https://training.galaxyproject.org/training-material/api/top-tools.json

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3705,7 +3705,8 @@ mapping:
         desc: |
           Displays a link to training material, if any includes the current tool.
           When activated the following options also need to be set:
-            - tool_training_recommendations_link
+            tool_training_recommendations_link,
+            tool_training_recommendations_api_url
 
       tool_training_recommendations_link:
         type: str

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3715,7 +3715,7 @@ mapping:
         desc: |
           Template URL to display all tutorials containing current tool.
           Valid template inputs are:
-            {repository}
+            {repository_owner}
             {name}
             {tool_id}
             {training_tool_identifier}

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3698,3 +3698,32 @@ mapping:
         desc: |
           Enables user preferences and api endpoint for the beacon integration.
 
+      tool_training_recommendations:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Displays a link to training material, if any includes the current tool.
+          When activated the following options also need to be set:
+            - tool_training_recommendations_link
+
+      tool_training_recommendations_link:
+        type: str
+        default: https://training.galaxyproject.org/training-material/by-tool/{training_tool_identifier}.html
+        required: false
+        desc: |
+          Template URL to display all tutorials containing current tool.
+          Valid template inputs are:
+            {repository}
+            {name}
+            {tool_id}
+            {training_tool_identifier}
+            {version}
+
+      tool_training_recommendations_api_url:
+        type: str
+        default: https://training.galaxyproject.org/training-material/api/top-tools.json
+        required: false
+        desc: |
+          URL to API describing tutorials containing specific tools.
+          When CORS is used, make sure to add this host.

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -203,6 +203,9 @@ class ConfigSerializer(base.ModelSerializer):
             "user_library_import_dir_available": lambda item, key, **context: bool(item.get("user_library_import_dir")),
             "welcome_directory": _use_config,
             "themes": _use_config,
+            "tool_training_recommendations": _use_config,
+            "tool_training_recommendations_link": _use_config,
+            "tool_training_recommendations_api_url": _use_config,
         }
 
 


### PR DESCRIPTION
closes #15612

Adds a "Tutorials" Section, if tutorials referencing current tool are available.
Feature can be turned off, or pointed to a custom API.

![Screenshot from 2023-02-21 13-21-46](https://user-images.githubusercontent.com/44241786/220344092-2418c570-f44f-4f63-b17e-5e3cc45e92eb.png)
*default collapsed state*

![Screenshot from 2023-02-21 13-21-29](https://user-images.githubusercontent.com/44241786/220344083-c2acdbb3-dee6-4f94-9cb5-77ce070d60d9.png)
*expanded*

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
