### PR TITLE
[23.0] Add 2 indexes to WorkflowRequest* tables on the workflow_invocation_id field

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8206,7 +8206,7 @@ class WorkflowRequestInputParameter(Base, Dictifiable, Serializable):
 
     id = Column(Integer, primary_key=True)
     workflow_invocation_id = Column(
-        Integer, ForeignKey("workflow_invocation.id", onupdate="CASCADE", ondelete="CASCADE")
+        Integer, ForeignKey("workflow_invocation.id", onupdate="CASCADE", ondelete="CASCADE"), index=True
     )
     name = Column(Unicode(255))
     value = Column(TEXT)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8236,7 +8236,7 @@ class WorkflowRequestStepState(Base, Dictifiable, Serializable):
 
     id = Column(Integer, primary_key=True)
     workflow_invocation_id = Column(
-        Integer, ForeignKey("workflow_invocation.id", onupdate="CASCADE", ondelete="CASCADE")
+        Integer, ForeignKey("workflow_invocation.id", onupdate="CASCADE", ondelete="CASCADE"), index=True
     )
     workflow_step_id = Column(Integer, ForeignKey("workflow_step.id"))
     value = Column(MutableJSONType)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
@@ -1,0 +1,32 @@
+"""add index workflow_request_step_states__workflow_invocation_id
+
+Revision ID: 3a2914d703ca
+Revises: c39f1de47a04
+Create Date: 2023-03-07 15:06:55.682273
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from galaxy.model.migrations.util import (
+    create_index,
+    drop_index,
+)
+
+# revision identifiers, used by Alembic.
+revision = "3a2914d703ca"
+down_revision = "c39f1de47a04"
+branch_labels = None
+depends_on = None
+
+table_name = "workflow_request_step_states"
+columns = ["workflow_invocation_id"]
+index_name = "ix_workflow_request_step_states_workflow_invocation_id"
+
+
+def upgrade():
+    create_index(index_name, table_name, columns)
+
+
+def downgrade():
+    drop_index(index_name, table_name, columns)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
@@ -5,9 +5,6 @@ Revises: c39f1de47a04
 Create Date: 2023-03-07 15:06:55.682273
 
 """
-import sqlalchemy as sa
-from alembic import op
-
 from galaxy.model.migrations.util import (
     create_index,
     drop_index,

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
@@ -5,9 +5,6 @@ Revises: 3a2914d703ca
 Create Date: 2023-03-07 15:10:44.943542
 
 """
-import sqlalchemy as sa
-from alembic import op
-
 from galaxy.model.migrations.util import (
     create_index,
     drop_index,

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
@@ -1,0 +1,33 @@
+"""add index workflow_request_input_parameters__workflow_invocation_id
+
+Revision ID: caa7742f7bca
+Revises: 3a2914d703ca
+Create Date: 2023-03-07 15:10:44.943542
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from galaxy.model.migrations.util import (
+    create_index,
+    drop_index,
+)
+
+# revision identifiers, used by Alembic.
+revision = "caa7742f7bca"
+down_revision = "3a2914d703ca"
+branch_labels = None
+depends_on = None
+
+
+table_name = "workflow_request_input_parameters"
+columns = ["workflow_invocation_id"]
+index_name = "ix_workflow_request_input_parameters_workflow_invocation_id"
+
+
+def upgrade():
+    create_index(index_name, table_name, columns)
+
+
+def downgrade():
+    drop_index(index_name, table_name, columns)

--- a/lib/galaxy/model/migrations/dbscript.py
+++ b/lib/galaxy/model/migrations/dbscript.py
@@ -36,8 +36,8 @@ REVISION_TAGS = {
     "22.01": "base",
     "release_22.05": "186d4835587b",
     "22.05": "186d4835587b",
-    "release_23.0": "c39f1de47a04",
-    "23.0": "c39f1de47a04",
+    "release_23.0": "caa7742f7bca",
+    "23.0": "caa7742f7bca",
 }
 
 

--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -17,9 +17,22 @@ def drop_column(table_name, column_name):
         batch_op.drop_column(column_name)
 
 
+def create_index(index_name, table_name, columns):
+    if index_exists(index_name, table_name):
+        msg = f"Index with name {index_name} on {table_name} already exists. Skipping revision."
+        log.info(msg)
+    else:
+        op.create_index(index_name, table_name, columns)
+
+
+def drop_index(index_name, table_name, columns):
+    if index_exists(index_name, table_name):
+        op.drop_index(index_name, table_name)
+
+
 def column_exists(table_name, column_name):
     if context.is_offline_mode():
-        return _handle_offline_mode(f"column_exists({table_name}, {column_name})", False)
+        return _handle_offline_mode(f"column_exists({table_name}, {column_name})")
 
     bind = op.get_context().bind
     insp = inspect(bind)
@@ -27,7 +40,17 @@ def column_exists(table_name, column_name):
     return any(c["name"] == column_name for c in columns)
 
 
-def _handle_offline_mode(code, return_value):
+def index_exists(index_name, table_name):
+    if context.is_offline_mode():
+        return _handle_offline_mode(f"index_exists({index_name}, {table_name})")
+
+    bind = op.get_context().bind
+    insp = inspect(bind)
+    indexes = insp.get_indexes(table_name)
+    return any(index["name"] == index_name for index in indexes)
+
+
+def _handle_offline_mode(code, return_value=False):
     msg = (
         "This script is being executed in offline mode and cannot connect to the database. "
         f"Therefore, `{code}` returns `{return_value}` by default."


### PR DESCRIPTION
Ref #15728

Add 2 indexes (model changes + migrations); add utilities for index migrations

Names match those added earlier to main. If index exists, migration step will be skipped with a log message; 
downgrade step will be skipped if index does not exist.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
