### PR TITLE
Merge conflicting db migration branches into one

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/460d0ecd1dd8_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/460d0ecd1dd8_.py
@@ -1,0 +1,28 @@
+"""Merge head revisions
+
+COMMENT: After merging 23.0 into dev in 0ac48236df7984ae2c74d6d0470a6b0aec8e9cc6,
+the gxy branch was split at revision c29f into 2 conflicting branches, each
+having 2 revisions on top of c29f. This revision merges the diverged branches
+back into one branch.
+
+Revision ID: 460d0ecd1dd8
+Revises: caa7742f7bca, 9540a051226e
+Create Date: 2023-03-11 19:40:06.135368
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "460d0ecd1dd8"
+down_revision = ("caa7742f7bca", "9540a051226e")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Intentionally empty
+    pass
+
+
+def downgrade():
+    # Intentionally empty
+    pass


### PR DESCRIPTION
This is meant to replace #15768.

The core issue is explained in #15768. Here's a visualization of what happened and the 2 solutions. From left to right:
1. 23.0: 2 revisions added on top of c39f
2. dev_pre_conflict: 2 *other* revisions added on top of c39f
3. dev_conflict: 23.0 merged into dev: we have 2 heads: caa7 and 9540.
Why is this a problem? Because when we want to upgrade, alembic can't know what head we want to upgrade to.
4. dev_solved_renamed: initially proposed solution: manually edit the `down_revision` value in d058, "rebasing" it onto caa7, thus rearranging the graph to have 1 gxy head
5. dev_solved_merged: alternative solution: add an empty merge revision 
(with `./scripts/run_alembic.sh merge caa7 9540`), thus restoring 1 gxy head

![image](https://user-images.githubusercontent.com/6132258/224518211-14e5e393-2d72-4c96-b9ef-422c5446f68a.png)

**Why renaming is not a good solution**
If we start with the pre-conflict dev branch (normal case for a development setup), the `alembic_version` table in the database will contain revisions 9540 and d4a6 (d4a6 is the tsi branch, so it's irrelevant in this context). Once we pull from upstream, we get the 2 new revisions from the merged-in 23.0 branch (3a29 and caa7), resulting in 2 gxy heads. We rename the down_migration in d058, ***effectively hiding 3a29 and caa7 from the database*** (@natefoo that's the problem case you referred to). So, running `manage_db.sh upgrade will be a noop, and the 2 indexes won't be added. 

By adding an explicit merge revision, we reconcile the diverged branches, while ensuring that revisions won't be silenced.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
No easy way to set this up. Here's [gist with a transcript of some of the testing I did of this approach](https://gist.github.com/jdavcs/b595fb29b661ea19b7b7bac1dfd4fac5). In summary:
- setup state: 
  -  branch: pre-conflict dev (current dev minus 3a29, caa7
  - brand new database (I ran this on sqlite and postgresql) via `manage_db.sh init`
- move to conflict state (add 2 migrations from 23.0)
- try to upgrade: verify error
- add a merge revision
- upgrade: no error
- downgrade to 23.0
- upgrade back to dev
(verify version, dbversion, and history after each step).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
