### PR TITLE
Adding fuzzy search functionality to front end search

### DIFF
--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -21,8 +21,8 @@
                 :title="titleAdvanced | l"
                 data-description="toggle advanced search"
                 @click="onToggle">
-                <icon v-if="showAdvanced" icon="angle-double-up" />
-                <icon v-else icon="angle-double-down" />
+                <icon v-if="showAdvanced" fixed-width icon="angle-double-up" />
+                <icon v-else fixed-width icon="angle-double-down" />
             </b-button>
             <b-button
                 v-b-tooltip.hover
@@ -32,8 +32,8 @@
                 :title="titleClear | l"
                 data-description="reset query"
                 @click="clearBox">
-                <icon v-if="loading" icon="spinner" spin />
-                <icon v-else icon="times" />
+                <icon v-if="loading" fixed-width icon="spinner" spin />
+                <icon v-else fixed-width icon="times" />
             </b-button>
         </b-input-group-append>
     </b-input-group>

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -22,8 +22,8 @@
                     title="Show Advanced Filter"
                     aria-label="Show advanced filter"
                     @click="onToggle">
-                    <icon v-if="showAdvanced" icon="angle-double-up" />
-                    <icon v-else icon="angle-double-down" />
+                    <icon v-if="showAdvanced" fixed-width icon="angle-double-up" />
+                    <icon v-else fixed-width icon="angle-double-down" />
                 </b-button>
                 <b-button
                     v-b-tooltip.hover
@@ -33,7 +33,7 @@
                     aria-label="Clear filters"
                     data-description="clear filters"
                     @click="updateFilter('')">
-                    <icon icon="times" />
+                    <icon fixed-width icon="times" />
                 </b-button>
             </b-input-group-append>
         </b-input-group>

--- a/client/src/components/Panels/Common/ToolSearch.test.js
+++ b/client/src/components/Panels/Common/ToolSearch.test.js
@@ -2,7 +2,12 @@ import { mount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
 import DelayedInput from "components/Common/DelayedInput";
 import ToolSearch from "./ToolSearch";
+import VueRouter from "vue-router";
+import "jest-location-mock";
+
 const localVue = getLocalVue();
+localVue.use(VueRouter);
+const router = new VueRouter();
 
 describe("ToolSearch", () => {
     it("test tools advanced filter panel", async () => {
@@ -14,10 +19,12 @@ describe("ToolSearch", () => {
                 toolbox: [],
             },
             localVue,
+            router,
             stubs: {
                 icon: { template: "<div></div>" },
             },
         });
+        const $router = wrapper.vm.$router;
 
         expect(wrapper.find("[data-description='toggle advanced search']").exists()).toBe(false);
         expect(wrapper.find("[description='advanced tool filters']").exists()).toBe(false);
@@ -25,6 +32,21 @@ describe("ToolSearch", () => {
         expect(wrapper.find("[data-description='toggle advanced search']").exists()).toBe(true);
         expect(wrapper.find("[description='advanced tool filters']").exists()).toBe(true);
 
+        // Test: changing panel view should change search by section field to search by ontology
+        expect(wrapper.find("[placeholder='any section']").exists()).toBe(true);
+        await wrapper.setProps({ currentPanelView: "ontology:edam_operations" });
+        expect(wrapper.find("[placeholder='any section']").exists()).toBe(false);
+        expect(wrapper.find("[placeholder='any ontology']").exists()).toBe(true);
+        await wrapper.setProps({ currentPanelView: "default" });
+
+        // Test: keyup.esc (should toggle the view out) --- doesn't work from name (DelayedInput) field
+        const sectionField = wrapper.find("[placeholder='any section']");
+        expect(wrapper.emitted()["update:show-advanced"]).toBeUndefined();
+        await sectionField.trigger("keyup.esc");
+        expect(wrapper.emitted()["update:show-advanced"].length - 1).toBeFalsy();
+
+        // Add filters to fields
+        await wrapper.setProps({ showAdvanced: true });
         const filterInputs = {
             name: "name-filter",
             "[placeholder='any section']": "section-filter",
@@ -44,20 +66,19 @@ describe("ToolSearch", () => {
             }
         });
 
-        // Test: values are stored in the filterSettings object
-        expect(Object.values(wrapper.vm.filterSettings)).toEqual(Object.values(filterInputs));
-
-        // Test: changing panel view should change search by section field to search by ontology
-        expect(wrapper.find("[placeholder='any section']").exists()).toBe(true);
-        await wrapper.setProps({ currentPanelView: "ontology:edam_operations" });
-        expect(wrapper.find("[placeholder='any section']").exists()).toBe(false);
-        expect(wrapper.find("[placeholder='any ontology']").exists()).toBe(true);
-        await wrapper.setProps({ currentPanelView: "default" });
-
-        // Test: keyup.esc (should toggle the view out) --- doesn't work from name (DelayedInput) field
-        const sectionField = wrapper.find("[placeholder='any section']");
-        expect(wrapper.emitted()["update:show-advanced"]).toBeUndefined();
-        await sectionField.trigger("keyup.esc");
-        expect(wrapper.emitted()["update:show-advanced"].length - 1).toBeFalsy();
+        // Test: we route to the list with filters
+        const mockMethod = jest.fn();
+        $router.push = mockMethod;
+        wrapper.find(".filter-search-btn").trigger("click");
+        const filterSettings = {
+            name: "name-filter",
+            section: "section-filter",
+            id: "id-filter",
+            help: "help-filter",
+        };
+        expect(mockMethod).toHaveBeenCalledWith({
+            path: "/tools/list",
+            query: filterSettings,
+        });
     });
 });

--- a/client/src/components/Panels/Common/ToolSearch.test.js
+++ b/client/src/components/Panels/Common/ToolSearch.test.js
@@ -74,6 +74,7 @@ describe("ToolSearch", () => {
             name: "name-filter",
             section: "section-filter",
             id: "id-filter",
+            owner: "owner-filter",
             help: "help-filter",
         };
         expect(mockMethod).toHaveBeenCalledWith({

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -166,8 +166,8 @@ export default {
     },
     mounted() {
         this.searchWorker = new Worker(new URL("../toolSearch.worker.js", import.meta.url));
-        this.searchWorker.onmessage = (event) => {
-            const { type, payload, query, closestTerm } = event.data;
+        this.searchWorker.onmessage = ({ data }) => {
+            const { type, payload, query, closestTerm } = data;
             if (type === "searchToolsByKeysResult" && query === this.query) {
                 this.$emit("onResults", payload, closestTerm);
             } else if (type === "clearFilterResult") {

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -120,7 +120,7 @@ function checkQuery(q: string) {
 
 function post(message: object) {
     searchWorker.value?.postMessage(message);
-};
+}
 
 function onSearch() {
     for (const [filter, value] of Object.entries(filterSettings.value)) {

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -164,7 +164,7 @@ export default {
                     this.$emit("onResults", this.favoritesResults);
                 } else {
                     // keys with sorting order
-                    const keys = { exact: 4, name: 3, hyphenated: 2, description: 1, combined: 0 };
+                    const keys = { exact: 3, name: 2, description: 1, combined: 0 };
                     this.$emit("onResults", searchToolsByKeys(this.toolsList, keys, q));
                 }
             } else {

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -1,3 +1,141 @@
+<script setup lang="ts">
+import { computed, ref, onMounted, onUnmounted, type PropType, type Ref } from "vue";
+import { flattenTools } from "../utilities.js";
+import DelayedInput from "@/components/Common/DelayedInput.vue";
+import _l from "@/utils/localization";
+import { useRouter } from "vue-router/composables";
+import { getGalaxyInstance } from "@/app";
+
+const router = useRouter();
+
+const KEYS = { exact: 3, name: 2, description: 1, combined: 0 };
+const FAVORITES = ["#favs", "#favorites", "#favourites"];
+const MIN_QUERY_LENGTH = 3;
+
+interface Tool {
+    name?: string;
+}
+interface FilterSettings {
+    [key: string]: any;
+    name?: string;
+    section?: string;
+    id?: string;
+    help?: string;
+}
+
+const props = defineProps({
+    currentPanelView: {
+        type: String,
+        required: true,
+    },
+    enableAdvanced: {
+        type: Boolean,
+        default: false,
+    },
+    placeholder: {
+        type: String,
+        default: "search tools",
+    },
+    query: {
+        type: String,
+        default: null,
+    },
+    queryPending: {
+        type: Boolean,
+        default: false,
+    },
+    showAdvanced: {
+        type: Boolean,
+        default: false,
+    },
+    toolbox: {
+        type: Array as PropType<Tool[]>,
+        required: true,
+    },
+});
+
+const emit = defineEmits<{
+    (e: "update:show-advanced", showAdvanced: boolean): void;
+    (e: "onResults", filtered: string[] | null, closestValue: string | null): void;
+    (e: "onQuery", query: string): void;
+}>();
+
+const filterSettings: Ref<FilterSettings> = ref({});
+const showHelp: Ref<boolean> = ref(false);
+const searchWorker: Ref<Worker | undefined> = ref(undefined);
+
+const sectionNames = computed(() => {
+    return props.toolbox.map((section) =>
+        section.name !== undefined && section.name !== "Uncategorized" ? section.name : ""
+    );
+});
+const sectionLabel = computed(() => {
+    return props.currentPanelView === "default" ? "section" : "ontology";
+});
+const toolsList = computed(() => {
+    return flattenTools(props.toolbox);
+});
+
+onMounted(() => {
+    searchWorker.value = new Worker(new URL("../toolSearch.worker.js", import.meta.url));
+    const Galaxy = getGalaxyInstance();
+    const favoritesResults = Galaxy?.user.getFavorites().tools;
+
+    searchWorker.value.onmessage = ({ data }) => {
+        const { type, payload, query, closestTerm } = data;
+        if (type === "searchToolsByKeysResult" && query === props.query) {
+            emit("onResults", payload, closestTerm);
+        } else if (type === "clearFilterResult") {
+            emit("onResults", null, null);
+        } else if (type === "favoriteToolsResult") {
+            emit("onResults", favoritesResults, null);
+        }
+    };
+});
+
+onUnmounted(() => {
+    searchWorker.value?.terminate();
+});
+
+function checkQuery(q: string) {
+    filterSettings.value["name"] = q;
+    emit("onQuery", q);
+    if (q && q.length >= MIN_QUERY_LENGTH) {
+        if (FAVORITES.includes(q)) {
+            post({ type: "favoriteTools" });
+        } else {
+            post({
+                type: "searchToolsByKeys",
+                payload: {
+                    tools: toolsList.value,
+                    keys: KEYS,
+                    query: q,
+                },
+            });
+        }
+    } else {
+        post({ type: "clearFilter" });
+    }
+}
+
+function post(message: object) {
+    searchWorker.value?.postMessage(message);
+};
+
+function onSearch() {
+    for (const [filter, value] of Object.entries(filterSettings.value)) {
+        if (!value) {
+            delete filterSettings.value[filter];
+        }
+    }
+    router.push({ path: "/tools/list", query: filterSettings.value });
+}
+
+function onToggle(toggleAdvanced: boolean) {
+    emit("update:show-advanced", toggleAdvanced);
+}
+</script>
+
 <template>
     <div>
         <small v-if="showAdvanced">Filter by name:</small>
@@ -31,13 +169,13 @@
             <small class="mt-1">Filter by help text:</small>
             <b-form-input v-model="filterSettings['help']" size="sm" placeholder="any help text" />
             <div class="mt-3">
-                <b-button class="mr-1" size="sm" variant="primary" @click="onSearch">
+                <b-button class="mr-1 filter-search-btn" size="sm" variant="primary" @click="onSearch">
                     <icon icon="search" />
-                    <span>{{ "Search" | localize }}</span>
+                    <span>{{ _l("Search") }}</span>
                 </b-button>
                 <b-button size="sm" @click="onToggle(false)">
                     <icon icon="redo" />
-                    <span>{{ "Cancel" | localize }}</span>
+                    <span>{{ _l("Cancel") }}</span>
                 </b-button>
                 <b-button title="Search Help" size="sm" @click="showHelp = true">
                     <icon icon="question" />
@@ -94,124 +232,3 @@
         </div>
     </div>
 </template>
-
-<script>
-import { getGalaxyInstance } from "app";
-import DelayedInput from "components/Common/DelayedInput";
-import { flattenTools } from "../utilities.js";
-
-export default {
-    name: "ToolSearch",
-    components: {
-        DelayedInput,
-    },
-    props: {
-        currentPanelView: {
-            type: String,
-            required: true,
-        },
-        enableAdvanced: {
-            type: Boolean,
-            default: false,
-        },
-        placeholder: {
-            type: String,
-            default: "search tools",
-        },
-        query: {
-            type: String,
-            default: null,
-        },
-        queryPending: {
-            type: Boolean,
-            default: false,
-        },
-        showAdvanced: {
-            type: Boolean,
-            default: false,
-        },
-        toolbox: {
-            type: Array,
-            required: true,
-        },
-    },
-    data() {
-        return {
-            favorites: ["#favs", "#favorites", "#favourites"],
-            minQueryLength: 3,
-            filterSettings: {},
-            showHelp: false,
-            searchWorker: null,
-        };
-    },
-    computed: {
-        favoritesResults() {
-            const Galaxy = getGalaxyInstance();
-            return Galaxy.user.getFavorites().tools;
-        },
-        sectionNames() {
-            return this.toolbox.map((section) =>
-                section.name !== undefined && section.name !== "Uncategorized" ? section.name : ""
-            );
-        },
-        sectionLabel() {
-            return this.currentPanelView === "default" ? "section" : "ontology";
-        },
-        toolsList() {
-            return flattenTools(this.toolbox);
-        },
-    },
-    beforeDestroy() {
-        this.searchWorker.terminate();
-    },
-    mounted() {
-        this.searchWorker = new Worker(new URL("../toolSearch.worker.js", import.meta.url));
-        this.searchWorker.onmessage = ({ data }) => {
-            const { type, payload, query, closestTerm } = data;
-            if (type === "searchToolsByKeysResult" && query === this.query) {
-                this.$emit("onResults", payload, closestTerm);
-            } else if (type === "clearFilterResult") {
-                this.$emit("onResults", null);
-            } else if (type === "favoriteToolsResult") {
-                this.$emit("onResults", this.favoritesResults);
-            }
-        };
-    },
-    methods: {
-        checkQuery(q) {
-            this.filterSettings["name"] = q;
-            this.$emit("onQuery", q);
-            if (q && q.length >= this.minQueryLength) {
-                if (this.favorites.includes(q)) {
-                    this.searchWorker.postMessage({ type: "favoriteTools" });
-                } else {
-                    // keys with sorting order
-                    const keys = { exact: 3, name: 2, description: 1, combined: 0 };
-                    const workerMessage = {
-                        type: "searchToolsByKeys",
-                        payload: {
-                            tools: this.toolsList,
-                            keys: keys,
-                            query: q,
-                        },
-                    };
-                    this.searchWorker.postMessage(workerMessage);
-                }
-            } else {
-                this.searchWorker.postMessage({ type: "clearFilter" });
-            }
-        },
-        onSearch() {
-            for (const [filter, value] of Object.entries(this.filterSettings)) {
-                if (!value) {
-                    delete this.filterSettings[filter];
-                }
-            }
-            this.$router.push({ path: "/tools/list", query: this.filterSettings });
-        },
-        onToggle(toggleAdvanced) {
-            this.$emit("update:show-advanced", toggleAdvanced);
-        },
-    },
-};
-</script>

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -144,9 +144,6 @@ export default {
             searchWorker: null,
         };
     },
-    beforeDestroy() {
-        this.searchWorker.terminate();
-    },
     computed: {
         favoritesResults() {
             const Galaxy = getGalaxyInstance();
@@ -163,6 +160,9 @@ export default {
         toolsList() {
             return flattenTools(this.toolbox);
         },
+    },
+    beforeDestroy() {
+        this.searchWorker.terminate();
     },
     mounted() {
         this.searchWorker = new Worker(new URL("../toolSearch.worker.js", import.meta.url));

--- a/client/src/components/Panels/ToolBox.test.js
+++ b/client/src/components/Panels/ToolBox.test.js
@@ -1,10 +1,6 @@
-import { createPinia } from "pinia";
-import { mount } from "@vue/test-utils";
-import { getLocalVue } from "tests/jest/helpers";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import { filterToolSections, filterTools } from "./utilities";
-import ToolBox from "./ToolBox";
 import toolsList from "./testToolsList";
 import { useConfig } from "composables/config";
 
@@ -16,38 +12,13 @@ useConfig.mockReturnValue({
     isLoaded: true,
 });
 
-const localVue = getLocalVue();
-
 describe("ToolBox", () => {
     const toolsMock = toolsList;
     const resultsMock = ["join1", "join_collections", "find1"];
     let axiosMock;
 
-    const searches = {
-        join: ["join1", "join_collections", "find1"],
-        find: ["find1"],
-        remove: ["remove1", "remove_duplicate"],
-        fi: null,
-    };
-
-    let wrapper;
-
     beforeEach(async () => {
-        const pinia = createPinia();
         axiosMock = new MockAdapter(axios);
-
-        wrapper = mount(ToolBox, {
-            propsData: {
-                toolbox: toolsList,
-                currentPanelView: "default",
-                storedWorkflowMenuEntries: [],
-            },
-            localVue,
-            stubs: {
-                icon: { template: "<div></div>" },
-            },
-            pinia,
-        });
     });
 
     it("test filter functions correctly matching: (1) Tools store array-of-objects with (2) Results array", async () => {
@@ -60,12 +31,5 @@ describe("ToolBox", () => {
         const toolsResultsSection = filterToolSections(toolsMock, resultsMock);
         expect(toolsResults.length).toBe(3);
         expect(toolsResultsSection.length).toBe(2);
-    });
-
-    it("test toolbox client search", async () => {
-        for (const [query, results] of Object.entries(searches)) {
-            await wrapper.setData({ query: query });
-            expect(wrapper.vm.results).toEqual(results);
-        }
     });
 });

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -26,6 +26,7 @@
                 :show-advanced.sync="showAdvanced"
                 :toolbox="tools"
                 :query="query"
+                :query-pending="queryPending"
                 @onQuery="onQuery"
                 @onResults="onResults" />
             <section v-if="!showAdvanced">

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -42,6 +42,9 @@
                 <div v-else-if="queryFinished" class="pb-2">
                     <b-badge class="alert-danger w-100">No results found!</b-badge>
                 </div>
+                <div v-else-if="misspelled" class="pb-2">
+                    <b-badge class="alert-danger w-100">You made a typo!</b-badge>
+                </div>
             </section>
         </div>
         <div v-if="!showAdvanced" class="unified-panel-body">
@@ -124,6 +127,9 @@ export default {
         },
         queryFinished() {
             return this.query && this.queryPending != true;
+        },
+        misspelled(){
+            return this.query && this.query.length >= 2;
         },
         sections() {
             if (this.showSections) {

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -42,9 +42,6 @@
                 <div v-else-if="queryFinished" class="pb-2">
                     <b-badge class="alert-danger w-100">No results found!</b-badge>
                 </div>
-                <div v-else-if="misspelled" class="pb-2">
-                    <b-badge class="alert-danger w-100">You made a typo!</b-badge>
-                </div>
             </section>
         </div>
         <div v-if="!showAdvanced" class="unified-panel-body">
@@ -127,9 +124,6 @@ export default {
         },
         queryFinished() {
             return this.query && this.queryPending != true;
-        },
-        misspelled(){
-            return this.query && this.query.length >= 2;
         },
         sections() {
             if (this.showSections) {

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -43,6 +43,15 @@
                 <div v-else-if="queryFinished" class="pb-2">
                     <b-badge class="alert-danger w-100">No results found!</b-badge>
                 </div>
+                <div v-if="closestTerm" class="pb-2">
+                    <b-badge class="alert-danger w-100">
+                        Did you mean:
+                        <i>
+                            <a href="javascript:void(0)" @click="onQuery(closestTerm)">{{ closestTerm }}</a>
+                        </i>
+                        ?
+                    </b-badge>
+                </div>
             </section>
         </div>
         <div v-if="!showAdvanced" class="unified-panel-body">
@@ -105,6 +114,7 @@ export default {
     },
     data() {
         return {
+            closestTerm: null,
             query: null,
             results: null,
             queryFilter: null,
@@ -168,8 +178,9 @@ export default {
             this.query = q;
             this.queryPending = true;
         },
-        onResults(results) {
+        onResults(results, closestTerm = null) {
             this.results = results;
+            this.closestTerm = closestTerm;
             this.queryFilter = this.hasResults ? this.query : null;
             this.setButtonText();
             this.queryPending = false;

--- a/client/src/components/Panels/toolSearch.worker.js
+++ b/client/src/components/Panels/toolSearch.worker.js
@@ -1,3 +1,7 @@
+/**
+ * A Web Worker that isolates the Tool Search into its own thread
+ */
+
 import { searchToolsByKeys } from "./utilities";
 
 // listen for messages from the main thread
@@ -5,9 +9,13 @@ self.addEventListener("message", (event) => {
     const { type, payload } = event.data;
     if (type === "searchToolsByKeys") {
         const { tools, keys, query } = payload;
-        const result = searchToolsByKeys(tools, keys, query);
+        const { results, closestTerm } = searchToolsByKeys(tools, keys, query);
         // send the result back to the main thread
-        self.postMessage({ type: "searchToolsByKeysResult", payload: result, query: query });
+        self.postMessage({ type: "searchToolsByKeysResult", payload: results, query: query, closestTerm: closestTerm });
+    } else if (type === "clearFilter") {
+        self.postMessage({ type: "clearFilterResult" });
+    } else if (type === "favoriteTools") {
+        self.postMessage({ type: "favoriteToolsResult" });
     }
 });
 

--- a/client/src/components/Panels/toolSearch.worker.js
+++ b/client/src/components/Panels/toolSearch.worker.js
@@ -1,0 +1,15 @@
+import { searchToolsByKeys } from "./utilities";
+
+// listen for messages from the main thread
+self.addEventListener("message", (event) => {
+    const { type, payload } = event.data;
+    if (type === "searchToolsByKeys") {
+        const { tools, keys, query } = payload;
+        const result = searchToolsByKeys(tools, keys, query);
+        // send the result back to the main thread
+        self.postMessage({ type: "searchToolsByKeysResult", payload: result, query: query });
+    }
+});
+
+// TODO: add error event listener
+// self.addEventListener('error', (event) => {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -154,6 +154,8 @@ export function flattenTools(tools) {
 export function dLDistance(query, value) {
     const searchTerm = query;
     const toolName = value;
+    const threshold = 1;
+    const minSimilarity = 1;
 
     // Initialize the matrix for the Damerau-Levenshtein distance algorithm
     const matrix = [];
@@ -201,8 +203,9 @@ export function dLDistance(query, value) {
     if (row !== -1) {
         const substr = toolName.substring(col - 1 - searchTerm.length + row, col)
         const similarity = (searchTerm.length - matrix[row][col]) / searchTerm.length
-        if (similarity >= minSimilarity && substr.includes(searchTerm)) {
-            return matrix[searchTerm.length][toolName.length] <= 1;
+        if (similarity >= minSimilarity) {
+            console.log('hi')
+            return matrix[searchTerm.length][toolName.length];
         }
         }
 
@@ -210,7 +213,7 @@ export function dLDistance(query, value) {
 
     // If the Damerau-Levenshtein distance is less than or equal to 1,
     // consider the tool a match
-    return matrix[searchTerm.length][toolName.length] <= 1;
+    return matrix[searchTerm.length][toolName.length] <= 2;
 }
 
 function isToolObject(tool) {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -26,13 +26,16 @@ export function createWorkflowQuery(filterSettings) {
     return query;
 }
 
-// - Takes filterSettings = {"name": "Tool Name", "section": "Collection", ...}
-// - Takes panelView (if not 'default', does ontology search at backend)
-// - Takes toolbox (to find ontology id if given ontology name)
-// - Returns parsed Whoosh query
-// e.g. fn call: createWhooshQuery(filterSettings, 'ontology:edam_topics', toolbox)
-// can return:
-//     query = "(name:(skew) name_exact:(skew) description:(skew)) AND (edam_topics:(topic_0797) AND )"
+/**
+ *
+ * @param {Object} filterSettings e.g.: {"name": "Tool Name", "section": "Collection", ...}
+ * @param {String} panelView (if not `default`, does ontology search at backend)
+ * @param {Array} toolbox (to find ontology id if given ontology name)
+ * @returns parsed Whoosh `query`
+ * @example
+ *      createWhooshQuery(filterSettings, 'ontology:edam_topics', toolbox)
+ *      return query = "(name:(skew) name_exact:(skew) description:(skew)) AND (edam_topics:(topic_0797) AND )"
+ */
 export function createWhooshQuery(filterSettings, panelView, toolbox) {
     let query = "(";
     // add description+name_exact fields = name, to do a combined OrGroup at backend
@@ -116,13 +119,47 @@ export function hasResults(results) {
     return Array.isArray(results) && results.length > 0;
 }
 
-// Given toolbox, keys to sort/search results by and a search query,
-// Does a direct string.match() comparison to find results,
-// If that produces nothing, runs levenshtein distance alg to allow misspells
-// Returns tool ids sorted by order of keys that are being searched
-export function searchToolsByKeys(tools, keys, query, usesDl = false, usesDLAgain = false) {
-    const returnedTools = [];
-    const minimumQueryLength = 5;
+export function normalizeTools(tools) {
+    tools = hideToolsSection(tools);
+    tools = flattenTools(tools);
+    return tools;
+}
+
+export function hideToolsSection(tools) {
+    return tools.filter((section) => !TOOLS_RESULTS_SECTIONS_HIDE.includes(section.name));
+}
+
+export function removeDisabledTools(tools) {
+    return tools.filter((section) => {
+        if (section.model_class === "ToolSectionLabel") {
+            return true;
+        } else if (!section.elems && section.disabled) {
+            return false;
+        } else if (section.elems) {
+            section.elems = section.elems.filter((el) => !el.disabled);
+            if (!section.elems.length) {
+                return false;
+            }
+        }
+        return true;
+    });
+}
+
+/**
+ * Given toolbox, keys to sort/search results by and a search query,
+ * Does a direct string.match() comparison to find results,
+ * If that produces nothing, runs DL distance alg to allow misspells
+ *
+ * @param {Array} tools - toolbox
+ * @param {Object} keys - keys to sort and search results by
+ * @param {String} query - a search query
+ * @param {Boolean} usesDL - Optional: used for recursive call with DL if no string.match()
+ * @returns tool ids sorted by order of keys that are being searched (+ closest matching term if DL)
+ */
+export function searchToolsByKeys(tools, keys, query, usesDL = false) {
+    let returnedTools = [];
+    let closestTerm = null;
+    const minimumQueryLength = 5; // for DL
     for (const tool of tools) {
         for (const key of Object.keys(keys)) {
             if (tool[key] || key === "combined") {
@@ -133,36 +170,42 @@ export function searchToolsByKeys(tools, keys, query, usesDl = false, usesDLAgai
                 } else {
                     actualValue = tool[key].trim().toLowerCase();
                 }
+                const actualValueWords = actualValue.split(" ");
                 STRING_REPLACEMENTS.forEach((rep) => {
                     queryValue = queryValue.replaceAll(rep, "");
                     actualValue = actualValue.replaceAll(rep, "");
                 });
                 // do we care for exact matches && is it an exact match ?
                 const order = keys.exact && actualValue === queryValue ? keys.exact : keys[key];
-                if (!usesDl && actualValue.match(queryValue)) {
+                if (!usesDL && actualValue.match(queryValue)) {
                     returnedTools.push({ id: tool.id, order });
                     break;
-                } else if (queryValue.length >= minimumQueryLength) {
-                    if (usesDl && key == "name" && dLDistance(queryValue, actualValue)) {
-                        returnedTools.push({ id: tool.id, order });
-                        break;
-                    } else if (usesDLAgain && key != "name" && dLDistance(queryValue, actualValue)) {
-                        returnedTools.push({ id: tool.id, order });
+                } else if (usesDL) {
+                    let substring = null;
+                    if ((key == "name" || key == "description") && queryValue.length >= minimumQueryLength) {
+                        substring = closestSubstring(queryValue, actualValue);
+                    }
+                    // there is a closestSubstring: matching tool found
+                    if (substring) {
+                        // get the closest matching term for substring
+                        const foundTerm = matchingTerm(actualValueWords, substring);
+                        if (foundTerm && (!closestTerm || (closestTerm && foundTerm.length < closestTerm.length))) {
+                            closestTerm = foundTerm;
+                        }
+                        returnedTools.push({ id: tool.id, order, closestTerm });
                         break;
                     }
                 }
             }
         }
     }
-    // no results with string.match():
-    // try DL with name key first, no results: try all other keys
-    if (!usesDl && !usesDLAgain && returnedTools.length == 0) {
+    // no results with string.match(): recursive call with usesDL
+    if (!usesDL && returnedTools.length == 0) {
         return searchToolsByKeys(tools, keys, query, true);
-    } else if (usesDl && !usesDLAgain && returnedTools.length == 0) {
-        return searchToolsByKeys(tools, keys, query, false, true);
     }
     // sorting results by indexed order of keys
-    return orderBy(returnedTools, ["order"], ["desc"]).map((tool) => tool.id);
+    returnedTools = orderBy(returnedTools, ["order"], ["desc"]).map((tool) => tool.id);
+    return { results: returnedTools, closestTerm: closestTerm };
 }
 
 export function flattenTools(tools) {
@@ -172,32 +215,38 @@ export function flattenTools(tools) {
     });
     return normalizedTools;
 
-function dLDistance(query, toolName) {
-    // Max distance a query and tool name substring can be apart
+/**
+ *
+ * @param {String} query
+ * @param {String} actualStr
+ * @returns substring with smallest DL distance, or null
+ */
+function closestSubstring(query, actualStr) {
+    // Max distance a query and substring can be apart
     const maxDistance = 1;
-    // Create an array of all toolName substrings that are query length, query length -1, and query length + 1
-    const substrings = Array.from({ length: toolName.length - query.length + 1 }, (_, i) =>
-        toolName.substr(i, query.length)
+    // Create an array of all actualStr substrings that are query length, query length -1, and query length + 1
+    const substrings = Array.from({ length: actualStr.length - query.length + 1 }, (_, i) =>
+        actualStr.substr(i, query.length)
     );
     if (query.length > 1) {
         substrings.push(
-            ...Array.from({ length: toolName.length - query.length + 2 }, (_, i) =>
-                toolName.substr(i, query.length - 1)
+            ...Array.from({ length: actualStr.length - query.length + 2 }, (_, i) =>
+                actualStr.substr(i, query.length - 1)
             )
         );
     }
-    if (toolName.length > query.length) {
+    if (actualStr.length > query.length) {
         substrings.push(
-            ...Array.from({ length: toolName.length - query.length }, (_, i) => toolName.substr(i, query.length + 1))
+            ...Array.from({ length: actualStr.length - query.length }, (_, i) => actualStr.substr(i, query.length + 1))
         );
     }
-    // check to see if any substings have a levenshtein distance less than the max distance and return True or False
+    // check to see if any substrings have a levenshtein distance less than the max distance
     for (const substring of substrings) {
         if (levenshteinDistance(query, substring, true) <= maxDistance) {
-            return true;
+            return substring;
         }
     }
-    return false;
+    return null;
 }
 
 function isToolObject(tool) {
@@ -208,6 +257,16 @@ function isToolObject(tool) {
         return true;
     }
     return false;
+
+// given array and a substring, get the closest matching term for substring
+function matchingTerm(termArray, substring) {
+    for (const i in termArray) {
+        const term = termArray[i];
+        if (term.match(substring)) {
+            return term;
+        }
+    }
+    return null;
 }
 
 function flattenToolsSection(section) {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -120,8 +120,7 @@ export function hasResults(results) {
 // Returns tool ids sorted by order of keys that are being searched
 export function searchToolsByKeys(tools, keys, query) {
     const returnedTools = [];
-    let lowestDistance = null;
-    let closestTool = null;
+    const minimumQueryLength = 5
     let usesDl = true;
     for (const tool of tools) {
         for (const key of Object.keys(keys)) {
@@ -136,20 +135,14 @@ export function searchToolsByKeys(tools, keys, query) {
             const queryLowerCase = query.trim().toLowerCase();
             // do we care for exact matches && is it an exact match ?
             const order = keys.exact && actualValue === queryLowerCase ? keys.exact : keys[key];
-            const distance = queryLowerCase.length >= 6 ? dLDistance(queryLowerCase, actualValue) : null;
+            const distance = queryLowerCase.length >= minimumQueryLength ? dLDistance(queryLowerCase, actualValue) : null;
             if (actualValue.match(queryLowerCase)) {
                 returnedTools.push({ id: tool.id, order, usesDl: false });
-                lowestDistance = 0;
-                closestTool = null;
                 usesDl = false;
                 break;
             }
             else if (key !== "combined" && distance && usesDl) {
-                if (key == "name" && distance && distance < lowestDistance) {
-                    lowestDistance = 
-                    closestTool = tool.name + tool.description;
-                }
-                returnedTools.push({ id: tool.id, order, usesDl: true });
+                returnedTools.push({ id: tool.id, order});
                 break;
             }
         }

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -154,10 +154,11 @@ export function searchToolsByKeys(tools, keys, query, usesDl = false, usesDLAgai
             }
         }
     }
-    // no results with string.match(): maybe user misspelled, so try usesDl = true
-    if (!usesDl && returnedTools.length == 0) {
+    // no results with string.match():
+    // try DL with name key first, no results: try all other keys
+    if (!usesDl && !usesDLAgain && returnedTools.length == 0) {
         return searchToolsByKeys(tools, keys, query, true);
-    } else if (!usesDLAgain && returnedTools.length == 0) {
+    } else if (usesDl && !usesDLAgain && returnedTools.length == 0) {
         return searchToolsByKeys(tools, keys, query, false, true);
     }
     // sorting results by indexed order of keys

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -169,22 +169,11 @@ export function flattenTools(tools) {
 
 export function dLDistance(query, toolName) {
     const matchThreshold = 1;
-
-    // Create array of all substrings of query length for a given tool name
-    const substrings = [];
-    for (let i = 0; i <= toolName.length - query.length; i++) {
-        substrings.push(toolName.substring(i, i + query.length));
+    const substrings = Array.from({ length: toolName.length - query.length + 1 }, (_, i) => toolName.substr(i, query.length));
+    if (query.length > 1) {
+        substrings.push(...Array.from({ length: toolName.length - query.length + 2 }, (_, i) => toolName.substr(i, query.length - 1)));
     }
-
-    // Call the levenshteinDistance algorithm with transpositions on the query and each tool name substring
-    for (const substring of substrings) {
-        const distance = levenshteinDistance(query, substring, true);
-        // Check if the substring matches our required threshold for a match
-        if (distance <= matchThreshold) {
-            return true;
-        }
-    }
-    return false;
+    return substrings.concat(toolName).some(substring => levenshteinDistance(query, substring, true) <= matchThreshold);
 }
 
 function isToolObject(tool) {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -168,12 +168,15 @@ export function flattenTools(tools) {
     return normalizedTools;
 
 export function dLDistance(query, toolName) {
-    const matchThreshold = 1;
+    // Max distance a query and tool name substring can be apart
+    const maxDistance = 1;
+    // Create an array of all toolName substrings that are query length or query length -1 
     const substrings = Array.from({ length: toolName.length - query.length + 1 }, (_, i) => toolName.substr(i, query.length));
     if (query.length > 1) {
         substrings.push(...Array.from({ length: toolName.length - query.length + 2 }, (_, i) => toolName.substr(i, query.length - 1)));
     }
-    return substrings.concat(toolName).some(substring => levenshteinDistance(query, substring, true) <= matchThreshold);
+    // check to see if any substings have a levenshtein distance less than the max distance and return True or False
+    return substrings.concat(toolName).some(substring => levenshteinDistance(query, substring, true) <= maxDistance);
 }
 
 function isToolObject(tool) {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -4,7 +4,6 @@
 import { orderBy } from "lodash";
 import levenshteinDistance from "utils/levenshtein";
 
-
 const TOOLS_RESULTS_SORT_LABEL = "apiSort";
 const TOOLS_RESULTS_SECTIONS_HIDE = ["Expression Tools"];
 
@@ -120,7 +119,7 @@ export function hasResults(results) {
 // Returns tool ids sorted by order of keys that are being searched
 export function searchToolsByKeys(tools, keys, query) {
     const returnedTools = [];
-    const minimumQueryLength = 5
+    const minimumQueryLength = 5;
     let usesDl = true;
     for (const tool of tools) {
         for (const key of Object.keys(keys)) {
@@ -135,14 +134,14 @@ export function searchToolsByKeys(tools, keys, query) {
             const queryLowerCase = query.trim().toLowerCase();
             // do we care for exact matches && is it an exact match ?
             const order = keys.exact && actualValue === queryLowerCase ? keys.exact : keys[key];
-            const distance = queryLowerCase.length >= minimumQueryLength ? dLDistance(queryLowerCase, actualValue) : null;
+            const distance =
+                queryLowerCase.length >= minimumQueryLength ? dLDistance(queryLowerCase, actualValue) : null;
             if (actualValue.match(queryLowerCase)) {
                 returnedTools.push({ id: tool.id, order, usesDl: false });
                 usesDl = false;
                 break;
-            }
-            else if (key !== "combined" && distance && usesDl) {
-                returnedTools.push({ id: tool.id, order});
+            } else if (key !== "combined" && distance && usesDl) {
+                returnedTools.push({ id: tool.id, order });
                 break;
             }
         }
@@ -165,15 +164,15 @@ export function dLDistance(query, toolName) {
     const substrings = [];
     for (let i = 0; i <= toolName.length - query.length; i++) {
         substrings.push(toolName.substring(i, i + query.length));
-      }
-      
+    }
+
     // Call the levenshteinDistance algorithm with transpositions on the query and each tool name substring
-    for (let substring of substrings) {
-        let distance = levenshteinDistance(query,substring,true)
+    for (const substring of substrings) {
+        const distance = levenshteinDistance(query, substring, true);
         // Check if the substring matches our required threshold for a match
-        if (distance <= matchThreshold){
+        if (distance <= matchThreshold) {
             return true;
-        }  
+        }
     }
     return false;
 }

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -166,19 +166,17 @@ export function flattenTools(tools) {
     return normalizedTools;
 
 export function dLDistance(query, toolName) {
-    const searchTerm = query;
-    const queryLength = query.length;
     const matchThreshold = 1;
 
     // Create array of all substrings of query length for a given tool name
     const substrings = [];
-    for (let i = 0; i <= toolName.length - queryLength; i++) {
-        substrings.push(toolName.substring(i, i + queryLength));
+    for (let i = 0; i <= toolName.length - query.length; i++) {
+        substrings.push(toolName.substring(i, i + query.length));
       }
-
+      
     // Call the levenshteinDistance algorithm with transpositions on the query and each tool name substring
     for (let substring of substrings) {
-        let distance = levenshteinDistance(searchTerm,substring,true)
+        let distance = levenshteinDistance(query,substring,true)
         // Check if the substring matches our required threshold for a match
         if (distance <= matchThreshold){
             return true;

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -170,10 +170,13 @@ export function flattenTools(tools) {
 export function dLDistance(query, toolName) {
     // Max distance a query and tool name substring can be apart
     const maxDistance = 1;
-    // Create an array of all toolName substrings that are query length or query length -1 
+    // Create an array of all toolName substrings that are query length, query length -1, and query length + 1
     const substrings = Array.from({ length: toolName.length - query.length + 1 }, (_, i) => toolName.substr(i, query.length));
     if (query.length > 1) {
         substrings.push(...Array.from({ length: toolName.length - query.length + 2 }, (_, i) => toolName.substr(i, query.length - 1)));
+    }
+    if (toolName.length > query.length) {
+        substrings.push(...Array.from({ length: toolName.length - query.length }, (_, i) => toolName.substr(i, query.length + 1)));
     }
     // check to see if any substings have a levenshtein distance less than the max distance and return True or False
     return substrings.concat(toolName).some(substring => levenshteinDistance(query, substring, true) <= maxDistance);

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -142,10 +142,8 @@ export function searchToolsByKeys(tools, keys, query, usesDl = false) {
                 if (!usesDl && actualValue.match(queryValue)) {
                     returnedTools.push({ id: tool.id, order });
                     break;
-                } else if (usesDl) {
-                    const distance =
-                        queryValue.length >= minimumQueryLength ? dLDistance(queryValue, actualValue) : null;
-                    if (distance) {
+                } else if (usesDl && queryValue.length >= minimumQueryLength) {
+                    if (dLDistance(queryValue, actualValue)) {
                         returnedTools.push({ id: tool.id, order });
                         break;
                     }
@@ -168,7 +166,7 @@ export function flattenTools(tools) {
     });
     return normalizedTools;
 
-export function dLDistance(query, toolName) {
+function dLDistance(query, toolName) {
     // Max distance a query and tool name substring can be apart
     const maxDistance = 1;
     // Create an array of all toolName substrings that are query length, query length -1, and query length + 1

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -26,8 +26,7 @@ export function createWorkflowQuery(filterSettings) {
     return query;
 }
 
-/**
- *
+/** Converts filters into tool search backend whoosh query.
  * @param {Object} filterSettings e.g.: {"name": "Tool Name", "section": "Collection", ...}
  * @param {String} panelView (if not `default`, does ontology search at backend)
  * @param {Array} toolbox (to find ontology id if given ontology name)
@@ -119,32 +118,6 @@ export function hasResults(results) {
     return Array.isArray(results) && results.length > 0;
 }
 
-export function normalizeTools(tools) {
-    tools = hideToolsSection(tools);
-    tools = flattenTools(tools);
-    return tools;
-}
-
-export function hideToolsSection(tools) {
-    return tools.filter((section) => !TOOLS_RESULTS_SECTIONS_HIDE.includes(section.name));
-}
-
-export function removeDisabledTools(tools) {
-    return tools.filter((section) => {
-        if (section.model_class === "ToolSectionLabel") {
-            return true;
-        } else if (!section.elems && section.disabled) {
-            return false;
-        } else if (section.elems) {
-            section.elems = section.elems.filter((el) => !el.disabled);
-            if (!section.elems.length) {
-                return false;
-            }
-        }
-        return true;
-    });
-}
-
 /**
  * Given toolbox, keys to sort/search results by and a search query,
  * Does a direct string.match() comparison to find results,
@@ -211,6 +184,27 @@ export function flattenTools(tools) {
         normalizedTools = normalizedTools.concat(flattenToolsSection(section));
     });
     return normalizedTools;
+}
+
+export function hideToolsSection(tools) {
+    return tools.filter((section) => !TOOLS_RESULTS_SECTIONS_HIDE.includes(section.name));
+}
+
+export function removeDisabledTools(tools) {
+    return tools.filter((section) => {
+        if (section.model_class === "ToolSectionLabel") {
+            return true;
+        } else if (!section.elems && section.disabled) {
+            return false;
+        } else if (section.elems) {
+            section.elems = section.elems.filter((el) => !el.disabled);
+            if (!section.elems.length) {
+                return false;
+            }
+        }
+        return true;
+    });
+}
 
 /**
  *
@@ -254,6 +248,7 @@ function isToolObject(tool) {
         return true;
     }
     return false;
+}
 
 // given array and a substring, get the closest matching term for substring
 function matchingTerm(termArray, substring) {

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -179,9 +179,36 @@ export function dLDistance(query, value) {
                 matrix[i][j] = Math.min(matrix[i][j], matrix[i - 2][j - 2] + cost);
             }
         }
+        }
+
+    // Search for a row or column with a value below the threshold
+    let row = -1
+    let col = -1
+    for (let i = 1; i <= searchTerm.length; i++) {
+      for (let j = 1; j <= toolName.length; j++) {
+        if (matrix[i][j] <= threshold) {
+          row = i
+          col = j
+          break
+        }
+      }
+      if (row !== -1) {
+        break
+      }
     }
 
-    // If the Damerau-Levenshtein distance is less than or equal to 2,
+    // If a row or column was found, check for a partial match
+    if (row !== -1) {
+        const substr = toolName.substring(col - 1 - searchTerm.length + row, col)
+        const similarity = (searchTerm.length - matrix[row][col]) / searchTerm.length
+        if (similarity >= minSimilarity && substr.includes(searchTerm)) {
+            return matrix[searchTerm.length][toolName.length] <= 1;
+        }
+        }
+
+        
+
+    // If the Damerau-Levenshtein distance is less than or equal to 1,
     // consider the tool a match
     return matrix[searchTerm.length][toolName.length] <= 1;
 }

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -116,7 +116,7 @@ describe("test helpers in tool searching utilities", () => {
     it("test tool fuzzy search", async () => {
         const expectedResults = ["__FILTER_FAILED_DATASETS__", "__FILTER_EMPTY_DATASETS__"];
         const keys = { description: 1, name: 2, combined: 0 };
-        const queries = [" filtr", "FILYER", "Fitler", "dataseas from a collection"]; // deletion, substitution, transpose, description
+        const queries = ["Fillter", " filtr", "FILYER", "Fitler", "datases from a collection", "from a colleection"];
         queries.forEach((q) => {
             const results = searchToolsByKeys(normalizeTools(toolsList), keys, q);
             expect(results).toEqual(expectedResults);

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -16,6 +16,7 @@ describe("test helpers in tool searching utilities and panel handling", () => {
         const widthB = determineWidth({ left: 30, right: 250 }, { left: 60 }, 30, 500, "left", 180);
         expect(widthB).toBe(340);
     });
+});
 
 const tempToolsList = [
     {
@@ -108,7 +109,7 @@ describe("test helpers in tool searching utilities", () => {
             },
         ];
         searches.forEach((search) => {
-            const { results } = searchToolsByKeys(normalizeTools(search.list), search.keys, search.q);
+            const { results } = searchToolsByKeys(flattenTools(search.list), search.keys, search.q);
             expect(results).toEqual(search.expectedResults);
         });
     });
@@ -118,13 +119,13 @@ describe("test helpers in tool searching utilities", () => {
         const keys = { description: 1, name: 2, combined: 0 };
         const filterQueries = ["Fillter", "FILYER", " Fitler", " filtr"];
         filterQueries.forEach((q) => {
-            const { results, closestTerm } = searchToolsByKeys(normalizeTools(toolsList), keys, q);
+            const { results, closestTerm } = searchToolsByKeys(flattenTools(toolsList), keys, q);
             expect(results).toEqual(expectedResults);
             expect(closestTerm).toEqual("filter");
         });
         const queries = ["datases from a collection", "from a colleection"];
         queries.forEach((q) => {
-            const { results } = searchToolsByKeys(normalizeTools(toolsList), keys, q);
+            const { results } = searchToolsByKeys(flattenTools(toolsList), keys, q);
             expect(results).toEqual(expectedResults);
         });
     });

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -108,7 +108,7 @@ describe("test helpers in tool searching utilities", () => {
             },
         ];
         searches.forEach((search) => {
-            const results = searchToolsByKeys(normalizeTools(search.list), search.keys, search.q);
+            const { results } = searchToolsByKeys(normalizeTools(search.list), search.keys, search.q);
             expect(results).toEqual(search.expectedResults);
         });
     });
@@ -116,9 +116,15 @@ describe("test helpers in tool searching utilities", () => {
     it("test tool fuzzy search", async () => {
         const expectedResults = ["__FILTER_FAILED_DATASETS__", "__FILTER_EMPTY_DATASETS__"];
         const keys = { description: 1, name: 2, combined: 0 };
-        const queries = ["Fillter", " filtr", "FILYER", "Fitler", "datases from a collection", "from a colleection"];
+        const filterQueries = ["Fillter", "FILYER", " Fitler", " filtr"];
+        filterQueries.forEach((q) => {
+            const { results, closestTerm } = searchToolsByKeys(normalizeTools(toolsList), keys, q);
+            expect(results).toEqual(expectedResults);
+            expect(closestTerm).toEqual("filter");
+        });
+        const queries = ["datases from a collection", "from a colleection"];
         queries.forEach((q) => {
-            const results = searchToolsByKeys(normalizeTools(toolsList), keys, q);
+            const { results } = searchToolsByKeys(normalizeTools(toolsList), keys, q);
             expect(results).toEqual(expectedResults);
         });
     });

--- a/client/src/utils/levenshtein.js
+++ b/client/src/utils/levenshtein.js
@@ -18,7 +18,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 */
 // Compute the edit distance between the two given strings
 //exports.getEditDistance = function(a, b){
-function levenshteinDistance(a, b) {
+function levenshteinDistance(a, b, transpose=false) {
     if (a.length === 0) {
         return b.length;
     }
@@ -50,9 +50,15 @@ function levenshteinDistance(a, b) {
                     matrix[i - 1][j - 1] + 1, // substitution
                     Math.min(
                         matrix[i][j - 1] + 1, // insertion
-                        matrix[i - 1][j] + 1
+                        matrix[i - 1][j] + 1 // deletion
                     )
-                ); // deletion
+                );
+                if (transpose == true){
+                    // Check for transpostions
+                    if (i > 1 && j > 1 && b.charAt(i - 1) === a.charAt(j - 2) && b.charAt(i - 2) === a.charAt(j - 1)) {
+                        matrix[i][j] = Math.min(matrix[i][j], matrix[i - 2][j - 2] + 1);
+                    }
+                }
             }
         }
     }

--- a/client/src/utils/levenshtein.js
+++ b/client/src/utils/levenshtein.js
@@ -18,7 +18,7 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 */
 // Compute the edit distance between the two given strings
 //exports.getEditDistance = function(a, b){
-function levenshteinDistance(a, b, transpose=false) {
+function levenshteinDistance(a, b, transpose = false) {
     if (a.length === 0) {
         return b.length;
     }
@@ -53,7 +53,7 @@ function levenshteinDistance(a, b, transpose=false) {
                         matrix[i - 1][j] + 1 // deletion
                     )
                 );
-                if (transpose == true){
+                if (transpose == true) {
                     // Check for transpostions
                     if (i > 1 && j > 1 && b.charAt(i - 1) === a.charAt(j - 2) && b.charAt(i - 2) === a.charAt(j - 1)) {
                         matrix[i][j] = Math.min(matrix[i][j], matrix[i - 2][j - 2] + 1);


### PR DESCRIPTION
Why: hackathon project: When searching for a tool using the front end search, the user should be able to make small typos and still receive search results.

What: On tool search an exact substring match is checked to see if a tool matches. If this fails, a modified form of the Damerau–Levenshtein distance algorithm is applied to to find similar results. 

[Galaxy.webm](https://user-images.githubusercontent.com/62220253/228048996-24b3889a-1bbe-4c08-8d37-8d55926edcef.webm)


## How to test the changes?

- [ ] Instructions for manual testing are as follows:
  1. Click the tool search bar to enter a search
  2. Search for a tool name with both correct and incorrect spelling to see how it appears

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
