### PR TITLE
[23.0] Validate history Related filter in backend

### DIFF
--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -538,7 +538,11 @@ class HistoryContentsFilters(
             # Type check whether hid is int
             if not qv_hid.isdigit():
                 raise glx_exceptions.RequestParameterInvalidException(
-                    "unparsable value for filter", column="related", operation="eq", value=qv_hid, ValueError="invalid type in filter"
+                    "unparsable value for filter",
+                    column="related",
+                    operation="eq",
+                    value=qv_hid,
+                    ValueError="invalid type in filter",
                 )
 
             # Make new q and qv excluding related filter

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -535,6 +535,12 @@ class HistoryContentsFilters(
             qv_index = query_filters.q.index("related-eq")
             qv_hid = query_filters.qv[qv_index]
 
+            # Type check whether hid is int
+            if not qv_hid.isdigit():
+                raise glx_exceptions.RequestParameterInvalidException(
+                    "unparsable value for filter", column="related", operation="eq", value=qv_hid, ValueError="invalid type in filter"
+                )
+
             # Make new q and qv excluding related filter
             new_q = [x for i, x in enumerate(query_filters.q) if i != qv_index]
             new_qv = [x for i, x in enumerate(query_filters.qv) if i != qv_index]


### PR DESCRIPTION
The history Related items filter was not type checking whether the `hid` from `related:hid` is `int`. 
Fixes #15712 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
