### PR TITLE
[23.0] Fix stock tool URL generation in BCOs

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -105,7 +105,7 @@ from galaxy.util.path import (
 )
 from ._bco_convert_utils import (
     bco_workflow_version,
-    SoftwarePrerequisteTracker,
+    SoftwarePrerequisiteTracker,
 )
 from .ro_crate_utils import WorkflowRunCrateProfileBuilder
 from ..custom_types import json_encoder
@@ -2547,7 +2547,7 @@ class BcoModelExportStore(WorkflowInvocationOnlyExportStore):
 
         # metrics = {}  ... TODO
         pipeline_steps: List[PipelineStep] = []
-        software_prerequisite_tracker = SoftwarePrerequisteTracker()
+        software_prerequisite_tracker = SoftwarePrerequisiteTracker()
         input_subdomain_items: List[InputSubdomainItem] = []
         output_subdomain_items: List[OutputSubdomainItem] = []
         for step in workflow_invocation.steps:

--- a/lib/galaxy/model/store/_bco_convert_utils.py
+++ b/lib/galaxy/model/store/_bco_convert_utils.py
@@ -14,7 +14,7 @@ from galaxy.schema.bco import (
 )
 
 
-class SoftwarePrerequisteTracker:
+class SoftwarePrerequisiteTracker:
     _recorded_tools: Set[str] = set()
     _software_prerequisites: List[SoftwarePrerequisite] = []
 

--- a/lib/galaxy/model/store/_bco_convert_utils.py
+++ b/lib/galaxy/model/store/_bco_convert_utils.py
@@ -1,3 +1,4 @@
+import urllib.parse
 from typing import (
     List,
     Set,
@@ -31,7 +32,7 @@ class SoftwarePrerequisteTracker:
             # tool shed tool - give them a link...
             uri = f"https://{tool_id}"
         else:
-            uri = f"gxstocktools://{tool_id}"
+            uri = f"gxstocktools://galaxyproject.org/{urllib.parse.quote(tool_id)}"
 
         access_time = None  # used to be uuid - but Pydanic validation... rightfully... disallows this
         software_prerequisite = SoftwarePrerequisite(

--- a/lib/galaxy/model/store/_bco_convert_utils.py
+++ b/lib/galaxy/model/store/_bco_convert_utils.py
@@ -28,11 +28,12 @@ class SoftwarePrerequisiteTracker:
 
         tool_version = step.tool_version
         self._recorded_tools.add(tool_id)
+        uri_safe_tool_id = urllib.parse.quote(tool_id)
         if "repos/" in tool_id:
             # tool shed tool - give them a link...
-            uri = f"https://{tool_id}"
+            uri = f"https://{uri_safe_tool_id}"
         else:
-            uri = f"gxstocktools://galaxyproject.org/{urllib.parse.quote(tool_id)}"
+            uri = f"gxstocktools://galaxyproject.org/{uri_safe_tool_id}"
 
         access_time = None  # used to be uuid - but Pydanic validation... rightfully... disallows this
         software_prerequisite = SoftwarePrerequisite(

--- a/test/unit/data/test_bco_utils.py
+++ b/test/unit/data/test_bco_utils.py
@@ -118,11 +118,17 @@ def test_software_prerequiste_tracker():
     step_4.tool_id = "cat1"
     step_4.tool_version = "1.0.0"
 
+    step_5 = WorkflowStep()
+    step_5.type = "tool"
+    step_5.tool_id = "Tool ID With Spaces"
+    step_5.tool_version = "1.0.0"
+
     tracker.register_step(step_0)
     tracker.register_step(step_1)
     tracker.register_step(step_2)
     tracker.register_step(step_3)
     tracker.register_step(step_4)
+    tracker.register_step(step_5)
 
     sps = tracker.software_prerequisites
-    assert len(sps) == 3
+    assert len(sps) == 4

--- a/test/unit/data/test_bco_utils.py
+++ b/test/unit/data/test_bco_utils.py
@@ -2,7 +2,7 @@ import json
 
 from galaxy.model import WorkflowStep
 from galaxy.model.orm.now import now
-from galaxy.model.store._bco_convert_utils import SoftwarePrerequisteTracker
+from galaxy.model.store._bco_convert_utils import SoftwarePrerequisiteTracker
 from galaxy.schema.bco import (
     BioComputeObjectCore,
     ContributionEnum,
@@ -93,8 +93,8 @@ def test_bco_writing(tmp_path):
     assert final_bco_object["object_id"] == object_id
 
 
-def test_software_prerequiste_tracker():
-    tracker = SoftwarePrerequisteTracker()
+def test_software_prerequisite_tracker():
+    tracker = SoftwarePrerequisiteTracker()
     step_0 = WorkflowStep()
     step_0.tool_id = "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0"
     step_0.type = "tool"

--- a/test/unit/data/test_bco_utils.py
+++ b/test/unit/data/test_bco_utils.py
@@ -110,7 +110,7 @@ def test_software_prerequisite_tracker():
     step_3 = WorkflowStep()
     step_3.tool_id = "toolshed.g2.bx.psu.edu/repos/iuc/extract_genomic_dna/Extract genomic DNA 1/3.0.3+galaxy2"
     step_3.type = "tool"
-    step_3.tool_version = "0.1.1"
+    step_3.tool_version = "3.0.3+galaxy2"
 
     # subworkflow step
     step_4 = WorkflowStep()

--- a/test/unit/data/test_bco_utils.py
+++ b/test/unit/data/test_bco_utils.py
@@ -107,21 +107,25 @@ def test_software_prerequisite_tracker():
     step_2.tool_id = "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1"
     step_2.type = "tool"
     step_2.tool_version = "0.1.1"
+    step_3 = WorkflowStep()
+    step_3.tool_id = "toolshed.g2.bx.psu.edu/repos/iuc/extract_genomic_dna/Extract genomic DNA 1/3.0.3+galaxy2"
+    step_3.type = "tool"
+    step_3.tool_version = "0.1.1"
 
     # subworkflow step
-    step_3 = WorkflowStep()
-    step_3.type = "subworkflow"
+    step_4 = WorkflowStep()
+    step_4.type = "subworkflow"
 
     # stock tool
-    step_4 = WorkflowStep()
-    step_4.type = "tool"
-    step_4.tool_id = "cat1"
-    step_4.tool_version = "1.0.0"
-
     step_5 = WorkflowStep()
     step_5.type = "tool"
-    step_5.tool_id = "Tool ID With Spaces"
+    step_5.tool_id = "cat1"
     step_5.tool_version = "1.0.0"
+
+    step_6 = WorkflowStep()
+    step_6.type = "tool"
+    step_6.tool_id = "Tool ID With Spaces"
+    step_6.tool_version = "1.0.0"
 
     tracker.register_step(step_0)
     tracker.register_step(step_1)
@@ -129,6 +133,7 @@ def test_software_prerequisite_tracker():
     tracker.register_step(step_3)
     tracker.register_step(step_4)
     tracker.register_step(step_5)
+    tracker.register_step(step_6)
 
     sps = tracker.software_prerequisites
-    assert len(sps) == 4
+    assert len(sps) == 5


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15664#issuecomment-1450247764

Some Galaxy Stock Tools can have "non-url-friendly" IDs like `Show beginning1` (even if it is not recommended) making the URL validation fail for `SoftwarePrerequisite`s.

https://github.com/davelopez/galaxy/blob/f1440723e47ec5df1fb6fed2c20672ef9b4a8e78/tools/filters/headWrapper.xml#L1

Since this kind of URL is "fake" anyway, I added a host (galaxyproject.org) and quoted the ID to avoid invalid characters on it.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
