### PR TITLE
[23.0] Dataset Counts Toggle

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -28,7 +28,7 @@
                 variant="link"
                 size="sm"
                 class="rounded-0 text-decoration-none"
-                @click="setFilter('deleted:true')">
+                @click="toggleDeleted()">
                 <icon icon="trash" />
                 <span>{{ numItemsDeleted }}</span>
             </b-button>
@@ -72,6 +72,7 @@ export default {
         history: { type: Object, required: true },
         isWatching: { type: Boolean, default: false },
         lastChecked: { type: Date, default: null },
+        filterText: { type: String, default: "" },
     },
     data() {
         return {
@@ -91,6 +92,20 @@ export default {
         },
         setFilter(newFilterText) {
             this.$emit("update:filter-text", newFilterText);
+        },
+        toggleDeleted() {
+            if (this.filterText === "deleted:true") {
+                this.setFilter("");
+            } else {
+                this.setFilter("deleted:true");
+            }
+        },
+        toggleHidden() {
+            if (this.filterText === "visible:false") {
+                this.setFilter("");
+            } else {
+                this.setFilter("visible:false");
+            }
         },
         updateTime() {
             const diffToNow = formatDistanceToNowStrict(this.lastChecked, { addSuffix: true, includeSeconds: true });


### PR DESCRIPTION
One way to address https://github.com/galaxyproject/galaxy/issues/15805; kept the implementation the same for 23.0 but this should probably interface with a store of the filter state in a central place, allowing individual toggles instead of string manipulation?

Right now those icons are pretty naive and don't interact with the rest of the advanced history or filtering at all, instead, just overwriting the filter state.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
