### PR TITLE
Use Animation Frame in Workflow Editor

### DIFF
--- a/client/src/components/Workflow/Editor/DraggablePan.vue
+++ b/client/src/components/Workflow/Editor/DraggablePan.vue
@@ -13,6 +13,7 @@
 
 <script>
 import Draggable from "./Draggable.vue";
+import { useAnimationFrameThrottle } from "@/composables/throttle";
 
 export default {
     components: {
@@ -42,6 +43,10 @@ export default {
             default: null,
         },
     },
+    setup() {
+        const { throttle } = useAnimationFrameThrottle();
+        return { throttle };
+    },
     data() {
         return {
             isPanning: false,
@@ -66,7 +71,10 @@ export default {
                 this.$emit("move", position);
             }
             this.timeout = setTimeout(() => {
-                this.emitPan(position);
+                // ensure the recursive call also runs in the animation frame
+                this.throttle(() => {
+                    this.emitPan(position);
+                });
             }, this.refreshRate);
         },
         onMove(position, event) {

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -78,9 +78,9 @@ const emit = defineEmits(["onAnnotation", "onLabel", "onAttemptRefactor", "onEdi
 const stepRef = toRef(props, "step");
 const { stepId, contentId, annotation, label, name, type, configForm } = useStepProps(stepRef);
 const stepStore = useWorkflowStepStore();
-const uniqueErrorLabel = useUniqueLabelError(stepStore, label?.value);
+const uniqueErrorLabel = useUniqueLabelError(stepStore, label.value);
 const stepTitle = computed(() => {
-    if (label?.value) {
+    if (label.value) {
         return label.value;
     }
     if (isSubworkflow.value) {

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -27,7 +27,6 @@
         <template v-slot:body>
             <FormElement
                 id="__label"
-                :key="stepId"
                 :value="label"
                 title="Label"
                 help="Add a step label."
@@ -35,7 +34,6 @@
                 @input="onLabel" />
             <FormElement
                 id="__annotation"
-                :key="stepId"
                 :value="annotation"
                 title="Step Annotation"
                 :area="true"

--- a/client/src/components/Workflow/Editor/composables/useStepProps.ts
+++ b/client/src/components/Workflow/Editor/composables/useStepProps.ts
@@ -1,14 +1,12 @@
 import type { Step } from "@/stores/workflowStepStore";
 import { toRefs } from "@vueuse/core";
 
-import type { Ref } from "vue";
+import { computed, type Ref } from "vue";
 
 export function useStepProps(step: Ref<Step>) {
     const {
         id: stepId,
         content_id: contentId,
-        annotation,
-        label,
         name,
         type,
         inputs: stepInputs,
@@ -16,6 +14,10 @@ export function useStepProps(step: Ref<Step>) {
         config_form: configForm,
         post_job_actions: postJobActions,
     } = toRefs(step);
+
+    const label = computed(() => step.value.label ?? undefined);
+    const annotation = computed(() => step.value.annotation ?? null);
+
     return {
         stepId,
         contentId,

--- a/client/src/composables/sensors/animationFrameSize.ts
+++ b/client/src/composables/sensors/animationFrameSize.ts
@@ -1,0 +1,24 @@
+import { resolveUnref, type MaybeComputedRef } from "@vueuse/core";
+import { useAnimationFrameResizeObserver } from "./animationFrameResizeObserver";
+import { ref } from "vue";
+
+export function useAnimationFrameSize(target: MaybeComputedRef<HTMLElement | null>) {
+    const width = ref(0);
+    const height = ref(0);
+
+    useAnimationFrameResizeObserver(target, () => {
+        const el = resolveUnref(target);
+
+        if (!el) {
+            return;
+        }
+
+        width.value = el.offsetWidth;
+        height.value = el.offsetHeight;
+    });
+
+    return {
+        width,
+        height,
+    };
+}

--- a/client/src/composables/throttle.ts
+++ b/client/src/composables/throttle.ts
@@ -1,0 +1,20 @@
+import { useAnimationFrame } from "./sensors/animationFrame";
+
+export function useAnimationFrameThrottle() {
+    let lastCallback: (() => void) | null = null;
+
+    const throttle = (callback: () => void) => {
+        lastCallback = callback;
+    };
+
+    useAnimationFrame(() => {
+        if (lastCallback) {
+            lastCallback();
+            lastCallback = null;
+        }
+    });
+
+    return {
+        throttle,
+    };
+}


### PR DESCRIPTION
Some small refactors to the Workflow editor.

* Moves all drag events to the browsers animation frame, making drag events smoother and more performant.
* Fixes an issue with "duplicate keys" errors being thrown when selecting a node in the editor.

*dev*:

https://user-images.githubusercontent.com/44241786/223420099-8fb7f91e-ffc1-4951-8fbc-a00bd9ea323b.mp4

---

*refactor*:

https://user-images.githubusercontent.com/44241786/223420151-a4ec3464-6765-47b9-bba1-b41723fc04e7.mp4

---

(the low fps of the recording makes it a bit less obvious. Best to try it out locally)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
