### PR TITLE
[23.0] Add galaxy prefix to shapefile path

### DIFF
--- a/config/plugins/visualizations/openlayers/src/script.js
+++ b/config/plugins/visualizations/openlayers/src/script.js
@@ -215,7 +215,7 @@ var MapViewer = (function(mv) {
             const sourceVec = new Vector({ format: formatType, url: filePath, wrapX: false });
             mv.createMap(filePath, sourceVec, options, chart, styleFunction, target);
         } else if (fileType === "shp") {
-            const fileUrl = prefixedDownloadUrl(options.root, filePath)
+            const fileUrl = prefixedDownloadUrl(options.root, filePath);
             axios.get(fileUrl, { responseType: "arraybuffer" }).then(shpfile => {
                 console.debug(shpfile);
                 shp(shpfile.data).then(

--- a/config/plugins/visualizations/openlayers/src/script.js
+++ b/config/plugins/visualizations/openlayers/src/script.js
@@ -215,7 +215,8 @@ var MapViewer = (function(mv) {
             const sourceVec = new Vector({ format: formatType, url: filePath, wrapX: false });
             mv.createMap(filePath, sourceVec, options, chart, styleFunction, target);
         } else if (fileType === "shp") {
-            axios.get(filePath, { responseType: "arraybuffer" }).then(shpfile => {
+            const fileUrl = prefixedDownloadUrl(options.root, filePath)
+            axios.get(fileUrl, { responseType: "arraybuffer" }).then(shpfile => {
                 console.debug(shpfile);
                 shp(shpfile.data).then(
                     geojson => {


### PR DESCRIPTION
We have already fixed the download URLs in relevant visualisation plugins in PR #15064 with relevant issue in #15047. Seems like we missed adding galaxy prefix for the shape file path in the OpenLayers visualisation plugin and this PR fixes it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
