### PR TITLE
[22.05] Backport cast job_key to string #15578

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -122,7 +122,7 @@ class JobFilesAPIController(BaseGalaxyAPIController):
 
         job_id = trans.security.decode_id(encoded_job_id)
         job_key = trans.security.encode_id(job_id, kind="jobs_files")
-        if not util.safe_str_cmp(kwargs["job_key"], job_key):
+        if not util.safe_str_cmp(str(kwargs["job_key"]), job_key):
             raise exceptions.ItemAccessibilityException("Invalid job_key supplied.")
 
         # Verify job is active. Don't update the contents of complete jobs.


### PR DESCRIPTION
Backport the commit that casts job_key to a string and fixes https://github.com/galaxyproject/galaxy/issues/15211