### PR TITLE
Fix masthead element padding and improve brand text contrast

### DIFF
--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -95,14 +95,14 @@ onMounted(() => {
         <b-navbar-nav>
             <b-navbar-brand
                 v-b-tooltip.hover
-                class="ml-2 mr-1"
+                class="ml-2 mr-2"
                 title="Home"
                 aria-label="homepage"
                 :href="withPrefix(logoUrl)">
                 <img alt="logo" :src="withPrefix(logoSrc)" />
                 <img v-if="logoSrcSecondary" alt="logo" :src="withPrefix(logoSrcSecondary)" />
             </b-navbar-brand>
-            <span v-if="brand" class="navbar-text">
+            <span v-if="brand" class="navbar-text px-2">
                 {{ brand }}
             </span>
         </b-navbar-nav>
@@ -187,12 +187,14 @@ onMounted(() => {
     .navbar-brand {
         cursor: pointer;
         img {
+            filter: drop-shadow(0 0 0.3rem $masthead-color);
             display: inline;
             border: none;
             height: 2.3rem;
         }
     }
     .navbar-text {
+        filter: drop-shadow(0 0 0.3rem $masthead-color);
         font-weight: bold;
         font-family: Verdana, sans-serif;
         font-size: 1rem;

--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -187,14 +187,14 @@ onMounted(() => {
     .navbar-brand {
         cursor: pointer;
         img {
-            filter: drop-shadow(0 0 0.3rem $masthead-color);
+            filter: $text-shadow;
             display: inline;
             border: none;
             height: 2.3rem;
         }
     }
     .navbar-text {
-        filter: drop-shadow(0 0 0.3rem $masthead-color);
+        filter: $text-shadow;
         font-weight: bold;
         font-family: Verdana, sans-serif;
         font-size: 1rem;

--- a/client/src/components/Masthead/QuotaMeter.test.js
+++ b/client/src/components/Masthead/QuotaMeter.test.js
@@ -97,8 +97,8 @@ describe("QuotaMeter.vue", () => {
             const store = createStore(user, config);
             const wrapper = mount(QuotaMeter, { localVue, store });
 
-            expect(wrapper.find(".quota-meter > a").text()).toBe("Using 7 KB");
-            expect(wrapper.find(".quota-meter > a").attributes("title")).not.toContain("7 KB");
+            expect(wrapper.find(".quota-text > a").text()).toBe("Using 7 KB");
+            expect(wrapper.find(".quota-text > a").attributes("title")).not.toContain("7 KB");
         }
 
         {
@@ -111,8 +111,8 @@ describe("QuotaMeter.vue", () => {
             const store = createStore(user, config);
             const wrapper = mount(QuotaMeter, { localVue, store });
 
-            expect(wrapper.find(".quota-meter > a").text()).toBe("Using 21 KB");
-            expect(wrapper.find(".quota-meter > a").attributes("title")).not.toContain("21 KB");
+            expect(wrapper.find(".quota-text > a").text()).toBe("Using 21 KB");
+            expect(wrapper.find(".quota-text > a").attributes("title")).not.toContain("21 KB");
         }
     });
 });

--- a/client/src/components/Masthead/QuotaMeter.vue
+++ b/client/src/components/Masthead/QuotaMeter.vue
@@ -1,10 +1,12 @@
 <template>
     <current-user>
-        <div class="quota-meter d-flex align-items-center">
-            <b-link v-if="!hasQuota" v-b-tooltip.hover.left to="/storage" class="ml-auto quota-text" :title="title">
+        <div v-if="!hasQuota" class="quota-text d-flex align-items-center">
+            <b-link v-b-tooltip.hover.left to="/storage" class="ml-auto" :title="title">
                 {{ usingString + " " + totalUsageString }}
             </b-link>
-            <b-link v-else v-b-tooltip.hover.left class="quota-progress" to="/storage" :title="title">
+        </div>
+        <div v-else class="quota-meter d-flex align-items-center">
+            <b-link v-b-tooltip.hover.left class="quota-progress" to="/storage" :title="title">
                 <b-progress :max="100">
                     <b-progress-bar aria-label="Quota usage" :value="usage" :variant="variant" />
                 </b-progress>
@@ -77,13 +79,23 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.quota-meter {
-    background: var(--masthead-link-color);
+.quote-container {
     position: relative;
     height: 100%;
     margin-right: 0.5rem;
     padding-right: 0.5rem;
     padding-left: 0.5rem;
+}
+.quota-text {
+    @extend .quote-container;
+    background: var(--masthead-link-color);
+    a {
+        color: var(--masthead-text-color);
+        text-decoration: none;
+    }
+}
+.quota-meter {
+    @extend .quote-container;
     .quota-progress {
         width: 100px;
         height: 16px;
@@ -98,10 +110,6 @@ export default {
             line-height: 1em;
             pointer-events: none;
         }
-    }
-    .quota-text {
-        color: var(--masthead-text-color);
-        text-decoration: none;
     }
     :deep(a) {
         &:focus-visible {

--- a/client/src/components/Masthead/QuotaMeter.vue
+++ b/client/src/components/Masthead/QuotaMeter.vue
@@ -98,7 +98,7 @@ export default {
     @extend .quote-container;
     .quota-progress {
         width: 100px;
-        height: 16px;
+        height: 1.4em;
         position: relative;
         & > * {
             position: absolute;
@@ -107,7 +107,7 @@ export default {
             text-align: center;
         }
         & > span {
-            line-height: 1em;
+            line-height: 1.4em;
             pointer-events: none;
         }
     }

--- a/client/src/components/Masthead/QuotaMeter.vue
+++ b/client/src/components/Masthead/QuotaMeter.vue
@@ -85,7 +85,7 @@ export default {
     padding-right: 0.5rem;
     padding-left: 0.5rem;
     .quota-progress {
-        width: 100%;
+        width: 100px;
         height: 16px;
         position: relative;
         & > * {

--- a/client/src/components/Masthead/QuotaMeter.vue
+++ b/client/src/components/Masthead/QuotaMeter.vue
@@ -83,12 +83,12 @@ export default {
     position: relative;
     height: 100%;
     margin-right: 0.5rem;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
 }
 .quota-text {
     @extend .quote-container;
     background: var(--masthead-link-color);
+    padding-right: 0.5rem;
+    padding-left: 0.5rem;
     a {
         color: var(--masthead-text-color);
         text-decoration: none;

--- a/client/src/components/Masthead/QuotaMeter.vue
+++ b/client/src/components/Masthead/QuotaMeter.vue
@@ -78,34 +78,31 @@ export default {
 
 <style lang="scss" scoped>
 .quota-meter {
+    background: var(--masthead-link-color);
     position: relative;
-    right: 0.8rem;
-    width: 100px;
     height: 100%;
-
+    margin-right: 0.5rem;
+    padding-right: 0.5rem;
+    padding-left: 0.5rem;
     .quota-progress {
         width: 100%;
         height: 16px;
         position: relative;
-
         & > * {
             position: absolute;
             width: 100%;
             height: 100%;
             text-align: center;
         }
-
         & > span {
             line-height: 1em;
             pointer-events: none;
         }
     }
-
     .quota-text {
         color: var(--masthead-text-color);
         text-decoration: none;
     }
-
     :deep(a) {
         &:focus-visible {
             outline: 2px solid var(--masthead-text-hover);

--- a/client/src/components/User/ThemeSelector.vue
+++ b/client/src/components/User/ThemeSelector.vue
@@ -80,6 +80,7 @@ watch(
     background: var(--masthead-link-active);
 }
 img {
+    filter: drop-shadow(0 0 0.3rem $masthead-color);
     cursor: pointer;
     display: inline;
     border: none;

--- a/client/src/components/User/ThemeSelector.vue
+++ b/client/src/components/User/ThemeSelector.vue
@@ -80,7 +80,7 @@ watch(
     background: var(--masthead-link-active);
 }
 img {
-    filter: drop-shadow(0 0 0.3rem $masthead-color);
+    filter: $text-shadow;
     cursor: pointer;
     display: inline;
     border: none;

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -22,6 +22,7 @@ $masthead-link-active: darken($masthead-color, 10%);
 $text-color: $brand-dark;
 $text-muted: lighten($text-color, 10%);
 $text-light: lighten($text-color, 20%);
+$text-shadow: drop-shadow(0 0 0.2rem $brand-dark);
 
 // Light grays for backgrounds
 $white: lighten($brand-light, 15%); // body background


### PR DESCRIPTION
This PR fixes issues related to the alignment and brand text contrast in the masthead. A shadow is added to the brand text to contrast better with varying masthead background colors and proper padding is added, particularly for the quota meter component.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
