### PR TITLE
[23.0] Fix User Preferences Manage External Identities element v-if

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -43,7 +43,7 @@
             to="/user/cloud_auth" />
         <ConfigProvider v-slot="{ config }">
             <user-preferences-element
-                v-if="!config.enable_oidc"
+                v-if="config.enable_oidc"
                 id="manage-third-party-identities"
                 icon="fa-id-card-o"
                 title="Manage Third-Party Identities"


### PR DESCRIPTION
The `Manage External Identities` option in `User Preferences` was made to render incorrectly:
Was `v-if="!config.enable_oidc"`
Fixed to `v-if="config.enable_oidc"`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
