### PR TITLE
[23.0] Fix Worflow editor loading issues

### DIFF
--- a/client/src/components/Workflow/Editor/composables/useTerminal.ts
+++ b/client/src/components/Workflow/Editor/composables/useTerminal.ts
@@ -1,7 +1,7 @@
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 import { terminalFactory } from "@/components/Workflow/Editor/modules/terminals";
 import type { Step, TerminalSource } from "@/stores/workflowStepStore";
-import { ref, watchEffect, type Ref } from "vue";
+import { ref, watch, type Ref } from "vue";
 
 export function useTerminal(
     stepId: Ref<Step["id"]>,
@@ -10,12 +10,19 @@ export function useTerminal(
 ) {
     const terminal = ref();
     const isMappedOver = ref(false);
-    watchEffect(() => {
-        // rebuild terminal if any of the tracked dependencies change
-        const newTerminal = terminalFactory(stepId.value, terminalSource.value, datatypesMapper.value);
-        newTerminal.getInvalidConnectedTerminals();
-        terminal.value = newTerminal;
-        isMappedOver.value = newTerminal.isMappedOver();
-    });
+    watch(
+        [stepId, terminalSource, datatypesMapper],
+        () => {
+            // rebuild terminal if any of the tracked dependencies change
+            console.log("use Terminal terminal Factory");
+            const newTerminal = terminalFactory(stepId.value, terminalSource.value, datatypesMapper.value);
+            newTerminal.getInvalidConnectedTerminals();
+            terminal.value = newTerminal;
+            isMappedOver.value = newTerminal.isMappedOver();
+        },
+        {
+            immediate: true,
+        }
+    );
     return { terminal: terminal as Ref<ReturnType<typeof terminalFactory>>, isMappedOver };
 }

--- a/client/src/components/Workflow/Editor/composables/useTerminal.ts
+++ b/client/src/components/Workflow/Editor/composables/useTerminal.ts
@@ -2,6 +2,7 @@ import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 import { terminalFactory } from "@/components/Workflow/Editor/modules/terminals";
 import type { Step, TerminalSource } from "@/stores/workflowStepStore";
 import { ref, watch, type Ref, computed } from "vue";
+import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 
 export function useTerminal(
     stepId: Ref<Step["id"]>,
@@ -9,7 +10,8 @@ export function useTerminal(
     datatypesMapper: Ref<DatatypesMapperModel>
 ) {
     const terminal: Ref<ReturnType<typeof terminalFactory> | null> = ref(null);
-    const isMappedOver = computed(() => terminal.value?.isMappedOver() ?? false);
+    const stepStore = useWorkflowStepStore();
+    const isMappedOver = computed(() => stepStore.stepMapOver[stepId.value]?.isCollection ?? false);
 
     watch(
         [stepId, terminalSource, datatypesMapper],

--- a/client/src/components/Workflow/Editor/composables/useTerminal.ts
+++ b/client/src/components/Workflow/Editor/composables/useTerminal.ts
@@ -1,24 +1,23 @@
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 import { terminalFactory } from "@/components/Workflow/Editor/modules/terminals";
 import type { Step, TerminalSource } from "@/stores/workflowStepStore";
-import { ref, watch, type Ref } from "vue";
+import { ref, watch, type Ref, computed } from "vue";
 
 export function useTerminal(
     stepId: Ref<Step["id"]>,
     terminalSource: Ref<TerminalSource>,
     datatypesMapper: Ref<DatatypesMapperModel>
 ) {
-    const terminal = ref();
-    const isMappedOver = ref(false);
+    const terminal: Ref<ReturnType<typeof terminalFactory> | null> = ref(null);
+    const isMappedOver = computed(() => terminal.value?.isMappedOver() ?? false);
+
     watch(
         [stepId, terminalSource, datatypesMapper],
         () => {
             // rebuild terminal if any of the tracked dependencies change
-            console.log("use Terminal terminal Factory");
             const newTerminal = terminalFactory(stepId.value, terminalSource.value, datatypesMapper.value);
             newTerminal.getInvalidConnectedTerminals();
             terminal.value = newTerminal;
-            isMappedOver.value = newTerminal.isMappedOver();
         },
         {
             immediate: true,


### PR DESCRIPTION
`watchEffect` was triggering recursive reactivity. Chaining it to `watch` seems to have fixed the issue.
Waiting for tests to check if this has unintended side-effects.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
