### PR TITLE
Stronger typing around galaxy exceptions.

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -15,6 +15,7 @@ bit web-oriented. However this module is a dependency of modules and tools that
 have nothing to do with the web - keep this in mind when defining exception names
 and messages.
 """
+from typing import Optional
 
 from .error_codes import (
     error_codes_by_name,
@@ -25,18 +26,19 @@ from .error_codes import (
 class MessageException(Exception):
     """Most generic Galaxy exception - indicates merely that some exceptional condition happened."""
 
+    err_msg: str
     # status code to be set when used with API.
     status_code: int = 400
     # Error code information embedded into API json responses.
     err_code: ErrorCode = error_codes_by_name["UNKNOWN"]
 
-    def __init__(self, err_msg=None, type="info", **extra_error_info):
+    def __init__(self, err_msg: Optional[str] = None, type="info", **extra_error_info):
         self.err_msg = err_msg or self.err_code.default_error_message
         self.type = type
         self.extra_error_info = extra_error_info
 
     @staticmethod
-    def from_code(status_code, message):
+    def from_code(status_code: int, message: Optional[str]) -> "MessageException":
         exception_class = MessageException
         if status_code == 404:
             exception_class = ObjectNotFound
@@ -44,7 +46,7 @@ class MessageException(Exception):
             exception_class = InternalServerError
         return exception_class(message)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.err_msg
 
 

--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -38,7 +38,7 @@ class MessageException(Exception):
         self.extra_error_info = extra_error_info
 
     @staticmethod
-    def from_code(status_code: int, message: Optional[str]) -> "MessageException":
+    def from_code(status_code: int, message: Optional[str] = None) -> "MessageException":
         exception_class = MessageException
         if status_code == 404:
             exception_class = ObjectNotFound

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -2514,9 +2514,9 @@ def populate_module_and_state(
         if step_errors:
             raise exceptions.MessageException(step_errors, err_data={step.order_index: step_errors})
         if step.upgrade_messages:
+            upgrade_messages = step.upgrade_messages
+            error_message = f'Workflow step "{step.id}" had upgrade messages: {upgrade_messages}'
             if allow_tool_state_corrections:
-                log.debug('Workflow step "%i" had upgrade messages: %s', step.id, step.upgrade_messages)
+                log.debug(error_message)
             else:
-                raise exceptions.MessageException(
-                    step.upgrade_messages, err_data={step.order_index: step.upgrade_messages}
-                )
+                raise exceptions.MessageException(error_message, err_data={step.order_index: upgrade_messages})


### PR DESCRIPTION
Fix err_msg backend issue.

My best guess at what the catch in https://github.com/galaxyproject/galaxy/pull/15865/files#diff-9864b6f83dde2c85ad9393e310363db7bd12a6b3c2747674b9b9a768eb8614e4R42 but I would need to play around with it.

```typescript
        .catch((error) => {
            const errData = error?.response?.data?.err_data;
            if( errData ) {
                 errorContent.value = Object.values(errData)[0];
            } else {
                 errorContent.value = errorMessageAsString(error);
            }
            loading.value = false;
        });

```

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
