### PR TITLE
[23.0] Fix saving workflow with conditional subworkflow step

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -27,6 +27,7 @@
         <template v-slot:body>
             <FormElement
                 id="__label"
+                :key="stepId"
                 :value="label"
                 title="Label"
                 help="Add a step label."
@@ -34,6 +35,7 @@
                 @input="onLabel" />
             <FormElement
                 id="__annotation"
+                :key="stepId"
                 :value="annotation"
                 title="Step Annotation"
                 :area="true"

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -4,7 +4,7 @@
             v-if="showCalloutActiveOutput"
             v-b-tooltip
             :class="['callout-terminal', output.name]"
-            title="Unchecked outputs will be hidden and are not available as subworkflow outputs."
+            title="Checked outputs will become primary workflow outputs and are available as subworkflow outputs."
             @keyup="onToggleActive"
             @click="onToggleActive">
             <i :class="['mark-terminal', activeClass]" />

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -7170,9 +7170,16 @@ class WorkflowStep(Base, RepresentById):
                     if inferred_order_index.isdigit():
                         input_subworkflow_steps = [self.subworkflow.step_by_index(int(inferred_order_index))]
                 if len(input_subworkflow_steps) != 1:
-                    raise galaxy.exceptions.MessageException(
-                        f"Invalid subworkflow connection at step index {self.order_index + 1}"
-                    )
+                    # `when` expression inputs don't need to be passed into subworkflow
+                    # In the absence of formal extra step inputs this seems like the best we can do.
+                    # A better way to do these validations is to validate that all required subworkflow inputs
+                    # are connected.
+                    if input_name not in (self.when_expression or ""):
+                        raise galaxy.exceptions.MessageException(
+                            f"Invalid subworkflow connection at step index {self.order_index + 1}"
+                        )
+                    else:
+                        input_subworkflow_steps = [None]
                 input_subworkflow_step = input_subworkflow_steps[0]
             conn.input_subworkflow_step = input_subworkflow_step
         return conn


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15646, https://github.com/galaxyproject/galaxy/issues/15644 and a bug found when writing the test (https://github.com/galaxyproject/galaxy/commit/a3962349f74a7337a29b64bc2e328d2d40e54605).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
