### PR TITLE
Enable no-throw-literal eslint rule

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -18,6 +18,7 @@
         "prefer-const": "error",
         "one-var": ["error", "never"],
         "curly": "error",
+        "no-throw-literal": "error",
 
         "vue/valid-v-slot": "error",
         "vue/v-slot-style": ["error", { "atComponent": "v-slot", "default": "v-slot", "named": "longform" }],
@@ -86,6 +87,9 @@
                 "plugin:@typescript-eslint/eslint-recommended",
                 "plugin:@typescript-eslint/recommended"
             ],
+            "rules": {
+                "@typescript-eslint/no-throw-literal": "error"
+            },
             "parser": "@typescript-eslint/parser",
             "parserOptions": {
                 "ecmaFeatures": { "jsx": true },

--- a/client/src/components/DataDialog/DataDialog.test.js
+++ b/client/src/components/DataDialog/DataDialog.test.js
@@ -21,7 +21,7 @@ describe("model.js", () => {
             model.add({ idx: 1 });
             throw Error("Accepted invalid record.");
         } catch (error) {
-            expect(error).toBe("Invalid record with no <id>.");
+            expect(error.message).toBe("Invalid record with no <id>.");
         }
         model.add({ id: 1 });
         expect(model.count()).toBe(1);

--- a/client/src/components/DataDialog/DataDialog.test.js
+++ b/client/src/components/DataDialog/DataDialog.test.js
@@ -19,7 +19,7 @@ describe("model.js", () => {
         const model = new Model();
         try {
             model.add({ idx: 1 });
-            throw "Accepted invalid record.";
+            throw Error("Accepted invalid record.");
         } catch (error) {
             expect(error).toBe("Invalid record with no <id>.");
         }

--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -47,6 +47,7 @@ import { Model } from "./model";
 import { Services } from "./services";
 import { getAppRoot } from "onload/loadConfig";
 import { useGlobalUploadModal } from "composables/globalUploadModal";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 Vue.use(BootstrapVue);
 
@@ -175,8 +176,8 @@ export default {
                     this.formatRows();
                     this.optionsShow = true;
                 })
-                .catch((errorMessage) => {
-                    this.errorMessage = errorMessage;
+                .catch((error) => {
+                    this.errorMessage = errorMessageAsString(error);
                 });
         },
     },

--- a/client/src/components/DataDialog/model.js
+++ b/client/src/components/DataDialog/model.js
@@ -18,7 +18,7 @@ export class Model {
                 delete this.values[key];
             }
         } else {
-            throw "Invalid record with no <id>.";
+            throw Error("Invalid record with no <id>.");
         }
     }
 

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -67,6 +67,7 @@ import { Model } from "./model";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretLeft } from "@fortawesome/free-solid-svg-icons";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 library.add(faCaretLeft);
 export default {
@@ -312,8 +313,8 @@ export default {
                         this.showTime = false;
                         this.showDetails = true;
                     })
-                    .catch((errorMessage) => {
-                        this.errorMessage = errorMessage;
+                    .catch((error) => {
+                        this.errorMessage = errorMessageAsString(error);
                     });
             } else {
                 this.services
@@ -325,8 +326,8 @@ export default {
                         this.showTime = true;
                         this.showDetails = false;
                     })
-                    .catch((errorMessage) => {
-                        this.errorMessage = errorMessage;
+                    .catch((error) => {
+                        this.errorMessage = errorMessageAsString(error);
                     });
             }
         },

--- a/client/src/components/FilesDialog/model.js
+++ b/client/src/components/FilesDialog/model.js
@@ -22,7 +22,7 @@ export class Model {
                 delete this.values[key];
             }
         } else {
-            throw "Invalid record with no <id>.";
+            throw Error("Invalid record with no <id>.");
         }
     }
 

--- a/client/src/components/Toolshed/services.js
+++ b/client/src/components/Toolshed/services.js
@@ -40,7 +40,7 @@ export class Services {
             const data = response.data;
             const table = Object.keys(data).map((key) => data[key]);
             if (table.length === 0) {
-                throw "Repository does not contain any installable revisions.";
+                throw Error("Repository does not contain any installable revisions.");
             }
             table.sort((a, b) => b.numeric_revision - a.numeric_revision);
             table.forEach((x) => {
@@ -67,7 +67,7 @@ export class Services {
                 result.repository_url = `${toolshedUrl}repository?repository_id=${result.id}`;
                 return result;
             } else {
-                throw "Repository details not found.";
+                throw Error("Repository details not found.");
             }
         } catch (e) {
             rethrowSimple(e);

--- a/client/src/components/Tour/runTour.js
+++ b/client/src/components/Tour/runTour.js
@@ -20,7 +20,7 @@ function getElement(selector) {
         try {
             return document.querySelector(selector);
         } catch (error) {
-            throw `Tour - Invalid selector. ${selector}`;
+            throw Error(`Tour - Invalid selector. ${selector}`);
         }
     }
 }

--- a/client/src/components/Workflow/Editor/NodeOutput.test.ts
+++ b/client/src/components/Workflow/Editor/NodeOutput.test.ts
@@ -29,7 +29,7 @@ function propsForStep(step: Step) {
 function stepForLabel(label: string, steps: Steps) {
     const step = Object.values(steps).find((step) => step.label === label);
     if (!step) {
-        throw "step not found for test";
+        throw Error("step not found for test");
     }
     return step;
 }

--- a/client/src/components/Workflow/Editor/modules/terminals.ts
+++ b/client/src/components/Workflow/Editor/modules/terminals.ts
@@ -218,7 +218,7 @@ class BaseInputTerminal extends Terminal {
     }
     attachable(terminal: BaseOutputTerminal): ConnectionAcceptable {
         // TODO: provide through Mixin
-        throw "Subclass needs to implement this";
+        throw Error("Subclass needs to implement this");
     }
     _getOutputStepsMapOver() {
         const connections = this._getOutputConnections();
@@ -947,5 +947,5 @@ export function terminalFactory<T extends TerminalSourceAndInvalid>(
     if (isInvalidOutputArg(terminalSource)) {
         return new InvalidOutputTerminal(terminalSource) as TerminalOf<T>;
     }
-    throw `Could not build terminal for ${terminalSource}`;
+    throw Error(`Could not build terminal for ${terminalSource}`);
 }

--- a/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/SendForm.vue
+++ b/client/src/components/Workflow/Invocation/Export/Plugins/BioComputeObject/SendForm.vue
@@ -60,7 +60,7 @@ async function generateBcoContent() {
             maxRetries -= 1;
         }
         if (!pollingResponse.data) {
-            throw "Timeout waiting for BioCompute Object export result!";
+            throw Error("Timeout waiting for BioCompute Object export result!");
         } else {
             const resultResponse = await axios.get(resultUrl);
             return resultResponse.data;

--- a/client/src/components/WorkflowInvocationState/InvocationMessage.vue
+++ b/client/src/components/WorkflowInvocationState/InvocationMessage.vue
@@ -93,7 +93,7 @@ const stepDescription = computed(() => {
     } else if (messageLevel === "error") {
         return "This step failed the invocation";
     } else {
-        throw "Unknown message level";
+        throw Error("Unknown message level");
     }
 });
 

--- a/client/src/composables/datatypesMapper.ts
+++ b/client/src/composables/datatypesMapper.ts
@@ -24,7 +24,7 @@ export function useDatatypesMapper() {
             datatypesMapperLoading.value = false;
         }
         if (!datatypesMapperStore.datatypesMapper) {
-            throw "Error creating datatypesMapper";
+            throw Error("Error creating datatypesMapper");
         }
     }
 

--- a/client/src/utils/assertions.ts
+++ b/client/src/utils/assertions.ts
@@ -1,12 +1,12 @@
 /**
  * Asserts that a value is not undefined or null
  * @param value value to test
- * @param errorMessage optional error message
+ * @param error optional error message, or Error object
  */
-export function assertDefined<T>(value: T, errorMessage?: string): asserts value is NonNullable<T> {
+export function assertDefined<T>(value: T, error?: string | Error): asserts value is NonNullable<T> {
     if (value === undefined || value === null) {
-        const message = errorMessage ?? `Value is undefined or null`;
-        throw message;
+        const message = error ?? TypeError(`Value is undefined or null`);
+        throw message instanceof Error ? message : TypeError(message);
     }
 }
 
@@ -15,12 +15,12 @@ export function assertDefined<T>(value: T, errorMessage?: string): asserts value
  * Can be used inline
  *
  * @param value value to test
- * @param errorMessage optional error message
+ * @param error optional error message, or Error object
  * @returns NonNullable value
  *
  * @see assertDefined
  */
-export function ensureDefined<T>(value: T, errorMessage?: string): NonNullable<T> {
-    assertDefined(value, errorMessage);
+export function ensureDefined<T>(value: T, error?: string | Error): NonNullable<T> {
+    assertDefined(value, error);
     return value;
 }

--- a/client/src/utils/navigation/index.js
+++ b/client/src/utils/navigation/index.js
@@ -76,7 +76,7 @@ function componentFromObject(name, object) {
             Object.keys(value).forEach((selectorKey) => {
                 const selectorValue = value[selectorKey];
                 if (selectorValue == undefined) {
-                    throw `Problem with selectors value ${selectorValue}`;
+                    throw Error(`Problem with selectors value ${selectorValue}`);
                 }
                 selectors[selectorKey] = selectorTemplateFromObject(selectorValue);
             });
@@ -116,7 +116,7 @@ class Component {
         if (hasOwnProperty("_")) {
             return this["_"];
         } else {
-            throw `No _ selector for [${this}]`;
+            throw Error(`No _ selector for [${this}]`);
         }
     }
 }

--- a/client/src/utils/simple-error.ts
+++ b/client/src/utils/simple-error.ts
@@ -12,5 +12,5 @@ export function errorMessageAsString(e: any, defaultMessage = "Request failed.")
 
 export function rethrowSimple(e: any): never {
     console.debug(e);
-    throw errorMessageAsString(e);
+    throw Error(errorMessageAsString(e));
 }

--- a/client/src/utils/simple-error.ts
+++ b/client/src/utils/simple-error.ts
@@ -4,6 +4,8 @@ export function errorMessageAsString(e: any, defaultMessage = "Request failed.")
         message = e.response.data.err_msg;
     } else if (e && e.response) {
         message = `${e.response.statusText} (${e.response.status})`;
+    } else if (e instanceof Error) {
+        message = e.message;
     } else if (typeof e == "string") {
         message = e;
     }


### PR DESCRIPTION
Enables the `no-throw-literal` eslint rule for js and ts files. This enforces to throw only `Error` objects, or objects extending `Error`.

Using Error objects instead of literals is considered good practice, as they offer usage benefits in Error handling.

![image](https://user-images.githubusercontent.com/44241786/227932239-2f65c27b-15de-426f-a5ad-ac88a7b63a1d.png)

As seen in this screenshot, the Error object contains additional information about the Errors origin, and it's name.

It also removes some of the type ambiguity in catch statements, as it increases the certainty a caught error will be an error object.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
