### PR TITLE
Fix anonymous user uploads when vault is configured

### DIFF
--- a/lib/galaxy/security/vault.py
+++ b/lib/galaxy/security/vault.py
@@ -195,7 +195,10 @@ class UserVaultWrapper(Vault):
         self.user = user
 
     def read_secret(self, key: str) -> Optional[str]:
-        return self.vault.read_secret(f"user/{self.user.id}/{key}")
+        if self.user:
+            return self.vault.read_secret(f"user/{self.user.id}/{key}")
+        else:
+            return None
 
     def write_secret(self, key: str, value: str) -> None:
         return self.vault.write_secret(f"user/{self.user.id}/{key}", value)


### PR DESCRIPTION
relative to this issue https://github.com/galaxyproject/galaxy/issues/15779  
I noticed this error 
```
File "cheetah_DynamicallyCompiledCheetahTemplate_1679993424_659615_81270.py", line 86, in respond
  File "/shared/mfs/data/dev/galaxy/server/lib/galaxy/security/vault.py", line 201, in read_secret
    return self.vault.read_secret(f"user/{self.user.id}/{key}")
AttributeError: 'NoneType' object has no attribute 'id'
```
I tried it on our test server, it solved the error. 
Thomas

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
