### PR TITLE
Exclude tests from TypeScript compilation

### DIFF
--- a/client/tsconfig.webpack.json
+++ b/client/tsconfig.webpack.json
@@ -1,4 +1,4 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["types/*.d.ts", "src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+    "exclude": ["./src/**/*.test.ts", "./tests/**/*.ts"]
 }


### PR DESCRIPTION
Tests were previously compiled by webpack. This is apparent when running the dev server, and including a type error in a test. This change removes tests from being compiled.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create an type error in a `.test.ts` file
  2. Run the dev server

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
