### PR TITLE
[23.0] Fix History filters includes related filter bug

### DIFF
--- a/client/src/stores/history/historyItemsStore.js
+++ b/client/src/stores/history/historyItemsStore.js
@@ -28,7 +28,9 @@ export const useHistoryItemsStore = defineStore("historyItemsStore", {
         getHistoryItems: (state) => {
             return (historyId, filterText) => {
                 const itemArray = state.items[historyId] || [];
-                const filters = HistoryFilters.getFilters(filterText).filter((filter) => !filter.includes("related"));
+                const filters = HistoryFilters.getFilters(filterText).filter(
+                    (filter) => !filter[0].includes("related")
+                );
                 const relatedHid = HistoryFilters.getFilterValue(filterText, "related");
                 const filtered = itemArray.filter((item) => {
                     if (!item) {


### PR DESCRIPTION
If some filter other than the related filter was set = "related" (e.g.: `state:related` || `tag:related`), we would remove the filter in `historyItemsStore.getHistoryItems`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
