### PR TITLE
[23.0] Fix short term storage archive export extension on download

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -1,3 +1,4 @@
+import mimetypes
 from tempfile import NamedTemporaryFile
 from typing import (
     Any,
@@ -125,10 +126,7 @@ def model_store_storage_target(
 ) -> ShortTermStorageTarget:
     cleaned_filename = ready_name_for_url(file_name)
     filename_with_extension = f"{cleaned_filename}.{model_store_format}"
-    if model_store_format.endswith("gz"):
-        mime_type = "application/x-gzip"
-    else:
-        mime_type = "application/x-tar"
+    mime_type = mimetypes.guess_type(filename_with_extension)[0] or "application/octet-stream"
 
     return short_term_storage_allocator.new_target(
         filename_with_extension,

--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -123,14 +123,15 @@ class ServedExportStore(NamedTuple):
 def model_store_storage_target(
     short_term_storage_allocator: ShortTermStorageAllocator, file_name: str, model_store_format: str
 ) -> ShortTermStorageTarget:
-    cleaned_filename = ready_name_for_url(f"{file_name}.{model_store_format}")
+    cleaned_filename = ready_name_for_url(file_name)
+    filename_with_extension = f"{cleaned_filename}.{model_store_format}"
     if model_store_format.endswith("gz"):
         mime_type = "application/x-gzip"
     else:
         mime_type = "application/x-tar"
 
     return short_term_storage_allocator.new_target(
-        cleaned_filename,
+        filename_with_extension,
         mime_type,
     )
 

--- a/test/unit/webapps/test_service_base.py
+++ b/test/unit/webapps/test_service_base.py
@@ -1,0 +1,37 @@
+from typing import Tuple
+
+import pytest
+
+from galaxy.schema.schema import ModelStoreFormat
+from galaxy.web.short_term_storage import ShortTermStorageAllocator
+from galaxy.webapps.galaxy.services.base import model_store_storage_target
+
+
+class MockShortTermStorageAllocator(ShortTermStorageAllocator):
+    def new_target(self, filename, mime_type):
+        return filename, mime_type
+
+
+@pytest.mark.parametrize(
+    "file_name, model_store_format, expected",
+    [
+        ("My Cool Object", "txt", ("My-Cool-Object.txt", "text/plain")),
+        ("!My Cool Object!", "json", ("My-Cool-Object.json", "application/json")),
+        ("Hello₩◎ґʟⅾ", "xml", ("Hello.xml", "application/xml")),
+        ("test", ModelStoreFormat.ROCRATE_ZIP.value, ("test.rocrate.zip", "application/zip")),
+        ("test", ModelStoreFormat.TAR.value, ("test.tar", "application/x-tar")),
+        ("test", ModelStoreFormat.TGZ.value, ("test.tgz", "application/x-tar")),
+        ("test", ModelStoreFormat.TAR_DOT_GZ.value, ("test.tar.gz", "application/x-tar")),
+        ("test", ModelStoreFormat.BAG_DOT_ZIP.value, ("test.bag.zip", "application/zip")),
+        ("test", ModelStoreFormat.BAG_DOT_TAR.value, ("test.bag.tar", "application/x-tar")),
+        ("test", ModelStoreFormat.BAG_DOT_TGZ.value, ("test.bag.tgz", "application/x-tar")),
+        ("test", ModelStoreFormat.BCO_JSON.value, ("test.bco.json", "application/json")),
+    ],
+)
+def test_model_store_storage_target(file_name: str, model_store_format: str, expected: Tuple[str, str]):
+    mock_sts_allocator = MockShortTermStorageAllocator()
+    actual = model_store_storage_target(
+        short_term_storage_allocator=mock_sts_allocator, file_name=file_name, model_store_format=model_store_format
+    )
+
+    assert actual == expected


### PR DESCRIPTION
Fixes #15840

- The format extension is now preserved on downloads.
- In addition, the mime type is now guessed more consistently on STS (Short Term Storage) exports.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Follow the steps on #15840

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
