### PR TITLE
Summarize long Workflow annotations in WorkflowList

### DIFF
--- a/client/src/components/Common/TextSummary.vue
+++ b/client/src/components/Common/TextSummary.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faChevronUp, faChevronDown } from "@fortawesome/free-solid-svg-icons";
+
+const props = defineProps({
+    description: {
+        type: String,
+        required: true,
+    },
+    showDetails: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const emit = defineEmits<{
+    (e: "update:show-details", showDetails: boolean): void;
+}>();
+
+const propShowDetails = computed({
+    get: () => {
+        return props.showDetails;
+    },
+    set: (val) => {
+        emit("update:show-details", val);
+    },
+});
+
+//@ts-ignore bad library types
+library.add(faChevronUp, faChevronDown);
+const collapsedEnableIcon = "fas fa-chevron-down";
+const collapsedDisableIcon = "fas fa-chevron-up";
+
+// max length (can be a prop, maybe?)
+const n = 150;
+// summarized length
+const x = Math.round(n - n / 2);
+
+const summary = computed(() => props.description.length > n);
+const text = computed(() => (props.description.length > n ? props.description.slice(0, x) : props.description));
+</script>
+
+<template>
+    <div>
+        {{ text }}
+        <span v-if="summary">
+            <a
+                v-if="!propShowDetails"
+                class="text-summary-expand"
+                href="javascript:void(0)"
+                @click.stop="propShowDetails = true">
+                ... <FontAwesomeIcon :icon="collapsedEnableIcon" />
+            </a>
+            <a v-else href="javascript:void(0)" @click.stop="propShowDetails = false">
+                ... <FontAwesomeIcon :icon="collapsedDisableIcon" />
+            </a>
+        </span>
+    </div>
+</template>

--- a/client/src/components/Common/TextSummary.vue
+++ b/client/src/components/Common/TextSummary.vue
@@ -13,6 +13,10 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+    maxLength: {
+        type: Number,
+        default: 150,
+    },
 });
 
 const emit = defineEmits<{
@@ -33,13 +37,13 @@ library.add(faChevronUp, faChevronDown);
 const collapsedEnableIcon = "fas fa-chevron-down";
 const collapsedDisableIcon = "fas fa-chevron-up";
 
-// max length (can be a prop, maybe?)
-const n = 150;
 // summarized length
-const x = Math.round(n - n / 2);
+const x = Math.round(props.maxLength - props.maxLength / 2);
 
-const summary = computed(() => props.description.length > n);
-const text = computed(() => (props.description.length > n ? props.description.slice(0, x) : props.description));
+const summary = computed(() => props.description.length > props.maxLength);
+const text = computed(() =>
+    props.description.length > props.maxLength ? props.description.slice(0, x) : props.description
+);
 </script>
 
 <template>

--- a/client/src/components/Workflow/WorkflowDropdown.test.js
+++ b/client/src/components/Workflow/WorkflowDropdown.test.js
@@ -1,5 +1,5 @@
 import WorkflowDropdown from "./WorkflowDropdown";
-import { shallowMount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
@@ -20,7 +20,7 @@ describe("WorkflowDropdown.vue", () => {
             root: "/root/",
             workflow: workflow,
         };
-        wrapper = shallowMount(WorkflowDropdown, {
+        wrapper = mount(WorkflowDropdown, {
             propsData,
             localVue,
         });

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -20,7 +20,9 @@
             <span v-if="description.summary">
                 <span v-if="!detailsShowing">
                     {{ description.value }}
-                    <a href="javascript:void(0)" @click.stop="$emit('toggleDetails')">... Show More</a>
+                    <a class="wf-show-more" href="javascript:void(0)" @click.stop="$emit('toggleDetails')">
+                        ... Show More
+                    </a>
                 </span>
                 <a v-else href="javascript:void(0)" @click.stop="$emit('toggleDetails')">Show Less ...</a>
             </span>

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -16,19 +16,8 @@
                 <font-awesome-icon class="workflow-external-link" icon="link" />
             </span>
         </b-link>
-        <p v-if="description" class="workflow-dropdown-description">
-            <span v-if="description.summary">
-                <span v-if="!detailsShowing">
-                    {{ description.value }}
-                    <a class="wf-show-more" href="javascript:void(0)" @click.stop="$emit('toggleDetails')">
-                        ... Show More
-                    </a>
-                </span>
-                <a v-else href="javascript:void(0)" @click.stop="$emit('toggleDetails')">Show Less ...</a>
-            </span>
-            <span v-else>
-                {{ description.value }}
-            </span>
+        <p v-if="workflow.description" class="workflow-dropdown-description">
+            <TextSummary :description="workflow.description" :show-details.sync="showDetails" />
         </p>
         <div class="dropdown-menu" aria-labelledby="workflow-dropdown">
             <a
@@ -93,6 +82,7 @@
 <script>
 import { Services } from "./services";
 import { withPrefix } from "utils/redirect";
+import TextSummary from "components/Common/TextSummary";
 
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
@@ -102,6 +92,7 @@ library.add(faCaretDown);
 
 export default {
     components: {
+        TextSummary,
         FontAwesomeIcon,
     },
     props: {
@@ -109,15 +100,13 @@ export default {
         detailsShowing: { type: Boolean, default: false },
     },
     computed: {
-        description() {
-            const n = 150;
-            const desc = this.workflow.description;
-            if (!desc) {
-                return null;
-            } else if (desc.length > n) {
-                return { value: desc.slice(0, n - 50), summary: true };
-            }
-            return { value: desc, summary: false };
+        showDetails: {
+            get() {
+                return this.detailsShowing;
+            },
+            set() {
+                this.$emit("toggleDetails");
+            },
         },
         urlEdit() {
             return `/workflows/edit?id=${this.workflow.id}`;

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -16,7 +16,18 @@
                 <font-awesome-icon class="workflow-external-link" icon="link" />
             </span>
         </b-link>
-        <p v-if="workflow.description" class="workflow-dropdown-description">{{ workflow.description }}</p>
+        <p v-if="description" class="workflow-dropdown-description">
+            <span v-if="description.summary">
+                <span v-if="!detailsShowing">
+                    {{ description.value }}
+                    <a href="javascript:void(0)" @click.stop="$emit('toggleDetails')">... Show More</a>
+                </span>
+                <a v-else href="javascript:void(0)" @click.stop="$emit('toggleDetails')">Show Less ...</a>
+            </span>
+            <span v-else>
+                {{ description.value }}
+            </span>
+        </p>
         <div class="dropdown-menu" aria-labelledby="workflow-dropdown">
             <a
                 v-if="!readOnly && !isDeleted"
@@ -91,8 +102,21 @@ export default {
     components: {
         FontAwesomeIcon,
     },
-    props: ["workflow"],
+    props: {
+        workflow: { type: Object, required: true },
+        detailsShowing: { type: Boolean, default: false },
+    },
     computed: {
+        description() {
+            const n = 150;
+            const desc = this.workflow.description;
+            if (!desc) {
+                return null;
+            } else if (desc.length > n) {
+                return { value: desc.slice(0, n - 50), summary: true };
+            }
+            return { value: desc, summary: false };
+        },
         urlEdit() {
             return `/workflows/edit?id=${this.workflow.id}`;
         },

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -39,7 +39,7 @@
                     @onSuccess="onSuccess"
                     @onError="onError"
                     @onRestore="onRestore"
-                    @toggleDetails="swapRowDetails(row)" />
+                    @toggleDetails="row.toggleDetails" />
             </template>
             <template v-slot:cell(tags)="row">
                 <Tags
@@ -286,9 +286,6 @@ export default {
         },
         onRestore: function (id) {
             this.refresh();
-        },
-        swapRowDetails(row) {
-            row.toggleDetails();
         },
     },
 };

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -32,12 +32,14 @@
             <template v-slot:cell(name)="row">
                 <WorkflowDropdown
                     :workflow="row.item"
+                    :details-showing="row.detailsShowing"
                     @onAdd="onAdd"
                     @onRemove="onRemove"
                     @onUpdate="onUpdate"
                     @onSuccess="onSuccess"
                     @onError="onError"
-                    @onRestore="onRestore" />
+                    @onRestore="onRestore"
+                    @toggleDetails="swapRowDetails(row)" />
             </template>
             <template v-slot:cell(tags)="row">
                 <Tags
@@ -67,6 +69,11 @@
             <template v-slot:cell(execute)="row">
                 <WorkflowRunButton v-if="!row.item.deleted" :id="row.item.id" :root="root" />
                 <div v-else>&#8212;</div>
+            </template>
+            <template v-slot:row-details="data">
+                <b-card>
+                    <p class="workflow-dropdown-description">{{ data.item.description }}</p>
+                </b-card>
             </template>
         </b-table>
         <b-pagination
@@ -279,6 +286,9 @@ export default {
         },
         onRestore: function (id) {
             this.refresh();
+        },
+        swapRowDetails(row) {
+            row.toggleDetails();
         },
     },
 };

--- a/client/src/components/Workflow/Workflows.test.js
+++ b/client/src/components/Workflow/Workflows.test.js
@@ -110,20 +110,20 @@ describe("WorkflowList.vue", () => {
             );
             expect(row.find(".fa-globe").exists()).toBe(true);
 
-            // test Show More button for longer annotations
-            const annotationHead = sampleLongAnnotation.substr(0, 100);
+            // test expand summary button for longer annotations
+            const annotationHead = sampleLongAnnotation.substr(0, 75);
             const annotationTail = sampleLongAnnotation.substr(sampleLongAnnotation.length - 50);
             expect(columns.at(0).text()).toContain(annotationHead);
             expect(columns.at(0).text()).not.toContain(annotationTail);
-            expect(columns.at(0).text()).toContain("Show More");
-            // click Show More: full annotation should be visible in a b-card
-            await columns.at(0).find("a.wf-show-more").trigger("click");
-            expect(columns.at(0).text()).not.toContain("Show More");
+            expect(columns.at(0).find("a > .fa-chevron-down").exists()).toBe(true);
+            // click Down Arrow: full annotation should be visible in a b-card
+            await columns.at(0).find("a.text-summary-expand").trigger("click");
+            expect(columns.at(0).find("a > .fa-chevron-down").exists()).toBe(false);
             rows = wrapper.findAll("tbody > tr").wrappers;
             expect(rows.length).toBe(3);
             const descriptionCard = rows[2].find("td");
             expect(descriptionCard.text()).toContain(annotationTail);
-            expect(columns.at(0).text()).toContain("Show Less");
+            expect(columns.at(0).find("a > .fa-chevron-up").exists()).toBe(true);
         });
 
         it("starts with an empty filter", async () => {

--- a/client/src/components/Workflow/Workflows.test.js
+++ b/client/src/components/Workflow/Workflows.test.js
@@ -10,6 +10,12 @@ const localVue = getLocalVue();
 
 jest.mock("app");
 
+const sampleLongAnnotation =
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor\
+    incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis\
+    eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,\
+    sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
 const mockWorkflowsData = [
     {
         id: "5f1915bcf9f35612",
@@ -17,6 +23,7 @@ const mockWorkflowsData = [
         create_time: "2021-01-04T17:40:58.407793",
         name: "workflow name",
         tags: ["tagmoo", "tagcow"],
+        annotations: [sampleLongAnnotation],
         published: true,
         show_in_tool_panel: true,
         owner: "test",
@@ -88,7 +95,7 @@ describe("WorkflowList.vue", () => {
         });
 
         it("renders one row", async () => {
-            const rows = wrapper.findAll("tbody > tr").wrappers;
+            let rows = wrapper.findAll("tbody > tr").wrappers;
             expect(rows.length).toBe(1);
             const row = rows[0];
             const columns = row.findAll("td");
@@ -102,6 +109,21 @@ describe("WorkflowList.vue", () => {
                 formatDistanceToNow(parseISO(`${mockWorkflowsData[0].update_time}Z`), { addSuffix: true })
             );
             expect(row.find(".fa-globe").exists()).toBe(true);
+
+            // test Show More button for longer annotations
+            const annotationHead = sampleLongAnnotation.substr(0, 100);
+            const annotationTail = sampleLongAnnotation.substr(sampleLongAnnotation.length - 50);
+            expect(columns.at(0).text()).toContain(annotationHead);
+            expect(columns.at(0).text()).not.toContain(annotationTail);
+            expect(columns.at(0).text()).toContain("Show More");
+            // click Show More: full annotation should be visible in a b-card
+            await columns.at(0).find("a.wf-show-more").trigger("click");
+            expect(columns.at(0).text()).not.toContain("Show More");
+            rows = wrapper.findAll("tbody > tr").wrappers;
+            expect(rows.length).toBe(3);
+            const descriptionCard = rows[2].find("td");
+            expect(descriptionCard.text()).toContain(annotationTail);
+            expect(columns.at(0).text()).toContain("Show Less");
         });
 
         it("starts with an empty filter", async () => {


### PR DESCRIPTION
For long workflow annotations, a `... Show More` button has been added that expands a summary view:

https://user-images.githubusercontent.com/78516064/231301761-6c56f21a-7bca-4c2f-b76f-acc7832150f9.mov

### Existing Implementation:
Currently, the annotation can take over the whole page:

![image](https://user-images.githubusercontent.com/78516064/231247258-3591f852-3d5b-43a5-817d-ea78b270a3cd.png)


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
