### PR TITLE
[WIP,RFC] Convert Enums to Literals in schema

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -3839,8 +3839,9 @@ export interface components {
             /**
              * Job Source Type
              * @description The type of job (model class) that produced this dataset collection. Used to track the state of the job.
+             * @enum {string}
              */
-            job_source_type?: components["schemas"]["JobSourceType"];
+            job_source_type?: "Job" | "ImplicitCollectionJobs" | "WorkflowInvocation";
             /**
              * Job State Summary
              * @description Overview of the job states working inside the dataset collection.
@@ -3973,8 +3974,9 @@ export interface components {
             /**
              * Job Source Type
              * @description The type of job (model class) that produced this dataset collection. Used to track the state of the job.
+             * @enum {string}
              */
-            job_source_type?: components["schemas"]["JobSourceType"];
+            job_source_type?: "Job" | "ImplicitCollectionJobs" | "WorkflowInvocation";
             /**
              * Job State Summary
              * @description Overview of the job states working inside the dataset collection.
@@ -4870,12 +4872,6 @@ export interface components {
              */
             active: boolean;
         };
-        /**
-         * JobSourceType
-         * @description Available types of job sources (model classes) that produce dataset collections.
-         * @enum {string}
-         */
-        JobSourceType: "Job" | "ImplicitCollectionJobs" | "WorkflowInvocation";
         /**
          * JobStateSummary
          * @description Base model definition with common configuration used by all derived models.

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -4853,12 +4853,6 @@ export interface components {
             update_time: string;
         };
         /**
-         * JobIndexSortByEnum
-         * @description An enumeration.
-         * @enum {string}
-         */
-        JobIndexSortByEnum: "create_time" | "update_time";
-        /**
          * JobIndexViewEnum
          * @description An enumeration.
          * @enum {string}
@@ -12024,7 +12018,7 @@ export interface operations {
                 history_id?: string;
                 workflow_id?: string;
                 invocation_id?: string;
-                order_by?: components["schemas"]["JobIndexSortByEnum"];
+                order_by?: "create_time" | "update_time";
                 search?: string;
                 limit?: number;
                 offset?: number;

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -6491,8 +6491,10 @@ export interface components {
              *  - make_public: The contents of the resource will be made publicly accessible.
              *  - make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
              *  - no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
+             *
+             * @enum {string}
              */
-            share_option?: components["schemas"]["SharingOptions"];
+            share_option?: "make_public" | "make_accessible_to_shared" | "no_changes";
             /**
              * User Identifiers
              * @description A collection of encoded IDs (or email addresses) of users that this resource will be shared with.
@@ -6558,12 +6560,6 @@ export interface components {
              */
             users_shared_with?: components["schemas"]["UserEmail"][];
         };
-        /**
-         * SharingOptions
-         * @description Options for sharing resources that may have restricted access to all or part of their contents.
-         * @enum {string}
-         */
-        SharingOptions: "make_public" | "make_accessible_to_shared" | "no_changes";
         /**
          * SharingStatus
          * @description Base model definition with common configuration used by all derived models.

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -5175,12 +5175,6 @@ export interface components {
             total_rows: number;
         };
         /**
-         * LibraryFolderPermissionAction
-         * @description An enumeration.
-         * @enum {string}
-         */
-        LibraryFolderPermissionAction: "set_permissions";
-        /**
          * LibraryFolderPermissionsPayload
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -5188,8 +5182,9 @@ export interface components {
             /**
              * Action
              * @description Indicates what action should be performed on the library folder.
+             * @enum {string}
              */
-            action?: components["schemas"]["LibraryFolderPermissionAction"];
+            action?: "set_permissions";
             /**
              * Add IDs
              * @description A list of role encoded IDs defining roles that should be able to add items to the library.
@@ -8881,7 +8876,7 @@ export interface operations {
         parameters: {
             /** @description Indicates what action should be performed on the Library. Currently only `set_permissions` is supported. */
             query?: {
-                action?: components["schemas"]["LibraryFolderPermissionAction"];
+                action?: "set_permissions";
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1883,8 +1883,9 @@ export interface components {
              * Type
              * @description The type of content to be created in the history.
              * @default dataset
+             * @enum {string}
              */
-            type?: components["schemas"]["HistoryContentType"];
+            type?: "dataset" | "dataset_collection";
         };
         /**
          * CreateHistoryFromStore
@@ -3489,8 +3490,9 @@ export interface components {
             /**
              * Content Type
              * @description The type of this item.
+             * @enum {string}
              */
-            history_content_type: components["schemas"]["HistoryContentType"];
+            history_content_type: "dataset" | "dataset_collection";
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
@@ -3701,8 +3703,9 @@ export interface components {
             /**
              * Content Type
              * @description The type of this item.
+             * @enum {string}
              */
-            history_content_type: components["schemas"]["HistoryContentType"];
+            history_content_type: "dataset" | "dataset_collection";
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
@@ -3816,8 +3819,9 @@ export interface components {
             /**
              * Content Type
              * @description The type of this item.
+             * @enum {string}
              */
-            history_content_type: components["schemas"]["HistoryContentType"];
+            history_content_type: "dataset" | "dataset_collection";
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
@@ -3951,8 +3955,9 @@ export interface components {
             /**
              * Content Type
              * @description The type of this item.
+             * @enum {string}
              */
-            history_content_type: components["schemas"]["HistoryContentType"];
+            history_content_type: "dataset" | "dataset_collection";
             /**
              * History ID
              * @description The encoded ID of the history associated with this item.
@@ -4252,8 +4257,9 @@ export interface components {
             /**
              * Content Type
              * @description The type of this item.
+             * @enum {string}
              */
-            history_content_type: components["schemas"]["HistoryContentType"];
+            history_content_type: "dataset" | "dataset_collection";
             /**
              * ID
              * @description The encoded ID of this entity.
@@ -4293,12 +4299,6 @@ export interface components {
              */
             total_matches: number;
         };
-        /**
-         * HistoryContentType
-         * @description Available types of History contents.
-         * @enum {string}
-         */
-        HistoryContentType: "dataset" | "dataset_collection";
         /**
          * HistoryContentsResult
          * @description List of history content items.
@@ -6962,8 +6962,9 @@ export interface components {
             /**
              * Content Type
              * @description The type of this item.
+             * @enum {string}
              */
-            history_content_type: components["schemas"]["HistoryContentType"];
+            history_content_type: "dataset" | "dataset_collection";
             /**
              * ID
              * @description The encoded ID of this entity.
@@ -10101,7 +10102,7 @@ export interface operations {
             /** @description View to be passed to the serializer */
             /** @description Comma-separated list of keys to be passed to the serializer */
             query?: {
-                type?: components["schemas"]["HistoryContentType"];
+                type?: "dataset" | "dataset_collection";
                 view?: string;
                 keys?: string;
             };
@@ -10568,7 +10569,7 @@ export interface operations {
             /** @description View to be passed to the serializer */
             /** @description Comma-separated list of keys to be passed to the serializer */
             query?: {
-                type?: components["schemas"]["HistoryContentType"];
+                type?: "dataset" | "dataset_collection";
                 fuzzy_count?: number;
                 view?: string;
                 keys?: string;
@@ -10618,7 +10619,7 @@ export interface operations {
             /** @description View to be passed to the serializer */
             /** @description Comma-separated list of keys to be passed to the serializer */
             query?: {
-                type?: components["schemas"]["HistoryContentType"];
+                type?: "dataset" | "dataset_collection";
                 view?: string;
                 keys?: string;
             };
@@ -10685,7 +10686,7 @@ export interface operations {
             /** @description View to be passed to the serializer */
             /** @description Comma-separated list of keys to be passed to the serializer */
             query?: {
-                type?: components["schemas"]["HistoryContentType"];
+                type?: "dataset" | "dataset_collection";
                 purge?: boolean;
                 recursive?: boolean;
                 stop_job?: boolean;
@@ -10875,7 +10876,7 @@ export interface operations {
             /** @description The ID of the History. */
             path: {
                 history_id: string;
-                type: components["schemas"]["HistoryContentType"];
+                type: "dataset" | "dataset_collection";
             };
         };
         requestBody: {
@@ -10935,7 +10936,7 @@ export interface operations {
             path: {
                 history_id: string;
                 id: string;
-                type: components["schemas"]["HistoryContentType"];
+                type: "dataset" | "dataset_collection";
             };
         };
         responses: {
@@ -10979,7 +10980,7 @@ export interface operations {
             path: {
                 history_id: string;
                 id: string;
-                type: components["schemas"]["HistoryContentType"];
+                type: "dataset" | "dataset_collection";
             };
         };
         requestBody: {
@@ -11045,7 +11046,7 @@ export interface operations {
             path: {
                 history_id: string;
                 id: string;
-                type: components["schemas"]["HistoryContentType"];
+                type: "dataset" | "dataset_collection";
             };
         };
         requestBody?: {
@@ -11094,7 +11095,7 @@ export interface operations {
             path: {
                 history_id: string;
                 id: string;
-                type: components["schemas"]["HistoryContentType"];
+                type: "dataset" | "dataset_collection";
             };
         };
         responses: {
@@ -11127,7 +11128,7 @@ export interface operations {
             path: {
                 history_id: string;
                 id: string;
-                type: components["schemas"]["HistoryContentType"];
+                type: "dataset" | "dataset_collection";
             };
         };
         requestBody: {
@@ -11162,7 +11163,7 @@ export interface operations {
             path: {
                 history_id: string;
                 id: string;
-                type: components["schemas"]["HistoryContentType"];
+                type: "dataset" | "dataset_collection";
             };
         };
         requestBody: {

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -44,6 +44,8 @@ from galaxy.schema.schema import (
     ExportObjectType,
     HDABasicInfo,
     ShareHistoryExtra,
+    ShareWithExtra,
+    SharingOptions,
 )
 from galaxy.security.validate_user_input import validate_preferred_object_store_id
 from galaxy.structured_app import MinimalManagerApp
@@ -271,8 +273,8 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         return job
 
     def get_sharing_extra_information(
-        self, trans, item, users: Set[model.User], errors: Set[str], option: Optional[sharable.SharingOptions] = None
-    ) -> Optional[sharable.ShareWithExtra]:
+        self, trans, item, users: Set[model.User], errors: Set[str], option: Optional[SharingOptions] = None
+    ) -> Optional[ShareWithExtra]:
         """Returns optional extra information about the datasets of the history that can be accessed by the users."""
         extra = ShareHistoryExtra()
         history = cast(model.History, item)
@@ -284,7 +286,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         owner_roles = owner.all_roles()
         can_change_dict = {}
         cannot_change_dict = {}
-        share_anyway = option is not None and option == sharable.SharingOptions.no_changes
+        share_anyway = option is not None and option == "no_changes"
         datasets = history.activatable_datasets
         total_dataset_count = len(datasets)
         for user in users:
@@ -303,9 +305,9 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
                     and not hda.dataset.library_associations
                 )
                 if option and owner_can_manage_dataset:
-                    if option == sharable.SharingOptions.make_accessible_to_shared:
+                    if option == "make_accessible_to_shared":
                         trans.app.security_agent.privately_share_dataset(hda.dataset, users=[owner, user])
-                    elif option == sharable.SharingOptions.make_public:
+                    elif option == "make_public":
                         trans.app.security_agent.make_dataset_public(hda.dataset)
                 else:
                     hda_id = trans.security.encode_id(hda.id)

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -40,10 +40,7 @@ from galaxy.model.index_filter_util import (
     text_column_filter,
 )
 from galaxy.model.scoped_session import galaxy_scoped_session
-from galaxy.schema.schema import (
-    JobIndexQueryPayload,
-    JobIndexSortByEnum,
-)
+from galaxy.schema.schema import JobIndexQueryPayload
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import StructuredApp
 from galaxy.util import (
@@ -200,7 +197,7 @@ class JobManager:
                         columns.append(model.Job.job_runner_name)
                     query = query.filter(raw_text_column_filter(columns, term))
 
-        if payload.order_by == JobIndexSortByEnum.create_time:
+        if payload.order_by == "create_time":
             order_by = model.Job.create_time.desc()
         else:
             order_by = model.Job.update_time.desc()

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -23,7 +23,6 @@ from galaxy.schema.schema import (
     ExportObjectRequestMetadata,
     ExportObjectResultMetadata,
     ExportObjectType,
-    HistoryContentType,
     ShortTermStoreExportPayload,
     WriteStoreToPayload,
 )
@@ -134,7 +133,7 @@ class ModelStoreManager:
             with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
                 short_term_storage_target.path
             ) as export_store:
-                if request.content_type == HistoryContentType.dataset:
+                if request.content_type == "dataset":
                     hda = self._sa_session.query(model.HistoryDatasetAssociation).get(request.content_id)
                     export_store.add_dataset(hda)
                 else:
@@ -196,7 +195,7 @@ class ModelStoreManager:
         with model.store.get_export_store_factory(
             self._app, model_store_format, export_files=export_files, user_context=user_context
         )(target_uri) as export_store:
-            if request.content_type == HistoryContentType.dataset:
+            if request.content_type == "dataset":
                 hda = self._sa_session.query(model.HistoryDatasetAssociation).get(request.content_id)
                 export_store.add_dataset(hda)
             else:

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -591,7 +591,5 @@ __all__ = (
     "SharableModelFilters",
     "SharableModelManager",
     "SharableModelSerializer",
-    "SharingOptions",
-    "ShareWithExtra",
     "SlugBuilder",
 )

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -252,12 +252,8 @@ class GroupModel(Model):
 # Available types of job sources (model classes) that produce dataset collections.
 JobSourceType = Literal["Job", "ImplicitCollectionJobs", "WorkflowInvocation"]
 
-
-class HistoryContentType(str, Enum):
-    """Available types of History contents."""
-
-    dataset = "dataset"
-    dataset_collection = "dataset_collection"
+# Available types of History contents.
+HistoryContentType = Literal["dataset", "dataset_collection"]
 
 
 class HistoryImportArchiveSourceType(str, Enum):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1106,9 +1106,7 @@ class WorkflowIndexQueryPayload(Model):
     skip_step_counts: bool = False
 
 
-class JobIndexSortByEnum(str, Enum):
-    create_time = "create_time"
-    update_time = "update_time"
+JobIndexSortByEnum = Literal["create_time", "update_time"]
 
 
 class JobIndexQueryPayload(Model):
@@ -1122,7 +1120,7 @@ class JobIndexQueryPayload(Model):
     history_id: Optional[DecodedDatabaseIdField] = None
     workflow_id: Optional[DecodedDatabaseIdField] = None
     invocation_id: Optional[DecodedDatabaseIdField] = None
-    order_by: JobIndexSortByEnum = JobIndexSortByEnum.update_time
+    order_by: JobIndexSortByEnum = "update_time"
     search: Optional[str] = None
     limit: int = 500
     offset: int = 0

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2974,12 +2974,8 @@ class HistoryContentsWithStatsResult(Model):
 
 
 # Sharing -----------------------------------------------------------------
-class SharingOptions(str, Enum):
-    """Options for sharing resources that may have restricted access to all or part of their contents."""
-
-    make_public = "make_public"
-    make_accessible_to_shared = "make_accessible_to_shared"
-    no_changes = "no_changes"
+# Options for sharing resources that may have restricted access to all or part of their contents.
+SharingOptions = Literal["make_public", "make_accessible_to_shared", "no_changes"]
 
 
 class ShareWithExtra(Model):
@@ -3010,9 +3006,9 @@ class ShareWithPayload(Model):
         description=(
             "User choice for sharing resources which its contents may be restricted:\n"
             " - None: The user did not choose anything yet or no option is needed.\n"
-            f" - {SharingOptions.make_public.value}: The contents of the resource will be made publicly accessible.\n"
-            f" - {SharingOptions.make_accessible_to_shared.value}: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.\n"
-            f" - {SharingOptions.no_changes.value}: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.\n"
+            " - make_public: The contents of the resource will be made publicly accessible.\n"
+            " - make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.\n"
+            " - no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.\n"
         ),
     )
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -249,12 +249,8 @@ class GroupModel(Model):
     )
 
 
-class JobSourceType(str, Enum):
-    """Available types of job sources (model classes) that produce dataset collections."""
-
-    Job = "Job"
-    ImplicitCollectionJobs = "ImplicitCollectionJobs"
-    WorkflowInvocation = "WorkflowInvocation"
+# Available types of job sources (model classes) that produce dataset collections.
+JobSourceType = Literal["Job", "ImplicitCollectionJobs", "WorkflowInvocation"]
 
 
 class HistoryContentType(str, Enum):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2593,8 +2593,7 @@ class LibraryPermissionsPayload(LibraryPermissionsPayloadBase):
 # Library Folders -----------------------------------------------------------------
 
 
-class LibraryFolderPermissionAction(str, Enum):
-    set_permissions = "set_permissions"
+LibraryFolderPermissionAction = Literal["set_permissions"]
 
 
 FolderNameField: str = Field(

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -148,7 +148,7 @@ class FastAPILibraryFolders:
             title="Action",
             description=(
                 "Indicates what action should be performed on the Library. "
-                f"Currently only `{LibraryFolderPermissionAction.set_permissions.value}` is supported."
+                "Currently only `set_permissions` is supported."
             ),
         ),
         payload: LibraryFolderPermissionsPayload = Body(...),

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -23,6 +23,7 @@ from starlette.responses import (
     Response,
     StreamingResponse,
 )
+from typing_extensions import get_args
 
 from galaxy import util
 from galaxy.managers.context import ProvidesHistoryContext
@@ -92,10 +93,10 @@ HistoryHDCAIDPathParam: DecodedDatabaseIdField = Path(
 )
 
 ContentTypeQueryParam = Query(
-    default=HistoryContentType.dataset,
+    default="dataset",
     title="Content Type",
     description="The type of the history element to show.",
-    example=HistoryContentType.dataset,
+    example="dataset",
 )
 
 CONTENT_DELETE_RESPONSES = {
@@ -233,7 +234,7 @@ def parse_legacy_index_query_params(
         else:  # Support ?types=dataset&types=dataset_collection
             content_types = util.listify(types)
     else:
-        content_types = [e.value for e in HistoryContentType]
+        content_types = list(get_args(HistoryContentType))
 
     id_list = None
     if ids:
@@ -560,7 +561,7 @@ class FastAPIHistoryContents:
             default=None,
             title="Content Type",
             description="The type of the history element to create.",
-            example=HistoryContentType.dataset,
+            example="dataset",
         ),
         serialization_params: SerializationParams = Depends(query_serialization_params),
         payload: CreateHistoryContentPayload = Body(...),

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -141,7 +141,7 @@ InvocationIdQueryParam: Optional[DecodedDatabaseIdField] = Query(
 )
 
 SortByQueryParam: JobIndexSortByEnum = Query(
-    default=JobIndexSortByEnum.update_time,
+    default="update_time",
     title="Sort By",
     description="Sort results by specified field.",
 )

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -457,9 +457,9 @@ class HistoriesContentsService(ServiceBase, ServesExportStores, ConsumesModelSto
         elif contents_type == HistoryContentType.dataset_collection:
             dataset_collection_instance = self.__get_accessible_collection(trans, id)
             job_source_type = dataset_collection_instance.job_source_type
-            if job_source_type == JobSourceType.Job:
+            if job_source_type == "Job":
                 job = dataset_collection_instance.job
-            elif job_source_type == JobSourceType.ImplicitCollectionJobs:
+            elif job_source_type == "ImplicitCollectionJobs":
                 implicit_collection_jobs = dataset_collection_instance.implicit_collection_jobs
 
         assert job is None or implicit_collection_jobs is None


### PR DESCRIPTION
`(str, Enum)` is redundant for type annotations, since `Literal` was introduced for that use case. `Enum` also requires more code and is less readable, both when defining the class and when using the values (e.g. `SharingOptions.make_public.value` vs `"value"`), with no practical benefit, since any mistyping would be caught by mypy.
`Enum` also introduced tricky bugs like those fixed in https://github.com/galaxyproject/galaxy/commit/a7ddf896908a637c83f55564c006e55b576f5566 and https://github.com/galaxyproject/galaxy/pull/15740.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
