### PR TITLE
[23.0] Fix API for latest FastAPI (0.95).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: |-
               # Add github.com to known hosts
               mkdir -p ~/.ssh
-              echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
+              echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
               ' >> ~/.ssh/known_hosts
 
               # Add the user ssh key and set correct perms

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -459,7 +459,7 @@ export interface paths {
          *
          * **Note**: this is a volatile endpoint and settings and behavior may change.
          */
-        get: operations["archive_api_histories__history_id__contents_archive_get"];
+        get: operations["history_contents__archive"];
     };
     "/api/histories/{history_id}/contents/archive/{filename}.{format}": {
         /**
@@ -468,7 +468,7 @@ export interface paths {
          *
          * **Note**: this is a volatile endpoint and settings and behavior may change.
          */
-        get: operations["archive_api_histories__history_id__contents_archive__filename___format__get"];
+        get: operations["history_contents__archive_named"];
     };
     "/api/histories/{history_id}/contents/bulk": {
         /**
@@ -10034,7 +10034,7 @@ export interface operations {
             };
         };
     };
-    archive_api_histories__history_id__contents_archive_get: {
+    history_contents__archive: {
         /**
          * Build and return a compressed archive of the selected history contents.
          * @description Build and return a compressed archive of the selected history contents.
@@ -10043,10 +10043,6 @@ export interface operations {
          */
         parameters: {
             /** @description The name that the Archive will have (defaults to history name). */
-            /**
-             * @deprecated
-             * @description Output format of the archive.
-             */
             /** @description Whether to return the archive and file paths only (as JSON) and not an actual archive file. */
             /**
              * @description Generally a property name to filter by followed by an (often optional) hyphen and operator string.
@@ -10064,7 +10060,6 @@ export interface operations {
              */
             query?: {
                 filename?: string;
-                format?: string;
                 dry_run?: boolean;
                 q?: string[];
                 qv?: string[];
@@ -10096,7 +10091,7 @@ export interface operations {
             };
         };
     };
-    archive_api_histories__history_id__contents_archive__filename___format__get: {
+    history_contents__archive_named: {
         /**
          * Build and return a compressed archive of the selected history contents.
          * @description Build and return a compressed archive of the selected history contents.
@@ -10132,6 +10127,11 @@ export interface operations {
                 "run-as"?: string;
             };
             /** @description The ID of the History. */
+            /** @description The name that the Archive will have (defaults to history name). */
+            /**
+             * @deprecated
+             * @description Output format of the archive.
+             */
             path: {
                 history_id: string;
                 filename: string;
@@ -10724,6 +10724,10 @@ export interface operations {
                 "run-as"?: string;
             };
             /** @description The ID of the History. */
+            /**
+             * @description The type of the target history element.
+             * @example dataset
+             */
             path: {
                 history_id: string;
                 type: components["schemas"]["HistoryContentType"];

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -73,7 +73,7 @@ export interface paths {
          * @description Download the content of a history dataset collection as a `zip` archive
          * while maintaining approximate collection structure.
          */
-        get: operations["download_dataset_collection_api_dataset_collections__id__download_get"];
+        get: operations["dataset_collections__download"];
     };
     "/api/dataset_collections/{id}/prepare_download": {
         /**
@@ -163,7 +163,7 @@ export interface paths {
     };
     "/api/datasets/{history_content_id}/metadata_file": {
         /** Returns the metadata file associated with this history item. */
-        get: operations["get_metadata_file_api_datasets__history_content_id__metadata_file_get"];
+        get: operations["datasets__get_metadata_file"];
     };
     "/api/datatypes": {
         /**
@@ -436,7 +436,7 @@ export interface paths {
          *
          * **Note**: Anonymous users are allowed to get their current history contents.
          */
-        get: operations["history_contents_api_histories__history_id__contents_get"];
+        get: operations["history_contents__index"];
         /**
          * Batch update specific properties of a set items contained in the given History.
          * @description Batch update specific properties of a set items contained in the given History.
@@ -450,7 +450,7 @@ export interface paths {
          * @deprecated
          * @description Create a new `HDA` or `HDCA` in the given History.
          */
-        post: operations["create_api_histories__history_id__contents_post"];
+        post: operations["history_contents__create"];
     };
     "/api/histories/{history_id}/contents/archive": {
         /**
@@ -485,7 +485,7 @@ export interface paths {
          * @description Download the content of a history dataset collection as a `zip` archive
          * while maintaining approximate collection structure.
          */
-        get: operations["download_dataset_collection_api_histories__history_id__contents_dataset_collections__id__download_get"];
+        get: operations["history_contents__download_collection"];
     };
     "/api/histories/{history_id}/contents/datasets/{id}/materialize": {
         /** Materialize a deferred dataset into real, usable dataset. */
@@ -516,7 +516,7 @@ export interface paths {
     };
     "/api/histories/{history_id}/contents/{history_content_id}/metadata_file": {
         /** Returns the metadata file associated with this history item. */
-        get: operations["get_metadata_file_api_histories__history_id__contents__history_content_id__metadata_file_get"];
+        get: operations["history_contents__get_metadata_file"];
     };
     "/api/histories/{history_id}/contents/{id}": {
         /**
@@ -526,20 +526,20 @@ export interface paths {
          *
          * **Note**: Anonymous users are allowed to get their current history contents.
          */
-        get: operations["history_content_api_histories__history_id__contents__id__get"];
+        get: operations["history_contents__show_legacy"];
         /**
-         * Updates the values for the history content item with the given ``ID``. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
+         * Updates the values for the history content item with the given ``ID`` and query specified type. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
          * @deprecated
          * @description Updates the values for the history content item with the given ``ID``.
          */
-        put: operations["update_api_histories__history_id__contents__id__put"];
+        put: operations["history_contents__update_legacy"];
         /**
          * Delete the history dataset with the given ``ID``.
-         * @description Delete the history content with the given ``ID`` and specified type (defaults to dataset).
+         * @description Delete the history content with the given ``ID`` and query specified type (defaults to dataset).
          *
          * **Note**: Currently does not stop any active jobs for which this dataset is an output.
          */
-        delete: operations["delete_api_histories__history_id__contents__id__delete"];
+        delete: operations["history_contents__delete_legacy"];
     };
     "/api/histories/{history_id}/contents/{id}/validate": {
         /**
@@ -551,19 +551,19 @@ export interface paths {
     "/api/histories/{history_id}/contents/{type}s": {
         /**
          * Returns the contents of the given history filtered by type.
-         * @description Return a list of `HDA`/`HDCA` data for the history with the given ``ID``.
+         * @description Return a list of either `HDA`/`HDCA` data for the history with the given ``ID``.
          *
          * - The contents can be filtered and queried using the appropriate parameters.
          * - The amount of information returned for each item can be customized.
          *
          * **Note**: Anonymous users are allowed to get their current history contents.
          */
-        get: operations["index_api_histories__history_id__contents__type_s_get"];
+        get: operations["history_contents__index_typed"];
         /**
          * Create a new `HDA` or `HDCA` in the given History.
          * @description Create a new `HDA` or `HDCA` in the given History.
          */
-        post: operations["create_api_histories__history_id__contents__type_s_post"];
+        post: operations["history_contents__create_typed"];
     };
     "/api/histories/{history_id}/contents/{type}s/{id}": {
         /**
@@ -572,19 +572,19 @@ export interface paths {
          *
          * **Note**: Anonymous users are allowed to get their current history contents.
          */
-        get: operations["history_content_typed_api_histories__history_id__contents__type_s__id__get"];
+        get: operations["history_contents__show"];
         /**
-         * Updates the values for the history content item with the given ``ID``.
+         * Updates the values for the history content item with the given ``ID`` and path specified type.
          * @description Updates the values for the history content item with the given ``ID``.
          */
-        put: operations["update_api_histories__history_id__contents__type_s__id__put"];
+        put: operations["history_contents__update_typed"];
         /**
-         * Delete the history content with the given ``ID`` and specified type.
-         * @description Delete the history content with the given ``ID`` and specified type (defaults to dataset).
+         * Delete the history content with the given ``ID`` and path specified type.
+         * @description Delete the history content with the given ``ID`` and path specified type.
          *
          * **Note**: Currently does not stop any active jobs for which this dataset is an output.
          */
-        delete: operations["delete_api_histories__history_id__contents__type_s__id__delete"];
+        delete: operations["history_contents__delete_typed"];
     };
     "/api/histories/{history_id}/contents/{type}s/{id}/jobs_summary": {
         /**
@@ -7701,17 +7701,13 @@ export interface operations {
             };
         };
     };
-    download_dataset_collection_api_dataset_collections__id__download_get: {
+    dataset_collections__download: {
         /**
          * Download the content of a dataset collection as a `zip` archive.
          * @description Download the content of a history dataset collection as a `zip` archive
          * while maintaining approximate collection structure.
          */
         parameters: {
-            /** @description The encoded database identifier of the History. */
-            query?: {
-                history_id?: string;
-            };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
                 "run-as"?: string;
@@ -8174,13 +8170,11 @@ export interface operations {
          * @description Streams the dataset for download or the contents preview to be displayed in a browser.
          */
         parameters: {
-            /** @description The encoded database identifier of the History. */
             /** @description Whether to get preview contents to be directly displayed on the web. If preview is False (default) the contents will be downloaded instead. */
-            /** @description TODO */
+            /** @description If non-null, get the specified filename from the extra files for this dataset. */
             /** @description The file extension when downloading the display data. Use the value `data` to let the server infer it from the data type. */
             /** @description The query parameter 'raw' should be considered experimental and may be dropped at some point in the future without warning. Generally, data should be processed by its datatype prior to display. */
             query?: {
-                history_id?: string;
                 preview?: boolean;
                 filename?: string;
                 to_ext?: string;
@@ -8212,13 +8206,11 @@ export interface operations {
          * @description Streams the dataset for download or the contents preview to be displayed in a browser.
          */
         parameters: {
-            /** @description The encoded database identifier of the History. */
             /** @description Whether to get preview contents to be directly displayed on the web. If preview is False (default) the contents will be downloaded instead. */
-            /** @description TODO */
+            /** @description If non-null, get the specified filename from the extra files for this dataset. */
             /** @description The file extension when downloading the display data. Use the value `data` to let the server infer it from the data type. */
             /** @description The query parameter 'raw' should be considered experimental and may be dropped at some point in the future without warning. Generally, data should be processed by its datatype prior to display. */
             query?: {
-                history_id?: string;
                 preview?: boolean;
                 filename?: string;
                 to_ext?: string;
@@ -8248,13 +8240,11 @@ export interface operations {
             };
         };
     };
-    get_metadata_file_api_datasets__history_content_id__metadata_file_get: {
+    datasets__get_metadata_file: {
         /** Returns the metadata file associated with this history item. */
         parameters: {
-            /** @description The encoded database identifier of the History. */
             /** @description The name of the metadata file to retrieve. */
             query: {
-                history_id?: string;
                 metadata_file: string;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
@@ -9850,7 +9840,7 @@ export interface operations {
             };
         };
     };
-    history_contents_api_histories__history_id__contents_get: {
+    history_contents__index: {
         /**
          * Returns the contents of the given history.
          * @description Return a list of `HDA`/`HDCA` data for the history with the given ``ID``.
@@ -9985,7 +9975,7 @@ export interface operations {
             };
         };
     };
-    create_api_histories__history_id__contents_post: {
+    history_contents__create: {
         /**
          * Create a new `HDA` or `HDCA` in the given History.
          * @deprecated
@@ -9993,7 +9983,7 @@ export interface operations {
          */
         parameters: {
             /**
-             * @description The type of the history element to create.
+             * @description The type of the target history element.
              * @example dataset
              */
             /** @description View to be passed to the serializer */
@@ -10212,7 +10202,7 @@ export interface operations {
             };
         };
     };
-    download_dataset_collection_api_histories__history_id__contents_dataset_collections__id__download_get: {
+    history_contents__download_collection: {
         /**
          * Download the content of a dataset collection as a `zip` archive.
          * @description Download the content of a history dataset collection as a `zip` archive
@@ -10223,6 +10213,7 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
+            /** @description The encoded database identifier of the History. */
             /** @description The ID of the `HDCA` contained in the history. */
             path: {
                 history_id: string;
@@ -10321,7 +10312,7 @@ export interface operations {
          */
         parameters: {
             /** @description Whether to get preview contents to be directly displayed on the web. If preview is False (default) the contents will be downloaded instead. */
-            /** @description TODO */
+            /** @description If non-null, get the specified filename from the extra files for this dataset. */
             /** @description The file extension when downloading the display data. Use the value `data` to let the server infer it from the data type. */
             /** @description The query parameter 'raw' should be considered experimental and may be dropped at some point in the future without warning. Generally, data should be processed by its datatype prior to display. */
             query?: {
@@ -10334,6 +10325,7 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
+            /** @description The encoded database identifier of the History. */
             /** @description The encoded database identifier of the dataset. */
             path: {
                 history_id: string;
@@ -10358,7 +10350,7 @@ export interface operations {
          */
         parameters: {
             /** @description Whether to get preview contents to be directly displayed on the web. If preview is False (default) the contents will be downloaded instead. */
-            /** @description TODO */
+            /** @description If non-null, get the specified filename from the extra files for this dataset. */
             /** @description The file extension when downloading the display data. Use the value `data` to let the server infer it from the data type. */
             /** @description The query parameter 'raw' should be considered experimental and may be dropped at some point in the future without warning. Generally, data should be processed by its datatype prior to display. */
             query?: {
@@ -10371,6 +10363,7 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
+            /** @description The encoded database identifier of the History. */
             /** @description The encoded database identifier of the dataset. */
             path: {
                 history_id: string;
@@ -10421,7 +10414,7 @@ export interface operations {
             };
         };
     };
-    get_metadata_file_api_histories__history_id__contents__history_content_id__metadata_file_get: {
+    history_contents__get_metadata_file: {
         /** Returns the metadata file associated with this history item. */
         parameters: {
             /** @description The name of the metadata file to retrieve. */
@@ -10432,6 +10425,7 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
+            /** @description The encoded database identifier of the History. */
             /** @description The encoded database identifier of the dataset. */
             path: {
                 history_id: string;
@@ -10449,7 +10443,7 @@ export interface operations {
             };
         };
     };
-    history_content_api_histories__history_id__contents__id__get: {
+    history_contents__show_legacy: {
         /**
          * Return detailed information about an HDA within a history. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
          * @deprecated
@@ -10459,7 +10453,7 @@ export interface operations {
          */
         parameters: {
             /**
-             * @description The type of the history element to show.
+             * @description The type of the target history element.
              * @example dataset
              */
             /** @description This value can be used to broadly restrict the magnitude of the number of elements returned via the API for large collections. The number of actual elements returned may be "a bit" more than this number or "a lot" less - varying on the depth of nesting, balance of nesting at each level, and size of target collection. The consumer of this API should not expect a stable number or pre-calculable number of elements to be produced given this parameter - the only promise is that this API will not respond with an order of magnitude more elements estimated with this value. The UI uses this parameter to fetch a "balanced" concept of the "start" of large collections at every depth of the collection. */
@@ -10502,15 +10496,15 @@ export interface operations {
             };
         };
     };
-    update_api_histories__history_id__contents__id__put: {
+    history_contents__update_legacy: {
         /**
-         * Updates the values for the history content item with the given ``ID``. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
+         * Updates the values for the history content item with the given ``ID`` and query specified type. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.
          * @deprecated
          * @description Updates the values for the history content item with the given ``ID``.
          */
         parameters: {
             /**
-             * @description The type of the history element to show.
+             * @description The type of the target history element.
              * @example dataset
              */
             /** @description View to be passed to the serializer */
@@ -10556,16 +10550,16 @@ export interface operations {
             };
         };
     };
-    delete_api_histories__history_id__contents__id__delete: {
+    history_contents__delete_legacy: {
         /**
          * Delete the history dataset with the given ``ID``.
-         * @description Delete the history content with the given ``ID`` and specified type (defaults to dataset).
+         * @description Delete the history content with the given ``ID`` and query specified type (defaults to dataset).
          *
          * **Note**: Currently does not stop any active jobs for which this dataset is an output.
          */
         parameters: {
             /**
-             * @description The type of the history element to show.
+             * @description The type of the target history element.
              * @example dataset
              */
             /**
@@ -10659,10 +10653,10 @@ export interface operations {
             };
         };
     };
-    index_api_histories__history_id__contents__type_s_get: {
+    history_contents__index_typed: {
         /**
          * Returns the contents of the given history filtered by type.
-         * @description Return a list of `HDA`/`HDCA` data for the history with the given ``ID``.
+         * @description Return a list of either `HDA`/`HDCA` data for the history with the given ``ID``.
          *
          * - The contents can be filtered and queried using the appropriate parameters.
          * - The amount of information returned for each item can be customized.
@@ -10732,7 +10726,7 @@ export interface operations {
             /** @description The ID of the History. */
             path: {
                 history_id: string;
-                type: string;
+                type: components["schemas"]["HistoryContentType"];
             };
         };
         responses: {
@@ -10752,7 +10746,7 @@ export interface operations {
             };
         };
     };
-    create_api_histories__history_id__contents__type_s_post: {
+    history_contents__create_typed: {
         /**
          * Create a new `HDA` or `HDCA` in the given History.
          * @description Create a new `HDA` or `HDCA` in the given History.
@@ -10769,6 +10763,10 @@ export interface operations {
                 "run-as"?: string;
             };
             /** @description The ID of the History. */
+            /**
+             * @description The type of the target history element.
+             * @example dataset
+             */
             path: {
                 history_id: string;
                 type: components["schemas"]["HistoryContentType"];
@@ -10806,7 +10804,7 @@ export interface operations {
             };
         };
     };
-    history_content_typed_api_histories__history_id__contents__type_s__id__get: {
+    history_contents__show: {
         /**
          * Return detailed information about a specific HDA or HDCA with the given `ID` within a history.
          * @description Return detailed information about an `HDA` or `HDCA` within a history.
@@ -10828,6 +10826,10 @@ export interface operations {
             };
             /** @description The ID of the History. */
             /** @description The ID of the item (`HDA`/`HDCA`) contained in the history. */
+            /**
+             * @description The type of the target history element.
+             * @example dataset
+             */
             path: {
                 history_id: string;
                 id: string;
@@ -10854,9 +10856,9 @@ export interface operations {
             };
         };
     };
-    update_api_histories__history_id__contents__type_s__id__put: {
+    history_contents__update_typed: {
         /**
-         * Updates the values for the history content item with the given ``ID``.
+         * Updates the values for the history content item with the given ``ID`` and path specified type.
          * @description Updates the values for the history content item with the given ``ID``.
          */
         parameters: {
@@ -10872,6 +10874,10 @@ export interface operations {
             };
             /** @description The ID of the History. */
             /** @description The ID of the item (`HDA`/`HDCA`) contained in the history. */
+            /**
+             * @description The type of the target history element.
+             * @example dataset
+             */
             path: {
                 history_id: string;
                 id: string;
@@ -10903,10 +10909,10 @@ export interface operations {
             };
         };
     };
-    delete_api_histories__history_id__contents__type_s__id__delete: {
+    history_contents__delete_typed: {
         /**
-         * Delete the history content with the given ``ID`` and specified type.
-         * @description Delete the history content with the given ``ID`` and specified type (defaults to dataset).
+         * Delete the history content with the given ``ID`` and path specified type.
+         * @description Delete the history content with the given ``ID`` and path specified type.
          *
          * **Note**: Currently does not stop any active jobs for which this dataset is an output.
          */
@@ -10938,6 +10944,10 @@ export interface operations {
             };
             /** @description The ID of the History. */
             /** @description The ID of the item (`HDA`/`HDCA`) contained in the history. */
+            /**
+             * @description The type of the target history element.
+             * @example dataset
+             */
             path: {
                 history_id: string;
                 id: string;
@@ -10987,6 +10997,10 @@ export interface operations {
             };
             /** @description The ID of the History. */
             /** @description The ID of the item (`HDA`/`HDCA`) contained in the history. */
+            /**
+             * @description The type of the target history element.
+             * @example dataset
+             */
             path: {
                 history_id: string;
                 id: string;
@@ -11020,6 +11034,10 @@ export interface operations {
             };
             /** @description The ID of the History. */
             /** @description The ID of the item (`HDA`/`HDCA`) contained in the history. */
+            /**
+             * @description The type of the target history element.
+             * @example dataset
+             */
             path: {
                 history_id: string;
                 id: string;
@@ -11055,6 +11073,10 @@ export interface operations {
             };
             /** @description The ID of the History. */
             /** @description The ID of the item (`HDA`/`HDCA`) contained in the history. */
+            /**
+             * @description The type of the target history element.
+             * @example dataset
+             */
             path: {
                 history_id: string;
                 id: string;

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -309,6 +309,7 @@ class FastAPIDatasets:
     @router.get(
         "/api/histories/{history_id}/contents/{history_content_id}/metadata_file",
         summary="Returns the metadata file associated with this history item.",
+        name="get_metadata_file",
         tags=["histories"],
         operation_id="history_contents__get_metadata_file",
         response_class=GalaxyFileResponse,

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -74,6 +74,36 @@ DatasetSourceQueryParam: DatasetSourceType = Query(
     description="Whether this dataset belongs to a history (HDA) or a library (LDDA).",
 )
 
+PreviewQueryParam = Query(
+    default=False,
+    description=(
+        "Whether to get preview contents to be directly displayed on the web. "
+        "If preview is False (default) the contents will be downloaded instead."
+    ),
+)
+
+FilenameQueryParam = Query(
+    default=None,
+    description="If non-null, get the specified filename from the extra files for this dataset.",
+)
+
+ToExtQueryParam = Query(
+    default=None,
+    description=(
+        "The file extension when downloading the display data. Use the value `data` to "
+        "let the server infer it from the data type."
+    ),
+)
+
+RawQueryParam = Query(
+    default=False,
+    description=(
+        "The query parameter 'raw' should be considered experimental and may be dropped at "
+        "some point in the future without warning. Generally, data should be processed by its "
+        "datatype prior to display."
+    ),
+)
+
 
 @router.cbv
 class FastAPIDatasets:
@@ -200,64 +230,66 @@ class FastAPIDatasets:
         return self.service.extra_files(trans, history_content_id)
 
     @router.get(
-        "/api/datasets/{history_content_id}/display",
+        "/api/histories/{history_id}/contents/{history_content_id}/display",
+        name="history_contents_display",
         summary="Displays (preview) or downloads dataset content.",
+        tags=["histories"],
         response_class=StreamingResponse,
     )
+    @router.head(
+        "/api/histories/{history_id}/contents/{history_content_id}/display",
+        name="history_contents_display",
+        summary="Check if dataset content can be previewed or downloaded.",
+        tags=["histories"],
+    )
+    def display_history_content(
+        self,
+        request: Request,
+        trans=DependsOnTrans,
+        history_id: Optional[DecodedDatabaseIdField] = Path(
+            description="The encoded database identifier of the History.",
+        ),
+        history_content_id: DecodedDatabaseIdField = DatasetIDPathParam,
+        preview: bool = PreviewQueryParam,
+        filename: Optional[str] = FilenameQueryParam,
+        to_ext: Optional[str] = ToExtQueryParam,
+        raw: bool = RawQueryParam,
+    ):
+        """Streams the dataset for download or the contents preview to be displayed in a browser."""
+        return self._display(request, trans, history_content_id, preview, filename, to_ext, raw)
+
     @router.get(
-        "/api/histories/{history_id}/contents/{history_content_id}/display",
-        name="history_contents_display",
+        "/api/datasets/{history_content_id}/display",
         summary="Displays (preview) or downloads dataset content.",
-        tags=["histories"],
         response_class=StreamingResponse,
     )
     @router.head(
         "/api/datasets/{history_content_id}/display",
         summary="Check if dataset content can be previewed or downloaded.",
-    )
-    @router.head(
-        "/api/histories/{history_id}/contents/{history_content_id}/display",
-        name="history_contents_display",
-        summary="Check if dataset content can be previewed or downloaded.",
-        tags=["histories"],
     )
     def display(
         self,
         request: Request,
         trans=DependsOnTrans,
-        history_id: Optional[DecodedDatabaseIdField] = Query(
-            default=None,
-            description="The encoded database identifier of the History.",
-        ),
         history_content_id: DecodedDatabaseIdField = DatasetIDPathParam,
-        preview: bool = Query(
-            default=False,
-            description=(
-                "Whether to get preview contents to be directly displayed on the web. "
-                "If preview is False (default) the contents will be downloaded instead."
-            ),
-        ),
-        filename: Optional[str] = Query(
-            default=None,
-            description="TODO",
-        ),
-        to_ext: Optional[str] = Query(
-            default=None,
-            description=(
-                "The file extension when downloading the display data. Use the value `data` to "
-                "let the server infer it from the data type."
-            ),
-        ),
-        raw: bool = Query(
-            default=False,
-            description=(
-                "The query parameter 'raw' should be considered experimental and may be dropped at "
-                "some point in the future without warning. Generally, data should be processed by its "
-                "datatype prior to display."
-            ),
-        ),
+        preview: bool = PreviewQueryParam,
+        filename: Optional[str] = FilenameQueryParam,
+        to_ext: Optional[str] = ToExtQueryParam,
+        raw: bool = RawQueryParam,
     ):
         """Streams the dataset for download or the contents preview to be displayed in a browser."""
+        return self._display(request, trans, history_content_id, preview, filename, to_ext, raw)
+
+    def _display(
+        self,
+        request: Request,
+        trans,
+        history_content_id: DecodedDatabaseIdField,
+        preview: bool,
+        filename: Optional[str],
+        to_ext: Optional[str],
+        raw: bool,
+    ):
         extra_params = get_query_parameters_from_request_excluding(
             request, {"preview", "filename", "to_ext", "raw", "dataset"}
         )
@@ -278,18 +310,13 @@ class FastAPIDatasets:
         "/api/histories/{history_id}/contents/{history_content_id}/metadata_file",
         summary="Returns the metadata file associated with this history item.",
         tags=["histories"],
+        operation_id="history_contents__get_metadata_file",
         response_class=GalaxyFileResponse,
     )
-    @router.get(
-        "/api/datasets/{history_content_id}/metadata_file",
-        summary="Returns the metadata file associated with this history item.",
-        response_class=GalaxyFileResponse,
-    )
-    def get_metadata_file(
+    def get_metadata_file_history_content(
         self,
         trans=DependsOnTrans,
-        history_id: Optional[DecodedDatabaseIdField] = Query(
-            default=None,
+        history_id: DecodedDatabaseIdField = Path(
             description="The encoded database identifier of the History.",
         ),
         history_content_id: DecodedDatabaseIdField = DatasetIDPathParam,
@@ -298,6 +325,31 @@ class FastAPIDatasets:
             description="The name of the metadata file to retrieve.",
         ),
     ):
+        return self._get_metadata_file(trans, history_content_id, metadata_file)
+
+    @router.get(
+        "/api/datasets/{history_content_id}/metadata_file",
+        summary="Returns the metadata file associated with this history item.",
+        response_class=GalaxyFileResponse,
+        operation_id="datasets__get_metadata_file",
+    )
+    def get_metadata_file_datasets(
+        self,
+        trans=DependsOnTrans,
+        history_content_id: DecodedDatabaseIdField = DatasetIDPathParam,
+        metadata_file: str = Query(
+            ...,
+            description="The name of the metadata file to retrieve.",
+        ),
+    ):
+        return self._get_metadata_file(trans, history_content_id, metadata_file)
+
+    def _get_metadata_file(
+        self,
+        trans,
+        history_content_id: DecodedDatabaseIdField,
+        metadata_file: str,
+    ) -> GalaxyFileResponse:
         metadata_file_path, headers = self.service.get_metadata_file(trans, history_content_id, metadata_file)
         return GalaxyFileResponse(path=cast(str, metadata_file_path), headers=headers)
 

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -77,7 +77,6 @@ HistoryIDPathParam: DecodedDatabaseIdField = Path(
 )
 
 JehaIDPathParam: Union[DecodedDatabaseIdField, LatestLiteral] = Path(
-    default="latest",
     title="Job Export History ID",
     description=(
         "The ID of the specific Job Export History Association or "

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -92,11 +92,59 @@ HistoryHDCAIDPathParam: DecodedDatabaseIdField = Path(
 )
 
 ContentTypeQueryParam = Query(
-    default=HistoryContentType.dataset,
+    default=None,
     title="Content Type",
-    description="The type of the history element to show.",
+    description="The type of the target history element.",
     example=HistoryContentType.dataset,
 )
+
+ContentTypePathParam = Path(
+    title="Content Type",
+    description="The type of the target history element.",
+    example=HistoryContentType.dataset,
+)
+
+FuzzyCountQueryParam = Query(
+    default=None,
+    title="Fuzzy Count",
+    description=(
+        "This value can be used to broadly restrict the magnitude "
+        "of the number of elements returned via the API for large "
+        "collections. The number of actual elements returned may "
+        'be "a bit" more than this number or "a lot" less - varying '
+        "on the depth of nesting, balance of nesting at each level, "
+        "and size of target collection. The consumer of this API should "
+        "not expect a stable number or pre-calculable number of "
+        "elements to be produced given this parameter - the only "
+        "promise is that this API will not respond with an order "
+        "of magnitude more elements estimated with this value. "
+        'The UI uses this parameter to fetch a "balanced" concept of '
+        'the "start" of large collections at every depth of the '
+        "collection."
+    ),
+)
+
+PurgeQueryParam = Query(
+    default=False,
+    title="Purge",
+    description="Whether to remove from disk the target HDA or child HDAs of the target HDCA.",
+    deprecated=True,
+)
+
+RecursiveQueryParam = Query(
+    default=False,
+    title="Recursive",
+    description="When deleting a dataset collection, whether to also delete containing datasets.",
+    deprecated=True,
+)
+
+StopJobQueryParam = Query(
+    default=False,
+    title="Stop Job",
+    description="Whether to stop the creating job if all outputs of the job have been deleted.",
+    deprecated=True,
+)
+
 
 CONTENT_DELETE_RESPONSES = {
     200: {
@@ -155,55 +203,76 @@ def parse_index_query_params(
         raise validation_error_to_message_exception(e)
 
 
+LegacyIdsQueryParam = Query(
+    default=None,
+    title="IDs",
+    description=(
+        "A comma-separated list of encoded `HDA/HDCA` IDs. If this list is provided, only information about the "
+        "specific datasets will be returned. Also, setting this value will return `all` details of the content item."
+    ),
+    deprecated=True,
+)
+
+LegacyTypesQueryParam = Query(
+    default=None,
+    title="Types",
+    description=(
+        "A list or comma-separated list of kinds of contents to return "
+        "(currently just `dataset` and `dataset_collection` are available). "
+        "If unset, all types will be returned."
+    ),
+    deprecated=True,
+)
+
+LegacyDetailsQueryParam = Query(
+    default=None,
+    title="Details",
+    description=("Legacy name for the `dataset_details` parameter."),
+    deprecated=True,
+)
+
+LegacyDeletedQueryParam = Query(
+    default=None,
+    title="Deleted",
+    description="Whether to return deleted or undeleted datasets only. Leave unset for both.",
+    deprecated=True,
+)
+
+LegacyVisibleQueryParam = Query(
+    default=None,
+    title="Visible",
+    description="Whether to return visible or hidden datasets only. Leave unset for both.",
+    deprecated=True,
+)
+
+ArchiveFilenamePathParam = Query(
+    default=None,
+    description="The name that the Archive will have (defaults to history name).",
+)
+
+ArchiveFilenameQueryParam = Query(
+    default=None,
+    description="The name that the Archive will have (defaults to history name).",
+)
+
+DryRunQueryParam = Query(
+    default=True,
+    description="Whether to return the archive and file paths only (as JSON) and not an actual archive file.",
+)
+
+
 def get_legacy_index_query_params(
-    ids: Optional[str] = Query(
-        default=None,
-        title="IDs",
-        description=(
-            "A comma-separated list of encoded `HDA/HDCA` IDs. If this list is provided, only information about the "
-            "specific datasets will be returned. Also, setting this value will return `all` details of the content item."
-        ),
-        deprecated=True,
-    ),
-    types: Optional[List[str]] = Query(
-        default=None,
-        title="Types",
-        description=(
-            "A list or comma-separated list of kinds of contents to return "
-            "(currently just `dataset` and `dataset_collection` are available). "
-            "If unset, all types will be returned."
-        ),
-        deprecated=True,
-    ),
-    type: Optional[str] = Query(
-        default=None,
-        include_in_schema=False,
-        deprecated=True,
-    ),
-    details: Optional[str] = Query(
-        default=None,
-        title="Details",
-        description=("Legacy name for the `dataset_details` parameter."),
-        deprecated=True,
-    ),
-    deleted: Optional[bool] = Query(
-        default=None,
-        title="Deleted",
-        description="Whether to return deleted or undeleted datasets only. Leave unset for both.",
-        deprecated=True,
-    ),
-    visible: Optional[bool] = Query(
-        default=None,
-        title="Visible",
-        description="Whether to return visible or hidden datasets only. Leave unset for both.",
-        deprecated=True,
-    ),
+    ids: Optional[str] = LegacyIdsQueryParam,
+    types: Optional[List[str]] = LegacyTypesQueryParam,
+    details: Optional[str] = LegacyDetailsQueryParam,
+    deleted: Optional[bool] = LegacyDeletedQueryParam,
+    visible: Optional[bool] = LegacyVisibleQueryParam,
 ) -> LegacyHistoryContentsIndexParams:
     """This function is meant to be used as a dependency to render the OpenAPI documentation
     correctly"""
     return parse_legacy_index_query_params(
         ids=ids,
-        types=types or type,
+        types=types or None,
         details=details,
         deleted=deleted,
         visible=visible,
@@ -302,7 +371,39 @@ class FastAPIHistoryContents:
     @router.get(
         "/api/histories/{history_id}/contents/{type}s",
         summary="Returns the contents of the given history filtered by type.",
+        operation_id="history_contents__index_typed",
     )
+    def index_typed(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        index_params: HistoryContentsIndexParams = Depends(get_index_query_params),
+        type: HistoryContentType = Path(),
+        legacy_params: LegacyHistoryContentsIndexParams = Depends(get_legacy_index_query_params),
+        serialization_params: SerializationParams = Depends(query_serialization_params),
+        filter_query_params: FilterQueryParams = Depends(get_filter_query_params),
+        accept: str = Header(default="application/json", include_in_schema=False),
+    ) -> Union[HistoryContentsResult, HistoryContentsWithStatsResult]:
+        """
+        Return a list of either `HDA`/`HDCA` data for the history with the given ``ID``.
+
+        - The contents can be filtered and queried using the appropriate parameters.
+        - The amount of information returned for each item can be customized.
+
+        **Note**: Anonymous users are allowed to get their current history contents.
+        """
+        legacy_params.types = legacy_params.types or [type]
+        items = self.service.index(
+            trans,
+            history_id,
+            index_params,
+            legacy_params,
+            serialization_params,
+            filter_query_params,
+            accept,
+        )
+        return items
+
     @router.get(
         "/api/histories/{history_id}/contents",
         name="history_contents",
@@ -324,12 +425,18 @@ class FastAPIHistoryContents:
                 },
             },
         },
+        operation_id="history_contents__index",
     )
     def index(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         index_params: HistoryContentsIndexParams = Depends(get_index_query_params),
+        type: Optional[HistoryContentType] = Query(
+            default=None,
+            include_in_schema=False,
+            deprecated=True,
+        ),
         legacy_params: LegacyHistoryContentsIndexParams = Depends(get_legacy_index_query_params),
         serialization_params: SerializationParams = Depends(query_serialization_params),
         filter_query_params: FilterQueryParams = Depends(get_filter_query_params),
@@ -343,6 +450,10 @@ class FastAPIHistoryContents:
 
         **Note**: Anonymous users are allowed to get their current history contents.
         """
+        if not legacy_params.types:
+            if type is not None:
+                legacy_params.types = [type]
+
         items = self.service.index(
             trans,
             history_id,
@@ -363,7 +474,7 @@ class FastAPIHistoryContents:
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
-        type: HistoryContentType = ContentTypeQueryParam,
+        type: HistoryContentType = ContentTypePathParam,
     ) -> AnyJobStateSummary:
         """Return detailed information about an `HDA` or `HDCAs` jobs.
 
@@ -378,38 +489,44 @@ class FastAPIHistoryContents:
         "/api/histories/{history_id}/contents/{type}s/{id}",
         name="history_content_typed",
         summary="Return detailed information about a specific HDA or HDCA with the given `ID` within a history.",
-    )
-    @router.get(
-        "/api/histories/{history_id}/contents/{id}",
-        name="history_content",
-        summary="Return detailed information about an HDA within a history. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.",
-        deprecated=True,
+        operation_id="history_contents__show",
     )
     def show(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
+        type: HistoryContentType = ContentTypePathParam,
+        fuzzy_count: Optional[int] = FuzzyCountQueryParam,
+        serialization_params: SerializationParams = Depends(query_serialization_params),
+    ) -> AnyHistoryContentItem:
+        """
+        Return detailed information about an `HDA` or `HDCA` within a history.
+
+        **Note**: Anonymous users are allowed to get their current history contents.
+        """
+        return self.service.show(
+            trans,
+            id=id,
+            serialization_params=serialization_params,
+            contents_type=type,
+            fuzzy_count=fuzzy_count,
+        )
+
+    @router.get(
+        "/api/histories/{history_id}/contents/{id}",
+        name="history_content",
+        summary="Return detailed information about an HDA within a history. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.",
+        deprecated=True,
+        operation_id="history_contents__show_legacy",
+    )
+    def show_legacy(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         type: HistoryContentType = ContentTypeQueryParam,
-        fuzzy_count: Optional[int] = Query(
-            default=None,
-            title="Fuzzy Count",
-            description=(
-                "This value can be used to broadly restrict the magnitude "
-                "of the number of elements returned via the API for large "
-                "collections. The number of actual elements returned may "
-                'be "a bit" more than this number or "a lot" less - varying '
-                "on the depth of nesting, balance of nesting at each level, "
-                "and size of target collection. The consumer of this API should "
-                "not expect a stable number or pre-calculable number of "
-                "elements to be produced given this parameter - the only "
-                "promise is that this API will not respond with an order "
-                "of magnitude more elements estimated with this value. "
-                'The UI uses this parameter to fetch a "balanced" concept of '
-                'the "start" of large collections at every depth of the '
-                "collection."
-            ),
-        ),
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
+        fuzzy_count: Optional[int] = FuzzyCountQueryParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),
     ) -> AnyHistoryContentItem:
         """
@@ -434,7 +551,7 @@ class FastAPIHistoryContents:
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
-        type: HistoryContentType = ContentTypeQueryParam,
+        type: HistoryContentType = ContentTypePathParam,
         payload: StoreExportPayload = Body(...),
     ) -> AsyncFile:
         return self.service.prepare_store_download(
@@ -453,7 +570,7 @@ class FastAPIHistoryContents:
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
-        type: HistoryContentType = ContentTypeQueryParam,
+        type: HistoryContentType = ContentTypePathParam,
         payload: WriteStoreToPayload = Body(...),
     ) -> AsyncTaskResultSummary:
         return self.service.write_store(
@@ -486,20 +603,32 @@ class FastAPIHistoryContents:
         "/api/histories/{history_id}/contents/dataset_collections/{id}/download",
         summary="Download the content of a dataset collection as a `zip` archive.",
         response_class=StreamingResponse,
+        operation_id="history_contents__download_collection",
     )
+    def download_dataset_collection_history_content(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: Optional[DecodedDatabaseIdField] = Path(
+            description="The encoded database identifier of the History.",
+        ),
+        id: DecodedDatabaseIdField = HistoryHDCAIDPathParam,
+    ):
+        """Download the content of a history dataset collection as a `zip` archive
+        while maintaining approximate collection structure.
+        """
+        archive = self.service.get_dataset_collection_archive_for_download(trans, id)
+        return StreamingResponse(archive.response(), headers=archive.get_headers())
+
     @router.get(
         "/api/dataset_collections/{id}/download",
         summary="Download the content of a dataset collection as a `zip` archive.",
         response_class=StreamingResponse,
         tags=["dataset collections"],
+        operation_id="dataset_collections__download",
     )
     def download_dataset_collection(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: Optional[DecodedDatabaseIdField] = Query(
-            default=None,
-            description="The encoded database identifier of the History.",
-        ),
         id: DecodedDatabaseIdField = HistoryHDCAIDPathParam,
     ):
         """Download the content of a history dataset collection as a `zip` archive
@@ -538,24 +667,43 @@ class FastAPIHistoryContents:
     @router.post(
         "/api/histories/{history_id}/contents/{type}s",
         summary="Create a new `HDA` or `HDCA` in the given History.",
+        operation_id="history_contents__create_typed",
     )
+    def create_typed(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        type: HistoryContentType = ContentTypePathParam,
+        serialization_params: SerializationParams = Depends(query_serialization_params),
+        payload: CreateHistoryContentPayload = Body(...),
+    ) -> Union[AnyHistoryContentItem, List[AnyHistoryContentItem]]:
+        """Create a new `HDA` or `HDCA` in the given History."""
+        return self._create(trans, history_id, type, serialization_params, payload)
+
     @router.post(
         "/api/histories/{history_id}/contents",
         summary="Create a new `HDA` or `HDCA` in the given History.",
         deprecated=True,
+        operation_id="history_contents__create",
     )
     def create(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
-        type: Optional[HistoryContentType] = Query(
-            default=None,
-            title="Content Type",
-            description="The type of the history element to create.",
-            example=HistoryContentType.dataset,
-        ),
+        type: Optional[HistoryContentType] = ContentTypeQueryParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),
         payload: CreateHistoryContentPayload = Body(...),
+    ) -> Union[AnyHistoryContentItem, List[AnyHistoryContentItem]]:
+        """Create a new `HDA` or `HDCA` in the given History."""
+        return self._create(trans, history_id, type, serialization_params, payload)
+
+    def _create(
+        self,
+        trans: ProvidesHistoryContext,
+        history_id: DecodedDatabaseIdField,
+        type: Optional[HistoryContentType],
+        serialization_params: SerializationParams,
+        payload: CreateHistoryContentPayload,
     ) -> Union[AnyHistoryContentItem, List[AnyHistoryContentItem]]:
         """Create a new `HDA` or `HDCA` in the given History."""
         payload.type = type or payload.type
@@ -631,14 +779,28 @@ class FastAPIHistoryContents:
 
     @router.put(
         "/api/histories/{history_id}/contents/{type}s/{id}",
-        summary="Updates the values for the history content item with the given ``ID``.",
+        summary="Updates the values for the history content item with the given ``ID`` and path specified type.",
+        operation_id="history_contents__update_typed",
     )
+    def update_typed(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
+        type: HistoryContentType = ContentTypePathParam,
+        serialization_params: SerializationParams = Depends(query_serialization_params),
+        payload: UpdateHistoryContentsPayload = Body(...),
+    ) -> AnyHistoryContentItem:
+        """Updates the values for the history content item with the given ``ID``."""
+        return self.service.update(trans, history_id, id, payload.dict(), serialization_params, contents_type=type)
+
     @router.put(
         "/api/histories/{history_id}/contents/{id}",
-        summary="Updates the values for the history content item with the given ``ID``. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.",
+        summary="Updates the values for the history content item with the given ``ID`` and query specified type. ``/api/histories/{history_id}/contents/{type}s/{id}`` should be used instead.",
         deprecated=True,
+        operation_id="history_contents__update_legacy",
     )
-    def update(
+    def update_legacy(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
@@ -652,15 +814,47 @@ class FastAPIHistoryContents:
 
     @router.delete(
         "/api/histories/{history_id}/contents/{type}s/{id}",
-        summary="Delete the history content with the given ``ID`` and specified type.",
+        summary="Delete the history content with the given ``ID`` and path specified type.",
         responses=CONTENT_DELETE_RESPONSES,
+        operation_id="history_contents__delete_typed",
     )
+    def delete_typed(
+        self,
+        response: Response,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        id: DecodedDatabaseIdField = HistoryItemIDPathParam,
+        type: HistoryContentType = ContentTypePathParam,
+        serialization_params: SerializationParams = Depends(query_serialization_params),
+        purge: Optional[bool] = PurgeQueryParam,
+        recursive: Optional[bool] = RecursiveQueryParam,
+        stop_job: Optional[bool] = StopJobQueryParam,
+        payload: DeleteHistoryContentPayload = Body(None),
+    ):
+        """
+        Delete the history content with the given ``ID`` and path specified type.
+
+        **Note**: Currently does not stop any active jobs for which this dataset is an output.
+        """
+        return self._delete(
+            response,
+            trans,
+            id,
+            type,
+            serialization_params,
+            purge,
+            recursive,
+            stop_job,
+            payload,
+        )
+
     @router.delete(
         "/api/histories/{history_id}/contents/{id}",
         summary="Delete the history dataset with the given ``ID``.",
         responses=CONTENT_DELETE_RESPONSES,
+        operation_id="history_contents__delete_legacy",
     )
-    def delete(
+    def delete_legacy(
         self,
         response: Response,
         trans: ProvidesHistoryContext = DependsOnTrans,
@@ -668,31 +862,40 @@ class FastAPIHistoryContents:
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypeQueryParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),
-        purge: Optional[bool] = Query(
-            default=False,
-            title="Purge",
-            description="Whether to remove from disk the target HDA or child HDAs of the target HDCA.",
-            deprecated=True,
-        ),
-        recursive: Optional[bool] = Query(
-            default=False,
-            title="Recursive",
-            description="When deleting a dataset collection, whether to also delete containing datasets.",
-            deprecated=True,
-        ),
-        stop_job: Optional[bool] = Query(
-            default=False,
-            title="Stop Job",
-            description="Whether to stop the creating job if all outputs of the job have been deleted.",
-            deprecated=True,
-        ),
+        purge: Optional[bool] = PurgeQueryParam,
+        recursive: Optional[bool] = RecursiveQueryParam,
+        stop_job: Optional[bool] = StopJobQueryParam,
         payload: DeleteHistoryContentPayload = Body(None),
     ):
         """
-        Delete the history content with the given ``ID`` and specified type (defaults to dataset).
+        Delete the history content with the given ``ID`` and query specified type (defaults to dataset).
 
         **Note**: Currently does not stop any active jobs for which this dataset is an output.
         """
+        return self._delete(
+            response,
+            trans,
+            id,
+            type,
+            serialization_params,
+            purge,
+            recursive,
+            stop_job,
+            payload,
+        )
+
+    def _delete(
+        self,
+        response: Response,
+        trans: ProvidesHistoryContext,
+        id: DecodedDatabaseIdField,
+        type: HistoryContentType,
+        serialization_params: SerializationParams,
+        purge: Optional[bool],
+        recursive: Optional[bool],
+        stop_job: Optional[bool],
+        payload: DeleteHistoryContentPayload,
+    ):
         # TODO: should we just use the default payload and deprecate the query params?
         if payload is None:
             payload = DeleteHistoryContentPayload()
@@ -714,28 +917,39 @@ class FastAPIHistoryContents:
     @router.get(
         "/api/histories/{history_id}/contents/archive/{filename}.{format}",
         summary="Build and return a compressed archive of the selected history contents.",
+        operation_id="history_contents__archive_named",
     )
+    def archive_named(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        filename: Optional[str] = ArchiveFilenamePathParam,
+        format: Optional[str] = Path(
+            description="Output format of the archive.",
+            deprecated=True,  # Looks like is not really used?
+        ),
+        dry_run: Optional[bool] = DryRunQueryParam,
+        filter_query_params: FilterQueryParams = Depends(get_filter_query_params),
+    ):
+        """Build and return a compressed archive of the selected history contents.
+
+        **Note**: this is a volatile endpoint and settings and behavior may change."""
+        archive = self.service.archive(trans, history_id, filter_query_params, filename, dry_run)
+        if isinstance(archive, HistoryContentsArchiveDryRunResult):
+            return archive
+        return StreamingResponse(archive.response(), headers=archive.get_headers())
+
     @router.get(
         "/api/histories/{history_id}/contents/archive",
         summary="Build and return a compressed archive of the selected history contents.",
+        operation_id="history_contents__archive",
     )
     def archive(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: DecodedDatabaseIdField = HistoryIDPathParam,
-        filename: Optional[str] = Query(
-            default=None,
-            description="The name that the Archive will have (defaults to history name).",
-        ),
-        format: Optional[str] = Query(
-            default="zip",
-            description="Output format of the archive.",
-            deprecated=True,  # Looks like is not really used?
-        ),
-        dry_run: Optional[bool] = Query(
-            default=True,
-            description="Whether to return the archive and file paths only (as JSON) and not an actual archive file.",
-        ),
+        filename: Optional[str] = ArchiveFilenameQueryParam,
+        dry_run: Optional[bool] = DryRunQueryParam,
         filter_query_params: FilterQueryParams = Depends(get_filter_query_params),
     ):
         """Build and return a compressed archive of the selected history contents.


### PR DESCRIPTION
xref https://fastapi.tiangolo.com/release-notes/

They tightened up parameter handling (for the better I think) and so we need to be a little more careful. The changes required seem pretty reasonable and it looks like it wouldn't break any obvious backward compatibility.

This doesn't rev the fastapi dependency for the core product but CI was running with the latest FastAPI for the package tests (intentionally) and this should fix that I hope.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
