### PR TITLE
Wrap check_jobs_at_startup operation in a transaction (SA 2.0 compatibility)

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -263,75 +263,67 @@ class JobHandlerQueue(Monitors):
         job handler starts.
         In case the activation is enforced it will filter out the jobs of inactive users.
         """
-        jobs_at_startup = []
+        stmt = self._build_check_jobs_at_startup_statement()
+        with self.sa_session() as session, session.begin():
+            jobs_at_startup = session.scalars(stmt)
+            for job in jobs_at_startup:
+                if not self.app.toolbox.has_tool(job.tool_id, job.tool_version, exact=True):
+                    log.warning(f"({job.id}) Tool '{job.tool_id}' removed from tool config, unable to recover job")
+                    self.job_wrapper(job).fail(
+                        "This tool was disabled before the job completed.  Please contact your Galaxy administrator."
+                    )
+                elif job.job_runner_name is not None and job.job_runner_external_id is None:
+                    # This could happen during certain revisions of Galaxy where a runner URL was persisted before the job was dispatched to a runner.
+                    log.debug(
+                        f"({job.id}) Job runner assigned but no external ID recorded, adding to the job handler queue"
+                    )
+                    job.job_runner_name = None
+                    if self.track_jobs_in_database:
+                        job.set_state(model.Job.states.NEW)
+                    else:
+                        self.queue.put((job.id, job.tool_id))
+                elif (
+                    job.job_runner_name is not None
+                    and job.job_runner_external_id is not None
+                    and job.destination_id is None
+                ):
+                    # This is the first start after upgrading from URLs to destinations, convert the URL to a destination and persist
+                    job_wrapper = self.job_wrapper(job)
+                    job_destination = self.dispatcher.url_to_destination(job.job_runner_name)
+                    if job_destination.id is None:
+                        job_destination.id = "legacy_url"
+                    job_wrapper.set_job_destination(job_destination, job.job_runner_external_id)
+                    self.dispatcher.recover(job, job_wrapper)
+                    log.info(f"({job.id}) Converted job from a URL to a destination and recovered")
+                elif job.job_runner_name is None:
+                    # Never (fully) dispatched
+                    log.debug(
+                        f"({job.id}) No job runner assigned and job still in '{job.state}' state, adding to the job handler queue"
+                    )
+                    if self.track_jobs_in_database:
+                        job.set_state(model.Job.states.NEW)
+                    else:
+                        self.queue.put((job.id, job.tool_id))
+                else:
+                    # Already dispatched and running
+                    job_wrapper = self.__recover_job_wrapper(job)
+                    self.dispatcher.recover(job, job_wrapper)
+
+    def _build_check_jobs_at_startup_statement(self):
         if self.track_jobs_in_database:
             in_list = (model.Job.states.QUEUED, model.Job.states.RUNNING, model.Job.states.STOPPED)
         else:
             in_list = (model.Job.states.NEW, model.Job.states.QUEUED, model.Job.states.RUNNING)
-        if self.app.config.user_activation_on:
-            jobs_at_startup = (
-                self.sa_session.query(model.Job)
-                .enable_eagerloads(False)
-                .outerjoin(model.User)
-                .filter(
-                    model.Job.state.in_(in_list)
-                    & (model.Job.handler == self.app.config.server_name)
-                    & or_((model.Job.user_id == null()), (model.User.active == true()))
-                )
-                .yield_per(model.YIELD_PER_ROWS)
-            )
-        else:
-            jobs_at_startup = (
-                self.sa_session.query(model.Job)
-                .enable_eagerloads(False)
-                .filter(model.Job.state.in_(in_list) & (model.Job.handler == self.app.config.server_name))
-                .yield_per(model.YIELD_PER_ROWS)
-            )
 
-        for job in jobs_at_startup:
-            if not self.app.toolbox.has_tool(job.tool_id, job.tool_version, exact=True):
-                log.warning(f"({job.id}) Tool '{job.tool_id}' removed from tool config, unable to recover job")
-                self.job_wrapper(job).fail(
-                    "This tool was disabled before the job completed.  Please contact your Galaxy administrator."
-                )
-            elif job.job_runner_name is not None and job.job_runner_external_id is None:
-                # This could happen during certain revisions of Galaxy where a runner URL was persisted before the job was dispatched to a runner.
-                log.debug(
-                    f"({job.id}) Job runner assigned but no external ID recorded, adding to the job handler queue"
-                )
-                job.job_runner_name = None
-                if self.track_jobs_in_database:
-                    job.set_state(model.Job.states.NEW)
-                else:
-                    self.queue.put((job.id, job.tool_id))
-            elif (
-                job.job_runner_name is not None
-                and job.job_runner_external_id is not None
-                and job.destination_id is None
-            ):
-                # This is the first start after upgrading from URLs to destinations, convert the URL to a destination and persist
-                job_wrapper = self.job_wrapper(job)
-                job_destination = self.dispatcher.url_to_destination(job.job_runner_name)
-                if job_destination.id is None:
-                    job_destination.id = "legacy_url"
-                job_wrapper.set_job_destination(job_destination, job.job_runner_external_id)
-                self.dispatcher.recover(job, job_wrapper)
-                log.info(f"({job.id}) Converted job from a URL to a destination and recovered")
-            elif job.job_runner_name is None:
-                # Never (fully) dispatched
-                log.debug(
-                    f"({job.id}) No job runner assigned and job still in '{job.state}' state, adding to the job handler queue"
-                )
-                if self.track_jobs_in_database:
-                    job.set_state(model.Job.states.NEW)
-                else:
-                    self.queue.put((job.id, job.tool_id))
-            else:
-                # Already dispatched and running
-                job_wrapper = self.__recover_job_wrapper(job)
-                self.dispatcher.recover(job, job_wrapper)
-        if self.sa_session.dirty:
-            self.sa_session.flush()
+        stmt = (
+            select(model.Job)
+            .execution_options(yield_per=model.YIELD_PER_ROWS)
+            .filter(model.Job.state.in_(in_list) & (model.Job.handler == self.app.config.server_name))
+        )
+        if self.app.config.user_activation_on:
+            # Filter out the jobs of inactive users.
+            stmt = stmt.outerjoin(model.User).filter(or_((model.Job.user_id == null()), (model.User.active == true())))
+        return stmt
 
     def __recover_job_wrapper(self, job):
         # Already dispatched and running


### PR DESCRIPTION
Ref #12541.

Solve same type of issue as in #15633.

NOTES:
`.enable_eagerloads` is only available on the legacy Query API. However, we don't need that here: there's no joined eager loading configured at mapping time; and if we add that in the future, we'll simply use the `lazyload(Job.foo)` loading option in the statement, where `foo` is the eagerly loaded relationship attribute (and we won't forget to do that, as SQLAlchemy will raise an error if we do).

We use the main session here, which we commit unconditionally. Previously, the session was flushed if it was in "dirty" state (flush = new transaction begin and commit). Here, we have to explicitly commit or rollback: with `autocommit=False` each statement is in transaction mode, and not closing the transaction will leave multiple locks hanging (for more details, see #15611). When committing or rolling back, all objects in the session are expired; so, if we need to access an attribute of a loaded Job object, a `select` statement will be automatically issued to the database that refreshes its state. I don't think that's an issue here, as the only case when the previous version might've had noticeably fewer database accesses is if (a) a lot of jobs where loaded, (b) not a single one was modified in the `for job in jobs_at_startup` loop, and (c) we needed to access all of them one at a time, before the next flush or refresh - which, I think, is an unlikely combination.

(@natefoo FYI)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
