### PR TITLE
[23.0] Backport of single/double quote change in filtering

### DIFF
--- a/client/src/utils/filtering.test.js
+++ b/client/src/utils/filtering.test.js
@@ -2,7 +2,7 @@ import { HistoryFilters } from "components/History/HistoryFilters";
 
 const filterTexts = [
     "name:'name of item' hid>10 hid<100 create-time>'2021-01-01' update-time<'2022-01-01' state:success extension:ext tag:first deleted:False visible:'TRUE'",
-    "name:'name of item' hid_gt:10 hid-lt:100 create_time-gt:'2021-01-01' update_time-lt:'2022-01-01' state:sUccEss extension:EXT tag:FirsT deleted:false visible:true",
+    'name:"name of item" hid_gt:10 hid-lt:100 create_time-gt:"2021-01-01" update_time-lt:\'2022-01-01\' state:sUccEss extension:EXT tag:FirsT deleted:false visible:true',
 ];
 
 describe("filtering", () => {
@@ -147,6 +147,12 @@ describe("filtering", () => {
         const filters = HistoryFilters.getFilters("tag:#test");
         expect(filters[0][0]).toBe("tag");
         expect(filters[0][1]).toBe("#test");
+        const filtersQuote = HistoryFilters.getFilters("tag:'#test me'");
+        expect(filtersQuote[0][0]).toBe("tag");
+        expect(filtersQuote[0][1]).toBe("#test me");
+        const filtersQuoteDouble = HistoryFilters.getFilters('tag:"#test me"');
+        expect(filtersQuoteDouble[0][0]).toBe("tag");
+        expect(filtersQuoteDouble[0][1]).toBe("#test me");
         const queryDict = HistoryFilters.getQueryDict("tag:#test");
         expect(queryDict["tag"]).toBe("name:test");
     });

--- a/client/src/utils/filtering.ts
+++ b/client/src/utils/filtering.ts
@@ -55,7 +55,7 @@ export function toBool<T>(value: T): boolean {
  * @returns {string} Lowercase value without quotation marks
  * */
 export function toLowerNoQuotes<T>(value: T): string {
-    return toLower(value).split("'").join("");
+    return toLower(value).replace(/('|")/g, "");
 }
 
 /** Converts name tags starting with '#' to 'name:'
@@ -231,7 +231,7 @@ export default class Filtering<T> {
      * @returns {object} Filters as dict of field->value pairs
      * */
     getFilters(filterText: string): [string, T][] {
-        const pairSplitRE = /[^\s']+(?:'[^']*'[^\s']*)*|(?:'[^']*'[^\s']*)+/g;
+        const pairSplitRE = /[^\s'"]+(?:['"][^'"]*['"][^\s'"]*)*|(?:['"][^'"]*['"][^\s'"]*)+/g;
         const matches = filterText.match(pairSplitRE);
         let result: Record<string, any> = {};
         let hasMatches = false;
@@ -354,7 +354,7 @@ export default class Filtering<T> {
      * */
     getFilterValue(filterText: string, filterName: string, alias = "eq"): string | boolean {
         const op = getOperatorForAlias(alias);
-        const reString = `${filterName}(?:${op}|[-|_]${alias}:)(?:'([^']*[^\\s']*)'|(\\S+))`;
+        const reString = `${filterName}(?:${op}|[-|_]${alias}:)(?:['"]([^'"]*[^\\s'"]*)['"]|(\\S+))`;
         const re = new RegExp(reString);
         const reMatch = re.exec(filterText);
         let filterVal = null;


### PR DESCRIPTION
[23.0] Backport of https://github.com/galaxyproject/galaxy/pull/15606/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
