### PR TITLE
[23.0] Revert pulsar-side stdio redirection

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -118,7 +118,7 @@ pkgutil-resolve-name==1.3.10 ; python_version >= "3.7" and python_version < "3.9
 prompt-toolkit==3.0.36 ; python_version >= "3.7" and python_version < "3.12"
 prov==1.5.1 ; python_version >= "3.7" and python_version < "3.12"
 psutil==5.9.4 ; python_version >= "3.7" and python_version < "3.12"
-pulsar-galaxy-lib==0.15.0.dev1 ; python_version >= "3.7" and python_version < "3.12"
+pulsar-galaxy-lib==0.15.0.dev2 ; python_version >= "3.7" and python_version < "3.12"
 pyasn1==0.4.8 ; python_version >= "3.7" and python_version < "3.12"
 pycparser==2.21 ; python_version >= "3.7" and python_version < "3.12"
 pycryptodome==3.16.0 ; python_version >= "3.7" and python_version < "3.12"

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -104,12 +104,12 @@ def build_command(
         else:
             commands_builder = CommandsBuilder(externalized_commands)
 
-    if not for_pulsar:
-        # Galaxy writes I/O files to outputs, Pulsar instruments own I/O redirection
-        io_directory = "../outputs"
-        commands_builder.capture_stdout_stderr(
-            f"{io_directory}/tool_stdout", f"{io_directory}/tool_stderr", stream_stdout_stderr=stream_stdout_stderr
-        )
+    # Galaxy writes I/O files to outputs, Pulsar uses metadata. metadata seems like
+    # it should be preferred - at least if the directory exists.
+    io_directory = "../metadata" if for_pulsar else "../outputs"
+    commands_builder.capture_stdout_stderr(
+        f"{io_directory}/tool_stdout", f"{io_directory}/tool_stderr", stream_stdout_stderr=stream_stdout_stderr
+    )
 
     # Don't need to create a separate tool working directory for Pulsar
     # jobs - that is handled by Pulsar.

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -407,7 +407,9 @@ def set_metadata_portable(
                             dataset.dataset.external_extra_files_path = pulsar_extra_files_path
                         elif dataset_filename_override and not object_store:
                             # pulsar, no remote metadata and no extended metadata
-                            dataset.dataset.external_extra_files_path = os.path.join(os.path.dirname(dataset_filename_override), extra_files_dir_name)
+                            dataset.dataset.external_extra_files_path = os.path.join(
+                                os.path.dirname(dataset_filename_override), extra_files_dir_name
+                            )
 
             file_dict = tool_provided_metadata.get_dataset_meta(output_name, dataset.dataset.id, dataset.dataset.uuid)
             if "ext" in file_dict:

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -36,5 +36,6 @@ test_tools = integration_util.integration_tool_runner(
         "tool_provided_metadata_9",
         "simple_constructs_y",
         "composite_output",
+        "detect_errors",
     ]
 )


### PR DESCRIPTION
It just happened to pass tests in
https://github.com/galaxyproject/galaxy/pull/15907 because the test framework looks at the stdio and stderr attributes, which are merged from tool_std{out,err} and job_std{out,err}.
It however fails the tests for detect_errors that specifically checks tool_stdout and tool_stderr.

I think it is a good idea to let pulsar handle the stdio redirection, but for this to work we'd have to ship parts of the command line to pulsar for final assembly, and that seems like a bigger change.

This should require a new pulsar release now.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
