### PR TITLE
[23.0] Fix Webhooks not rendering

### DIFF
--- a/client/src/utils/webhooks.js
+++ b/client/src/utils/webhooks.js
@@ -37,9 +37,8 @@ const WebhookView = Backbone.View.extend({
     },
 
     render: function (model) {
-        const webhook = model.toJSON();
-        this.$el.html(`<div id="${webhook.id}"></div>`);
-        Utils.appendScriptStyle(webhook);
+        this.$el.html(`<div id="${model.id}"></div>`);
+        Utils.appendScriptStyle(model);
         return this;
     },
 });
@@ -70,7 +69,7 @@ function filterType(data, type) {
 }
 
 function weightedRandomPick(data) {
-    const weights = data.pluck("weight");
+    const weights = data.map((d) => d.weight);
     const sum = weights.reduce((a, b) => a + b);
 
     const normalizedWeightsMap = new Map();


### PR DESCRIPTION
The [phdcomics webhook](https://github.com/usegalaxy-eu/galaxy-webhooks) on galaxy eu failed to render. After investigating the issue, I discovered this was due to missing prototype functions in `webhooks.js`. These seem to have been provided by backbone.js in the past, but were currently missing from the objects. Unsure where these functions were meant to be injected, I removed the use of them instead. This fixed the rendering issue.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
