### PR TITLE
[23.0] Fix Encoded ID schema example in OpenAPI

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1432,9 +1432,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the role
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -1564,9 +1562,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of the element.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id?: string;
             /**
@@ -1793,9 +1789,7 @@ export interface components {
             /**
              * Folder Id
              * @description The ID of the library folder that will contain the collection. Required if `instance_type=library`.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             folder_id?: string;
             /**
@@ -1807,9 +1801,7 @@ export interface components {
             /**
              * History Id
              * @description The ID of the history that will contain the collection. Required if `instance_type=history`.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             history_id?: string;
             /**
@@ -1866,17 +1858,13 @@ export interface components {
             /**
              * From HDA ID
              * @description The ID of an accessible HDA to copy into the library.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             from_hda_id?: string;
             /**
              * From HDCA ID
              * @description The ID of an accessible HDCA to copy into the library. Nested collections are not allowed, you must flatten the collection first.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             from_hdca_id?: string;
             /**
@@ -1966,9 +1954,7 @@ export interface components {
             /**
              * Folder Id
              * @description The ID of the library folder that will contain the collection. Required if `instance_type=library`.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             folder_id?: string;
             /**
@@ -1980,9 +1966,7 @@ export interface components {
             /**
              * History Id
              * @description The ID of the history that will contain the collection. Required if `instance_type=history`.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             history_id?: string;
             /**
@@ -2023,9 +2007,7 @@ export interface components {
             /**
              * Workflow invocation ID
              * @description Encoded ID used by workflow generated reports.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             invocation_id?: string;
             /**
@@ -2092,9 +2074,7 @@ export interface components {
             /**
              * ID
              * @description The `encoded identifier` of the quota.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -2170,9 +2150,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -2226,9 +2204,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -2423,9 +2399,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -2726,9 +2700,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of the history item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -2840,9 +2812,7 @@ export interface components {
         ExportObjectRequestMetadata: {
             /**
              * Object Id
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             object_id: string;
             object_type: components["schemas"]["ExportObjectType"];
@@ -2852,9 +2822,7 @@ export interface components {
                 | components["schemas"]["ShortTermStoreExportPayload"];
             /**
              * User Id
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             user_id?: string;
         };
@@ -2902,9 +2870,7 @@ export interface components {
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             history_id: string;
             /** Targets */
@@ -2998,9 +2964,7 @@ export interface components {
             file_size: string;
             /**
              * Id
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /** Is Private */
@@ -3009,9 +2973,7 @@ export interface components {
             is_unrestricted: boolean;
             /**
              * Ldda Id
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             ldda_id: string;
             /** Message */
@@ -3132,9 +3094,7 @@ export interface components {
             description?: string;
             /**
              * Id
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /** Name */
@@ -3244,9 +3204,7 @@ export interface components {
             /**
              * ID
              * @description Encoded group ID
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -3293,9 +3251,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the role
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -3328,9 +3284,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the user
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -3387,9 +3341,7 @@ export interface components {
             /**
              * Dataset ID
              * @description The encoded ID of the dataset associated with this item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             dataset_id: string;
             /**
@@ -3458,17 +3410,13 @@ export interface components {
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             history_id: string;
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -3611,17 +3559,13 @@ export interface components {
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             history_id: string;
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -3651,9 +3595,7 @@ export interface components {
             /**
              * Dataset ID
              * @description The encoded ID of the dataset associated with this item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             dataset_id: string;
             /**
@@ -3680,17 +3622,13 @@ export interface components {
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             history_id: string;
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -3746,9 +3684,7 @@ export interface components {
             /**
              * Collection ID
              * @description The encoded ID of the dataset collection associated with this HDCA.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             collection_id: string;
             /**
@@ -3801,25 +3737,19 @@ export interface components {
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             history_id: string;
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
              * Job Source ID
              * @description The encoded ID of the Job that produced this dataset collection. Used to track the state of the job.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             job_source_id?: string;
             /**
@@ -3899,9 +3829,7 @@ export interface components {
             /**
              * Collection ID
              * @description The encoded ID of the dataset collection associated with this HDCA.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             collection_id: string;
             /**
@@ -3943,25 +3871,19 @@ export interface components {
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             history_id: string;
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
              * Job Source ID
              * @description The encoded ID of the Job that produced this dataset collection. Used to track the state of the job.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             job_source_id?: string;
             /**
@@ -4249,9 +4171,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
         };
@@ -4367,9 +4287,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -4444,9 +4362,7 @@ export interface components {
             /**
              * User ID
              * @description The encoded ID of the user that owns this History.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             user_id: string;
             /**
@@ -4478,9 +4394,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -4544,9 +4458,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -4585,9 +4497,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -4661,9 +4571,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the install tool shed repository.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -4713,9 +4621,7 @@ export interface components {
             /**
              * Item ID
              * @description The `encoded identifier` of the item whose tags will be updated.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             item_id: string;
             /**
@@ -4760,17 +4666,13 @@ export interface components {
             /**
              * ID
              * @description The encoded database ID of the export request.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
              * Job ID
              * @description The encoded database ID of the job that generated this history export archive.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             job_id: string;
             /**
@@ -4797,9 +4699,7 @@ export interface components {
             /**
              * Job ID
              * @description The encoded database ID of the job that is currently processing a particular request.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             job_id: string;
         };
@@ -4828,17 +4728,13 @@ export interface components {
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             history_id?: string;
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -4904,9 +4800,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -5094,9 +4988,7 @@ export interface components {
         LibraryFolderDestination: {
             /**
              * Library Folder Id
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             library_folder_id: string;
             /**
@@ -5130,9 +5022,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the library folder.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -5161,17 +5051,13 @@ export interface components {
             /**
              * Parent Folder ID
              * @description Encoded ID of the parent folder. Empty if it's the root folder.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             parent_id?: string;
             /**
              * Parent Library ID
              * @description Encoded ID of the Library this folder belongs to.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             parent_library_id: string;
             /**
@@ -5198,9 +5084,7 @@ export interface components {
             full_path: string[][];
             /**
              * Parent Library Id
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             parent_library_id: string;
             /** Total Rows */
@@ -5266,9 +5150,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the Library.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -5286,9 +5168,7 @@ export interface components {
             /**
              * Root Folder ID
              * @description Encoded ID of the Library's base folder.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             root_folder_id: string;
             /**
@@ -5390,9 +5270,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the Library.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -5415,9 +5293,7 @@ export interface components {
             /**
              * Root Folder ID
              * @description Encoded ID of the Library's base folder.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             root_folder_id: string;
             /**
@@ -5511,9 +5387,7 @@ export interface components {
              * - The encoded id of the source library dataset
              * - The encoded id of the the HDA
              *
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             content?: string;
             /**
@@ -5737,9 +5611,7 @@ export interface components {
             /**
              * ID
              * @description The encoded database ID of the export request.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -5826,9 +5698,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the Page.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -5839,9 +5709,7 @@ export interface components {
             /**
              * Latest revision ID
              * @description The encoded ID of the last revision of this Page.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             latest_revision_id: string;
             /**
@@ -5901,9 +5769,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the Page.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -5914,9 +5780,7 @@ export interface components {
             /**
              * Latest revision ID
              * @description The encoded ID of the last revision of this Page.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             latest_revision_id: string;
             /**
@@ -6175,9 +6039,7 @@ export interface components {
             /**
              * ID
              * @description The `encoded identifier` of the quota.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -6219,9 +6081,7 @@ export interface components {
             /**
              * ID
              * @description The `encoded identifier` of the quota.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -6325,9 +6185,7 @@ export interface components {
             /**
              * ID
              * @description Encoded ID of the role
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -6569,9 +6427,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of the resource to be shared.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -6625,9 +6481,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of the resource to be shared.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -7025,9 +6879,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
         };
@@ -7224,9 +7076,7 @@ export interface components {
             /**
              * User ID
              * @description The encoded ID of the user.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
         };
@@ -7253,9 +7103,7 @@ export interface components {
             /**
              * ID
              * @description User ID
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**
@@ -7316,9 +7164,7 @@ export interface components {
             /**
              * ID
              * @description The encoded ID of this entity.
-             * @example [
-             *   "0123456789ABCDEF"
-             * ]
+             * @example 0123456789ABCDEF
              */
             id: string;
             /**

--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -43,7 +43,7 @@ class BaseDatabaseIdField:
         field_schema.update(
             minLength=16,
             pattern="[0-9a-fA-F]+",
-            example=["0123456789ABCDEF"],
+            example="0123456789ABCDEF",
             type="string",
         )
 


### PR DESCRIPTION
Noticed while browsing the interactive API docs. The examples for encoded IDs were rendered as `List["0123456789ABCDEF"]` instead of just `0123456789ABCDEF`.

## Before
![Screenshot from 2023-02-23 15-18-16](https://user-images.githubusercontent.com/46503462/220934305-e1a5dcb8-7084-414d-b718-bc23f3c9fc09.png)

## After
![image](https://user-images.githubusercontent.com/46503462/220935564-84543fd3-ef33-44c1-ae8c-f4ae76507ef3.png)


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
