### PR TITLE
Initial end-to-end tests for separate quota sources per object store

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -69,7 +69,7 @@
                         :title="reloadButtonTitle"
                         :variant="reloadButtonVariant"
                         size="sm"
-                        class="rounded-0 text-decoration-none"
+                        class="rounded-0 text-decoration-none history-refresh-button"
                         @click="reloadContents()">
                         <span :class="reloadButtonCls" />
                     </b-button>

--- a/client/src/components/User/DiskUsage/Quota/QuotaUsageBar.vue
+++ b/client/src/components/User/DiskUsage/Quota/QuotaUsageBar.vue
@@ -60,11 +60,15 @@ defineExpose({
             </span>
             {{ storageSourceText }}
         </component>
-        <component :is="usageTag" v-if="!compact">
+        <component
+            :is="usageTag"
+            v-if="!compact"
+            :data-quota-usage="quotaUsage.totalDiskUsageInBytes"
+            class="quota-usage">
             <b>{{ quotaUsage.niceTotalDiskUsage }}</b>
             <span v-if="quotaHasLimit"> of {{ quotaUsage.niceQuota }}</span> used
         </component>
-        <span v-if="quotaHasLimit && !compact" class="quota-percent-text">
+        <span v-if="quotaHasLimit && !compact" class="quota-percent-text" :data-quota-percent="quotaUsage.quotaPercent">
             {{ quotaUsage.quotaPercent }}{{ percentOfDiskQuotaUsedText }}
         </span>
         <b-progress

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -210,7 +210,7 @@ history_panel:
       alltags: '${_} .stateless-tags .tag'
       metadata_file_download: '${_} [data-description="download ${metadata_name}"]'
 
-      dataset_operations_dropdown: '${_}  .dataset-actions'
+      dataset_operations: '${_} .dataset-actions'
 
   # re-usable history editor, scoped for use in different layout scenarios (multi, etc.)
   editor:

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -130,7 +130,10 @@ object_store_details:
   selectors:
     stored_by_name: '.display-os-by-name'
     badge_of_type: '.object-store-badge-wrapper [data-badge-type="${type}"]'
-
+    usage_details: '.quota-usage-bar'
+    usage_bytes: '.quota-usage'
+    usage_percent: '.quota-percent-text'
+    usage_progress: '.quota-usage-bar .progress'
 
 history_panel:
   menu:
@@ -780,6 +783,13 @@ admin:
       repo_search: '#toolshed-repo-search'
       search_results: '#shed-search-results'
       upgrade_notification: '#repository-table .badge'
+
+  quota:
+    selectors:
+      add_new: '.quotas .manage-table-actions .action-button'
+      items: '.quotas tbody tr td'
+      add_form: "[url='/admin/create_quota']"
+      add_form_submit: "[url='/admin/create_quota'] #submit"
 
   index:
     selectors:

--- a/lib/galaxy/navigation/components.py
+++ b/lib/galaxy/navigation/components.py
@@ -46,7 +46,7 @@ class Target(metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
     def component_locator(self) -> LocatorT:
-        """Return a (by, selector) Selenium elment locator tuple for this selector."""
+        """Return a (by, selector) Selenium element locator tuple for this selector."""
 
     @property
     def selenium_locator(self) -> Tuple[str, str]:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1651,7 +1651,7 @@ class NavigatesGalaxy(HasDriver):
 
     def history_panel_item_view_dataset_details(self, hid):
         item = self.history_panel_item_component(hid=hid)
-        item.dataset_operations_dropdown.wait_for_and_click()
+        item.dataset_operations.wait_for_visible()
         item.info_button.wait_for_and_click()
         self.components.dataset_details._.wait_for_visible()
 

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -393,6 +393,11 @@ class NavigatesGalaxy(HasDriver):
     def history_panel_wait_for_hid_deferred(self, hid, allowed_force_refreshes=0):
         return self.history_panel_wait_for_hid_state(hid, "deferred", allowed_force_refreshes=allowed_force_refreshes)
 
+    def wait_for_hid_ok_and_open_details(self, hid):
+        self.history_panel_wait_for_hid_ok(hid, allowed_force_refreshes=1)
+        self.history_panel_click_item_title(hid=hid)
+        self.history_panel_item_view_dataset_details(hid)
+
     def history_panel_item_component(self, history_item=None, hid=None, multi_history_panel=False):
         assert hid
         return self.content_item_by_attributes(hid=hid, multi_history_panel=multi_history_panel)
@@ -1078,6 +1083,41 @@ class NavigatesGalaxy(HasDriver):
     def admin_open(self):
         self.components.masthead.admin.wait_for_and_click()
 
+    def create_quota(
+        self,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        amount: Optional[str] = None,
+        quota_source_label: Optional[str] = None,
+        user: Optional[str] = None,
+    ):
+        admin_component = self.components.admin
+
+        self.admin_open()
+        quota_link = admin_component.index.quotas
+        quota_link.wait_for_and_click()
+        quota_component = admin_component.quota
+
+        quota_component.add_new.wait_for_and_click()
+        form = quota_component.add_form.wait_for_visible()
+
+        name = name or self._get_random_name()
+        description = description or f"quota description for {name}"
+        amount = amount or ""
+        self.fill(
+            form,
+            {
+                "name": name,
+                "description": description,
+                "amount": amount,
+            },
+        )
+        if quota_source_label:
+            self.select2_set_value("#quota_source_label", quota_source_label)
+        if user:
+            self.select2_set_value("#in_users", user)
+        quota_component.add_form_submit.wait_for_and_click()
+
     def select_dataset_from_lib_import_modal(self, filenames):
         for name in filenames:
             self.components.libraries.folder.select_import_dir_item(name=name).wait_for_and_click()
@@ -1375,6 +1415,22 @@ class NavigatesGalaxy(HasDriver):
         tool_element = tool_link.wait_for_present()
         self.driver.execute_script("arguments[0].scrollIntoView(true);", tool_element)
         tool_link.wait_for_and_click()
+
+    def run_environment_test_tool(self, inttest_value="42", select_storage: Optional[str] = None):
+        self.home()
+        self.tool_open("environment_variables")
+        if select_storage:
+            self.components.tool_form.storage_options.wait_for_and_click()
+            self.select_storage(select_storage)
+        self.tool_set_value("inttest", inttest_value)
+        self.tool_form_execute()
+
+    def select_storage(self, storage_id: str) -> None:
+        selection_component = self.components.preferences.object_store_selection
+        selection_component.option_buttons.wait_for_present()
+        button = selection_component.option_button(object_store_id=storage_id)
+        button.wait_for_and_click()
+        selection_component.option_buttons.wait_for_absent_or_hidden()
 
     def create_page_and_edit(self, name=None, slug=None, screenshot_name=None):
         name = self.create_page(name=name, slug=slug, screenshot_name=screenshot_name)

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -126,15 +126,13 @@ class TestHistoryDatasetState(SeleniumTestCase, UsesHistoryItemAssertions):
 
     def _assert_downloadable(self, hid, is_downloadable=True):
         item = self.history_panel_item_component(hid=hid)
-        item.dataset_operations_dropdown.wait_for_and_click()
+        item.dataset_operations.wait_for_visible()
         item.info_button.wait_for_visible()
         if is_downloadable:
             assert item.download_button.is_displayed
         else:
             item.download_button.assert_absent_or_hidden()
-
-        # close menu...
-        item.dataset_operations_dropdown.wait_for_and_click()
+        item.dataset_operations.wait_for_visible()
         self.sleep_for(self.wait_types.UX_RENDER)
 
     def _assert_buttons(self, hid, expected_buttons):


### PR DESCRIPTION
Last commit introduces the new tests. Builds on all the fixes in https://github.com/galaxyproject/galaxy/pull/15795 for the functionality added in https://github.com/galaxyproject/galaxy/pull/14073 and builds on the testing abstractions introduced in https://github.com/galaxyproject/galaxy/pull/15785. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
