### PR TITLE
[23.0] Ignore spurious mypy error

### DIFF
--- a/lib/galaxy/web/framework/helpers/__init__.py
+++ b/lib/galaxy/web/framework/helpers/__init__.py
@@ -35,7 +35,7 @@ def time_ago(x):
         kwargs = dict()
         if not default_locale("LC_TIME"):
             kwargs["locale"] = "en_US_POSIX"
-        return format_timedelta(x - datetime.utcnow(), threshold=1, add_direction=True, **kwargs)
+        return format_timedelta(x - datetime.utcnow(), threshold=1, add_direction=True, **kwargs)  # type: ignore[arg-type] # https://github.com/python/mypy/issues/9676
 
 
 def iff(a, b, c):


### PR DESCRIPTION
Workaround the following errors in Galaxy package tests:

```
galaxy/web/framework/helpers/__init__.py:38: error: Argument 4 to
"format_timedelta" has incompatible type "**Dict[str, str]"; expected
"Literal['year', 'month', 'week', 'day', 'hour', 'minute', 'second']"
[arg-type]
    ...elta(x - datetime.utcnow(), threshold=1, add_direction=True, **kwargs)
                                                                      ^
galaxy/web/framework/helpers/__init__.py:38: error: Argument 4 to
"format_timedelta" has incompatible type "**Dict[str, str]"; expected
"Literal['narrow', 'short', 'medium', 'long']"  [arg-type]
    ...elta(x - datetime.utcnow(), threshold=1, add_direction=True, **kwargs)
                                                                      ^
```

These started with the release of Babel 2.12.1, which includes type annotations.

xref. https://github.com/python/mypy/issues/9676

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
