### PR TITLE
[23.0] Improve performance for rendering and changing large workflows

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -656,6 +656,7 @@ export default {
             getModule(stepData, id, this.stateStore.setLoadingState).then((response) => {
                 this.stepStore.updateStep({
                     ...stepData,
+                    id: id,
                     tool_state: response.tool_state,
                     inputs: response.inputs,
                     outputs: response.outputs,

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -81,7 +81,6 @@
                 :root-offset="rootOffset"
                 :scroll="scroll"
                 :scale="scale"
-                v-on="$listeners"
                 @onChange="onChange" />
             <div v-if="showRule" class="rule" />
             <node-output
@@ -97,7 +96,7 @@
                 :scroll="scroll"
                 :scale="scale"
                 :datatypes-mapper="datatypesMapper"
-                v-on="$listeners"
+                @onDragConnector="onDragConnector"
                 @stopDragging="onStopDragging"
                 @onChange="onChange" />
         </div>
@@ -117,7 +116,7 @@ import NodeOutput from "@/components/Workflow/Editor/NodeOutput.vue";
 import DraggableWrapper from "@/components/Workflow/Editor/DraggablePan.vue";
 import { computed, ref } from "vue";
 import { useNodePosition } from "@/components/Workflow/Editor/composables/useNodePosition";
-import { useWorkflowStateStore, type XYPosition } from "@/stores/workflowEditorStateStore";
+import { useWorkflowStateStore, type TerminalPosition, type XYPosition } from "@/stores/workflowEditorStateStore";
 import type { Step } from "@/stores/workflowStepStore";
 import { DatatypesMapperModel } from "@/components/Datatypes/model";
 import type { UseElementBoundingReturn, UseScrollReturn } from "@vueuse/core";
@@ -126,6 +125,7 @@ import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 import { faCodeBranch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
+import type { OutputTerminals } from "./modules/terminals";
 
 Vue.use(BootstrapVue);
 
@@ -158,6 +158,7 @@ const emit = defineEmits([
     "onClone",
     "onUpdateStepPosition",
     "pan-by",
+    "onDragConnector",
     "stopDragging",
 ]);
 
@@ -239,6 +240,10 @@ const outputs = computed(() => {
     }
     return [...stepOutputs, ...invalidOutputs.value];
 });
+
+function onDragConnector(dragPosition: TerminalPosition, terminal: OutputTerminals) {
+    emit("onDragConnector", dragPosition, terminal);
+}
 
 function onMoveTo(position: XYPosition) {
     emit("onUpdateStepPosition", props.id, {

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -196,9 +196,6 @@ export default {
         dragLeave(event) {
             this.$root.$emit("bv::hide::tooltip", this.iconId);
         },
-        onChange() {
-            this.$emit("onChange");
-        },
         onRemove() {
             const connections = this.connectionStore.getConnectionsForTerminal(this.id);
             connections.forEach((connection) => this.terminal.disconnect(connection));

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -107,17 +107,15 @@ async function toggleChildComponent() {
 
 function onToggleActive() {
     const step = stepStore.getStep(stepId.value);
+    let stepWorkflowOutputs = [...(step.workflow_outputs || [])];
     if (workflowOutput.value) {
-        step.workflow_outputs = (step.workflow_outputs || []).filter(
+        stepWorkflowOutputs = stepWorkflowOutputs.filter(
             (workflowOutput) => workflowOutput.output_name !== output.value.name
         );
     } else {
-        if (!step.workflow_outputs) {
-            step.workflow_outputs = [];
-        }
-        step.workflow_outputs.push({ output_name: output.value.name });
+        stepWorkflowOutputs.push({ output_name: output.value.name });
     }
-    stepStore.updateStep(step);
+    stepStore.updateStep({ ...step, workflow_outputs: stepWorkflowOutputs });
 }
 
 function onToggleVisible() {

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -1,3 +1,213 @@
+<script setup lang="ts">
+import DraggableWrapper from "./DraggablePan.vue";
+import { useCoordinatePosition, type ElementBounding } from "./composables/useCoordinatePosition";
+import { useTerminal } from "./composables/useTerminal";
+import { ref, computed, watch, nextTick, toRefs, onBeforeUnmount, type Ref } from "vue";
+import type { DatatypesMapperModel } from "@/components/Datatypes/model";
+import { useWorkflowStateStore, type XYPosition } from "@/stores/workflowEditorStateStore";
+import ConnectionMenu from "@/components/Workflow/Editor/ConnectionMenu.vue";
+import {
+    useWorkflowStepStore,
+    type OutputTerminalSource,
+    type Step,
+    type PostJobActions,
+    type PostJobAction,
+} from "@/stores/workflowStepStore";
+import type { UseScrollReturn } from "@vueuse/core";
+
+const props = defineProps<{
+    output: OutputTerminalSource;
+    workflowOutputs: NonNullable<Step["workflow_outputs"]>;
+    stepType: Step["type"];
+    stepId: number;
+    postJobActions: PostJobActions;
+    stepPosition: NonNullable<Step["position"]>;
+    rootOffset: Ref<ElementBounding>;
+    scroll: UseScrollReturn;
+    scale: number;
+    datatypesMapper: DatatypesMapperModel;
+}>();
+
+const emit = defineEmits(["pan-by", "stopDragging", "onDragConnector"]);
+const stateStore = useWorkflowStateStore();
+const stepStore = useWorkflowStepStore();
+const el = ref(null);
+const { rootOffset, stepPosition, output, stepId, datatypesMapper } = toRefs(props);
+const position = useCoordinatePosition(el, rootOffset, stepPosition);
+const extensions = computed(() => {
+    let changeDatatype: PostJobAction | undefined;
+    if ("label" in props.output && props.postJobActions[`ChangeDatatypeAction${props.output.label}`]) {
+        changeDatatype = props.postJobActions[`ChangeDatatypeAction${props.output.label}`];
+    } else {
+        changeDatatype = props.postJobActions[`ChangeDatatypeAction${props.output.name}`];
+    }
+    let extensions =
+        changeDatatype?.action_arguments.newtype ||
+        ("extensions" in props.output && props.output.extensions) ||
+        ("type" in props.output && props.output.type) ||
+        "unspecified";
+    if (!Array.isArray(extensions)) {
+        extensions = [extensions];
+    }
+    return extensions;
+});
+const effectiveOutput = ref({ ...output.value, extensions: extensions.value });
+watch(extensions, () => {
+    effectiveOutput.value = { ...output.value, extensions: extensions.value };
+});
+const { terminal, isMappedOver: isMultiple } = useTerminal(stepId, effectiveOutput, datatypesMapper);
+
+const workflowOutput = computed(() =>
+    props.workflowOutputs.find((workflowOutput) => workflowOutput.output_name == props.output.name)
+);
+const activeClass = computed(() => workflowOutput.value && "mark-terminal-active");
+const isVisible = computed(() => {
+    const isHidden = `HideDatasetAction${props.output.name}` in props.postJobActions;
+    return !isHidden;
+});
+const visibleClass = computed(() => (isVisible.value ? "mark-terminal-visible" : "mark-terminal-hidden"));
+const visibleHint = computed(() => {
+    if (isVisible.value) {
+        return `Output will be visible in history. Click to hide output.`;
+    } else {
+        return `Output will be hidden in history. Click to make output visible.`;
+    }
+});
+const label = computed(() => {
+    const activeLabel = workflowOutput.value?.label || props.output.name;
+    return `${activeLabel} (${extensions.value.join(", ")})`;
+});
+const rowClass = computed(() => {
+    const classes = ["form-row", "dataRow", "output-data-row"];
+    if ("valid" in props.output && props.output?.valid === false) {
+        classes.push("form-row-error");
+    }
+    return classes;
+});
+
+const menu: Ref<InstanceType<typeof ConnectionMenu> | undefined> = ref();
+const icon: Ref<HTMLElement | undefined> = ref();
+const showChildComponent = ref(false);
+
+function closeMenu() {
+    showChildComponent.value = false;
+}
+
+async function toggleChildComponent() {
+    showChildComponent.value = !showChildComponent.value;
+    if (showChildComponent.value) {
+        await nextTick();
+        if (menu.value?.$el instanceof HTMLElement) {
+            menu.value!.$el.focus();
+        }
+    } else {
+        icon.value!.focus();
+    }
+}
+
+function onToggleActive() {
+    const step = stepStore.getStep(stepId.value);
+    if (workflowOutput.value) {
+        step.workflow_outputs = (step.workflow_outputs || []).filter(
+            (workflowOutput) => workflowOutput.output_name !== output.value.name
+        );
+    } else {
+        if (!step.workflow_outputs) {
+            step.workflow_outputs = [];
+        }
+        step.workflow_outputs.push({ output_name: output.value.name });
+    }
+    stepStore.updateStep(step);
+}
+
+function onToggleVisible() {
+    const actionKey = `HideDatasetAction${props.output.name}`;
+    const step = stepStore.getStep(stepId.value);
+    if (isVisible.value) {
+        step.post_job_actions = {
+            ...step.post_job_actions,
+            [actionKey]: {
+                action_type: "HideDatasetAction",
+                output_name: props.output.name,
+                action_arguments: {},
+            },
+        };
+    } else {
+        if (step.post_job_actions) {
+            const { [actionKey]: ignoreUnused, ...newPostJobActions } = step.post_job_actions;
+            step.post_job_actions = newPostJobActions;
+        } else {
+            step.post_job_actions = {};
+        }
+    }
+    stepStore.updateStep(step);
+}
+
+function onPanBy(panBy: XYPosition) {
+    emit("pan-by", panBy);
+}
+
+function onStopDragging() {
+    isDragging.value = false;
+    dragX.value = 0;
+    dragY.value = 0;
+    emit("stopDragging");
+}
+
+const dragX = ref(0);
+const dragY = ref(0);
+const isDragging = ref(false);
+
+const startX = computed(() => position.left + props.scroll.x.value / props.scale + position.width / 2);
+const startY = computed(() => position.top + props.scroll.y.value / props.scale + position.height / 2);
+const endX = computed(() => {
+    return (dragX.value || startX.value) + props.scroll.x.value / props.scale;
+});
+const endY = computed(() => {
+    return (dragY.value || startY.value) + props.scroll.y.value / props.scale;
+});
+const dragPosition = computed(() => {
+    return {
+        startX: startX.value,
+        endX: endX.value,
+        startY: startY.value,
+        endY: endY.value,
+    };
+});
+const terminalPosition = computed(() => {
+    return Object.freeze({ startX: startX.value, startY: startY.value });
+});
+
+watch([dragPosition, isDragging], () => {
+    if (isDragging.value) {
+        emit("onDragConnector", dragPosition.value, terminal.value);
+    }
+});
+
+watch(terminalPosition, () =>
+    stateStore.setOutputTerminalPosition(props.stepId, props.output.name, terminalPosition.value)
+);
+
+function onMove(dragPosition: XYPosition) {
+    dragX.value = dragPosition.x + position.width / 2;
+    dragY.value = dragPosition.y + position.height / 2;
+}
+
+const id = computed(() => `node-${props.stepId}-output-${props.output.name}`);
+const showCalloutActiveOutput = computed(() => props.stepType === "tool" || props.stepType === "subworkflow");
+const showCalloutVisible = computed(() => props.stepType === "tool");
+const terminalClass = computed(() => {
+    const cls = "terminal output-terminal";
+    if (isMultiple.value) {
+        return `${cls} multiple`;
+    }
+    return cls;
+});
+
+onBeforeUnmount(() => {
+    stateStore.deleteOutputTerminalPosition(props.stepId, props.output.name);
+});
+</script>
 <template>
     <div :class="rowClass">
         <div
@@ -50,267 +260,3 @@
         </draggable-wrapper>
     </div>
 </template>
-
-<script>
-import DraggableWrapper from "./DraggablePan";
-import { useCoordinatePosition } from "./composables/useCoordinatePosition";
-import { useTerminal } from "./composables/useTerminal";
-import { ref, computed, watch, nextTick, toRefs } from "vue";
-import { DatatypesMapperModel } from "@/components/Datatypes/model";
-import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
-import ConnectionMenu from "@/components/Workflow/Editor/ConnectionMenu";
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
-
-export default {
-    components: {
-        ConnectionMenu,
-        DraggableWrapper,
-    },
-    props: {
-        output: {
-            type: Object,
-            required: true,
-        },
-        workflowOutputs: {
-            type: Array,
-            required: true,
-        },
-        stepType: {
-            type: String,
-            required: true,
-        },
-        stepId: {
-            type: Number,
-            required: true,
-        },
-        postJobActions: {
-            type: Object,
-            required: true,
-        },
-        stepPosition: {
-            type: Object,
-            required: true,
-        },
-        rootOffset: {
-            type: Object,
-            required: true,
-        },
-        scroll: {
-            type: Object,
-            required: true,
-        },
-        scale: {
-            type: Number,
-            required: true,
-        },
-        datatypesMapper: {
-            type: DatatypesMapperModel,
-            required: true,
-        },
-    },
-    setup(props) {
-        const stateStore = useWorkflowStateStore();
-        const stepStore = useWorkflowStepStore();
-        const el = ref(null);
-        const { rootOffset, stepPosition, output, stepId, datatypesMapper } = toRefs(props);
-        const position = useCoordinatePosition(el, rootOffset, stepPosition);
-        const extensions = computed(() => {
-            const changeDatatype =
-                props.postJobActions[`ChangeDatatypeAction${props.output.label}`] ||
-                props.postJobActions[`ChangeDatatypeAction${props.output.name}`];
-            let extensions =
-                changeDatatype?.action_arguments.newtype ||
-                props.output.extensions ||
-                props.output.type ||
-                "unspecified";
-            if (!Array.isArray(extensions)) {
-                extensions = [extensions];
-            }
-            return extensions;
-        });
-        const effectiveOutput = ref({ ...output.value, extensions: extensions.value });
-        watch(extensions, () => {
-            effectiveOutput.value = { ...output.value, extensions: extensions.value };
-        });
-        const { terminal, isMappedOver: isMultiple } = useTerminal(stepId, effectiveOutput, datatypesMapper);
-
-        const workflowOutput = computed(() =>
-            props.workflowOutputs.find((workflowOutput) => workflowOutput.output_name == props.output.name)
-        );
-        const activeClass = computed(() => workflowOutput.value && "mark-terminal-active");
-        const isVisible = computed(() => {
-            const isHidden = `HideDatasetAction${props.output.name}` in props.postJobActions;
-            return !isHidden;
-        });
-        const visibleClass = computed(() => (isVisible.value ? "mark-terminal-visible" : "mark-terminal-hidden"));
-        const visibleHint = computed(() => {
-            if (isVisible.value) {
-                return `Output will be visible in history. Click to hide output.`;
-            } else {
-                return `Output will be hidden in history. Click to make output visible.`;
-            }
-        });
-        const label = computed(() => {
-            const activeLabel = workflowOutput.value?.label || props.output.name;
-            return `${activeLabel} (${extensions.value.join(", ")})`;
-        });
-        const rowClass = computed(() => {
-            const classes = ["form-row", "dataRow", "output-data-row"];
-            if (props.output?.valid === false) {
-                classes.push("form-row-error");
-            }
-            return classes;
-        });
-
-        const menu = ref(null);
-        const icon = ref(null);
-        const showChildComponent = ref(false);
-
-        function closeMenu() {
-            showChildComponent.value = false;
-        }
-
-        async function toggleChildComponent() {
-            showChildComponent.value = !showChildComponent.value;
-            if (showChildComponent.value) {
-                await nextTick();
-                menu.value.$el.focus();
-            } else {
-                icon.value.focus();
-            }
-        }
-
-        function onToggleActive() {
-            const step = stepStore.getStep(stepId.value);
-            if (workflowOutput.value) {
-                step.workflow_outputs = step.workflow_outputs.filter(
-                    (workflowOutput) => workflowOutput.output_name !== output.value.name
-                );
-            } else {
-                step.workflow_outputs.push({ output_name: output.value.name });
-            }
-            stepStore.updateStep(step);
-        }
-
-        function onToggleVisible() {
-            const actionKey = `HideDatasetAction${props.output.name}`;
-            const step = stepStore.getStep(stepId.value);
-            if (isVisible.value) {
-                step.post_job_actions = {
-                    ...step.post_job_actions,
-                    [actionKey]: {
-                        action_type: "HideDatasetAction",
-                        output_name: props.output.name,
-                        action_arguments: {},
-                    },
-                };
-            } else {
-                const { [actionKey]: ignoreUnused, ...newPostJobActions } = step.post_job_actions;
-                step.post_job_actions = newPostJobActions;
-            }
-            stepStore.updateStep(step);
-        }
-
-        return {
-            el,
-            icon,
-            position,
-            activeClass,
-            visibleClass,
-            visibleHint,
-            rowClass,
-            isVisible,
-            terminal,
-            isMultiple,
-            label,
-            stateStore,
-            menu,
-            showChildComponent,
-            toggleChildComponent,
-            closeMenu,
-            effectiveOutput,
-            onToggleActive,
-            onToggleVisible,
-        };
-    },
-    data() {
-        return {
-            isDragging: false,
-            dragX: 0,
-            dragY: 0,
-        };
-    },
-    computed: {
-        terminalPosition() {
-            return Object.freeze({ startX: this.startX, startY: this.startY });
-        },
-        startX() {
-            return this.position.left + this.scroll.x.value / this.scale + this.position.width / 2;
-        },
-        startY() {
-            return this.position.top + this.scroll.y.value / this.scale + this.position.height / 2;
-        },
-        endX() {
-            return (this.dragX || this.startX) + this.scroll.x.value / this.scale;
-        },
-        endY() {
-            return (this.dragY || this.startY) + this.scroll.y.value / this.scale;
-        },
-        dragPosition() {
-            return {
-                startX: this.startX,
-                endX: this.endX,
-                startY: this.startY,
-                endY: this.endY,
-            };
-        },
-        id() {
-            return `node-${this.stepId}-output-${this.output.name}`;
-        },
-        showCalloutActiveOutput() {
-            return this.stepType === "tool" || this.stepType === "subworkflow";
-        },
-        showCalloutVisible() {
-            return this.stepType === "tool";
-        },
-        terminalClass() {
-            const cls = "terminal output-terminal";
-            if (this.isMultiple) {
-                return `${cls} multiple`;
-            }
-            return cls;
-        },
-    },
-    watch: {
-        terminalPosition(position) {
-            this.stateStore.setOutputTerminalPosition(this.stepId, this.output.name, position);
-        },
-        dragPosition() {
-            if (this.isDragging) {
-                this.$emit("onDragConnector", this.dragPosition, this.terminal);
-            }
-        },
-    },
-    beforeDestroy() {
-        this.stateStore.deleteOutputTerminalPosition({
-            stepId: this.stepId,
-            outputName: this.output.name,
-        });
-    },
-    methods: {
-        onPanBy(panBy) {
-            this.$emit("pan-by", panBy);
-        },
-        onMove(position, event) {
-            this.dragX = position.x + this.position.width / 2;
-            this.dragY = position.y + this.position.height / 2;
-        },
-        onStopDragging(e) {
-            this.isDragging = false;
-            this.dragX = 0;
-            this.dragY = 0;
-            this.$emit("stopDragging");
-        },
-    },
-};
-</script>

--- a/client/src/stores/workflowConnectionStore.ts
+++ b/client/src/stores/workflowConnectionStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { useWorkflowStepStore } from "@/stores/workflowStepStore";
-import { state } from "@/store/tagStore";
+import { pushOrSet } from "@/utils/pushOrSet";
 import Vue from "vue";
 
 interface InvalidConnections {
@@ -10,6 +10,9 @@ interface InvalidConnections {
 export interface State {
     connections: Connection[];
     invalidConnections: InvalidConnections;
+    inputTerminalToOutputTerminals: TerminalToOutputTerminals;
+    terminalToConnection: { [index: string]: Connection[] };
+    stepToConnections: { [index: number]: Connection[] };
 }
 
 export class Connection {
@@ -45,81 +48,37 @@ interface TerminalToOutputTerminals {
     [index: string]: OutputTerminal[];
 }
 
-interface TerminalToInputTerminals {
-    [index: string]: InputTerminal[];
-}
-
 export const useConnectionStore = defineStore("workflowConnectionStore", {
     state: (): State => ({
         connections: [] as Connection[],
         invalidConnections: {} as InvalidConnections,
+        inputTerminalToOutputTerminals: {} as TerminalToOutputTerminals,
+        terminalToConnection: {} as { [index: string]: Connection[] },
+        stepToConnections: {} as { [index: number]: Connection[] },
     }),
     getters: {
         getOutputTerminalsForInputTerminal(state: State) {
-            const inputTerminalToOutputTerminals: TerminalToOutputTerminals = {};
-            state.connections.map((connection) => {
-                const terminals = getTerminals(connection);
-                const inputTerminalId = getTerminalId(terminals.input);
-                inputTerminalId in inputTerminalToOutputTerminals
-                    ? inputTerminalToOutputTerminals[inputTerminalId].push(terminals.output)
-                    : (inputTerminalToOutputTerminals[inputTerminalId] = [terminals.output]);
-            });
             return (terminalId: string): OutputTerminal[] => {
-                return inputTerminalToOutputTerminals[terminalId] || [];
-            };
-        },
-        getInputTerminalsForOutputTerminal(state: State) {
-            const outputTerminalToInputTerminals: TerminalToInputTerminals = {};
-            state.connections.map((connection) => {
-                const terminals = getTerminals(connection);
-                const outputTerminalId = getTerminalId(terminals.output);
-                outputTerminalId in outputTerminalToInputTerminals
-                    ? outputTerminalToInputTerminals[outputTerminalId].push(terminals.input)
-                    : (outputTerminalToInputTerminals[outputTerminalId] = [terminals.input]);
-            });
-            return (terminalId: string): BaseTerminal[] => {
-                return outputTerminalToInputTerminals[terminalId] || [];
+                return state.inputTerminalToOutputTerminals[terminalId] || [];
             };
         },
         getConnectionsForTerminal(state: State) {
-            const terminalToConnection: { [index: string]: Connection[] } = {};
-            state.connections.map((connection) => {
-                const terminals = getTerminals(connection);
-                const outputTerminalId = getTerminalId(terminals.output);
-                if (outputTerminalId in terminalToConnection) {
-                    terminalToConnection[outputTerminalId].push(connection);
-                } else {
-                    terminalToConnection[outputTerminalId] = [connection];
-                }
-                const inputTerminalId = getTerminalId(terminals.input);
-                if (inputTerminalId in terminalToConnection) {
-                    terminalToConnection[inputTerminalId].push(connection);
-                } else {
-                    terminalToConnection[inputTerminalId] = [connection];
-                }
-            });
             return (terminalId: string): Connection[] => {
-                return terminalToConnection[terminalId] || [];
+                return state.terminalToConnection[terminalId] || [];
             };
         },
         getConnectionsForStep(state: State) {
-            const stepToConnections: { [index: number]: Connection[] } = {};
-            state.connections.map((connection) => {
-                connection.input.stepId in stepToConnections
-                    ? stepToConnections[connection.input.stepId].push(connection)
-                    : (stepToConnections[connection.input.stepId] = [connection]);
-                connection.output.stepId in stepToConnections
-                    ? stepToConnections[connection.output.stepId].push(connection)
-                    : (stepToConnections[connection.output.stepId] = [connection]);
-            });
-            return (stepId: number): Connection[] => stepToConnections[stepId] || [];
+            return (stepId: number): Connection[] => state.stepToConnections[stepId] || [];
         },
     },
     actions: {
-        addConnection(this: State, connection: Connection) {
+        addConnection(this, connection: Connection) {
             this.connections.push(connection);
             const stepStore = useWorkflowStepStore();
             stepStore.addConnection(connection);
+            this.terminalToConnection = updateTerminalToConnection(this.connections);
+            this.inputTerminalToOutputTerminals = updateTerminalToTerminal(this.connections);
+            this.stepToConnections = updateStepToConnections(this.connections)
         },
         markInvalidConnection(this: State, connectionId: string, reason: string) {
             Vue.set(this.invalidConnections, connectionId, reason);
@@ -127,7 +86,7 @@ export const useConnectionStore = defineStore("workflowConnectionStore", {
         dropFromInvalidConnections(this: State, connectionId: string) {
             Vue.delete(this.invalidConnections, connectionId);
         },
-        removeConnection(this: State, terminal: InputTerminal | OutputTerminal | Connection["id"]) {
+        removeConnection(this, terminal: InputTerminal | OutputTerminal | Connection["id"]) {
             const stepStore = useWorkflowStepStore();
             this.connections = this.connections.filter((connection) => {
                 if (typeof terminal === "string") {
@@ -155,10 +114,49 @@ export const useConnectionStore = defineStore("workflowConnectionStore", {
                         return true;
                     }
                 }
+
             });
+            this.terminalToConnection = updateTerminalToConnection(this.connections);
+            this.inputTerminalToOutputTerminals = updateTerminalToTerminal(this.connections);
+            this.stepToConnections = updateStepToConnections(this.connections)
         },
     },
 });
+
+
+function updateTerminalToTerminal(connections: Connection[]) {
+    const inputTerminalToOutputTerminals: TerminalToOutputTerminals = {};
+    connections.map((connection) => {
+        const terminals = getTerminals(connection);
+        const inputTerminalId = getTerminalId(terminals.input);
+        pushOrSet(inputTerminalToOutputTerminals, inputTerminalId, terminals.output)
+    });
+    return inputTerminalToOutputTerminals;
+}
+
+
+function updateTerminalToConnection(connections: Connection[]) {
+    const terminalToConnection: { [index: string]: Connection[] } = {};
+    connections.map((connection) => {
+        const terminals = getTerminals(connection);
+        const outputTerminalId = getTerminalId(terminals.output);
+        pushOrSet(terminalToConnection, outputTerminalId, connection);
+        const inputTerminalId = getTerminalId(terminals.input);
+        pushOrSet(terminalToConnection, inputTerminalId, connection);
+    });
+    return terminalToConnection;
+}
+
+
+function updateStepToConnections(connections: Connection[]) {
+    const stepToConnections: { [index: number]: Connection[] } = {};
+    connections.map((connection) => {
+        pushOrSet(stepToConnections, connection.input.stepId, connection);
+        pushOrSet(stepToConnections, connection.output.stepId, connection);
+    });
+    return stepToConnections
+}
+
 
 export function getTerminalId(item: BaseTerminal): string {
     return `node-${item.stepId}-${item.connectorType}-${item.name}`;

--- a/client/src/stores/workflowConnectionStore.ts
+++ b/client/src/stores/workflowConnectionStore.ts
@@ -72,13 +72,14 @@ export const useConnectionStore = defineStore("workflowConnectionStore", {
         },
     },
     actions: {
-        addConnection(this, connection: Connection) {
+        addConnection(this, _connection: Connection) {
+            const connection = Object.freeze(_connection);
             this.connections.push(connection);
             const stepStore = useWorkflowStepStore();
             stepStore.addConnection(connection);
             this.terminalToConnection = updateTerminalToConnection(this.connections);
             this.inputTerminalToOutputTerminals = updateTerminalToTerminal(this.connections);
-            this.stepToConnections = updateStepToConnections(this.connections)
+            this.stepToConnections = updateStepToConnections(this.connections);
         },
         markInvalidConnection(this: State, connectionId: string, reason: string) {
             Vue.set(this.invalidConnections, connectionId, reason);
@@ -114,26 +115,23 @@ export const useConnectionStore = defineStore("workflowConnectionStore", {
                         return true;
                     }
                 }
-
             });
             this.terminalToConnection = updateTerminalToConnection(this.connections);
             this.inputTerminalToOutputTerminals = updateTerminalToTerminal(this.connections);
-            this.stepToConnections = updateStepToConnections(this.connections)
+            this.stepToConnections = updateStepToConnections(this.connections);
         },
     },
 });
-
 
 function updateTerminalToTerminal(connections: Connection[]) {
     const inputTerminalToOutputTerminals: TerminalToOutputTerminals = {};
     connections.map((connection) => {
         const terminals = getTerminals(connection);
         const inputTerminalId = getTerminalId(terminals.input);
-        pushOrSet(inputTerminalToOutputTerminals, inputTerminalId, terminals.output)
+        pushOrSet(inputTerminalToOutputTerminals, inputTerminalId, terminals.output);
     });
     return inputTerminalToOutputTerminals;
 }
-
 
 function updateTerminalToConnection(connections: Connection[]) {
     const terminalToConnection: { [index: string]: Connection[] } = {};
@@ -147,16 +145,14 @@ function updateTerminalToConnection(connections: Connection[]) {
     return terminalToConnection;
 }
 
-
 function updateStepToConnections(connections: Connection[]) {
     const stepToConnections: { [index: number]: Connection[] } = {};
     connections.map((connection) => {
         pushOrSet(stepToConnections, connection.input.stepId, connection);
         pushOrSet(stepToConnections, connection.output.stepId, connection);
     });
-    return stepToConnections
+    return stepToConnections;
 }
-
 
 export function getTerminalId(item: BaseTerminal): string {
     return `node-${item.stepId}-${item.connectorType}-${item.name}`;

--- a/client/src/stores/workflowEditorStateStore.ts
+++ b/client/src/stores/workflowEditorStateStore.ts
@@ -4,6 +4,16 @@ import { defineStore } from "pinia";
 import type { OutputTerminals } from "@/components/Workflow/Editor/modules/terminals";
 import type { UseElementBoundingReturn } from "@vueuse/core";
 
+export interface InputTerminalPosition {
+    endX: number;
+    endY: number;
+}
+
+export interface OutputTerminalPosition {
+    startX: number;
+    startY: number;
+}
+
 export interface TerminalPosition {
     startX: number;
     endX: number;
@@ -17,8 +27,8 @@ export interface XYPosition {
 }
 
 interface State {
-    inputTerminals: { [index: number]: { [index: string]: TerminalPosition } };
-    outputTerminals: { [index: number]: { [index: string]: TerminalPosition } };
+    inputTerminals: { [index: number]: { [index: string]: InputTerminalPosition } };
+    outputTerminals: { [index: number]: { [index: string]: OutputTerminalPosition } };
     draggingPosition: TerminalPosition | null;
     draggingTerminal: OutputTerminals | null;
     activeNodeId: number | null;
@@ -50,14 +60,14 @@ export const useWorkflowStateStore = defineStore("workflowStateStore", {
         },
     },
     actions: {
-        setInputTerminalPosition(stepId: number, inputName: string, position: TerminalPosition) {
+        setInputTerminalPosition(stepId: number, inputName: string, position: InputTerminalPosition) {
             if (!this.inputTerminals[stepId]) {
                 Vue.set(this.inputTerminals, stepId, { [inputName]: position });
             } else {
                 Vue.set(this.inputTerminals[stepId], inputName, position);
             }
         },
-        setOutputTerminalPosition(stepId: number, outputName: string, position: TerminalPosition) {
+        setOutputTerminalPosition(stepId: number, outputName: string, position: OutputTerminalPosition) {
             if (!this.outputTerminals[stepId]) {
                 Vue.set(this.outputTerminals, stepId, { [outputName]: position });
             } else {

--- a/client/src/stores/workflowStepStore.test.ts
+++ b/client/src/stores/workflowStepStore.test.ts
@@ -12,6 +12,7 @@ const stepInputConnection: StepInputConnection = {
 };
 
 const workflowStepZero: NewStep = {
+    id: 0,
     input_connections: {},
     inputs: [],
     name: "a step",
@@ -33,7 +34,7 @@ describe("Connection Store", () => {
         const stepStore = useWorkflowStepStore();
         expect(stepStore.steps).toStrictEqual({});
         stepStore.addStep(workflowStepZero);
-        expect(stepStore.getStep(0)).toBe(workflowStepZero);
+        expect(stepStore.getStep(0)).toStrictEqual(workflowStepZero);
         expect(workflowStepZero.id).toBe(0);
     });
     it("removes step", () => {

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -129,7 +129,7 @@ export interface ConnectionOutputLink {
     input_subworkflow_step_id?: number;
 }
 
-interface WorkflowOutputs {
+export interface WorkflowOutputs {
     [index: string]: {
         stepId: number;
         outputName: string;

--- a/client/src/utils/pushOrSet.ts
+++ b/client/src/utils/pushOrSet.ts
@@ -1,0 +1,7 @@
+export function pushOrSet(object: { [index: string | number]: any[] }, key: string | number, value: any) {
+    if (key in object) {
+        object[key].push(value);
+    } else {
+        object[key] = [value];
+    }
+}


### PR DESCRIPTION
Key changes are freezing the step object and connections, not using `v-on="$listeners"` in NodeInput / NodeOutput, and pre-caching the getters that access all steps whenever a step changes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
