### PR TITLE
Use chevrons instead of eye for showing expandable/collapsible sections

### DIFF
--- a/client/src/components/Form/FormCard.vue
+++ b/client/src/components/Form/FormCard.vue
@@ -10,8 +10,8 @@
                     variant="link"
                     size="sm"
                     class="float-right">
-                    <font-awesome-icon v-if="expanded" icon="eye-slash" class="fa-fw" />
-                    <font-awesome-icon v-else icon="eye" class="fa-fw" />
+                    <font-awesome-icon v-if="expanded" icon="chevron-up" class="fa-fw" />
+                    <font-awesome-icon v-else icon="chevron-down" class="fa-fw" />
                 </span>
             </div>
             <span class="portlet-title">
@@ -28,10 +28,10 @@
 <script>
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+import { faChevronUp, faChevronDown } from "@fortawesome/free-solid-svg-icons";
 
-library.add(faEye);
-library.add(faEyeSlash);
+library.add(faChevronUp);
+library.add(faChevronDown);
 
 export default {
     components: {


### PR DESCRIPTION
Followup from https://github.com/galaxyproject/galaxy/pull/15661.  

Debating link-styling the title text still, and I welcome any opinions.  It used to be prior to #15661, but I think I slightly prefer without additional highlighting since the whole bar is now clickable and has an appropriate pointer.

current:
![image](https://user-images.githubusercontent.com/155398/222477305-ddb60a84-980e-4d9d-9722-cb3344b7b40b.png)

proposed:
![image](https://user-images.githubusercontent.com/155398/222477124-d73d0063-f11d-42e3-b4ac-fe0884e3d6da.png)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
