### PR TITLE
[23.0] Don't include output name in css classes for node outputs

### DIFF
--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -1,9 +1,9 @@
 <template>
-    <div :class="rowClass">
+    <div :class="rowClass" :data-output-name="output.name">
         <div
             v-if="showCalloutActiveOutput"
             v-b-tooltip
-            :class="['callout-terminal', output.name]"
+            class="callout-terminal"
             title="Checked outputs will become primary workflow outputs and are available as subworkflow outputs."
             @keyup="onToggleActive"
             @click="onToggleActive">
@@ -12,7 +12,7 @@
         <div
             v-if="showCalloutVisible"
             v-b-tooltip
-            :class="['callout-terminal', output.name]"
+            class="callout-terminal"
             :title="visibleHint"
             @keyup="onToggleVisible"
             @click="onToggleVisible">

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -589,8 +589,8 @@ workflow_editor:
       output_terminal: "${_} [output-name='${name}']"
       input_terminal: "${_} [input-name='${name}']"
       input_mapping_icon: "${_} [input-name='${name}'].multiple"
-      workflow_output_toggle: "${_} .callout-terminal.${name}"
-      workflow_output_toggle_active: "${_} .callout-terminal.${name} .mark-terminal-active"
+      workflow_output_toggle: "${_} [data-output-name='${name}'] .callout-terminal "
+      workflow_output_toggle_active: "${_} [data-output-name='${name}'] .mark-terminal-active"
   selectors:
     canvas_body: '#workflow-canvas'
     edit_annotation: '#workflow-annotation'


### PR DESCRIPTION
Fixes wrong css being applied to outputs that match css variables, like `terminal` for the table compute tool:

<img width="272" alt="Screenshot 2023-03-13 at 17 19 50" src="https://user-images.githubusercontent.com/6804901/224762853-a9f65436-f12d-47c5-80c8-a0259a080add.png">

Has been a problem for a while ...

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
