### PR TITLE
Drop use_legacy_history from config 

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1941,18 +1941,6 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~
-``use_legacy_history``
-~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Server-wide default selection to use the legacy history during the
-    transition period, after which this option will disappear.  Users
-    will remain able to swap back and forth per their preference.
-:Default: ``false``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``user_preferences_extra_conf_path``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1244,11 +1244,6 @@ galaxy:
   # <config_dir>.
   #trs_servers_config_file: trs_servers_conf.yml
 
-  # Server-wide default selection to use the legacy history during the
-  # transition period, after which this option will disappear.  Users
-  # will remain able to swap back and forth per their preference.
-  #use_legacy_history: false
-
   # Location of the configuration file containing extra user
   # preferences.
   # The value of this option will be resolved with respect to

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1396,15 +1396,6 @@ mapping:
           If this is null (the default), a simple configuration containing
           just Dockstore will be used.
 
-      use_legacy_history:
-        type: bool
-        default: false
-        required: false
-        desc: |
-          Server-wide default selection to use the legacy history during the
-          transition period, after which this option will disappear.  Users will
-          remain able to swap back and forth per their preference.
-
       user_preferences_extra_conf_path:
         type: str
         default: 'user_preferences_extra_conf.yml'

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -156,7 +156,6 @@ class ConfigSerializer(base.ModelSerializer):
             "enable_unique_workflow_defaults": _use_config,
             "enable_beta_markdown_export": _use_config,
             "enable_beacon_integration": _use_config,
-            "use_legacy_history": _use_config,
             "simplified_workflow_run_ui": _use_config,
             "simplified_workflow_run_ui_target_history": _use_config,
             "simplified_workflow_run_ui_job_cache": _use_config,


### PR DESCRIPTION
Just cleanup.  This is no longer possible, drops config setting (that does nothing).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
