### PR TITLE
[23.0] Fix Short Term Storage cleanup when metadata is lost

### DIFF
--- a/lib/galaxy/web/short_term_storage/__init__.py
+++ b/lib/galaxy/web/short_term_storage/__init__.py
@@ -285,7 +285,7 @@ class ShortTermStorageManager(ShortTermStorageAllocator, ShortTermStorageMonitor
             self._delete(request_id)
 
     def _delete(self, request_id: UUID):
-        shutil.rmtree(self._directory(request_id))
+        shutil.rmtree(self._directory(request_id), ignore_errors=True)
 
     def cleanup(self):
         for directory in self._root.glob("*/*/*/*"):


### PR DESCRIPTION
Fixes #15722

If the metadata file is lost for some reason, the STS request directory will be deleted. If this is too much, we can just skip the deletion and log a warning, but since these files are temporal by design maybe is good enough just to remove them.

This situation is unlikely to happen unless there is an error writing the metadata file or some files/directories were manually removed.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
