### PR TITLE
[22.01] Fix container resolution for ``type="singularity"`` requirements

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
@@ -1,4 +1,5 @@
 """This module describes the :class:`ExplicitContainerResolver` ContainerResolver plugin."""
+import copy
 import logging
 import os
 
@@ -77,11 +78,10 @@ class CachedExplicitSingularityContainerResolver(CliContainerResolver):
         hence the container_description hack here.
         """
         for container_description in tool_info.container_descriptions:  # type: ContainerDescription
+            container_description = copy.copy(container_description)
             if container_description.type == 'docker':
-                desc_dict = container_description.to_dict()
-                desc_dict['type'] = self.container_type
-                desc_dict['identifier'] = f"docker://{container_description.identifier}"
-                container_description = container_description.from_dict(desc_dict)
+                container_description.type = self.container_type
+                container_description.identifier = f"docker://{container_description.identifier}"
             if not self._container_type_enabled(container_description, enabled_container_types):
                 return None
             if not self.cli_available:


### PR DESCRIPTION
otherwise `container_description.identifier = cache_path` (at the end of the function) will modify the original (i.e. the tools) container description which influences i.e. (may break) successive container resolutions.

Bug occured only for containers of `type="singularity"` .. for explicit docker container requirements a copy was already created by dictifying and undictifying it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

Found this while working on https://github.com/galaxyproject/galaxy/pull/15614 .. tests are coming. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
