### PR TITLE
Add clean up job working directory as celery task

### DIFF
--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import os
 import shutil
 from concurrent.futures import TimeoutError
 from functools import lru_cache
@@ -519,7 +518,7 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
     def get_failed_jobs():
         return sa_session.query(model.Job.id).filter(
             model.Job.state == "error",
-            model.Job.update_time > datetime.datetime.now() - datetime.timedelta(days=days),
+            model.Job.update_time < datetime.datetime.now() - datetime.timedelta(days=days),
             model.Job.object_store_id is not None,
         )
 

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -523,22 +523,22 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
             model.Job.object_store_id is not None,
         )
 
-    def delete_jwd(jwd_path):
+    def delete_jwd(job):
         try:
             # Get job working directory from object store
             path = object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
-            shutil.rmtree(jwd_path)
+            shutil.rmtree(path)
         except ObjectNotFound:
             # job working directory already deleted
             pass
         except OSError as e:
-            log.error(f"Error deleting job working directory: {jwd_path} : {e.strerror}")
-    
+            log.error(f"Error deleting job working directory: {path} : {e.strerror}")
+
     failed_jobs = get_failed_jobs()
 
     if not failed_jobs:
         log.info("No failed jobs found within the last %s days", days)
 
-    for job in failed_jobs.items():
+    for job in failed_jobs:
         delete_jwd(job)
         log.info("Deleted job working directory for job %s", job.id)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -24,6 +24,7 @@ from galaxy.celery import (
 from galaxy.config import GalaxyAppConfiguration
 from galaxy.datatypes import sniff
 from galaxy.datatypes.registry import Registry as DatatypesRegistry
+from galaxy.exceptions import ObjectNotFound
 from galaxy.jobs import MinimalJobWrapper
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.datasets import (

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -513,7 +513,7 @@ def dispatch_pending_notifications(notification_manager: NotificationManager):
 
 
 @galaxy_task(action="clean up job working directories")
-def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStore):
+def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStore, days: Optional[int] = 5):
     """Cleanup job working directories for failed jobs that are older than X days"""
 
     def get_failed_jobs():
@@ -533,9 +533,7 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
             pass
         except OSError as e:
             log.error(f"Error deleting job working directory: {jwd_path} : {e.strerror}")
-
-    # days should be converted to a config option
-    days = 5
+    
     failed_jobs = get_failed_jobs()
 
     if not failed_jobs:

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -1,10 +1,10 @@
-import json
-from concurrent.futures import TimeoutError
 import datetime
-from functools import lru_cache
+import json
 import os
-from pathlib import Path
 import shutil
+from concurrent.futures import TimeoutError
+from functools import lru_cache
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -514,10 +514,13 @@ def dispatch_pending_notifications(notification_manager: NotificationManager):
 @galaxy_task(action="clean up job working directories")
 def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStore):
     """Cleanup job working directories for failed jobs that are older than X days"""
+
     def get_failed_jobs():
         failed_jobs = {}
         jobs = sa_session.query(model.Job).filter(
-            model.Job.state == "error", model.Job.update_time > datetime.datetime.now() - datetime.timedelta(days=days), model.Job.object_store_id is not None
+            model.Job.state == "error",
+            model.Job.update_time > datetime.datetime.now() - datetime.timedelta(days=days),
+            model.Job.object_store_id is not None,
         )
 
         for job in jobs:

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -512,14 +512,14 @@ def dispatch_pending_notifications(notification_manager: NotificationManager):
 
 
 @galaxy_task(action="clean up job working directories")
-def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStore, days: Optional[int] = 5):
+def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStore, days: Optional[float] = 5):
     """Cleanup job working directories for failed jobs that are older than X days"""
 
     def get_failed_jobs():
         return sa_session.query(model.Job.id).filter(
             model.Job.state == "error",
             model.Job.update_time < datetime.datetime.now() - datetime.timedelta(days=days),
-            model.Job.object_store_id is not None,
+            model.Job.object_store_id.isnot(None),
         )
 
     def delete_jwd(job):

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -551,6 +551,6 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
     if not failed_jobs:
         log.info("No failed jobs found within the last %s days", days)
 
-    for job_id, job_working_directory in failed_jobs.items():
-        delete_jwd(job_working_directory)
-        log.info("Deleted job working directory for job %s", job_id)
+    for job in failed_jobs.items():
+        delete_jwd(job)
+        log.info("Deleted job working directory for job %s", job.id)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -516,17 +516,11 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
     """Cleanup job working directories for failed jobs that are older than X days"""
 
     def get_failed_jobs():
-        failed_jobs = {}
-        jobs = sa_session.query(model.Job).filter(
+        return sa_session.query(model.Job.id).filter(
             model.Job.state == "error",
             model.Job.update_time > datetime.datetime.now() - datetime.timedelta(days=days),
             model.Job.object_store_id is not None,
         )
-
-        for job in jobs:
-            failed_jobs[job.id] = object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
-
-        return failed_jobs
 
     def delete_jwd(jwd_path):
         try:

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -543,19 +543,11 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
 
     # days should be converted to a config option
     days = 5
-    galaxy_log_dir = "/var/log/galaxy"
-    log_file_name = f"jwds_cleanup_{datetime.datetime.now().strftime('%d_%m_%Y-%I_%M_%S')}.log"
-
     failed_jobs = get_failed_jobs()
 
     if not failed_jobs:
         log.info("No failed jobs found within the last %s days", days)
 
-    with open(f"{galaxy_log_dir}/{log_file_name}", "w") as jwd_log:
-        jwd_log.write(
-            "The following job working directories (JWDs) belonging "
-            "to the failed jobs are deleted\nJob id: JWD path\n"
-                )
         for job_id, job_working_directory in failed_jobs.items():
             delete_jwd(job_working_directory)
-            jwd_log.write(f"{job_id}: {job_working_directory}")
+            log.info("Deleted job working directory for job %s", job_id)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -553,8 +553,8 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
 
     with open(f"{galaxy_log_dir}/{log_file_name}", "w") as jwd_log:
         jwd_log.write(
-                    "The following job working directories (JWDs) belonging "
-                    "to the failed jobs are deleted\nJob id: JWD path\n"
+            "The following job working directories (JWDs) belonging "
+            "to the failed jobs are deleted\nJob id: JWD path\n"
                 )
         for job_id, job_working_directory in failed_jobs.items():
             delete_jwd(job_working_directory)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -512,7 +512,7 @@ def dispatch_pending_notifications(notification_manager: NotificationManager):
 
 
 @galaxy_task(action="clean up job working directories")
-def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStore, days: Optional[float] = 5):
+def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStore, days: int = 5):
     """Cleanup job working directories for failed jobs that are older than X days"""
 
     def get_failed_jobs():

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -548,6 +548,6 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
     if not failed_jobs:
         log.info("No failed jobs found within the last %s days", days)
 
-        for job_id, job_working_directory in failed_jobs.items():
-            delete_jwd(job_working_directory)
-            log.info("Deleted job working directory for job %s", job_id)
+    for job_id, job_working_directory in failed_jobs.items():
+        delete_jwd(job_working_directory)
+        log.info("Deleted job working directory for job %s", job_id)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -530,17 +530,12 @@ def cleanup_jwds(sa_session: galaxy_scoped_session, object_store: BaseObjectStor
 
     def delete_jwd(jwd_path):
         try:
-            # Validate that the path is a JWD
-            # It is a JWD if the following conditions are true:
-            # 1. Check if tool_script.sh exists
-            # 2. Check if directories 'inputs', and 'outputs' exist
-            if (
-                os.path.exists(jwd_path)
-                and os.path.exists(f"{jwd_path}/tool_script.sh")
-                and os.path.exists(f"{jwd_path}/inputs")
-                and os.path.exists(f"{jwd_path}/outputs")
-            ):
-                shutil.rmtree(jwd_path)
+            # Get job working directory from object store
+            path = object_store.get_filename(job, base_dir="job_work", dir_only=True, obj_dir=True)
+            shutil.rmtree(jwd_path)
+        except ObjectNotFound:
+            # job working directory already deleted
+            pass
         except OSError as e:
             log.error(f"Error deleting job working directory: {jwd_path} : {e.strerror}")
 


### PR DESCRIPTION
**WHAT:**
Adds a new celery task to clean up job working directories for failed jobs that are older than X days
See the initial PR: https://github.com/galaxyproject/galaxy/pull/15618 for the discussion

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).

fixes https://github.com/galaxyproject/galaxy/issues/15977
