### PR TITLE
[23.0] Fix regression in distinguishing between select and text types.

### DIFF
--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -270,7 +270,7 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
                 :id="props.id"
                 v-model="currentValue"
                 :data-label="props.title"
-                :type="props.type ?? 'text'"
+                :type="props.type ?? (attrs.options ? 'select' : 'text')"
                 :attributes="attrs" />
             <FormInput v-else :id="props.id" v-model="currentValue" :area="attrs['area']" />
         </div>


### PR DESCRIPTION
Previously if `type` was missing but `options` were present the form input would be rendered as a select box and not a text box. This can be seen as a problem when adding new quota objects in the admin menu.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1.  Load the form mentioned above without this change and see the text boxes are not selects, apply the change and see the improved/fixed UI.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
