### PR TITLE
[23.0] Fix toggling output visibility

### DIFF
--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -120,7 +120,7 @@ function onToggleActive() {
 
 function onToggleVisible() {
     const actionKey = `HideDatasetAction${props.output.name}`;
-    const step = stepStore.getStep(stepId.value);
+    const step = { ...stepStore.getStep(stepId.value) };
     if (isVisible.value) {
         step.post_job_actions = {
             ...step.post_job_actions,


### PR DESCRIPTION
steps coming out of the step store are frozen, this should fix
```
TypeError: "post_job_actions" is read-only
    onToggleVisible NodeOutput.vue:137
    VueJS 3
    sentryWrapped helpers.js:74
instrument.js:109
    instrumentConsole instrument.js:109
    VueJS 6
    sentryWrapped helpers.js:74
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
