### PR TITLE
Advanced tool search result tweaks

### DIFF
--- a/client/src/components/ToolsList/ScrollToTopButton.vue
+++ b/client/src/components/ToolsList/ScrollToTopButton.vue
@@ -30,8 +30,8 @@ export default {
 
 <style lang="scss" scoped>
 .back-to-top {
-    bottom: 0.5rem;
-    left: 0.5rem;
+    bottom: 0.25rem;
+    right: 0.25rem;
     position: absolute;
     opacity: 0;
     transition: opacity 0.4s;

--- a/client/src/components/ToolsList/ToolsListItem.vue
+++ b/client/src/components/ToolsList/ToolsListItem.vue
@@ -46,7 +46,7 @@ library.add(faWrench, faExternalLinkAlt, faCheck, faTimes, faAngleDown, faAngleU
 </script>
 
 <template>
-    <div class="tool-list-item ui-portlet-section">
+    <div class="tool-list-item">
         <div class="top-bar bg-secondary px-2 py-1 rounded-right">
             <div class="py-1 d-flex flex-wrap flex-gapx-1">
                 <span>
@@ -82,18 +82,18 @@ library.add(faWrench, faExternalLinkAlt, faCheck, faTimes, faAngleDown, faAngleU
             </div>
         </div>
 
-        <div class="portlet-content">
+        <div class="tool-list-item-content">
             <div class="d-flex flex-gapx-1 py-2">
-                <span v-if="props.section" class="info px-1 rounded">
+                <span v-if="props.section" class="tag info">
                     <b>Section:</b> <b-link :to="`/tools/list?section=${props.section}`">{{ section }}</b-link>
                 </span>
 
-                <span v-if="!props.local" class="info px-1 rounded">
+                <span v-if="!props.local" class="tag info">
                     <FontAwesomeIcon icon="fa-external-link-alt" fixed-width />
                     External
                 </span>
 
-                <span v-if="!props.workflowCompatible" class="warn px-1 rounded">
+                <span v-if="!props.workflowCompatible" class="tag warn">
                     <FontAwesomeIcon icon="fa-exclamation-triangle" />
                     Not Workflow compatible
                 </span>
@@ -121,16 +121,33 @@ library.add(faWrench, faExternalLinkAlt, faCheck, faTimes, faAngleDown, faAngleU
 @import "theme/blue.scss";
 
 .tool-list-item {
+    border-left: solid 3px $brand-secondary;
+    border-radius: 0.25rem;
+
+    .tool-list-item-content {
+        padding-left: 0.5rem;
+    }
+
+    .tag {
+        border-style: solid;
+        border-width: 0 2px 1px 0;
+        border-radius: 4px;
+        padding: 0 0.5rem;
+    }
+
     .info {
         background-color: scale-color($brand-info, $lightness: +75%);
+        border-color: scale-color($brand-info, $lightness: +55%);
     }
 
     .success {
         background-color: scale-color($brand-success, $lightness: +75%);
+        border-color: scale-color($brand-success, $lightness: +55%);
     }
 
     .warn {
         background-color: scale-color($brand-warning, $lightness: +75%);
+        border-color: scale-color($brand-warning, $lightness: +55%);
     }
 
     .top-bar {

--- a/client/src/components/ToolsList/ToolsListItem.vue
+++ b/client/src/components/ToolsList/ToolsListItem.vue
@@ -63,24 +63,22 @@ library.add(faWrench, faExternalLinkAlt, faCheck, faTimes, faAngleDown, faAngleU
                 <span itemprop="description">{{ props.description }}</span>
                 <span>(Galaxy Version {{ props.version }})</span>
             </div>
-            <div>
-                <b-button-group>
-                    <ToolFavoriteButton :id="props.id" />
+            <div class="d-flex align-items-start">
+                <ToolFavoriteButton :id="props.id" />
 
-                    <b-button
-                        v-if="props.local"
-                        class="text-nowrap"
-                        variant="primary"
-                        size="sm"
-                        @click="() => emit('open')">
-                        <FontAwesomeIcon icon="fa-wrench" fixed-width />
-                        Open
-                    </b-button>
-                    <b-button v-else class="text-nowrap" variant="primary" size="sm" :href="props.link">
-                        <FontAwesomeIcon icon="fa-external-link-alt" fixed-width />
-                        Open
-                    </b-button>
-                </b-button-group>
+                <b-button
+                    v-if="props.local"
+                    class="text-nowrap"
+                    variant="primary"
+                    size="sm"
+                    @click="() => emit('open')">
+                    <FontAwesomeIcon icon="fa-wrench" fixed-width />
+                    Open
+                </b-button>
+                <b-button v-else class="text-nowrap" variant="primary" size="sm" :href="props.link">
+                    <FontAwesomeIcon icon="fa-external-link-alt" fixed-width />
+                    Open
+                </b-button>
             </div>
         </div>
 

--- a/client/src/components/ToolsList/ToolsListTable.vue
+++ b/client/src/components/ToolsList/ToolsListTable.vue
@@ -133,7 +133,7 @@ export default {
 .tools-list-table {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 1rem;
 
     .list-end {
         width: 100%;


### PR DESCRIPTION
Minor style adjustments to tool search results:

- makes open button round on all corners to match run button from tool form
- moves scroll to top button to the right, so it doesn't cover text
- move scroll to top button closer to the edge, to avoid confusing alignment
- make item color consistent. It was slightly brighter at the edge before
- make attribute tags look like the tag component tags

![image](https://user-images.githubusercontent.com/44241786/230393251-4cdd2353-02e3-41b5-9208-bca80df27bf2.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
