### PR TITLE
Tweaks to new object store and quota APIs

### DIFF
--- a/client/src/components/ObjectStore/ShowSelectedObjectStore.test.js
+++ b/client/src/components/ObjectStore/ShowSelectedObjectStore.test.js
@@ -25,7 +25,7 @@ describe("ShowSelectedObjectStore", () => {
     });
 
     it("should show a loading message and then a DescribeObjectStore component", async () => {
-        axiosMock.onGet(`/api/object_store/${TEST_OBJECT_ID}`).reply(200, OBJECT_STORE_DATA);
+        axiosMock.onGet(`/api/object_stores/${TEST_OBJECT_ID}`).reply(200, OBJECT_STORE_DATA);
         wrapper = mount(ShowSelectedObjectStore, {
             propsData: { preferredObjectStoreId: TEST_OBJECT_ID, forWhat: "Data goes into..." },
             localVue,

--- a/client/src/components/ObjectStore/services.ts
+++ b/client/src/components/ObjectStore/services.ts
@@ -1,6 +1,6 @@
 import { fetcher } from "@/schema/fetcher";
 
-const getObjectStores = fetcher.path("/api/object_store").method("get").create();
+const getObjectStores = fetcher.path("/api/object_stores").method("get").create();
 
 export async function getSelectableObjectStores() {
     const { data } = await getObjectStores({ selectable: true });

--- a/client/src/components/providers/ObjectStoreProvider.js
+++ b/client/src/components/providers/ObjectStoreProvider.js
@@ -4,7 +4,7 @@ import { SingleQueryProvider } from "components/providers/SingleQueryProvider";
 import { rethrowSimple } from "utils/simple-error";
 
 async function objectStoreDetails({ id }) {
-    const url = `${getAppRoot()}api/object_store/${id}`;
+    const url = `${getAppRoot()}api/object_stores/${id}`;
     try {
         const { data } = await axios.get(url);
         return data;

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -889,13 +889,13 @@ export interface paths {
          */
         post: operations["create_api_metrics_post"];
     };
-    "/api/object_store": {
+    "/api/object_stores": {
         /** Get a list of (currently only concrete) object stores configured with this Galaxy instance. */
-        get: operations["index_api_object_store_get"];
+        get: operations["index_api_object_stores_get"];
     };
-    "/api/object_store/{object_store_id}": {
+    "/api/object_stores/{object_store_id}": {
         /** Get information about a concrete object store configured with Galaxy. */
-        get: operations["show_info_api_object_store__object_store_id__get"];
+        get: operations["show_info_api_object_stores__object_store_id__get"];
     };
     "/api/pages": {
         /**
@@ -12483,7 +12483,7 @@ export interface operations {
             };
         };
     };
-    index_api_object_store_get: {
+    index_api_object_stores_get: {
         /** Get a list of (currently only concrete) object stores configured with this Galaxy instance. */
         parameters?: {
             /** @description Restrict index query to user selectable object stores, the current implementation requires this to be true. */
@@ -12510,7 +12510,7 @@ export interface operations {
             };
         };
     };
-    show_info_api_object_store__object_store_id__get: {
+    show_info_api_object_stores__object_store_id__get: {
         /** Get information about a concrete object store configured with Galaxy. */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -14027,9 +14027,9 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
-            /** @description The ID of the user to get or __current__. */
+            /** @description The ID of the user to get or 'current'. */
             path: {
-                user_id: string;
+                user_id: string | "current";
             };
         };
         responses: {
@@ -14054,10 +14054,10 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
-            /** @description The ID of the user to get or __current__. */
+            /** @description The ID of the user to get or 'current'. */
             /** @description The label corresponding to the quota source to fetch usage information about. */
             path: {
-                user_id: string;
+                user_id: string | "current";
                 label: string;
             };
         };

--- a/lib/galaxy/webapps/galaxy/api/object_store.py
+++ b/lib/galaxy/webapps/galaxy/api/object_store.py
@@ -44,7 +44,7 @@ class FastAPIObjectStore:
     object_store: BaseObjectStore = depends(BaseObjectStore)
 
     @router.get(
-        "/api/object_store",
+        "/api/object_stores",
         summary="Get a list of (currently only concrete) object stores configured with this Galaxy instance.",
         response_description="A list of the configured object stores.",
     )
@@ -61,7 +61,7 @@ class FastAPIObjectStore:
         return [self._model_for(selectable_id) for selectable_id in selectable_ids]
 
     @router.get(
-        "/api/object_store/{object_store_id}",
+        "/api/object_stores/{object_store_id}",
         summary="Get information about a concrete object store configured with Galaxy.",
     )
     def show_info(

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1375,6 +1375,17 @@ class BaseDatasetPopulator(BasePopulator):
             timeout=timeout,
         )
 
+    def selectable_object_stores(self) -> List[Dict[str, Any]]:
+        selectable_object_stores_response = self._get("object_stores?selectable=true")
+        selectable_object_stores_response.raise_for_status()
+        selectable_object_stores = selectable_object_stores_response.json()
+        return selectable_object_stores
+
+    def selectable_object_store_ids(self) -> List[str]:
+        selectable_object_stores = self.selectable_object_stores()
+        selectable_object_store_ids = [s["object_store_id"] for s in selectable_object_stores]
+        return selectable_object_store_ids
+
     def new_page(
         self, slug: str = "mypage", title: str = "MY PAGE", content_format: str = "html", content: Optional[str] = None
     ) -> Dict[str, Any]:

--- a/test/integration/objectstore/test_selection_with_user_preferred_object_store.py
+++ b/test/integration/objectstore/test_selection_with_user_preferred_object_store.py
@@ -174,10 +174,7 @@ class TestObjectStoreSelectionWithPreferredObjectStoresIntegration(BaseObjectSto
         assert response.status_code == 400
 
     def test_index_query(self):
-        selectable_object_stores_response = self._get("object_store?selectable=true")
-        selectable_object_stores_response.raise_for_status()
-        selectable_object_stores = selectable_object_stores_response.json()
-        selectable_object_store_ids = [s["object_store_id"] for s in selectable_object_stores]
+        selectable_object_store_ids = self.dataset_populator.selectable_object_store_ids()
         assert "default" in selectable_object_store_ids
         assert "static" in selectable_object_store_ids
         assert "dynamic_s3" not in selectable_object_store_ids


### PR DESCRIPTION
Based on @mvdbeek's review of #15388.

Switches ``api/object_store`` to ``api/object_stores``. I get the request and made the change but I think I was originally thinking of it as "give me the parts of the root the object store" - so I think the old API endpoint made sense but this new one is fine also and is more consistent with how we're using the API in practice in the client.

This also improves on the typing of user path parameter in the quota endpoints as requested.

xref https://github.com/galaxyproject/galaxy/issues/15692


## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
