### PR TITLE
doc: API `/api/dependency_resolvers/toolbox`

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
@@ -209,13 +209,13 @@ class ToolDependenciesAPIController(BaseGalaxyAPIController):
         :type   index:    int
         :param  index:    index of the dependency resolver
         :type   tool_ids: str
-        :param  tool_ids: tool_id to install dependency for
+        :param  tool_ids: comma separated tool_ids to summarize dependencies for
         :type   resolver_type:  str
-        :param  resolver_type:  restrict to uninstall to specified resolver type
+        :param  resolver_type:  restrict to specified resolver type
         :type   include_containers: bool
         :param  include_containers: include container resolvers in resolution
         :type   container_type: str
-        :param  container_type: restrict to uninstall to specified container type
+        :param  container_type: restrict to specified container type
         :type   index_by: str
         :param  index_by: By default consider only context of requirements, group tools by requirements.
                           Set this to 'tools' to summarize across all tools though. Tools may provide additional

--- a/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
@@ -193,11 +193,19 @@ class ToolDependenciesAPIController(BaseGalaxyAPIController):
         """
         GET /api/dependency_resolvers/toolbox
 
-        Summarize requirements across toolbox (for Tool Management grid). This is an experiemental
-        API particularly tied to the GUI - expect breaking changes until this notice is removed.
+        Summarize requirements and their dependencies across toolbox (for Tool Management grid).
+        This is an experimental API particularly tied to the GUI - expect
+        breaking changes until this notice is removed.
 
         Container resolution via this API is especially experimental and the container resolution
         API should be used to summarize this information instead in most cases.
+
+        The results are computed with `_requirements_to_dependencies_dict()` of
+        `tool_util.deps.DependencyManager` Note that for container resolution by
+        default resolvers are skipped that require online access or may
+        build/cache a container, i.e.  resolvers that
+        - define `builds_on_resolution` i.e. `build_mulled` and `build_mulled_singularity`
+        - unless `install=True` only resolvers starting with `"cached"`, `"explicit"`, or `"fallback"` are used
 
         :type   index:    int
         :param  index:    index of the dependency resolver
@@ -215,8 +223,10 @@ class ToolDependenciesAPIController(BaseGalaxyAPIController):
                           context for container resolution for instance.
 
         :rtype:     list
-        :returns:   dictified descriptions of the dependencies, with attribute
-                    ``dependency_type: None`` if no match was found.
+        :returns:   list of dicts with keys "requirements", "status", "tool_ids"
+                    - requirements: list of dictified ToolRequirement(s)
+                    - status: list of dictified descriptions of the dependencies, with attribute ``dependency_type: None`` if no match was found
+                    - tool_ids: list of tool_ids
         """
         kwds["for_json"] = True
         index_by = kwds.get("index_by", "requirements")
@@ -232,7 +242,7 @@ class ToolDependenciesAPIController(BaseGalaxyAPIController):
         POST /api/dependency_resolvers/{index}/toolbox/install
         POST /api/dependency_resolvers/toolbox/install
 
-        Install described requirement against specified dependency resolver(s). This is an experiemental
+        Install described requirement against specified dependency resolver(s). This is an experimental
         API particularly tied to the GUI - expect breaking changes until this notice is removed.
 
         :type   index:          int
@@ -266,7 +276,7 @@ class ToolDependenciesAPIController(BaseGalaxyAPIController):
         POST /api/dependency_resolvers/{index}/toolbox/uninstall
         POST /api/dependency_resolvers/toolbox/uninstall
 
-        Uninstall described requirement against specified dependency resolver(s). This is an experiemental
+        Uninstall described requirement against specified dependency resolver(s). This is an experimental
         API particularly tied to the GUI - expect breaking changes until this notice is removed.
 
         :type   index:          int

--- a/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
@@ -200,12 +200,11 @@ class ToolDependenciesAPIController(BaseGalaxyAPIController):
         Container resolution via this API is especially experimental and the container resolution
         API should be used to summarize this information instead in most cases.
 
-        The results are computed with `_requirements_to_dependencies_dict()` of
-        `tool_util.deps.DependencyManager` Note that for container resolution by
-        default resolvers are skipped that require online access or may
-        build/cache a container, i.e.  resolvers that
-        - define `builds_on_resolution` i.e. `build_mulled` and `build_mulled_singularity`
-        - unless `install=True` only resolvers starting with `"cached"`, `"explicit"`, or `"fallback"` are used
+        Note that for container resolution by default resolvers are skipped that require online access
+        or may build/cache a container, i.e.
+        - `build_mulled` and `build_mulled_singularity`
+        - and unless `install=True` only resolvers whose name starts with `"cached"`, `"explicit"`,
+          or `"fallback"` are used
 
         :type   index:    int
         :param  index:    index of the dependency resolver

--- a/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
@@ -201,9 +201,7 @@ class ToolDependenciesAPIController(BaseGalaxyAPIController):
         API should be used to summarize this information instead in most cases.
 
         Note that for container resolution by default resolvers are skipped that require online access
-        or may build/cache a container, i.e.
-        - `build_mulled` and `build_mulled_singularity`
-        - and unless `install=True` only resolvers whose name starts with `"cached"`, `"explicit"`,
+        or may build/cache a container, i.e. only resolvers whose name starts with `"cached"`,`"explicit"`,
           or `"fallback"` are used
 
         :type   index:    int


### PR DESCRIPTION
add missing details and correct return type docs

spent a day finding out how this thing works and hope that I can spare this time for others. I think it deserves this in particular because it's at the moment the only route accessible from bioblend that helps with dependency resolution (in particular container resolution).

I'm not sure if I'm right with `install`, i.e. can one set `install=True` in this route or does the user need to use `/api/dependency_resolvers/toolbox/install`? 


## How to test the changes?
- [x] This is a refactoring of components

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
