### PR TITLE
[23.0] Fix tool stdio on pulsar and implement job stdio

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -82,10 +82,8 @@ def build_command(
 
     __handle_task_splitting(commands_builder, job_wrapper)
 
-    externalized = False
     for_pulsar = "pulsar_version" in remote_command_params
     if (container and modify_command_for_container) or job_wrapper.commands_in_new_shell:
-        externalized = True
         if container and modify_command_for_container:
             # Many Docker containers do not have /bin/bash.
             external_command_shell = container.shell
@@ -106,11 +104,9 @@ def build_command(
         else:
             commands_builder = CommandsBuilder(externalized_commands)
 
-    wrap_stdio = externalized or not for_pulsar
-    if wrap_stdio:
-        # Galaxy writes I/O files to outputs, Pulsar uses metadata. metadata seems like
-        # it should be preferred - at least if the directory exists.
-        io_directory = "../metadata" if for_pulsar else "../outputs"
+    if not for_pulsar:
+        # Galaxy writes I/O files to outputs, Pulsar instruments own I/O redirection
+        io_directory = "../outputs"
         commands_builder.capture_stdout_stderr(
             f"{io_directory}/tool_stdout", f"{io_directory}/tool_stderr", stream_stdout_stderr=stream_stdout_stderr
         )

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -619,15 +619,16 @@ class PulsarJobRunner(AsynchronousJobRunner):
         assert isinstance(
             job_state, AsynchronousJobState
         ), f"job_state type is '{type(job_state)}', expected AsynchronousJobState"
-        stderr = stdout = ""
         job_wrapper = job_state.job_wrapper
         try:
             client = self.get_client_from_state(job_state)
             run_results = client.full_status()
             remote_metadata_directory = run_results.get("metadata_directory", None)
-            stdout = run_results.get("stdout", "")
-            stderr = run_results.get("stderr", "")
-            exit_code = run_results.get("returncode", None)
+            tool_stdout = run_results.get("stdout", "")
+            tool_stderr = run_results.get("stderr", "")
+            job_stdout = run_results.get("job_stdout")
+            job_stderr = run_results.get("job_stderr")
+            exit_code = run_results.get("returncode")
             pulsar_outputs = PulsarOutputs.from_status_response(run_results)
             state = job_wrapper.get_state()
             # Use Pulsar client code to transfer/copy files back
@@ -668,9 +669,11 @@ class PulsarJobRunner(AsynchronousJobRunner):
             ):
                 job_metrics_directory = job_wrapper.working_directory
             job_wrapper.finish(
-                stdout,
-                stderr,
+                tool_stdout,
+                tool_stderr,
                 exit_code,
+                job_stdout=job_stdout,
+                job_stderr=job_stderr,
                 remote_metadata_directory=remote_metadata_directory,
                 job_metrics_directory=job_metrics_directory,
             )

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -31,6 +31,7 @@ test_tools = integration_util.integration_tool_runner(
         "vcf_bgzip_test",
         "environment_variables",
         "multi_output_assign_primary_ext_dbkey",
+        "job_properties",
         "strict_shell",
         "tool_provided_metadata_9",
     ]

--- a/test/integration/test_pulsar_embedded_extended_metadata.py
+++ b/test/integration/test_pulsar_embedded_extended_metadata.py
@@ -29,7 +29,7 @@ test_tools = integration_util.integration_tool_runner(
         "version_command_tool_dir",
         "simple_constructs",
         "metadata_bam",
-        # "job_properties",  # https://github.com/galaxyproject/galaxy/issues/11813
+        "job_properties",
         "from_work_dir_glob",
     ]
 )

--- a/test/integration/test_pulsar_embedded_remote_metadata.py
+++ b/test/integration/test_pulsar_embedded_remote_metadata.py
@@ -26,6 +26,6 @@ test_tools = integration_util.integration_tool_runner(
     [
         "simple_constructs",
         "metadata_bam",
-        # "job_properties",  # https://github.com/galaxyproject/galaxy/issues/11813
+        "job_properties",
     ]
 )


### PR DESCRIPTION
split job and tool stdio depends on https://github.com/galaxyproject/pulsar/pull/318, but this works on its own.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
