### PR TITLE
[23.0] Fix GTN webhook

### DIFF
--- a/client/src/entry/analysis/index.ts
+++ b/client/src/entry/analysis/index.ts
@@ -13,6 +13,10 @@ pinia.use(piniaPluginPersistedstate);
 addInitialization((Galaxy: any) => {
     console.log("App setup");
     const router = getRouter(Galaxy);
+    // When initializing the primary app we bind the routing back to Galaxy for
+    // external use (e.g. gtn webhook) -- longer term we discussed plans to
+    // parameterize webhooks and initialize them explicitly with state.
+    Galaxy.router = router;
     new Vue({
         el: "#app",
         setup() {

--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -138,7 +138,7 @@
                         if (tool_id === "upload1" || tool_id === "upload") {
                             document.getElementById("tool-panel-upload-button").click();
                         } else {
-                            Galaxy.router.push("/", { tool_id: encodeURI(tool_id) });
+                            Galaxy.router.push({ path: `/?tool_id=${encodeURIComponent(tool_id)}` });
                         }
                         removeOverlay();
                     });


### PR DESCRIPTION
This still reaches into Galaxy internals, expecting a Galaxy.router, and we don't know the limit of what else was, yet.  We don't want to continue this pattern, instead, manually passing an initialization context.  TODO in dev.

Fixes https://github.com/galaxyproject/galaxy/issues/15749

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
