### PR TITLE
[22.05] Account for charge and spin in den_fmt sniffer

### DIFF
--- a/lib/galaxy/datatypes/test/YbCuAs2.den_fmt
+++ b/lib/galaxy/datatypes/test/YbCuAs2.den_fmt
@@ -1,0 +1,13 @@
+ BEGIN header
+  
+           Real Lattice(A)               Lattice parameters(A)    Cell Angles
+     3.8420000     0.0000000     0.0000000     a =    3.842000  alpha =   90.000000
+     0.0000000     3.8420000     0.0000000     b =    3.842000  beta  =   90.000000
+     0.0000000     0.0000000     9.7430000     c =    9.743000  gamma =   90.000000
+  
+   2                            ! nspins
+  32    32    90                ! fine FFT grid along <a,b,c>
+ END header: data is "<a b c> charge spin" in units of electrons/grid_point * nu
+ mber of grid_points
+  
+     1     1     1           47.798968            0.000070

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -1188,6 +1188,9 @@ class FormattedDensity(Text):
         >>> fname = get_test_fname('Si.den_fmt')
         >>> FormattedDensity().sniff(fname)
         True
+        >>> fname = get_test_fname('YbCuAs2.den_fmt')
+        >>> FormattedDensity().sniff(fname)
+        True
         >>> fname = get_test_fname('Si.param')
         >>> FormattedDensity().sniff(fname)
         False
@@ -1195,6 +1198,11 @@ class FormattedDensity(Text):
         begin_header = "BEGIN header"
         end_header = 'END header: data is "<a b c> charge" in units of electrons/grid_point * number'
         grid_points = "of grid_points"
+        end_header_spin = 'END header: data is "<a b c> charge spin" in units of electrons/grid_point * nu'
+        grid_points_spin = "mber of grid_points"
         handle = file_prefix.string_io()
         lines = handle.readlines()
-        return lines[0].strip() == begin_header and lines[9].strip() == end_header and lines[10].strip() == grid_points
+        return lines[0].strip() == begin_header and (
+            (lines[9].strip() == end_header and lines[10].strip() == grid_points)
+            or (lines[9].strip() == end_header_spin and lines[10].strip() == grid_points_spin)
+        )


### PR DESCRIPTION
Added alternative header text for `den_fmt` files containing both charge and spin. Previously only accounted for charge due to an oversight when creating the sniffer.

Closes #15796

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
