### PR TITLE
Add option to create list for all datasets in a history to dropdown

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.test.js
@@ -150,6 +150,14 @@ describe("History Selection Operations", () => {
                 expect(wrapper.find(buildPairOption).exists()).toBe(false);
                 expect(wrapper.find(buildListOfPairsOption).exists()).toBe(false);
             });
+
+            it("should display list building option when all are selected", async () => {
+                const buildListOption = '[data-description="build list all"]';
+                await wrapper.setProps({ selectionSize: 105 });
+                await wrapper.setProps({ totalItemsInQuery: 105 });
+                await wrapper.setProps({ isQuerySelection: true });
+                expect(wrapper.find(buildListOption).exists()).toBe(true);
+            });
         });
 
         describe("Operation Run", () => {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -328,8 +328,8 @@ export default {
             // have to hide the source items if that was requested
             if (modalResult.hide_source_items) {
                 this.$emit("hide-selection", allContents);
-                this.$emit("reset-selection");
             }
+            this.$emit("reset-selection");
         },
         async buildDatasetPair() {
             await this.buildNewCollection("paired");

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -205,7 +205,7 @@ export default {
         },
         /** @returns {Boolean} */
         showBuildOptionForAll() {
-            return !this.showBuildOptions && this.selectionMatchesQuery
+            return !this.showBuildOptions && this.selectionMatchesQuery;
         },
         /** @returns {Number} */
         numSelected() {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -165,8 +165,7 @@ import SingleItemSelector from "components/SingleItemSelector";
 import { StatelessTags } from "components/Tags";
 import ConfigProvider from "components/providers/ConfigProvider";
 import { HistoryFilters } from "components/History/HistoryFilters";
-import { getAppRoot } from "onload/loadConfig";
-import axios from "axios";
+import { getHistoryContent } from "components/History/model/queries";
 
 export default {
     components: {
@@ -315,20 +314,9 @@ export default {
         },
         async buildDatasetListAll() {
             let allContents = [];
-            //TODO: set visible/deleted/purged to true/false/false as defaults, but user may override in search
-            //use the user's search filters then append defaults in case they are not set
-            const filterQuery = `v=dev&q=visible&qv=true&q=deleted&qv=false&q=purged&qv=false`;
             const filters = HistoryFilters.getQueryDict(this.filterText);
-            const uri = `${getAppRoot()}api/histories/${this.history.id}/contents/datasets?${filterQuery}`;
 
-            await axios
-                .get(uri)
-                .then((response) => {
-                    allContents = response.data;
-                })
-                .catch((error) => {
-                    console.error(error);
-                });
+            allContents = await getHistoryContent(this.history.id, filters, "dataset");
 
             const modalResult = await buildCollectionModal("list", allContents, this.history.id);
             await createDatasetCollection(this.history, modalResult);

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -322,14 +322,7 @@ export default {
 
             allContents = await getHistoryContent(this.history.id, filters, "dataset");
 
-            const modalResult = await buildCollectionModal("list", allContents, this.history.id);
-            await createDatasetCollection(this.history, modalResult);
-
-            // have to hide the source items if that was requested
-            if (modalResult.hide_source_items) {
-                this.$emit("hide-selection", allContents);
-            }
-            this.$emit("reset-selection");
+            this.buildNewCollection("list", allContents);
         },
         async buildDatasetPair() {
             await this.buildNewCollection("paired");
@@ -340,8 +333,11 @@ export default {
         async buildCollectionFromRules() {
             await this.buildNewCollection("rules");
         },
-        async buildNewCollection(collectionType) {
-            const modalResult = await buildCollectionModal(collectionType, this.contentSelection, this.history.id);
+        async buildNewCollection(collectionType, contents) {
+            if (contents === undefined) {
+                contents = this.contentSelection;
+            }
+            const modalResult = await buildCollectionModal(collectionType, contents, this.history.id);
             await createDatasetCollection(this.history, modalResult);
 
             // have to hide the source items if that was requested

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -315,7 +315,8 @@ export default {
         },
         async buildDatasetListAll() {
             let allContents = [];
-            const uri = `${getAppRoot()}api/histories/${this.history.id}/contents/datasets`;
+            const filterQuery = `v=dev&q=visible&qv=true&q=deleted&qv=false&q=purged&qv=false`;
+            const uri = `${getAppRoot()}api/histories/${this.history.id}/contents/datasets?${filterQuery}`;
 
             await axios
                 .get(uri)
@@ -331,7 +332,7 @@ export default {
 
             // have to hide the source items if that was requested
             if (modalResult.hide_source_items) {
-                this.$emit("hide-selection", this.contentSelection);
+                this.$emit("hide-selection", allContents);
                 this.$emit("reset-selection");
             }
         },

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -50,9 +50,9 @@
                     @click="buildCollectionFromRules">
                     <span v-localize>Build Collection from Rules</span>
                 </b-dropdown-item>
-                <b-dropdown-divider v-if="!showBuildOptions && selectionMatchesQuery" />
+                <b-dropdown-divider v-if="showBuildOptionForAll" />
                 <b-dropdown-item
-                    v-if="!showBuildOptions && selectionMatchesQuery"
+                    v-if="showBuildOptionForAll"
                     data-description="build list all"
                     @click="buildDatasetListAll">
                     <span v-localize>Build Dataset List</span>
@@ -202,6 +202,10 @@ export default {
         /** @returns {Boolean} */
         showBuildOptions() {
             return !this.isQuerySelection && !this.showHidden && !this.showDeleted;
+        },
+        /** @returns {Boolean} */
+        showBuildOptionForAll() {
+            return !this.showBuildOptions && this.selectionMatchesQuery
         },
         /** @returns {Number} */
         numSelected() {

--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -315,7 +315,10 @@ export default {
         },
         async buildDatasetListAll() {
             let allContents = [];
+            //TODO: set visible/deleted/purged to true/false/false as defaults, but user may override in search
+            //use the user's search filters then append defaults in case they are not set
             const filterQuery = `v=dev&q=visible&qv=true&q=deleted&qv=false&q=purged&qv=false`;
+            const filters = HistoryFilters.getQueryDict(this.filterText);
             const uri = `${getAppRoot()}api/histories/${this.history.id}/contents/datasets?${filterQuery}`;
 
             await axios

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -65,6 +65,39 @@ export async function updateContentFields(content, newFields = {}) {
     return doResponse(response);
 }
 
+/** Get all objects that match filters in a history
+ *
+ * @param {string} historyId
+ * @param {Object} filters
+ * @param {string} type
+ *
+ */
+export async function getHistoryContent(historyId, filters = {}, type = "dataset") {
+    const vDefault = { visible: true };
+    const dDefault = { deleted: false };
+    const pDefault = { purged: false };
+    //check if filters inclues hidden, deleted, or purged
+    const filterKeys = Object.keys(filters);
+    const hasVisible = filterKeys.includes("visible");
+    const hasDeleted = filterKeys.includes("deleted");
+    const hasPurged = filterKeys.includes("purged");
+    //if filters does not include hidden, deleted, or purged, set defaults to false
+    if (!hasVisible) {
+        filters = Object.assign({}, vDefault, filters);
+    }
+    if (!hasDeleted) {
+        filters = Object.assign({}, dDefault, filters);
+    }
+    if (!hasPurged) {
+        filters = Object.assign({}, pDefault, filters);
+    }
+
+    const filterQuery = buildQueryStringFrom(filters);
+    const url = `api/histories/${historyId}/contents/${type}s?v=dev&${filterQuery}`;
+    const response = await axios.get(prependPath(url));
+    return doResponse(response);
+}
+
 /**
  * Performs an operation on a specific set of items or all the items
  * matching the filters.

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -73,25 +73,6 @@ export async function updateContentFields(content, newFields = {}) {
  *
  */
 export async function getHistoryContent(historyId, filters = {}, type = "dataset") {
-    const vDefault = { visible: true };
-    const dDefault = { deleted: false };
-    const pDefault = { purged: false };
-    //check if filters inclues hidden, deleted, or purged
-    const filterKeys = Object.keys(filters);
-    const hasVisible = filterKeys.includes("visible");
-    const hasDeleted = filterKeys.includes("deleted");
-    const hasPurged = filterKeys.includes("purged");
-    //if filters does not include hidden, deleted, or purged, set defaults to false
-    if (!hasVisible) {
-        filters = Object.assign({}, vDefault, filters);
-    }
-    if (!hasDeleted) {
-        filters = Object.assign({}, dDefault, filters);
-    }
-    if (!hasPurged) {
-        filters = Object.assign({}, pDefault, filters);
-    }
-
     const filterQuery = buildQueryStringFrom(filters);
     const url = `api/histories/${historyId}/contents/${type}s?v=dev&${filterQuery}`;
     const response = await axios.get(prependPath(url));


### PR DESCRIPTION
implements request in #14967

I added an option in the selection operations that allows users to create a simple list collection if the number of datasets in their history exceeds the 100 allowed currently. 

To do so, I request all datasets (only) from the `/api/histories/{history_id}/contents/datasets` endpoint and pipe them into the ListCollectionCreator. It seems to handle a history with over 300 duplicates pretty quickly, and most users won't have many files that are named the same (in my case, a lot of Pasted Entry datasets) 

[Screencast from 04-17-2023 12:28:39 PM.webm](https://user-images.githubusercontent.com/26912553/232550947-e6fb4bc6-13a4-4cee-90be-e3df37d07086.webm)

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Create a history of more than 100 datasets
  2. Select all items in history and select "Build Dataset List" from the dropdown menu
  3. Note how the Collection Creator is populated with all the datasets from your history.  
  4. Click Create Collection and notice the number of items in your collection is the same as the number you selected. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
