### PR TITLE
[23.0] Fix run_form=true if trs_url is used

### DIFF
--- a/client/src/components/Workflow/Import/TrsImport.vue
+++ b/client/src/components/Workflow/Import/TrsImport.vue
@@ -41,7 +41,9 @@ const trsSelection: Ref<TrsSelection | null> = ref(null);
 const errorMessage: Ref<string | null> = ref(null);
 const toolId = ref(props.queryTrsId);
 const isAnonymous: Ref<boolean> = getGalaxyInstance().user?.isAnonymous();
-const isAutoImport = ref(Boolean(props.queryTrsVersionId && props.queryTrsServer && props.queryTrsId));
+const isAutoImport = ref(
+    Boolean((props.queryTrsVersionId && props.queryTrsServer && props.queryTrsId) || props.queryTrsUrl)
+);
 
 const toolIdTrimmed = computed(() => {
     return toolId.value?.trim() || null;
@@ -186,7 +188,9 @@ async function importVersionFromUrl(url: string, isRunFormRedirect = false) {
             </div>
             <hr />
             <div>
-                <TrsUrlImport :query-trs-url="props.queryTrsUrl" @onImport="(url) => importVersionFromUrl(url)" />
+                <TrsUrlImport
+                    :query-trs-url="props.queryTrsUrl"
+                    @onImport="(url) => importVersionFromUrl(url, isRun)" />
             </div>
         </b-card>
         <b-alert v-else class="text-center my-2" show variant="danger">


### PR DESCRIPTION
You can try this with a URL like http://localhost:8080/workflows/trs_import?run_form=true&trs_version=1&trs_url=https%3A%2F%2Ftraining.galaxyproject.org%2Ftraining-material%2Fapi%2Fga4gh%2Ftrs%2Fv2%2Ftools%2Fintroduction-galaxy-intro-short%2Fversions%2Fgalaxy-workflowlaxy-intro-short

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
