### PR TITLE
Add text-break to wrap long published titles

### DIFF
--- a/client/src/components/Common/Published.vue
+++ b/client/src/components/Common/Published.vue
@@ -6,7 +6,7 @@
         <FlexPanel side="right">
             <div v-if="modelTitle" class="m-3">
                 <h1 class="h-sm">About this {{ modelTitle }}</h1>
-                <h2 class="h-md">{{ item.title || item.name }}</h2>
+                <h2 class="h-md text-break">{{ item.title || item.name }}</h2>
                 <img :src="gravatarSource" alt="user avatar" />
                 <StatelessTags v-if="item.tags" class="tags mt-2" :value="item.tags" :disabled="true" />
                 <br />

--- a/client/src/components/Markdown/Elements/HistoryDatasetDetails.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDetails.vue
@@ -1,5 +1,5 @@
 <template>
-    <pre><code class="text-normalwrap">{{ content }}</code></pre>
+    <pre><code class="word-wrap-normal">{{ content }}</code></pre>
 </template>
 
 <script>

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.test.js
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.test.js
@@ -68,7 +68,7 @@ describe("History Text Dataset Display", () => {
     });
 
     it("should render text", () => {
-        const renderedText = wrapper.find(".text-normalwrap");
+        const renderedText = wrapper.find(".word-wrap-normal");
         expect(renderedText.exists()).toBe(true);
         expect(renderedText.text()).toBe(text.item_data);
     });

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -81,7 +81,7 @@
                                 </UrlDataProvider>
                             </div>
                             <pre v-else>
-                                    <code class="text-normalwrap">{{ itemContent.item_data }}</code>
+                                    <code class="word-wrap-normal">{{ itemContent.item_data }}</code>
                                 </pre>
                         </div>
                         <div v-else>No content found.</div>

--- a/client/src/components/Markdown/Elements/ToolStd.vue
+++ b/client/src/components/Markdown/Elements/ToolStd.vue
@@ -1,7 +1,7 @@
 <template>
     <b-card nobody class="content-height">
         <div :class="name" :job_id="args.job_id">
-            <pre><code class="text-normalwrap">{{ jobContent }}</code></pre>
+            <pre><code class="word-wrap-normal">{{ jobContent }}</code></pre>
         </div>
     </b-card>
 </template>

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -22,7 +22,7 @@
                 </b-button>
                 <h1 class="float-right align-middle mr-1 mt-2 h-md">Galaxy {{ markdownConfig.model_class }}</h1>
                 <span class="float-left font-weight-light mb-3">
-                    <small>Title: {{ markdownConfig.title || markdownConfig.model_class }}</small>
+                    <small class="text-break">Title: {{ markdownConfig.title || markdownConfig.model_class }}</small>
                     <br />
                     <small>Created by {{ markdownConfig.username }}</small>
                 </span>

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -27,8 +27,8 @@
                     <small>Created by {{ markdownConfig.username }}</small>
                 </span>
             </div>
-            <b-badge variant="info" class="w-100 rounded mb-3">
-                <div class="float-left m-1">Published with Galaxy {{ version }} on {{ time }}</div>
+            <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
+                <div class="float-left m-1 text-break">Published with Galaxy {{ version }} on {{ time }}</div>
                 <div class="float-right m-1">Identifier {{ markdownConfig.id }}</div>
             </b-badge>
             <div>

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -79,10 +79,6 @@ body {
     @include clearfix();
 }
 
-.text-normalwrap {
-    word-wrap: normal;
-}
-
 // ==== Page layout styles ====
 
 .full-content {

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -40,6 +40,16 @@
     overflow: auto !important;
 }
 
+// utility class to set word wrap to normal
+.word-wrap-normal {
+    word-wrap: normal;
+}
+
+// utility class to set white space wrapping to normal
+.white-space-normal {
+    white-space: normal;
+}
+
 // default margins
 $ui-margin-vertical: $margin-v * 0.25;
 $ui-margin-vertical-large: $margin-v * 0.5;


### PR DESCRIPTION
Minor fix to ensure that very long titles are wrapped in the published view.

Before:
<img width="150" alt="image" src="https://user-images.githubusercontent.com/2105447/233767911-cebe389e-0267-4275-82c6-6220a50ec843.png">

After:
<img width="150" alt="image" src="https://user-images.githubusercontent.com/2105447/233767878-decfe98e-b2e2-4118-9573-9247057c5dfe.png">

Contains additional fixes to properly wrap markdown editor details. Applies consistent naming to utility css helpers, and adds an additional helper to selectively allow normal wrapping of white-spaces.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
