### PR TITLE
[23.0] convert activate method substitutions to f-strings

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -284,12 +284,13 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
         if email is not None:
             email = unquote(email)
         activation_token = params.get("activation_token", None)
+        index_url = web.url_for(controller="root", action="index")
 
         if email is None or activation_token is None:
             #  We don't have the email or activation_token, show error.
             return trans.show_error_message(
-                "You are using an invalid activation link. Try to log in and we will send you a new activation email. <br><a href='%s'>Go to login page.</a>"
-            ) % web.url_for(controller="root", action="index")
+                f"You are using an invalid activation link. Try to log in and we will send you a new activation email. <br><a href='{index_url}'>Go to login page.</a>"
+            )
         else:
             # Find the user
             user = (
@@ -298,25 +299,24 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
             if not user:
                 # Probably wrong email address
                 return trans.show_error_message(
-                    "You are using an invalid activation link. Try to log in and we will send you a new activation email. <br><a href='%s'>Go to login page.</a>"
-                ) % web.url_for(controller="root", action="index")
+                    f"You are using an invalid activation link. Try to log in and we will send you a new activation email. <br><a href='{index_url}'>Go to login page.</a>"
+                )
             # If the user is active already don't try to activate
             if user.active is True:
                 return trans.show_ok_message(
-                    "Your account is already active. Nothing has changed. <br><a href='%s'>Go to login page.</a>"
-                ) % web.url_for(controller="root", action="index")
+                    f"Your account is already active. Nothing has changed. <br><a href='{index_url}'>Go to login page.</a>"
+                )
             if user.activation_token == activation_token[:64]:
                 user.activation_token = None
                 self.user_manager.activate(user)
                 return trans.show_ok_message(
-                    "Your account has been successfully activated! <br><a href='%s'>Go to login page.</a>"
-                ) % web.url_for(controller="root", action="index")
+                    f"Your account has been successfully activated! <br><a href='{index_url}'>Go to login page.</a>"
+                )
             else:
                 #  Tokens don't match. Activation is denied.
                 return trans.show_error_message(
-                    "You are using an invalid activation link. Try to log in and we will send you a new activation email. <br><a href='%s'>Go to login page.</a>"
-                ) % web.url_for(controller="root", action="index")
-        return
+                    f"You are using an invalid activation link. Try to log in and we will send you a new activation email. <br><a href='{index_url}'>Go to login page.</a>"
+                )
 
     @expose_api_anonymous_and_sessionless
     def change_password(self, trans, payload=None, **kwd):


### PR DESCRIPTION
somehow this prevents the:

`ValueError: unsupported format character ',' (0x2c) at index 2885`

that we are getting on Test and Main (only)

closes https://github.com/galaxyproject/galaxy/issues/15626

(but it is a bit scary that we do not know what is happening here, ideas @nsoranzo ?)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. create user on Test/Main
  2. follow the activation url you were sent
  3. you DO NOT land on "internal server error" page AND your activation will go through correctly

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
