### PR TITLE
"Rebase" migrations in dev that diverged from release_23.0 after merge

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/d0583094c8cd_add_quota_source_labels.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/d0583094c8cd_add_quota_source_labels.py
@@ -21,7 +21,7 @@ from galaxy.model.migrations.util import (
 
 # revision identifiers, used by Alembic.
 revision = "d0583094c8cd"
-down_revision = "c39f1de47a04"
+down_revision = "caa7742f7bca"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
I merged release_23.0 into dev this morning, which brought two new DB migrations from 23.0 - however, dev also had its own migrations added after release_23.0 was branched, so this caused them to diverge, resulting two heads.

So this "rebases" the dev migrations onto the 23.0 ones. I don't know what this means for any dev instances that already have the dev-only migrations applied, hopefully alembic knows what to do?

Fixes #15765

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
