### PR TITLE
Add transactional state to JobHandlerStopQueue

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -194,30 +194,36 @@ class ItemGrabber:
                     trans.rollback()
 
 
-class JobHandlerQueue(Monitors):
+class BaseJobHandlerQueue(Monitors):
+
+    STOP_SIGNAL = object()
+
+    def __init__(self, app: MinimalManagerApp, dispatcher):
+        """
+        Initializes the Queue, creates (unstarted) monitoring thread.
+        """
+        self.app = app
+        self.dispatcher = dispatcher
+        self.sa_session = app.model.context  # scoped session registry
+        self.track_jobs_in_database = self.app.config.track_jobs_in_database
+        # Keep track of the pid that started the job manager, only it has valid threads
+        self.parent_pid = os.getpid()
+        # This queue is not used if track_jobs_in_database is True.
+        self.queue: Queue[Tuple[int, str]] = Queue()
+
+
+class JobHandlerQueue(BaseJobHandlerQueue):
     """
     Job Handler's Internal Queue, this is what actually implements waiting for
     jobs to be runnable and dispatching to a JobRunner.
     """
 
-    STOP_SIGNAL = object()
-
     def __init__(self, app: MinimalManagerApp, dispatcher):
-        """Initializes the Job Handler Queue, creates (unstarted) monitoring thread"""
-        self.app = app
-        self.dispatcher = dispatcher
-
-        self.sa_session = app.model.context
-        self.track_jobs_in_database = self.app.config.track_jobs_in_database
+        super().__init__(app, dispatcher)
+        # self.queue contains tuples: (job_id, tool_id)
 
         # Initialize structures for handling job limits
         self.__clear_job_count()
-
-        # Keep track of the pid that started the job manager, only it
-        # has valid threads
-        self.parent_pid = os.getpid()
-        # Contains a tuple of new new job and tool id. Note this is not used if track_jobs_in_database is True
-        self.queue: Queue[Tuple[int, str]] = Queue()
         # Contains job ids for jobs that are waiting (only use from monitor thread)
         self.waiting_jobs: List[int] = []
         # Contains wrappers of jobs that are limited or ready (so they aren't created unnecessarily/multiple times)
@@ -1037,7 +1043,7 @@ class JobHandlerQueue(Monitors):
         else:
             log.info("sending stop signal to worker thread")
             self.stop_monitoring()
-            if not self.app.config.track_jobs_in_database:
+            if not self.track_jobs_in_database:
                 self.queue.put(self.STOP_SIGNAL)
             # A message could still be received while shutting down, should be ok since they will be picked up on next startup.
             self.sleeper.wake()
@@ -1046,46 +1052,32 @@ class JobHandlerQueue(Monitors):
             self.dispatcher.shutdown()
 
 
-class JobHandlerStopQueue(Monitors):
+class JobHandlerStopQueue(BaseJobHandlerQueue):
     """
     A queue for jobs which need to be terminated prematurely.
     """
 
-    STOP_SIGNAL = object()
-
     def __init__(self, app: MinimalManagerApp, dispatcher):
-        self.app = app
-        self.dispatcher = dispatcher
-
-        self.sa_session = app.model.context
-
-        # Keep track of the pid that started the job manager, only it
-        # has valid threads
-        self.parent_pid = os.getpid()
-        # Contains a tuple of job_id and error message. Note this is not used if track_jobs_in_database is True
-        self.queue: Queue[Tuple[int, str]] = Queue()
-
-        # Contains job ids that are waiting (only use from monitor thread)
-        self.waiting: List[int] = []
+        super().__init__(app, dispatcher)
+        # self.queue contains tuples: (job_id, error message)
 
         name = "JobHandlerStopQueue.monitor_thread"
-        self._init_monitor_thread(name, config=app.config)
-        log.info("job handler stop queue started")
+        self._init_monitor_thread(name, target=self.__monitor, config=app.config)
 
     def start(self):
         # Start the queue
         self.monitor_thread.start()
         log.info("job handler stop queue started")
 
-    def monitor(self):
+    def __monitor(self):
         """
-        Continually iterate the waiting jobs, stop any that are found.
+        Continually iterate and stop appropriate jobs.
         """
         # HACK: Delay until after forking, we need a way to do post fork notification!!!
         time.sleep(10)
         while self.monitor_running:
             try:
-                self.monitor_step()
+                self.__monitor_step()
             except Exception:
                 log.exception("Exception in monitor_step")
             # Sleep
@@ -1105,7 +1097,7 @@ class JobHandlerStopQueue(Monitors):
         session.add(job)
         session.flush()
 
-    def monitor_step(self):
+    def __monitor_step(self):
         """
         Called repeatedly by `monitor` to stop jobs.
         """
@@ -1119,7 +1111,7 @@ class JobHandlerStopQueue(Monitors):
             self._check_jobs(session, jobs_to_check)
 
     def put(self, job_id, error_msg=None):
-        if not self.app.config.track_jobs_in_database:
+        if not self.track_jobs_in_database:
             self.queue.put((job_id, error_msg))
 
     def shutdown(self):
@@ -1130,7 +1122,7 @@ class JobHandlerStopQueue(Monitors):
         else:
             log.info("sending stop signal to worker thread")
             self.stop_monitoring()
-            if not self.app.config.track_jobs_in_database:
+            if not self.track_jobs_in_database:
                 self.queue.put(self.STOP_SIGNAL)
             self.shutdown_monitor()
             log.info("job handler stop queue stopped")
@@ -1146,7 +1138,7 @@ class JobHandlerStopQueue(Monitors):
         return session.get(model.Job, job_id)
 
     def _add_newly_deleted_jobs(self, session, jobs_to_check):
-        if self.app.config.track_jobs_in_database:
+        if self.track_jobs_in_database:
             newly_deleted_jobs = self._get_new_jobs(session)
             for job in newly_deleted_jobs:
                 # job.stderr is always a string (job.job_stderr + job.tool_stderr, possibly `''`),

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -1013,22 +1013,6 @@ class JobHandlerQueue(BaseJobHandlerQueue):
                             return JOB_WAIT
         return JOB_READY
 
-    def _handle_setup_msg(self, job_id=None):
-        job = self.sa_session.query(model.Job).get(job_id)
-        if job.handler is None:
-            job.handler = self.app.config.server_name
-            self.sa_session.add(job)
-            self.sa_session.flush()
-            # If not tracking jobs in the database
-            self.put(job.id, job.tool_id)
-        else:
-            log.warning(
-                "(%s) Handler '%s' received setup message but handler '%s' is already assigned, ignoring",
-                job.id,
-                self.app.config.server_name,
-                job.handler,
-            )
-
     def put(self, job_id, tool_id):
         """Add a job to the queue (by job identifier)"""
         if not self.track_jobs_in_database:


### PR DESCRIPTION
Ref #12541 

Solve same type of issue as in #15633. 

The edits in this PR address mostly the `autocommit=False` requirement (there will be more edits to the SA syntax in this module addressing other 2.0-compatibility requirements in subsequent PRs). When launching with `autocommit=False`, this removes 40 locks and gets a transaction unstuck.

Notes:
- Expunging is not needed: the session is empty
- enable_eagerloads(False) not needed (see note in #15643)
- I've done some refactoring and minor cleanup (a by-product of me trying to understand the code).
- I've added a `StopSignalException` as a means to handle the case when we need to return early when the queue returns the `STOP_SIGNAL`: the alternative was to propagate a true/false return to the calling method (which was [ugly and not intuitive](https://github.com/galaxyproject/galaxy/pull/15671/commits/369fdbca0222f80a0e3fda098242d552d6719052#diff-03ca1f9bbd851e03c327003008485960cd0c9b35fda6a76f7f0bf082afc1818fR1133)); or to leave the logic inlined in the original method, which resulted in ugly nesting with the addition of the new `with session...` nesting level. Not using the `with session` context manager would have required closing the session before the early return... In other words, the try/except approach made sense here; besides, the stop signal seems to qualify as a case requiring "special handling" (like StopIteration), so the try/except, I think, is justified.
- Not assigning a Session instance in the constructor is intentional: the constructor is called by the main thread, whereas the `__monitor` method of each class is called by different threads, which need to access their own Session - so we store a scoped session registry, not a Session instance.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
