### PR TITLE
[22.05] Bump tuswsgi middleware

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -227,7 +227,7 @@ tqdm==4.64.0; python_version >= "2.7" and python_full_version < "3.0.0" or pytho
 trio-websocket==0.9.2; python_version >= "3.7" and python_version < "4.0"
 trio==0.21.0; python_version >= "3.7" and python_version < "4.0"
 tuspy==0.2.5
-tuswsgi==0.5.4
+tuswsgi==0.5.5
 twill==3.0.2
 typed-ast==1.5.4; python_version < "3.8" and implementation_name == "cpython" and python_full_version >= "3.6.2" and python_version >= "3.7"
 typing-extensions==4.2.0; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -159,7 +159,7 @@ tenacity==8.0.1; python_version >= "3.6"
 tifffile==2021.11.2; python_version >= "3.7"
 tornado==6.1; python_version >= "3.5"
 tqdm==4.64.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-tuswsgi==0.5.4
+tuswsgi==0.5.5
 typing-extensions==4.2.0; python_version >= "3.7"
 tzlocal==2.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 ubiquerg==0.6.2


### PR DESCRIPTION
The middleware (prior to 0.5.5) attempts to cleanup files on every upload, this can be a problem if there are many files in the upload directory, especially on NFS.

Should help with
```
uvicorn.access INFO 2023-02-27 14:44:26,392 [pN:main.1,p:23,tN:MainThread] 10.80.0.13:42166 - "POST /api/upload/resumable_upload/ HTTP/1.0" 500
[2023-02-27 14:44:26 +0000] [23] [ERROR] Exception in ASGI application
Traceback (most recent call last):
  File "/galaxy/server/.venv/lib/python3.10/site-packages/anyio/streams/memory.py", line 94, in receive
    return self.receive_nowait()
  File "/galaxy/server/.venv/lib/python3.10/site-packages/anyio/streams/memory.py", line 89, in receive_nowait
    raise WouldBlock
anyio.WouldBlock

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 43, in call_next
    message = await recv_stream.receive()
  File "/galaxy/server/.venv/lib/python3.10/site-packages/anyio/streams/memory.py", line 114, in receive
    raise EndOfStream
anyio.EndOfStream

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/galaxy/server/.venv/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 366, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/fastapi/applications.py", line 269, in __call__
    await super().__call__(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/exceptions.py", line 93, in __call__
    raise exc
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/galaxy/server/.venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/routing.py", line 418, in handle
    await self.app(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/fastapi/applications.py", line 269, in __call__
    await super().__call__(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 68, in __call__
    response = await self.dispatch_func(request, call_next)
  File "/galaxy/server/lib/galaxy/webapps/base/api.py", line 163, in dispatch
    return await call_next(request)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 46, in call_next
    raise app_exc
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 36, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette_context/middleware/raw_middleware.py", line 96, in __call__
    await self.app(scope, receive, send_wrapper)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 68, in __call__
    response = await self.dispatch_func(request, call_next)
  File "/galaxy/server/lib/galaxy/webapps/galaxy/fast_app.py", line 99, in add_x_frame_options
    response = await call_next(request)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 46, in call_next
    raise app_exc
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/middleware/base.py", line 36, in coro
    await self.app(scope, request.receive, send_stream.send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/exceptions.py", line 93, in __call__
    raise exc
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/exceptions.py", line 82, in __call__
    await self.app(scope, receive, sender)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/galaxy/server/.venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/routing.py", line 670, in __call__
    await route.handle(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/starlette/routing.py", line 418, in handle
    await self.app(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/a2wsgi/wsgi.py", line 140, in __call__
    return await responder(scope, receive, send)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/a2wsgi/wsgi.py", line 172, in __call__
    await self.loop.run_in_executor(
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/a2wsgi/wsgi.py", line 222, in wsgi
    for chunk in self.app(environ, start_response):
  File "/galaxy/server/.venv/lib/python3.10/site-packages/paste/urlmap.py", line 216, in __call__
    return app(environ, start_response)
  File "/galaxy/server/lib/galaxy/web/framework/middleware/request_id.py", line 15, in __call__
    return self.app(environ, start_response)
  File "/galaxy/server/lib/galaxy/web/framework/middleware/xforwardedhost.py", line 23, in __call__
    return self.app(environ, start_response)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/tuswsgi.py", line 215, in __call__
    self.handle(env)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/tuswsgi.py", line 254, in handle
    self.post(env)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/tuswsgi.py", line 280, in post
    self.create_files(env)
  File "/galaxy/server/.venv/lib/python3.10/site-packages/tuswsgi.py", line 431, in create_files
    self.cleanup()
  File "/galaxy/server/.venv/lib/python3.10/site-packages/tuswsgi.py", line 602, in cleanup
    os.remove(fpath)
OSError: [Errno 16] Device or resource busy: '/galaxy/server/database/tmp/.nfs00000000001e38fa00000038'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
