### PR TITLE
[23.0] Use more efficient model properties when serializing histories

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -539,8 +539,6 @@ class HistorySerializer(sharable.SharableModelSerializer, deletable.PurgableSeri
             "contents_url": lambda item, key, **context: self.url_for(
                 "history_contents", history_id=self.app.security.encode_id(item.id), context=context
             ),
-            "empty": lambda item, key, **context: (len(item.datasets) + len(item.dataset_collections)) <= 0,
-            "count": lambda item, key, **context: len(item.datasets),
             "hdas": lambda item, key, **context: [self.app.security.encode_id(hda.id) for hda in item.datasets],
             "state_details": self.serialize_state_counts,
             "state_ids": self.serialize_state_ids,

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -815,7 +815,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
             prev_galaxy_session
             and prev_galaxy_session.current_history
             and not prev_galaxy_session.current_history.deleted
-            and prev_galaxy_session.current_history.datasets
+            and not prev_galaxy_session.current_history.empty
             and (prev_galaxy_session.current_history.user is None or prev_galaxy_session.current_history.user == user)
         ):
             # If the previous galaxy session had a history, associate it with the new session, but only if it didn't
@@ -959,7 +959,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         )
         default_history = None
         for history in unnamed_histories:
-            if len(history.datasets) == 0:
+            if history.empty:
                 # Found suitable default history.
                 default_history = history
                 break


### PR DESCRIPTION
The model decorators are based on the hid_counter column, and don't require loading up all datasets into python land just to count them.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
