### PR TITLE
[23.0] Pin client release version for 23.0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galaxyproject/galaxy-client",
-  "version": "0.1.0",
+  "version": "23.0.0",
   "description": "Galaxy client application build system",
   "keywords": [
     "galaxy"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/galaxyproject/galaxy#readme",
   "dependencies": {
-    "@galaxyproject/galaxy-client": "^0.1.0",
+    "@galaxyproject/galaxy-client": "^23.0.0",
     "cpy-cli": "^4.2.0"
   }
 }


### PR DESCRIPTION
Sets the pin for the prebuilt client for the formal 23.0.0 release.  23.0.0 is available on npm now, and we'll update this with point releases as necessary.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `make install-client` and try your galaxy.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
