### PR TITLE
[23.0] Rework collapsible FormCard handling; 

### DIFF
--- a/client/src/components/Form/FormCard.vue
+++ b/client/src/components/Form/FormCard.vue
@@ -1,27 +1,20 @@
 <template>
     <div class="ui-portlet-section">
-        <div class="portlet-header">
+        <div :tabindex="collapsible ? 0 : -1" :class="portletHeaderClasses" @keydown="onKeyDown" @click="onCollapse">
             <div class="portlet-operations">
                 <slot name="operations" />
-                <b-button
+                <span
                     v-if="collapsible"
                     v-b-tooltip.hover.bottom
-                    role="button"
                     title="Collapse/Expand"
                     variant="link"
                     size="sm"
-                    class="float-right"
-                    @click="onCollapse">
+                    class="float-right">
                     <font-awesome-icon v-if="expanded" icon="eye-slash" class="fa-fw" />
                     <font-awesome-icon v-else icon="eye" class="fa-fw" />
-                </b-button>
+                </span>
             </div>
-            <b-link v-if="collapsible" class="portlet-title" href="#" @click="onCollapse">
-                <span v-if="icon" :class="['portlet-title-icon fa mr-1', icon]" />
-                <b class="portlet-title-text" itemprop="name">{{ title }}</b>
-                <span class="portlet-title-description" itemprop="description">{{ description }}</span>
-            </b-link>
-            <span v-else class="portlet-title">
+            <span class="portlet-title">
                 <span v-if="icon" :class="['portlet-title-icon fa mr-1', icon]" />
                 <b class="portlet-title-text" itemprop="name">{{ title }}</b>
                 <span class="portlet-title-description" itemprop="description">{{ description }}</span>
@@ -69,7 +62,20 @@ export default {
     data() {
         return {};
     },
+    computed: {
+        portletHeaderClasses() {
+            return {
+                "portlet-header": true,
+                "cursor-pointer": this.collapsible,
+            };
+        },
+    },
     methods: {
+        onKeyDown(event) {
+            if (event.key === "Enter" || event.key === " ") {
+                this.onCollapse();
+            }
+        },
         onCollapse() {
             if (this.collapsible) {
                 this.$emit("update:expanded", !this.expanded);


### PR DESCRIPTION
Fixes #15363.  Reworks collapsible formcard title handling.  Still shows an icon for a clear state display but the whole card header is clickable and keyboard navigable now so it works like our ContentItem expansion.  In doing this I took the 'eye' collapse state icon out of a button so it looks different from other 'operations' that show up in this space in other contexts.  We probably want to consider (in dev) swapping this from the eye to a more standard collapsed/expanded arrowdown/arrowup or the like.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
