### PR TITLE
[23.0] List tags in ``/api/dataset_collections/{hdca_id}/contents/{parent_id}``

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -3580,6 +3580,8 @@ export interface components {
              * @description The current state of this dataset.
              */
             state: components["schemas"]["galaxy__model__Dataset__states"];
+            /** Tags */
+            tags: string[];
         };
         /**
          * HDASummary

--- a/lib/galaxy/managers/collections_util.py
+++ b/lib/galaxy/managers/collections_util.py
@@ -178,6 +178,7 @@ def dictify_element_reference(element, rank_fuzzy_counts=None, recursive=True, s
             object_details["state"] = element_object.state
             object_details["hda_ldda"] = "hda"
             object_details["history_id"] = element_object.history_id
+            object_details["tags"] = element_object.make_tag_string_list()
 
         dictified["object"] = object_details
     else:

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -646,6 +646,7 @@ class HDAObject(Model):
     state: Dataset.states = DatasetStateField
     hda_ldda: DatasetSourceType = HdaLddaField
     history_id: DecodedDatabaseIdField = HistoryIdField
+    tags: List[str]
 
     class Config:
         extra = Extra.allow  # Can contain more fields like metadata_*


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15878. I don't love it, but the endpoint is paginated, and if we want to show tags in the summary view I think we have to do this.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
