### PR TITLE
[23.0] Fix backbone-based data selector to materialize consistent attribute set

### DIFF
--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -178,11 +178,12 @@ export default {
             const params = this.buildFormData();
             if (JSON.stringify(params) != JSON.stringify(this.formData)) {
                 this.formData = params;
-                this.resetError();
+                this.resetErrors();
                 this.$emit("onChange", params, refreshOnChange);
             }
         },
         onErrors() {
+            this.resetErrors();
             if (this.errors) {
                 const errorMessages = matchErrors(this.formIndex, this.errors);
                 for (const inputId in errorMessages) {
@@ -234,7 +235,7 @@ export default {
                 input.warning = message;
             }
         },
-        resetError() {
+        resetErrors() {
             Object.values(this.formIndex).forEach((input) => {
                 input.error = null;
             });

--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -113,13 +113,7 @@ export default {
             this.$emit("onValidation", this.validation);
         },
         errors() {
-            this.resetError();
-            if (this.errors) {
-                const errorMessages = matchErrors(this.formIndex, this.errors);
-                for (const inputId in errorMessages) {
-                    this.setError(inputId, errorMessages[inputId]);
-                }
-            }
+            this.onErrors();
         },
         replaceParams() {
             this.onReplaceParams();
@@ -131,6 +125,8 @@ export default {
         this.formData = this.buildFormData();
         // emit back to parent, so that parent has submittable data
         this.$emit("onChange", this.formData);
+        // highlight initial errors
+        this.onErrors();
     },
     methods: {
         buildFormData() {
@@ -177,7 +173,15 @@ export default {
                 this.$emit("onChange", params, refreshOnChange);
             }
         },
-        getOffsetTop(element, padding = 100) {
+        onErrors() {
+            if (this.errors) {
+                const errorMessages = matchErrors(this.formIndex, this.errors);
+                for (const inputId in errorMessages) {
+                    this.setError(inputId, errorMessages[inputId]);
+                }
+            }
+        },
+        getOffsetTop(element, padding = 150) {
             let offsetTop = 0;
             while (element) {
                 offsetTop += element.offsetTop;

--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -17,7 +17,7 @@
 <script>
 import Vue from "vue";
 import FormInputs from "./FormInputs";
-import { visitInputs, validateInputs, matchErrors } from "./utilities";
+import { visitInputs, validateInputs, matchInputs } from "./utilities";
 export default {
     components: {
         FormInputs,
@@ -185,7 +185,7 @@ export default {
         onErrors() {
             this.resetErrors();
             if (this.errors) {
-                const errorMessages = matchErrors(this.formIndex, this.errors);
+                const errorMessages = matchInputs(this.formIndex, this.errors);
                 for (const inputId in errorMessages) {
                     this.setError(inputId, errorMessages[inputId]);
                 }
@@ -193,7 +193,7 @@ export default {
         },
         onWarnings() {
             if (this.warnings) {
-                const warningMessages = matchErrors(this.formIndex, this.warnings);
+                const warningMessages = matchInputs(this.formIndex, this.warnings);
                 for (const inputId in warningMessages) {
                     this.setWarning(inputId, warningMessages[inputId]);
                 }

--- a/client/src/components/Form/FormDisplay.vue
+++ b/client/src/components/Form/FormDisplay.vue
@@ -71,6 +71,10 @@ export default {
             type: Object,
             default: null,
         },
+        warnings: {
+            type: Object,
+            default: null,
+        },
         workflowBuildingMode: {
             type: Boolean,
             default: false,
@@ -118,6 +122,9 @@ export default {
         replaceParams() {
             this.onReplaceParams();
         },
+        warnings() {
+            this.onWarnings();
+        },
     },
     created() {
         this.onCloneInputs();
@@ -125,6 +132,8 @@ export default {
         this.formData = this.buildFormData();
         // emit back to parent, so that parent has submittable data
         this.$emit("onChange", this.formData);
+        // highlight initial warnings
+        this.onWarnings();
         // highlight initial errors
         this.onErrors();
     },
@@ -181,6 +190,14 @@ export default {
                 }
             }
         },
+        onWarnings() {
+            if (this.warnings) {
+                const warningMessages = matchErrors(this.formIndex, this.warnings);
+                for (const inputId in warningMessages) {
+                    this.setWarning(inputId, warningMessages[inputId]);
+                }
+            }
+        },
         getOffsetTop(element, padding = 150) {
             let offsetTop = 0;
             while (element) {
@@ -209,6 +226,12 @@ export default {
             const input = this.formIndex[inputId];
             if (input) {
                 input.error = message;
+            }
+        },
+        setWarning(inputId, message) {
+            const input = this.formIndex[inputId];
+            if (input) {
+                input.warning = message;
             }
         },
         resetError() {

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -27,6 +27,7 @@ interface FormElementProps {
     refreshOnChange?: boolean;
     help?: string;
     error?: string;
+    warning?: string;
     backbonejs?: boolean;
     disabled?: boolean;
     attributes?: FormParameterAttributes;
@@ -120,7 +121,7 @@ function onConnect() {
 
 const isHidden = computed(() => attrs.value["hidden"]);
 const elementId = computed(() => `form-element-${props.id}`);
-const hasError = computed(() => Boolean(props.error));
+const hasAlert = computed(() => Boolean(props.error || props.warning));
 const showPreview = computed(() => (collapsed.value && attrs.value["collapsible_preview"]) || props.disabled);
 const showField = computed(() => !collapsed.value && !props.disabled);
 
@@ -174,10 +175,10 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
         v-show="!isHidden"
         :id="elementId"
         class="ui-form-element section-row"
-        :class="{ alert: hasError, 'alert-info': hasError }">
-        <div v-if="hasError" class="ui-form-error">
+        :class="{ alert: hasAlert, 'alert-info': hasAlert }">
+        <div v-if="hasAlert" class="ui-form-error">
             <FontAwesomeIcon class="mr-1" icon="fa-exclamation" />
-            <span class="ui-form-error-text" v-html="props.error" />
+            <span class="ui-form-error-text" v-html="props.warning || props.error" />
         </div>
 
         <div class="ui-form-title">

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -178,7 +178,7 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
         :class="{ alert: hasAlert, 'alert-info': hasAlert }">
         <div v-if="hasAlert" class="ui-form-error">
             <FontAwesomeIcon class="mr-1" icon="fa-exclamation" />
-            <span class="ui-form-error-text" v-html="props.warning || props.error" />
+            <span class="ui-form-error-text" v-html="props.error || props.warning" />
         </div>
 
         <div class="ui-form-title">

--- a/client/src/components/Form/FormInputs.vue
+++ b/client/src/components/Form/FormInputs.vue
@@ -71,6 +71,7 @@
                 :title="input.label || input.name"
                 :type="input.type"
                 :error="input.error"
+                :warning="input.warning"
                 :help="input.help"
                 :refresh-on-change="input.refresh_on_change"
                 :attributes="input.attributes || input"

--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -71,11 +71,11 @@ export function matchCase(input, value) {
     return -1;
 }
 
-/** Match server validation response to highlight errors
+/** Match server validation response to highlight inputs
  * @param{dict}   index     - Index of input elements
- * @param{dict}   response  - Nested dictionary with error messages
+ * @param{dict}   response  - Nested dictionary with error/warning messages
  */
-export function matchErrors(index, response) {
+export function matchInputs(index, response) {
     var result = {};
     function search(id, head) {
         if (typeof head === "string") {

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -1,4 +1,4 @@
-import { visitInputs, validateInputs, matchCase, matchErrors } from "./utilities";
+import { visitInputs, validateInputs, matchCase, matchInputs } from "./utilities";
 import toolModel from "./test-data/tool";
 
 function visitInputsString(inputs) {
@@ -129,7 +129,7 @@ describe("form component utilities", () => {
             input_b: ["error_b"],
             input_c: { input_d: "error_d" },
         };
-        const result = matchErrors(index, values);
+        const result = matchInputs(index, values);
         expect(result["input_a"]).toEqual("error_a");
         expect(result["input_b_0"]).toEqual("error_b");
         expect(result["input_c|input_d"]).toEqual("error_d");

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -43,6 +43,7 @@
                                 <FormDisplay
                                     :id="toolId"
                                     :inputs="formConfig.inputs"
+                                    :errors="formConfig.warnings || {}"
                                     :validation-scroll-to="validationScrollTo"
                                     @onChange="onChange"
                                     @onValidation="onValidation" />

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -43,12 +43,11 @@
                                 <FormDisplay
                                     :id="toolId"
                                     :inputs="formConfig.inputs"
-                                    :errors="formConfig.warnings || {}"
+                                    :errors="toolErrors"
                                     :validation-scroll-to="validationScrollTo"
                                     @onChange="onChange"
                                     @onValidation="onValidation" />
                             </div>
-
                             <div
                                 v-if="emailAllowed(config, user) || remapAllowed || reuseAllowed(user)"
                                 class="mt-2 mb-4">
@@ -193,6 +192,11 @@ export default {
             // not re-rendered when versions change.
             const { id, version } = this.formConfig;
             return id.endsWith(version) ? id : `${id}/${version}`;
+        },
+        toolErrors() {
+            const errors = this.formConfig.errors ?? {};
+            const warnings = this.formConfig.warnings ?? {};
+            return { ...errors, ...warnings };
         },
         tooltip() {
             return `Run tool: ${this.formConfig.name} (${this.formConfig.version})`;

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -43,8 +43,9 @@
                                 <FormDisplay
                                     :id="toolId"
                                     :inputs="formConfig.inputs"
-                                    :errors="toolErrors"
+                                    :errors="formConfig.errors"
                                     :validation-scroll-to="validationScrollTo"
+                                    :warnings="formConfig.warnings"
                                     @onChange="onChange"
                                     @onValidation="onValidation" />
                             </div>
@@ -192,11 +193,6 @@ export default {
             // not re-rendered when versions change.
             const { id, version } = this.formConfig;
             return id.endsWith(version) ? id : `${id}/${version}`;
-        },
-        toolErrors() {
-            const errors = this.formConfig.errors ?? {};
-            const warnings = this.formConfig.warnings ?? {};
-            return { ...errors, ...warnings };
         },
         tooltip() {
             return `Run tool: ${this.formConfig.name} (${this.formConfig.version})`;

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -329,14 +329,12 @@ export default {
                     const nJobs = jobResponse && jobResponse.jobs ? jobResponse.jobs.length : 0;
                     if (nJobs > 0) {
                         this.showForm = false;
-                        this.jobDef = jobDef;
-                        this.jobResponse = jobResponse;
-                        const response = {
-                            jobDef: this.jobDef,
-                            jobResponse: this.jobResponse,
-                            toolName: this.toolName,
-                        };
-                        this.saveLatestResponse(response);
+                        const toolName = this.toolName;
+                        this.saveLatestResponse({
+                            jobDef,
+                            jobResponse,
+                            toolName,
+                        });
                         changeRoute = prevRoute === this.$route.fullPath;
                     } else {
                         this.showError = true;

--- a/client/src/components/Tool/ToolSuccess.vue
+++ b/client/src/components/Tool/ToolSuccess.vue
@@ -8,7 +8,7 @@ import ToolRecommendation from "../ToolRecommendation.vue";
 import ToolSuccessMessage from "./ToolSuccessMessage.vue";
 import Webhook from "@/components/Common/Webhook.vue";
 
-const { config } = useConfig();
+const { config } = useConfig(true);
 const jobStore = useJobStore();
 const router = useRouter();
 

--- a/client/src/components/Tool/ToolSuccess.vue
+++ b/client/src/components/Tool/ToolSuccess.vue
@@ -1,33 +1,30 @@
 <script setup lang="ts">
 import { computed, onMounted } from "vue";
+import { useConfig } from "@/composables/config";
 import { useJobStore } from "@/stores/jobStore";
 import { useRouter } from "vue-router/composables";
-import { getGalaxyInstance } from "@/app";
 import ToolEntryPoints from "@/components/ToolEntryPoints/ToolEntryPoints.vue";
-import ToolSuccessMessage from "./ToolSuccessMessage.vue";
 import ToolRecommendation from "../ToolRecommendation.vue";
+import ToolSuccessMessage from "./ToolSuccessMessage.vue";
 import Webhook from "@/components/Common/Webhook.vue";
 
+const { config } = useConfig();
 const jobStore = useJobStore();
 const router = useRouter();
 
+const jobDef = computed(() => responseVal.value.jobDef);
+const jobResponse = computed(() => responseVal.value.jobResponse);
 const responseVal = computed(() => jobStore.getLatestResponse);
+const showRecommendation = computed(() => config.value.enable_tool_recommendations);
+const toolName = computed(() => responseVal.value.toolName);
 
 /* lifecyle */
 onMounted(() => {
-    // no response means no ToolForm ran in this session (nothing in store)
+    // no response means that no tool was run in this session i.e. no data in the store
     if (Object.keys(responseVal.value).length === 0) {
         router.push(`/`);
     }
 });
-
-const jobDef = computed(() => responseVal.value.jobDef);
-const jobResponse = computed(() => responseVal.value.jobResponse);
-const toolName = computed(() => responseVal.value.toolName);
-
-// getGalaxyInstance is not reactive
-const configEnableRecommendations = getGalaxyInstance().config.enable_tool_recommendations;
-const showRecommendation: boolean = [true, "true"].includes(configEnableRecommendations);
 </script>
 
 <template>
@@ -35,8 +32,14 @@ const showRecommendation: boolean = [true, "true"].includes(configEnableRecommen
         <div v-if="jobResponse.produces_entry_points">
             <ToolEntryPoints v-for="job in jobResponse.jobs" :key="job.id" :job-id="job.id" />
         </div>
-        <ToolSuccessMessage :job-def="jobDef" :job-response="jobResponse" :tool-name="toolName" />
+        <ToolSuccessMessage :job-response="jobResponse" :tool-name="toolName" />
         <Webhook type="tool" :tool-id="jobDef.tool_id" />
         <ToolRecommendation v-if="showRecommendation" :tool-id="jobDef.tool_id" />
+    </section>
+    <section v-else>
+        <b-alert v-localize show variant="info">
+            The last job details are not available anymore, but you can obtain this information by accessing the
+            corresponding history items.
+        </b-alert>
     </section>
 </template>

--- a/client/src/components/Tool/ToolSuccess.vue
+++ b/client/src/components/Tool/ToolSuccess.vue
@@ -28,7 +28,7 @@ onMounted(() => {
 </script>
 
 <template>
-    <section v-if="jobResponse && jobDef">
+    <section>
         <div v-if="jobResponse.produces_entry_points">
             <ToolEntryPoints v-for="job in jobResponse.jobs" :key="job.id" :job-id="job.id" />
         </div>

--- a/client/src/components/Tool/ToolSuccess.vue
+++ b/client/src/components/Tool/ToolSuccess.vue
@@ -36,10 +36,4 @@ onMounted(() => {
         <Webhook type="tool" :tool-id="jobDef.tool_id" />
         <ToolRecommendation v-if="showRecommendation" :tool-id="jobDef.tool_id" />
     </section>
-    <section v-else>
-        <b-alert v-localize show variant="info">
-            The last job details are not available anymore, but you can obtain this information by accessing the
-            corresponding history items.
-        </b-alert>
-    </section>
 </template>

--- a/client/src/components/Tool/ToolSuccessMessage.vue
+++ b/client/src/components/Tool/ToolSuccessMessage.vue
@@ -3,12 +3,6 @@
         <p>
             Started tool <b>{{ toolName }}</b> and successfully added {{ nJobsText }} to the queue.
         </p>
-        <p>The tool uses {{ nInputsText }}:</p>
-        <ul>
-            <li v-for="item of inputs" :key="item.hid">
-                <b>{{ item.hid }}: {{ item.name }}</b>
-            </li>
-        </ul>
         <p>It produces {{ nOutputsText }}:</p>
         <ul>
             <li v-for="item of jobResponse.outputs" :key="item.hid">
@@ -26,10 +20,6 @@
 <script>
 export default {
     props: {
-        jobDef: {
-            type: Object,
-            required: true,
-        },
         jobResponse: {
             type: Object,
             required: true,
@@ -40,25 +30,6 @@ export default {
         },
     },
     computed: {
-        inputs() {
-            const inputs = [];
-            const index = {};
-            for (const i in this.jobDef.inputs) {
-                const input = this.jobDef.inputs[i];
-                if (input && Array.isArray(input.values)) {
-                    for (const j of input.values) {
-                        if (j.src && !index[j.id]) {
-                            inputs.push(j);
-                            index[j.id] = true;
-                        }
-                    }
-                }
-            }
-            return inputs;
-        },
-        nInputs() {
-            return this.inputs.length;
-        },
         nOutputs() {
             return this.jobResponse && this.jobResponse.outputs ? this.jobResponse.outputs.length : 0;
         },
@@ -67,9 +38,6 @@ export default {
         },
         nJobsText() {
             return this.nJobs > 1 ? `${this.nJobs} jobs` : `1 job`;
-        },
-        nInputsText() {
-            return this.nInputs > 1 ? `${this.nInputs} inputs` : `this input`;
         },
         nOutputsText() {
             return this.nOutputs > 1 ? `${this.nOutputs} outputs` : `this output`;

--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -225,7 +225,8 @@ const View = Backbone.View.extend({
         const galaxy = getGalaxyInstance();
         if (new_value) {
             this._patchValue(new_value);
-            this.model.set("value", new_value);
+            const result = this._batch(this._pickValue(new_value));
+            this.model.set("value", result);
         }
         const current = this.model.get("current");
         if (this.config[current]) {
@@ -248,7 +249,7 @@ const View = Backbone.View.extend({
                         }
                     }
                     result.values.sort((a, b) => a.hid - b.hid);
-                    return result;
+                    return this._pickValue(result);
                 }
             }
         } else {
@@ -482,6 +483,17 @@ const View = Backbone.View.extend({
     /** Source helper matches history_content_types to source types */
     _getSource: function (v) {
         return v.history_content_type == "dataset_collection" ? "hdca" : "hda";
+    },
+
+    /** Only utilize id and source when specifiying input value **/
+    _pickValue: function (v) {
+        if (v && v.values) {
+            v.values = v.values.map((v) => ({
+                id: v.id,
+                src: v.src,
+            }));
+        }
+        return v;
     },
 
     /** Library datasets are displayed and selected together with history datasets,

--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -485,12 +485,13 @@ const View = Backbone.View.extend({
         return v.history_content_type == "dataset_collection" ? "hdca" : "hda";
     },
 
-    /** Only utilize id and source when specifiying input value **/
+    /** Only utilize id, source and map_over_type when specifiying input value **/
     _pickValue: function (v) {
         if (v && v.values) {
-            v.values = v.values.map((v) => ({
-                id: v.id,
-                src: v.src,
+            v.values = v.values.map((entry) => ({
+                id: entry.id,
+                src: entry.src,
+                map_over_type: entry.map_over_type,
             }));
         }
         return v;

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -490,6 +490,7 @@ tool_form:
     options: '.tool-dropdown'
     execute: 'button#execute'
     parameter_div: 'div.ui-form-element[id="form-element-${parameter}"]'
+    parameter_error: 'div.ui-form-element[id="form-element-${parameter}"] .ui-form-error-text'
     parameter_checkbox: 'div.ui-form-element[id="form-element-${parameter}"] .ui-switch'
     parameter_input: 'div.ui-form-element[id="form-element-${parameter}"] .ui-input'
     parameter_textarea: 'div.ui-form-element[id="form-element-${parameter}"] textarea'

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -494,6 +494,9 @@ tool_form:
     parameter_checkbox: 'div.ui-form-element[id="form-element-${parameter}"] .ui-switch'
     parameter_input: 'div.ui-form-element[id="form-element-${parameter}"] .ui-input'
     parameter_textarea: 'div.ui-form-element[id="form-element-${parameter}"] textarea'
+    parameter_data_input_single:
+      type: xpath
+      selector: //div[@id='form-element-${parameter}']//i[contains(@class, 'fa-file-o')]/parent::label
     parameter_batch_dataset_collection:
       type: xpath
       selector: //div[@id='form-element-${parameter}']//i[contains(@class, 'fa-folder-o')]/parent::label

--- a/client/tests/qunit/tests/ui_tests.js
+++ b/client/tests/qunit/tests/ui_tests.js
@@ -746,13 +746,13 @@ QUnit.test("select-content", function (assert) {
     assert.ok(select.button_type.value() == 0, "Initial mode selected by default.");
     select.model.set("data", {
         hda: [
-            { id: "id0", name: "name0", hid: "hid0" },
-            { id: "id1", name: "name1", hid: "hid1" },
+            { id: "id0", name: "name0", hid: "hid0", src: "hda" },
+            { id: "id1", name: "name1", hid: "hid1", src: "hda" },
         ],
         hdca: [
-            { id: "id2", name: "name2", hid: "hid2" },
-            { id: "id3", name: "name3", hid: "hid3" },
-            { id: "id4", name: "name4", hid: "hid4" },
+            { id: "id2", name: "name2", hid: "hid2", src: "hdca"  },
+            { id: "id3", name: "name3", hid: "hid3", src: "hdca"  },
+            { id: "id4", name: "name4", hid: "hid4", src: "hdca"  },
         ],
     });
 
@@ -845,30 +845,29 @@ QUnit.test("select-content", function (assert) {
     select.model.set("optional", false);
     assert.ok(select.fields[0].data[0].value != "__null__", "First option is not optional value");
 
-    select.model.set("value", { values: [{ id: "id1", src: "hda" }] });
+    select.model.set("value", { values: [{ id: "id1", name: "name1", src: "hda" }] });
     assert.ok(
-        JSON.stringify(select.value()) == '{"values":[{"id":"id1","name":"name1","hid":"hid1"}],"batch":false}',
+        JSON.stringify(select.value()) == '{"values":[{"id":"id1","src":"hda"}],"batch":false}',
         "Checking single value"
     );
-
     assert.ok(select.config[select.model.get("current")].src == "hda", "Matched dataset field");
     assert.ok(!select.config[select.model.get("current")].multiple, "Matched single select field");
     select.model.set("value", {
         values: [
-            { id: "id0", src: "hda" },
-            { id: "id1", src: "hda" },
+            { id: "id0", src: "hda", name: "name0" },
+            { id: "id1", src: "hda", name: "name1" },
         ],
     });
     assert.ok(select.config[select.model.get("current")].multiple, "Matched multiple field");
     assert.ok(
         JSON.stringify(select.value()) ==
-            '{"values":[{"id":"id0","name":"name0","hid":"hid0"},{"id":"id1","name":"name1","hid":"hid1"}],"batch":true}',
+            '{"values":[{"id":"id0","src":"hda"},{"id":"id1","src":"hda"}],"batch":true}',
         "Checking multiple values"
     );
-    select.model.set("value", { values: [{ id: "id2", src: "hdca" }] });
+    select.model.set("value", { values: [{ id: "id2", src: "hdca", name: "name2" }] });
     assert.ok(select.config[select.model.get("current")].src == "hdca", "Matched collection field");
     assert.ok(
-        JSON.stringify(select.value()) == '{"values":[{"id":"id2","name":"name2","hid":"hid2"}],"batch":true}',
+        JSON.stringify(select.value()) == '{"values":[{"id":"id2","src":"hdca"}],"batch":true}',
         "Checking collection value"
     );
 

--- a/client/tests/qunit/tests/ui_tests.js
+++ b/client/tests/qunit/tests/ui_tests.js
@@ -750,7 +750,7 @@ QUnit.test("select-content", function (assert) {
             { id: "id1", name: "name1", hid: "hid1", src: "hda" },
         ],
         hdca: [
-            { id: "id2", name: "name2", hid: "hid2", src: "hdca"  },
+            { id: "id2", name: "name2", hid: "hid2", src: "hdca", map_over_type: "map"  },
             { id: "id3", name: "name3", hid: "hid3", src: "hdca"  },
             { id: "id4", name: "name4", hid: "hid4", src: "hdca"  },
         ],
@@ -867,7 +867,7 @@ QUnit.test("select-content", function (assert) {
     select.model.set("value", { values: [{ id: "id2", src: "hdca", name: "name2" }] });
     assert.ok(select.config[select.model.get("current")].src == "hdca", "Matched collection field");
     assert.ok(
-        JSON.stringify(select.value()) == '{"values":[{"id":"id2","src":"hdca"}],"batch":true}',
+        JSON.stringify(select.value()) == '{"values":[{"id":"id2","src":"hdca","map_over_type":"map"}],"batch":true}',
         "Checking collection value"
     );
 

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -121,6 +121,7 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         self.perform_upload(test_path)
         self.history_panel_wait_for_hid_ok(1)
         self.tool_open("column_param")
+        self.select2_set_value("#col", "3")
         self.tool_form_execute()
         self.history_panel_wait_for_hid_ok(2)
         # delete source dataset and click re-run on resulting dataset
@@ -134,6 +135,11 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         assert (
             input_warning.text
             == "parameter 'input1': the previously selected dataset has been deleted. Using default: ''."
+        )
+        input_warning = self.components.tool_form.parameter_error(parameter="col").wait_for_visible()
+        assert (
+            input_warning.text
+            == "parameter 'col': an invalid option ('3') was selected (valid options: 1)"
         )
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -130,14 +130,33 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         item = self.history_panel_item_component(hid=2)
         item.title.wait_for_and_click()
         item.rerun_button.wait_for_and_click()
-        # validate form error text
-        input_warning = self.components.tool_form.parameter_error(parameter="input1").wait_for_visible()
+        # validate initial warnings
+        error_input1 = self.components.tool_form.parameter_error(parameter="input1").wait_for_visible()
+        error_col = self.components.tool_form.parameter_error(parameter="col").wait_for_visible()
         assert (
-            input_warning.text
+            error_input1.text
             == "parameter 'input1': the previously selected dataset has been deleted. Using default: ''."
         )
-        input_warning = self.components.tool_form.parameter_error(parameter="col").wait_for_visible()
-        assert input_warning.text == "parameter 'col': an invalid option ('3') was selected (valid options: 1)"
+        assert error_col.text == "parameter 'col': an invalid option ('3') was selected (valid options: 1)"
+        # validate errors when inputs are missing
+        self.components.tool_form.parameter_batch_dataset_collection(parameter="input1").wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        error_input1 = self.components.tool_form.parameter_error(parameter="input1").wait_for_visible()
+        error_col = self.components.tool_form.parameter_error(parameter="col").wait_for_visible()
+        error_col_names = self.components.tool_form.parameter_error(parameter="col_names").wait_for_visible()
+        assert error_input1.text == "Please provide a value for this option."
+        assert error_col.text == "parameter 'col': an invalid option (None) was selected, please verify"
+        assert error_col_names.text == "parameter 'col_names': an invalid option (None) was selected, please verify"
+        # validate warnings when inputs are restored
+        self.components.tool_form.parameter_data_input_single(parameter="input1").wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        error_input1 = self.components.tool_form.parameter_error(parameter="input1").wait_for_visible()
+        error_col = self.components.tool_form.parameter_error(parameter="col").wait_for_visible()
+        assert (
+            error_input1.text
+            == "parameter 'input1': the previously selected dataset has been deleted. Using default: ''."
+        )
+        assert error_col.text == "parameter 'col': an invalid option ('3') was selected (valid options: 1)"
 
     @selenium_test
     def test_rerun_dataset_collection_element(self):

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -131,7 +131,10 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         item.rerun_button.wait_for_and_click()
         # validate form error text
         input_warning = self.components.tool_form.parameter_error(parameter="input1").wait_for_visible()
-        assert input_warning.text == "parameter 'input1': the previously selected dataset has been deleted. Using default: ''."
+        assert (
+            input_warning.text
+            == "parameter 'input1': the previously selected dataset has been deleted. Using default: ''."
+        )
 
     @selenium_test
     def test_rerun_dataset_collection_element(self):

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -115,6 +115,25 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
         self._check_dataset_details_for_inttest_value(2)
 
     @selenium_test
+    def test_rerun_deleted_dataset(self):
+        # upload a first dataset that should not become selected on re-run
+        test_path = self.get_filename("1.tabular")
+        self.perform_upload(test_path)
+        self.history_panel_wait_for_hid_ok(1)
+        self.tool_open("column_param")
+        self.tool_form_execute()
+        self.history_panel_wait_for_hid_ok(2)
+        # delete source dataset and click re-run on resulting dataset
+        item = self.history_panel_item_component(hid=1)
+        item.delete_button.wait_for_and_click()
+        item = self.history_panel_item_component(hid=2)
+        item.title.wait_for_and_click()
+        item.rerun_button.wait_for_and_click()
+        # validate form error text
+        input_warning = self.components.tool_form.parameter_error(parameter="input1").wait_for_visible()
+        assert input_warning.text == "parameter 'input1': the previously selected dataset has been deleted. Using default: ''."
+
+    @selenium_test
     def test_rerun_dataset_collection_element(self):
         # upload a first dataset that should not become selected on re-run
         test_path = self.get_filename("1.fasta")

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -137,10 +137,7 @@ class TestToolForm(SeleniumTestCase, UsesHistoryItemAssertions):
             == "parameter 'input1': the previously selected dataset has been deleted. Using default: ''."
         )
         input_warning = self.components.tool_form.parameter_error(parameter="col").wait_for_visible()
-        assert (
-            input_warning.text
-            == "parameter 'col': an invalid option ('3') was selected (valid options: 1)"
-        )
+        assert input_warning.text == "parameter 'col': an invalid option ('3') was selected (valid options: 1)"
 
     @selenium_test
     def test_rerun_dataset_collection_element(self):


### PR DESCRIPTION
Fixes #10402. Currently the content selector populates the value with `id`, `src` and `name` and other custom attributes. The backend however only requires `id`, `src` and `map_over_type` as actual input values for job runs, this leads to value changes which trigger build requests and prevent the error highlighting from being displayed properly. This PR fixes this in the backbone-based by ensuring that the input element only materializes the `id`, `src` attributes in the value. This dramatically reduces the number of tool build requests.

However as a consequence, the tool run success message does now only display the output datasets but not the input datasets anymore. This should not be an issue tho, since the inputs are known to the user who has selected them in the tool form and can be displayed again when clicking either on the info icon or the re-run button.

The highlighting here is a first step, moving forward we can consider to relax the condition and re-populate the original dataset with a warning e.g. saying that it is currently deleted or for some other reason unavailable.

This fix is applied to the backbone-based data selector input element which we should replace with a Vue component as soon as possible.

<img width="652" alt="image" src="https://github.com/galaxyproject/galaxy/assets/2105447/991c6c6f-7a1a-4fc3-80cd-76efd056ca3d">

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
