### PR TITLE
[23.0] Fix loading of job submission success page on route change

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -316,9 +316,11 @@ export default {
                 jobDef.inputs["use_cached_job"] = true;
             }
             console.debug("toolForm::onExecute()", jobDef);
+            const prevRoute = this.$route.fullPath;
             submitJob(jobDef).then(
                 (jobResponse) => {
                     this.showExecuting = false;
+                    let changeRoute = false;
                     refreshContentsWrapper();
                     if (jobResponse.produces_entry_points) {
                         this.showEntryPoints = true;
@@ -335,17 +337,21 @@ export default {
                             toolName: this.toolName,
                         };
                         this.saveLatestResponse(response);
-                        this.$router.push(`/jobs/submission/success`);
+                        changeRoute = prevRoute === this.$route.fullPath;
                     } else {
                         this.showError = true;
                         this.showForm = true;
                         this.errorTitle = "Job submission rejected.";
                         this.errorContent = jobResponse;
                     }
-                    if ([true, "true"].includes(config.enable_tool_recommendations)) {
-                        this.showRecommendation = true;
+                    if (changeRoute) {
+                        this.$router.push(`/jobs/submission/success`);
+                    } else {
+                        if ([true, "true"].includes(config.enable_tool_recommendations)) {
+                            this.showRecommendation = true;
+                        }
+                        document.querySelector(".center-panel").scrollTop = 0;
                     }
-                    document.querySelector(".center-panel").scrollTop = 0;
                 },
                 (e) => {
                     this.errorMessage = e?.response?.data?.err_msg;


### PR DESCRIPTION
As reported here: Fixes https://github.com/galaxyproject/galaxy/issues/15704 : Job submission page (`/jobs/submission/success`) would flicker into view if user changed route immediately after submitting a job. This happened because of the `Promise` created by `submitJob` not completing before the user changes route, and meanwhile as the `Promise` completes, the route is `then()` changed to `/jobs/submission/success`.
Fixed it so we check the route and make sure we route to `/jobs/submission/success` only if the current route is the active `ToolForm`. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
