### PR TITLE
Adding onFocus and onBlur functionality to Tool Search input

### DIFF
--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -9,6 +9,8 @@
             :placeholder="placeholder"
             @input="delayQuery"
             @change="setQuery"
+            @focus="selectText"
+            @blur="textSelected = false"
             @keydown.esc="setQuery('')" />
         <b-input-group-append>
             <b-button
@@ -69,6 +71,7 @@ export default {
             queryCurrent: null,
             titleClear: "clear search (esc)",
             titleAdvanced: "toggle advanced search",
+            textSelected: true,
         };
     },
     watch: {
@@ -97,6 +100,15 @@ export default {
             if (this.queryCurrent !== this.queryInput || this.queryCurrent !== queryNew) {
                 this.queryCurrent = this.queryInput = queryNew;
                 this.$emit("change", this.queryCurrent);
+            }
+        },
+        selectText() {
+            if (!this.textSelected) {
+                this.$refs.toolInput.select();
+                this.textSelected = true;
+            } else {
+                this.$refs.toolInput.focus();
+                this.textSelected = false;
             }
         },
         clearBox() {


### PR DESCRIPTION
Why: @afgane hackathon request: When clicking back into the Tool Search (i.e. to begin searching for a new tool), the text should be automatically highlighted so it clears out easier. 
What: On Focus, text is Selected; on Blur, text is unselected; On a second focused click, I just added focus to wherever the mouse is in the input field. 

Screencast is a little weird because I couldn't tell where my mouse was while it was recording... 


https://user-images.githubusercontent.com/26912553/227967926-a3745e40-65f2-4dc4-b38f-60acefb8b50c.mp4


## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Begin typing something in the tool search
  2. Click away
  3. When you click back all the text should be selected
  4. If you click a second time, the cursor will appear wherever your mouse is within the field
  5. When you click somewhere else on the screen, the text will be unselected. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
