### PR TITLE
Allow pending inputs in some collection operation tools

### DIFF
--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -694,6 +694,30 @@ class TestToolsApi(ApiTestCase, TestsTools):
             )
             assert zipped_hdca["collection_type"] == "list:paired"
 
+    @skip_without_tool("__EXTRACT_DATASET__")
+    @skip_without_tool("cat_data_and_sleep")
+    def test_database_operation_tool_with_pending_inputs(self):
+        with self.dataset_populator.test_history(require_new=False) as history_id:
+            hdca1_id = self.dataset_collection_populator.create_list_in_history(
+                history_id, contents=["a\nb\nc\nd", "e\nf\ng\nh"], wait=True
+            ).json()["outputs"][0]["id"]
+            self.dataset_populator.run_tool(
+                tool_id="cat_data_and_sleep",
+                inputs={
+                    "sleep_time": 15,
+                    "input1": {"batch": True, "values": [{"src": "hdca", "id": hdca1_id}]},
+                },
+                history_id=history_id,
+            )
+            run_response = self.dataset_populator.run_tool(
+                tool_id="__EXTRACT_DATASET__",
+                inputs={
+                    "data_collection": {"src": "hdca", "id": hdca1_id},
+                },
+                history_id=history_id,
+            )
+            assert run_response["outputs"][0]["state"] != "ok"
+
     @skip_without_tool("__FILTER_FAILED_DATASETS__")
     def test_filter_failed_list(self):
         with self.dataset_populator.test_history(require_new=False) as history_id:


### PR DESCRIPTION
For those tools where it makes sense. We can't of course do this for tools that filter outputs based on dataset size or dataset state, or tools that make decisions based on extra datasets (e.g text files with new identifiers or tags).

As mentioned inline, we could allow more tools to run with pending input collections, but that doesn't work if we need to read an additional file from disk. To be more flexible for those cases we could add more special casing or we could let the job handler loop handle the waiting for datasets for us, neither of which seems worth doing right now.

Does a bit of what is requested in https://github.com/galaxyproject/galaxy/issues/15879

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
