### PR TITLE
[PROCEDURES] Add Laila as a committer

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -56,6 +56,7 @@ Members
 - Aysam Guerler (@guerler)
 - Jennifer Hillman Jackson (@jennaj)
 - David López (@davelopez)
+- Laila Los (@ElectronicBlueberry)
 - Anton Nekrutenko (@nekrut)
 - Helena Rasche (@hexylena)
 - Nicola Soranzo (@nsoranzo)


### PR DESCRIPTION
Laila has made many fantastic contributions since joining (https://github.com/galaxyproject/galaxy/pulls?q=is%3Apr+author%3AElectronicBlueberry), has been very helpful and constructive in code review, and has provided valuable insight in technical discussions and decision making -- especially in the UI/UX group, but reaching into other areas as well.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).