### PR TITLE
[23.0] Add ``ca_certs`` option for sentry client

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2927,6 +2927,18 @@
 :Type: float
 
 
+~~~~~~~~~~~~~~~~~~~
+``sentry_ca_certs``
+~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Use this option to provide the path to location of the CA
+    (Certificate Authority) certificate file if the sentry server uses
+    a self-signed certificate.
+:Default: ``None``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~
 ``statsd_host``
 ~~~~~~~~~~~~~~~

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -202,6 +202,7 @@ class SentryClientMixin:
                 release=f"{self.config.version_major}.{self.config.version_minor}",
                 integrations=[sentry_logging],
                 traces_sample_rate=self.config.sentry_traces_sample_rate,
+                ca_certs=self.config.sentry_ca_certs,
             )
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1675,6 +1675,11 @@ galaxy:
   # to Sentry. A value higher than 0 is required to analyze performance.
   #sentry_traces_sample_rate: 0.0
 
+  # Use this option to provide the path to location of the CA
+  # (Certificate Authority) certificate file if the sentry server uses a
+  # self-signed certificate.
+  #sentry_ca_certs: null
+
   # Log to statsd Statsd is an external statistics aggregator
   # (https://github.com/etsy/statsd) Enabling the following options will
   # cause galaxy to log request timing and other statistics to the

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -316,6 +316,11 @@ tool_shed:
   # to Sentry. A value higher than 0 is required to analyze performance.
   #sentry_traces_sample_rate: 0.0
 
+  # Use this option to provide the path to location of the CA
+  # (Certificate Authority) certificate file if the sentry server uses a
+  # self-signed certificate.
+  #sentry_ca_certs: null
+
   # Galaxy Session Timeout This provides a timeout (in minutes) after
   # which a user will have to log back in. A duration of 0 disables this
   # feature.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -2117,6 +2117,13 @@ mapping:
           will have that percentage chance of being sent to Sentry. A value higher than 0
           is required to analyze performance.
 
+      sentry_ca_certs:
+        type: str
+        required: False
+        desc: |
+          Use this option to provide the path to location of the CA (Certificate Authority)
+          certificate file if the sentry server uses a self-signed certificate.
+
       statsd_host:
         type: str
         required: false

--- a/lib/galaxy/config/schemas/tool_shed_config_schema.yml
+++ b/lib/galaxy/config/schemas/tool_shed_config_schema.yml
@@ -566,6 +566,13 @@ mapping:
           will have that percentage chance of being sent to Sentry. A value higher than 0
           is required to analyze performance.
 
+      sentry_ca_certs:
+        type: str
+        required: False
+        desc: |
+          Use this option to provide the path to location of the CA (Certificate Authority)
+          certificate file if the sentry server uses a self-signed certificate.
+
       session_duration:
         type: int
         default: 0


### PR DESCRIPTION
We may use this in the admin training

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
