### PR TITLE
Fix nullable deleted column in API Keys table

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10140,7 +10140,7 @@ class APIKeys(Base, RepresentById):
     user_id = Column(Integer, ForeignKey("galaxy_user.id"), index=True)
     key = Column(TrimmedString(32), index=True, unique=True)
     user = relationship("User", back_populates="api_keys")
-    deleted = Column(Boolean, index=True, default=False, nullable=False)
+    deleted = Column(Boolean, index=True, server_default=false(), nullable=False)
 
 
 def copy_list(lst, *args, **kwds):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -10140,7 +10140,7 @@ class APIKeys(Base, RepresentById):
     user_id = Column(Integer, ForeignKey("galaxy_user.id"), index=True)
     key = Column(TrimmedString(32), index=True, unique=True)
     user = relationship("User", back_populates="api_keys")
-    deleted = Column(Boolean, index=True, default=False)
+    deleted = Column(Boolean, index=True, default=False, nullable=False)
 
 
 def copy_list(lst, *args, **kwds):

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/b855b714e8b8_make_api_keys_deleted_non_nullable.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/b855b714e8b8_make_api_keys_deleted_non_nullable.py
@@ -1,0 +1,39 @@
+"""make api_keys deleted non nullable
+
+Revision ID: b855b714e8b8
+Revises: 3356bc2ecfc4
+Create Date: 2023-04-19 18:41:13.500332
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from galaxy.model.migrations.util import (
+    alter_column,
+    transaction,
+)
+
+# revision identifiers, used by Alembic.
+revision = "b855b714e8b8"
+down_revision = "3356bc2ecfc4"
+branch_labels = None
+depends_on = None
+
+
+table_name = "api_keys"
+column_name = "deleted"
+
+
+def upgrade():
+    with transaction():
+        # Update any existing rows with a deleted=NULL value to be deleted=True.
+        # This will expire any existing API keys that didn't have a deleted value set.
+        table = sa.sql.table(table_name, sa.Column(column_name, sa.Boolean(), nullable=True))
+        op.execute(table.update().where(table.c.deleted.is_(None)).values(deleted=True))
+
+        # Make the column non-nullable.
+        alter_column(table_name, column_name, existing_type=sa.Boolean(), nullable=False, server_default=sa.false())
+
+
+def downgrade():
+    alter_column(table_name, column_name, existing_type=sa.Boolean(), nullable=True, server_default=None)


### PR DESCRIPTION
By default, the `deleted` column is nullable even if it has a [default value of False](https://github.com/galaxyproject/galaxy/blob/1a984f27ab755b71a817f2bb95139af9fd43c7aa/lib/galaxy/model/__init__.py#L9700).

There is a chance, some external scripts that create API keys for users directly in the database might not set the `deleted` value explicitly causing possible incongruences with multiple API keys for the user not being explicitly deleted=False.

This restricts those cases by forcing a non-null value.

We could also try to handle possible null values in the API logic, I can change the approach if this is more desirable than altering the database schema at this point.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
