### PR TITLE
Misc. fixes to migration revision scripts

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/186d4835587b_drop_job_state_history_update_time_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/186d4835587b_drop_job_state_history_update_time_.py
@@ -5,13 +5,15 @@ Revises: 6a67bf27e6a6
 Create Date: 2022-06-01 17:50:22.629894
 
 """
-from alembic import op
 from sqlalchemy import (
     Column,
     DateTime,
 )
 
-from galaxy.model.migrations.util import drop_column
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+)
 from galaxy.model.orm.now import now
 
 # revision identifiers, used by Alembic.
@@ -21,12 +23,12 @@ branch_labels = None
 depends_on = None
 
 table_name = "job_state_history"
-column_name = "update_time"
+column = Column("update_time", DateTime, default=now, onupdate=now)
 
 
 def upgrade():
-    drop_column(table_name, column_name)
+    drop_column(table_name, column.name)
 
 
 def downgrade():
-    op.add_column(table_name, Column("update_time", DateTime, default=now, onupdate=now))
+    add_column(table_name, column)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/3100452fa030_add_workflow_invocation_message_table.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/3100452fa030_add_workflow_invocation_message_table.py
@@ -5,7 +5,6 @@ Revises: 518c8438a91b
 Create Date: 2023-01-13 16:13:09.578391
 
 """
-from alembic import op
 from sqlalchemy import (
     Column,
     ForeignKey,
@@ -14,6 +13,10 @@ from sqlalchemy import (
 )
 
 from galaxy.model.custom_types import TrimmedString
+from galaxy.model.migrations.util import (
+    create_table,
+    drop_table,
+)
 
 # revision identifiers, used by Alembic.
 revision = "3100452fa030"
@@ -21,13 +24,11 @@ down_revision = "518c8438a91b"
 branch_labels = None
 depends_on = None
 
-
-# database object names used in this revision
 table_name = "workflow_invocation_message"
 
 
 def upgrade():
-    op.create_table(
+    create_table(
         table_name,
         Column("id", Integer, primary_key=True),
         Column("reason", String(32)),
@@ -43,4 +44,4 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_table(table_name)
+    drop_table(table_name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
@@ -26,4 +26,4 @@ def upgrade():
 
 
 def downgrade():
-    drop_index(index_name, table_name, columns)
+    drop_index(index_name, table_name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/518c8438a91b_add_when_expression_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/518c8438a91b_add_when_expression_column.py
@@ -6,11 +6,10 @@ Create Date: 2022-10-24 16:43:39.565871
 
 """
 import sqlalchemy as sa
-from alembic import op
 
 from galaxy.model.custom_types import JSONType
 from galaxy.model.migrations.util import (
-    column_exists,
+    add_column,
     drop_column,
 )
 
@@ -22,13 +21,14 @@ depends_on = None
 
 # database object names used in this revision
 table_name = "workflow_step"
-column_name = "when_expression"
+column = sa.Column("when_expression", JSONType)
 
 
 def upgrade():
-    if not column_exists(table_name, column_name):
-        op.add_column(table_name, sa.Column(column_name, JSONType))
+    return
+    add_column(table_name, column)
 
 
 def downgrade():
-    drop_column(table_name, column_name)
+    return
+    drop_column(table_name, column.name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/518c8438a91b_add_when_expression_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/518c8438a91b_add_when_expression_column.py
@@ -25,10 +25,8 @@ column = sa.Column("when_expression", JSONType)
 
 
 def upgrade():
-    return
     add_column(table_name, column)
 
 
 def downgrade():
-    return
     drop_column(table_name, column.name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/59e024ceaca1_add_export_association_table.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/59e024ceaca1_add_export_association_table.py
@@ -5,7 +5,6 @@ Revises: e0e3bb173ee6
 Create Date: 2022-10-12 18:02:34.659770
 
 """
-from alembic import op
 from sqlalchemy import (
     Column,
     DateTime,
@@ -17,6 +16,10 @@ from galaxy.model.custom_types import (
     TrimmedString,
     UUIDType,
 )
+from galaxy.model.migrations.util import (
+    create_table,
+    drop_table,
+)
 
 # revision identifiers, used by Alembic.
 revision = "59e024ceaca1"
@@ -24,12 +27,11 @@ down_revision = "e0e3bb173ee6"
 branch_labels = None
 depends_on = None
 
-
 table_name = "store_export_association"
 
 
 def upgrade():
-    op.create_table(
+    create_table(
         table_name,
         Column("id", Integer, primary_key=True),
         Column("task_uuid", UUIDType(), index=True, unique=True),
@@ -41,4 +43,4 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_table(table_name)
+    drop_table(table_name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/6a67bf27e6a6_deferred_data_tables.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/6a67bf27e6a6_deferred_data_tables.py
@@ -27,12 +27,10 @@ column = Column("metadata_deferred", Boolean(), default=False)
 
 
 def upgrade():
-    return
     add_column(table1_name, column)
     add_column(table2_name, column)
 
 
 def downgrade():
-    return
     drop_column(table1_name, column.name)
     drop_column(table2_name, column.name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/6a67bf27e6a6_deferred_data_tables.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/6a67bf27e6a6_deferred_data_tables.py
@@ -5,13 +5,15 @@ Revises: b182f655505f
 Create Date: 2022-03-14 12:17:55.313830
 
 """
-from alembic import op
 from sqlalchemy import (
     Boolean,
     Column,
 )
 
-from galaxy.model.migrations.util import drop_column
+from galaxy.model.migrations.util import (
+    add_column,
+    drop_column,
+)
 
 # revision identifiers, used by Alembic.
 revision = "6a67bf27e6a6"
@@ -19,12 +21,18 @@ down_revision = "b182f655505f"
 branch_labels = None
 depends_on = None
 
+table1_name = "history_dataset_association"
+table2_name = "library_dataset_dataset_association"
+column = Column("metadata_deferred", Boolean(), default=False)
+
 
 def upgrade():
-    op.add_column("history_dataset_association", Column("metadata_deferred", Boolean(), default=False))
-    op.add_column("library_dataset_dataset_association", Column("metadata_deferred", Boolean(), default=False))
+    return
+    add_column(table1_name, column)
+    add_column(table2_name, column)
 
 
 def downgrade():
-    drop_column("history_dataset_association", "metadata_deferred")
-    drop_column("library_dataset_dataset_association", "metadata_deferred")
+    return
+    drop_column(table1_name, column.name)
+    drop_column(table2_name, column.name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
@@ -5,12 +5,11 @@ Revises: e7b6dcb09efd
 Create Date: 2022-03-14 12:56:57.067748
 
 """
-from alembic import op
 from sqlalchemy import Column
 
 from galaxy.model.custom_types import JSONType
 from galaxy.model.migrations.util import (
-    column_exists,
+    add_column,
     drop_column,
 )
 
@@ -20,15 +19,15 @@ down_revision = "e7b6dcb09efd"
 branch_labels = None
 depends_on = None
 
-# database object names used in this revision
 table_name = "workflow"
-column_name = "source_metadata"
+column = Column("source_metadata", JSONType)
 
 
 def upgrade():
-    if not column_exists(table_name, column_name):
-        op.add_column(table_name, Column(column_name, JSONType))
+    return
+    add_column(table_name, column)
 
 
 def downgrade():
-    drop_column(table_name, column_name)
+    return
+    drop_column(table_name, column.name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b182f655505f_add_workflow_source_metadata_column.py
@@ -24,10 +24,8 @@ column = Column("source_metadata", JSONType)
 
 
 def upgrade():
-    return
     add_column(table_name, column)
 
 
 def downgrade():
-    return
     drop_column(table_name, column.name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
@@ -16,7 +16,6 @@ down_revision = "3a2914d703ca"
 branch_labels = None
 depends_on = None
 
-
 table_name = "workflow_request_input_parameters"
 columns = ["workflow_invocation_id"]
 index_name = "ix_workflow_request_input_parameters_workflow_invocation_id"
@@ -27,4 +26,4 @@ def upgrade():
 
 
 def downgrade():
-    drop_index(index_name, table_name, columns)
+    drop_index(index_name, table_name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/e0e3bb173ee6_add_column_deleted_to_api_keys.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/e0e3bb173ee6_add_column_deleted_to_api_keys.py
@@ -5,14 +5,13 @@ Revises: 186d4835587b
 Create Date: 2022-09-27 14:09:05.890227
 
 """
-from alembic import op
 from sqlalchemy import (
     Boolean,
     Column,
 )
 
 from galaxy.model.migrations.util import (
-    column_exists,
+    add_column,
     drop_column,
 )
 
@@ -22,16 +21,13 @@ down_revision = "186d4835587b"
 branch_labels = None
 depends_on = None
 
-
-# database object names used in this revision
 table_name = "api_keys"
-column_name = "deleted"
+column = Column("deleted", Boolean, default=False)
 
 
 def upgrade():
-    if not column_exists(table_name, column_name):
-        op.add_column(table_name, Column(column_name, Boolean(), default=False))
+    add_column(table_name, column)
 
 
 def downgrade():
-    drop_column(table_name, column_name)
+    drop_column(table_name, column.name)

--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -1,59 +1,143 @@
+"""
+Utility functions for use in revision scripts.
+"""
 import logging
+from typing import (
+    Any,
+    Optional,
+    Sequence,
+)
 
+import sqlalchemy as sa
 from alembic import (
     context,
     op,
 )
-from sqlalchemy import inspect
 
 log = logging.getLogger(__name__)
 
 
-def drop_column(table_name, column_name):
-    if context.is_offline_mode():
-        return _handle_offline_mode(f"drop_column({table_name}, {column_name})", None)
-
-    with op.batch_alter_table(table_name) as batch_op:
-        batch_op.drop_column(column_name)
-
-
-def create_index(index_name, table_name, columns):
-    if index_exists(index_name, table_name):
-        msg = f"Index with name {index_name} on {table_name} already exists. Skipping revision."
-        log.info(msg)
+def create_table(table_name: str, *columns: sa.schema.SchemaItem, **kw: Any) -> Optional[sa.Table]:
+    """Create table if not exists. Return Table object if created."""
+    if not table_exists(table_name, False):
+        return op.create_table(table_name, *columns, **kw)
     else:
-        op.create_index(index_name, table_name, columns)
+        _log_object_exists_message(table_name)
+        return None
 
 
-def drop_index(index_name, table_name, columns):
-    if index_exists(index_name, table_name):
-        op.drop_index(index_name, table_name)
+def drop_table(table_name: str) -> None:
+    """Drop table if exists."""
+    if table_exists(table_name, True):
+        op.drop_table(table_name)
+    else:
+        _log_object_does_not_exist_message(table_name)
 
 
-def column_exists(table_name, column_name):
+def table_exists(table_name: str, default: bool) -> bool:
+    """Check if table exists. If running in offline mode, return default."""
     if context.is_offline_mode():
-        return _handle_offline_mode(f"column_exists({table_name}, {column_name})")
+        _log_offline_mode_message(table_exists.__name__, default)
+        return default
+    return _inspector().has_table(table_name)
 
-    bind = op.get_context().bind
-    insp = inspect(bind)
-    columns = insp.get_columns(table_name)
+
+def add_column(table_name: str, column: sa.Column) -> None:
+    """
+    Add column to table if not exists.
+
+    Use Alembic's batch operations to handle limitations of SQLite.
+    """
+    if context.is_offline_mode():
+        log.info("Generation of `alter` statements is disabled in offline mode.")
+        return
+
+    if not column_exists(table_name, column.name, False):
+        with op.batch_alter_table(table_name) as batch_op:
+            batch_op.add_column(column)
+    else:
+        name = _column_name(column.name, table_name)
+        return _log_object_exists_message(name)
+
+
+def drop_column(table_name: str, column_name: str) -> None:
+    """
+    Drop column if exists.
+
+    Use Alembic's batch operations to handle limitations of SQLite.
+    """
+    if context.is_offline_mode():
+        log.info("Generation of `alter` statements is disabled in offline mode.")
+        return
+
+    if column_exists(table_name, column_name, True):
+        with op.batch_alter_table(table_name) as batch_op:
+            batch_op.drop_column(column_name)
+    else:
+        name = _column_name(column_name, table_name)
+        _log_object_does_not_exist_message(name)
+
+
+def column_exists(table_name: str, column_name: str, default: bool) -> bool:
+    """Check if column exists. If running in offline mode, return default."""
+    if context.is_offline_mode():
+        _log_offline_mode_message(column_exists.__name__, default)
+        return default
+    columns = _inspector().get_columns(table_name)
     return any(c["name"] == column_name for c in columns)
 
 
-def index_exists(index_name, table_name):
-    if context.is_offline_mode():
-        return _handle_offline_mode(f"index_exists({index_name}, {table_name})")
+def create_index(index_name: str, table_name: str, columns: Sequence) -> None:
+    """Create index if not exists."""
+    if not index_exists(index_name, table_name, False):
+        op.create_index(index_name, table_name, columns)
+    else:
+        name = _index_name(index_name, table_name)
+        _log_object_exists_message(name)
 
-    bind = op.get_context().bind
-    insp = inspect(bind)
-    indexes = insp.get_indexes(table_name)
+
+def drop_index(index_name: str, table_name: str) -> None:
+    """Drop index if exists."""
+    if index_exists(index_name, table_name, True):
+        op.drop_index(index_name, table_name)
+    else:
+        name = _index_name(index_name, table_name)
+        _log_object_does_not_exist_message(name)
+
+
+def index_exists(index_name: str, table_name: str, default: bool) -> bool:
+    """Check if index exists. If running in offline mode, return default."""
+    if context.is_offline_mode():
+        _log_offline_mode_message(index_exists.__name__, default)
+        return default
+    indexes = _inspector().get_indexes(table_name)
     return any(index["name"] == index_name for index in indexes)
 
 
-def _handle_offline_mode(code, return_value=False):
-    msg = (
-        "This script is being executed in offline mode and cannot connect to the database. "
-        f"Therefore, `{code}` returns `{return_value}` by default."
+def _log_offline_mode_message(function_name: str, return_value: Any) -> None:
+    log.info(
+        f"This script is being executed in offline mode, so it cannot connect to the database. "
+        f"Therefore, function `{function_name}` will return the value `{return_value}`, "
+        f"which is the expected value during normal operation."
     )
-    log.info(msg)
-    return return_value
+
+
+def _log_object_exists_message(object_name: str) -> None:
+    log.info(f"{object_name} already exists. Skipping revision.")
+
+
+def _log_object_does_not_exist_message(object_name: str) -> None:
+    log.info(f"{object_name} does not exist. Skipping revision.")
+
+
+def _column_name(column_name: str, table_name: str) -> str:
+    return f"{column_name} on {table_name} table"
+
+
+def _index_name(index_name: str, table_name: str) -> str:
+    return f"{index_name} on {table_name} table"
+
+
+def _inspector():
+    bind = op.get_context().bind
+    return sa.inspect(bind)


### PR DESCRIPTION
These fixes were triggered by a variety of migration errors experienced independently by @ahmedhamidawan and myself in (at least) two different contexts while moving between revisions. These fixes should address all or most of the root causes.

Inlcuded:
- Consistent use of checking if object exists (when adding) and not exists (when dropping). Use case: when the alembic version gets out of sync with the state of the database (frequently happens during development), it was impossible to just `./manage_db.sh upgrade` (or downgrade) because most conflicting steps raised an error. This fixes it: migration steps that conflict with the state of the database will be noops, with appropriate messages logged. Also, now one can simply delete the rows from `alembic_version` and run `./manage_db.sh upgrade`: all migrations will be re-applied regardless of the state of the database.
- Consistent use of batch mode for `alter` operations: this is required to make column additions/drops possible under SQLite; this was used for adding columns, but not dropping (this may have caused inconsistent sqlite database state in dev environments).
- Disable offline mode for `alter` operations: this raises an error under sqlite: there's no elegant fix for this. 
- Reasonable refactoring and prettifying of affected scripts and the util module.

It seems reasonable to target `release_23.0`, as this fixes some bugs; but I can re-target to `dev` if needed.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Assuming your database is postgresql. On dev: `psql -c "\c your-database" -c "delete from alembic_version;"`  This empties the version table
  2. `./manage_db.sh upgrade` Observe error.
  3. Switch to this branch, run the upgrade script again: there will be no error. Check the database version to verify (`./manage_db.sh dbversion` or psql to your database)
  4. Change your `database_connection` in `config/galaxy.yml` to point to a sqlite database. Then redo the steps above (using sqlite3 instead of psql).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
