### PR TITLE
Enable per-destination ``container_resolver_config_file``

### DIFF
--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -79,14 +79,16 @@ class ContainerFinder:
         destination_id = destination_info.get("id")  # Probably not the way to get the ID?
         destination_container_registry = None
         if destination_id and destination_id not in self.destination_container_registeries:
-            if "container_resolvers" in destination_info:
+            if "container_resolvers" in destination_info or "container_resolvers_config_file" in destination_info:
                 destination_container_registry = ContainerRegistry(
                     self.app_info,
                     destination_info=destination_info,
                     mulled_resolution_cache=self.mulled_resolution_cache,
                 )
                 self.destination_container_registeries[destination_id] = destination_container_registry
-        elif not destination_id and "container_resolvers" in destination_info:
+        elif not destination_id and (
+            "container_resolvers" in destination_info or "container_resolvers_config_file" in destination_info
+        ):
             destination_container_registry = ContainerRegistry(
                 self.app_info, destination_info=destination_info, mulled_resolution_cache=self.mulled_resolution_cache
             )
@@ -249,9 +251,11 @@ class ContainerRegistry:
         app_conf_file = getattr(app_info, "container_resolvers_config_file", None)
         app_conf_dict = getattr(app_info, "container_resolvers_config_dict", None)
 
-        if destination_info is not None:
-            conf_file = destination_info.get("container_resolvers_config_file", app_conf_file)
-            conf_dict = destination_info.get("container_resolvers", app_conf_dict)
+        if destination_info is not None and (
+            "container_resolvers" in destination_info or "container_resolvers_config_file" in destination_info
+        ):
+            conf_file = destination_info.get("container_resolvers_config_file")
+            conf_dict = destination_info.get("container_resolvers")
         else:
             conf_file = app_conf_file
             conf_dict = app_conf_dict

--- a/test/integration/fallback_container_resolver.yml
+++ b/test/integration/fallback_container_resolver.yml
@@ -1,0 +1,2 @@
+- type: fallback
+  identifier: 'quay.io/biocontainers/bwa:0.7.15--0'


### PR DESCRIPTION
- per destination container_resolvers per `container_resolvers_config_file` did not work because `ContainerFinder` did not check if this key is set  in the `destination_info` (but only `container_resolvers`) this is crucial for job configuration using XML
- per destination container_resolvers did not work if a global config was given with `container_resolvers` and per  destination config used `container_resolvers_config_file`

Why this is needed / how I stumbled over this: Finally had an idea for migrating to containers on my site: I will define a 

- per destination config using `cached_explicit_singularity`, `cached_mulled_singularity`, i.e. this will only pick up containers that have been cached. tools that do not have a container installed will fall back to conda
- global config using `cached_explicit_singularity`, `cached_mulled_singularity`, `mulled_singularity` which allows me to pull containers via AdminUI / API

Unfortunately my job config is still XML, so I need `container_resolvers_config_file` for the per destination config. 

If someone wants to have this backported then I can do. For me it's fine to carry the single commit in my deployment branch for 1 release. 


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
