### PR TITLE
[23.0] Fix history export papercuts

### DIFF
--- a/client/src/components/History/Export/HistoryExport.test.ts
+++ b/client/src/components/History/Export/HistoryExport.test.ts
@@ -19,7 +19,13 @@ const mockGetExportRecords = getExportRecords as jest.MockedFunction<typeof getE
 mockGetExportRecords.mockResolvedValue([]);
 
 const FAKE_HISTORY_ID = "fake-history-id";
+const FAKE_HISTORY = {
+    id: FAKE_HISTORY_ID,
+    name: "fake-history-name",
+};
+
 const REMOTE_FILES_API_ENDPOINT = new RegExp("/api/remote_files/plugins");
+const GET_HISTORY_ENDPOINT = new RegExp(`/api/histories/${FAKE_HISTORY_ID}`);
 
 type FilesSourcePluginList = components["schemas"]["FilesSourcePlugin"][];
 const REMOTE_FILES_API_RESPONSE: FilesSourcePluginList = [
@@ -50,10 +56,17 @@ describe("HistoryExport.vue", () => {
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
         axiosMock.onGet(REMOTE_FILES_API_ENDPOINT).reply(200, []);
+        axiosMock.onGet(GET_HISTORY_ENDPOINT).reply(200, FAKE_HISTORY);
     });
 
     afterEach(() => {
         axiosMock.restore();
+    });
+
+    it("should render the history name", async () => {
+        const wrapper = await mountHistoryExport();
+
+        expect(wrapper.find("#history-name").text()).toBe(FAKE_HISTORY.name);
     });
 
     it("should render export options", async () => {

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -5,7 +5,7 @@ import LoadingSpan from "components/LoadingSpan";
 import ExportRecordDetails from "components/Common/ExportRecordDetails.vue";
 import ExportRecordTable from "components/Common/ExportRecordTable.vue";
 import ExportOptions from "./ExportOptions.vue";
-import ExportToFileSourceForm from "components/Common/ExportForm.vue";
+import ExportForm from "components/Common/ExportForm.vue";
 import { getHistoryById } from "@/store/historyStore/model/queries";
 import { getExportRecords, exportToFileSource, reimportHistoryFromRecord } from "./services";
 import { useTaskMonitor } from "composables/taskMonitor";
@@ -29,7 +29,7 @@ const { hasWritable: hasWritableFileSources } = useFileSources();
 
 const {
     isPreparing: isPreparingDownload,
-    downloadHistory,
+    prepareHistoryDownload,
     downloadObjectByRequestId,
     getDownloadObjectUrl,
 } = useShortTermStorage();
@@ -56,6 +56,14 @@ const exportRecords = ref(null);
 
 const historyName = computed(() => history.value?.name ?? props.historyId);
 const latestExportRecord = computed(() => (exportRecords.value?.length ? exportRecords.value.at(0) : null));
+const isLatestExportRecordReadyToDownload = computed(
+    () =>
+        latestExportRecord.value &&
+        latestExportRecord.value.isUpToDate &&
+        latestExportRecord.value.canDownload &&
+        latestExportRecord.value.exportParams?.equals(exportParams)
+);
+const canGenerateDownload = computed(() => !isPreparingDownload.value && !isLatestExportRecordReadyToDownload.value);
 const previousExportRecords = computed(() => (exportRecords.value ? exportRecords.value.slice(1) : null));
 const hasPreviousExports = computed(() => previousExportRecords.value?.length > 0);
 const availableRecordsMessage = computed(() =>
@@ -114,12 +122,7 @@ async function doExportToFileSource(exportDirectory, fileName) {
 }
 
 async function prepareDownload() {
-    const upToDateDownloadRecord = findValidUpToDateDownloadRecord();
-    if (upToDateDownloadRecord) {
-        downloadObjectByRequestId(upToDateDownloadRecord.stsDownloadId);
-        return;
-    }
-    await downloadHistory(props.historyId, { pollDelayInMs: POLLING_DELAY, exportParams: exportParams });
+    await prepareHistoryDownload(props.historyId, { pollDelayInMs: POLLING_DELAY, exportParams: exportParams });
     updateExports();
 }
 
@@ -134,14 +137,6 @@ function copyDownloadLinkFromRecord(record) {
         const relativeLink = getDownloadObjectUrl(record.stsDownloadId);
         sendToClipboard(absPath(relativeLink), "Download link copied to your clipboard");
     }
-}
-
-function findValidUpToDateDownloadRecord() {
-    return exportRecords.value
-        ? exportRecords.value.find(
-              (record) => record.canDownload && record.isUpToDate && record.exportParams?.equals(exportParams)
-          )
-        : null;
 }
 
 async function reimportFromRecord(record) {
@@ -185,11 +180,13 @@ function updateExportParams(newParams) {
 
         <export-options
             id="history-export-options"
+            class="mt-3"
             :export-params="exportParams"
             @onValueChanged="updateExportParams" />
 
+        <h2 class="h-md mt-3">How do you want to export this history?</h2>
         <b-card no-body class="mt-3">
-            <b-tabs pills card>
+            <b-tabs pills card vertical>
                 <b-tab id="direct-download-tab" title="to direct download" title-link-class="tab-export-to-link" active>
                     <p>
                         Here you can generate a temporal download for your history. When your download link expires or
@@ -201,15 +198,19 @@ function updateExportParams(newParams) {
                         Galaxy server.
                     </b-alert>
                     <b-button
-                        class="direct-download-btn"
-                        :disabled="isPreparingDownload"
+                        class="gen-direct-download-btn"
+                        :disabled="!canGenerateDownload"
                         variant="primary"
                         @click="prepareDownload">
-                        Download
+                        Generate direct download
                     </b-button>
                     <span v-if="isPreparingDownload">
                         <loading-span message="Galaxy is preparing your download, this will likely take a while" />
                     </span>
+                    <b-alert v-else-if="isLatestExportRecordReadyToDownload" variant="success" class="mt-3" show>
+                        The latest export record is ready. Use the download button below to download it or change the
+                        advanced export options above to generate a new one.
+                    </b-alert>
                 </b-tab>
                 <b-tab
                     v-if="hasWritableFileSources"
@@ -221,10 +222,7 @@ function updateExportParams(newParams) {
                         one of the available remote file sources here. You will be able to re-import it later as long as
                         it remains available on the remote server.
                     </p>
-                    <export-to-file-source-form
-                        what="history"
-                        :clear-input-after-export="true"
-                        @export="doExportToFileSource" />
+                    <export-form what="history" :clear-input-after-export="true" @export="doExportToFileSource" />
                 </b-tab>
             </b-tabs>
         </b-card>
@@ -232,17 +230,19 @@ function updateExportParams(newParams) {
         <b-alert v-if="errorMessage" id="last-export-record-error-alert" variant="danger" class="mt-3" show>
             {{ errorMessage }}
         </b-alert>
-        <export-record-details
-            v-else-if="latestExportRecord"
-            :record="latestExportRecord"
-            object-type="history"
-            class="mt-3"
-            :action-message="actionMessage"
-            :action-message-variant="actionMessageVariant"
-            @onDownload="downloadFromRecord"
-            @onCopyDownloadLink="copyDownloadLinkFromRecord"
-            @onReimport="reimportFromRecord"
-            @onActionMessageDismissed="onActionMessageDismissedFromRecord" />
+        <div v-else-if="latestExportRecord">
+            <h2 class="h-md mt-3">Latest Export Record</h2>
+            <export-record-details
+                :record="latestExportRecord"
+                object-type="history"
+                class="mt-3"
+                :action-message="actionMessage"
+                :action-message-variant="actionMessageVariant"
+                @onDownload="downloadFromRecord"
+                @onCopyDownloadLink="copyDownloadLinkFromRecord"
+                @onReimport="reimportFromRecord"
+                @onActionMessageDismissed="onActionMessageDismissedFromRecord" />
+        </div>
         <b-alert v-else id="no-export-records-alert" variant="info" class="mt-3" show>
             {{ availableRecordsMessage }}
         </b-alert>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -425,7 +425,7 @@ history_export:
 
 history_export_tasks:
   selectors:
-    direct_download: '.direct-download-btn'
+    direct_download: '.gen-direct-download-btn'
     file_source_tab: '.tab-export-to-file'
     remote_file_name_input: '#file-source-tab #name'
     toggle_options_link: '#toggle-options-link'


### PR DESCRIPTION
Hopefully fixes #15989

- Displays the history name (retrieving the history from the server, for now, will use the pinia histories store on dev)
- Changes the Tab to a vertical layout to make it more obvious they are 2 different tab options instead of plain buttons.
- Changes the "Download" button inside the direct download export option to "Generate Direct Download". Before this was doing 2 things, preparing the export package inside the Short-Term-Storage and then triggering the download in the browser. Now it only prepares the download and nudges you into downloading the package from the *Latest Export Record* where you can also copy the link if you don´t want to download it locally at all.
- Some other minor cosmetic changes

### With no downloads generated yet
![image](https://user-images.githubusercontent.com/46503462/234273157-2dbb3287-f164-4c0a-a650-3a8795cbf69f.png)

### After generating a new direct download
![image](https://user-images.githubusercontent.com/46503462/234273359-ea6edaba-0df4-4fce-a615-f395b6abc093.png)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
