### PR TITLE
Fix log message

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -882,11 +882,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             if labels is not None:
                 tool.labels = labels
         except OSError as exc:
-            msg = "Error reading tool configuration file from path '%s': %s", path, unicodify(exc)
-            if exc.errno == ENOENT:
-                log.error(msg)
-            else:
-                log.exception(msg)
+            exc_info = exc.errno != ENOENT
+            log.error("Error reading tool configuration file from path '%s': %s", path, exc, exc_info=exc_info)
         except Exception:
             log.exception("Error reading tool from path: %s", path)
 


### PR DESCRIPTION
fixes the output for `Error reading tool configuration file from path`

which was assigned first to a variable: `msg = "Error reading tool configuration file from path '%s': %s", path, unicodify(exc)` which is then a tuple. Printing the tuple does not expand the placeholders.

## How to test the changes?
- [x] This is a refactoring of components 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
