### PR TITLE
[23.0] Show `HistoryCounter` in `HistoryView`

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -6,6 +6,7 @@
             variant="link"
             size="sm"
             class="rounded-0 text-decoration-none"
+            :disabled="!showControls"
             @click="onDashboard">
             <icon icon="database" />
             <span>{{ historySize | niceFileSize }}</span>
@@ -28,6 +29,7 @@
                 variant="link"
                 size="sm"
                 class="rounded-0 text-decoration-none"
+                :pressed="filterText == 'deleted:true'"
                 @click="toggleDeleted()">
                 <icon icon="trash" />
                 <span>{{ numItemsDeleted }}</span>
@@ -39,6 +41,7 @@
                 variant="link"
                 size="sm"
                 class="rounded-0 text-decoration-none"
+                :pressed="filterText == 'visible:false'"
                 @click="setFilter('visible:false')">
                 <icon icon="eye-slash" />
                 <span>{{ numItemsHidden }}</span>
@@ -73,6 +76,7 @@ export default {
         isWatching: { type: Boolean, default: false },
         lastChecked: { type: Date, default: null },
         filterText: { type: String, default: "" },
+        showControls: { type: Boolean, default: false },
     },
     data() {
         return {

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -39,10 +39,10 @@
                         @update:history="$emit('updateHistory', $event)" />
                     <HistoryMessages :history="history" />
                     <HistoryCounter
-                        v-if="showControls"
                         :history="history"
                         :is-watching="isWatching"
                         :last-checked="lastChecked"
+                        :show-controls="showControls"
                         :filter-text.sync="filterText"
                         @reloadContents="reloadContents" />
                     <HistoryOperations

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -1,6 +1,6 @@
 <template>
     <CurrentUser v-slot="{ user }">
-        <UserHistories v-if="user" v-slot="{ handlers }" :user="user">
+        <UserHistories v-if="user" v-slot="{ currentHistory, handlers }" :user="user">
             <div v-if="history" class="d-flex flex-column h-100">
                 <b-alert v-if="history.purged" variant="info" show>This history has been purged.</b-alert>
                 <div v-else class="flex-row flex-grow-0">
@@ -9,6 +9,7 @@
                         size="sm"
                         variant="outline-info"
                         title="Switch to this history"
+                        :disabled="currentHistory.id == history.id"
                         @click="handlers.setCurrentHistory(history)">
                         Switch to this history
                     </b-button>


### PR DESCRIPTION
Fixes #15742 
Now showing the counter in history view:
| Before |
| ------ |
| ![image](https://user-images.githubusercontent.com/78516064/230506444-ea39447a-6d5f-4251-afc7-61f8ab14c5bc.png) |

| After |
| ------ |
| ![image](https://user-images.githubusercontent.com/78516064/230506547-9bef354a-aa60-44c5-80fc-58b81e8a7d96.png) |

Clicking on the counter buttons gives them the `:pressed` attribute so the user knows that they are seeing `hidden` or `deleted` items if they clicked either button.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
