### PR TITLE
[23.0] Temporarily restore old BCO export mechanism (without Celery)

### DIFF
--- a/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/BioComputeObjectExportCard.vue
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/BioComputeObjectExportCard.vue
@@ -1,0 +1,174 @@
+<!--
+    WARNING
+    This component is temporal and should be dropped once Celery is the default task system in Galaxy.
+    The plugin system should be used instead.
+-->
+<template>
+    <div>
+        <p>
+            A BioCompute Object (BCO) is the unofficial name for a JSON object that adheres to the
+            <a href="https://standards.ieee.org/ieee/2791/7337/">IEEE-2791-2020 standard</a>. A BCO is designed to
+            communicate High-throughput Sequencing (HTS) analysis results, data set creation, data curation, and
+            bioinformatics verification protocols.
+        </p>
+        <p>Learn more about <a href="https://biocomputeobject.org/" target="_blank">BioCompute Objects</a>.</p>
+        <p>
+            Instructions for
+            <a href="https://w3id.org/biocompute/tutorials/galaxy_quick_start" target="_blank"
+                >creating a BCO using Galaxy</a
+            >.
+        </p>
+        <b-tabs lazy>
+            <b-tab title="Download">
+                <a class="bco-json" style="padding-left: 1em" :href="bcoDownloadLink"><b>Download BCO</b></a>
+            </b-tab>
+            <b-tab title="Submit To BCODB">
+                <div>
+                    <p>
+                        To submit to a BCODB you need to already have an authenticated account. Instructions on
+                        submitting a BCO from Galaxy are available
+                        <a href="https://w3id.org/biocompute/tutorials/galaxy_quick_start/" target="_blank">here</a>.
+                    </p>
+                    <form @submit.prevent="submitForm">
+                        <div class="form-group">
+                            <label for="fetch">
+                                <input
+                                    id="fetch"
+                                    v-model="form.fetch"
+                                    type="text"
+                                    class="form-control"
+                                    placeholder="https://biocomputeobject.org"
+                                    autocomplete="off"
+                                    required />
+                                BCO DB URL (example: https://biocomputeobject.org)
+                            </label>
+                        </div>
+                        <div class="form-group">
+                            <label for="authorization">
+                                <input
+                                    id="authorization"
+                                    v-model="form.authorization"
+                                    type="password"
+                                    class="form-control"
+                                    autocomplete="off"
+                                    required />
+                                User API Key
+                            </label>
+                        </div>
+                        <div class="form-group">
+                            <label for="table">
+                                <input
+                                    id="table"
+                                    v-model="form.table"
+                                    type="text"
+                                    class="form-control"
+                                    placeholder="GALXY"
+                                    required />
+                                Prefix
+                            </label>
+                        </div>
+                        <div class="form-group">
+                            <label for="owner_group">
+                                <input
+                                    id="owner_group"
+                                    v-model="form.owner_group"
+                                    type="text"
+                                    class="form-control"
+                                    autocomplete="off"
+                                    required />
+                                User Name
+                            </label>
+                        </div>
+                        <div class="form-group">
+                            <button class="btn btn-primary">{{ "Submit" | localize }}</button>
+                        </div>
+                    </form>
+                </div>
+            </b-tab>
+        </b-tabs>
+    </div>
+</template>
+
+<script>
+import { getRootFromIndexLink } from "onload";
+import { getAppRoot } from "onload/loadConfig";
+import axios from "axios";
+const getUrl = (path) => getRootFromIndexLink() + path;
+export default {
+    props: {
+        invocationId: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            form: {
+                fetch: "",
+                authorization: "",
+                table: "",
+                owner_group: "",
+            },
+        };
+    },
+    computed: {
+        bcoDownloadLink: function () {
+            return `${getAppRoot()}api/invocations/${this.invocationId}/biocompute/download`;
+        },
+    },
+    methods: {
+        async submitForm() {
+            const bco = await axios
+                .get(getUrl(`./api/invocations/${this.invocationId}/biocompute/`))
+                .then((response) => {
+                    this.bco = response.data;
+                    return this.bco;
+                })
+                .catch((e) => {
+                    this.errors.push(e);
+                });
+            const bcoString = {
+                POST_api_objects_draft_create: [
+                    {
+                        contents: bco,
+                        owner_group: this.form.owner_group,
+                        schema: "IEEE",
+                        prefix: this.form.table,
+                    },
+                ],
+            };
+            const headers = {
+                Authorization: "Token " + this.form.authorization,
+                "Content-type": "application/json; charset=UTF-8",
+            };
+            const submitURL = this.form.fetch;
+            axios
+                .post(`${submitURL}/api/objects/drafts/create/`, bcoString, { headers: headers })
+                .then((response) => {
+                    if (response.status === 200) {
+                        console.log("response:", response);
+                        alert(response.data[0].message);
+                    }
+                    if (response.status === 207) {
+                        console.log("response:", response);
+                        alert(response.data[0].message);
+                    }
+                })
+                .catch(function (error) {
+                    console.log("Error", { ...error });
+                    if (error.response.status == 401) {
+                        alert(error.response.data.detail);
+                        console.log("Error response: ", error);
+                    } else {
+                        console.log("Error", error);
+                        alert("Error", error);
+                    }
+                });
+            this.form.owner_group = "";
+            this.form.authorization = "";
+            this.form.owner_group = "";
+            this.form.fetch = "";
+        },
+    },
+};
+</script>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationExportOptions.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationExportOptions.vue
@@ -1,8 +1,13 @@
 <script setup>
+import { BCard } from "bootstrap-vue";
 import InvocationExportPluginCard from "components/Workflow/Invocation/Export/InvocationExportPluginCard.vue";
+import BioComputeObjectExportCard from "components/Workflow/Invocation/Export/Plugins/BioComputeObject/BioComputeObjectExportCard.vue";
 import { AVAILABLE_INVOCATION_EXPORT_PLUGINS } from "components/Workflow/Invocation/Export/Plugins";
+import { useConfig } from "composables/config";
 
 const exportPlugins = AVAILABLE_INVOCATION_EXPORT_PLUGINS;
+
+const { config } = useConfig(true);
 
 defineProps({
     invocationId: {
@@ -13,9 +18,19 @@ defineProps({
 </script>
 
 <template>
-    <div>
+    <div v-if="config.enable_celery_tasks">
         <div v-for="(plugin, index) in exportPlugins" :key="index" class="mb-2">
             <invocation-export-plugin-card :export-plugin="plugin" :invocation-id="invocationId" />
         </div>
+    </div>
+    <div v-else>
+        <!--
+            WARNING
+            This is temporal fix and should be dropped once Celery is the default task system in Galaxy.
+            The task-based plugin system above should be used instead.
+        -->
+        <b-card title="BioCompute Object Export" class="export-plugin-card">
+            <bio-compute-object-export-card :invocation-id="invocationId" />
+        </b-card>
     </div>
 </template>

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -17,7 +17,7 @@
         <!-- <b-tab title="Workflow Overview">
             <p>TODO: Insert readonly version of workflow editor here</p>
         </b-tab> -->
-        <b-tab v-if="canExecuteTasks" title="Export">
+        <b-tab title="Export">
             <div v-if="invocationAndJobTerminal">
                 <workflow-invocation-export-options :invocation-id="invocation.id" />
             </div>
@@ -39,7 +39,6 @@ import WorkflowInvocationExportOptions from "./WorkflowInvocationExportOptions.v
 import JOB_STATES_MODEL from "utils/job-states-model";
 import mixin from "components/JobStates/mixin";
 import { mapGetters, mapActions } from "vuex";
-import { useConfig } from "composables/config";
 
 export default {
     components: {
@@ -59,13 +58,6 @@ export default {
             required: false,
             default: null,
         },
-    },
-    setup() {
-        const { config, isLoaded: isConfigLoaded } = useConfig();
-        return {
-            config,
-            isConfigLoaded,
-        };
     },
     data() {
         return {
@@ -101,9 +93,6 @@ export default {
         jobStatesSummary() {
             const jobsSummary = this.getInvocationJobsSummaryById(this.invocationId);
             return !jobsSummary ? null : new JOB_STATES_MODEL.JobStatesSummary(jobsSummary);
-        },
-        canExecuteTasks() {
-            return this.isConfigLoaded && this.config.enable_celery_tasks;
         },
     },
     created: function () {


### PR DESCRIPTION
Follow up on #15556 and partially addresses #15664 

This allows exporting invocations as BCO using the previous non-task-based approach instead of completely disabling the invocation export options in the UI when Celery is not enabled in the instance.

This change is meant to be temporal until Celery becomes the default task system in Galaxy.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Go to an invocation and select the Export tab
  2. You should see the old BCO export UI

![image](https://user-images.githubusercontent.com/46503462/222136658-d201f947-2c45-4c9b-a3a1-db438b4a2e1a.png)


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
