### PR TITLE
Improve display chunk generation for BAMs

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -609,30 +609,34 @@ class BamNative(CompressedArchive, _BamOrSam):
             try:
                 with pysam.AlignmentFile(dataset.file_name, "rb", check_sq=False) as bamfile:
                     ck_size = 300  # 300 lines
-                    ck_data = ""
-                    header_line_count = 0
                     if offset == 0:
-                        ck_data = bamfile.text.replace("\t", " ")  # type: ignore[attr-defined]
-                        header_line_count = bamfile.text.count("\n")  # type: ignore[attr-defined]
+                        offset = bamfile.tell()
+                        ck_lines = bamfile.text.strip().replace("\t", " ").splitlines()  # type: ignore[attr-defined]
                     else:
                         bamfile.seek(offset)
-                    for line_number, alignment in enumerate(bamfile):
+                        ck_lines = []
+                    for line_number, alignment in enumerate(bamfile, len(ck_lines)):
                         # return only Header lines if 'header_line_count' exceeds 'ck_size'
                         # FIXME: Can be problematic if bam has million lines of header
-                        offset = bamfile.tell()
-                        if (line_number + header_line_count) > ck_size:
+                        if line_number > ck_size:
                             break
-                        else:
-                            bamline = alignment.tostring(bamfile)
-                            # Galaxy display each tag as separate column because 'tostring()' funcition put tabs in between each tag of tags column.
-                            # Below code will remove spaces between each tag.
-                            bamline_modified = ("\t").join(bamline.split()[:11] + [(" ").join(bamline.split()[11:])])
-                            ck_data = f"{ck_data}\n{bamline_modified}"
+
+                        offset = bamfile.tell()
+                        bamline = alignment.tostring(bamfile)
+                        # With multiple tags, Galaxy would display each as a separate column
+                        # because the 'tostring()' function uses tabs also between tags.
+                        # Below code will turn these extra tabs into spaces.
+                        n_tabs = bamline.count('\t')
+                        if n_tabs > 11:
+                            bamline, *extra_tags = bamline.rsplit('\t', maxsplit=n_tabs - 11)
+                            bamline = f"{bamline} {' '.join(extra_tags)
+                        ck_lines.append(f"{bamline} {' '.join(extra_tags)}")
                     else:
                         # Nothing to enumerate; we've either offset to the end
                         # of the bamfile, or there is no data. (possible with
                         # header-only bams)
                         offset = -1
+                    ck_data = "\n".join(ck_lines)
             except Exception as e:
                 offset = -1
                 ck_data = f"Could not display BAM file, error was:\n{e}"

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -629,8 +629,8 @@ class BamNative(CompressedArchive, _BamOrSam):
                         n_tabs = bamline.count('\t')
                         if n_tabs > 11:
                             bamline, *extra_tags = bamline.rsplit('\t', maxsplit=n_tabs - 11)
-                            bamline = f"{bamline} {' '.join(extra_tags)
-                        ck_lines.append(f"{bamline} {' '.join(extra_tags)}")
+                            bamline = f"{bamline} {' '.join(extra_tags)}"
+                        ck_lines.append(bamline)
                     else:
                         # Nothing to enumerate; we've either offset to the end
                         # of the bamfile, or there is no data. (possible with

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -626,9 +626,9 @@ class BamNative(CompressedArchive, _BamOrSam):
                         # With multiple tags, Galaxy would display each as a separate column
                         # because the 'tostring()' function uses tabs also between tags.
                         # Below code will turn these extra tabs into spaces.
-                        n_tabs = bamline.count('\t')
+                        n_tabs = bamline.count("\t")
                         if n_tabs > 11:
-                            bamline, *extra_tags = bamline.rsplit('\t', maxsplit=n_tabs - 11)
+                            bamline, *extra_tags = bamline.rsplit("\t", maxsplit=n_tabs - 11)
                             bamline = f"{bamline} {' '.join(extra_tags)}"
                         ck_lines.append(bamline)
                     else:


### PR DESCRIPTION
As discussed in #15970 I tried to improve the BAM datatype's chunk logic.

I failed to get rid off the deprecated pysam.AlignmentFile.text attribute, but the new code now trims newlines from it.
Along the way I spotted a few other issues and fixed them. 
The new version is now considerably faster (~ factor 2) even for lines containing multiple tabs and optimizes the no or one tag cases further.
It also fixes a subtle bug that would drop a line at chunk boundaries.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
