### PR TITLE
[23.0] Avoid passing headers argument twice in datatypes display - take 2

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -2019,7 +2019,7 @@ class H5MLM(H5):
         to_ext: Optional[str] = None,
         **kwd,
     ):
-        headers = kwd.get("headers", {})
+        headers = kwd.pop("headers", {})
         preview = util.string_as_bool(preview)
 
         if to_ext or not preview:

--- a/lib/galaxy/datatypes/spaln.py
+++ b/lib/galaxy/datatypes/spaln.py
@@ -134,7 +134,7 @@ class _SpalnDb(Data):
         If preview is `True` allows us to format the data shown in the central pane via the "eye" icon.
         If preview is `False` triggers download.
         """
-        headers = kwd.get("headers", {})
+        headers = kwd.pop("headers", {})
         if not preview:
             return super().display_data(
                 trans,

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -176,7 +176,7 @@ class TabularData(Text):
         ck_size: Optional[int] = None,
         **kwd,
     ):
-        headers = kwd.get("headers", {})
+        headers = kwd.pop("headers", {})
         preview = util.string_as_bool(preview)
         if offset is not None:
             return self.get_chunk(trans, dataset, offset, ck_size), headers

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -203,17 +203,12 @@ class Ipynb(Json):
         to_ext: Optional[str] = None,
         **kwd,
     ):
-        headers = kwd.get("headers", {})
         config = trans.app.config
         trust = getattr(config, "trust_jupyter_notebook_conversion", False)
         if trust:
-            return self._display_data_trusted(
-                trans, dataset, preview=preview, filename=filename, to_ext=to_ext, headers=headers, **kwd
-            )
+            return self._display_data_trusted(trans, dataset, preview=preview, filename=filename, to_ext=to_ext, **kwd)
         else:
-            return super().display_data(
-                trans, dataset, preview=preview, filename=filename, to_ext=to_ext, headers=headers, **kwd
-            )
+            return super().display_data(trans, dataset, preview=preview, filename=filename, to_ext=to_ext, **kwd)
 
     def _display_data_trusted(
         self,
@@ -224,7 +219,7 @@ class Ipynb(Json):
         to_ext: Optional[str] = None,
         **kwd,
     ) -> Tuple[IO, Headers]:
-        headers = kwd.get("headers", {})
+        headers = kwd.pop("headers", {})
         preview = string_as_bool(preview)
         if to_ext or not preview:
             return self._serve_raw(dataset, to_ext, headers, **kwd)


### PR DESCRIPTION
#15738 reapplied to release_23.0

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
