### PR TITLE
[23.0] Show workflow errors in embedded markdown element

### DIFF
--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.test.js
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.test.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import flushPromises from "flush-promises";
 import MockAdapter from "axios-mock-adapter";
 import { mount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
@@ -6,38 +7,68 @@ import MountTarget from "./WorkflowDisplay";
 
 const localVue = getLocalVue(true);
 
-describe("WorkflowDisplay", () => {
-    let wrapper;
-    let axiosMock;
+let axiosMock;
 
-    beforeEach(() => {
-        axiosMock = new MockAdapter(axios);
-        const data = {};
-        axiosMock.onGet(`/api/workflows/workflow_id/download?style=preview`).reply(200, data);
-        wrapper = mount(MountTarget, {
-            propsData: {
-                args: {
-                    workflow_id: "workflow_id",
-                },
-                embedded: false,
-                expanded: false,
+function mountDefault() {
+    axiosMock = new MockAdapter(axios);
+    const data = {
+        name: "workflow_name",
+    };
+    axiosMock.onGet(`/api/workflows/workflow_id/download?style=preview`).reply(200, data);
+    return mount(MountTarget, {
+        propsData: {
+            args: {
+                workflow_id: "workflow_id",
             },
-            localVue,
-        });
+            embedded: false,
+            expanded: false,
+        },
+        localVue,
     });
+}
 
-    afterEach(() => {
-        axiosMock.reset();
+function mountError() {
+    axiosMock = new MockAdapter(axios);
+    const data = {
+        err_msg: {
+            firstError: "firstValue",
+            secondError: "secondValue",
+        },
+    };
+    axiosMock.onGet(`/api/workflows/workflow_id/download?style=preview`).reply(400, data);
+    return mount(MountTarget, {
+        propsData: {
+            args: {
+                workflow_id: "workflow_id",
+            },
+            embedded: false,
+            expanded: false,
+        },
+        localVue,
     });
+}
 
+describe("WorkflowDisplay", () => {
     it("basics", async () => {
+        const wrapper = mountDefault();
+        await flushPromises();
         const cardHeader = wrapper.find(".card-header");
-        expect(cardHeader.text()).toBe("Workflow:");
+        expect(cardHeader.text()).toBe("Workflow: workflow_name");
         const downloadUrl = wrapper.find("[data-description='workflow download']");
         expect(downloadUrl.attributes("href")).toBe("/api/workflows/workflow_id/download?format=json-download");
         const importUrl = wrapper.find("[data-description='workflow import']");
         expect(importUrl.attributes("href")).toBe("/workflow/imp?id=workflow_id");
         const dataRequest = axiosMock.history.get[0].url;
         expect(dataRequest).toBe("/api/workflows/workflow_id/download?style=preview");
+    });
+
+    it("error messages", async () => {
+        const wrapper = mountError();
+        await flushPromises();
+        const cardHeader = wrapper.find(".card-header");
+        expect(cardHeader.text()).toBe("Workflow: ...");
+        const errorMessages = wrapper.findAll("li");
+        expect(errorMessages.at(0).text()).toBe("firstError: firstValue");
+        expect(errorMessages.at(1).text()).toBe("secondError: secondValue");
     });
 });

--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.test.js
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.test.js
@@ -27,13 +27,10 @@ function mountDefault() {
     });
 }
 
-function mountError() {
+function mountError(errContent) {
     axiosMock = new MockAdapter(axios);
     const data = {
-        err_msg: {
-            firstError: "firstValue",
-            secondError: "secondValue",
-        },
+        err_msg: errContent,
     };
     axiosMock.onGet(`/api/workflows/workflow_id/download?style=preview`).reply(400, data);
     return mount(MountTarget, {
@@ -62,13 +59,23 @@ describe("WorkflowDisplay", () => {
         expect(dataRequest).toBe("/api/workflows/workflow_id/download?style=preview");
     });
 
-    it("error messages", async () => {
-        const wrapper = mountError();
+    it("error message as object", async () => {
+        const wrapper = mountError({
+            firstError: "firstValue",
+            secondError: "secondValue",
+        });
         await flushPromises();
         const cardHeader = wrapper.find(".card-header");
         expect(cardHeader.text()).toBe("Workflow: ...");
-        const errorMessages = wrapper.findAll("li");
-        expect(errorMessages.at(0).text()).toBe("firstError: firstValue");
-        expect(errorMessages.at(1).text()).toBe("secondError: secondValue");
+        const errorContent = wrapper.findAll("li");
+        expect(errorContent.at(0).text()).toBe("firstError: firstValue");
+        expect(errorContent.at(1).text()).toBe("secondError: secondValue");
+    });
+
+    it("error message as text", async () => {
+        const wrapper = mountError("Something went wrong.");
+        await flushPromises();
+        const errorContent = wrapper.find(".alert > div");
+        expect(errorContent.text()).toBe("Something went wrong.");
     });
 });

--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
@@ -34,13 +34,14 @@
         <b-card-body>
             <LoadingSpan v-if="loading" message="Loading Workflow" />
             <div v-else :class="!expanded && 'content-height'">
-                <b-alert v-if="errorDict" variant="danger" show>
+                <b-alert v-if="errorContent" variant="danger" show>
                     <b>Please fix the following error(s):</b>
-                    <ul class="my-2">
-                        <li v-for="(errorValue, errorKey) in errorDict" :key="errorKey">
+                    <ul v-if="typeof errorContent === 'object'" class="my-2">
+                        <li v-for="(errorValue, errorKey) in errorContent" :key="errorKey">
                             {{ errorKey }}: {{ errorValue }}
                         </li>
                     </ul>
+                    <div v-else>{{ errorContent }}</div>
                 </b-alert>
                 <div v-else>
                     <div v-for="step in itemContent.steps" :key="step.order_index" class="mb-2">
@@ -79,7 +80,7 @@ export default {
     },
     data() {
         return {
-            errorDict: null,
+            errorContent: null,
             itemContent: null,
             loading: true,
         };
@@ -105,8 +106,8 @@ export default {
                 this.itemContent = data;
                 this.loading = false;
             })
-            .catch((errorDict) => {
-                this.errorDict = errorDict;
+            .catch((errorContent) => {
+                this.errorContent = errorContent;
                 this.loading = false;
             });
     },

--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
@@ -34,9 +34,19 @@
         <b-card-body>
             <LoadingSpan v-if="loading" message="Loading Workflow" />
             <div v-else :class="!expanded && 'content-height'">
-                <div v-for="step in itemContent.steps" :key="step.order_index" class="mb-2">
-                    <div>Step {{ step.order_index + 1 }}: {{ step.label }}</div>
-                    <WorkflowTree :input="step" :skip-head="true" />
+                <b-alert v-if="errorDict" variant="danger" show>
+                    <b>Please fix the following error(s):</b>
+                    <ul class="my-2">
+                        <li v-for="(errorValue, errorKey) in errorDict" :key="errorKey">
+                            {{ errorKey }}: {{ errorValue }}
+                        </li>
+                    </ul>
+                </b-alert>
+                <div v-else>
+                    <div v-for="step in itemContent.steps" :key="step.order_index" class="mb-2">
+                        <div>Step {{ step.order_index + 1 }}: {{ step.label }}</div>
+                        <WorkflowTree :input="step" :skip-head="true" />
+                    </div>
                 </div>
             </div>
         </b-card-body>
@@ -69,6 +79,7 @@ export default {
     },
     data() {
         return {
+            errorDict: null,
             itemContent: null,
             loading: true,
         };
@@ -89,10 +100,15 @@ export default {
     },
     created() {
         const url = this.itemUrl;
-        urlData({ url }).then((data) => {
-            this.itemContent = data;
-            this.loading = false;
-        });
+        urlData({ url })
+            .then((data) => {
+                this.itemContent = data;
+                this.loading = false;
+            })
+            .catch((errorDict) => {
+                this.errorDict = errorDict;
+                this.loading = false;
+            });
     },
 };
 </script>

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -805,7 +805,8 @@ class SubWorkflowModule(WorkflowModule):
             if step.type == "tool":
                 assert isinstance(step.module, ToolModule)
                 tool = step.module.tool
-                assert tool
+                if tool is None:
+                    raise ToolMissingException("Tool in subworkflow missing.", tool_id=step.module.tool_id)
                 tool_inputs = step.module.state
 
                 def callback(input, prefixed_name, prefixed_label, value=None, **kwds):


### PR DESCRIPTION
Workflow errors such as missing values are currently not displayed when embedding workflows as markdown elements into pages. This PR displays the recognized errors as list within a message alert. Additionally, this PR contains a fix to ensure that missing tools in subworkflows are properly propagated. The error rendering in this PR is a relatively small fix targeting release, we should revisit this issue in dev and add a more comprehensive reusable component which renders these errors properly, in some workflow views we currently only display the resulting error content as unformatted json.

<img width="846" alt="image" src="https://user-images.githubusercontent.com/2105447/225340812-2bc66e2c-036e-48f3-8b1b-77f3564d3b3d.png">

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
