### PR TITLE
[23.0] Don't set datatype for optional datasets that were not provided

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -47,7 +47,6 @@ if TYPE_CHECKING:
     from galaxy.model.metadata import MetadataCollection
     from galaxy.tools import Tool
     from galaxy.tools.parameters.basic import (
-        BaseDataToolParameter,
         SelectToolParameter,
         ToolParameter,
     )
@@ -357,22 +356,12 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         io_type: str = "input",
         formats: Optional[List[str]] = None,
     ) -> None:
+        dataset_instance: Optional[DatasetInstance] = None
         if not dataset:
-            dataset_instance: Optional[DatasetInstance] = None
-            ext = "data"
-            if tool is not None and name is not None:
-                try:
-                    tool_input = tool.inputs[name]
-                    if TYPE_CHECKING:
-                        assert isinstance(tool_input, BaseDataToolParameter)
-                    # TODO: allow this to work when working with grouping
-                    ext = tool_input.extensions[0]
-                except Exception:
-                    pass
             self.dataset = cast(
                 DatasetInstance,
                 wrap_with_safe_string(
-                    NoneDataset(datatypes_registry=datatypes_registry, ext=ext),
+                    NoneDataset(datatypes_registry=datatypes_registry),
                     no_wrap_classes=ToolParameterValueWrapper,
                 ),
             )

--- a/test/functional/tools/data_optional.xml
+++ b/test/functional/tools/data_optional.xml
@@ -1,0 +1,31 @@
+<tool id="data_optional" name="data select" version="1.0.0">
+    <command><![CDATA[
+        echo INPUT $names >> '$output' &&
+
+        ## verify that ext is "data" for absent optional input
+        echo INPUT ext $names.ext >> '$output' &&
+
+        ## verify that is_of_type for absent optional input
+        ## does not evaluate to True for any of the allowed datatypes
+        echo ISOFTYPE mothur.names $names.is_of_type("mothur.names") >> '$output' &&
+        echo ISOFTYPE mothur.count_table $names.is_of_type("mothur.count_table") >> '$output'
+    ]]></command>
+    <inputs>
+        <param name="names" type="data" format="mothur.names,mothur.count_table" optional="true"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="INPUT None" />
+                    <has_line line="INPUT ext data" />
+                    <has_line line="ISOFTYPE mothur.names False" />
+                    <has_line line="ISOFTYPE mothur.count_table False" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -45,6 +45,7 @@
   <tool file="tool_provided_metadata_12.xml" />
   <tool file="empty_datasets.xml" />
   <tool file="is_of_type.xml" />
+  <tool file="data_optional.xml" />
   <tool file="inputs_as_json.xml" />
   <tool file="inputs_as_json_profile.xml" />
   <tool file="inputs_as_json_with_paths.xml" />


### PR DESCRIPTION
Minimal version of https://github.com/galaxyproject/galaxy/pull/15870. I don't think we should add the extra refactorings, I am in particular not convinced we should place those asserts.
 
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
