### PR TITLE
Update supports_skip_locked, supports_returning for SA 2.0 compatibility

### DIFF
--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -160,9 +160,9 @@ def supports_skip_locked(engine: Engine) -> bool:
 def _statement_executed_without_error(statement: ClauseElement, engine: Engine) -> bool:
     # Execute statement against database, then issue a rollback.
     try:
-        with engine.begin() as conn:
+        with engine.connect() as conn, conn.begin() as trans:
             conn.execute(statement)
-            conn.rollback()  # ensure no changes to database
+            trans.rollback()  # ensure no changes to database
             return True
     except Exception:
         return False

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -2,12 +2,21 @@ import sqlite3
 from contextlib import contextmanager
 from typing import Optional
 
-from sqlalchemy import create_engine
+from sqlalchemy import (
+    create_engine,
+    select,
+    update,
+)
+from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.sql.compiler import IdentifierPreparer
-from sqlalchemy.sql.expression import text
+from sqlalchemy.sql.expression import (
+    ClauseElement,
+    text,
+)
 
 from galaxy.exceptions import ConfigurationError
+from galaxy.model import Job
 
 
 def database_exists(db_url, database=None):
@@ -130,3 +139,30 @@ def is_one_database(db1_url: str, db2_url: Optional[str]):
     # TODO: Consider more aggressive check here that this is not the same
     # database file under the hood.
     return not (db1_url and db2_url and db1_url != db2_url)
+
+
+def supports_returning(engine: Engine) -> bool:
+    """
+    Return True if the database bound to `engine` supports the `RETURNING` SQL clause.
+    """
+    stmt = update(Job).where(Job.id == -1).values(create_time=None).returning(Job.id)
+    return _statement_executed_without_error(stmt, engine)
+
+
+def supports_skip_locked(engine: Engine) -> bool:
+    """
+    Return True if the database bound to `engine` supports the `SKIP_LOCKED` parameter.
+    """
+    stmt = select(Job).where(Job.id == -1).with_for_update(skip_locked=True)
+    return _statement_executed_without_error(stmt, engine)
+
+
+def _statement_executed_without_error(statement: ClauseElement, engine: Engine) -> bool:
+    # Execute statement against database, then issue a rollback.
+    try:
+        with engine.begin() as conn:
+            conn.execute(statement)
+            conn.rollback()  # ensure no changes to database
+            return True
+    except Exception:
+        return False


### PR DESCRIPTION
Ref #12541.

Solve same issue as in #15611: under `autocommit=False`, each of the 2 operations (check support for `returning` and for `skip_locked`) resulted in +15 locks and +1 transaction stuck in idle mode. This fixes both.

A few changes:
1. Database interactions moved to `model.database_utils`, as it seems to be the appropriate location for such logic.
2. We explicitly rollback the transaction (limited to one place only), so even though we operate on `Job.id == -1`, that guarantees there are no changes to the database. (Can be reused for adding similar functions.)
3. The previous update statement (`job_table.update().where(job_table.c.id == -1).returning(job_table.c.id)`) did not raise an error only because of the `onupdate=now` option set in the Job model specification for that column. Without it, the column(s) to be updated must be specified (i.e., the `SET` SQL clause). I've added an explicit `values` clause to guard against this possibility. 


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
