### PR TITLE
Show backend search errors in hist panel

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -51,7 +51,13 @@
             <b-form-input v-model="filterSettings['tag:']" size="sm" placeholder="any tag" />
             <small class="mt-1">Filter by state:</small>
             <b-input-group>
-                <b-form-input v-model="filterSettings['state:']" size="sm" placeholder="any state" list="stateSelect" />
+                <b-form-input
+                    v-model="filterSettings['state:']"
+                    v-b-tooltip.focus.v-danger="hasError('state:')"
+                    :class="hasError('state:') && 'ui-input-error'"
+                    size="sm"
+                    placeholder="any state"
+                    list="stateSelect" />
                 <b-form-datalist id="stateSelect" :options="states"></b-form-datalist>
                 <b-input-group-append>
                     <b-button title="States Help" size="sm" @click="showHelp = true">
@@ -65,25 +71,25 @@
             <small class="mt-1">Filter by related to item index:</small>
             <b-form-input
                 v-model="filterSettings['related:']"
-                v-b-tooltip="hasError('related')"
+                v-b-tooltip.focus.v-danger="hasError('related:')"
+                :class="hasError('related:') && 'ui-input-error'"
                 size="sm"
-                placeholder="index equals"
-                :autofocus="hasError('related') !== ''" />
+                placeholder="index equals" />
             <small class="mt-1">Filter by item index:</small>
             <b-form-group class="m-0">
                 <b-input-group>
                     <b-form-input
                         v-model="filterSettings['hid>']"
-                        v-b-tooltip="hasError('hid', 'gt')"
+                        v-b-tooltip.focus.v-danger="hasError('hid>')"
+                        :class="hasError('hid>') && 'ui-input-error'"
                         size="sm"
-                        placeholder="index greater"
-                        :autofocus="hasError('hid', 'gt') !== ''" />
+                        placeholder="index greater" />
                     <b-form-input
                         v-model="filterSettings['hid<']"
-                        v-b-tooltip="hasError('hid', 'lt')"
+                        v-b-tooltip.focus.v-danger="hasError('hid<')"
+                        :class="hasError('hid<') && 'ui-input-error'"
                         size="sm"
-                        placeholder="index lower"
-                        :autofocus="hasError('hid', 'lt') !== ''" />
+                        placeholder="index lower" />
                 </b-input-group>
             </b-form-group>
             <small class="mt-1">Filter by creation time:</small>
@@ -91,19 +97,19 @@
                 <b-input-group>
                     <b-form-input
                         v-model="create_time_gt"
-                        v-b-tooltip="hasError('create_time', 'gt')"
+                        v-b-tooltip.focus.v-danger="hasError('create_time>')"
+                        :class="hasError('create_time>') && 'ui-input-error'"
                         size="sm"
-                        placeholder="created after"
-                        :autofocus="hasError('create_time', 'gt') !== ''" />
+                        placeholder="created after" />
                     <b-input-group-append>
                         <b-form-datepicker v-model="create_time_gt" reset-button button-only size="sm" />
                     </b-input-group-append>
                     <b-form-input
                         v-model="create_time_lt"
-                        v-b-tooltip="hasError('create_time', 'lt')"
+                        v-b-tooltip.focus.v-danger="hasError('create_time<')"
+                        :class="hasError('create_time<') && 'ui-input-error'"
                         size="sm"
-                        placeholder="created before"
-                        :autofocus="hasError('create_time', 'lt') !== ''" />
+                        placeholder="created before" />
                     <b-input-group-append>
                         <b-form-datepicker v-model="create_time_lt" reset-button button-only size="sm" />
                     </b-input-group-append>
@@ -140,7 +146,7 @@ export default {
     props: {
         filterText: { type: String, default: null },
         showAdvanced: { type: Boolean, default: false },
-        searchError: { type: Object, required: false },
+        searchError: { type: Object, default: null },
     },
     data() {
         return {
@@ -173,20 +179,14 @@ export default {
             this.create_time_gt = this.filterSettings["create_time>"];
             this.create_time_lt = this.filterSettings["create_time<"];
         },
-        searchError(newVal) {
-            if (newVal) {
-                this.onToggle();
-            }
+        showAdvanced(newVal) {
+            this.showHelp = !newVal ? false : this.showHelp;
         },
     },
     methods: {
-        hasError(col, op = "eq") {
-            if (
-                this.searchError &&
-                (this.searchError.column == col || this.searchError.col == col) &&
-                (this.searchError.operation == op || this.searchError.op == op)
-            ) {
-                return this.searchError.ValueError || this.searchError.err_msg;
+        hasError(field) {
+            if (this.searchError && this.searchError.filter == field) {
+                return this.searchError.typeError || this.searchError.msg;
             }
             return "";
         },

--- a/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
+++ b/client/src/components/History/CurrentHistory/HistoryFilters/HistoryFilters.vue
@@ -63,22 +63,47 @@
             <small>Filter by database:</small>
             <b-form-input v-model="filterSettings['genome_build:']" size="sm" placeholder="any database" />
             <small class="mt-1">Filter by related to item index:</small>
-            <b-form-input v-model="filterSettings['related:']" size="sm" placeholder="index equals" />
+            <b-form-input
+                v-model="filterSettings['related:']"
+                v-b-tooltip="hasError('related')"
+                size="sm"
+                placeholder="index equals"
+                :autofocus="hasError('related') !== ''" />
             <small class="mt-1">Filter by item index:</small>
             <b-form-group class="m-0">
                 <b-input-group>
-                    <b-form-input v-model="filterSettings['hid>']" size="sm" placeholder="index greater" />
-                    <b-form-input v-model="filterSettings['hid<']" size="sm" placeholder="index lower" />
+                    <b-form-input
+                        v-model="filterSettings['hid>']"
+                        v-b-tooltip="hasError('hid', 'gt')"
+                        size="sm"
+                        placeholder="index greater"
+                        :autofocus="hasError('hid', 'gt') !== ''" />
+                    <b-form-input
+                        v-model="filterSettings['hid<']"
+                        v-b-tooltip="hasError('hid', 'lt')"
+                        size="sm"
+                        placeholder="index lower"
+                        :autofocus="hasError('hid', 'lt') !== ''" />
                 </b-input-group>
             </b-form-group>
             <small class="mt-1">Filter by creation time:</small>
             <b-form-group class="m-0">
                 <b-input-group>
-                    <b-form-input v-model="create_time_gt" size="sm" placeholder="created after" />
+                    <b-form-input
+                        v-model="create_time_gt"
+                        v-b-tooltip="hasError('create_time', 'gt')"
+                        size="sm"
+                        placeholder="created after"
+                        :autofocus="hasError('create_time', 'gt') !== ''" />
                     <b-input-group-append>
                         <b-form-datepicker v-model="create_time_gt" reset-button button-only size="sm" />
                     </b-input-group-append>
-                    <b-form-input v-model="create_time_lt" size="sm" placeholder="created before" />
+                    <b-form-input
+                        v-model="create_time_lt"
+                        v-b-tooltip="hasError('create_time', 'lt')"
+                        size="sm"
+                        placeholder="created before"
+                        :autofocus="hasError('create_time', 'lt') !== ''" />
                     <b-input-group-append>
                         <b-form-datepicker v-model="create_time_lt" reset-button button-only size="sm" />
                     </b-input-group-append>
@@ -115,6 +140,7 @@ export default {
     props: {
         filterText: { type: String, default: null },
         showAdvanced: { type: Boolean, default: false },
+        searchError: { type: Object, required: false },
     },
     data() {
         return {
@@ -147,8 +173,23 @@ export default {
             this.create_time_gt = this.filterSettings["create_time>"];
             this.create_time_lt = this.filterSettings["create_time<"];
         },
+        searchError(newVal) {
+            if (newVal) {
+                this.onToggle();
+            }
+        },
     },
     methods: {
+        hasError(col, op = "eq") {
+            if (
+                this.searchError &&
+                (this.searchError.column == col || this.searchError.col == col) &&
+                (this.searchError.operation == op || this.searchError.op == op)
+            ) {
+                return this.searchError.ValueError || this.searchError.err_msg;
+            }
+            return "";
+        },
         onOption(name, value) {
             this.filterSettings[name] = value;
         },

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -344,8 +344,12 @@ export default {
                 this.searchError = null;
                 this.loading = false;
             } catch (error) {
-                console.error("HistoryPanel - Load items error.", error);
-                this.searchError = error.err_msg ? error : null;
+                if (error.response && error.response.data && error.response.data.err_msg) {
+                    console.debug("HistoryPanel - Load items error:", error.response.data.err_msg);
+                    this.searchError = error.response.data;
+                } else {
+                    console.debug("HistoryPanel - Load items error.", error);
+                }
                 this.loading = false;
             }
         },

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -94,10 +94,10 @@
                         </b-alert>
                         <div v-else-if="itemsLoaded.length === 0">
                             <HistoryEmpty v-if="queryDefault" class="m-2" />
-                            <b-alert v-else-if="searchError" class="m-2" variant="danger" show>
+                            <b-alert v-else-if="formattedSearchError" class="m-2" variant="danger" show>
                                 Error in filter:
                                 <a href="javascript:void(0)" @click="showAdvanced = true">
-                                    {{ formattedSearchError.filter }}'{{ formattedSearchError.value }}''
+                                    {{ formattedSearchError.filter }}'{{ formattedSearchError.value }}'
                                 </a>
                             </b-alert>
                             <b-alert v-else class="m-2" variant="info" show>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -93,6 +93,9 @@
                         </b-alert>
                         <div v-else-if="itemsLoaded.length === 0">
                             <HistoryEmpty v-if="queryDefault" class="m-2" />
+                            <b-alert v-else-if="historySearchError" class="m-2" variant="danger" show>
+                                {{ historySearchError }}
+                            </b-alert>
                             <b-alert v-else class="m-2" variant="info" show>
                                 No data found for selected filter.
                             </b-alert>
@@ -247,6 +250,10 @@ export default {
         isWatching() {
             const { getWatchingVisibility } = storeToRefs(useHistoryItemsStore());
             return getWatchingVisibility.value;
+        },
+        /** @returns {String} */
+        historySearchError() {
+            return useHistoryItemsStore().error[`${this.historyId}-${this.filterText}`];
         },
         /** @returns {String} */
         storeFilterText() {

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -31,7 +31,8 @@
                     v-if="showControls"
                     class="content-operations-filters mx-3"
                     :filter-text.sync="filterText"
-                    :show-advanced.sync="showAdvanced" />
+                    :show-advanced.sync="showAdvanced"
+                    :search-error="searchError" />
                 <section v-if="!showAdvanced">
                     <HistoryDetails
                         :history="history"
@@ -93,8 +94,8 @@
                         </b-alert>
                         <div v-else-if="itemsLoaded.length === 0">
                             <HistoryEmpty v-if="queryDefault" class="m-2" />
-                            <b-alert v-else-if="historySearchError" class="m-2" variant="danger" show>
-                                {{ historySearchError }}
+                            <b-alert v-else-if="searchError" class="m-2" variant="danger" show>
+                                {{ searchErrorMessage }}
                             </b-alert>
                             <b-alert v-else class="m-2" variant="info" show>
                                 No data found for selected filter.
@@ -251,9 +252,14 @@ export default {
             const { getWatchingVisibility } = storeToRefs(useHistoryItemsStore());
             return getWatchingVisibility.value;
         },
-        /** @returns {String} */
-        historySearchError() {
+        /** @returns {Object} */
+        searchError() {
             return useHistoryItemsStore().error[`${this.historyId}-${this.filterText}`];
+        },
+        /** @returns {String} */
+        searchErrorMessage() {
+            const { column, col, operation, op, value, val, err_msg } = this.searchError;
+            return `For filter:"${column || col}-${operation || op}" and value:"${value || val}", Error: ${err_msg}`;
         },
         /** @returns {String} */
         storeFilterText() {

--- a/client/src/stores/history/historyItemsStore.js
+++ b/client/src/stores/history/historyItemsStore.js
@@ -12,7 +12,7 @@ import { mergeArray } from "store/historyStore/model/utilities";
 import { HistoryFilters } from "components/History/HistoryFilters";
 
 const limit = 100;
-const queue = new LastQueue();
+const queue = new LastQueue(1000, true);
 
 export const useHistoryItemsStore = defineStore("historyItemsStore", {
     state: () => ({

--- a/client/src/stores/history/historyItemsStore.js
+++ b/client/src/stores/history/historyItemsStore.js
@@ -16,6 +16,7 @@ const queue = new LastQueue();
 
 export const useHistoryItemsStore = defineStore("historyItemsStore", {
     state: () => ({
+        error: {},
         items: {},
         itemKey: "hid",
         totalMatchesCount: undefined,
@@ -73,6 +74,10 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
                 const payload = data.contents;
                 const relatedHid = HistoryFilters.getFilterValue(filterText, "related");
                 this.saveHistoryItems(historyId, payload, relatedHid);
+            })
+            .catch((error) => {
+                console.error(error);
+                Vue.set(this.error, `${historyId}-${filterText}`, error);
             });
         },
         // Setters

--- a/client/src/stores/history/historyItemsStore.js
+++ b/client/src/stores/history/historyItemsStore.js
@@ -68,17 +68,18 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
             const params = `v=dev&order=hid&offset=${offset}&limit=${limit}`;
             const url = `/api/histories/${historyId}/contents?${params}&${queryString}`;
             const headers = { accept: "application/vnd.galaxy.history.contents.stats+json" };
-            await queue.enqueue(urlData, { url, headers }, historyId).then((data) => {
-                const stats = data.stats;
-                this.totalMatchesCount = stats.total_matches;
-                const payload = data.contents;
-                const relatedHid = HistoryFilters.getFilterValue(filterText, "related");
-                this.saveHistoryItems(historyId, payload, relatedHid);
-            })
-            .catch((error) => {
-                console.error(error);
-                Vue.set(this.error, `${historyId}-${filterText}`, error);
-            });
+            await queue
+                .enqueue(urlData, { url, headers }, historyId)
+                .then((data) => {
+                    const stats = data.stats;
+                    this.totalMatchesCount = stats.total_matches;
+                    const payload = data.contents;
+                    const relatedHid = HistoryFilters.getFilterValue(filterText, "related");
+                    this.saveHistoryItems(historyId, payload, relatedHid);
+                })
+                .catch((error) => {
+                    Vue.set(this.error, `${historyId}-${filterText}`, error);
+                });
         },
         // Setters
         saveHistoryItems(historyId, payload, relatedHid = null) {

--- a/client/src/stores/history/historyItemsStore.js
+++ b/client/src/stores/history/historyItemsStore.js
@@ -16,7 +16,6 @@ const queue = new LastQueue();
 
 export const useHistoryItemsStore = defineStore("historyItemsStore", {
     state: () => ({
-        error: {},
         items: {},
         itemKey: "hid",
         totalMatchesCount: undefined,
@@ -68,18 +67,13 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
             const params = `v=dev&order=hid&offset=${offset}&limit=${limit}`;
             const url = `/api/histories/${historyId}/contents?${params}&${queryString}`;
             const headers = { accept: "application/vnd.galaxy.history.contents.stats+json" };
-            await queue
-                .enqueue(urlData, { url, headers }, historyId)
-                .then((data) => {
-                    const stats = data.stats;
-                    this.totalMatchesCount = stats.total_matches;
-                    const payload = data.contents;
-                    const relatedHid = HistoryFilters.getFilterValue(filterText, "related");
-                    this.saveHistoryItems(historyId, payload, relatedHid);
-                })
-                .catch((error) => {
-                    Vue.set(this.error, `${historyId}-${filterText}`, error);
-                });
+            return await queue.enqueue(urlData, { url, headers }, historyId).then((data) => {
+                const stats = data.stats;
+                this.totalMatchesCount = stats.total_matches;
+                const payload = data.contents;
+                const relatedHid = HistoryFilters.getFilterValue(filterText, "related");
+                this.saveHistoryItems(historyId, payload, relatedHid);
+            });
         },
         // Setters
         saveHistoryItems(historyId, payload, relatedHid = null) {

--- a/client/src/stores/history/historyItemsStore.js
+++ b/client/src/stores/history/historyItemsStore.js
@@ -12,7 +12,7 @@ import { mergeArray } from "store/historyStore/model/utilities";
 import { HistoryFilters } from "components/History/HistoryFilters";
 
 const limit = 100;
-const queue = new LastQueue(1000, true);
+const queue = new LastQueue();
 
 export const useHistoryItemsStore = defineStore("historyItemsStore", {
     state: () => ({
@@ -67,7 +67,7 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
             const params = `v=dev&order=hid&offset=${offset}&limit=${limit}`;
             const url = `/api/histories/${historyId}/contents?${params}&${queryString}`;
             const headers = { accept: "application/vnd.galaxy.history.contents.stats+json" };
-            return await queue.enqueue(urlData, { url, headers }, historyId).then((data) => {
+            return await queue.enqueue(urlData, { url, headers, errorSimplify: false }, historyId).then((data) => {
                 const stats = data.stats;
                 this.totalMatchesCount = stats.total_matches;
                 const payload = data.contents;

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -213,6 +213,10 @@ $ui-margin-horizontal-large: $margin-v * 2;
     }
 }
 
+.ui-input-error {
+    border-color: $brand-danger;
+}
+
 .ui-textarea {
     @extend .ui-input;
     height: 100px !important;

--- a/client/src/utils/promise-queue.js
+++ b/client/src/utils/promise-queue.js
@@ -5,9 +5,8 @@
  * See also: https://stackoverflow.com/questions/53540348/js-async-await-tasks-queue
  */
 export class LastQueue {
-    constructor(throttlePeriod = 1000, urlHeaders = false) {
+    constructor(throttlePeriod = 1000) {
         this.throttlePeriod = throttlePeriod;
-        this.urlHeaders = urlHeaders;
         this.nextPromise = {};
         this.pendingPromise = false;
     }
@@ -27,20 +26,8 @@ export class LastQueue {
             delete this.nextPromise[nextKey];
             this.pendingPromise = true;
             try {
-                if (this.urlHeaders) {
-                    const { url, headers } = item.args;
-                    const response = await fetch(url, { headers });
-                    if (!response.ok) {
-                        const error = await response.json();
-                        item.reject(error);
-                    } else {
-                        const payload = await response.json();
-                        item.resolve(payload);
-                    }
-                } else {
-                    const payload = await item.action(item.args);
-                    item.resolve(payload);
-                }
+                const payload = await item.action(item.args);
+                item.resolve(payload);
             } catch (e) {
                 item.reject(e);
             } finally {

--- a/client/src/utils/promise-queue.js
+++ b/client/src/utils/promise-queue.js
@@ -5,8 +5,9 @@
  * See also: https://stackoverflow.com/questions/53540348/js-async-await-tasks-queue
  */
 export class LastQueue {
-    constructor(throttlePeriod = 1000) {
+    constructor(throttlePeriod = 1000, urlHeaders = false) {
         this.throttlePeriod = throttlePeriod;
+        this.urlHeaders = urlHeaders;
         this.nextPromise = {};
         this.pendingPromise = false;
     }
@@ -26,13 +27,18 @@ export class LastQueue {
             delete this.nextPromise[nextKey];
             this.pendingPromise = true;
             try {
-                const { url, headers } = item.args;
-                const response = await fetch(url, { headers });
-                if (!response.ok) {
-                    const error = await response.json();
-                    item.reject(error);
+                if (this.urlHeaders) {
+                    const { url, headers } = item.args;
+                    const response = await fetch(url, { headers });
+                    if (!response.ok) {
+                        const error = await response.json();
+                        item.reject(error);
+                    } else {
+                        const payload = await response.json();
+                        item.resolve(payload);
+                    }
                 } else {
-                    const payload = await response.json();
+                    const payload = await item.action(item.args);
                     item.resolve(payload);
                 }
             } catch (e) {

--- a/client/src/utils/promise-queue.js
+++ b/client/src/utils/promise-queue.js
@@ -26,8 +26,15 @@ export class LastQueue {
             delete this.nextPromise[nextKey];
             this.pendingPromise = true;
             try {
-                const payload = await item.action(item.args);
-                item.resolve(payload);
+                const { url, headers } = item.args;
+                const response = await fetch(url, { headers });
+                if (!response.ok) {
+                    const error = await response.json();
+                    item.reject(error);
+                } else {
+                    const payload = await response.json();
+                    item.resolve(payload);
+                }
             } catch (e) {
                 item.reject(e);
             } finally {

--- a/client/src/utils/url.js
+++ b/client/src/utils/url.js
@@ -2,14 +2,18 @@ import axios from "axios";
 import { withPrefix } from "utils/redirect";
 import { rethrowSimple } from "utils/simple-error";
 
-export async function urlData({ url, headers, params }) {
+export async function urlData({ url, headers, params, errorSimplify = true }) {
     try {
         headers = headers || {};
         params = params || {};
         const { data } = await axios.get(withPrefix(url), { headers, params });
         return data;
     } catch (e) {
-        rethrowSimple(e);
+        if (errorSimplify) {
+            rethrowSimple(e);
+        } else {
+            throw e;
+        }
     }
 }
 


### PR DESCRIPTION
Currently, if a history panel search is performed and there is an error returned from the backend for an invalid filter/value, we do not show the error to the user. Added an error message to the history listing view as well an indicator in the advanced filters field that produced the backend error.

https://user-images.githubusercontent.com/78516064/236307133-b1489c65-3a06-40f4-ad09-2c624b3028b5.mov

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
