### PR TITLE
[23.0] Fix library bulk selection

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/services.js
+++ b/client/src/components/Libraries/LibraryFolder/services.js
@@ -31,14 +31,21 @@ export class Services {
     }
 
     async getFilteredFolderContents(id, excluded, searchText) {
-        const contents = await axios.get(`${this.root}api/folders/${id}/contents?${this.getSearchQuery(searchText)}`);
+        // The intent of this method is to get folder contents applying
+        // seachText filters only; we explicitly set limit to 0
+        const config = {
+            params: {
+                limit: 0,
+            },
+        };
+        searchText = searchText?.trim();
+        if (searchText) {
+            config.params.search_text = searchText;
+        }
+        const contents = await axios.get(`${this.root}api/folders/${id}/contents`, config);
         return contents.data.folder_contents.filter((item) => {
             return !excluded.some((exc) => exc.id === item.id);
         });
-    }
-
-    getSearchQuery(searchText) {
-        return searchText ? `&search_text=${encodeURI(searchText.trim())}` : "";
     }
 
     updateFolder(item, onSucess, onError) {

--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -404,7 +404,7 @@ class FolderManager:
             sub_folders_query = sub_folders_query.order_by(sort_column.desc() if payload.sort_desc else sort_column)
         else:  # Sort by name alphabetically by default
             sub_folders_query = sub_folders_query.order_by(model.LibraryFolder.name)
-        if limit is not None:
+        if limit is not None and limit > 0:
             sub_folders_query = sub_folders_query.limit(limit)
         if offset is not None:
             sub_folders_query = sub_folders_query.offset(offset)
@@ -414,7 +414,7 @@ class FolderManager:
         # Update pagination
         num_folders_returned = len(folders)
         num_folders_skipped = total_sub_folders - num_folders_returned
-        if limit:
+        if limit is not None and limit > 0:
             limit -= num_folders_returned
         if offset:
             offset -= num_folders_skipped
@@ -422,7 +422,7 @@ class FolderManager:
 
         datasets_query = self._get_contained_datasets_query(sa_session, folder, security_params, payload)
         total_datasets = datasets_query.count()
-        if limit is not None:
+        if limit is not None and limit > 0:
             datasets_query = datasets_query.limit(limit)
         if offset is not None:
             datasets_query = datasets_query.offset(offset)


### PR DESCRIPTION
Fix library filter select. The intent here was for the filter select to
extend beyond the paginated view while still supporting explicit
deselection.

Without this, select all uses the default limit of 10 items (regardless
of active page size) making the select all filter selection inaccurate
and actually worse than the explicit one.

There's probably a better way to have a standard 'coerce an explicit
None' in fastapi, suggestions welcome.

(this set of components needs a rework and some tests)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
