### PR TITLE
[23.0] Tabular Dataset Display Fixes

### DIFF
--- a/client/src/components/Visualizations/Tabular/TabularChunkedView.vue
+++ b/client/src/components/Visualizations/Tabular/TabularChunkedView.vue
@@ -88,7 +88,8 @@ function processChunk(chunk: TabularChunk) {
         parsedChunk = chunk.ck_data.trim().split("\n");
         parsedChunk = parsedChunk.map((line) => {
             try {
-                return parse(line, { delimiter: delimiter.value })[0];
+                const parsedLine = parse(line, { delimiter: delimiter.value })[0];
+                return parsedLine || [line];
             } catch (error) {
                 // Failing lines get passed through intact for row-level
                 // rendering/parsing.

--- a/client/src/components/Visualizations/Tabular/TabularChunkedView.vue
+++ b/client/src/components/Visualizations/Tabular/TabularChunkedView.vue
@@ -181,8 +181,14 @@ onMounted(() => {
             </b-thead>
             <b-tbody>
                 <b-tr v-for="(row, index) in tabularData.rows" :key="index">
-                    <b-td v-for="(element, elementIndex) in row" :key="elementIndex" :class="columnStyle[elementIndex]">
+                    <b-td
+                        v-for="(element, elementIndex) in row.slice(0, -1)"
+                        :key="elementIndex"
+                        :class="columnStyle[elementIndex]">
                         {{ element }}
+                    </b-td>
+                    <b-td :class="columnStyle[row.length - 1]" :colspan="1 + columns.length - row.length">
+                        {{ row.slice(-1)[0] }}
                     </b-td>
                 </b-tr>
             </b-tbody>


### PR DESCRIPTION
Handle empty lines correctly in tabular rendering, this was the error with the smaller dataset in https://github.com/galaxyproject/galaxy/issues/15940

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. See linked issue for test bam

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
