### PR TITLE
Adding onFocus and onBlur functionality to editing the history name

### DIFF
--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -30,7 +30,9 @@
                 max-rows="4"
                 data-description="name input"
                 @keyup.enter="onSave"
-                @keyup.esc="onToggle" />
+                @keyup.esc="onToggle"
+                @focus="selectText"
+                @blur="textSelected = false" />
             <b-textarea
                 v-if="showAnnotation"
                 v-model="localProps.annotation"
@@ -87,6 +89,7 @@ export default {
         return {
             editing: false,
             localProps: {},
+            textSelected: false,
         };
     },
     computed: {
@@ -121,6 +124,15 @@ export default {
                     this.$refs.name.focus();
                 }
             });
+        },
+        selectText() {
+            if (!this.textSelected) {
+                this.$refs.name.select();
+                this.textSelected = true;
+            } else {
+                this.$refs.name.focus();
+                this.textSelected = false;
+            }
         },
     },
 };


### PR DESCRIPTION
Why: @afgane hackathon request: When editing the History Name, the text should be automatically highlighted so it clears out easier.
What: On Focus, text is Selected; on Blur, text is unselected; On a second focused click, I just added focus to wherever the mouse is in the input field.

https://user-images.githubusercontent.com/26912553/228017937-dd9726fe-aa79-4601-8caa-ccd47551e470.mp4

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Click the pencil to edit the history name
  2. Note how the history name is automatically selected, so that history can be renamed easily
 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
