### PR TITLE
[22.05] Fix mixed outputs_to_working_directory pulsar destinations

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -35,6 +35,7 @@ from galaxy.tool_util.deps.dependencies import (
 )
 from galaxy.tool_util.output_checker import DETECTED_JOB_STATE
 from galaxy.util import (
+    asbool,
     DATABASE_MAX_STRING_SIZE,
     ExecutionTimer,
     in_directory,
@@ -333,7 +334,7 @@ class BaseJobRunner:
         output_paths = {}
         for dataset_path in job_wrapper.job_io.get_output_fnames():
             path = dataset_path.real_path
-            if job_wrapper.get_destination_configuration("outputs_to_working_directory", False):
+            if asbool(job_wrapper.get_destination_configuration("outputs_to_working_directory", False)):
                 path = dataset_path.false_path
             output_paths[dataset_path.dataset_id] = path
 


### PR DESCRIPTION
By casting destination param string to bool when checking truthyness. It's unclear why the destination parameter values are strings on .eu but not in my local testing ... they are defined as yaml booleans, but this is a safe fix and we treat all the other instances in the codebase where we check for boolean values in destination parameters the same way.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
