### PR TITLE
[23.0] Fix history RO-crate export with discarded datasets

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2420,6 +2420,15 @@ class WriteCrates:
         for dataset, _ in self.included_datasets.values():
             if dataset.dataset.id in self.dataset_id_to_path:
                 file_name, _ = self.dataset_id_to_path[dataset.dataset.id]
+                if file_name is None:
+                    # The dataset was discarded or no longer exists. No file to export.
+                    # TODO: should this be registered in the crate as a special case?
+                    log.warning(
+                        "RO-Crate export: skipping dataset [%s] with state [%s] because file does not exist.",
+                        dataset.id,
+                        dataset.state,
+                    )
+                    continue
                 name = dataset.name
                 encoding_format = dataset.datatype.get_mime()
                 properties = {


### PR DESCRIPTION
Fixes #15821

After some time debugging on usegalaxy.eu with @bgruening we figured out the history exports that failed with:
```
ValueError: dest_path must be provided if source is not a path or URI
```
contained `discarded` datasets that were not handled when exporting to RO-crate, which requires a file name as a reference.

The simple solution here is just to skip those when exporting (as the other export formats do). We can revisit this when implementing a full RO-crate profile for histories down the road.

I was confused when investigating this issue in my local galaxy because I could reproduce sometimes the same stack-trace but it turns out it was for a completely different reason... Go to https://github.com/galaxyproject/galaxy/pull/15916#issuecomment-1500171837 if you want to read the full explanation.


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
