### PR TITLE
[23.0] Fix Invocation RO-Crate metadata

### DIFF
--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -15,6 +15,8 @@ from rocrate.model.softwareapplication import SoftwareApplication
 from rocrate.rocrate import ROCrate
 
 from galaxy.model import (
+    HistoryDatasetAssociation,
+    HistoryDatasetCollectionAssociation,
     JobParameter,
     JobToInputDatasetAssociation,
     JobToOutputDatasetAssociation,
@@ -28,11 +30,32 @@ from galaxy.model import (
 logger = logging.getLogger(__name__)
 
 
+PROFILES_VERSION = "0.1"
+WROC_PROFILE_VERSION = "1.0"
+
+GALAXY_EXPORT_VERSION = "2.0"
+
+ATTRS_FILENAME_HISTORY = "history_attrs.txt"
+ATTRS_FILENAME_DATASETS = "datasets_attrs.txt"
+ATTRS_FILENAME_JOBS = "jobs_attrs.txt"
+ATTRS_FILENAME_IMPLICIT_COLLECTION_JOBS = "implicit_collection_jobs_attrs.txt"
+ATTRS_FILENAME_COLLECTIONS = "collections_attrs.txt"
+ATTRS_FILENAME_EXPORT = "export_attrs.txt"
+ATTRS_FILENAME_LIBRARIES = "libraries_attrs.txt"
+ATTRS_FILENAME_LIBRARY_FOLDERS = "library_folders_attrs.txt"
+ATTRS_FILENAME_INVOCATIONS = "invocation_attrs.txt"
+
+
 class WorkflowRunCrateProfileBuilder:
     def __init__(self, model_store: Any):
         self.model_store = model_store
         self.invocation: WorkflowInvocation = model_store.included_invocations[0]
         self.workflow: Workflow = self.invocation.workflow
+        self.collection_type_mapping = {
+            "list": "https://training.galaxyproject.org/training-material/faqs/galaxy/collections_build_list.html",
+            "paired": "https://training.galaxyproject.org/training-material/faqs/galaxy/collections_build_list_paired.html",
+            None: "https://training.galaxyproject.org/training-material/faqs/galaxy/collections_build_list.html",
+        }
         self.param_type_mapping = {
             "integer": "Integer",
             "text": "Text",
@@ -54,7 +77,7 @@ class WorkflowRunCrateProfileBuilder:
             "rules": "Text",
             "directory_uri": "URI",
             "drill_down": "Text",
-            None: "None",
+            None: "Text",
         }
 
         self.ignored_parameter_type = [
@@ -67,88 +90,147 @@ class WorkflowRunCrateProfileBuilder:
             "dbkey",
             "__input_ext",
         ]
+        self.workflow_entities: Dict[int, Any] = {}
+        self.collection_entities: Dict[int, Any] = {}
+        self.file_entities: Dict[int, Any] = {}
+        self.param_entities: Dict[int, Any] = {}
         self.pv_entities: Dict[str, Any] = {}
 
     def build_crate(self):
         crate = ROCrate()
-        file_entities = self._add_files(crate)
-        self._add_collections(crate, file_entities)
         self._add_workflows(crate)
         self._add_engine_run(crate)
-        self._add_actions(crate, file_entities)
+        self._add_create_action(crate)
+        self._add_collections(crate)
+        self._add_files(crate)
+        self._add_profiles(crate)
+        self._add_parameters(crate)
+        self._add_attrs_files(crate)
         return crate
 
-    def _add_files(self, crate: ROCrate) -> Dict[int, Any]:
-        file_entities: Dict[int, Any] = {}
-        for dataset, _ in self.model_store.included_datasets.values():
-            if dataset.dataset.id in self.model_store.dataset_id_to_path:
-                filename, _ = self.model_store.dataset_id_to_path[dataset.dataset.id]
-                if not filename:
-                    filename = f"datasets/dataset_{dataset.dataset.uuid}"
-                name = dataset.name
-                encoding_format = dataset.datatype.get_mime()
-                properties = {
-                    "name": name,
-                    "encodingFormat": encoding_format,
-                    "exampleOfWork": {"@id": dataset.dataset.uuid.urn},
-                }
-                file_entity = crate.add_file(
-                    filename,
-                    dest_path=filename,
-                    properties=properties,
-                )
-                file_entities[dataset.dataset.id] = file_entity
-        return file_entities
-
-    def _add_collections(self, crate: ROCrate, file_entities: Dict[int, Any]) -> Dict[int, Any]:
-        collection_entities: Dict[int, Any] = {}
-        for collection in self.model_store.included_collections:
-            name = collection.name
-            dataset_ids = []
-            for dataset in collection.dataset_instances:
-                if dataset.dataset:
-                    dataset_id = file_entities.get(dataset.dataset.id)
-                    if dataset_id:
-                        dataset_ids.append({"@id": dataset_id.id})
-
-            properties = {
-                "name": name,
-                "@type": "Collection",
-                "additionalType": collection.collection.collection_type,
-                "hasPart": dataset_ids,
-            }
-            collection_entity = crate.add(
-                ContextEntity(
-                    crate,
-                    collection.type_id,
-                    properties=properties,
-                )
+    def _add_file(self, dataset: HistoryDatasetAssociation, properties: Dict, crate: ROCrate) -> Dict[int, Any]:
+        if dataset.dataset.id in self.model_store.dataset_id_to_path:
+            filename, _ = self.model_store.dataset_id_to_path[dataset.dataset.id]
+            if not filename:
+                filename = f"datasets/dataset_{str(dataset.dataset.uuid)}"
+            name = dataset.name
+            encoding_format = dataset.datatype.get_mime()
+            properties["name"] = name
+            properties["encodingFormat"] = encoding_format
+            file_entity = crate.add_file(
+                filename,
+                dest_path=filename,
+                properties=properties,
             )
-            collection_entities[collection.collection.id] = collection_entity
+            self.file_entities[dataset.dataset.id] = file_entity
 
-        crate.root_dataset["mentions"] = [{"@id": coll.id} for coll in collection_entities.values() if coll]
-        return collection_entities
+            return file_entity
+
+    def _add_files(self, crate: ROCrate) -> Dict[int, Any]:
+        for wfda in self.invocation.input_datasets:
+            if not self.file_entities.get(wfda.dataset.dataset.id):
+                properties = {
+                    "exampleOfWork": {"@id": f"#{str(wfda.dataset.dataset.uuid)}"},
+                }
+                file_entity = self._add_file(wfda.dataset, properties, crate)
+                dataset_formal_param = self._add_dataset_formal_parameter(wfda.dataset, crate)
+                crate.mainEntity.append_to("input", dataset_formal_param)
+                self.create_action.append_to("object", file_entity)
+
+        for wfda in self.invocation.output_datasets:
+            if not self.file_entities.get(wfda.dataset.dataset.id):
+                properties = {
+                    "exampleOfWork": {"@id": f"#{str(wfda.dataset.dataset.uuid)}"},
+                }
+                file_entity = self._add_file(wfda.dataset, properties, crate)
+                dataset_formal_param = self._add_dataset_formal_parameter(wfda.dataset, crate)
+                crate.mainEntity.append_to("output", dataset_formal_param)
+                self.create_action.append_to("result", file_entity)
+
+    def _add_collection(self, hdca: HistoryDatasetCollectionAssociation, crate: ROCrate) -> Dict[int, Any]:
+
+        name = hdca.name
+        dataset_ids = []
+        for hda in hdca.dataset_instances:
+            if hda.dataset:
+                properties = {}
+                self._add_file(hda, properties, crate)
+                dataset_id = self.file_entities.get(hda.dataset.id)
+                dataset_ids.append({"@id": dataset_id.id})
+
+        collection_properties = {
+            "name": name,
+            "@type": "Collection",
+            "additionalType": self.collection_type_mapping[hdca.collection.collection_type],
+            "hasPart": dataset_ids,
+            "exampleOfWork": {"@id": f"{hdca.type_id}-param"},
+        }
+        collection_entity = crate.add(
+            ContextEntity(
+                crate,
+                hdca.type_id,
+                properties=collection_properties,
+            )
+        )
+        self.collection_entities[hdca.collection.id] = collection_entity
+
+        crate.root_dataset.append_to("mentions", collection_entity)
+
+        return collection_entity
+
+    def _add_collections(self, crate: ROCrate) -> Dict[int, Any]:
+        for wfdca in self.invocation.input_dataset_collections:
+            collection_entity = self._add_collection(wfdca.dataset_collection, crate)
+            collection_formal_param = self._add_collection_formal_parameter(wfdca.dataset_collection, crate)
+            crate.mainEntity.append_to("input", collection_formal_param)
+            self.create_action.append_to("object", collection_entity)
+
+        for wfdca in self.invocation.output_dataset_collections:
+            collection_entity = self._add_collection(wfdca.dataset_collection, crate)
+            collection_formal_param = self._add_collection_formal_parameter(wfdca.dataset_collection, crate)
+            crate.mainEntity.append_to("output", collection_formal_param)
+            self.create_action.append_to("result", collection_entity)
 
     def _add_workflows(self, crate: ROCrate):
         workflows_directory = self.model_store.workflows_directory
 
         if os.path.exists(workflows_directory):
             for filename in os.listdir(workflows_directory):
+                is_main_wf = filename.endswith(".gxwf.yml")
                 is_computational_wf = not filename.endswith(".cwl")
                 workflow_cls = ComputationalWorkflow if is_computational_wf else WorkflowDescription
                 lang = "galaxy" if not filename.endswith(".cwl") else "cwl"
                 dest_path = os.path.join("workflows", filename)
 
-                crate.add_workflow(
+                wf = crate.add_workflow(
                     source=os.path.join(workflows_directory, filename),
                     dest_path=dest_path,
-                    main=is_computational_wf,
+                    main=is_main_wf,
                     cls=workflow_cls,
                     lang=lang,
                 )
+                self.workflow_entities[wf.id] = wf
+                if lang == "cwl":
+                    cwl_wf = wf
 
             crate.license = self.workflow.license or ""
             crate.mainEntity["name"] = self.workflow.name
+            crate.mainEntity["subjectOf"] = cwl_wf
+
+    def _add_create_action(self, crate: ROCrate):
+        self.create_action = crate.add(
+            ContextEntity(
+                crate,
+                properties={
+                    "@type": "CreateAction",
+                    "name": self.workflow.name,
+                    "startTime": self.invocation.workflow.create_time.isoformat(),
+                    "endTime": self.invocation.workflow.update_time.isoformat(),
+                    "instrument": {"@id": crate.mainEntity["@id"]},
+                },
+            )
+        )
+        crate.root_dataset.append_to("mentions", self.create_action)
 
     def _add_engine_run(self, crate: ROCrate):
         roc_engine = crate.add(SoftwareApplication(crate, properties={"name": "Galaxy workflow engine"}))
@@ -159,208 +241,173 @@ class WorkflowRunCrateProfileBuilder:
                     "@type": "OrganizeAction",
                     "name": f"Run of {roc_engine['name']}",
                     "startTime": self.invocation.create_time.isoformat(),
+                    "endTime": self.invocation.update_time.isoformat(),
                 },
             )
         )
         roc_engine_run["instrument"] = roc_engine
         self.roc_engine_run = roc_engine_run
 
-    def _add_actions(self, crate: ROCrate, file_entities: Dict[int, Any]):
-        input_formal_params: Dict[int, Any] = {}
-        output_formal_params = []
-        workflow_inputs = []
-        workflow_outputs = []
+    def _add_attrs_files(self, crate: ROCrate):
+        targets = [ATTRS_FILENAME_HISTORY, ATTRS_FILENAME_DATASETS, ATTRS_FILENAME_JOBS, ATTRS_FILENAME_IMPLICIT_COLLECTION_JOBS,
+                   ATTRS_FILENAME_COLLECTIONS, ATTRS_FILENAME_EXPORT, ATTRS_FILENAME_LIBRARIES, ATTRS_FILENAME_LIBRARY_FOLDERS,
+                   ATTRS_FILENAME_INVOCATIONS]
+        for attrs in targets:
+            attrs_path = os.path.join(self.model_store.export_directory, attrs)
+            description = " ".join(attrs.split("_")[:-1])
+            if os.path.exists(attrs_path):
 
-        for param in self.invocation.input_step_parameters:
-            property_value = self._add_wf_property_value(crate, param)
-            workflow_inputs.append(property_value)
-            formal_param = self._add_formal_parameter(crate, param.workflow_step)
-            input_formal_params[formal_param.id] = formal_param
+                properties = {
+                    "@type": "File",
+                    "version": GALAXY_EXPORT_VERSION,
+                    "description": f"{description} properties",
+                    "encodingFormat": "application/json",
+                }
+                crate.add_file(
+                    attrs,
+                    dest_path=attrs,
+                    properties=properties,
+                )
 
-        for output_step in self.invocation.steps:
-            for job in output_step.jobs:
-                for job_input in job.input_datasets:
-                    formal_param = self._add_formal_parameter_input(crate, job_input)
-                    input_formal_params[formal_param.id] = formal_param
-                    dataset_id = job_input.dataset.dataset.id
-                    input_file_entity = file_entities.get(dataset_id)
-                    workflow_inputs.append(input_file_entity)
-                for job_output in job.output_datasets:
-                    formal_param = self._add_formal_parameter_output(crate, job_output)
-                    output_formal_params.append(formal_param)
-                    dataset_id = job_output.dataset.dataset.id
-                    output_file_entity = file_entities.get(dataset_id)
-                    workflow_outputs.append(output_file_entity)
-                for param in job.parameters:
-                    if param.name not in self.ignored_parameter_type and not param.name.startswith("__"):
-                        property_value = self._add_job_property_value(crate, param)
-                        workflow_inputs.append(property_value)
-                        formal_param = self._add_formal_parameter(crate, output_step.workflow_step, param.name)
-                        input_formal_params[formal_param.id] = formal_param
-            if output_step.workflow_step.type == "parameter_input":
-                property_value = self._add_param_property_value(crate, output_step)
-                workflow_inputs.append(property_value)
-                formal_param = self._add_formal_parameter(crate, output_step.workflow_step)
-                input_formal_params[formal_param.id] = formal_param
-            if output_step.workflow_step.type == "tool":
-                for tool_input in output_step.workflow_step.tool_inputs.keys():
-                    if tool_input not in self.ignored_parameter_type and not tool_input.startswith("__"):
-                        property_value = self._add_tool_property_value(crate, output_step, tool_input)
-                        workflow_inputs.append(property_value)
-                        formal_param = self._add_formal_parameter(crate, output_step.workflow_step, tool_input)
-                        input_formal_params[formal_param.id] = formal_param
-
-        wf_input_param_ids = [{"@id": entity.id} for entity in input_formal_params.values()]
-        crate.mainEntity["input"] = wf_input_param_ids
-        wf_input_ids = [{"@id": input.id} for input in workflow_inputs if input]
-        wf_output_param_ids = [{"@id": entity.id} for entity in output_formal_params]
-        crate.mainEntity["output"] = wf_output_param_ids
-        wf_output_ids = [{"@id": output.id} for output in workflow_outputs if output]
-
-        input_param_value = crate.add(
-            ContextEntity(
-                crate,
-                properties={
-                    "@type": "CreateAction",
-                    "name": self.workflow.name,
-                    "instrument": {"@id": crate.mainEntity["@id"]},
-                    "object": wf_input_ids,
-                    "result": wf_output_ids,
-                },
+        prov_target = f"{ATTRS_FILENAME_DATASETS}.provenance"
+        provenance_attrs_path = os.path.join(self.model_store.export_directory, prov_target)
+        description = " ".join(prov_target.split("_")[:-1])
+        if os.path.exists(provenance_attrs_path):
+            crate.add(
+                ContextEntity(
+                    crate,
+                    prov_target,
+                    properties={
+                        "@type": "CreativeWork",
+                        "version": GALAXY_EXPORT_VERSION,
+                        "description": f"{description} provenance properties",
+                        "encodingFormat": "json",
+                    }
+                )
             )
-        )
-        self.main_action = input_param_value
 
-    def _add_formal_parameter(self, crate: ROCrate, step: WorkflowStep, tool_input: Optional[str] = None):
-        param_id = ""
-        param_type = None
-        if not tool_input:
-            if step.output_connections:
-                param_id = step.output_connections[0].input_name
-            if step.annotations:
-                param_type = step.annotations[0].workflow_step.tool_inputs.get("parameter_type")
-            if step.tool_inputs:
-                param_type = param_type or step.tool_inputs.get("parameter_type")
-        else:
-            param_id = tool_input
+    def _add_profiles(self, crate: ROCrate):
+        profiles = []
+        for p in "process", "workflow":
+            id_ = f"https://w3id.org/ro/wfrun/{p}/{PROFILES_VERSION}"
+            profiles.append(crate.add(ContextEntity(crate, id_, properties={
+                "@type": "CreativeWork",
+                "name": f"{p.title()} Run Crate",
+                "version": PROFILES_VERSION,
+            })))
+        # FIXME: in the future, this could go out of sync with the wroc
+        # profile added by ro-crate-py to the metadata descriptor
+        wroc_profile_id = f"https://w3id.org/workflowhub/workflow-ro-crate/{WROC_PROFILE_VERSION}"
+        profiles.append(crate.add(ContextEntity(crate, wroc_profile_id, properties={
+            "@type": "CreativeWork",
+            "name": "Workflow RO-Crate",
+            "version": WROC_PROFILE_VERSION,
+        })))
+        crate.root_dataset["conformsTo"] = profiles
 
+    def _add_parameters(self, crate: ROCrate):
+        for step in self.invocation.steps:
+            if step.workflow_step.type == "parameter_input":
+                property_value = self._add_step_parameter_pv(step, crate)
+                formal_param = self._add_step_parameter_fp(step, crate)
+                crate.mainEntity.append_to("input", formal_param)
+                self.create_action.append_to("object", property_value)
+            if step.workflow_step.type == "tool":
+                for tool_input in step.workflow_step.tool_inputs.keys():
+                    if tool_input not in self.ignored_parameter_type and tool_input not in step.workflow_step.inputs_by_name.keys() and not tool_input.startswith("__"):
+                        property_value = self._add_step_tool_pv(step, tool_input, crate)
+                        formal_param = self._add_step_tool_fp(step, tool_input, crate)
+                        crate.mainEntity.append_to("input", formal_param)
+                        self.create_action.append_to("object", property_value)
+
+    def _add_step_parameter_pv(self, step: WorkflowInvocationStep, crate: ROCrate):
+        param_id = step.workflow_step.label
         return crate.add(
             ContextEntity(
                 crate,
-                f"{param_id}-param",
+                f"{param_id}-pv",
                 properties={
-                    "@type": "FormalParameter",
-                    "additionalType": self.param_type_mapping[param_type],
-                    "description": step.annotations[0].annotation if step.annotations else "",
-                    "name": f"{step.label} parameter",
-                    "valueRequired": not step.input_optional,
+                    "@type": "PropertyValue",
+                    "name": f"{param_id} PropertyValue",
+                    "value": step.output_value.value,
+                    "exampleOfWork": {"@id": f"#{param_id}-param"},
                 },
             )
         )
 
-    def _add_formal_parameter_input(self, crate: ROCrate, input: JobToInputDatasetAssociation):
+    def _add_step_parameter_fp(self, step: WorkflowInvocationStep, crate: ROCrate):
+        param_id = step.workflow_step.label
+        param_type = step.workflow_step.tool_inputs['parameter_type']
+        return ContextEntity(
+            crate,
+            f"{param_id}-param",
+            properties={
+                "@type": "FormalParameter",
+                "additionalType": self.param_type_mapping[param_type],
+                "description": step.workflow_step.annotations[0].annotation if step.workflow_step.annotations else "",
+                "name": f"{param_id} parameter",
+                "valueRequired": str(not step.workflow_step.input_optional),
+            },
+        )
+
+    def _add_step_tool_pv(self, step: WorkflowInvocationStep, tool_input: str, crate: ROCrate):
+        param_id = tool_input
         return crate.add(
             ContextEntity(
                 crate,
-                input.dataset.dataset.uuid.urn,
+                f"{param_id}-pv",
+                properties={
+                    "@type": "PropertyValue",
+                    "name": f"{step.workflow_step.label} PropertyValue",
+                    "value": step.workflow_step.tool_inputs[tool_input],
+                    "exampleOfWork": {"@id": f"#{param_id}-param"},
+                },
+            )
+        )
+
+    def _add_step_tool_fp(self, step: WorkflowInvocationStep, tool_input: str, crate: ROCrate):
+        param_id = tool_input
+        param_type = "text"
+        return ContextEntity(
+            crate,
+            f"{param_id}-param",
+            properties={
+                "@type": "FormalParameter",
+                "additionalType": self.param_type_mapping[param_type],
+                "description": step.workflow_step.annotations[0].annotation if step.workflow_step.annotations else "",
+                "name": f"{step.workflow_step.label} parameter",
+                "valueRequired": str(not step.workflow_step.input_optional),
+            },
+        )
+
+    def _add_dataset_formal_parameter(self, hda: HistoryDatasetAssociation, crate: ROCrate):
+        return crate.add(
+            ContextEntity(
+                crate,
+                str(hda.dataset.uuid),
                 properties={
                     "@type": "FormalParameter",
                     "additionalType": "File",  # TODO: always a dataset/File?
-                    "description": input.dataset.annotations[0].annotation
-                    if input.dataset.annotations
-                    else input.dataset.info or "",
-                    "name": input.name,
+                    "description": hda.annotations[0].annotation
+                    if hda.annotations
+                    else hda.info or "",
+                    "name": hda.name,
                 },
             )
         )
 
-    def _add_formal_parameter_output(self, crate: ROCrate, output: JobToOutputDatasetAssociation):
+    def _add_collection_formal_parameter(self, hdca: HistoryDatasetCollectionAssociation, crate: ROCrate):
         return crate.add(
             ContextEntity(
                 crate,
-                output.dataset.dataset.uuid.urn,
+                f"{hdca.type_id}-param",
                 properties={
                     "@type": "FormalParameter",
                     "additionalType": "File",  # TODO: always a dataset/File?
-                    "description": output.dataset.annotations[0].annotation
-                    if output.dataset.annotations
-                    else output.dataset.info or "",
-                    "name": output.name,
+                    "description": hdca.annotations[0].annotation
+                    if hdca.annotations
+                    else "",
+                    "name": hdca.name,
                 },
             )
         )
-
-    def _add_job_property_value(self, crate: ROCrate, param: JobParameter):
-        input_name = param.name
-        if self.pv_entities.get(input_name):
-            return
-        job_pv = crate.add(
-            ContextEntity(
-                crate,
-                f"{input_name}-pv",
-                properties={
-                    "@type": "PropertyValue",
-                    "name": input_name,
-                    "value": param.value,
-                    "exampleOfWork": {"@id": f"#{input_name}-param"},
-                },
-            )
-        )
-        self.pv_entities[input_name] = job_pv
-        return job_pv
-
-    def _add_wf_property_value(self, crate: ROCrate, param: WorkflowRequestInputStepParameter):
-        input_name = param.workflow_step.output_connections[0].input_name
-        if self.pv_entities.get(input_name):
-            return
-        wf_pv = crate.add(
-            ContextEntity(
-                crate,
-                f"{input_name}-pv",
-                properties={
-                    "@type": "PropertyValue",
-                    "name": input_name,
-                    "value": param.parameter_value,
-                    "exampleOfWork": {"@id": f"#{input_name}-param"},
-                },
-            )
-        )
-        self.pv_entities[input_name] = wf_pv
-        return wf_pv
-
-    def _add_tool_property_value(self, crate: ROCrate, invocation_step: WorkflowInvocationStep, tool_input: str):
-        if self.pv_entities.get(tool_input):
-            return
-        tool_pv = crate.add(
-            ContextEntity(
-                crate,
-                f"{tool_input}-pv",
-                properties={
-                    "@type": "PropertyValue",
-                    "name": tool_input,
-                    "value": invocation_step.workflow_step.tool_inputs[tool_input],
-                    "exampleOfWork": {"@id": f"#{tool_input}-param"},
-                },
-            )
-        )
-        self.pv_entities[tool_input] = tool_pv
-        return tool_pv
-
-    def _add_param_property_value(self, crate: ROCrate, invocation_step: WorkflowInvocationStep):
-        input_name = invocation_step.workflow_step.output_connections[0].input_name
-        if self.pv_entities.get(input_name):
-            return
-        param_pv = crate.add(
-            ContextEntity(
-                crate,
-                f"{input_name}-pv",
-                properties={
-                    "@type": "PropertyValue",
-                    "name": invocation_step.workflow_step.label,
-                    "value": invocation_step.output_value.value,
-                    "exampleOfWork": {"@id": f"#{input_name}-param"},
-                },
-            )
-        )
-        self.pv_entities[input_name] = param_pv
-        return param_pv

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -143,7 +143,6 @@ class WorkflowRunCrateProfileBuilder:
                 self.create_action.append_to("result", file_entity)
 
     def _add_collection(self, hdca: HistoryDatasetCollectionAssociation, crate: ROCrate) -> ContextEntity:
-
         name = hdca.name
         dataset_ids = []
         for hda in hdca.dataset_instances:
@@ -261,7 +260,6 @@ class WorkflowRunCrateProfileBuilder:
             attrs_path = os.path.join(self.model_store.export_directory, attrs)
             description = " ".join(attrs.split("_")[:-1])
             if os.path.exists(attrs_path):
-
                 properties = {
                     "@type": "File",
                     "version": GALAXY_EXPORT_VERSION,

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -107,7 +107,7 @@ class WorkflowRunCrateProfileBuilder:
         if dataset.dataset.id in self.model_store.dataset_id_to_path:
             filename, _ = self.model_store.dataset_id_to_path[dataset.dataset.id]
             if not filename:
-                filename = f"datasets/dataset_{str(dataset.dataset.uuid)}"
+                filename = f"datasets/dataset_{dataset.dataset.uuid}"
             name = dataset.name
             encoding_format = dataset.datatype.get_mime()
             properties["name"] = name
@@ -125,7 +125,7 @@ class WorkflowRunCrateProfileBuilder:
         for wfda in self.invocation.input_datasets:
             if not self.file_entities.get(wfda.dataset.dataset.id):
                 properties = {
-                    "exampleOfWork": {"@id": f"#{str(wfda.dataset.dataset.uuid)}"},
+                    "exampleOfWork": {"@id": f"#{wfda.dataset.dataset.uuid}"},
                 }
                 file_entity = self._add_file(wfda.dataset, properties, crate)
                 dataset_formal_param = self._add_dataset_formal_parameter(wfda.dataset, crate)
@@ -135,7 +135,7 @@ class WorkflowRunCrateProfileBuilder:
         for wfda in self.invocation.output_datasets:
             if not self.file_entities.get(wfda.dataset.dataset.id):
                 properties = {
-                    "exampleOfWork": {"@id": f"#{str(wfda.dataset.dataset.uuid)}"},
+                    "exampleOfWork": {"@id": f"#{wfda.dataset.dataset.uuid}"},
                 }
                 file_entity = self._add_file(wfda.dataset, properties, crate)
                 dataset_formal_param = self._add_dataset_formal_parameter(wfda.dataset, crate)

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -3,7 +3,6 @@ import os
 from typing import (
     Any,
     Dict,
-    Union,
 )
 
 from rocrate.model.computationalworkflow import (

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -3,7 +3,6 @@ import os
 from typing import (
     Any,
     Dict,
-    Optional,
 )
 
 from rocrate.model.computationalworkflow import (
@@ -17,14 +16,9 @@ from rocrate.rocrate import ROCrate
 from galaxy.model import (
     HistoryDatasetAssociation,
     HistoryDatasetCollectionAssociation,
-    JobParameter,
-    JobToInputDatasetAssociation,
-    JobToOutputDatasetAssociation,
     Workflow,
     WorkflowInvocation,
     WorkflowInvocationStep,
-    WorkflowRequestInputStepParameter,
-    WorkflowStep,
 )
 
 logger = logging.getLogger(__name__)
@@ -249,9 +243,17 @@ class WorkflowRunCrateProfileBuilder:
         self.roc_engine_run = roc_engine_run
 
     def _add_attrs_files(self, crate: ROCrate):
-        targets = [ATTRS_FILENAME_HISTORY, ATTRS_FILENAME_DATASETS, ATTRS_FILENAME_JOBS, ATTRS_FILENAME_IMPLICIT_COLLECTION_JOBS,
-                   ATTRS_FILENAME_COLLECTIONS, ATTRS_FILENAME_EXPORT, ATTRS_FILENAME_LIBRARIES, ATTRS_FILENAME_LIBRARY_FOLDERS,
-                   ATTRS_FILENAME_INVOCATIONS]
+        targets = [
+            ATTRS_FILENAME_HISTORY,
+            ATTRS_FILENAME_DATASETS,
+            ATTRS_FILENAME_JOBS,
+            ATTRS_FILENAME_IMPLICIT_COLLECTION_JOBS,
+            ATTRS_FILENAME_COLLECTIONS,
+            ATTRS_FILENAME_EXPORT,
+            ATTRS_FILENAME_LIBRARIES,
+            ATTRS_FILENAME_LIBRARY_FOLDERS,
+            ATTRS_FILENAME_INVOCATIONS,
+        ]
         for attrs in targets:
             attrs_path = os.path.join(self.model_store.export_directory, attrs)
             description = " ".join(attrs.split("_")[:-1])
@@ -282,7 +284,7 @@ class WorkflowRunCrateProfileBuilder:
                         "version": GALAXY_EXPORT_VERSION,
                         "description": f"{description} provenance properties",
                         "encodingFormat": "json",
-                    }
+                    },
                 )
             )
 
@@ -290,19 +292,35 @@ class WorkflowRunCrateProfileBuilder:
         profiles = []
         for p in "process", "workflow":
             id_ = f"https://w3id.org/ro/wfrun/{p}/{PROFILES_VERSION}"
-            profiles.append(crate.add(ContextEntity(crate, id_, properties={
-                "@type": "CreativeWork",
-                "name": f"{p.title()} Run Crate",
-                "version": PROFILES_VERSION,
-            })))
+            profiles.append(
+                crate.add(
+                    ContextEntity(
+                        crate,
+                        id_,
+                        properties={
+                            "@type": "CreativeWork",
+                            "name": f"{p.title()} Run Crate",
+                            "version": PROFILES_VERSION,
+                        },
+                    )
+                )
+            )
         # FIXME: in the future, this could go out of sync with the wroc
         # profile added by ro-crate-py to the metadata descriptor
         wroc_profile_id = f"https://w3id.org/workflowhub/workflow-ro-crate/{WROC_PROFILE_VERSION}"
-        profiles.append(crate.add(ContextEntity(crate, wroc_profile_id, properties={
-            "@type": "CreativeWork",
-            "name": "Workflow RO-Crate",
-            "version": WROC_PROFILE_VERSION,
-        })))
+        profiles.append(
+            crate.add(
+                ContextEntity(
+                    crate,
+                    wroc_profile_id,
+                    properties={
+                        "@type": "CreativeWork",
+                        "name": "Workflow RO-Crate",
+                        "version": WROC_PROFILE_VERSION,
+                    },
+                )
+            )
+        )
         crate.root_dataset["conformsTo"] = profiles
 
     def _add_parameters(self, crate: ROCrate):
@@ -314,7 +332,11 @@ class WorkflowRunCrateProfileBuilder:
                 self.create_action.append_to("object", property_value)
             if step.workflow_step.type == "tool":
                 for tool_input in step.workflow_step.tool_inputs.keys():
-                    if tool_input not in self.ignored_parameter_type and tool_input not in step.workflow_step.inputs_by_name.keys() and not tool_input.startswith("__"):
+                    if (
+                        tool_input not in self.ignored_parameter_type
+                        and tool_input not in step.workflow_step.inputs_by_name.keys()
+                        and not tool_input.startswith("__")
+                    ):
                         property_value = self._add_step_tool_pv(step, tool_input, crate)
                         formal_param = self._add_step_tool_fp(step, tool_input, crate)
                         crate.mainEntity.append_to("input", formal_param)
@@ -337,7 +359,7 @@ class WorkflowRunCrateProfileBuilder:
 
     def _add_step_parameter_fp(self, step: WorkflowInvocationStep, crate: ROCrate):
         param_id = step.workflow_step.label
-        param_type = step.workflow_step.tool_inputs['parameter_type']
+        param_type = step.workflow_step.tool_inputs["parameter_type"]
         return ContextEntity(
             crate,
             f"{param_id}-param",
@@ -388,9 +410,7 @@ class WorkflowRunCrateProfileBuilder:
                 properties={
                     "@type": "FormalParameter",
                     "additionalType": "File",  # TODO: always a dataset/File?
-                    "description": hda.annotations[0].annotation
-                    if hda.annotations
-                    else hda.info or "",
+                    "description": hda.annotations[0].annotation if hda.annotations else hda.info or "",
                     "name": hda.name,
                 },
             )
@@ -404,9 +424,7 @@ class WorkflowRunCrateProfileBuilder:
                 properties={
                     "@type": "FormalParameter",
                     "additionalType": "File",  # TODO: always a dataset/File?
-                    "description": hdca.annotations[0].annotation
-                    if hdca.annotations
-                    else "",
+                    "description": hdca.annotations[0].annotation if hdca.annotations else "",
                     "name": hdca.name,
                 },
             )

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2816,21 +2816,20 @@ input collection 2:
             crate = self.workflow_populator.get_ro_crate(invocation_id, include_files=True)
             workflow = crate.mainEntity
             root = crate.root_dataset
-            assert len(root["mentions"]) == 3
+            assert len(root["mentions"]) == 4
             actions = [_ for _ in crate.contextual_entities if "CreateAction" in _.type]
             assert len(actions) == 1
             wf_action = actions[0]
             wf_objects = wf_action["object"]
-            assert len(workflow["input"]) == 7
-            assert len(workflow["output"]) == 2
+            assert len(workflow["input"]) == 4
+            assert len(workflow["output"]) == 3
             collections = [_ for _ in crate.contextual_entities if "Collection" in _.type]
             assert len(collections) == 3
             collection = collections[0]
-            assert collection["additionalType"] == "list"
+            assert collection["additionalType"] == "https://training.galaxyproject.org/training-material/faqs/galaxy/collections_build_list.html"
             assert collection.type == "Collection"
             assert len(collection["hasPart"]) == 2
-            for dataset in collection["hasPart"]:
-                assert dataset in wf_objects
+            assert collection in wf_objects
 
             coll_dataset = collection["hasPart"][0].id
             assert coll_dataset in [_.id for _ in collections[2]["hasPart"]]

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2751,8 +2751,7 @@ steps:
       advanced:
         conflict:
           __current_case__: 0
-          duplicate_options: suffix_conflict
-          suffix_pattern: _#
+          duplicate_options: keep_first
       inputs:
       - __index__: 0
         input:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2821,7 +2821,7 @@ input collection 2:
             assert len(actions) == 1
             wf_action = actions[0]
             wf_objects = wf_action["object"]
-            assert len(workflow["input"]) == 4
+            assert len(workflow["input"]) == 3
             assert len(workflow["output"]) == 3
             collections = [_ for _ in crate.contextual_entities if "Collection" in _.type]
             assert len(collections) == 3
@@ -2837,7 +2837,7 @@ input collection 2:
             coll_dataset = collection["hasPart"][0].id
             assert coll_dataset in [_.id for _ in collections[2]["hasPart"]]
             property_values = [_ for _ in crate.contextual_entities if "PropertyValue" in _.type]
-            assert len(property_values) == 2
+            assert len(property_values) == 1
             for pv in property_values:
                 assert pv in wf_objects
                 assert pv["exampleOfWork"] in workflow["input"]

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2826,7 +2826,10 @@ input collection 2:
             collections = [_ for _ in crate.contextual_entities if "Collection" in _.type]
             assert len(collections) == 3
             collection = collections[0]
-            assert collection["additionalType"] == "https://training.galaxyproject.org/training-material/faqs/galaxy/collections_build_list.html"
+            assert (
+                collection["additionalType"]
+                == "https://training.galaxyproject.org/training-material/faqs/galaxy/collections_build_list.html"
+            )
             assert collection.type == "Collection"
             assert len(collection["hasPart"]) == 2
             assert collection in wf_objects

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -457,7 +457,6 @@ def validate_invocation_collection_crate_directory(crate_directory):
     assert len(actions) == 1
     wf_action = actions[0]
     assert wf_action in root["mentions"]
-    # wf_objects = wf_action["object"]
     assert len(workflow["input"]) == 2
     assert len(workflow["output"]) == 1
     assert len(root["mentions"]) == 4

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm.scoping import scoped_session
 from galaxy import model
 from galaxy.model import store
 from galaxy.model.metadata import MetadataTempFile
+from galaxy.model.orm.now import now
 from galaxy.model.unittest_utils import GalaxyDataTestApp
 from galaxy.model.unittest_utils.store_fixtures import (
     deferred_hda_model_store_dict,
@@ -36,7 +37,6 @@ from ..test_galaxy_mapping import (
     _invocation_for_workflow,
     _workflow_from_steps,
 )
-from galaxy.model.orm.now import now
 
 TESTCASE_DIRECTORY = pathlib.Path(__file__).parent
 TEST_PATH_1 = TESTCASE_DIRECTORY / "1.txt"
@@ -466,7 +466,10 @@ def validate_invocation_collection_crate_directory(crate_directory):
     assert len(collections) == 3
     collection = collections[0]
     assert collection.type == "Collection"
-    assert collection["additionalType"] == "https://training.galaxyproject.org/training-material/faqs/galaxy/collections_build_list.html"
+    assert (
+        collection["additionalType"]
+        == "https://training.galaxyproject.org/training-material/faqs/galaxy/collections_build_list.html"
+    )
     assert len(collection["hasPart"]) == 2
     for dataset in collection["hasPart"]:
         assert dataset in root["hasPart"]

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -36,6 +36,7 @@ from ..test_galaxy_mapping import (
     _invocation_for_workflow,
     _workflow_from_steps,
 )
+from galaxy.model.orm.now import now
 
 TESTCASE_DIRECTORY = pathlib.Path(__file__).parent
 TEST_PATH_1 = TESTCASE_DIRECTORY / "1.txt"
@@ -396,7 +397,7 @@ def validate_main_entity(ro_crate: ROCrate):
     assert workflow["name"] == "Test Workflow"
     assert "SoftwareSourceCode" in workflow.type
     assert "ComputationalWorkflow" in workflow.type
-    assert len(workflow["input"]) == 2
+    assert len(workflow["input"]) == 1
     assert len(workflow["output"]) == 1
 
 
@@ -409,7 +410,7 @@ def validate_create_action(ro_crate: ROCrate):
     assert wf_action["instrument"] is workflow
     wf_objects = wf_action["object"]
     wf_results = wf_action["result"]
-    assert len(wf_objects) == 2
+    assert len(wf_objects) == 1
     assert len(wf_results) == 1
     for entity in wf_results:
         if entity.id.endswith(".txt"):
@@ -424,7 +425,7 @@ def validate_other_entities(ro_crate: ROCrate):
     inputs = workflow["input"]
     outputs = workflow["output"]
     assert inputs[0]["additionalType"] == "File"
-    assert inputs[1]["additionalType"] == "None"
+    # assert inputs[1]["additionalType"] == "Text"
     assert outputs[0]["additionalType"] == "File"
 
     for entity in inputs + outputs:
@@ -456,18 +457,19 @@ def validate_invocation_collection_crate_directory(crate_directory):
     actions = [_ for _ in ro_crate.contextual_entities if "CreateAction" in _.type]
     assert len(actions) == 1
     wf_action = actions[0]
-    wf_objects = wf_action["object"]
-    assert len(workflow["input"]) == 3
+    assert wf_action in root["mentions"]
+    # wf_objects = wf_action["object"]
+    assert len(workflow["input"]) == 2
     assert len(workflow["output"]) == 1
-    assert len(root["mentions"]) == 3
+    assert len(root["mentions"]) == 4
     collections = [_ for _ in ro_crate.contextual_entities if "Collection" in _.type]
     assert len(collections) == 3
     collection = collections[0]
     assert collection.type == "Collection"
-    assert collection["additionalType"] == "list"
+    assert collection["additionalType"] == "https://training.galaxyproject.org/training-material/faqs/galaxy/collections_build_list.html"
     assert len(collection["hasPart"]) == 2
     for dataset in collection["hasPart"]:
-        assert dataset in wf_objects
+        assert dataset in root["hasPart"]
 
 
 def test_export_history_to_ro_crate(tmp_path):
@@ -483,6 +485,15 @@ def test_export_history_to_ro_crate(tmp_path):
 def test_export_invocation_to_ro_crate(tmp_path):
     app = _mock_app()
     workflow_invocation = _setup_invocation(app)
+    crate_directory = tmp_path / "crate"
+    with store.ROCrateModelExportStore(crate_directory, app=app) as export_store:
+        export_store.export_workflow_invocation(workflow_invocation)
+    validate_invocation_crate_directory(crate_directory)
+
+
+def test_export_simple_invocation_to_ro_crate(tmp_path):
+    app = _mock_app()
+    workflow_invocation = _setup_simple_invocation(app)
     crate_directory = tmp_path / "crate"
     with store.ROCrateModelExportStore(crate_directory, app=app) as export_store:
         export_store.export_workflow_invocation(workflow_invocation)
@@ -842,7 +853,6 @@ def _setup_invocation(app):
     workflow_step_1 = model.WorkflowStep()
     workflow_step_1.order_index = 0
     workflow_step_1.type = "data_input"
-    workflow_step_1.tool_inputs = {}
     sa_session.add(workflow_step_1)
     workflow_1 = _workflow_from_steps(u, [workflow_step_1])
     workflow_1.license = "MIT"
@@ -853,16 +863,14 @@ def _setup_invocation(app):
     invocation_step.workflow_step = workflow_step_1
     invocation_step.job = j
     sa_session.add(invocation_step)
-    input_assoc = model.WorkflowRequestToInputDatasetAssociation()
-    input_assoc.workflow_invocation = workflow_invocation
-    input_assoc.workflow_step = workflow_step_1
-    input_assoc.dataset = d1
-    invocation_step.input_datasets = [input_assoc]
     output_assoc = model.WorkflowInvocationStepOutputDatasetAssociation()
     output_assoc.dataset = d2
     invocation_step.output_datasets = [output_assoc]
     workflow_invocation.steps = [invocation_step]
     workflow_invocation.user = u
+    workflow_invocation.add_input(d1, step=workflow_step_1)
+    wf_output = model.WorkflowOutput(workflow_step_1, label="output_label")
+    workflow_invocation.add_output(wf_output, workflow_step_1, d2)
     sa_session.add(workflow_invocation)
     sa_session.flush()
     return workflow_invocation
@@ -930,27 +938,42 @@ def _setup_collection_invocation(app):
     workflow_1.name = "Test Workflow"
     sa_session.add(workflow_1)
     workflow_invocation = _invocation_for_workflow(u, workflow_1)
-    invocation_step = model.WorkflowInvocationStep()
-    invocation_step.workflow_step = workflow_step_1
-    invocation_step.job = j
-    sa_session.add(invocation_step)
-    input_assoc = model.WorkflowRequestToInputDatasetCollectionAssociation()
-    input_assoc.workflow_invocation = workflow_invocation
-    input_assoc.workflow_step = workflow_step_1
-    input_assoc.dataset_collection = hc1
-    input_assoc1 = model.WorkflowRequestToInputDatasetCollectionAssociation()
-    input_assoc1.workflow_invocation = workflow_invocation
-    input_assoc1.workflow_step = workflow_step_1
-    input_assoc1.dataset_collection = hc2
-    invocation_step.input_dataset_collections = [input_assoc, input_assoc1]
-    output_assoc = model.WorkflowInvocationStepOutputDatasetCollectionAssociation()
-    output_assoc.dataset_collection = hc3
-    invocation_step.output_dataset_collections = [output_assoc]
-    workflow_invocation.steps = [invocation_step]
     workflow_invocation.user = u
+    workflow_invocation.add_input(hc1, step=workflow_step_1)
+    workflow_invocation.add_input(hc2, step=workflow_step_1)
+    wf_output = model.WorkflowOutput(workflow_step_1, label="output_label")
+    workflow_invocation.add_output(wf_output, workflow_step_1, hc3)
+
     sa_session.add(workflow_invocation)
     sa_session.flush()
     return workflow_invocation
+
+
+def _setup_simple_invocation(app):
+    sa_session = app.model.context
+
+    u, h, d1, d2, j = _setup_simple_cat_job(app)
+    j.parameters = [model.JobParameter(name="index_path", value='"/old/path/human"')]
+
+    workflow_step_1 = model.WorkflowStep()
+    workflow_step_1.order_index = 0
+    workflow_step_1.type = "data_input"
+    workflow_step_1.tool_inputs = {}
+    sa_session.add(workflow_step_1)
+    workflow = _workflow_from_steps(u, [workflow_step_1])
+    workflow.license = "MIT"
+    workflow.name = "Test Workflow"
+    workflow.create_time = now()
+    workflow.update_time = now()
+    sa_session.add(workflow)
+    invocation = _invocation_for_workflow(u, workflow)
+    invocation.create_time = now()
+    invocation.update_time = now()
+
+    invocation.add_input(d1, step=workflow_step_1)
+    wf_output = model.WorkflowOutput(workflow_step_1, label="output_label")
+    invocation.add_output(wf_output, workflow_step_1, d2)
+    return invocation
 
 
 def _import_export_history(app, h, dest_export=None, export_files=None, import_options=None, include_hidden=False):

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -425,7 +425,6 @@ def validate_other_entities(ro_crate: ROCrate):
     inputs = workflow["input"]
     outputs = workflow["output"]
     assert inputs[0]["additionalType"] == "File"
-    # assert inputs[1]["additionalType"] == "Text"
     assert outputs[0]["additionalType"] == "File"
 
     for entity in inputs + outputs:


### PR DESCRIPTION
Follow up on #15101 to fix bugs in the exported RO-Crate metadata as specified in the issue #15642 and described in more detail here https://github.com/ResearchObject/workflow-run-crate/pull/44

This PR implements the required changes to the RO-Crate metadata and updates to the corresponding unit/api/integration tests.

## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
