### PR TITLE
Fix WorkflowDisplay error message handling

### DIFF
--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.test.js
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.test.js
@@ -17,9 +17,7 @@ function mountDefault() {
     axiosMock.onGet(`/api/workflows/workflow_id/download?style=preview`).reply(200, data);
     return mount(MountTarget, {
         propsData: {
-            args: {
-                workflow_id: "workflow_id",
-            },
+            workflowId: "workflow_id",
             embedded: false,
             expanded: false,
         },
@@ -35,9 +33,7 @@ function mountError(errContent) {
     axiosMock.onGet(`/api/workflows/workflow_id/download?style=preview`).reply(400, data);
     return mount(MountTarget, {
         propsData: {
-            args: {
-                workflow_id: "workflow_id",
-            },
+            workflowId: "workflow_id",
             embedded: false,
             expanded: false,
         },

--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
@@ -1,49 +1,43 @@
-<script setup>
+<script setup lang="ts">
 import axios from "axios";
 import { computed, ref, onMounted } from "vue";
-import { withPrefix } from "utils/redirect";
-import LoadingSpan from "components/LoadingSpan";
-import WorkflowTree from "./WorkflowTree";
+import { withPrefix } from "@/utils/redirect";
+import LoadingSpan from "@/components/LoadingSpan.vue";
+import WorkflowTree from "./WorkflowTree.vue";
 
-const props = defineProps({
-    args: {
-        type: Object,
-        required: true,
-    },
-    embedded: {
-        type: Boolean,
-        default: false,
-    },
-    expanded: {
-        type: Boolean,
-        default: false,
-    },
+interface WorkflowDisplayProps {
+    workflowId: string;
+    embedded?: boolean;
+    expanded?: boolean;
+}
+
+const props = withDefaults(defineProps<WorkflowDisplayProps>(), {
+    embedded: false,
+    expanded: false,
 });
 
-const errorContent = ref(null);
-const itemContent = ref(null);
+type ItemContent = {
+    name: string;
+    steps: Array<any>; // This isn't actually a proper workflow step type, right?  TODO, unify w/ workflowStepStore?
+};
+
+const errorContent = ref();
+const itemContent = ref<ItemContent | null>(null);
 const loading = ref(true);
 
 const workflowName = computed(() => (itemContent.value ? itemContent.value.name : "..."));
-const downloadUrl = computed(() =>
-    withPrefix(`/api/workflows/${props.args.workflow_id}/download?format=json-download`)
-);
-const importUrl = computed(() => withPrefix(`/workflow/imp?id=${props.args.workflow_id}`));
-const itemUrl = computed(() => withPrefix(`/api/workflows/${props.args.workflow_id}/download?style=preview`));
-
-const showError = computed(() => errorContent.value !== null);
-const showItem = computed(() => itemContent.value !== null);
+const downloadUrl = computed(() => withPrefix(`/api/workflows/${props.workflowId}/download?format=json-download`));
+const importUrl = computed(() => withPrefix(`/workflow/imp?id=${props.workflowId}`));
+const itemUrl = computed(() => withPrefix(`/api/workflows/${props.workflowId}/download?style=preview`));
 
 onMounted(async () => {
     axios
         .get(itemUrl.value)
         .then((response) => {
-            console.debug(response);
             itemContent.value = response.data;
             loading.value = false;
         })
         .catch((error) => {
-            console.debug(error);
             errorContent.value = error.response.data.err_msg;
             loading.value = false;
         });
@@ -86,7 +80,7 @@ onMounted(async () => {
         <b-card-body>
             <LoadingSpan v-if="loading" message="Loading Workflow" />
             <div v-else :class="!expanded && 'content-height'">
-                <b-alert v-if="showError" variant="danger" show>
+                <b-alert v-if="errorContent !== null" variant="danger" show>
                     <b>Please fix the following error(s):</b>
                     <ul v-if="typeof errorContent === 'object'" class="my-2">
                         <li v-for="(errorValue, errorKey) in errorContent" :key="errorKey">
@@ -95,8 +89,8 @@ onMounted(async () => {
                     </ul>
                     <div v-else>{{ errorContent }}</div>
                 </b-alert>
-                <div v-if="showItem">
-                    <div v-for="step in itemContent.steps" :key="step.order_index" class="mb-2">
+                <div v-if="itemContent !== null">
+                    <div v-for="step in itemContent?.steps" :key="step.order_index" class="mb-2">
                         <div>Step {{ step.order_index + 1 }}: {{ step.label }}</div>
                         <WorkflowTree :input="step" :skip-head="true" />
                     </div>

--- a/client/src/components/Markdown/MarkdownContainer.vue
+++ b/client/src/components/Markdown/MarkdownContainer.vue
@@ -81,7 +81,10 @@ const isVisible = computed(() => !isCollapsible.value || toggle.value);
             <InvocationTime v-else-if="name == 'invocation_time'" :args="args" :invocations="invocations" />
             <JobMetrics v-else-if="name == 'job_metrics'" :args="args" />
             <JobParameters v-else-if="name == 'job_parameters'" :args="args" />
-            <WorkflowDisplay v-else-if="name == 'workflow_display'" :args="args" :workflows="workflows" />
+            <WorkflowDisplay
+                v-else-if="name == 'workflow_display'"
+                :workflow-id="args.workflow_id"
+                :workflows="workflows" />
             <Visualization v-else-if="name == 'visualization'" :args="args" />
             <HistoryDatasetCollectionDisplay
                 v-else-if="name == 'history_dataset_collection_display'"

--- a/client/src/components/Workflow/WorkflowPublished.vue
+++ b/client/src/components/Workflow/WorkflowPublished.vue
@@ -1,7 +1,7 @@
 <template>
     <Published :item="workflow">
         <template v-slot>
-            <WorkflowDisplay :args="{ workflow_id: id }" :workflow="workflow" :expanded="true" />
+            <WorkflowDisplay :workflow-id="id" :workflow="workflow" :expanded="true" />
         </template>
     </Published>
 </template>

--- a/client/src/utils/simple-error.ts
+++ b/client/src/utils/simple-error.ts
@@ -1,4 +1,6 @@
 export function errorMessageAsString(e: any, defaultMessage = "Request failed.") {
+    // Note that despite the name, this can actually currently return an object,
+    // depending on what data.err_msg is (e.g. an object)
     let message = defaultMessage;
     if (e && e.response && e.response.data && e.response.data.err_msg) {
         message = e.response.data.err_msg;


### PR DESCRIPTION
Resolves the two currently failing jest tests in dev.  The issue was relying on an API endpoint returning an object as `err_message` instead of a string before when it should probably be returning a message, with some associated error data in another field.  With recent changes to error handling, this 

This fixes the client as-is, but @jmchilton is going to follow up on updating the backend (xref #15868)  and then we can re-adapt this to handle the updated response.  We did need to swap away from `urlData` with the simple error handling either way.

Also converts the component to composition/typescript.

Swaps WorkflowDisplay to take a `workflowId` prop, instead of a bag of `args` that was unpacked to `workflowId` -- these components should take the most specific props possible.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
