### PR TITLE
[23.0] Fix attribute error on base models

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -305,7 +305,7 @@ class ModelManager(Generic[U]):
         """
         Returns a tuple of columns for the default order when getting multiple models.
         """
-        return (self.model_class.table.c.create_time,)
+        return (self.model_class.__table__.c.create_time,)
 
     def _apply_orm_limit_offset(self, query: Query, limit: Optional[int], offset: Optional[int]) -> Query:
         """
@@ -356,7 +356,7 @@ class ModelManager(Generic[U]):
         """
         Gets a model by primary id.
         """
-        id_filter = self.model_class.table.c.id == id
+        id_filter = self.model_class.__table__.c.id == id
         return self.one(filters=id_filter)
 
     # .... multirow queries
@@ -449,7 +449,7 @@ class ModelManager(Generic[U]):
         """
         if not ids:
             return []
-        ids_filter = parsed_filter("orm", self.model_class.table.c.id.in_(ids))
+        ids_filter = parsed_filter("orm", self.model_class.__table__.c.id.in_(ids))
         found = self.list(filters=self._munge_filters(ids_filter, filters), **kwargs)
         # TODO: this does not order by the original 'ids' array
 
@@ -1159,7 +1159,7 @@ class ModelFilterParser(HasAModelManager):
         # note: column_map[ 'column' ] takes precedence
         if "column" in column_map:
             attr = column_map["column"]
-        column = self.model_class.table.columns.get(attr)
+        column = self.model_class.__table__.columns.get(attr)
         if column is None:
             # could be a property (hybrid_property, etc.) - assume we can make a filter from it
             column = getattr(self.model_class, attr)


### PR DESCRIPTION
In some contexts, the `table` in `__declare_last__` hook for models is not yet defined and can end up in errors like:

```
Traceback (most recent call last):
  File "/opt/galaxy/venv/lib64/python3.8/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/opt/galaxy/venv/lib64/python3.8/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/opt/galaxy/server/lib/galaxy/celery/__init__.py", line 163, in wrapper
    rval = app.magic_partial(func)(*args, **kwds)
  File "/opt/galaxy/venv/lib64/python3.8/site-packages/lagom/wrapping.py", line 28, in _bound_func
    return inner_func(*bound_args, **bound_kwargs)
  File "/opt/galaxy/venv/lib64/python3.8/site-packages/lagom/wrapping.py", line 45, in _error_handling_func
    return func(*args, **kwargs)
  File "/opt/galaxy/server/lib/galaxy/celery/tasks.py", line 302, in prepare_history_download
    model_store_manager.prepare_history_download(request)
  File "/opt/galaxy/server/lib/galaxy/managers/model_stores.py", line 108, in prepare_history_download
    history = self._history_manager.by_id(request.history_id)
  File "/opt/galaxy/server/lib/galaxy/managers/base.py", line 359, in by_id
    id_filter = self.model_class.table.c.id == id
AttributeError: type object 'History' has no attribute 'table'
```

I decided to change it to `__table__` instead of directly accessing the attribute because otherwise `mypy` will complain as the generic type bound is `model._HasTable` which doesn't have the `id` attribute.

https://github.com/galaxyproject/galaxy/blob/be5f22d58432e6eda6ea1fc38a9f0277b6ded9d8/lib/galaxy/managers/base.py#L208



## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
