### PR TITLE
[23.0] Cast ``url_for()`` output to ``str``

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -173,7 +173,7 @@ class UrlBuilder:
         query_params = path_params.pop("query_params", None)
         try:
             if qualified:
-                url = self.request.url_for(name, **path_params)
+                url = str(self.request.url_for(name, **path_params))
             else:
                 url = self.request.app.url_path_for(name, **path_params)
             if query_params:


### PR DESCRIPTION
Starlette 0.26.0 has changed the return type of `HTTPConnection.url_for()` from `str` to `URL`, which breaks the Galaxy package mypy tests:

```
mypy . --enable-incomplete-feature=Unpack
galaxy/webapps/galaxy/api/__init__.py:180: error: Incompatible types in
assignment (expression has type "str", variable has type "URL")  [assignment]
                    url = f"{url}?{urlencode(query_params)}"
                          ^
Found 1 error in 1 file (checked 255 source files)
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
