### PR TITLE
Quota source labelling bug fixes and improvements 

### DIFF
--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -272,7 +272,7 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
                 :id="props.id"
                 v-model="currentValue"
                 :data-label="props.title"
-                :type="props.type ?? 'text'"
+                :type="props.type ?? (attrs.options ? 'select' : 'text')"
                 :attributes="attrs" />
             <FormInput v-else :id="props.id" v-model="currentValue" :area="attrs['area']" />
         </div>

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -699,7 +699,7 @@ class AdminGalaxy(controller.JSAppLauncher):
             all_users = []
             all_groups = []
             labels = trans.app.object_store.get_quota_source_map().get_quota_source_labels()
-            label_options = [("Default Quota", None)]
+            label_options = [("Default Quota", "__default__")]
             label_options.extend([(label, label) for label in labels])
             for user in (
                 trans.sa_session.query(trans.app.model.User)
@@ -752,6 +752,9 @@ class AdminGalaxy(controller.JSAppLauncher):
             return rval
         else:
             try:
+                quota_source_label = payload.get("quota_source_label")
+                if quota_source_label == "__default__":
+                    payload["quota_source_label"] = None
                 quota, message = self.quota_manager.create_quota(payload, decode_id=trans.security.decode_id)
                 return {"message": message}
             except ActionInputError as e:

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -408,6 +408,15 @@ class QuotaListGrid(grids.Grid):
                 return len(quota.groups)
             return 0
 
+    class QuotaSourceLabelColumn(grids.TextColumn):
+        def get_value(self, trans, grid, quota):
+            raw_label = quota.quota_source_label
+            if raw_label is None:
+                rval = "<i>unlabelled object stores</i>"
+            else:
+                rval = raw_label
+            return rval
+
     # Grid definition
     title = "Quotas"
     model_class = model.Quota
@@ -427,6 +436,7 @@ class QuotaListGrid(grids.Grid):
         AmountColumn("Amount", key="amount", model_class=model.Quota, attach_popup=False),
         UsersColumn("Users", attach_popup=False),
         GroupsColumn("Groups", attach_popup=False),
+        QuotaSourceLabelColumn("Source Label", key="quota_source_label", visible=False, filterable="advanced"),
         StatusColumn("Status", attach_popup=False),
         # Columns that are valid for filtering but are not visible.
         grids.DeletedColumn("Deleted", key="deleted", visible=False, filterable="advanced"),
@@ -690,6 +700,9 @@ class AdminGalaxy(controller.JSAppLauncher):
         if message:
             kwargs["message"] = util.sanitize_text(message)
             kwargs["status"] = status or "done"
+        labels = trans.app.object_store.get_quota_source_map().get_quota_source_labels()
+        if labels:
+            self.quota_list_grid.columns[5].visible = True
         return self.quota_list_grid(trans, **kwargs)
 
     @web.legacy_expose_api


### PR DESCRIPTION
#14073 brought in the ability to label object stores as contributing to different pools of quota - giving concrete object stores the ability to have "quota source labels" (effectively just plain text keys). This brings in some bug fixes and improvements to the admin UI around these:

- includes the stable bug fix (https://github.com/galaxyproject/galaxy/pull/15792) 
- adds another fix for changed form behavior but that only affects dev - namely, null keys on these older parameters no longer work properly with the new form setup - so I've replaced null with `__default__` when creating quota. Doesn't affect the stable API - just the grid interaction stuff.
- Updates the quota list grid to show information about quota source labels (only when configured) and allow sorting and filtering on this information. In classic-John style this information was unavailable outside the API/DB after creation by admins in the original PR.

Screen shot of advanced search of the quota demonstrating the new column and the ability to filter it:

<img width="927" alt="Screen Shot 2023-03-14 at 10 48 38 AM" src="https://user-images.githubusercontent.com/216771/225047020-ecb8a305-9651-462a-889e-e3c02da7d387.png">

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
- 1. Load the MSI object store configuration example in object store conf (added in #15707) 
   2. Admin -> Quota -> Add New
   3. Add a few different quota or different types and with different quota source labels - note the bug fixes and improvements listed above

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
