### PR TITLE
[23.0] Fail linked job if task fails

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2528,6 +2528,15 @@ class TaskWrapper(JobWrapper):
     ):
         log.error(f"TaskWrapper Failure {message}")
         self.status = "error"
+        super().fail(
+            message,
+            exception=exception,
+            tool_stdout=tool_stdout,
+            tool_stderr=tool_stderr,
+            exit_code=exit_code,
+            job_stdout=job_stdout,
+            job_stderr=job_stderr,
+        )
         # How do we want to handle task failure?  Fail the job and let it clean up?
 
     def change_state(self, state, info=False, flush=True, job=None):


### PR DESCRIPTION
I suppose we fixed something in the 23.0 release cycle that makes it necessary to implement failing associated jobs. Fixes the indefinite hand when running the framework tests against pulsar.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

```diff
diff --git a/test/integration/test_pulsar_embedded.py b/test/integration/test_pulsar_embedded.py
index 5a329b52c9..e2a245500d 100644
--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -34,5 +34,6 @@ test_tools = integration_util.integration_tool_runner(
         "job_properties",
         "strict_shell",
         "tool_provided_metadata_9",
+        "parallelism",
     ]
 )
```

run that test and see it fails instead of hanging indefinitely.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
