### PR TITLE
Fix/Enhance recalculate disk usage API endpoint

### DIFF
--- a/client/src/components/User/DiskUsage/DiskUsageSummary.vue
+++ b/client/src/components/User/DiskUsage/DiskUsageSummary.vue
@@ -88,7 +88,7 @@ export default {
         },
         async requestDiskUsageRecalculation() {
             try {
-                await axios.put(`${getAppRoot()}api/users/recalculate_disk_usage`);
+                await axios.put(`${getAppRoot()}api/users/current/recalculate_disk_usage`);
             } catch (e) {
                 rethrowSimple(e);
             }

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -6508,9 +6508,9 @@ export interface components {
              * Share Option
              * @description User choice for sharing resources which its contents may be restricted:
              *  - None: The user did not choose anything yet or no option is needed.
-             *  - SharingOptions.make_public: The contents of the resource will be made publicly accessible.
-             *  - SharingOptions.make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
-             *  - SharingOptions.no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
+             *  - make_public: The contents of the resource will be made publicly accessible.
+             *  - make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
+             *  - no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
              */
             share_option?: components["schemas"]["SharingOptions"];
             /**
@@ -8894,7 +8894,7 @@ export interface operations {
          * @description Sets the permissions to manage a library folder.
          */
         parameters: {
-            /** @description Indicates what action should be performed on the Library. Currently only `LibraryFolderPermissionAction.set_permissions` is supported. */
+            /** @description Indicates what action should be performed on the Library. Currently only `set_permissions` is supported. */
             query?: {
                 action?: components["schemas"]["LibraryFolderPermissionAction"];
             };

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1161,8 +1161,23 @@ export interface paths {
          */
         post: operations["update_tour_api_tours__tour_id__post"];
     };
+    "/api/users/current/recalculate_disk_usage": {
+        /**
+         * Triggers a recalculation of the current user disk usage.
+         * @description This route will be removed in a future version.
+         *
+         * Please use `/api/users/current/recalculate_disk_usage` instead.
+         */
+        put: operations["recalculate_disk_usage_api_users_current_recalculate_disk_usage_put"];
+    };
     "/api/users/recalculate_disk_usage": {
-        /** Triggers a recalculation of the current user disk usage. */
+        /**
+         * Triggers a recalculation of the current user disk usage.
+         * @deprecated
+         * @description This route will be removed in a future version.
+         *
+         * Please use `/api/users/current/recalculate_disk_usage` instead.
+         */
         put: operations["recalculate_disk_usage_api_users_recalculate_disk_usage_put"];
     };
     "/api/users/{user_id}/api_key": {
@@ -6493,9 +6508,9 @@ export interface components {
              * Share Option
              * @description User choice for sharing resources which its contents may be restricted:
              *  - None: The user did not choose anything yet or no option is needed.
-             *  - make_public: The contents of the resource will be made publicly accessible.
-             *  - make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
-             *  - no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
+             *  - SharingOptions.make_public: The contents of the resource will be made publicly accessible.
+             *  - SharingOptions.make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
+             *  - SharingOptions.no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
              */
             share_option?: components["schemas"]["SharingOptions"];
             /**
@@ -8879,7 +8894,7 @@ export interface operations {
          * @description Sets the permissions to manage a library folder.
          */
         parameters: {
-            /** @description Indicates what action should be performed on the Library. Currently only `set_permissions` is supported. */
+            /** @description Indicates what action should be performed on the Library. Currently only `LibraryFolderPermissionAction.set_permissions` is supported. */
             query?: {
                 action?: components["schemas"]["LibraryFolderPermissionAction"];
             };
@@ -13830,8 +13845,13 @@ export interface operations {
             };
         };
     };
-    recalculate_disk_usage_api_users_recalculate_disk_usage_put: {
-        /** Triggers a recalculation of the current user disk usage. */
+    recalculate_disk_usage_api_users_current_recalculate_disk_usage_put: {
+        /**
+         * Triggers a recalculation of the current user disk usage.
+         * @description This route will be removed in a future version.
+         *
+         * Please use `/api/users/current/recalculate_disk_usage` instead.
+         */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -13839,7 +13859,44 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description The asynchronous task summary to track the task state. */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["AsyncTaskResultSummary"];
+                };
+            };
+            /** @description The background task was submitted but there is no status tracking ID available. */
+            204: never;
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    recalculate_disk_usage_api_users_recalculate_disk_usage_put: {
+        /**
+         * Triggers a recalculation of the current user disk usage.
+         * @deprecated
+         * @description This route will be removed in a future version.
+         *
+         * Please use `/api/users/current/recalculate_disk_usage` instead.
+         */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description The asynchronous task summary to track the task state. */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["AsyncTaskResultSummary"];
+                };
+            };
+            /** @description The background task was submitted but there is no status tracking ID available. */
             204: never;
             /** @description Validation Error */
             422: {

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -66,7 +66,7 @@ def cached_create_tool_from_representation(app, raw_tool_source):
     )
 
 
-@galaxy_task(ignore_result=True, action="recalculate a user's disk usage")
+@galaxy_task(action="recalculate a user's disk usage")
 def recalculate_user_disk_usage(
     session: galaxy_scoped_session, object_store: BaseObjectStore, user_id: Optional[int] = None
 ):

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -74,7 +74,6 @@ def recalculate_user_disk_usage(
         user = session.query(model.User).get(user_id)
         if user:
             user.calculate_and_set_disk_usage(object_store)
-            log.info(f"New user disk usage is {user.disk_usage}")
         else:
             log.error(f"Recalculate user disk usage task failed, user {user_id} not found")
     else:

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -218,6 +218,8 @@ class HDAManager(
         quota_source_info = hda.dataset.quota_source_info
         if quota_amount_reduction and quota_source_info.use:
             user.adjust_total_disk_usage(-quota_amount_reduction, quota_source_info.label)
+            # TODO: don't flush above if we're going to re-flush here
+            object_session(user).flush()
 
     # .... states
     def error_if_uploading(self, hda):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -977,7 +977,11 @@ ON CONFLICT
                 binds.append(bindparam(key, expanding=expand_binding))
             statement = statement.bindparams(*binds)
             sa_session.execute(statement, args)
-            sa_session.flush()
+            # expire user.disk_usage so sqlalchemy knows to ignore
+            # the existing value - we're setting it in raw SQL for
+            # performance reasons and bypassing object properties.
+            sa_session.expire(self, ["disk_usage"])
+        sa_session.flush()
 
     @staticmethod
     def user_template_environment(user):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -216,12 +216,15 @@ def reload_sanitize_allowlist(app):
 
 
 def recalculate_user_disk_usage(app, **kwargs):
+    object_store = kwargs.get("object_store", None)
     user_id = kwargs.get("user_id", None)
     sa_session = app.model.context
+    if object_store is None:
+        log.error("Recalculate user disk usage task received without object_store.")
     if user_id:
         user = sa_session.query(app.model.User).get(user_id)
         if user:
-            user.calculate_and_set_disk_usage()
+            user.calculate_and_set_disk_usage(object_store)
         else:
             log.error(f"Recalculate user disk usage task failed, user {user_id} not found")
     else:

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -43,7 +43,10 @@ from galaxy.model import (
 )
 from galaxy.schema import APIKeyModel
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.schema import UserBeaconSetting
+from galaxy.schema.schema import (
+    AsyncTaskResultSummary,
+    UserBeaconSetting,
+)
 from galaxy.security.validate_user_input import (
     validate_email,
     validate_password,
@@ -90,6 +93,17 @@ QuotaSourceLabelPathParam: str = Path(
     description="The label corresponding to the quota source to fetch usage information about.",
 )
 
+RecalculateDiskUsageSummary = "Triggers a recalculation of the current user disk usage."
+RecalculateDiskUsageResponseDescriptions = {
+    200: {
+        "model": AsyncTaskResultSummary,
+        "description": "The asynchronous task summary to track the task state.",
+    },
+    204: {
+        "description": "The background task was submitted but there is no status tracking ID available.",
+    },
+}
+
 
 @router.cbv
 class FastAPIUsers:
@@ -98,15 +112,15 @@ class FastAPIUsers:
 
     @router.put(
         "/api/users/recalculate_disk_usage",
-        summary="Triggers a recalculation of the current user disk usage.",
-        status_code=status.HTTP_204_NO_CONTENT,
+        summary=RecalculateDiskUsageSummary,
+        responses=RecalculateDiskUsageResponseDescriptions,
     )
     def recalculate_disk_usage(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
     ):
-        self.service.recalculate_disk_usage(trans)
-        return Response(status_code=status.HTTP_204_NO_CONTENT)
+        result = self.service.recalculate_disk_usage(trans)
+        return Response(status_code=status.HTTP_204_NO_CONTENT) if result is None else result
 
     @router.get(
         "/api/users/{user_id}/api_key",

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -111,14 +111,24 @@ class FastAPIUsers:
     user_serializer: users.UserSerializer = depends(users.UserSerializer)
 
     @router.put(
+        "/api/users/current/recalculate_disk_usage",
+        summary=RecalculateDiskUsageSummary,
+        responses=RecalculateDiskUsageResponseDescriptions,
+    )
+    @router.put(
         "/api/users/recalculate_disk_usage",
         summary=RecalculateDiskUsageSummary,
         responses=RecalculateDiskUsageResponseDescriptions,
+        deprecated=True,
     )
     def recalculate_disk_usage(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
     ):
+        """This route will be removed in a future version.
+
+        Please use `/api/users/current/recalculate_disk_usage` instead.
+        """
         result = self.service.recalculate_disk_usage(trans)
         return Response(status_code=status.HTTP_204_NO_CONTENT) if result is None else result
 

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -36,7 +36,10 @@ class UsersService(ServiceBase):
             send_local_control_task(
                 trans.app,
                 "recalculate_user_disk_usage",
-                kwargs={"user_id": trans.user.id},
+                kwargs={
+                    "object_store": trans.app.object_store,
+                    "user_id": trans.user.id,
+                },
             )
 
     def get_api_key(self, trans: ProvidesUserContext, user_id: int) -> Optional[APIKeyModel]:

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -7,7 +7,10 @@ from galaxy.managers.users import UserManager
 from galaxy.queue_worker import send_local_control_task
 from galaxy.schema import APIKeyModel
 from galaxy.security.idencoding import IdEncodingHelper
-from galaxy.webapps.galaxy.services.base import ServiceBase
+from galaxy.webapps.galaxy.services.base import (
+    async_task_summary,
+    ServiceBase,
+)
 
 
 class UsersService(ServiceBase):
@@ -31,7 +34,8 @@ class UsersService(ServiceBase):
         if trans.app.config.enable_celery_tasks:
             from galaxy.celery.tasks import recalculate_user_disk_usage
 
-            recalculate_user_disk_usage.delay(user_id=trans.user.id)
+            result = recalculate_user_disk_usage.delay(user_id=trans.user.id)
+            return async_task_summary(result)
         else:
             send_local_control_task(
                 trans.app,
@@ -41,6 +45,7 @@ class UsersService(ServiceBase):
                     "user_id": trans.user.id,
                 },
             )
+            return None
 
     def get_api_key(self, trans: ProvidesUserContext, user_id: int) -> Optional[APIKeyModel]:
         """Returns the current API key or None if the user doesn't have any valid API key."""

--- a/test/integration/test_recalculate_user_disk_usage.py
+++ b/test/integration/test_recalculate_user_disk_usage.py
@@ -1,0 +1,39 @@
+from galaxy_test.base.populators import DatasetPopulator
+from galaxy_test.driver.integration_util import IntegrationTestCase
+
+
+class TestRecalculateUserDiskUsageIntegration(IntegrationTestCase):
+    task_based = True
+    dataset_populator: DatasetPopulator
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["allow_user_dataset_purge"] = True
+
+    def test_recalculate_user_disk_usage(self):
+        # The initial disk usage is 0
+        current_usage = self.dataset_populator.get_usage_for(None)
+        assert current_usage["total_disk_usage"] == 0
+        size = 100
+        history_id = self.dataset_populator.new_history()
+        hda_id = self.dataset_populator.new_dataset(history_id, content=f"{'0'*size}", wait=True)["id"]
+        expected_usage = size + 1  # +1 for the new line character in the dataset
+        # The usage should be the total of the datasets
+        current_usage = self.dataset_populator.get_usage_for(None)
+        assert current_usage["total_disk_usage"] == expected_usage
+        self.dataset_populator.delete_dataset(history_id, hda_id, purge=True, wait_for_purge=True)
+        # After purging the disk usage might not be automatically recalculated yet
+        current_usage = self.dataset_populator.get_usage_for(None)
+
+        recalculate_response = self._put("users/current/recalculate_disk_usage")
+        task_ok = self.dataset_populator.wait_on_task(recalculate_response)
+        assert task_ok
+
+        # The disk usage should be 0 again
+        current_usage = self.dataset_populator.get_usage_for(None)
+        assert current_usage["total_disk_usage"] == 0

--- a/test/integration/test_recalculate_user_disk_usage.py
+++ b/test/integration/test_recalculate_user_disk_usage.py
@@ -27,8 +27,11 @@ class TestRecalculateUserDiskUsageIntegration(IntegrationTestCase):
         current_usage = self.dataset_populator.get_usage_for(None)
         assert current_usage["total_disk_usage"] == expected_usage
         self.dataset_populator.delete_dataset(history_id, hda_id, purge=True, wait_for_purge=True)
-        # After purging the disk usage might not be automatically recalculated yet
+
+        # Purging that dataset should result in usage dropping back
+        # down to zero.
         current_usage = self.dataset_populator.get_usage_for(None)
+        assert current_usage["total_disk_usage"] == 0
 
         recalculate_response = self._put("users/current/recalculate_disk_usage")
         task_ok = self.dataset_populator.wait_on_task(recalculate_response)

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -111,6 +111,37 @@ class TestCalculateUsage(BaseModelTestCase):
 
         assert u.calculate_disk_usage_default_source(object_store) == 10
 
+    def test_calculate_usage_readjusts_incorrect_quota(self):
+        u = self.u
+
+        self._add_dataset(10)
+
+        object_store = MockObjectStore()
+        assert u.calculate_disk_usage_default_source(object_store) == 10
+        assert u.disk_usage is None
+        u.calculate_and_set_disk_usage(object_store)
+        assert u.calculate_disk_usage_default_source(object_store) == 10
+
+        self._refresh_user_and_assert_disk_usage_is(10)
+
+        # lets break this to simulate the actual bugs we observe in Galaxy.
+        u.disk_usage = -10
+        self.persist(u)
+        self._refresh_user_and_assert_disk_usage_is(-10)
+
+        # recalculate and verify it is fixed
+        u.calculate_and_set_disk_usage(object_store)
+        self._refresh_user_and_assert_disk_usage_is(10)
+
+        # break it again
+        u.disk_usage = 1000
+        self.persist(u)
+        self._refresh_user_and_assert_disk_usage_is(1000)
+
+        # recalculate and verify it is fixed
+        u.calculate_and_set_disk_usage(object_store)
+        self._refresh_user_and_assert_disk_usage_is(10)
+
     def test_calculate_usage_disabled_quota(self):
         u = self.u
 
@@ -252,6 +283,11 @@ class TestCalculateUsage(BaseModelTestCase):
 
         assert usages[1].quota_source_label == "alt_source"
         assert usages[1].total_disk_usage == 15
+
+    def _refresh_user_and_assert_disk_usage_is(self, usage):
+        u = self.u
+        self.model.context.refresh(u)
+        assert u.disk_usage == usage
 
 
 class TestQuota(BaseModelTestCase):


### PR DESCRIPTION
## Fix (affects only dev)
The `recalculate_user_disk_usage` task has the required object store instance now.

## Enhancements
- The API route has changed to `/api/users/current/recalculate_disk_usage` to be more consistent with other endpoints affecting the current user. The old one has been marked as deprecated.
- The API endpoint now returns the `AsyncTaskResultSummary` when Celery is enabled to be able to track the status of the task if necessary.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
