### PR TITLE
[22.05] Fix pulsar error when when home_target is pwd

### DIFF
--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -1139,6 +1139,8 @@ class PulsarComputeEnvironment(ComputeEnvironment):
             return self._shared_home_dir
         elif target == "job_home":
             return "$_GALAXY_JOB_HOME_DIR"
+        elif target == "pwd":
+            os.path.join(self.working_directory(), "working")
         else:
             raise Exception(f"Unknown target type [{target}]")
 

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -33,5 +33,6 @@ test_tools = integration_util.integration_tool_runner(
         "multi_output_assign_primary_ext_dbkey",
         "strict_shell",
         "tool_provided_metadata_9",
+        "simple_constructs_y",
     ]
 )


### PR DESCRIPTION
Fixes:
```
ERROR    galaxy.jobs.runners.pulsar:pulsar.py:531 failure running job 533
Traceback (most recent call last):
  File "/home/runner/work/pulsar/pulsar/galaxy/lib/galaxy/jobs/runners/pulsar.py", line 484, in __prepare_job
    job_wrapper.prepare(**prepare_kwds)
  File "/home/runner/work/pulsar/pulsar/galaxy/lib/galaxy/jobs/__init__.py", line 1253, in prepare
    ) = tool_evaluator.build()
  File "/home/runner/work/pulsar/pulsar/galaxy/lib/galaxy/tools/evaluation.py", line 560, in build
    global_tool_logs(self._build_environment_variables, config_file, "Building Environment Variables")
  File "/home/runner/work/pulsar/pulsar/galaxy/lib/galaxy/tools/evaluation.py", line 90, in global_tool_logs
    raise e
  File "/home/runner/work/pulsar/pulsar/galaxy/lib/galaxy/tools/evaluation.py", line 86, in global_tool_logs
    return func()
  File "/home/runner/work/pulsar/pulsar/galaxy/lib/galaxy/tools/evaluation.py", line 664, in _build_environment_variables
    home_dir = self.compute_environment.home_directory()
  File "/home/runner/work/pulsar/pulsar/galaxy/lib/galaxy/jobs/runners/pulsar.py", line 1163, in home_directory
    return self._target_to_directory(self.job_wrapper.home_target)
  File "/home/runner/work/pulsar/pulsar/galaxy/lib/galaxy/jobs/runners/pulsar.py", line 1179, in _target_to_directory
    raise Exception(f"Unknown target type [{target}]")
Exception: Unknown target type [pwd]
```

I think that was just missing when this was added to JobWrapper._target_to_directory

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
