### PR TITLE
Add WorkflowBox to Activity bar Side Panel

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -3,6 +3,7 @@ import { useUserStore } from "@/stores/userStore";
 import UploadItem from "./Items/UploadItem.vue";
 import ToolBox from "@/components/Panels/ProviderAwareToolBox.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";
+import WorkflowBox from "@/components/Panels/WorkflowBox.vue";
 import ActivityItem from "./ActivityItem";
 
 const userStore = useUserStore();
@@ -25,14 +26,15 @@ function onToggleSidebar(toggle) {
                     icon="wrench"
                     title="Tools"
                     tooltip="Search and run tools"
-                    :is-active="sidebarIsActive('search')"
-                    @click="onToggleSidebar('search')" />
+                    :is-active="sidebarIsActive('tools')"
+                    @click="onToggleSidebar('tools')" />
                 <ActivityItem
                     id="activity-workflow"
                     title="Workflow"
                     icon="sitemap"
                     tooltip="Chain tools into workflows"
-                    to="/workflows/list" />
+                    :is-active="sidebarIsActive('workflows')"
+                    @click="onToggleSidebar('workflows')" />
                 <ActivityItem
                     id="activity-visualization"
                     icon="chart-bar"
@@ -49,8 +51,11 @@ function onToggleSidebar(toggle) {
                     to="/user" />
             </b-nav>
         </div>
-        <FlexPanel v-if="sidebarIsActive('search')" key="search" side="left" :collapsible="false">
+        <FlexPanel v-if="sidebarIsActive('tools')" key="tools" side="left" :collapsible="false">
             <ToolBox />
+        </FlexPanel>
+        <FlexPanel v-else-if="sidebarIsActive('workflows')" key="workflows" side="left" :collapsible="false">
+            <WorkflowBox />
         </FlexPanel>
     </div>
 </template>

--- a/client/src/components/Panels/WorkflowBox.vue
+++ b/client/src/components/Panels/WorkflowBox.vue
@@ -1,79 +1,20 @@
 <script setup lang="ts">
 import { getGalaxyInstance } from "@/app";
-import { getAppRoot } from "@/onload";
 import { withPrefix } from "@/utils/redirect";
-import { useRouter } from "vue-router/composables";
-import { ref, computed, onMounted, type ComputedRef } from "vue";
-import { useWorkflowStore, type Workflow } from "@/stores/workflowStore";
+import { computed, type ComputedRef } from "vue";
 import WorkflowSearch from "@/components/Workflow/WorkflowSearch.vue";
-import FavoritesButton from "@/components/Panels/Buttons/FavoritesButton.vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { faUpload } from "@fortawesome/free-solid-svg-icons";
+import { faUpload, faGlobe } from "@fortawesome/free-solid-svg-icons";
 import { library } from "@fortawesome/fontawesome-svg-core";
 
-const workflowStore = useWorkflowStore();
-const router = useRouter();
-
-const query = ref("");
-const queryPending = ref(false);
-const showAdvanced = ref(false);
-
-const panelFilter: ComputedRef<any> = computed(() => {
-    return { name: query.value };
-});
-
-// on Mount, load all Workflows
-onMounted(async () => {
-    queryPending.value = true;
-    await workflowStore.fetchWorkflows(panelFilter.value);
-    queryPending.value = false;
-});
-
-//@ts-ignore bad library types
-library.add(faUpload);
+// @ts-ignore bad library types
+library.add(faUpload, faGlobe);
 
 // computed
 const isUser: ComputedRef<boolean> = computed(() => {
     const Galaxy = getGalaxyInstance();
     return !!(Galaxy.user && Galaxy.user.id);
 });
-const workflows = computed(() => {
-    if (isUser.value) {
-        let results: Workflow[] = [];
-        if (query.value === "#favorites") {
-            const Galaxy = getGalaxyInstance();
-            results = Galaxy.config.stored_workflow_menu_entries;
-        } else if (!queryTooShort.value) {
-            results = workflowStore.getWorkflows(panelFilter.value);
-        }
-        return [
-            ...results.map((wf) => {
-                return {
-                    id: wf.id,
-                    name: wf.name,
-                    href: `${getAppRoot()}workflows/run?id=${wf.id}`,
-                };
-            }),
-        ];
-    }
-    return [];
-});
-const hasWorkflows: ComputedRef<boolean> = computed(() => workflows.value.length !== 0);
-const hasQuery: ComputedRef<boolean> = computed(() => query.value !== "");
-const queryTooShort: ComputedRef<boolean> = computed(() => query.value !== "" && query.value.length < 3);
-
-// functions
-async function onQuery(q: string) {
-    query.value = !q ? "" : q;
-    queryPending.value = true;
-    if (!queryTooShort.value && q !== "#favorites") {
-        await workflowStore.fetchWorkflows(panelFilter.value);
-    }
-    queryPending.value = false;
-}
-function onOpen(route: string) {
-    router.push(route);
-}
 </script>
 
 <template>
@@ -81,66 +22,37 @@ function onOpen(route: string) {
         <div unselectable="on">
             <div class="unified-panel-header-inner">
                 <nav class="d-flex justify-content-between mx-3 my-2">
-                    <h2 v-if="!showAdvanced" id="workflowbox-heading" v-localize class="m-1 h-sm">Workflows</h2>
-                    <h2 v-else id="workflowbox-heading" v-localize class="m-1 h-sm">Advanced Workflow Search</h2>
-
+                    <h2 id="workflowbox-heading" v-localize class="m-1 h-sm">Workflows</h2>
                     <div v-if="isUser" class="panel-header-buttons">
-                        <b-button-group>
-                            <favorites-button v-if="!showAdvanced" :query="query" @onFavorites="onQuery" />
-                            <b-button
-                                v-b-tooltip.bottom.hover
-                                data-description="create new workflow"
-                                size="sm"
-                                variant="link"
-                                title="Create new workflow"
-                                @click="$router.push('/workflows/create')">
-                                <Icon fixed-width icon="plus" />
-                            </b-button>
-                        </b-button-group>
+                        <b-button
+                            v-b-tooltip.bottom.hover
+                            data-description="create new workflow"
+                            size="sm"
+                            variant="link"
+                            title="Create new workflow"
+                            @click="$router.push('/workflows/create')">
+                            <Icon fixed-width icon="plus" />
+                        </b-button>
                     </div>
                 </nav>
             </div>
         </div>
-        <div v-if="!isUser">
-            <b-badge class="alert-info w-100">
-                Please <a :href="withPrefix('/login')">log in or register</a> to use this feature.
-            </b-badge>
-        </div>
-        <div v-else>
-            <div class="unified-panel-controls">
-                <WorkflowSearch
-                    enable-advanced
-                    :loading="queryPending"
-                    :show-advanced.sync="showAdvanced"
-                    :query="query"
-                    @onQuery="onQuery" />
-                <div v-if="!showAdvanced">
-                    <b-button
-                        id="workflow-import"
-                        class="upload-button"
-                        size="sm"
-                        @click="$router.push('/workflows/import')">
-                        <FontAwesomeIcon icon="upload" />
-                        Import Workflow
-                    </b-button>
-                    <div v-if="!queryPending" class="pb-2">
-                        <b-badge class="alert-danger w-100">
-                            <span v-if="queryTooShort">Search string too short!</span>
-                            <span v-else-if="!hasQuery && !hasWorkflows">No workflows found!</span>
-                            <span v-else-if="hasQuery && !hasWorkflows">No results found!</span>
-                        </b-badge>
-                    </div>
-                </div>
+        <div class="unified-panel-controls">
+            <div v-if="!isUser">
+                <b-badge class="alert-info w-100">
+                    Please <a :href="withPrefix('/login')">log in or register</a> to create workflows.
+                </b-badge>
             </div>
-            <div v-if="!showAdvanced" class="unified-panel-body">
-                <div class="toolMenuContainer">
-                    <div id="internal-workflows" class="toolSectionBody">
-                        <div class="toolSectionBg" />
-                        <div v-for="wf in workflows" :key="wf.id" class="toolTitle">
-                            <a class="title-link" href="javascript:void(0)" @click="onOpen(wf.href)">{{ wf.name }}</a>
-                        </div>
-                    </div>
-                </div>
+            <div v-else>
+                <b-button v-if="isUser" class="upload-button" size="sm" @click="$router.push('/workflows/import')">
+                    <FontAwesomeIcon icon="upload" />
+                    Import Workflow
+                </b-button>
+                <b-button class="upload-button" size="sm" @click="$router.push('/workflows/list_published')">
+                    <FontAwesomeIcon icon="fa-globe" />
+                    Published Workflows
+                </b-button>
+                <WorkflowSearch />
             </div>
         </div>
     </div>

--- a/client/src/components/Panels/WorkflowBox.vue
+++ b/client/src/components/Panels/WorkflowBox.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { getGalaxyInstance } from "@/app";
+import { getAppRoot } from "@/onload";
+import { useRouter } from "vue-router/composables";
+import { ref, computed, onMounted, type ComputedRef } from "vue";
+import { useWorkflowStore, type Workflow } from "@/stores/workflowStore";
+import WorkflowSearch from "@/components/Workflow/WorkflowSearch.vue";
+import FavoritesButton from "@/components/Panels/Buttons/FavoritesButton.vue";
+import LoadingSpan from "@/components/LoadingSpan.vue";
+
+const workflowStore = useWorkflowStore();
+const router = useRouter();
+
+const query = ref("");
+const queryPending = ref(false);
+const showAdvanced = ref(false);
+
+const panelFilter: ComputedRef<any> = computed(() => {
+    return { name: query.value };
+});
+
+// on Mount, load all Workflows
+onMounted(async () => {
+    queryPending.value = true;
+    await workflowStore.fetchWorkflows(panelFilter.value);
+    queryPending.value = false;
+});
+
+// computed
+const workflows = computed(() => {
+    let results: Workflow[] = [];
+    if (query.value === "#favorites") {
+        const Galaxy = getGalaxyInstance();
+        results = Galaxy.config.stored_workflow_menu_entries;
+    } else if (!queryTooShort.value) {
+        results = workflowStore.getWorkflows(panelFilter.value);
+    }
+    return [
+        ...results.map((wf) => {
+            return {
+                id: wf.id,
+                name: wf.name,
+                href: `${getAppRoot()}workflows/run?id=${wf.id}`,
+            };
+        }),
+    ];
+});
+const queryTooShort: ComputedRef<boolean> = computed(() => query.value !== "" && query.value.length < 3);
+
+// functions
+async function onQuery(q: string) {
+    query.value = !q ? "" : q;
+    queryPending.value = true;
+    if (!queryTooShort.value && q !== "#favorites") {
+        await workflowStore.fetchWorkflows(panelFilter.value);
+    }
+    queryPending.value = false;
+}
+function onOpen(route: string) {
+    router.push(route);
+}
+</script>
+
+<template>
+    <div class="unified-panel" aria-labelledby="workflowbox-heading">
+        <div unselectable="on">
+            <div class="unified-panel-header-inner">
+                <nav class="d-flex justify-content-between mx-3 my-2">
+                    <h2 v-if="!showAdvanced" id="workflowbox-heading" v-localize class="m-1 h-sm">Workflows</h2>
+                    <h2 v-else id="workflowbox-heading" v-localize class="m-1 h-sm">Advanced Workflow Search</h2>
+
+                    <div class="panel-header-buttons">
+                        <b-button-group>
+                            <favorites-button v-if="!showAdvanced" :query="query" @onFavorites="onQuery" />
+                        </b-button-group>
+                    </div>
+                </nav>
+            </div>
+        </div>
+        <div class="unified-panel-controls">
+            <WorkflowSearch enable-advanced :show-advanced.sync="showAdvanced" :query="query" @onQuery="onQuery" />
+            <section v-if="!showAdvanced">
+                <div v-if="queryPending" class="pb-2">
+                    <b-badge class="alert-info w-100"><LoadingSpan message="Loading workflows" /></b-badge>
+                </div>
+                <div v-else-if="queryTooShort" class="pb-2">
+                    <b-badge class="alert-danger w-100">Search string too short!</b-badge>
+                </div>
+                <div v-else-if="workflows.length == 0" class="pb-2">
+                    <b-badge class="alert-danger w-100">No results found!</b-badge>
+                </div>
+            </section>
+        </div>
+        <div v-if="!showAdvanced" class="unified-panel-body">
+            <div class="toolMenuContainer">
+                <div id="internal-workflows" class="toolSectionBody">
+                    <div class="toolSectionBg" />
+                    <div v-for="wf in workflows" :key="wf.id" class="toolTitle">
+                        <a class="title-link" href="javascript:void(0)" @click="onOpen(wf.href)">{{ wf.name }}</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/client/src/components/Panels/WorkflowBox.vue
+++ b/client/src/components/Panels/WorkflowBox.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { getGalaxyInstance } from "@/app";
 import { withPrefix } from "@/utils/redirect";
-import { computed, type ComputedRef } from "vue";
+import { useUserStore } from "@/stores/userStore";
+import { computed } from "vue";
 import WorkflowSearch from "@/components/Workflow/WorkflowSearch.vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faUpload, faGlobe } from "@fortawesome/free-solid-svg-icons";
@@ -10,11 +10,15 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 // @ts-ignore bad library types
 library.add(faUpload, faGlobe);
 
-// computed
-const isUser: ComputedRef<boolean> = computed(() => {
-    const Galaxy = getGalaxyInstance();
-    return !!(Galaxy.user && Galaxy.user.id);
-});
+const isAnonymous = computed(() => useUserStore().isAnonymous);
+
+function userTitle(title: string) {
+    if (isAnonymous.value == true) {
+        return `Log in to ${title}`;
+    } else {
+        return title;
+    }
+}
 </script>
 
 <template>
@@ -22,38 +26,48 @@ const isUser: ComputedRef<boolean> = computed(() => {
         <div unselectable="on">
             <div class="unified-panel-header-inner">
                 <nav class="d-flex justify-content-between mx-3 my-2">
-                    <h2 id="workflowbox-heading" v-localize class="m-1 h-sm">Workflows</h2>
-                    <div v-if="isUser" class="panel-header-buttons">
+                    <h2 v-localize class="m-1 h-sm">Workflows</h2>
+                    <b-button-group>
                         <b-button
                             v-b-tooltip.bottom.hover
                             data-description="create new workflow"
                             size="sm"
                             variant="link"
-                            title="Create new workflow"
+                            :title="userTitle('Create new workflow')"
+                            :disabled="isAnonymous"
                             @click="$router.push('/workflows/create')">
                             <Icon fixed-width icon="plus" />
                         </b-button>
-                    </div>
+                        <b-button
+                            v-b-tooltip.bottom.hover
+                            data-description="import workflow"
+                            size="sm"
+                            variant="link"
+                            :title="userTitle('Import workflow')"
+                            :disabled="isAnonymous"
+                            @click="$router.push('/workflows/import')">
+                            <FontAwesomeIcon icon="upload" />
+                        </b-button>
+                        <b-button
+                            v-b-tooltip.bottom.hover
+                            data-description="published workflows"
+                            size="sm"
+                            variant="link"
+                            title="Published workflows"
+                            @click="$router.push('/workflows/list_published')">
+                            <FontAwesomeIcon icon="fa-globe" />
+                        </b-button>
+                    </b-button-group>
                 </nav>
             </div>
         </div>
         <div class="unified-panel-controls">
-            <div v-if="!isUser">
+            <div v-if="isAnonymous">
                 <b-badge class="alert-info w-100">
                     Please <a :href="withPrefix('/login')">log in or register</a> to create workflows.
                 </b-badge>
             </div>
-            <div v-else>
-                <b-button v-if="isUser" class="upload-button" size="sm" @click="$router.push('/workflows/import')">
-                    <FontAwesomeIcon icon="upload" />
-                    Import Workflow
-                </b-button>
-                <b-button class="upload-button" size="sm" @click="$router.push('/workflows/list_published')">
-                    <FontAwesomeIcon icon="fa-globe" />
-                    Published Workflows
-                </b-button>
-                <WorkflowSearch />
-            </div>
+            <WorkflowSearch v-else />
         </div>
     </div>
 </template>

--- a/client/src/components/Panels/WorkflowBox.vue
+++ b/client/src/components/Panels/WorkflowBox.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { getGalaxyInstance } from "@/app";
 import { getAppRoot } from "@/onload";
+import { withPrefix } from "@/utils/redirect";
 import { useRouter } from "vue-router/composables";
 import { ref, computed, onMounted, type ComputedRef } from "vue";
 import { useWorkflowStore, type Workflow } from "@/stores/workflowStore";
 import WorkflowSearch from "@/components/Workflow/WorkflowSearch.vue";
 import FavoritesButton from "@/components/Panels/Buttons/FavoritesButton.vue";
-import LoadingSpan from "@/components/LoadingSpan.vue";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faUpload } from "@fortawesome/free-solid-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
 
 const workflowStore = useWorkflowStore();
 const router = useRouter();
@@ -26,25 +29,37 @@ onMounted(async () => {
     queryPending.value = false;
 });
 
+//@ts-ignore bad library types
+library.add(faUpload);
+
 // computed
-const workflows = computed(() => {
-    let results: Workflow[] = [];
-    if (query.value === "#favorites") {
-        const Galaxy = getGalaxyInstance();
-        results = Galaxy.config.stored_workflow_menu_entries;
-    } else if (!queryTooShort.value) {
-        results = workflowStore.getWorkflows(panelFilter.value);
-    }
-    return [
-        ...results.map((wf) => {
-            return {
-                id: wf.id,
-                name: wf.name,
-                href: `${getAppRoot()}workflows/run?id=${wf.id}`,
-            };
-        }),
-    ];
+const isUser: ComputedRef<boolean> = computed(() => {
+    const Galaxy = getGalaxyInstance();
+    return !!(Galaxy.user && Galaxy.user.id);
 });
+const workflows = computed(() => {
+    if (isUser.value) {
+        let results: Workflow[] = [];
+        if (query.value === "#favorites") {
+            const Galaxy = getGalaxyInstance();
+            results = Galaxy.config.stored_workflow_menu_entries;
+        } else if (!queryTooShort.value) {
+            results = workflowStore.getWorkflows(panelFilter.value);
+        }
+        return [
+            ...results.map((wf) => {
+                return {
+                    id: wf.id,
+                    name: wf.name,
+                    href: `${getAppRoot()}workflows/run?id=${wf.id}`,
+                };
+            }),
+        ];
+    }
+    return [];
+});
+const hasWorkflows: ComputedRef<boolean> = computed(() => workflows.value.length !== 0);
+const hasQuery: ComputedRef<boolean> = computed(() => query.value !== "");
 const queryTooShort: ComputedRef<boolean> = computed(() => query.value !== "" && query.value.length < 3);
 
 // functions
@@ -69,34 +84,61 @@ function onOpen(route: string) {
                     <h2 v-if="!showAdvanced" id="workflowbox-heading" v-localize class="m-1 h-sm">Workflows</h2>
                     <h2 v-else id="workflowbox-heading" v-localize class="m-1 h-sm">Advanced Workflow Search</h2>
 
-                    <div class="panel-header-buttons">
+                    <div v-if="isUser" class="panel-header-buttons">
                         <b-button-group>
                             <favorites-button v-if="!showAdvanced" :query="query" @onFavorites="onQuery" />
+                            <b-button
+                                v-b-tooltip.bottom.hover
+                                data-description="create new workflow"
+                                size="sm"
+                                variant="link"
+                                title="Create new workflow"
+                                @click="$router.push('/workflows/create')">
+                                <Icon fixed-width icon="plus" />
+                            </b-button>
                         </b-button-group>
                     </div>
                 </nav>
             </div>
         </div>
-        <div class="unified-panel-controls">
-            <WorkflowSearch enable-advanced :show-advanced.sync="showAdvanced" :query="query" @onQuery="onQuery" />
-            <section v-if="!showAdvanced">
-                <div v-if="queryPending" class="pb-2">
-                    <b-badge class="alert-info w-100"><LoadingSpan message="Loading workflows" /></b-badge>
-                </div>
-                <div v-else-if="queryTooShort" class="pb-2">
-                    <b-badge class="alert-danger w-100">Search string too short!</b-badge>
-                </div>
-                <div v-else-if="workflows.length == 0" class="pb-2">
-                    <b-badge class="alert-danger w-100">No results found!</b-badge>
-                </div>
-            </section>
+        <div v-if="!isUser">
+            <b-badge class="alert-info w-100">
+                Please <a :href="withPrefix('/login')">log in or register</a> to use this feature.
+            </b-badge>
         </div>
-        <div v-if="!showAdvanced" class="unified-panel-body">
-            <div class="toolMenuContainer">
-                <div id="internal-workflows" class="toolSectionBody">
-                    <div class="toolSectionBg" />
-                    <div v-for="wf in workflows" :key="wf.id" class="toolTitle">
-                        <a class="title-link" href="javascript:void(0)" @click="onOpen(wf.href)">{{ wf.name }}</a>
+        <div v-else>
+            <div class="unified-panel-controls">
+                <WorkflowSearch
+                    enable-advanced
+                    :loading="queryPending"
+                    :show-advanced.sync="showAdvanced"
+                    :query="query"
+                    @onQuery="onQuery" />
+                <div v-if="!showAdvanced">
+                    <b-button
+                        id="workflow-import"
+                        class="upload-button"
+                        size="sm"
+                        @click="$router.push('/workflows/import')">
+                        <FontAwesomeIcon icon="upload" />
+                        Import Workflow
+                    </b-button>
+                    <div v-if="!queryPending" class="pb-2">
+                        <b-badge class="alert-danger w-100">
+                            <span v-if="queryTooShort">Search string too short!</span>
+                            <span v-else-if="!hasQuery && !hasWorkflows">No workflows found!</span>
+                            <span v-else-if="hasQuery && !hasWorkflows">No results found!</span>
+                        </b-badge>
+                    </div>
+                </div>
+            </div>
+            <div v-if="!showAdvanced" class="unified-panel-body">
+                <div class="toolMenuContainer">
+                    <div id="internal-workflows" class="toolSectionBody">
+                        <div class="toolSectionBg" />
+                        <div v-for="wf in workflows" :key="wf.id" class="toolTitle">
+                            <a class="title-link" href="javascript:void(0)" @click="onOpen(wf.href)">{{ wf.name }}</a>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -1,10 +1,25 @@
 /**
- * Utilities file for Tool Search (panel/client search + advanced/backend search)
+ * Utilities file for Panel Searches (panel/client search + advanced/backend search)
  */
 import { orderBy } from "lodash";
 
 const TOOLS_RESULTS_SORT_LABEL = "apiSort";
 const TOOLS_RESULTS_SECTIONS_HIDE = ["Expression Tools"];
+
+// Converts filterSettings { key: value } to query = "key:value"
+export function createWorkflowQuery(filterSettings) {
+    let query = "";
+    query = Object.entries(filterSettings)
+        .filter(([filter, value]) => value)
+        .map(([filter, value]) => {
+            return `${filter}:${value}`;
+        })
+        .join(" ");
+    if (Object.keys(filterSettings).length == 1 && filterSettings.name) {
+        return filterSettings.name;
+    }
+    return query;
+}
 
 // - Takes filterSettings = {"name": "Tool Name", "section": "Collection", ...}
 // - Takes panelView (if not 'default', does ontology search at backend)

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -12,6 +12,9 @@ export function createWorkflowQuery(filterSettings) {
     query = Object.entries(filterSettings)
         .filter(([filter, value]) => value)
         .map(([filter, value]) => {
+            if (value === true) {
+                return `is:${filter}`;
+            }
             return `${filter}:${value}`;
         })
         .join(" ");

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -1,6 +1,7 @@
 import toolsList from "components/ToolsView/testData/toolsList";
 import {
     createWhooshQuery,
+    createWorkflowQuery,
     determineWidth,
     filterTools,
     filterToolSections,
@@ -92,5 +93,19 @@ describe("test helpers in tool searching utilities and panel handling", () => {
         ).toHaveLength(1);
         // check length of filtered tools without sections
         expect(filterTools(toolsList, ids)).toHaveLength(2);
+    });
+});
+
+describe("test helpers in workflow searching utilities", () => {
+    it("test helper that creates workflow query given filters", async () => {
+        const settings = {
+            name: "extract",
+            tag: "Genomic",
+            published: null,
+            shared_with_me: true,
+            deleted: false,
+        };
+        const q = createWorkflowQuery(settings);
+        expect(q).toEqual("name:extract tag:Genomic is:shared_with_me");
     });
 });

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -186,6 +186,7 @@ export default {
             // Render the published workflows version of this grid.
             type: Boolean,
             default: false,
+        },
         query: {
             type: String,
             required: false,

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -189,6 +189,7 @@ export default {
         query: {
             type: String,
             required: false,
+            default: "",
         },
     },
     data() {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -186,6 +186,9 @@ export default {
             // Render the published workflows version of this grid.
             type: Boolean,
             default: false,
+        query: {
+            type: String,
+            required: false,
         },
     },
     data() {
@@ -224,6 +227,9 @@ export default {
     created() {
         this.root = getAppRoot();
         this.services = new Services();
+        if (this.query) {
+            this.filter = this.query;
+        }
     },
     methods: {
         decorateData(item) {

--- a/client/src/components/Workflow/WorkflowSearch.vue
+++ b/client/src/components/Workflow/WorkflowSearch.vue
@@ -1,0 +1,86 @@
+<template>
+    <div>
+        <small v-if="showAdvanced">Filter by name:</small>
+        <DelayedInput
+            :class="!showAdvanced && 'mb-3'"
+            :query="query"
+            :delay="100"
+            :show-advanced="showAdvanced"
+            :enable-advanced="enableAdvanced"
+            :placeholder="showAdvanced ? 'any name' : placeholder"
+            @change="checkQuery"
+            @onToggle="onToggle" />
+        <div
+            v-if="showAdvanced"
+            description="advanced workflow filters"
+            @keyup.enter="onSearch"
+            @keyup.esc="onToggle(false)">
+            <small class="mt-1">Filter by tag:</small>
+            <b-form-input v-model="filterSettings['tag']" size="sm" placeholder="any tag" />
+            <div class="mt-3">
+                <b-button class="mr-1" size="sm" variant="primary" @click="onSearch">
+                    <icon icon="search" />
+                    <span>{{ "Search" | localize }}</span>
+                </b-button>
+                <b-button size="sm" @click="onToggle(false)">
+                    <icon icon="redo" />
+                    <span>{{ "Cancel" | localize }}</span>
+                </b-button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import DelayedInput from "components/Common/DelayedInput";
+import _l from "utils/localization";
+import { createWorkflowQuery } from "components/Panels/utilities";
+
+export default {
+    name: "WorkflowSearch",
+    components: {
+        DelayedInput,
+    },
+    props: {
+        enableAdvanced: {
+            type: Boolean,
+            default: false,
+        },
+        placeholder: {
+            type: String,
+            default: _l("search workflows"),
+        },
+        query: {
+            type: String,
+            default: null,
+        },
+        showAdvanced: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    data() {
+        return {
+            favorites: ["#favs", "#favorites", "#favourites"],
+            filterSettings: {},
+        };
+    },
+    methods: {
+        checkQuery(q) {
+            this.filterSettings["name"] = q;
+            if (this.favorites.includes(q)) {
+                this.$emit("onQuery", "#favorites");
+            } else {
+                this.$emit("onQuery", q);
+            }
+        },
+        onToggle(toggleAdvanced) {
+            this.$emit("update:show-advanced", toggleAdvanced);
+        },
+        onSearch() {
+            const query = { query: createWorkflowQuery(this.filterSettings) };
+            this.$router.push({ path: "/workflows/list", query: query });
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/WorkflowSearch.vue
+++ b/client/src/components/Workflow/WorkflowSearch.vue
@@ -1,23 +1,83 @@
+<script setup lang="ts">
+import { ref, type Ref } from "vue";
+import { useRouter } from "vue-router/composables";
+import DelayedInput from "@/components/Common/DelayedInput.vue";
+import _l from "@/utils/localization";
+import { createWorkflowQuery } from "@/components/Panels/utilities";
+
+const router = useRouter();
+
+type FilterSettings = {
+    name?: string;
+    tag?: string;
+    published?: boolean;
+    shared_with_me?: boolean;
+    deleted?: boolean;
+};
+
+const emit = defineEmits<{
+    (e: "onQuery", query: string): void;
+    (e: "update:show-advanced", showAdvanced: boolean): void;
+}>();
+
+const props = defineProps({
+    enableAdvanced: { type: Boolean, default: false },
+    loading: { type: Boolean, default: false },
+    placeholder: { type: String, default: _l("search workflows") },
+    query: { type: String, default: null },
+    showAdvanced: { type: Boolean, default: false },
+});
+
+const favorites = ["#favs", "#favorites", "#favourites"];
+const options = [
+    { text: "Yes", value: true },
+    { text: "No", value: false },
+];
+
+const filterSettings: Ref<FilterSettings> = ref({
+    published: false,
+    shared: false,
+    deleted: false,
+});
+
+function checkQuery(q: string) {
+    filterSettings.value.name = q;
+    if (favorites.includes(q)) {
+        emit("onQuery", "#favorites");
+    } else {
+        emit("onQuery", q);
+    }
+}
+function onToggle(toggleAdvanced: boolean) {
+    emit("update:show-advanced", toggleAdvanced);
+}
+function onSearch() {
+    const query = createWorkflowQuery(filterSettings.value);
+    const path = "/workflows/list";
+    const routerParams = query ? { path, query: { query } } : { path };
+    router.push(routerParams);
+}
+</script>
 <template>
     <div>
-        <small v-if="showAdvanced">Filter by name:</small>
+        <small v-if="props.showAdvanced">Filter by name:</small>
         <DelayedInput
-            :class="!showAdvanced && 'mb-3'"
-            :query="query"
+            :class="!props.showAdvanced && 'mb-3'"
+            :query="props.query"
             :delay="100"
-            :loading="loading"
-            :show-advanced="showAdvanced"
-            :enable-advanced="enableAdvanced"
-            :placeholder="showAdvanced ? 'any name' : placeholder"
+            :loading="props.loading"
+            :show-advanced="props.showAdvanced"
+            :enable-advanced="props.enableAdvanced"
+            :placeholder="props.showAdvanced ? 'any name' : props.placeholder"
             @change="checkQuery"
             @onToggle="onToggle" />
         <div
-            v-if="showAdvanced"
+            v-if="props.showAdvanced"
             description="advanced workflow filters"
             @keyup.enter="onSearch"
             @keyup.esc="onToggle(false)">
             <small class="mt-1">Filter by tag:</small>
-            <b-form-input v-model="filterSettings['tag']" size="sm" placeholder="any tag" />
+            <b-form-input v-model="filterSettings.tag" size="sm" placeholder="any tag" />
             <small>Published:</small>
             <b-form-group class="m-0">
                 <b-form-radio-group
@@ -30,7 +90,7 @@
             <small>Shared:</small>
             <b-form-group class="m-0">
                 <b-form-radio-group
-                    v-model="filterSettings.shared"
+                    v-model="filterSettings.shared_with_me"
                     :options="options"
                     size="sm"
                     buttons
@@ -48,81 +108,13 @@
             <div class="mt-3">
                 <b-button class="mr-1" size="sm" variant="primary" @click="onSearch">
                     <icon icon="search" />
-                    <span>{{ "Search" | localize }}</span>
+                    <span>{{ _l("Search") }}</span>
                 </b-button>
                 <b-button size="sm" @click="onToggle(false)">
                     <icon icon="redo" />
-                    <span>{{ "Cancel" | localize }}</span>
+                    <span>{{ _l("Cancel") }}</span>
                 </b-button>
             </div>
         </div>
     </div>
 </template>
-
-<script>
-import DelayedInput from "components/Common/DelayedInput";
-import _l from "utils/localization";
-import { createWorkflowQuery } from "components/Panels/utilities";
-
-export default {
-    name: "WorkflowSearch",
-    components: {
-        DelayedInput,
-    },
-    props: {
-        loading: {
-            type: Boolean,
-            default: false,
-        },
-        enableAdvanced: {
-            type: Boolean,
-            default: false,
-        },
-        placeholder: {
-            type: String,
-            default: _l("search workflows"),
-        },
-        query: {
-            type: String,
-            default: null,
-        },
-        showAdvanced: {
-            type: Boolean,
-            default: false,
-        },
-    },
-    data() {
-        return {
-            favorites: ["#favs", "#favorites", "#favourites"],
-            filterSettings: {
-                published: false,
-                shared: false,
-                deleted: false,
-            },
-            options: [
-                { text: "Yes", value: true },
-                { text: "No", value: false },
-            ],
-        };
-    },
-    methods: {
-        checkQuery(q) {
-            this.filterSettings["name"] = q;
-            if (this.favorites.includes(q)) {
-                this.$emit("onQuery", "#favorites");
-            } else {
-                this.$emit("onQuery", q);
-            }
-        },
-        onToggle(toggleAdvanced) {
-            this.$emit("update:show-advanced", toggleAdvanced);
-        },
-        onSearch() {
-            const query = createWorkflowQuery(this.filterSettings);
-            const path = "/workflows/list";
-            const routerParams = query ? { path, query: { query } } : { path };
-            this.$router.push(routerParams);
-        },
-    },
-};
-</script>

--- a/client/src/components/Workflow/WorkflowSearch.vue
+++ b/client/src/components/Workflow/WorkflowSearch.vue
@@ -3,9 +3,6 @@ import { ref, type Ref } from "vue";
 import { useRouter } from "vue-router/composables";
 import _l from "@/utils/localization";
 import { createWorkflowQuery } from "@/components/Panels/utilities";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { faAngleDoubleUp, faAngleDoubleDown } from "@fortawesome/free-solid-svg-icons";
-import { library } from "@fortawesome/fontawesome-svg-core";
 
 const router = useRouter();
 
@@ -16,9 +13,6 @@ type FilterSettings = {
     shared_with_me?: boolean;
     deleted?: boolean;
 };
-
-// @ts-ignore bad library types
-library.add(faAngleDoubleUp, faAngleDoubleDown);
 
 const options = [
     { text: "Yes", value: true },
@@ -31,8 +25,6 @@ const filterSettings: Ref<FilterSettings> = ref({
     deleted: false,
 });
 
-const showAdvanced = ref(true);
-
 function onSearch() {
     const query = createWorkflowQuery(filterSettings.value);
     const path = "/workflows/list";
@@ -42,26 +34,12 @@ function onSearch() {
 </script>
 <template>
     <div>
-        <b-button
-            class="upload-button"
-            size="sm"
-            :pressed="showAdvanced"
-            :variant="showAdvanced ? 'info' : 'secondary'"
-            @click="showAdvanced = !showAdvanced">
-            <FontAwesomeIcon v-if="!showAdvanced" icon="angle-double-down" />
-            <FontAwesomeIcon v-else icon="angle-double-up" />
-            Search for Workflows
-        </b-button>
-        <div
-            v-if="showAdvanced"
-            description="advanced workflow filters"
-            @keyup.enter="onSearch"
-            @keyup.esc="showAdvanced = false">
+        <div description="advanced workflow filters" @keyup.enter="onSearch">
             <small class="mt-1">Filter by name:</small>
             <b-form-input v-model="filterSettings.name" size="sm" placeholder="any name" />
             <small class="mt-1">Filter by tag:</small>
             <b-form-input v-model="filterSettings.tag" size="sm" placeholder="any tag" />
-            <small>Published:</small>
+            <small>Search published workflows:</small>
             <b-form-group class="m-0">
                 <b-form-radio-group
                     v-model="filterSettings.published"
@@ -70,7 +48,7 @@ function onSearch() {
                     buttons
                     description="filter published" />
             </b-form-group>
-            <small>Shared:</small>
+            <small>Search shared workflows:</small>
             <b-form-group class="m-0">
                 <b-form-radio-group
                     v-model="filterSettings.shared_with_me"
@@ -79,7 +57,7 @@ function onSearch() {
                     buttons
                     description="filter shared" />
             </b-form-group>
-            <small>Deleted:</small>
+            <small>Search deleted workflows:</small>
             <b-form-group class="m-0">
                 <b-form-radio-group
                     v-model="filterSettings.deleted"
@@ -92,10 +70,6 @@ function onSearch() {
                 <b-button class="mr-1" size="sm" variant="primary" @click="onSearch">
                     <icon icon="search" />
                     <span>{{ _l("Search") }}</span>
-                </b-button>
-                <b-button size="sm" @click="showAdvanced = false">
-                    <icon icon="redo" />
-                    <span>{{ _l("Cancel") }}</span>
                 </b-button>
             </div>
         </div>

--- a/client/src/components/Workflow/WorkflowSearch.vue
+++ b/client/src/components/Workflow/WorkflowSearch.vue
@@ -5,6 +5,7 @@
             :class="!showAdvanced && 'mb-3'"
             :query="query"
             :delay="100"
+            :loading="loading"
             :show-advanced="showAdvanced"
             :enable-advanced="enableAdvanced"
             :placeholder="showAdvanced ? 'any name' : placeholder"
@@ -17,6 +18,33 @@
             @keyup.esc="onToggle(false)">
             <small class="mt-1">Filter by tag:</small>
             <b-form-input v-model="filterSettings['tag']" size="sm" placeholder="any tag" />
+            <small>Published:</small>
+            <b-form-group class="m-0">
+                <b-form-radio-group
+                    v-model="filterSettings.published"
+                    :options="options"
+                    size="sm"
+                    buttons
+                    description="filter published" />
+            </b-form-group>
+            <small>Shared:</small>
+            <b-form-group class="m-0">
+                <b-form-radio-group
+                    v-model="filterSettings.shared"
+                    :options="options"
+                    size="sm"
+                    buttons
+                    description="filter shared" />
+            </b-form-group>
+            <small>Deleted:</small>
+            <b-form-group class="m-0">
+                <b-form-radio-group
+                    v-model="filterSettings.deleted"
+                    :options="options"
+                    size="sm"
+                    buttons
+                    description="filter deleted" />
+            </b-form-group>
             <div class="mt-3">
                 <b-button class="mr-1" size="sm" variant="primary" @click="onSearch">
                     <icon icon="search" />
@@ -42,6 +70,10 @@ export default {
         DelayedInput,
     },
     props: {
+        loading: {
+            type: Boolean,
+            default: false,
+        },
         enableAdvanced: {
             type: Boolean,
             default: false,
@@ -62,7 +94,15 @@ export default {
     data() {
         return {
             favorites: ["#favs", "#favorites", "#favourites"],
-            filterSettings: {},
+            filterSettings: {
+                published: false,
+                shared: false,
+                deleted: false,
+            },
+            options: [
+                { text: "Yes", value: true },
+                { text: "No", value: false },
+            ],
         };
     },
     methods: {
@@ -78,8 +118,10 @@ export default {
             this.$emit("update:show-advanced", toggleAdvanced);
         },
         onSearch() {
-            const query = { query: createWorkflowQuery(this.filterSettings) };
-            this.$router.push({ path: "/workflows/list", query: query });
+            const query = createWorkflowQuery(this.filterSettings);
+            const path = "/workflows/list";
+            const routerParams = query ? { path, query: { query } } : { path };
+            this.$router.push(routerParams);
         },
     },
 };

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -462,6 +462,7 @@ export function getRouter(Galaxy) {
                         props: (route) => ({
                             importMessage: route.query["message"],
                             importStatus: route.query["status"],
+                            query: route.query["query"],
                         }),
                     },
                     {

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -22,7 +22,7 @@ interface Preferences {
 export const useUserStore = defineStore(
     "userStore",
     () => {
-        const toggledSideBar = ref("search");
+        const toggledSideBar = ref("tools");
         const showActivityBar = ref(false);
         const currentUser = ref<User | null>(null);
         const currentPreferences = ref<Preferences | null>(null);

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -1,18 +1,15 @@
 import { defineStore } from "pinia";
 import axios from "axios";
 import type { Steps } from "@/stores/workflowStepStore";
-import { createWorkflowQuery } from "@/components/Panels/utilities";
 import { getAppRoot } from "@/onload/loadConfig";
 
-export interface Workflow {
+interface Workflow {
     [index: string]: any;
     steps: Steps;
 }
 
 export const useWorkflowStore = defineStore("workflowStore", {
     state: () => ({
-        allWorkflows: [] as Workflow[],
-        workflowResults: [] as Workflow[],
         workflowsByInstanceId: {} as { [index: string]: Workflow },
     }),
     getters: {
@@ -37,15 +34,6 @@ export const useWorkflowStore = defineStore("workflowStore", {
                 return storedWorkflow?.id;
             };
         },
-        getWorkflows: (state) => {
-            return (filterSettings: Record<string, string | boolean>) => {
-                if (Object.keys(filterSettings).length === 0) {
-                    return state.allWorkflows;
-                } else {
-                    return state.workflowResults;
-                }
-            };
-        },
     },
     actions: {
         async fetchWorkflowForInstanceId(workflowId: string) {
@@ -55,21 +43,6 @@ export const useWorkflowStore = defineStore("workflowStore", {
             this.$patch((state) => {
                 state.workflowsByInstanceId[workflowId] = data as Workflow;
             });
-        },
-        async fetchWorkflows(filterSettings: Record<string, string | boolean>) {
-            if (Object.keys(filterSettings).length !== 0) {
-                const query = createWorkflowQuery(filterSettings); // remove from here?
-                const { data } = await axios.get(`${getAppRoot()}api/workflows`, {
-                    params: { search: query, skip_step_counts: true },
-                });
-                this.workflowResults = data;
-            } else if (this.allWorkflows.length === 0) {
-                // TODO: add all params: ?limit=50&offset=0&search=&skip_step_counts=true
-                const { data } = await axios.get(`${getAppRoot()}api/workflows`, {
-                    params: { skip_step_counts: true },
-                });
-                this.allWorkflows = data;
-            }
         },
     },
 });

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -1,15 +1,18 @@
 import { defineStore } from "pinia";
 import axios from "axios";
 import type { Steps } from "@/stores/workflowStepStore";
+import { createWorkflowQuery } from "@/components/Panels/utilities";
 import { getAppRoot } from "@/onload/loadConfig";
 
-interface Workflow {
+export interface Workflow {
     [index: string]: any;
     steps: Steps;
 }
 
 export const useWorkflowStore = defineStore("workflowStore", {
     state: () => ({
+        allWorkflows: [] as Workflow[],
+        workflowResults: [] as Workflow[],
         workflowsByInstanceId: {} as { [index: string]: Workflow },
     }),
     getters: {
@@ -34,6 +37,15 @@ export const useWorkflowStore = defineStore("workflowStore", {
                 return storedWorkflow?.id;
             };
         },
+        getWorkflows: (state) => {
+            return (filterSettings: Record<string, string | boolean>) => {
+                if (Object.keys(filterSettings).length === 0) {
+                    return state.allWorkflows;
+                } else {
+                    return state.workflowResults;
+                }
+            };
+        },
     },
     actions: {
         async fetchWorkflowForInstanceId(workflowId: string) {
@@ -43,6 +55,21 @@ export const useWorkflowStore = defineStore("workflowStore", {
             this.$patch((state) => {
                 state.workflowsByInstanceId[workflowId] = data as Workflow;
             });
+        },
+        async fetchWorkflows(filterSettings: Record<string, string | boolean>) {
+            if (Object.keys(filterSettings).length !== 0) {
+                const query = createWorkflowQuery(filterSettings); // remove from here?
+                const { data } = await axios.get(`${getAppRoot()}api/workflows`, {
+                    params: { search: query, skip_step_counts: true },
+                });
+                this.workflowResults = data;
+            } else if (this.allWorkflows.length === 0) {
+                // TODO: add all params: ?limit=50&offset=0&search=&skip_step_counts=true
+                const { data } = await axios.get(`${getAppRoot()}api/workflows`, {
+                    params: { skip_step_counts: true },
+                });
+                this.allWorkflows = data;
+            }
         },
     },
 });


### PR DESCRIPTION
Add a "WorkflowBox" to the new ActivityBar side panel:
It has links to workflow activities/routes, as well as an advanced search workflow menu for the `WorkflowList`

https://github.com/galaxyproject/galaxy/assets/78516064/941c4d3a-4500-4a94-bcfb-986b4a156d35

<br ><br >

# Alternative Ideas for the future:
### A `WorkflowBox` identical (in terms of UI) to the `ToolBox` with all workflows (with just their names) in the client side search:
https://user-images.githubusercontent.com/78516064/236548780-ccd6d10b-3cdb-4a5b-b118-2c771c9f71ca.mov

### Only showing the bookmarked workflows in the panel (with more details for each workflow in view)
https://github.com/galaxyproject/galaxy/assets/78516064/60f8723f-c9a4-4526-91eb-c90109861a32
## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
