### PR TITLE
[23.0] Fix plugin framework build compatibility with node 16

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -149,14 +149,16 @@ function buildPlugins(callback, forceRebuild) {
                         }
                     );
                     console.log(`Building ${pluginName}`);
-                    if (
-                        child_process.spawnSync("yarn", ["build"], {
-                            cwd: pluginDir,
-                            stdio: "inherit",
-                            shell: true,
-                            env: { ...process.env, NODE_OPTIONS: "--openssl-legacy-provider" },
-                        }).status === 0
-                    ) {
+                    const opts = {
+                        cwd: pluginDir,
+                        stdio: "inherit",
+                        shell: true,
+                    };
+                    // if node version is >16, set NODE_OPTIONS to use legacy openssl provider
+                    if (process.versions.node.split(".")[0] > "16") {
+                        opts.env = { ...process.env, NODE_OPTIONS: "--openssl-legacy-provider" };
+                    }
+                    if (child_process.spawnSync("yarn", ["build"], opts).status === 0) {
                         console.log(`Successfully built, saving build state to ${hashFilePath}`);
                         child_process.exec(`(git rev-parse HEAD 2>/dev/null || echo \`\`) > ${hashFilePath}`);
                     } else {


### PR DESCRIPTION
Going > node 16, changes were made to openssl and for some libraries (webpack), we need to specify "yeah, yeah, use the old insecure openssl provider methods..".  We did this in the plugin build framework when we jumped to node 18, but I'm adding this back in order to support still building on 16 if one wishes (or has to -- e.g. el7 node versions).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
