### PR TITLE
Build container with nodejs

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -155,6 +155,7 @@ RUN set -xe; \
         less \
         bzip2 \
         tini \
+    	nodejs \
     && update-alternatives --install /usr/bin/nano nano /bin/nano-tiny 0 \
     && update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 0 \
     && echo "set nocompatible\nset backspace=indent,eol,start" >> /usr/share/vim/vimrc.tiny \

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -155,7 +155,7 @@ RUN set -xe; \
         less \
         bzip2 \
         tini \
-    	nodejs \
+        nodejs \
     && update-alternatives --install /usr/bin/nano nano /bin/nano-tiny 0 \
     && update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 0 \
     && echo "set nocompatible\nset backspace=indent,eol,start" >> /usr/share/vim/vimrc.tiny \


### PR DESCRIPTION
The `galaxy-min` Docker image built for Kubernetes does not include `nodejs`; in fact the files for node are clean up in the previous stages.  This prevents the expression tools that depend on node being present from running.

This pull request performs an `apt-get install nodejs` in the final stage to reinstall a minimal node package.  We could modify one of the previous stages to leave node installed and copy to the final image, but this seems like the easiest and cleanest way to get node installed without extraneous packages.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
