### PR TITLE
Emit filterText to HistoryPanel from historyStore

### DIFF
--- a/client/src/components/Dataset/DatasetList.vue
+++ b/client/src/components/Dataset/DatasetList.vue
@@ -115,7 +115,7 @@ export default {
         this.load();
     },
     methods: {
-        ...mapActions(useHistoryStore, ["loadHistories", "setCurrentHistory", "applyFilterText"]),
+        ...mapActions(useHistoryStore, ["loadHistories", "applyFilterText"]),
         load(concat = false) {
             this.loading = true;
             getDatasets({

--- a/client/src/components/Dataset/DatasetList.vue
+++ b/client/src/components/Dataset/DatasetList.vue
@@ -115,7 +115,7 @@ export default {
         this.load();
     },
     methods: {
-        ...mapActions(useHistoryStore, ["loadHistories", "setCurrentHistory"]),
+        ...mapActions(useHistoryStore, ["loadHistories", "setCurrentHistory", "applyFilterText"]),
         load(concat = false) {
             this.loading = true;
             getDatasets({
@@ -153,7 +153,7 @@ export default {
         async onShowDataset(item) {
             const historyId = item.history_id;
             try {
-                await this.setCurrentHistory(historyId);
+                await this.applyFilterText(historyId, `hid:${item.hid}`);
             } catch (error) {
                 this.onError(error);
             }

--- a/client/src/components/Dataset/DatasetName.vue
+++ b/client/src/components/Dataset/DatasetName.vue
@@ -22,7 +22,7 @@
         <div class="dropdown-menu" aria-labelledby="dataset-dropdown">
             <a class="dropdown-item" href="#" @click.prevent="showDataset">
                 <span class="fa fa-eye fa-fw mr-1" />
-                <span>Switch to History containing dataset</span>
+                <span>Show in History containing dataset</span>
             </a>
             <a class="dropdown-item" href="#" @click.prevent="copyDataset">
                 <span class="fa fa-copy fa-fw mr-1" />

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -92,7 +92,7 @@
                 v-if="expandDataset"
                 :dataset="item"
                 :writable="writable"
-                :show-highlight="isHistoryItem && filterable"
+                :show-highlight="isHistoryItem"
                 :item-urls="itemUrls"
                 @edit="onEdit"
                 @toggleHighlights="toggleHighlights" />

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -92,7 +92,7 @@
                 v-if="expandDataset"
                 :dataset="item"
                 :writable="writable"
-                :show-highlight="isHistoryItem"
+                :show-highlight="(isHistoryItem && filterable) || addHighlightBtn"
                 :item-urls="itemUrls"
                 @edit="onEdit"
                 @toggleHighlights="toggleHighlights" />
@@ -125,6 +125,7 @@ export default {
     props: {
         writable: { type: Boolean, default: true },
         expandDataset: { type: Boolean, required: true },
+        addHighlightBtn: { type: Boolean, default: false },
         highlight: { type: String, default: null },
         id: { type: Number, required: true },
         isDataset: { type: Boolean, default: true },

--- a/client/src/components/History/Content/Dataset/DatasetActions.vue
+++ b/client/src/components/History/Content/Dataset/DatasetActions.vue
@@ -55,7 +55,7 @@
                 <b-button
                     v-if="showHighlight"
                     class="highlight-btn px-1"
-                    title="Show Inputs for this item"
+                    title="Show Related Items"
                     size="sm"
                     variant="link"
                     @click.stop="onHighlight">

--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -12,6 +12,7 @@
                 @update:expand-dataset="expandDataset = $event"
                 @view-collection="viewCollection = !viewCollection"
                 @delete="onDelete(item)"
+                @toggleHighlights="onHighlight(item)"
                 @undelete="onUndelete(item)"
                 @unhide="onUnhide(item)" />
             <div v-if="viewCollection">
@@ -69,6 +70,9 @@ export default {
         },
         onUnhide(item) {
             updateContentFields(item, { visible: true });
+        },
+        onHighlight(item) {
+            this.$emit("toggleHighlights", item);
         },
     },
 };

--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -29,6 +29,7 @@ import { deleteContent, updateContentFields } from "components/History/model/que
 import ContentItem from "./ContentItem";
 import GenericElement from "./GenericElement";
 import { mapActions } from "pinia";
+import { useHistoryStore } from "@/stores/historyStore";
 
 export default {
     components: {

--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -4,6 +4,7 @@
         <div v-else>
             <ContentItem
                 :id="item.hid"
+                add-highlight-btn
                 is-history-item
                 :item="item"
                 :name="item.name"

--- a/client/src/components/History/Content/GenericItem.vue
+++ b/client/src/components/History/Content/GenericItem.vue
@@ -28,6 +28,7 @@ import { DatasetCollectionProvider, DatasetProvider } from "components/providers
 import { deleteContent, updateContentFields } from "components/History/model/queries";
 import ContentItem from "./ContentItem";
 import GenericElement from "./GenericElement";
+import { mapActions } from "pinia";
 
 export default {
     components: {
@@ -59,6 +60,7 @@ export default {
         },
     },
     methods: {
+        ...mapActions(useHistoryStore, ["applyFilterText"]),
         onDelete(item) {
             deleteContent(item);
         },
@@ -72,7 +74,9 @@ export default {
             updateContentFields(item, { visible: true });
         },
         onHighlight(item) {
-            this.$emit("toggleHighlights", item);
+            const { history_id } = item;
+            const filterText = `related:${item.hid}`;
+            this.applyFilterText(history_id, filterText);
         },
     },
 };

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -252,7 +252,7 @@ export default {
         storeFilterText() {
             const { currentFilterText } = storeToRefs(useHistoryStore());
             return currentFilterText.value;
-        }
+        },
     },
     watch: {
         queryKey() {
@@ -268,8 +268,13 @@ export default {
         filter(newVal) {
             this.filterText = newVal;
         },
-        storeFilterText(newVal, oldVal) {
-            if (this.filterable && newVal !== oldVal) {
+        filterText(newVal) {
+            if (this.filterable) {
+                this.setCurrentFilterText(newVal);
+            }
+        },
+        storeFilterText(newVal) {
+            if (this.filterable) {
                 this.filterText = newVal;
             }
         },
@@ -284,7 +289,7 @@ export default {
         await this.loadHistoryItems();
     },
     methods: {
-        ...mapActions(useHistoryStore, ["loadHistoryById"]),
+        ...mapActions(useHistoryStore, ["loadHistoryById", "setCurrentFilterText"]),
         ...mapActions(useHistoryItemsStore, ["fetchHistoryItems"]),
         getHighlight(item) {
             if (this.filterText.includes("related:" + item.hid)) {

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -248,6 +248,10 @@ export default {
             const { getWatchingVisibility } = storeToRefs(useHistoryItemsStore());
             return getWatchingVisibility.value;
         },
+        /** @returns {String} */
+        storeFilterText() {
+            return this.currentFilterText();
+        }
     },
     watch: {
         queryKey() {
@@ -263,6 +267,11 @@ export default {
         filter(newVal) {
             this.filterText = newVal;
         },
+        storeFilterText(newVal, oldVal) {
+            if (newVal !== oldVal) {
+                this.filterText = newVal;
+            }
+        },
         offset() {
             this.loadHistoryItems();
         },
@@ -274,7 +283,7 @@ export default {
         await this.loadHistoryItems();
     },
     methods: {
-        ...mapActions(useHistoryStore, ["loadHistoryById"]),
+        ...mapActions(useHistoryStore, ["loadHistoryById", "currentFilterText"]),
         ...mapActions(useHistoryItemsStore, ["fetchHistoryItems"]),
         getHighlight(item) {
             if (this.filterText.includes("related:" + item.hid)) {

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -250,7 +250,8 @@ export default {
         },
         /** @returns {String} */
         storeFilterText() {
-            return this.currentFilterText();
+            const { currentFilterText } = storeToRefs(useHistoryStore());
+            return currentFilterText.value;
         }
     },
     watch: {
@@ -268,7 +269,7 @@ export default {
             this.filterText = newVal;
         },
         storeFilterText(newVal, oldVal) {
-            if (newVal !== oldVal) {
+            if (this.filterable && newVal !== oldVal) {
                 this.filterText = newVal;
             }
         },
@@ -283,7 +284,7 @@ export default {
         await this.loadHistoryItems();
     },
     methods: {
-        ...mapActions(useHistoryStore, ["loadHistoryById", "currentFilterText"]),
+        ...mapActions(useHistoryStore, ["loadHistoryById"]),
         ...mapActions(useHistoryItemsStore, ["fetchHistoryItems"]),
         getHighlight(item) {
             if (this.filterText.includes("related:" + item.hid)) {

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
@@ -11,7 +11,13 @@ const props = defineProps({
     },
 });
 
+const emit = defineEmits(["toggleHighlights"]);
+
 const { workflow } = useWorkflowInstance(props.invocation.workflow_id);
+
+function onHighlight(item) {
+    emit("toggleHighlights", item);
+}
 
 function dataInputStepLabel(key, input) {
     const invocationStep = props.invocation.steps[key];
@@ -50,7 +56,7 @@ function dataInputStepLabel(key, input) {
             <b-tab v-if="Object.keys(invocation.output_collections).length" title="Output Collections">
                 <div v-for="(output, key) in invocation.output_collections" :key="output.id">
                     <b>{{ key }}:</b>
-                    <generic-history-item :item-id="output.id" :item-src="output.src" />
+                    <generic-history-item :item-id="output.id" :item-src="output.src" @toggle-highlights="onHighlight"  />
                 </div>
             </b-tab>
             <b-tab v-if="workflow" title="Steps">

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
@@ -11,13 +11,7 @@ const props = defineProps({
     },
 });
 
-const emit = defineEmits(["toggleHighlights"]);
-
 const { workflow } = useWorkflowInstance(props.invocation.workflow_id);
-
-function onHighlight(item) {
-    emit("toggleHighlights", item);
-}
 
 function dataInputStepLabel(key, input) {
     const invocationStep = props.invocation.steps[key];
@@ -56,7 +50,7 @@ function dataInputStepLabel(key, input) {
             <b-tab v-if="Object.keys(invocation.output_collections).length" title="Output Collections">
                 <div v-for="(output, key) in invocation.output_collections" :key="output.id">
                     <b>{{ key }}:</b>
-                    <generic-history-item :item-id="output.id" :item-src="output.src" @toggle-highlights="onHighlight"  />
+                    <generic-history-item :item-id="output.id" :item-src="output.src" />
                 </div>
             </b-tab>
             <b-tab v-if="workflow" title="Steps">

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -24,6 +24,7 @@ export const useHistoryStore = defineStore(
         const historiesLoading = ref(false);
         const pinnedHistories = ref<{ id: string }[]>([]);
         const storedCurrentHistoryId = ref<string | null>(null);
+        const storedCurrentFilterText = ref<string | null>(null);
         const storedHistories = ref<{ [key: string]: HistorySummary }>({});
 
         const histories = computed(() => {
@@ -47,6 +48,10 @@ export const useHistoryStore = defineStore(
             } else {
                 return storedCurrentHistoryId.value;
             }
+        });
+
+        const currentFilterText = computed(() => {
+            return storedCurrentFilterText.value;
         });
 
         const getHistoryById = computed(() => {
@@ -73,6 +78,10 @@ export const useHistoryStore = defineStore(
 
         function setCurrentHistoryId(historyId: string) {
             storedCurrentHistoryId.value = historyId;
+        }
+
+        function setCurrentFilterText(filterText: string) {
+            storedCurrentFilterText.value = filterText;
         }
 
         function setHistory(history: HistorySummary) {
@@ -117,6 +126,13 @@ export const useHistoryStore = defineStore(
         function selectHistory(history: HistorySummary) {
             setHistory(history);
             setCurrentHistoryId(history.id);
+        }
+
+        function applyFilterText(history_id: string, filterText: string) {
+            setCurrentFilterText(filterText);
+            if (currentHistoryId.value !== history_id) {
+                return setCurrentHistory(history_id);
+            }
         }
 
         async function copyHistory(history: HistorySummary, name: string, copyAll: boolean) {
@@ -182,16 +198,19 @@ export const useHistoryStore = defineStore(
             histories,
             currentHistory,
             currentHistoryId,
+            currentFilterText,
             pinnedHistories,
             getHistoryById,
             getHistoryNameById,
             setCurrentHistory,
             setCurrentHistoryId,
+            setCurrentFilterText,
             setHistory,
             setHistories,
             pinHistory,
             unpinHistory,
             selectHistory,
+            applyFilterText,
             copyHistory,
             createNewHistory,
             deleteHistory,


### PR DESCRIPTION
Added a variable in `historyStore` called `currentFilterText` that tracks the filter in the **current** history in the history panel.
`filterText` can then be emitted to the active historyPanel from anywhere in Galaxy.
E.g.: Clicking on the related filter button (`sitemap` icon) on a history content item will emit filter text: `related:hid` and change the history to the history containing that item

https://user-images.githubusercontent.com/78516064/234110417-196cac30-a24b-465c-83a5-50ba4a565c22.mov



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
