### PR TITLE
[22.05] Fix IT port parsing to be compatible with newer docker versions

### DIFF
--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -197,6 +197,7 @@ def parse_port_text(port_text):
     >>> slurm_ports = parse_port_text("8888/tcp -> 0.0.0.0:32769")
     >>> slurm_ports[8888]['host']
     '0.0.0.0'
+    >>> ports = parse_port_text("80/tcp -> [::]:32787")
     >>> ports = parse_port_text("5432/tcp -> :::5432")
     """
     ports = None
@@ -207,7 +208,7 @@ def parse_port_text(port_text):
                 raise Exception(f"Cannot parse host and port from line [{line}]")
             tool, host = line.split(" -> ", 1)
             hostname, port = host.rsplit(":", 1)
-            if hostname == "::":
+            if "::" in hostname:
                 # Skip unspecified IPv6 address, which is also specified as 0:0:0:0 in another line.
                 # This is brittle of course, but so is parsing the container ports like this.
                 continue


### PR DESCRIPTION
Galaxy uses the output from the `docker port` command to parse an interactive tool container's ip/port. Newer docker versions appear to be adding extra brackets around ipv6 addresses, which causes the parsing code to incorrectly parse `[::]` as a hostname, instead of ignoring it.

```
user1@dev-w1:~$ sudo docker port e15e322b901f
80/tcp -> 0.0.0.0:49181
80/tcp -> :::49181
user1@dev-w1:~$ docker --version
Docker version 20.10.19, build d85ef84

user2@aarnet-w4:~$ sudo docker port d2db684e0656
80/tcp -> 0.0.0.0:32787
80/tcp -> [::]:32787
user2@aarnet-w4:~$ docker --version
Docker version 23.0.1, build a5ee5b1
```

This  fix generalizes the skip logic to skip over any hostname with `::` in it.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
