### PR TITLE
[23.0] AWS Batch python dependency bugfix

### DIFF
--- a/lib/galaxy/jobs/runners/aws.py
+++ b/lib/galaxy/jobs/runners/aws.py
@@ -597,6 +597,7 @@ class AWSBatchJobRunner(AsynchronousJobRunner):
             "exit_code_path": exit_code_path,
             "working_directory": job_wrapper.working_directory,
             "shell": job_wrapper.shell,
+            "galaxy_virtual_env": None,
         }
         job_file_contents = self.get_job_file(job_wrapper, **job_script_props)
         self.write_executable_script(job_file, job_file_contents, job_io=job_wrapper.job_io)


### PR DESCRIPTION
Disable galaxy virtual env for aws batch job runner.  This was causing some containers to attempt to use galaxy's python dependencies which are unavailable to batch, instead of container-installed dependencies as appropriate.  Thanks @jmchilton 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. Try running a python tool that uses pandas

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
