### PR TITLE
[23.0] Fix task-based export error handling

### DIFF
--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -29,7 +29,7 @@ const props = defineProps({
     },
 });
 
-const POLLING_DELAY = 10000;
+const POLLING_DELAY = 3000;
 
 const exportParams = reactive(DEFAULT_EXPORT_PARAMS);
 const isLoadingRecords = ref(true);

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -29,6 +29,8 @@ const props = defineProps({
     },
 });
 
+const POLLING_DELAY = 10000;
+
 const exportParams = reactive(DEFAULT_EXPORT_PARAMS);
 const isLoadingRecords = ref(true);
 const exportRecords = ref(null);
@@ -66,7 +68,7 @@ async function updateExports() {
             !taskMonitorRequestFailed.value &&
             !taskHasFailed.value;
         if (shouldWaitForTask) {
-            waitForTask(latestExportRecord.value.taskUUID, 3000);
+            waitForTask(latestExportRecord.value.taskUUID, POLLING_DELAY);
         }
         if (taskMonitorRequestFailed.value) {
             errorMessage.value = "Something went wrong trying to get the export progress. Please check back later.";
@@ -92,7 +94,7 @@ async function prepareDownload() {
         downloadObjectByRequestId(upToDateDownloadRecord.stsDownloadId);
         return;
     }
-    await downloadHistory(props.historyId, { pollDelayInMs: 3000, exportParams: exportParams });
+    await downloadHistory(props.historyId, { pollDelayInMs: POLLING_DELAY, exportParams: exportParams });
     updateExports();
 }
 

--- a/client/src/composables/taskMonitor.js
+++ b/client/src/composables/taskMonitor.js
@@ -4,7 +4,7 @@ import axios from "axios";
 const SUCCESS_STATE = "SUCCESS";
 const FAILURE_STATE = "FAILURE";
 const TASK_READY_STATES = [SUCCESS_STATE, FAILURE_STATE];
-const DEFAULT_POLL_DELAY = 1000;
+const DEFAULT_POLL_DELAY = 10000;
 
 /**
  * Composable for waiting on Galaxy background tasks.

--- a/client/src/composables/taskMonitor.js
+++ b/client/src/composables/taskMonitor.js
@@ -55,6 +55,7 @@ export function useTaskMonitor() {
         status.value = err;
         requestHasFailed.value = true;
         isRunning.value = false;
+        resetTimeout();
     }
 
     function resetTimeout() {


### PR DESCRIPTION
When a user tries to export a history using the task-based export system and there is an error in the backend while processing the task, instead of stopping the task status polling, the status check was immediately retriggered causing a large number of requests...

This fixes the issue by immediately stopping the status check if the task or (task request) failed. In addition, the polling delay has been increased from 3 to 10 seconds while checking for the task status.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Set `enable_celery_tasks: true` in your galaxy.yml config file.
  - Under `celery_conf`, disable or comment out the `result_backend` setting in the config file.
  - Try to export a History from http://127.0.0.1:8080/histories/{history_id}/export
  - You should see an error instead of an "in progress" message and no further requests are made to check the status of the exporting task.
  

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
