### PR TITLE
[23.0] Prevent anonymous access to Storage Dashboard

### DIFF
--- a/client/src/entry/analysis/routes/storageDashboardRoutes.ts
+++ b/client/src/entry/analysis/routes/storageDashboardRoutes.ts
@@ -6,6 +6,7 @@ export default [
     {
         path: "/storage",
         component: Base,
+        meta: { requiresRegisteredUser: true },
         children: [
             {
                 path: "",


### PR DESCRIPTION
Follow-up and similar to #15906

Still minimal changes for 23.0, the Storage Dashboard only works for registered users.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
