### PR TITLE
[23.0] Find correct collection type if collection_type_source points at input of "any" collection type

### DIFF
--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -232,13 +232,7 @@ const invalidOutputs = computed(() => {
     });
 });
 const outputs = computed(() => {
-    let stepOutputs = props.step.outputs;
-    if (props.step.when) {
-        stepOutputs = stepOutputs.map((output) => {
-            return { ...output, optional: true };
-        });
-    }
-    return [...stepOutputs, ...invalidOutputs.value];
+    return [...props.step.outputs, ...invalidOutputs.value];
 });
 
 function onDragConnector(dragPosition: TerminalPosition, terminal: OutputTerminals) {

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -14,6 +14,7 @@ import {
     type PostJobAction,
 } from "@/stores/workflowStepStore";
 import type { UseScrollReturn } from "@vueuse/core";
+import { NULL_COLLECTION_TYPE_DESCRIPTION } from "./modules/collectionTypeDescription";
 
 const props = defineProps<{
     output: OutputTerminalSource;
@@ -201,6 +202,21 @@ const terminalClass = computed(() => {
     }
     return cls;
 });
+const outputDetails = computed(() => {
+    let collectionType = "collectionType" in terminal.value && terminal.value.collectionType;
+    const outputType =
+        collectionType && collectionType.isCollection
+            ? `output is ${collectionType.collectionType} dataset collection`
+            : `output is dataset`;
+    if (isMultiple.value) {
+        if (!collectionType) {
+            collectionType = NULL_COLLECTION_TYPE_DESCRIPTION;
+        }
+        const effectiveOutputType = terminal.value.mapOver.append(collectionType);
+        return `${outputType} and mapped-over to produce a ${effectiveOutputType.collectionType} dataset collection`;
+    }
+    return outputType;
+});
 
 onBeforeUnmount(() => {
     stateStore.deleteOutputTerminalPosition(props.stepId, props.output.name);
@@ -243,6 +259,7 @@ onBeforeUnmount(() => {
             @move="onMove">
             <div
                 ref="icon"
+                v-b-tooltip.hover="outputDetails"
                 class="icon prevent-zoom"
                 tabindex="0"
                 :aria-label="`Connect output ${output.name} to input. Press space to see a list of available inputs`"

--- a/client/src/components/Workflow/Editor/composables/useTerminal.ts
+++ b/client/src/components/Workflow/Editor/composables/useTerminal.ts
@@ -11,7 +11,7 @@ export function useTerminal(
 ) {
     const terminal: Ref<ReturnType<typeof terminalFactory> | null> = ref(null);
     const stepStore = useWorkflowStepStore();
-    const step = computed(() => stepStore.getStep(stepId.value))
+    const step = computed(() => stepStore.getStep(stepId.value));
     const isMappedOver = computed(() => stepStore.stepMapOver[stepId.value]?.isCollection ?? false);
 
     watch(

--- a/client/src/components/Workflow/Editor/composables/useTerminal.ts
+++ b/client/src/components/Workflow/Editor/composables/useTerminal.ts
@@ -11,10 +11,11 @@ export function useTerminal(
 ) {
     const terminal: Ref<ReturnType<typeof terminalFactory> | null> = ref(null);
     const stepStore = useWorkflowStepStore();
+    const step = computed(() => stepStore.getStep(stepId.value))
     const isMappedOver = computed(() => stepStore.stepMapOver[stepId.value]?.isCollection ?? false);
 
     watch(
-        [stepId, terminalSource, datatypesMapper],
+        [step, terminalSource, datatypesMapper],
         () => {
             // rebuild terminal if any of the tracked dependencies change
             const newTerminal = terminalFactory(stepId.value, terminalSource.value, datatypesMapper.value);

--- a/client/src/components/Workflow/Editor/modules/terminals.test.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.test.ts
@@ -379,6 +379,18 @@ describe("canAccept", () => {
         dataInTwo.disconnect(dataOut);
         expect(dataIn.mapOver).toEqual(NULL_COLLECTION_TYPE_DESCRIPTION);
     });
+    it("maintains step map over state when disconnecting output", () => {
+        const listListOut = terminals["list:list input"]["output"] as OutputCollectionTerminal;
+        const filterFailedInput = terminals["filter_failed"]["input"] as InputCollectionTerminal;
+        const filterFailedOutput = terminals["filter_failed"]["output"] as OutputCollectionTerminal;
+        const dataIn = terminals["simple data"]["input"] as InputTerminal;
+        filterFailedInput.connect(listListOut);
+        dataIn.connect(filterFailedOutput);
+        expect(filterFailedInput.isMappedOver()).toBe(true);
+        expect(stepStore.stepMapOver[filterFailedOutput.stepId].isCollection).toBe(true);
+        dataIn.disconnect(filterFailedOutput);
+        expect(stepStore.stepMapOver[filterFailedOutput.stepId].isCollection).toBe(true);
+    });
     it("rejects connecting incompatible connection types", () => {
         const pairedOut = terminals["paired input"]["output"] as OutputCollectionTerminal;
         const collectionIn = terminals["list collection input"]["input1"] as InputCollectionTerminal;

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -232,7 +232,12 @@ class BaseInputTerminal extends Terminal {
             const terminalSource = step.outputs[0];
             if (terminalSource) {
                 const terminal = terminalFactory(step.id, terminalSource, this.datatypesMapper);
+                // drop mapping restrictions
                 terminal.resetMappingIfNeeded();
+                // re-establish map over through inputs
+                step.inputs.forEach((input) => {
+                    terminalFactory(step.id, input, this.datatypesMapper).getStepMapOver();
+                });
             }
         });
     }

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -719,7 +719,15 @@ export class OutputCollectionTerminal extends BaseOutputTerminal {
                                 otherCollectionType.canMapOver(collectionType)
                         );
                         if (connectedCollectionType) {
-                            return connectedCollectionType;
+                            if (connectedCollectionType.collectionType === "any") {
+                                // if the input collection type is "any" this output's collection type
+                                // is exactly the same as the connected output
+                                return otherCollectionType;
+                            } else {
+                                // else we pick the matching input collection type
+                                // so that the map over logic applies correctly
+                                return connectedCollectionType;
+                            }
                         }
                     }
                 }

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -349,9 +349,6 @@ class BaseInputTerminal extends Terminal {
                 });
             }
             const postJobActionKey = `ChangeDatatypeAction${connection.output.name}`;
-            if (outputStep.when) {
-                terminalSource = { ...terminalSource, optional: true };
-            }
             if (
                 "extensions" in terminalSource &&
                 outputStep.post_job_actions &&
@@ -611,7 +608,7 @@ class BaseOutputTerminal extends Terminal {
     constructor(attr: BaseOutputTerminalArgs) {
         super(attr);
         this.datatypes = attr.datatypes;
-        this.optional = attr.optional;
+        this.optional = attr.optional || Boolean(this.stepStore.getStep(this.stepId)?.when);
         this.terminalType = "output";
     }
     getConnectedTerminals(): InputTerminalsAndInvalid[] {

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -11,6 +11,7 @@ _:  # global stuff
   selectors:
     editable_text: '.editable-text'
     tooltip_balloon: '.tooltip'
+    tooltip_inner: .tooltip-inner
     left_panel_drag: '#left > .unified-panel-footer > .drag'
     left_panel_collapse: '#left > .unified-panel-footer > .panel-collapse'
     right_panel_drag: '#right > .unified-panel-footer > .drag'


### PR DESCRIPTION
And also adds a hover hint on the output terminal that mentions what type of output this is:

![image](https://user-images.githubusercontent.com/6804901/226002976-b0bca578-0a62-403e-b594-5e559bbc4eba.png)


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
