### PR TITLE
[23.0] Add missing history export link

### DIFF
--- a/client/src/components/Common/ExportRecordDetails.vue
+++ b/client/src/components/Common/ExportRecordDetails.vue
@@ -4,10 +4,16 @@ import { BAlert, BCard, BCardTitle } from "bootstrap-vue";
 import LoadingSpan from "components/LoadingSpan";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faExclamationCircle, faExclamationTriangle, faCheckCircle, faClock } from "@fortawesome/free-solid-svg-icons";
+import {
+    faExclamationCircle,
+    faExclamationTriangle,
+    faCheckCircle,
+    faClock,
+    faLink,
+} from "@fortawesome/free-solid-svg-icons";
 import { ExportRecordModel } from "./models/exportRecordModel";
 
-library.add(faExclamationCircle, faExclamationTriangle, faCheckCircle, faClock);
+library.add(faExclamationCircle, faExclamationTriangle, faCheckCircle, faClock, faLink);
 
 const props = defineProps({
     record: {
@@ -28,7 +34,7 @@ const props = defineProps({
     },
 });
 
-const emit = defineEmits(["onReimport", "onDownload", "onActionMessageDismissed"]);
+const emit = defineEmits(["onReimport", "onDownload", "onCopyDownloadLink", "onActionMessageDismissed"]);
 
 const title = computed(() => (props.record.isReady ? `Exported` : `Export started`));
 const preparingMessage = computed(
@@ -41,6 +47,10 @@ async function reimportObject() {
 
 function downloadObject() {
     emit("onDownload", props.record);
+}
+
+function copyDownloadLink() {
+    emit("onCopyDownloadLink", props.record);
 }
 
 function onMessageDismissed() {
@@ -112,6 +122,14 @@ function onMessageDismissed() {
                         variant="primary"
                         @click="downloadObject">
                         Download
+                    </b-button>
+                    <b-button
+                        v-if="props.record.canDownload"
+                        title="Copy Download Link"
+                        size="sm"
+                        variant="link"
+                        @click.stop="copyDownloadLink">
+                        <font-awesome-icon icon="link" />
                     </b-button>
                     <b-button
                         v-if="props.record.canReimport"

--- a/client/src/components/Common/ExportRecordTable.vue
+++ b/client/src/components/Common/ExportRecordTable.vue
@@ -9,9 +9,10 @@ import {
     faDownload,
     faFileImport,
     faSpinner,
+    faLink,
 } from "@fortawesome/free-solid-svg-icons";
 
-library.add(faExclamationCircle, faCheckCircle, faDownload, faFileImport, faSpinner);
+library.add(faExclamationCircle, faCheckCircle, faDownload, faFileImport, faSpinner, faLink);
 
 const props = defineProps({
     records: {
@@ -40,6 +41,10 @@ async function reimportObject(record) {
 
 function downloadObject(record) {
     emit("onDownload", record);
+}
+
+function copyDownloadLink(record) {
+    emit("onCopyDownloadLink", record);
 }
 </script>
 
@@ -112,6 +117,12 @@ function downloadObject(record) {
                                     title="Download"
                                     @click="downloadObject(row.item)">
                                     <font-awesome-icon icon="download" />
+                                </b-button>
+                                <b-button
+                                    v-if="row.item.canDownload"
+                                    title="Copy Download Link"
+                                    @click.stop="copyDownloadLink(row.item)">
+                                    <font-awesome-icon icon="link" />
                                 </b-button>
                                 <b-button
                                     v-b-tooltip.hover.bottom

--- a/client/src/components/Common/ExportRecordTable.vue
+++ b/client/src/components/Common/ExportRecordTable.vue
@@ -33,7 +33,7 @@ const fields = [
 ];
 
 const isExpanded = ref(false);
-const title = computed(() => (isExpanded.value ? `Hide export records` : `Show export records`));
+const title = computed(() => (isExpanded.value ? `Hide old export records` : `Show old export records`));
 
 async function reimportObject(record) {
     emit("onReimport", record);

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -11,6 +11,8 @@ import { useTaskMonitor } from "composables/taskMonitor";
 import { useFileSources } from "composables/fileSources";
 import { useShortTermStorage, DEFAULT_EXPORT_PARAMS } from "composables/shortTermStorage";
 import { useConfirmDialog } from "composables/confirmDialog";
+import { copy as sendToClipboard } from "utils/clipboard";
+import { absPath } from "@/utils/redirect";
 
 const {
     isRunning: isExportTaskRunning,
@@ -18,8 +20,16 @@ const {
     requestHasFailed: taskMonitorRequestFailed,
     hasFailed: taskHasFailed,
 } = useTaskMonitor();
+
 const { hasWritable: hasWritableFileSources } = useFileSources();
-const { isPreparing: isPreparingDownload, downloadHistory, downloadObjectByRequestId } = useShortTermStorage();
+
+const {
+    isPreparing: isPreparingDownload,
+    downloadHistory,
+    downloadObjectByRequestId,
+    getDownloadObjectUrl,
+} = useShortTermStorage();
+
 const { confirm } = useConfirmDialog();
 
 const props = defineProps({
@@ -101,6 +111,13 @@ async function prepareDownload() {
 function downloadFromRecord(record) {
     if (record.canDownload) {
         downloadObjectByRequestId(record.stsDownloadId);
+    }
+}
+
+function copyDownloadLinkFromRecord(record) {
+    if (record.canDownload) {
+        const relativeLink = getDownloadObjectUrl(record.stsDownloadId);
+        sendToClipboard(absPath(relativeLink), "Download link copied to your clipboard");
     }
 }
 
@@ -203,6 +220,7 @@ function updateExportParams(newParams) {
             :action-message="actionMessage"
             :action-message-variant="actionMessageVariant"
             @onDownload="downloadFromRecord"
+            @onCopyDownloadLink="copyDownloadLinkFromRecord"
             @onReimport="reimportFromRecord"
             @onActionMessageDismissed="onActionMessageDismissedFromRecord" />
         <b-alert v-else id="no-export-records-alert" variant="info" class="mt-3" show>

--- a/client/src/composables/shortTermStorage.js
+++ b/client/src/composables/shortTermStorage.js
@@ -30,8 +30,13 @@ export function useShortTermStorage() {
         return prepareObjectDownload(invocationId, "invocations", options);
     }
 
-    function downloadObjectByRequestId(storageRequestId) {
+    function getDownloadObjectUrl(storageRequestId) {
         const url = withPrefix(`/api/short_term_storage/${storageRequestId}`);
+        return url;
+    }
+
+    function downloadObjectByRequestId(storageRequestId) {
+        const url = getDownloadObjectUrl(storageRequestId);
         window.location.assign(url);
     }
 
@@ -119,5 +124,10 @@ export function useShortTermStorage() {
          * Whether the download is still being prepared.
          */
         isPreparing: readonly(isPreparing),
+        /**
+         * Given a storageRequestId it returns the download URL for that object.
+         * @param {String} storageRequestId The storage request ID associated to the object to be downloaded
+         */
+        getDownloadObjectUrl,
     };
 }


### PR DESCRIPTION
Fixes #15752

Since RO-Crate packages are in Zip format I had to add support for importing zip archives in d15815a2b52466a4b8ad2a13ab6f6f72da9b635c otherwise the import would fail for those exports.

Also renames the list of previous export records to make it clear that the list contains the `old` ones since the latest export record is always visible.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Export a History using the `Direct Download` option
  - See that a new `Copy Download Link` button appears next to the Download button whenever the history is ready for download
  - Pasting this link to the `Import` History dialog will successfully import the history

![ExportDownloadLinks](https://user-images.githubusercontent.com/46503462/224281029-41599041-2bf3-4bc7-84e0-a6f5116e07e5.gif)


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
