### PR TITLE
[23.0] Fix folder listing via file browser

### DIFF
--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -1507,7 +1507,6 @@ class GalaxyRBACAgent(RBACAgent):
             return True, ""
         action = self.permitted_actions.DATASET_ACCESS
 
-        raise
         lddas = (
             self.sa_session.query(self.model.LibraryDatasetDatasetAssociation)
             .join("library_dataset")


### PR DESCRIPTION
Added in https://github.com/galaxyproject/galaxy/pull/15340 by accident.
Fixes:

```
RuntimeError: No active exception to reraise
  File "galaxy/web/framework/decorators.py", line 337, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/library_contents.py", line 130, in index
    for content in traverse(library.root_folder):
  File "galaxy/webapps/galaxy/api/library_contents.py", line 84, in traverse
    can_access, folder_ids = trans.app.security_agent.check_folder_contents(
  File "galaxy/model/security.py", line 1510, in check_folder_contents
    raise
```
in https://sentry.galaxyproject.org/share/issue/38df4490ff61415090c319ad0e16f1fa/

You can trigger this in the UI using the "Browse Files" if you're not an admin.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
