### PR TITLE
Add selenium test for history Related filter

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -54,7 +54,7 @@
                 </b-button>
                 <b-button
                     v-if="showHighlight"
-                    class="px-1"
+                    class="highlight-btn px-1"
                     title="Show Inputs for this item"
                     size="sm"
                     variant="link"

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -200,6 +200,7 @@ history_panel:
       # Action buttons...
       download_button: '${_} .download-btn'
       info_button: '${_} .params-btn'
+      highlight_button: '${_} .highlight-btn'
       alltags: '${_} .stateless-tags .tag'
       metadata_file_download: '${_} [data-description="download ${metadata_name}"]'
 

--- a/lib/galaxy_test/selenium/test_history_related_filter.py
+++ b/lib/galaxy_test/selenium/test_history_related_filter.py
@@ -36,5 +36,4 @@ class TestHistoryRelatedFilter(SeleniumTestCase):
         assert initial_value == f"related:{CURRENT_HID}", initial_value
         self.history_element("clear filters").wait_for_and_click()
         filter_element.send_keys(f"related:{UNRELATED_HID}")
-        self.sleep_for(self.wait_types.UX_TRANSITION)
-        current_hda.assert_absent_or_hidden()
+        current_hda.wait_for_absent()

--- a/lib/galaxy_test/selenium/test_history_related_filter.py
+++ b/lib/galaxy_test/selenium/test_history_related_filter.py
@@ -36,4 +36,5 @@ class TestHistoryRelatedFilter(SeleniumTestCase):
         assert initial_value == f"related:{CURRENT_HID}", initial_value
         self.history_element("clear filters").wait_for_and_click()
         filter_element.send_keys(f"related:{UNRELATED_HID}")
+        self.sleep_for(self.wait_types.UX_TRANSITION)
         current_hda.assert_absent_or_hidden()

--- a/lib/galaxy_test/selenium/test_history_related_filter.py
+++ b/lib/galaxy_test/selenium/test_history_related_filter.py
@@ -1,0 +1,39 @@
+from .framework import (
+    selenium_test,
+    SeleniumTestCase,
+)
+
+PASTED_CONTENT = "this is pasted"
+CURRENT_HID = 1
+RELATED_HID = 2
+UNRELATED_HID = 3
+
+
+class TestHistoryRelatedFilter(SeleniumTestCase):
+    @selenium_test
+    def test_history_related_filter(self):
+        self.register()
+        # upload (current) dataset to get related item for
+        self.perform_upload_of_pasted_content(PASTED_CONTENT)
+        self.history_panel_wait_for_hid_ok(CURRENT_HID)
+        # create related item through a tool
+        self.tool_open("cat")
+        self.tool_form_execute()
+        self.history_panel_wait_for_hid_ok(RELATED_HID)
+        # create an item unrelated to other items
+        self.perform_upload_of_pasted_content(PASTED_CONTENT)
+        self.history_panel_wait_for_hid_ok(UNRELATED_HID)
+
+        # test related filter on current item using button: only current and related items show
+        current_hda = self.history_panel_click_item_title(CURRENT_HID, wait=True)
+        current_hda.highlight_button.wait_for_and_click()
+        unrelated_hda = self.history_panel_item_component(hid=UNRELATED_HID)
+        unrelated_hda.assert_absent_or_hidden()
+
+        # test related filter on unrelated item using filterText: only unrelated item shows
+        filter_element = self.history_element("filter text input").wait_for_and_click()
+        initial_value = filter_element.get_attribute("value")
+        assert initial_value == f"related:{CURRENT_HID}", initial_value
+        self.history_element("clear filters").wait_for_and_click()
+        filter_element.send_keys(f"related:{UNRELATED_HID}")
+        current_hda.assert_absent_or_hidden()


### PR DESCRIPTION
Added a selenium test for related filter added in https://github.com/galaxyproject/galaxy/pull/15210

Failed tests seem unrelated:
`ERROR  - ImportError: cannot import name 'Exchange' from 'kombu' (/tmp/gxpkgtestenv6iXrqW/lib/python3.7/site-packages/kombu/__init__.py)`
`test_galaxy_packages: exit 1 (526.61 seconds) /home/runner/work/galaxy/galaxy/galaxy root> bash packages/test.sh pid=3849`

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
