### PR TITLE
Handle `response` validation errors

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -223,6 +223,16 @@ class DeprecatedMethod(MessageException):
     err_code = error_codes_by_name["DEPRECATED_API_CALL"]
 
 
+class UnprocessableContent(MessageException):
+    """
+    The server understands the content type of the request entity, and the syntax of
+    the request entity is correct, but it was unable to process the contained instructions.
+    """
+
+    status_code = 422
+    err_code = error_codes_by_name["UNPROCESSABLE_CONTENT"]
+
+
 class ConfigurationError(Exception):
     status_code = 500
     err_code = error_codes_by_name["CONFIG_ERROR"]

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -150,6 +150,11 @@
       "message": "This API method or call signature has been deprecated and is no longer available"
    },
    {
+      "name": "UNPROCESSABLE_CONTENT",
+      "code": 422001,
+      "message": "The server understands the content type of the request entity, and the syntax of the request entity is correct, but it was unable to process the contained instructions."
+   },
+   {
       "name": "INTERNAL_SERVER_ERROR",
       "code": 500001,
       "message": "Internal server error."

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -13,6 +13,7 @@ from galaxy.exceptions import (
     MessageException,
     RequestParameterInvalidException,
     RequestParameterMissingException,
+    UnprocessableContent,
 )
 from galaxy.util import (
     parse_non_hex_float,
@@ -394,7 +395,8 @@ def validation_error_to_message_exception(e: ValidationError, from_request: bool
             return RequestParameterMissingException(str(e), validation_errors=loads(e.json()))
         else:
             return RequestParameterInvalidException(str(e), validation_errors=loads(e.json()))
-    return MessageException(str(e), validation_errors=loads(e.json()))
+    # The validation of the response object failed
+    return UnprocessableContent(str(e), validation_errors=loads(e.json()))
 
 
 def api_error_message(trans, **kwds):

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -381,7 +381,7 @@ def format_return_as_json(rval, jsonp_callback=None, pretty=False):
     return json
 
 
-def validation_error_to_message_exception(e: ValidationError) -> MessageException:
+def validation_error_to_message_exception(e: ValidationError, from_request: bool = True) -> MessageException:
     invalid_found = False
     missing_found = False
     for error in e.errors():
@@ -389,10 +389,12 @@ def validation_error_to_message_exception(e: ValidationError) -> MessageExceptio
             missing_found = True
         elif error["type"].startswith("type_error"):
             invalid_found = True
-    if missing_found and not invalid_found:
-        return RequestParameterMissingException(str(e), validation_errors=loads(e.json()))
-    else:
-        return RequestParameterInvalidException(str(e), validation_errors=loads(e.json()))
+    if from_request:
+        if missing_found and not invalid_found:
+            return RequestParameterMissingException(str(e), validation_errors=loads(e.json()))
+        else:
+            return RequestParameterInvalidException(str(e), validation_errors=loads(e.json()))
+    return MessageException(str(e), validation_errors=loads(e.json()))
 
 
 def api_error_message(trans, **kwds):

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -11,6 +11,7 @@ from fastapi import (
 )
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from pydantic import ValidationError
 from starlette.responses import (
     FileResponse,
     Response,
@@ -171,9 +172,10 @@ def get_error_response_for_request(request: Request, exc: MessageException) -> J
 
 
 def add_exception_handler(app: FastAPI) -> None:
-    @app.exception_handler(RequestValidationError)
-    async def validate_exception_middleware(request: Request, exc: RequestValidationError) -> Response:
-        message_exception = validation_error_to_message_exception(exc)
+    @app.exception_handler(ValidationError)
+    async def validate_exception_middleware(request: Request, exc: ValidationError) -> Response:
+        from_request = isinstance(exc, RequestValidationError)
+        message_exception = validation_error_to_message_exception(exc, from_request)
         return get_error_response_for_request(request, message_exception)
 
     @app.exception_handler(MessageException)


### PR DESCRIPTION
Currently, we are handling `Request` validation errors, but since many API endpoints work with pydantic models sometimes the responses might be invalid too.

Right now these validation errors will end up in the client as Internal Server Errors. On the other hand, It didn't feel right to return a 400 (Bad Request) in those situations so I created a 422 ([Unprocessable Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422)) exception for those cases.

I'm still not 100% sure this is what we want, but it may be useful in cases such as https://github.com/galaxyproject/galaxy/issues/15664#issuecomment-1450247764

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
