### PR TITLE
[23.0] Change default watchdog inotify_buffer log level to info

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -111,6 +111,10 @@ LOGGING_CONFIG_DEFAULT: Dict[str, Any] = {
             "propagate": False,
             "handlers": ["console"],
         },
+        "watchdog.observers.inotify_buffer": {
+            "level": "INFO",
+            "qualname": "watchdog.observers.inotify_buffer",
+        },
     },
     "filters": {
         "stack": {


### PR DESCRIPTION
We're getting milions of
```
nt <InotifyEvent: src_path=b'/srv/galaxy/config/TPV_DO_NOT_TOUCH/tpv_rules_local.yml', wd=1, mask=IN_OPEN, cookie=0, name='tpv_rules_local.yml'>
Apr 20 09:01:44 gat-4.eu.galaxy.training galaxyctl[435287]: watchdog.observers.inotify_buffer DEBUG 2023-04-20 09:01:44,917 [pN:handler_1,p:435287,tN:Thread-11] in-event <InotifyEvent: src_path=b'/srv/galaxy/config/TPV_DO_NOT_TOUCH/tpv_rules_local.yml', wd=1, mask=IN_OPEN, cookie=0, name='tpv_rules_local.yml'>
Apr 20 09:01:44 gat-4.eu.galaxy.training galaxyctl[435287]: watchdog.observers.inotify_buffer DEBUG 2023-04-20 09:01:44,918 [pN:handler_1,p:435287,tN:Thread-11] in-event <InotifyEvent: src_path=b'/srv/galaxy/config/TPV_DO_NOT_TOUCH/tpv_rules_local.yml', wd=1, mask=IN_OPEN, cookie=0, name='tpv_rules_local.yml'>
Apr 20 09:01:44 gat-4.eu.galaxy.training galaxyctl[435287]: watchdog.observers.inotify_buffer DEBUG 2023-04-20 09:01:44,918 [pN:handler_1,p:435287,tN:Thread-11] in-event <InotifyEvent: src_path=b'/srv/galaxy/config/TPV_DO_NOT_TOUCH/tpv_rules_local.yml', wd=1, mask=IN_OPEN, cookie=0, name='tpv_rules_local.yml'>
```
in the job handler logs after activating TPV.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
