### PR TITLE
[23.0] Fix history annotation filtering: make it case insensitive

### DIFF
--- a/lib/galaxy/managers/annotatable.py
+++ b/lib/galaxy/managers/annotatable.py
@@ -4,7 +4,10 @@ Mixins for Annotatable model managers and serializers.
 
 import abc
 import logging
-from typing import Dict
+from typing import (
+    Dict,
+    Optional,
+)
 
 from sqlalchemy.orm import scoped_session
 
@@ -21,7 +24,7 @@ log = logging.getLogger(__name__)
 # needed to extract this for use in manager *and* serializer, ideally, would use self.manager.annotation
 # from serializer, but history_contents has no self.manager
 # TODO: fix
-def _match_by_user(item, user):
+def _match_by_user(item, user) -> Optional[str]:
     if not user:
         return None
     for annotation in item.annotations:
@@ -38,7 +41,7 @@ class AnnotatableManagerMixin:
     def session(self) -> scoped_session:
         ...
 
-    def annotation(self, item):
+    def annotation(self, item) -> Optional[str]:
         """
         Return the annotation string made by the `item`'s owner or `None` if there
         is no annotation.
@@ -106,20 +109,20 @@ class AnnotatableDeserializerMixin:
 class AnnotatableFilterMixin:
     fn_filter_parsers: FunctionFilterParsersType
 
-    def _owner_annotation(self, item):
+    def _owner_annotation(self, item) -> Optional[str]:
         """
         Get the annotation by the item's owner.
         """
         return _match_by_user(item, item.user)
 
-    def filter_annotation_contains(self, item, val):
+    def filter_annotation_contains(self, item, val: str) -> bool:
         """
         Test whether `val` is in the owner's annotation.
         """
         owner_annotation = self._owner_annotation(item)
         if owner_annotation is None:
             return False
-        return val in owner_annotation
+        return val.lower() in owner_annotation.lower()
 
     def _add_parsers(self):
         self.fn_filter_parsers.update(

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -813,6 +813,15 @@ class TestHistoryFilters(BaseTestCase):
         )
         assert shining_examples == [history3]
 
+        case_insensitive_examples = self.history_manager.list(
+            filters=self.filter_parser.parse_filters(
+                [
+                    ("annotation", "contains", "all"),
+                ]
+            )
+        )
+        assert case_insensitive_examples == [history1, history3]
+
     def test_fn_filter_currying(self):
         self.filter_parser.fn_filter_parsers = {"name_len": {"op": {"lt": lambda i, v: len(i.name) < v}, "val": int}}
         self.log("should be 2 filters now")


### PR DESCRIPTION
Partially addresses #15831

This makes the annotation filtering case insensitive in the backend and adds a few type hints while at it.

You still need to use `annotation:something` to get those histories whose annotation contains `something`.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
