### PR TITLE
Record input datasets and collections at full parameter path

### DIFF
--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -201,7 +201,15 @@ class RenameDatasetAction(DefaultJobAction):
                 # repeat in cat1 would be something like queries_0.input2.
                 input_file_var = input_file_var.replace(".", "|")
 
-                replacement = input_names.get(input_file_var, "")
+                replacement = None
+                if input_file_var in input_names:
+                    replacement = input_names[input_file_var]
+                else:
+                    for input_name, _replacement in input_names.items():
+                        if "|" in input_name and input_name.endswith(input_file_var):
+                            # best effort attempt at matching up unqualified input
+                            replacement = _replacement
+                            break
 
                 # In case name was None.
                 replacement = replacement or ""

--- a/lib/galaxy/tool_util/parser/output_objects.py
+++ b/lib/galaxy/tool_util/parser/output_objects.py
@@ -347,17 +347,7 @@ class ToolOutputCollectionStructure:
     def collection_prototype(self, inputs, type_registry):
         # either must have specified structured_like or something worse
         if self.structured_like:
-            if self.structured_like in inputs:
-                collection_prototype = inputs[self.structured_like].collection
-            else:
-                for key, value in inputs.items():
-                    if key.split("|")[-1] == self.structured_like:
-                        collection_prototype = value.collection
-                        break
-                else:
-                    raise ValueError(
-                        f'Output collection specified `structured_like="{self.structured_like}", but no such input was found.`'
-                    )
+            collection_prototype = inputs[self.structured_like].collection
         else:
             collection_type = self.collection_type
             assert collection_type

--- a/lib/galaxy/tool_util/parser/output_objects.py
+++ b/lib/galaxy/tool_util/parser/output_objects.py
@@ -347,7 +347,17 @@ class ToolOutputCollectionStructure:
     def collection_prototype(self, inputs, type_registry):
         # either must have specified structured_like or something worse
         if self.structured_like:
-            collection_prototype = inputs[self.structured_like].collection
+            if self.structured_like in inputs:
+                collection_prototype = inputs[self.structured_like].collection
+            else:
+                for key, value in inputs.items():
+                    if key.split("|")[-1] == self.structured_like:
+                        collection_prototype = value.collection
+                        break
+                else:
+                    raise ValueError(
+                        f'Output collection specified `structured_like="{self.structured_like}", but no such input was found.`'
+                    )
         else:
             collection_type = self.collection_type
             assert collection_type

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -10,6 +10,7 @@ import re
 import tarfile
 import tempfile
 import threading
+from collections.abc import MutableMapping
 from pathlib import Path
 from typing import (
     cast,
@@ -2701,7 +2702,7 @@ class OutputParameterJSONTool(Tool):
     def _prepare_json_param_dict(self, param_dict):
         rval = {}
         for key, value in param_dict.items():
-            if isinstance(value, dict):
+            if isinstance(value, MutableMapping):
                 rval[key] = self._prepare_json_param_dict(value)
             elif isinstance(value, list):
                 rval[key] = self._prepare_json_list(value)

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -209,17 +209,17 @@ class ToolEvaluator:
         # Parameters added after this line are not sanitized
         self.__populate_non_job_params(param_dict)
 
-        if "input" not in param_dict:
+        if "input" not in param_dict.data:
 
             def input():
                 raise InputNotFoundSyntaxError(
                     "Unbound variable 'input'."
                 )  # Don't let $input hang Python evaluation process.
 
-            param_dict["input"] = input
+            param_dict.data["input"] = input
 
-        # Return the dictionary of parameters
-        return param_dict
+        # Return the dictionary of parameters without injected parameters
+        return param_dict.clean_copy()
 
     def _materialize_objects(
         self, deferred_objects: Dict[str, DeferrableObjectsT], job_working_directory: str

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -359,6 +359,9 @@ class ToolEvaluator:
                 input_values[input.name] = InputValueWrapper(
                     input, value, param_dict, profile=self.tool and self.tool.profile
                 )
+            if input.name not in param_dict:
+                # also provide as unprefixed variant ... we should put this behind a profile version and deprecate this
+                param_dict[input.name] = input_values[input.name]
 
         # HACK: only wrap if check_values is not false, this deals with external
         #       tools where the inputs don't even get passed through. These

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -359,9 +359,6 @@ class ToolEvaluator:
                 input_values[input.name] = InputValueWrapper(
                     input, value, param_dict, profile=self.tool and self.tool.profile
                 )
-            if input.name not in param_dict:
-                # also provide as unprefixed variant ... we should put this behind a profile version and deprecate this
-                param_dict[input.name] = input_values[input.name]
 
         # HACK: only wrap if check_values is not false, this deals with external
         #       tools where the inputs don't even get passed through. These

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -59,7 +59,10 @@ from galaxy.util import (
     safe_makedirs,
     unicodify,
 )
-from galaxy.util.template import fill_template
+from galaxy.util.template import (
+    fill_template,
+    InputNotFoundSyntaxError,
+)
 from galaxy.work.context import WorkRequestContext
 
 log = logging.getLogger(__name__)
@@ -184,7 +187,9 @@ class ToolEvaluator:
         param_dict = self.param_dict
 
         def input():
-            raise SyntaxError("Unbound variable input.")  # Don't let $input hang Python evaluation process.
+            raise InputNotFoundSyntaxError(
+                "Unbound variable 'input'."
+            )  # Don't let $input hang Python evaluation process.
 
         param_dict["input"] = input
         param_dict["__datatypes_config__"] = param_dict["GALAXY_DATATYPES_CONF_FILE"] = os.path.join(

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -187,12 +187,6 @@ class ToolEvaluator:
 
         param_dict = TreeDict(self.param_dict)
 
-        def input():
-            raise InputNotFoundSyntaxError(
-                "Unbound variable 'input'."
-            )  # Don't let $input hang Python evaluation process.
-
-        param_dict["input"] = input
         param_dict["__datatypes_config__"] = param_dict["GALAXY_DATATYPES_CONF_FILE"] = os.path.join(
             job_working_directory, "registry.xml"
         )
@@ -214,6 +208,15 @@ class ToolEvaluator:
         self.__sanitize_param_dict(param_dict)
         # Parameters added after this line are not sanitized
         self.__populate_non_job_params(param_dict)
+
+        if "input" not in param_dict:
+
+            def input():
+                raise InputNotFoundSyntaxError(
+                    "Unbound variable 'input'."
+                )  # Don't let $input hang Python evaluation process.
+
+            param_dict["input"] = input
 
         # Return the dictionary of parameters
         return param_dict

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -63,6 +63,7 @@ from galaxy.util.template import (
     fill_template,
     InputNotFoundSyntaxError,
 )
+from galaxy.util.tree_dict import TreeDict
 from galaxy.work.context import WorkRequestContext
 
 log = logging.getLogger(__name__)
@@ -184,7 +185,7 @@ class ToolEvaluator:
         compute_environment = self.compute_environment
         job_working_directory = compute_environment.working_directory()
 
-        param_dict = self.param_dict
+        param_dict = TreeDict(self.param_dict)
 
         def input():
             raise InputNotFoundSyntaxError(

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -1,3 +1,5 @@
+from collections import UserDict
+
 from galaxy.tools.parameters.basic import (
     DataCollectionToolParameter,
     DataToolParameter,
@@ -18,6 +20,28 @@ from galaxy.tools.wrappers import (
 )
 
 PARAMS_UNWRAPPED = object()
+
+
+class LegacyUnprefixedDict(UserDict):
+    """
+    It used to be valid to access members of conditionals without specifying the conditional.
+    This dict provides a fallback when dict lookup fails using those old rules
+    """
+
+    def __init__(self, dict=None, /, **kwargs):
+        self._legacy_cache_data = {}
+        super().__init__(dict, **kwargs)
+
+    def __getitem__(self, key):
+        if key not in self.data:
+            if key in self._legacy_cache_data:
+                return self._legacy_cache_data[key]
+        return super().__getitem__(key)
+
+    def __contains__(self, key: object) -> bool:
+        if super().__contains__(key):
+            return True
+        return key in self._legacy_mapping
 
 
 def copy_identifiers(source, destination):
@@ -131,4 +155,4 @@ def make_list_copy(from_list):
     return new_list
 
 
-__all__ = ("WrappedParameters", "make_dict_copy")
+__all__ = ("LegacyUnprefixedDict", "WrappedParameters", "make_dict_copy")

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -23,12 +23,12 @@ PARAMS_UNWRAPPED = object()
 
 
 class LegacyUnprefixedDict(UserDict):
-    """
-    It used to be valid to access members of conditionals without specifying the conditional.
-    This dict provides a fallback when dict lookup fails using those old rules
-    """
+    """Track and provide access to prefixed and unprefixed tool parameter values."""
 
-    def __init__(self, dict=None, /, **kwargs):
+    # It used to be valid to access members of conditionals without specifying the conditional.
+    # This dict provides a fallback when dict lookup fails using those old rules
+
+    def __init__(self, dict=None, **kwargs):
         self._legacy_cache_data = {}
         super().__init__(dict, **kwargs)
 

--- a/lib/galaxy/tools/parameters/wrapped.py
+++ b/lib/galaxy/tools/parameters/wrapped.py
@@ -1,4 +1,5 @@
 from collections import UserDict
+from typing import Dict
 
 from galaxy.tools.parameters.basic import (
     DataCollectionToolParameter,
@@ -29,13 +30,15 @@ class LegacyUnprefixedDict(UserDict):
     # This dict provides a fallback when dict lookup fails using those old rules
 
     def __init__(self, dict=None, **kwargs):
-        self._legacy_cache_data = {}
+        self._legacy_mapping: Dict[str, str] = {}
         super().__init__(dict, **kwargs)
 
+    def set_legacy_alias(self, new_key: str, old_key: str):
+        self._legacy_mapping[old_key] = new_key
+
     def __getitem__(self, key):
-        if key not in self.data:
-            if key in self._legacy_cache_data:
-                return self._legacy_cache_data[key]
+        if key not in self.data and key in self._legacy_mapping:
+            return super().__getitem__(self._legacy_mapping[key])
         return super().__getitem__(key)
 
     def __contains__(self, key: object) -> bool:

--- a/lib/galaxy/util/template.py
+++ b/lib/galaxy/util/template.py
@@ -19,6 +19,10 @@ myfixes = [f for f in myfixes if not f.startswith("libpasteurize")]
 refactoring_tool = RefactoringTool(myfixes, {"print_function": True})
 
 
+class InputNotFoundSyntaxError(SyntaxError):
+    pass
+
+
 class FixedModuleCodeCompiler(Compiler):
     module_code = None
 
@@ -81,7 +85,7 @@ def fill_template(
     t = klass(searchList=[context])
     try:
         return unicodify(t, log_exception=False)
-    except NotFound as e:
+    except (NotFound, InputNotFoundSyntaxError) as e:
         if first_exception is None:
             first_exception = e
         tb = e.__traceback__

--- a/lib/galaxy/util/template.py
+++ b/lib/galaxy/util/template.py
@@ -82,39 +82,44 @@ def fill_template(
                 python_template_version=python_template_version,
             )
         raise first_exception or e
-    if isinstance(context, TreeDict):
-        # Re-establish injected top level keys, which might have been modified (e.g. HDA replaced with DatasetFilenameWrapper)
-        context = TreeDict(context.data)
     t = klass(searchList=[context])
     try:
         return unicodify(t, log_exception=False)
     except (NotFound, InputNotFoundSyntaxError) as e:
         if first_exception is None:
             first_exception = e
+        if not isinstance(context, TreeDict):
+            masked_input = None
+            if "input" in context and callable(context["input"]):
+                masked_input = context.pop("input", None)
+            context = TreeDict(context)
+            if "input" not in context and masked_input:
+                context["input"] = masked_input
         tb = e.__traceback__
-        if retry > 0 and python_template_version.release[0] < 3:
-            last_stack = traceback.extract_tb(tb)[-1]
-            if last_stack.name == "<listcomp>" and last_stack.lineno:
-                # On python 3 list, dict and set comprehensions as well as generator expressions
-                # have their own local scope, which prevents accessing frame variables in cheetah.
-                # We can work around this by replacing `$var` with `var`, but we only do this for
-                # list comprehensions, as this has never worked for dict or set comprehensions or
-                # generator expressions in Cheetah.
-                var_not_found = e.args[0].split("'")[1]
-                replace_str = f'VFFSL(SL,"{var_not_found}",True)'
-                lineno = last_stack.lineno - 1
-                module_code = t._CHEETAH_generatedModuleCode.splitlines()
-                module_code[lineno] = module_code[lineno].replace(replace_str, var_not_found)
-                module_code = "\n".join(module_code)
-                compiler_class = create_compiler_class(module_code)
-                return fill_template(
-                    template_text=template_text,
-                    context=context,
-                    retry=retry - 1,
-                    compiler_class=compiler_class,
-                    first_exception=first_exception,
-                    python_template_version=python_template_version,
-                )
+        if retry > 0:
+            if python_template_version.release[0] < 3:
+                last_stack = traceback.extract_tb(tb)[-1]
+                if last_stack.name == "<listcomp>" and last_stack.lineno:
+                    # On python 3 list, dict and set comprehensions as well as generator expressions
+                    # have their own local scope, which prevents accessing frame variables in cheetah.
+                    # We can work around this by replacing `$var` with `var`, but we only do this for
+                    # list comprehensions, as this has never worked for dict or set comprehensions or
+                    # generator expressions in Cheetah.
+                    var_not_found = e.args[0].split("'")[1]
+                    replace_str = f'VFFSL(SL,"{var_not_found}",True)'
+                    lineno = last_stack.lineno - 1
+                    module_code = t._CHEETAH_generatedModuleCode.splitlines()
+                    module_code[lineno] = module_code[lineno].replace(replace_str, var_not_found)
+                    module_code = "\n".join(module_code)
+                    compiler_class = create_compiler_class(module_code)
+            return fill_template(
+                template_text=template_text,
+                context=context,
+                retry=retry - 1,
+                compiler_class=compiler_class,
+                first_exception=first_exception,
+                python_template_version=python_template_version,
+            )
         raise first_exception or e
     except Exception as e:
         if first_exception is None:

--- a/lib/galaxy/util/tree_dict.py
+++ b/lib/galaxy/util/tree_dict.py
@@ -34,12 +34,14 @@ class TreeDict(UserDict):
             _item._parent_data = self
             _item.update(item)
             item = _item
-        if self._parent_data is not None and key != "__current_case__":
+        current_parent_data = self._parent_data
+        while current_parent_data is not None and key != "__current_case__":
             if (
-                key not in self._parent_data
+                key not in current_parent_data
                 or key == "input"
-                and key in self._parent_data
-                and callable(self._parent_data[key])
+                and key in current_parent_data
+                and callable(current_parent_data[key])
             ):
-                self._parent_data._injected_data[key] = item
+                current_parent_data._injected_data[key] = item
+            current_parent_data = current_parent_data._parent_data
         return super().__setitem__(key, item)

--- a/lib/galaxy/util/tree_dict.py
+++ b/lib/galaxy/util/tree_dict.py
@@ -1,11 +1,21 @@
 from collections import UserDict
-from collections.abc import MutableMapping
+from collections.abc import (
+    ItemsView,
+    MutableMapping,
+)
 from typing import (
     Any,
     Optional,
 )
 
 from boltons.iterutils import remap
+
+
+def enter(path, key, value):
+    if isinstance(value, MutableMapping):
+        return value.__class__(), ItemsView(value)
+    else:
+        return value, False
 
 
 class TreeDict(UserDict):
@@ -28,7 +38,7 @@ class TreeDict(UserDict):
                 value = value.data
             return key, value
 
-        return remap(self.data, strip_tree_dict)
+        return remap(self.data, strip_tree_dict, enter=enter)
 
     def __getitem__(self, key: Any) -> Any:
         if key in self.data:

--- a/lib/galaxy/util/tree_dict.py
+++ b/lib/galaxy/util/tree_dict.py
@@ -1,0 +1,24 @@
+from collections import UserDict
+from typing import Any
+
+
+class TreeDict(UserDict):
+    """
+    Dictionary that inserts its own keys in a parent dictionary.
+    """
+
+    def __init__(self, dict=None, **kwargs):
+        self._parent_data = None
+        self._child_data = {}
+        super().__init__(dict, **kwargs)
+
+    def __setitem__(self, key: Any, item: Any) -> None:
+        if isinstance(item, dict):
+            d = TreeDict()
+            d._parent_data = self
+            d.update(item)
+            item = d
+        if self._parent_data is not None:
+            if key not in self._parent_data:
+                self._parent_data[key] = item
+        return super().__setitem__(key, item)

--- a/lib/galaxy/util/tree_dict.py
+++ b/lib/galaxy/util/tree_dict.py
@@ -5,6 +5,8 @@ from typing import (
     Optional,
 )
 
+from boltons.iterutils import remap
+
 
 class TreeDict(UserDict):
     """
@@ -15,6 +17,18 @@ class TreeDict(UserDict):
         self._parent_data: Optional[TreeDict] = None
         self._injected_data = {}
         super().__init__(dict, **kwargs)
+
+    def clean_copy(self):
+        """
+        Copy without injected data.
+        """
+
+        def strip_tree_dict(path, key, value):
+            if isinstance(value, TreeDict):
+                value = value.data
+            return key, value
+
+        return remap(self.data, strip_tree_dict)
 
     def __getitem__(self, key: Any) -> Any:
         if key in self.data:

--- a/lib/galaxy/util/tree_dict.py
+++ b/lib/galaxy/util/tree_dict.py
@@ -1,5 +1,9 @@
 from collections import UserDict
-from typing import Any
+from collections.abc import MutableMapping
+from typing import (
+    Any,
+    Optional,
+)
 
 
 class TreeDict(UserDict):
@@ -8,15 +12,28 @@ class TreeDict(UserDict):
     """
 
     def __init__(self, dict=None, **kwargs):
-        self._parent_data = None
+        self._parent_data: Optional[TreeDict] = None
+        self._injected_data = {}
         super().__init__(dict, **kwargs)
 
+    def __getitem__(self, key: Any) -> Any:
+        if key in self.data:
+            return super().__getitem__(key)
+        else:
+            return self._injected_data[key]
+
+    def __contains__(self, key: object) -> bool:
+        if super().__contains__(key):
+            return True
+        return key in self._injected_data
+
     def __setitem__(self, key: Any, item: Any) -> None:
-        if isinstance(item, dict):
-            d = TreeDict()
-            d._parent_data = self
-            d.update(item)
-            item = d
+        if isinstance(item, MutableMapping):
+            # We're not doing item = TreeDict(item) because we want to record the keys in _parent_data
+            _item = TreeDict()
+            _item._parent_data = self
+            _item.update(item)
+            item = _item
         if self._parent_data is not None:
             if (
                 key not in self._parent_data
@@ -24,5 +41,5 @@ class TreeDict(UserDict):
                 and key in self._parent_data
                 and callable(self._parent_data[key])
             ):
-                self._parent_data[key] = item
+                self._parent_data._injected_data[key] = item
         return super().__setitem__(key, item)

--- a/lib/galaxy/util/tree_dict.py
+++ b/lib/galaxy/util/tree_dict.py
@@ -34,7 +34,7 @@ class TreeDict(UserDict):
             _item._parent_data = self
             _item.update(item)
             item = _item
-        if self._parent_data is not None:
+        if self._parent_data is not None and key != "__current_case__":
             if (
                 key not in self._parent_data
                 or key == "input"

--- a/lib/galaxy/util/tree_dict.py
+++ b/lib/galaxy/util/tree_dict.py
@@ -9,7 +9,6 @@ class TreeDict(UserDict):
 
     def __init__(self, dict=None, **kwargs):
         self._parent_data = None
-        self._child_data = {}
         super().__init__(dict, **kwargs)
 
     def __setitem__(self, key: Any, item: Any) -> None:
@@ -19,6 +18,11 @@ class TreeDict(UserDict):
             d.update(item)
             item = d
         if self._parent_data is not None:
-            if key not in self._parent_data:
+            if (
+                key not in self._parent_data
+                or key == "input"
+                and key in self._parent_data
+                and callable(self._parent_data[key])
+            ):
                 self._parent_data[key] = item
         return super().__setitem__(key, item)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5224,9 +5224,7 @@ steps:
         $link: fasta_input
     outputs:
       out_file1:
-        # Wish it was qualified for conditionals but it doesn't seem to be. -John
-        # rename: "#{fastq_input.fastq_input1 | basename} suffix"
-        rename: "#{fastq_input1 | basename} suffix"
+        rename: "#{fastq_input.fastq_input1 | basename} suffix"
 """,
                 test_data="""
 fasta_input:
@@ -5267,9 +5265,7 @@ steps:
         $link: fasta_input
     outputs:
       out_file1:
-        # Wish it was qualified for conditionals but it doesn't seem to be. -John
-        # rename: "#{fastq_input.fastq_input1 | basename} suffix"
-        rename: "#{fastq_input1} suffix"
+        rename: "#{fastq_input.fastq_input1 | basename} suffix"
 """,
                 test_data="""
 fasta_input:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5245,6 +5245,49 @@ fastq_input:
             assert name == "fastq1 suffix", name
 
     @skip_without_tool("mapper2")
+    def test_run_rename_based_on_input_conditional_legacy_pja_reference(self):
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs(
+                """
+class: GalaxyWorkflow
+inputs:
+  fasta_input: data
+  fastq_input: data
+steps:
+  mapping:
+    tool_id: mapper2
+    state:
+      fastq_input:
+        fastq_input_selector: single
+        fastq_input1:
+          $link: fastq_input
+      reference:
+        $link: fasta_input
+    outputs:
+      out_file1:
+        # The fully prefixed variant test in "test_run_rename_based_on_input_conditional" should be preferred,
+        # but we don't want to break old workflow renaming actions
+        rename: "#{fastq_input1 | basename} suffix"
+""",
+                test_data="""
+fasta_input:
+  value: 1.fasta
+  type: File
+  name: fasta1
+  file_type: fasta
+fastq_input:
+  value: 1.fastqsanger
+  type: File
+  name: fastq1
+  file_type: fastqsanger
+""",
+                history_id=history_id,
+            )
+            content = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=True)
+            name = content["name"]
+            assert name == "fastq1 suffix", name
+
+    @skip_without_tool("mapper2")
     def test_run_rename_based_on_input_collection(self):
         with self.dataset_populator.test_history() as history_id:
             self._run_jobs(

--- a/test/functional/tools/format_source_in_conditional.xml
+++ b/test/functional/tools/format_source_in_conditional.xml
@@ -1,0 +1,45 @@
+<tool id="format_source_in_conditional" name="format source in conditional" version="0.1.0">
+    <command>cp '$input1' '$output1'</command>
+    <inputs>
+        <conditional name="cond">
+            <param name="select" type="select">
+                <option value="no_extra_nesting">No extra nesting</option>
+                <option value="extra_nesting">One more conditional</option>
+            </param>
+            <when value="no_extra_nesting">
+                <param name="input1" type="data" format="tabular"/>
+            </when>
+            <when value="extra_nesting">
+                <conditional name="inner_cond">
+                    <param name="inner_select" type="select">
+                        <option value="value">the only option</option>
+                    </param>
+                    <when value="value">
+                        <param name="input1" type="data" format="txt"/>
+                    </when>
+                </conditional>
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="output1" format_source="cond|input1"/>
+    </outputs>
+    <tests>
+        <test>
+            <conditional name="cond">
+                <param name="select" value="no_extra_nesting"/>
+                <param name="input1" value="1.tabular" ftype="tabular"/>
+            </conditional>
+            <output name="output1" value="1.tabular" ftype="tabular" lines_diff="2"/>
+        </test>
+        <test>
+            <conditional name="cond">
+                <param name="select" value="extra_nesting"/>
+                <conditional name="inner_cond">
+                    <param name="input1" value="1.txt" ftype="txt"/>
+                </conditional>
+            </conditional>
+            <output name="output1" value="1.txt" ftype="txt"/>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -109,6 +109,7 @@
   <tool file="output_format.xml" />
   <tool file="output_format_deprecated_when.xml" />
   <tool file="output_format_collection.xml" />
+  <tool file="format_source_in_conditional.xml" />
   <tool file="output_filter.xml" />
   <tool file="output_empty_work_dir.xml" />
   <tool file="output_filter_with_input.xml" />


### PR DESCRIPTION
This aligns with most other uses of visit_input_values and fixes the job cache when data inputs are in nested conditionals.  Without the fix the `name` attribute of `JobToInputDatasetAssociation` would not contain the fully prefixed parameter. For trinity
(https://github.com/galaxyproject/tools-iuc/blob/72ae2e05f35098c4cb6dd4f038bff07fd36917ed/tools/trinity/trinity.xml#L195) this would be `pool|left_input`, where `pool` is the outer conditional. With this fix it would be `pool|inputs|left_input`, which matches what we have in the tool state.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
