### PR TITLE
[23.0] Allow duplicate labels in linter if outputs contain filters 

### DIFF
--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -52,7 +52,7 @@ def lint_output(tool_xml, lint_ctx):
                     node=output
                 )
             else:
-                lint_ctx.error(f"Tool output [{name}] uses duplicated label '{label}'", node=output)
+                lint_ctx.warn(f"Tool output [{name}] uses duplicated label '{label}'", node=output)
         labels.add(label)
 
         format_set = False

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -49,7 +49,7 @@ def lint_output(tool_xml, lint_ctx):
             if filter_node is not None:
                 lint_ctx.warn(
                     f"Tool output [{name}] uses duplicated label '{label}', double check if filters imply disjoint cases",
-                    node=output
+                    node=output,
                 )
             else:
                 lint_ctx.warn(f"Tool output [{name}] uses duplicated label '{label}'", node=output)

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -45,7 +45,14 @@ def lint_output(tool_xml, lint_ctx):
 
         label = output.attrib.get("label", "${tool.name} on ${on_string}")
         if label in labels:
-            lint_ctx.error(f"Tool output [{name}] uses duplicated label '{label}'", node=output)
+            filter_node = output.find(".//filter")
+            if filter_node is not None:
+                lint_ctx.info(
+                    f"Tool output [{name}] uses duplicated label '{label}', double check if filters imply disjoint cases",
+                    node=output
+                )
+            else:
+                lint_ctx.error(f"Tool output [{name}] uses duplicated label '{label}'", node=output)
         labels.add(label)
 
         format_set = False

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -47,7 +47,7 @@ def lint_output(tool_xml, lint_ctx):
         if label in labels:
             filter_node = output.find(".//filter")
             if filter_node is not None:
-                lint_ctx.info(
+                lint_ctx.warn(
                     f"Tool output [{name}] uses duplicated label '{label}', double check if filters imply disjoint cases",
                     node=output
                 )

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1499,14 +1499,14 @@ def test_outputs_duplicated_name_label(lint_ctx):
     tool_source = get_xml_tool_source(OUTPUTS_DUPLICATED_NAME_LABEL)
     run_lint(lint_ctx, outputs.lint_output, tool_source)
     assert "4 outputs found." in lint_ctx.info_messages
+    assert len(lint_ctx.info_messages) == 1
+    assert not lint_ctx.valid_messages
+    assert len(lint_ctx.warn_messages) == 2
+    assert "Tool output [valid_name] uses duplicated label '${tool.name} on ${on_string}'" in lint_ctx.warn_messages
     assert (
         "Tool output [yet_another_valid_name] uses duplicated label 'same label may be OK if there is a filter', double check if filters imply disjoint cases"
-        in lint_ctx.info_messages
+        in lint_ctx.warn_messages
     )
-    assert len(lint_ctx.info_messages) == 2
-    assert not lint_ctx.valid_messages
-    assert len(lint_ctx.warn_messages) == 1
-    assert "Tool output [valid_name] uses duplicated label '${tool.name} on ${on_string}'" in lint_ctx.warn_messages
     assert "Tool output [valid_name] has duplicated name" in lint_ctx.error_messages
     assert len(lint_ctx.error_messages) == 1
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1505,10 +1505,10 @@ def test_outputs_duplicated_name_label(lint_ctx):
     )
     assert len(lint_ctx.info_messages) == 2
     assert not lint_ctx.valid_messages
-    assert not lint_ctx.warn_messages
+    assert len(lint_ctx.warn_messages) == 1
+    assert "Tool output [valid_name] uses duplicated label '${tool.name} on ${on_string}'" in lint_ctx.warn_messages
     assert "Tool output [valid_name] has duplicated name" in lint_ctx.error_messages
-    assert "Tool output [valid_name] uses duplicated label '${tool.name} on ${on_string}'" in lint_ctx.error_messages
-    assert len(lint_ctx.error_messages) == 2
+    assert len(lint_ctx.error_messages) == 1
 
 
 def test_stdio_default_for_default_profile(lint_ctx):

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -566,6 +566,12 @@ OUTPUTS_DUPLICATED_NAME_LABEL = """
     <outputs>
         <data name="valid_name" format="fasta"/>
         <data name="valid_name" format="fasta"/>
+        <data name="another_valid_name" format="fasta" label="same label may be OK if there is a filter">
+            <filter>a condition</filter>
+        </data>
+        <data name="yet_another_valid_name" format="fasta" label="same label may be OK if there is a filter">
+            <filter>another condition</filter>
+        </data>
     </outputs>
 </tool>
 """
@@ -1492,8 +1498,12 @@ def test_outputs_discover_tool_provided_metadata(lint_ctx):
 def test_outputs_duplicated_name_label(lint_ctx):
     tool_source = get_xml_tool_source(OUTPUTS_DUPLICATED_NAME_LABEL)
     run_lint(lint_ctx, outputs.lint_output, tool_source)
-    assert "2 outputs found." in lint_ctx.info_messages
-    assert len(lint_ctx.info_messages) == 1
+    assert "4 outputs found." in lint_ctx.info_messages
+    assert (
+        "Tool output [yet_another_valid_name] uses duplicated label 'same label may be OK if there is a filter', double check if filters imply disjoint cases"
+        in lint_ctx.info_messages
+    )
+    assert len(lint_ctx.info_messages) == 2
     assert not lint_ctx.valid_messages
     assert not lint_ctx.warn_messages
     assert "Tool output [valid_name] has duplicated name" in lint_ctx.error_messages


### PR DESCRIPTION
duplicated labels may be OK if there are filters

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
