### PR TITLE
[23.0] Fix Celery configuration for integration tests

### DIFF
--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -742,7 +742,9 @@ def launch_gravity(port, gxit_port=None, galaxy_config=None):
     if "interactivetools_proxy_host" not in galaxy_config:
         galaxy_config["interactivetools_proxy_host"] = f"localhost:{gxit_port}"
     # Can't use in-memory celery broker, just fall back to sqlalchemy
-    galaxy_config.update({"celery_conf": {"broker_url": None}})
+    celery_conf = galaxy_config.get("celery_conf", {})
+    celery_conf.update({"broker_url": None})
+    galaxy_config["celery_conf"] = celery_conf
     state_dir = tempfile.mkdtemp(suffix="state")
     config = {
         "gravity": {


### PR DESCRIPTION
Follow up on #14708

I guess the intent was to have both `broker_url` and `result_backend` set up here. The previous code was setting just `result_backend` and leaving the rest as default.


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
