### PR TITLE
Add StatesInfo component

### DIFF
--- a/client/src/components/History/Content/model/StatesInfo.vue
+++ b/client/src/components/History/Content/model/StatesInfo.vue
@@ -5,6 +5,7 @@ import type { States, HelpText } from "./stateTypes";
 
 const props = defineProps({
     showHelp: { type: Boolean, default: false },
+    excludeStates: { type: Array<keyof typeof STATES>, required: false, default: () => [] },
 });
 
 const emit = defineEmits<{
@@ -26,6 +27,12 @@ const helpText: HelpText = {
     failed: "The job failed to run.",
     ok: "The dataset has no errors.",
 };
+
+if (props.excludeStates) {
+    for (const state of props.excludeStates) {
+        delete states[state];
+    }
+}
 
 function onFilter(value: string) {
     propShowHelp.value = false;

--- a/client/src/components/History/Content/model/StatesInfo.vue
+++ b/client/src/components/History/Content/model/StatesInfo.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { STATES } from "./states";
+import type { ComputedRef } from "vue";
+import { computed } from "vue";
+
+type State = {
+    status: string;
+    text?: string;
+    icon?: string;
+    spin?: boolean;
+};
+interface States {
+    [key: string]: State;
+}
+interface HelpText {
+    [key: string]: string;
+}
+
+const props = defineProps({
+    showHelp: { type: Boolean, default: false },
+});
+
+const emit = defineEmits<{
+    (e: "update:show-help", showHelp: boolean): void;
+    (e: "set-filter", filter: string, value: string): void;
+}>();
+
+const propShowHelp = computed({
+    get: () => {
+        return props.showHelp;
+    },
+    set: (val) => {
+        emit("update:show-help", val);
+    },
+});
+const states: ComputedRef<States> = computed(() => STATES);
+
+const helpText: HelpText = {
+    failed: "The dataset failed to run.",
+    ok: "The dataset has no errors and is useable and readable in the history.",
+};
+
+function onFilter(value: string) {
+    propShowHelp.value = false;
+    emit("set-filter", `state:`, value);
+}
+</script>
+
+<template>
+    <b-modal v-model="propShowHelp" title="History Item States Help" ok-only>
+        <p>Here are all available item states in Galaxy:</p>
+        <p><i>(Note that the colors for each state correspond to content item state colors in the history)</i></p>
+        <dl v-for="(state, key, index) in states" :key="index">
+            <b-alert :variant="state.status || 'success'" show>
+                <dt>
+                    <a href="javascript:void(0)" @click="onFilter(key)"
+                        ><code>{{ key }}</code></a
+                    >
+                    <icon v-if="state.icon" :icon="state.icon" />
+                </dt>
+                <dd>{{ helpText[key] || state.text }}</dd>
+            </b-alert>
+        </dl>
+    </b-modal>
+</template>

--- a/client/src/components/History/Content/model/StatesInfo.vue
+++ b/client/src/components/History/Content/model/StatesInfo.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { STATES } from "./states";
-import type { ComputedRef } from "vue";
 import { computed } from "vue";
 
 type State = {
@@ -33,11 +32,11 @@ const propShowHelp = computed({
         emit("update:show-help", val);
     },
 });
-const states: ComputedRef<States> = computed(() => STATES);
 
+const states = STATES as States;
 const helpText: HelpText = {
-    failed: "The dataset failed to run.",
-    ok: "The dataset has no errors and is useable and readable in the history.",
+    failed: "The job failed to run.",
+    ok: "The dataset has no errors.",
 };
 
 function onFilter(value: string) {

--- a/client/src/components/History/Content/model/StatesInfo.vue
+++ b/client/src/components/History/Content/model/StatesInfo.vue
@@ -1,19 +1,7 @@
 <script setup lang="ts">
 import { STATES } from "./states";
 import { computed } from "vue";
-
-type State = {
-    status: string;
-    text?: string;
-    icon?: string;
-    spin?: boolean;
-};
-interface States {
-    [key: string]: State;
-}
-interface HelpText {
-    [key: string]: string;
-}
+import type { States, HelpText } from "./stateTypes";
 
 const props = defineProps({
     showHelp: { type: Boolean, default: false },
@@ -52,7 +40,7 @@ function onFilter(value: string) {
         <dl v-for="(state, key, index) in states" :key="index">
             <b-alert :variant="state.status || 'success'" show>
                 <dt>
-                    <a href="javascript:void(0)" @click="onFilter(key)"
+                    <a class="text-decoration-none" href="javascript:void(0)" @click="onFilter(key)"
                         ><code>{{ key }}</code></a
                     >
                     <icon v-if="state.icon" :icon="state.icon" />

--- a/client/src/components/History/Content/model/stateTypes.d.ts
+++ b/client/src/components/History/Content/model/stateTypes.d.ts
@@ -1,0 +1,16 @@
+import { STATES } from "./states";
+
+export type State = {
+    status: string;
+    text?: string;
+    icon?: string;
+    spin?: boolean;
+};
+
+export type States = {
+    [key in keyof typeof STATES]: State;
+};
+
+export interface HelpText {
+    [key: string]: string;
+}

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -3,54 +3,20 @@
     for a list of available states.
 */
 export const STATES = {
-    /** deleted while uploading */
-    discarded: {
-        status: "danger",
-        text: "This dataset is discarded - the job creating it may have been cancelled or it may have been imported without file data.",
-        icon: "exclamation-triangle",
-    },
-    deferred: {
-        status: "info",
-        text: "This dataset is remote, has not been ingested by Galaxy, and full metadata may not be available.",
-        icon: "cloud",
+    /** has successfully completed running */
+    ok: {
+        status: "success",
     },
     /** has no data */
     empty: {
         status: "success",
         text: "No data.",
     },
-    /** the tool producing this dataset has errored */
-    error: {
-        status: "danger",
-        text: "An error occurred with this dataset:",
-        icon: "exclamation-triangle",
-    },
-    /** the job has failed, this is not a dataset but a job state used in the collection job state summary. */
-    failed: {
-        status: "danger",
-        icon: "exclamation-triangle",
-    },
-    /** metadata discovery/setting failed or errored (but otherwise ok) */
-    failed_metadata: {
-        status: "danger",
-        text: "Metadata generation failed. Please retry.",
-        icon: "exclamation-triangle",
-    },
     /** was created without a tool */
     new: {
         status: "warning",
         text: "This is a new dataset and not all of its data are available yet.",
         icon: "clock",
-    },
-    /** has successfully completed running */
-    ok: {
-        status: "success",
-    },
-    /** the job that will produce the dataset paused */
-    paused: {
-        status: "info",
-        text: "This job is paused. Use the 'Resume Paused Jobs' in the history menu to resume.",
-        icon: "pause",
     },
     /** the job that will produce the dataset queued in the runner */
     queued: {
@@ -78,6 +44,41 @@ export const STATES = {
         text: "This dataset is currently uploading.",
         icon: "spinner",
         spin: true,
+    },
+    /** remote dataset */
+    deferred: {
+        status: "info",
+        text: "This dataset is remote, has not been ingested by Galaxy, and full metadata may not be available.",
+        icon: "cloud",
+    },
+    /** the job that will produce the dataset paused */
+    paused: {
+        status: "info",
+        text: "This job is paused. Use the 'Resume Paused Jobs' in the history menu to resume.",
+        icon: "pause",
+    },
+    /** deleted while uploading */
+    discarded: {
+        status: "danger",
+        text: "This dataset is discarded - the job creating it may have been cancelled or it may have been imported without file data.",
+        icon: "exclamation-triangle",
+    },
+    /** the tool producing this dataset has errored */
+    error: {
+        status: "danger",
+        text: "An error occurred with this dataset:",
+        icon: "exclamation-triangle",
+    },
+    /** metadata discovery/setting failed or errored (but otherwise ok) */
+    failed_metadata: {
+        status: "danger",
+        text: "Metadata generation failed. Please retry.",
+        icon: "exclamation-triangle",
+    },
+    /** the job has failed, this is not a dataset but a job state used in the collection job state summary. */
+    failed: {
+        status: "danger",
+        icon: "exclamation-triangle",
     },
 };
 

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -85,3 +85,6 @@ export const STATES = {
  * This list is ordered from highest to lowest priority. If any element is in error state the whole collection should be in error.
  */
 export const HIERARCHICAL_COLLECTION_JOB_STATES = ["error", "failed", "upload", "paused", "running", "queued", "new"];
+
+/** Datalist recommended states for the advanced history panel search */
+export const COMMON_HISTORY_PANEL_STATES = ["ok", "error", "failed", "upload", "paused", "running", "queued", "new"];

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -85,6 +85,3 @@ export const STATES = {
  * This list is ordered from highest to lowest priority. If any element is in error state the whole collection should be in error.
  */
 export const HIERARCHICAL_COLLECTION_JOB_STATES = ["error", "failed", "upload", "paused", "running", "queued", "new"];
-
-/** Datalist recommended states for the advanced history panel search */
-export const COMMON_HISTORY_PANEL_STATES = ["ok", "error", "failed", "upload", "paused", "running", "queued", "new"];

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -44,8 +44,18 @@
             <small class="mt-1">Filter by tag:</small>
             <b-form-input v-model="filterSettings['tag:']" size="sm" placeholder="any tag" />
             <small class="mt-1">Filter by state:</small>
-            <b-form-input v-model="filterSettings['state:']" size="sm" placeholder="any state" list="stateSelect" />
-            <b-form-datalist id="stateSelect" :options="states"></b-form-datalist>
+            <b-input-group>
+                <b-form-input v-model="filterSettings['state:']" size="sm" placeholder="any state" list="stateSelect" />
+                <b-form-datalist id="stateSelect" :options="commonStates"></b-form-datalist>
+                <b-input-group-append>
+                    <b-button
+                        title="States Help"
+                        size="sm"
+                        @click="showHelp = true">
+                        <icon icon="question" />
+                    </b-button>
+                </b-input-group-append>
+            </b-input-group>
             <small>Filter by database:</small>
             <b-form-input v-model="filterSettings['genome_build:']" size="sm" placeholder="any database" />
             <small class="mt-1">Filter by related to item index:</small>
@@ -81,6 +91,14 @@
                     <span>{{ "Cancel" | localize }}</span>
                 </b-button>
             </div>
+            <b-modal v-model="showHelp" title="History Item States Help" ok-only>
+                <p>This input can be used to filter history items by different states.</p>
+                <p>The available item states in Galaxy are:</p>
+                <dl v-for="state in Object.keys(allStates)" :key="state">
+                    <dt><code>{{ state }}</code></dt>
+                    <dd>{{ allStates[state].text }}</dd>
+                </dl>
+            </b-modal>
         </div>
     </div>
 </template>
@@ -88,8 +106,9 @@
 <script>
 import DebouncedInput from "components/DebouncedInput";
 import HistoryFiltersDefault from "./HistoryFiltersDefault";
-import { COMMON_HISTORY_PANEL_STATES } from "components/History/Content/model/states";
+import { STATES, COMMON_HISTORY_PANEL_STATES } from "components/History/Content/model/states";
 import { HistoryFilters } from "components/History/HistoryFilters";
+import filtersMixin from "components/Indices/filtersMixin";
 
 export default {
     components: {
@@ -100,11 +119,14 @@ export default {
         filterText: { type: String, default: null },
         showAdvanced: { type: Boolean, default: false },
     },
+    mixins: [filtersMixin],
     data() {
         return {
             create_time_gt: "",
             create_time_lt: "",
-            states: COMMON_HISTORY_PANEL_STATES,
+            commonStates: COMMON_HISTORY_PANEL_STATES,
+            allStates: STATES,
+            showHelp: false,
         };
     },
     computed: {

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -46,7 +46,7 @@
             <small class="mt-1">Filter by state:</small>
             <b-input-group>
                 <b-form-input v-model="filterSettings['state:']" size="sm" placeholder="any state" list="stateSelect" />
-                <b-form-datalist id="stateSelect" :options="commonStates"></b-form-datalist>
+                <b-form-datalist id="stateSelect" :options="states"></b-form-datalist>
                 <b-input-group-append>
                     <b-button title="States Help" size="sm" @click="showHelp = true">
                         <icon icon="question" />
@@ -96,7 +96,7 @@
 <script>
 import DebouncedInput from "components/DebouncedInput";
 import HistoryFiltersDefault from "./HistoryFiltersDefault";
-import { COMMON_HISTORY_PANEL_STATES } from "components/History/Content/model/states";
+import { STATES } from "components/History/Content/model/states";
 import StatesInfo from "components/History/Content/model/StatesInfo";
 import { HistoryFilters } from "components/History/HistoryFilters";
 
@@ -114,7 +114,7 @@ export default {
         return {
             create_time_gt: "",
             create_time_lt: "",
-            commonStates: COMMON_HISTORY_PANEL_STATES,
+            states: Object.keys(STATES),
             showHelp: false,
         };
     },

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -88,7 +88,7 @@
 <script>
 import DebouncedInput from "components/DebouncedInput";
 import HistoryFiltersDefault from "./HistoryFiltersDefault";
-import { STATES } from "components/History/Content/model/states";
+import { COMMON_HISTORY_PANEL_STATES } from "components/History/Content/model/states";
 import { HistoryFilters } from "components/History/HistoryFilters";
 
 export default {
@@ -104,6 +104,7 @@ export default {
         return {
             create_time_gt: "",
             create_time_lt: "",
+            states: COMMON_HISTORY_PANEL_STATES,
         };
     },
     computed: {
@@ -119,9 +120,6 @@ export default {
                     this.updateFilter(newVal);
                 }
             },
-        },
-        states() {
-            return Object.keys(STATES);
         },
     },
     watch: {

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -52,7 +52,7 @@
                         <icon icon="question" />
                     </b-button>
                 </b-input-group-append>
-                <StatesInfo :show-help.sync="showHelp" @set-filter="onOption" />
+                <StatesInfo :show-help.sync="showHelp" :exclude-states="excludeStates" @set-filter="onOption" />
             </b-input-group>
             <small>Filter by database:</small>
             <b-form-input v-model="filterSettings['genome_build:']" size="sm" placeholder="any database" />
@@ -114,7 +114,7 @@ export default {
         return {
             create_time_gt: "",
             create_time_lt: "",
-            states: Object.keys(STATES),
+            excludeStates: ["empty", "failed", "upload"],
             showHelp: false,
         };
     },
@@ -131,6 +131,9 @@ export default {
                     this.updateFilter(newVal);
                 }
             },
+        },
+        states() {
+            return Object.keys(STATES).filter((state) => !this.excludeStates.includes(state));
         },
     },
     watch: {

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -48,13 +48,11 @@
                 <b-form-input v-model="filterSettings['state:']" size="sm" placeholder="any state" list="stateSelect" />
                 <b-form-datalist id="stateSelect" :options="commonStates"></b-form-datalist>
                 <b-input-group-append>
-                    <b-button
-                        title="States Help"
-                        size="sm"
-                        @click="showHelp = true">
+                    <b-button title="States Help" size="sm" @click="showHelp = true">
                         <icon icon="question" />
                     </b-button>
                 </b-input-group-append>
+                <StatesInfo :show-help.sync="showHelp" @set-filter="onOption" />
             </b-input-group>
             <small>Filter by database:</small>
             <b-form-input v-model="filterSettings['genome_build:']" size="sm" placeholder="any database" />
@@ -91,14 +89,6 @@
                     <span>{{ "Cancel" | localize }}</span>
                 </b-button>
             </div>
-            <b-modal v-model="showHelp" title="History Item States Help" ok-only>
-                <p>This input can be used to filter history items by different states.</p>
-                <p>The available item states in Galaxy are:</p>
-                <dl v-for="state in Object.keys(allStates)" :key="state">
-                    <dt><code>{{ state }}</code></dt>
-                    <dd>{{ allStates[state].text }}</dd>
-                </dl>
-            </b-modal>
         </div>
     </div>
 </template>
@@ -106,26 +96,25 @@
 <script>
 import DebouncedInput from "components/DebouncedInput";
 import HistoryFiltersDefault from "./HistoryFiltersDefault";
-import { STATES, COMMON_HISTORY_PANEL_STATES } from "components/History/Content/model/states";
+import { COMMON_HISTORY_PANEL_STATES } from "components/History/Content/model/states";
+import StatesInfo from "components/History/Content/model/StatesInfo";
 import { HistoryFilters } from "components/History/HistoryFilters";
-import filtersMixin from "components/Indices/filtersMixin";
 
 export default {
     components: {
         DebouncedInput,
         HistoryFiltersDefault,
+        StatesInfo,
     },
     props: {
         filterText: { type: String, default: null },
         showAdvanced: { type: Boolean, default: false },
     },
-    mixins: [filtersMixin],
     data() {
         return {
             create_time_gt: "",
             create_time_lt: "",
             commonStates: COMMON_HISTORY_PANEL_STATES,
-            allStates: STATES,
             showHelp: false,
         };
     },


### PR DESCRIPTION
(Fixes #15569) Added a states help info `b-modal` to the state filter field that works as follows:

https://user-images.githubusercontent.com/78516064/225109180-0133748d-8fab-4fb5-a21d-45b2e1457a47.mov

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
