### PR TITLE
[23.0] Fix Toast variant color for errors

### DIFF
--- a/client/src/composables/toast.ts
+++ b/client/src/composables/toast.ts
@@ -30,7 +30,7 @@ export const Toast = {
     },
 
     error(message: string, title = "Error") {
-        toastRef.value?.showToast(message, title, "error");
+        toastRef.value?.showToast(message, title, "danger");
     },
 };
 


### PR DESCRIPTION
I think this was unintentional, the error toast messages were rendered in "white" instead of "red".

### Before this change
![Screenshot from 2023-04-12 11-47-24](https://user-images.githubusercontent.com/46503462/231422061-2225fee6-6f1b-454c-b078-3593f115ab7d.png)

### After this change
![image](https://user-images.githubusercontent.com/46503462/231422379-fe6fd960-2bbc-4c37-b4bb-6249136ccf2a.png)




## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
