### PR TITLE
[23.0] Fix invalid link to "workflows by owner"

### DIFF
--- a/client/src/components/Common/Published.vue
+++ b/client/src/components/Common/Published.vue
@@ -70,7 +70,7 @@ export default {
             return this.plural.toLowerCase();
         },
         publishedByUser() {
-            return `/${this.pluralPath}/list_published?f-username=${this.item.username}`;
+            return `/${this.pluralPath}/list_published?f-username=${this.owner}`;
         },
         urlAll() {
             return `/${this.pluralPath}/list_published`;


### PR DESCRIPTION
Fixes  #15974 by using the `owner` computed, instead of `item.username` which does not exist on workflows

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Publish a workflow
  2. Navigate to published workflow
  3. Click 'Published Workflows by *Username*'
  4. Check URL

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
