### PR TITLE
Fix Enums in API docs

### DIFF
--- a/.github/workflows/lint_openapi_schema.yml
+++ b/.github/workflows/lint_openapi_schema.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.7', '3.11']
     steps:
       - uses: actions/checkout@v3
         with:

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3011,9 +3011,9 @@ class ShareWithPayload(Model):
         description=(
             "User choice for sharing resources which its contents may be restricted:\n"
             " - None: The user did not choose anything yet or no option is needed.\n"
-            f" - {SharingOptions.make_public}: The contents of the resource will be made publicly accessible.\n"
-            f" - {SharingOptions.make_accessible_to_shared}: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.\n"
-            f" - {SharingOptions.no_changes}: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.\n"
+            f" - {SharingOptions.make_public.value}: The contents of the resource will be made publicly accessible.\n"
+            f" - {SharingOptions.make_accessible_to_shared.value}: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.\n"
+            f" - {SharingOptions.no_changes.value}: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.\n"
         ),
     )
 

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -148,7 +148,7 @@ class FastAPILibraryFolders:
             title="Action",
             description=(
                 "Indicates what action should be performed on the Library. "
-                f"Currently only `{LibraryFolderPermissionAction.set_permissions}` is supported."
+                f"Currently only `{LibraryFolderPermissionAction.set_permissions.value}` is supported."
             ),
         ),
         payload: LibraryFolderPermissionsPayload = Body(...),


### PR DESCRIPTION
Apparently, string enums are converted to string differently between python versions making the `make update-client-api-schema` command return different results.

This should make sure the underlying value of the enum is printed instead. I've included python 3.11 to the OpenAPI linting GitHub Workflow to make sure it works.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
