### PR TITLE
Allow importing a workflow from a shared URL

### DIFF
--- a/client/src/components/Workflow/Import/FromFileOrUrl.test.js
+++ b/client/src/components/Workflow/Import/FromFileOrUrl.test.js
@@ -1,0 +1,64 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "tests/jest/helpers";
+import FromFileOrUrl from "./FromFileOrUrl.vue";
+
+let lastPostRequest;
+
+jest.mock("axios", () => ({
+    post: (_url, request) => {
+        lastPostRequest = request;
+    },
+}));
+
+const localVue = getLocalVue(true);
+
+const sharedUrl = "http://127.0.0.1:8081/u/admin/w/unnamed-workflow";
+const sharedUrlTrailingSlash = "http://127.0.0.1:8081/u/admin/w/unnamed-workflow/";
+const sharedUrlJson = "http://127.0.0.1:8081/u/admin/w/unnamed-workflow/json";
+const invalidUrl = "http://127.0.0.1:8081/u/admin/w/unnamed-workflow/additional-stuff/";
+
+describe("FromFileOrUrl", () => {
+    it("converts shared urls to json urls", async () => {
+        const wrapper = mount(FromFileOrUrl, { localVue });
+
+        {
+            const input = wrapper.find("#workflow-import-url-input");
+            await input.setValue(sharedUrl);
+
+            const form = wrapper.find("form");
+            await form.trigger("submit");
+
+            expect(lastPostRequest.get("archive_source")).toEqual(sharedUrlJson);
+        }
+
+        {
+            const input = wrapper.find("#workflow-import-url-input");
+            await input.setValue(sharedUrlTrailingSlash);
+
+            const form = wrapper.find("form");
+            await form.trigger("submit");
+
+            expect(lastPostRequest.get("archive_source")).toEqual(sharedUrlJson);
+        }
+
+        {
+            const input = wrapper.find("#workflow-import-url-input");
+            await input.setValue(sharedUrlJson);
+
+            const form = wrapper.find("form");
+            await form.trigger("submit");
+
+            expect(lastPostRequest.get("archive_source")).toEqual(sharedUrlJson);
+        }
+
+        {
+            const input = wrapper.find("#workflow-import-url-input");
+            await input.setValue(invalidUrl);
+
+            const form = wrapper.find("form");
+            await form.trigger("submit");
+
+            expect(lastPostRequest.get("archive_source")).toEqual(invalidUrl);
+        }
+    });
+});

--- a/client/src/components/Workflow/Import/FromFileOrUrl.vue
+++ b/client/src/components/Workflow/Import/FromFileOrUrl.vue
@@ -28,6 +28,18 @@ const hasErrorMessage = computed(() => {
     return errorMessage.value != null;
 });
 
+function autoAppendJson(urlString: string): string {
+    const sharedWorkflowRegex = /^(https?:\/\/[\S]+\/u\/[\S]+\/w\/[^\s/]+)\/?$/;
+    const matches = urlString.match(sharedWorkflowRegex);
+    const bareUrl = matches?.[1];
+
+    if (bareUrl) {
+        return `${bareUrl}/json`;
+    } else {
+        return urlString;
+    }
+}
+
 const router = useRouter();
 
 async function submit(ev: SubmitEvent) {
@@ -39,7 +51,8 @@ async function submit(ev: SubmitEvent) {
     }
 
     if (sourceURL.value) {
-        formData.append("archive_source", sourceURL.value);
+        const url = autoAppendJson(sourceURL.value);
+        formData.append("archive_source", url);
     }
 
     loading.value = true;


### PR DESCRIPTION
fixes #15658 by automatically appending `/json` to shared workflow urls.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
