### PR TITLE
[23.0] Allow messagebox rich contents

### DIFF
--- a/client/src/entry/analysis/App.vue
+++ b/client/src/entry/analysis/App.vue
@@ -18,7 +18,8 @@
                 class="rounded-0 m-0 p-2"
                 :variant="config.message_box_class || 'info'">
                 <span class="fa fa-fw mr-1 fa-exclamation" />
-                <span>{{ config.message_box_content }}</span>
+                <!-- eslint-disable-next-line vue/no-v-html -->
+                <span v-html="config.message_box_content"></span>
             </Alert>
             <Alert
                 v-if="config.show_inactivity_warning && config.inactivity_box_content"


### PR DESCRIPTION
Fixes a regression where the messagebox wasn't accepting html.

![image](https://user-images.githubusercontent.com/155398/230482506-6a9536a1-195e-43fc-9ae1-b58f8386b65e.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
