### PR TITLE
[23.0] Admin interface navguard

### DIFF
--- a/client/src/components/ClientError.vue
+++ b/client/src/components/ClientError.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+// TODO -- Pretty this up a bit so it's not just a barebones Alert, include
+// general client error verbiage and admin/help contact protocol below.
+//
+// Right now this is only used as a destination for navigation failures
+// (AdminRequired), but could be used for other client errors that need to be
+// presented to the user interrupting the normal flow and context of the app.
+
+import { defineProps } from "vue";
+import Alert from "@/components/Alert.vue";
+
+const props = defineProps<{
+    error: Error;
+}>();
+</script>
+<template>
+    <div class="container error-container"><Alert :message="props.error.message" variant="error" /></div>
+</template>
+<style scoped>
+.error-container {
+    margin: 4rem auto;
+}
+</style>

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -19,6 +19,7 @@ import StorageDashboardRoutes from "entry/analysis/routes/storageDashboardRoutes
 // child components
 import Citations from "components/Citation/Citations";
 import AboutGalaxy from "components/AboutGalaxy.vue";
+import ClientError from "components/ClientError";
 import CollectionEditView from "components/Collections/common/CollectionEditView";
 import CustomBuilds from "components/User/CustomBuilds";
 import DatasetAttributes from "components/DatasetInformation/DatasetAttributes";
@@ -120,6 +121,12 @@ export function getRouter(Galaxy) {
                 path: "/published/workflow",
                 component: WorkflowPublished,
                 props: (route) => ({ id: route.query.id }),
+            },
+            {
+                name: "error",
+                path: "/client-error/",
+                component: ClientError,
+                props: true,
             },
             /** Analysis routes */
             {
@@ -498,16 +505,23 @@ export function getRouter(Galaxy) {
     });
 
     router.beforeEach(async (to, from, next) => {
-        // Check parent hierarchy to see if any routes require admin
+        // TODO: merge anon redirect functionality here for more standard handling
+
+        // Check parent route hierarchy to see if we require admin access here.
+        // Access is required if *any* component in the hierarchy requires it.
         if (to.matched.some((record) => record.meta.requiresAdmin === true)) {
-            next({
-                path: "/login",
-                // save the location we were at to come back later
-                query: { redirect: to.fullPath },
-            });
-        } else {
-            next();
+            const isAdmin = getGalaxyInstance()?.user?.isAdmin() || false;
+            if (!isAdmin) {
+                const error = new Error(`Administrator Access Required for '${to.path}'.`);
+                error.name = "AdminRequired";
+                next(error);
+            }
         }
+        next();
+    });
+
+    router.onError((error) => {
+        router.push({ name: "error", params: { error: error } });
     });
 
     return router;

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -81,7 +81,7 @@ function redirectAnon() {
 
 // produces the client router
 export function getRouter(Galaxy) {
-    return new VueRouter({
+    const router = new VueRouter({
         base: getAppRoot(),
         mode: "history",
         routes: [
@@ -496,4 +496,19 @@ export function getRouter(Galaxy) {
             },
         ],
     });
+
+    router.beforeEach(async (to, from, next) => {
+        // Check parent hierarchy to see if any routes require admin
+        if (to.matched.some((record) => record.meta.requiresAdmin === true)) {
+            next({
+                path: "/login",
+                // save the location we were at to come back later
+                query: { redirect: to.fullPath },
+            });
+        } else {
+            next();
+        }
+    });
+
+    return router;
 }

--- a/client/src/entry/analysis/routes/admin-routes.js
+++ b/client/src/entry/analysis/routes/admin-routes.js
@@ -25,6 +25,7 @@ export default [
     {
         path: "/admin",
         component: Admin,
+        meta: { requiresAdmin: true }, // All children of this route require admin
         children: [
             {
                 path: "",


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15904

Kept this minimal for 23.0, but left a few notes inline.  We should also add e2e test for these routes, and we should overhaul the anonymous user handling as well -- it could continue to redirect back to the root but it should probably be updated to use the navigation guard and we need to kick a message to the user as to why they're back at the homepage randomly.



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
