### PR TITLE
[23.0] Display dialog when saving workflow with invalid connections

### DIFF
--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -9,6 +9,7 @@ const emit = defineEmits<{
     (e: "onReport"): void;
     (e: "onSaveAs"): void;
     (e: "onLayout"): void;
+    (e: "onLint"): void;
     (e: "onUpgrade"): void;
     (e: "onDownload"): void;
     (e: "onRun"): void;

--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -1,3 +1,55 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { BDropdown, BDropdownItem, BButton } from "bootstrap-vue";
+import { useConfirmDialog } from "@/composables/confirmDialog";
+
+const emit = defineEmits<{
+    (e: "onAttributes"): void;
+    (e: "onSave"): void;
+    (e: "onReport"): void;
+    (e: "onSaveAs"): void;
+    (e: "onLayout"): void;
+    (e: "onUpgrade"): void;
+    (e: "onDownload"): void;
+    (e: "onRun"): void;
+}>();
+
+const props = defineProps<{
+    hasChanges?: boolean;
+    hasInvalidConnections?: boolean;
+    requiredReindex?: boolean;
+}>();
+
+const { confirm } = useConfirmDialog();
+
+const saveHover = computed(() => {
+    if (!props.hasChanges) {
+        return "Workflow has no changes";
+    } else if (props.hasInvalidConnections) {
+        return "Workflow has invalid connections, review and remove invalid connections";
+    } else {
+        return "Save Workflow";
+    }
+});
+
+async function onSave() {
+    if (props.hasInvalidConnections) {
+        console.log("getting confirmation");
+        const confirmed = await confirm(
+            `Workflow has invalid connections. You can save the workflow, but it may not run correctly.`,
+            {
+                id: "save-workflow-confirmation",
+                okTitle: "Save Workflow",
+            }
+        );
+        if (confirmed) {
+            emit("onSave");
+        }
+    } else {
+        emit("onSave");
+    }
+}
+</script>
 <template>
     <div class="panel-header-buttons">
         <b-button
@@ -18,8 +70,8 @@
                 variant="link"
                 aria-label="Save Workflow"
                 class="editor-button-save"
-                :disabled="!hasChanges || hasInvalidConnections"
-                @click="$emit('onSave')">
+                :disabled="!hasChanges"
+                @click="onSave">
                 <span class="fa fa-floppy-o" />
             </b-button>
         </b-button-group>
@@ -76,24 +128,3 @@
         </b-button>
     </div>
 </template>
-
-<script setup lang="ts">
-import { computed } from "vue";
-import { BDropdown, BDropdownItem, BButton } from "bootstrap-vue";
-
-const props = defineProps<{
-    hasChanges?: boolean;
-    hasInvalidConnections?: boolean;
-    requiredReindex?: boolean;
-}>();
-
-const saveHover = computed(() => {
-    if (!props.hasChanges) {
-        return "Workflow has no changes";
-    } else if (props.hasInvalidConnections) {
-        return "Workflow has invalid connections, review and remove invalid connections";
-    } else {
-        return "Save Workflow";
-    }
-});
-</script>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -665,6 +665,7 @@ workflow_editor:
     connector_invalid_for: "#connection-${sink_id}-${source_id} .ribbon-inner-invalid"
     connector_destroy_callout: '.delete-terminal'
     save_button: '.editor-button-save'
+    save_workflow_confirmation_button: '#save-workflow-confirmation .btn-primary'
     state_modal_body: '.state-upgrade-modal'
     modal_button_continue: '.modal-footer .btn'
 

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -557,17 +557,17 @@ steps:
         editor.select_datatype(datatype="bam").wait_for_and_click()
         editor.node.output_data_row(output_name="out_file1", extension="bam").wait_for_visible()
         self.assert_connection_invalid("create_2#out_file1", "checksum#input")
+        # Assert save button
         save_button = self.components.workflow_editor.save_button
-        # Assert save button is disabled
-        assert save_button.has_class("disabled")
+        save_button.wait_for_and_click()
+        # Will trigger confirmation modal
+        self.components.workflow_editor.save_workflow_confirmation_button.wait_for_and_click()
         # Make connection valid again
         editor.change_datatype.wait_for_and_click()
         editor.select_datatype_text_search.wait_for_and_send_keys("tabular")
         editor.select_datatype(datatype="tabular").wait_for_and_click()
         # Assert connection is valid
         self.assert_connected("create_2#out_file1", "checksum#input")
-        # Assert save button is enabled
-        assert not save_button.has_class("disabled")
 
     @selenium_test
     def test_change_datatype_post_job_action_lost_regression(self):


### PR DESCRIPTION
Closes https://github.com/galaxyproject/galaxy/issues/15753


<img width="959" alt="Screenshot 2023-03-17 at 15 41 02" src="https://user-images.githubusercontent.com/6804901/225936745-19a4280b-3a17-436c-8f45-4f22f3339fc7.png">


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
