### PR TITLE
[22.05] backport: fix hostname parsing for newer Docker versions

### DIFF
--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -198,6 +198,11 @@ def parse_port_text(port_text):
     >>> slurm_ports[8888]['host']
     '0.0.0.0'
     >>> ports = parse_port_text("5432/tcp -> :::5432")
+    >>> len(ports)
+    0
+    >>> ports_new = parse_port_text("5432/tcp -> [::]:5432")
+    >>> len(ports_new)
+    0
     """
     ports = None
     if port_text is not None:
@@ -207,7 +212,7 @@ def parse_port_text(port_text):
                 raise Exception(f"Cannot parse host and port from line [{line}]")
             tool, host = line.split(" -> ", 1)
             hostname, port = host.rsplit(":", 1)
-            if hostname == "::":
+            if hostname in ["::", "[::]"]:
                 # Skip unspecified IPv6 address, which is also specified as 0:0:0:0 in another line.
                 # This is brittle of course, but so is parsing the container ports like this.
                 continue


### PR DESCRIPTION
backport https://github.com/galaxyproject/galaxy/pull/15561

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
