### PR TITLE
[23.0] Fix defineProps warning in client build.

### DIFF
--- a/client/src/components/ClientError.vue
+++ b/client/src/components/ClientError.vue
@@ -6,7 +6,6 @@
 // (AdminRequired), but could be used for other client errors that need to be
 // presented to the user interrupting the normal flow and context of the app.
 
-import { defineProps } from "vue";
 import Alert from "@/components/Alert.vue";
 
 const props = defineProps<{


### PR DESCRIPTION
Fixes warning in build about defineProps being a compiler macro and no longer needs to be imported.  Just a warning, no error/harm, but targeting 23.0 to eliminate it as a source of confusion.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
