### PR TITLE
[22.05] Fix sentry in WSGI/ASGI context

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -181,21 +181,18 @@ class SentryClientMixin:
                 "CRITICAL",
             ], f"Invalid sentry event level '{self.config.sentry.event_level}'"
 
-            def postfork_sentry_client():
-                import sentry_sdk
-                from sentry_sdk.integrations.logging import LoggingIntegration
+            import sentry_sdk
+            from sentry_sdk.integrations.logging import LoggingIntegration
 
-                sentry_logging = LoggingIntegration(
-                    level=logging.INFO,  # Capture info and above as breadcrumbs
-                    event_level=getattr(logging, event_level),  # Send errors as events
-                )
-                self.sentry_client = sentry_sdk.init(
-                    self.config.sentry_dsn,
-                    release=f"{self.config.version_major}.{self.config.version_minor}",
-                    integrations=[sentry_logging],
-                )
-
-            self.application_stack.register_postfork_function(postfork_sentry_client)
+            sentry_logging = LoggingIntegration(
+                level=logging.INFO,  # Capture info and above as breadcrumbs
+                event_level=getattr(logging, event_level),  # Send errors as events
+            )
+            self.sentry_client = sentry_sdk.init(
+                self.config.sentry_dsn,
+                release=f"{self.config.version_major}.{self.config.version_minor}",
+                integrations=[sentry_logging],
+            )
 
 
 class ConfiguresGalaxyMixin:


### PR DESCRIPTION
We need to have initialised sentry before building the FastAPI app, and if we postpone until after forking that won't work.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
