### PR TITLE
[23.0] Allow hyphenated tool-name to be searchable in `ToolSearch`

### DIFF
--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -110,7 +110,7 @@ export default {
                     this.$emit("onResults", this.favoritesResults);
                 } else {
                     // keys with sorting order
-                    const keys = { exact: 3, name: 2, description: 1, combined: 0 };
+                    const keys = { exact: 4, name: 3, description: 2, combined: 1, hyphenated: 0 };
                     this.$emit("onResults", searchToolsByKeys(this.toolsList, keys, q));
                 }
             } else {

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -110,7 +110,7 @@ export default {
                     this.$emit("onResults", this.favoritesResults);
                 } else {
                     // keys with sorting order
-                    const keys = { exact: 4, name: 3, description: 2, combined: 1, hyphenated: 0 };
+                    const keys = { exact: 4, name: 3, hyphenated: 2, description: 1, combined: 0 };
                     this.$emit("onResults", searchToolsByKeys(this.toolsList, keys, q));
                 }
             } else {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -92,6 +92,8 @@ export function searchToolsByKeys(tools, keys, query) {
             let actualValue = "";
             if (key === "combined") {
                 actualValue = tool.name.toLowerCase() + " " + tool.description.toLowerCase();
+            } else if (key === "hyphenated") {
+                actualValue = tool.name.toLowerCase().replaceAll("-", " ");
             } else {
                 actualValue = tool[key] ? tool[key].toLowerCase() : "";
             }

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -44,6 +44,28 @@ describe("test helpers in tool searching utilities", () => {
         keys = { description: 1, name: 2, combined: 0 };
         results = searchToolsByKeys(normalizeTools(toolsList), keys, q);
         expect(results).toEqual(expectedResults);
+
+        const tempToolsList = [
+            {
+                elems: [
+                    {
+                        panel_section_name: "Collection Operations",
+                        description: "Extract UMI from fastq files",
+                        id: "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/1.1.2+galaxy2",
+                        name: "UMI-tools extract",
+                    },
+                ],
+                model_class: "ToolSection",
+                id: "fasta/fastq",
+                name: "FASTA/FASTQ",
+            },
+        ];
+        // hyphenated tool-name is searchable
+        q = "uMi tools extract ";
+        expectedResults = ["toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/1.1.2+galaxy2"];
+        keys = { description: 1, name: 2, hyphenated: 0 };
+        results = searchToolsByKeys(normalizeTools(tempToolsList), keys, q);
+        expect(results).toEqual(expectedResults);
     });
 
     it("test tool filtering helpers on toolsList given list of ids", async () => {

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -49,7 +49,7 @@ describe("test helpers in tool searching utilities", () => {
             {
                 elems: [
                     {
-                        panel_section_name: "Collection Operations",
+                        panel_section_name: "FASTA/FASTQ",
                         description: "Extract UMI from fastq files",
                         id: "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/1.1.2+galaxy2",
                         name: "UMI-tools extract",


### PR DESCRIPTION
Reported by @bgruening that if a tool name is hyphenated: e.g.: `"name": "UMI-tools extract"`, and the user searches with the query: "umi tools", the tool is not searchable. Allowed for such tools to be searchable in this PR.

_**This can target 23.0 if needed**_

| Before | After |
| ------ | ------|
| ![image](https://user-images.githubusercontent.com/78516064/224862769-be3cc2a1-4335-46c2-aefc-c88606f6c194.png) | ![image](https://user-images.githubusercontent.com/78516064/224862878-4d4f9af3-7116-4601-b6c7-d712c5e234df.png) |


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
