### PR TITLE
[23.0] Fix escaped html in alert regarding login activation

### DIFF
--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -4,7 +4,7 @@
             <template v-if="!confirmURL">
                 <div class="col col-lg-6">
                     <b-alert :show="!!messageText" :variant="messageVariant">
-                        {{ messageText }}
+                        <span v-html="messageText" />
                     </b-alert>
                     <b-form id="login" @submit.prevent="submitLogin()">
                         <b-card no-body :header="headerWelcome">

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -16,8 +16,8 @@
                                     </b-form-group>
                                     <b-form-group :label="labelPassword">
                                         <b-form-input v-model="password" name="password" type="password" />
-                                        <b-form-text v-localize>
-                                            Forgot password?
+                                        <b-form-text>
+                                            <span v-localize>Forgot password?</span>
                                             <a
                                                 v-localize
                                                 href="javascript:void(0)"

--- a/client/src/nls/es/locale.js
+++ b/client/src/nls/es/locale.js
@@ -60,9 +60,9 @@ define({
     "Log in here.": false,
     "Create a Galaxy account": false,
     "Or, register with email": false,
-    "Forgot password?": false,
-    "Register here.": false,
-    "Click here to reset your password.": false,
+    "Forgot password?": "¿Olvidó su contraseña?",
+    "Register here.": "Regístrese aquí.",
+    "Click here to reset your password.": "Haga clic aquí para restablecer su contraseña.",
     "Logged in as": "Se ha conectado como",
 
     Preferences: "Preferencias",


### PR DESCRIPTION
This content comes from the server and only includes a valid email address as user content, so v-html is fine.

Fixes https://github.com/galaxyproject/galaxy/issues/15607

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
