### PR TITLE
[23.0] Fix bioblend ``GalaxyClient`` import for mypy

### DIFF
--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -70,7 +70,7 @@ from uuid import UUID
 import cwltest.compare
 import requests
 import yaml
-from bioblend.galaxy import GalaxyClient
+from bioblend.galaxyclient import GalaxyClient
 from gxformat2 import (
     convert_and_import_workflow,
     ImporterGalaxyInterface,


### PR DESCRIPTION
Fix the following error in the ``test_galaxy_packages`` tests:

```
mypy .
galaxy_test/base/populators.py:73: error: Module "bioblend.galaxy" does not
explicitly export attribute "GalaxyClient"  [attr-defined]
    from bioblend.galaxy import GalaxyClient
    ^
Found 1 error in 1 file (checked 20 source files)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
