### PR TITLE
[23.0] Fix overly strict map over constraints

### DIFF
--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -385,16 +385,13 @@ describe("canAccept", () => {
         expect(collectionIn.canAccept(pairedOut).canAccept).toBe(false);
         expect(collectionIn.canAccept(pairedOut).reason).toBe("Incompatible collection type(s) for attachment.");
     });
-    it("rejects mapping over collection input if other inputs have an incompatible map over collection type", () => {
+    it("accepts a collection input if other input has a map over collection type", () => {
         const collectionOut = terminals["list input"]["output"] as OutputCollectionTerminal;
         const listListOut = terminals["list:list input"]["output"] as OutputCollectionTerminal;
         const listOneIn = terminals["two list inputs"]["kind|f1"] as InputCollectionTerminal;
         const listTwoIn = terminals["two list inputs"]["kind|f2"] as InputCollectionTerminal;
         listOneIn.connect(listListOut);
-        expect(listTwoIn.canAccept(collectionOut).canAccept).toBe(false);
-        expect(listTwoIn.canAccept(collectionOut).reason).toBe(
-            "Can't map over this input with output collection type - other inputs have an incompatible map over collection type. Disconnect inputs (and potentially outputs) and retry."
-        );
+        expect(listTwoIn.canAccept(collectionOut).canAccept).toBe(true);
     });
     it("rejects mapping over collection input if outputs constrain input to incompatible collection type", () => {
         const collectionOut = terminals["list input"]["output"] as OutputCollectionTerminal;
@@ -404,11 +401,15 @@ describe("canAccept", () => {
         const mapOverOut = terminals["two list inputs"]["out1"] as OutputTerminal;
         const dataIn = terminals["simple data"]["input"] as InputTerminal;
         listOneIn.connect(listListOut);
+        // two list inputs constrained to a list map over
         dataIn.connect(mapOverOut);
         listOneIn.disconnect(listListOut);
-        // TODO: this should be possible eventually IMHO
-        expect(listTwoIn.canAccept(collectionOut).canAccept).toBe(false);
-        expect(listTwoIn.canAccept(collectionOut).reason).toBe(
+        // still constrained to list map over via output connection
+        // can accept other input
+        expect(listTwoIn.canAccept(collectionOut).canAccept).toBe(true);
+        // but cannot accept on the constrained input
+        expect(listOneIn.canAccept(collectionOut).canAccept).toBe(false);
+        expect(listOneIn.canAccept(collectionOut).reason).toBe(
             "Can't map over this input with output collection type - this step has outputs defined constraining the mapping of this tool. Disconnect outputs and retry."
         );
     });
@@ -462,7 +463,7 @@ describe("canAccept", () => {
         );
     });
     it("rejects connections to input collection constrained by other input", () => {
-        const collectionOut = terminals["list input"]["output"] as OutputCollectionTerminal;
+        const listListListOut = terminals["list:list:list input"]["output"] as OutputCollectionTerminal;
         const dataIn = terminals["simple data"]["input"] as InputTerminal;
         const listOneIn = terminals["two list inputs"]["kind|f1"] as InputCollectionTerminal;
         const listTwoIn = terminals["two list inputs"]["kind|f2"] as InputCollectionTerminal;
@@ -472,8 +473,8 @@ describe("canAccept", () => {
         listOneIn.connect(listListOut);
         dataIn.connect(mapOverOut);
         // Can't connect list as output acts like "list:list"
-        expect(listTwoIn.canAccept(collectionOut).canAccept).toBe(false);
-        expect(listTwoIn.canAccept(collectionOut).reason).toBe(
+        expect(listTwoIn.canAccept(listListListOut).canAccept).toBe(false);
+        expect(listTwoIn.canAccept(listListListOut).reason).toBe(
             "Can't map over this input with output collection type - other inputs have an incompatible map over collection type. Disconnect inputs (and potentially outputs) and retry."
         );
     });

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -540,7 +540,7 @@ export class InputCollectionTerminal extends BaseInputTerminal {
         return NULL_COLLECTION_TYPE_DESCRIPTION;
     }
     _effectiveCollectionTypes() {
-        return this.collectionTypes.map((t) => this.mapOver.append(t));
+        return this.collectionTypes.map((t) => this.localMapOver.append(t));
     }
     attachable(other: BaseOutputTerminal) {
         const otherCollectionType = this._otherCollectionType(other);


### PR DESCRIPTION
If there is a direct match on an input terminal node it won't alter the map over state, we don't need to disallow this.
I was covering this with test cases, I just didn't realize that this is actually valid ...

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
