### PR TITLE
build_mulled: also use namespace for building singularity images

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -688,7 +688,7 @@ class BuildMulledDockerContainerResolver(CliContainerResolver):
         if len(targets) == 0:
             return None
         if self.auto_install or install:
-            mull_targets(targets, involucro_context=self.involucro_context, namespace=self.namespace, **self._mulled_kwds)
+            mull_targets(targets, involucro_context=self.involucro_context, **self._mulled_kwds)
         return docker_cached_container_description(targets, self.namespace, hash_func=self.hash_func, shell=self.shell)
 
     def __str__(self):

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -688,7 +688,7 @@ class BuildMulledDockerContainerResolver(CliContainerResolver):
         if len(targets) == 0:
             return None
         if self.auto_install or install:
-            mull_targets(targets, involucro_context=self.involucro_context, **self._mulled_kwds)
+            mull_targets(targets, involucro_context=self.involucro_context, namespace=self.namespace, **self._mulled_kwds)
         return docker_cached_container_description(targets, self.namespace, hash_func=self.hash_func, shell=self.shell)
 
     def __str__(self):

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -714,6 +714,7 @@ class BuildMulledSingularityContainerResolver(SingularityCliContainerResolver):
             "channels": self._get_config_option("mulled_channels", DEFAULT_CHANNELS),
             "hash_func": self.hash_func,
             "command": "build-and-test",
+            "namespace": "local",
             "singularity": True,
             "singularity_image_dir": self.cache_directory.path,
         }


### PR DESCRIPTION
Lookup for the cached container uses the namespace, but creation always is in `"biocontainers"`

Otherwise this test fails https://github.com/galaxyproject/galaxy/blob/dae5069868c90b6b716c28e48718357679068695/test/integration/test_containerized_jobs.py#L158

But this test seems not to be executed at the moment. Can we enable it?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
