### PR TITLE
[23.0] Fix History Import Bugs

### DIFF
--- a/client/src/components/providers/UserHistories.js
+++ b/client/src/components/providers/UserHistories.js
@@ -28,7 +28,9 @@ export default {
             return null;
         },
         historyModels() {
-            return this.histories.map((h) => Object.assign({}, h));
+            return this.histories
+                .map((h) => Object.assign({}, h))
+                .filter((h) => !h.user_id || h.user_id === this.user.id);
         },
     },
     methods: {

--- a/client/src/store/historyStore/historyStore.js
+++ b/client/src/store/historyStore/historyStore.js
@@ -16,7 +16,7 @@ import {
 const state = {
     // selected history
     currentHistoryId: null,
-    // histories for current user
+    // histories for current user, can also have other user histories loaded for HistoryView
     histories: {},
     historiesLoading: false,
 };
@@ -98,7 +98,7 @@ let isLoadingHistories = false;
 const actions = {
     async copyHistory({ dispatch }, { history, name, copyAll }) {
         const newHistory = await cloneHistory(history, name, copyAll);
-        return dispatch("selectHistory", newHistory);
+        return dispatch("setCurrentHistory", newHistory.id);
     },
     async createNewHistory({ dispatch }) {
         // create history, then select it as current at the same time


### PR DESCRIPTION
Fixes #15917 
Fixes bugs 2 and 3 from #15917:
> 2. Just viewing an external shared history adds it to the current user's history switch menu (even without importing it).

^ Now we check against the `user_id` of the history in `UserHistories` to prevent that

> 3. Importing a new history doesn't potentially set it as current history on server

^ This is because the history was only being added to the state in `historyStore`. Now, it is also set as current by calling `setCurrentHistoryOnServer`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
