### PR TITLE
Fetcher Mock utility

### DIFF
--- a/client/tests/jest/mockFetcher.ts
+++ b/client/tests/jest/mockFetcher.ts
@@ -1,0 +1,90 @@
+import type { paths } from "@/schema";
+
+jest.mock("@/schema", () => ({
+    fetcher: mockFetcher,
+}));
+
+jest.mock("@/schema/fetcher", () => ({
+    fetcher: mockFetcher,
+}));
+
+type Path = keyof paths;
+type Method = "get" | "post" | "put" | "delete";
+
+interface MockValue {
+    path: Path | RegExp;
+    method: Method;
+    value: any;
+}
+
+const mockValues: MockValue[] = [];
+
+function getMockReturn(path: Path, method: Method, args: any[]) {
+    for (let i = mockValues.length - 1; i >= 0; i--) {
+        const matchPath = mockValues[i]!.path;
+        const matchMethod = mockValues[i]!.method;
+        const value = mockValues[i]!.value;
+
+        const getValue = () => {
+            if (typeof value === "function") {
+                return value(...args);
+            } else {
+                return value;
+            }
+        };
+
+        if (matchMethod !== method) {
+            continue;
+        }
+
+        if (typeof matchPath === "string") {
+            if (matchPath === path) {
+                return getValue();
+            }
+        } else {
+            if (path.match(matchPath)) {
+                return getValue();
+            }
+        }
+    }
+
+    return null;
+}
+
+function setMockReturn(path: Path | RegExp, method: Method, value: any) {
+    mockValues.push({
+        path,
+        method,
+        value,
+    });
+}
+
+/**
+ * Mock implementation for the fetcher found in `@/schema/fetcher`
+ *
+ * Importing this will mock fetcher automatically.
+ *
+ * To specify return values for the mock, use
+ * `mockFetcher.path(...).method(...).mock(desiredReturnValue)`
+ * This will cause any use of fetcher on the same path and method to receive the contents of `desiredReturnValue`.
+ *
+ * If this return value is a function, it will be ran and passed the parameters passed to the fetcher, and it's result returned.
+ *
+ * `path(...)` can take a `RegExp`, in which case any path matching the Regular Expression with a fitting method will be used.
+ *
+ * If multiple mock paths match a path, the latest defined will be used.
+ *
+ * `clearMocks()` can be used to reset all mock return values set with `.mock()`
+ */
+export const mockFetcher = {
+    path: (path: Path | RegExp) => ({
+        method: (method: Method) => ({
+            // prettier-ignore
+            create: () => async (...args: any[]) => getMockReturn(path as Path, method, args),
+            mock: (mockReturn: any) => setMockReturn(path, method, mockReturn),
+        }),
+    }),
+    clearMocks: () => {
+        mockValues.length = 0;
+    },
+};

--- a/client/tests/jest/standalone/mockFetcher.test.ts
+++ b/client/tests/jest/standalone/mockFetcher.test.ts
@@ -1,0 +1,39 @@
+import { mockFetcher } from "../mockFetcher";
+import { fetcher } from "@/schema";
+
+mockFetcher.path("/api/configuration").method("get").mock("CONFIGURATION");
+
+mockFetcher
+    .path(/^.*\/histories\/.*$/)
+    .method("get")
+    .mock("HISTORY");
+
+mockFetcher
+    .path(/\{history_id\}/)
+    .method("put")
+    .mock((param: { history_id: string }) => `param:${param.history_id}`);
+
+describe("mockFetcher", () => {
+    it("mocks fetcher", async () => {
+        {
+            const fetch = fetcher.path("/api/configuration").method("get").create();
+            const value = await fetch({});
+
+            expect(value).toEqual("CONFIGURATION");
+        }
+
+        {
+            const fetch = fetcher.path("/api/histories/deleted").method("get").create();
+            const value = await fetch({});
+
+            expect(value).toEqual("HISTORY");
+        }
+
+        {
+            const fetchHistory = fetcher.path("/api/histories/{history_id}/exports").method("put").create();
+            const value = await fetchHistory({ history_id: "test" });
+
+            expect(value).toEqual("param:test");
+        }
+    });
+});


### PR DESCRIPTION
The idea for this utility arose from the UI/UX WG chat.

This utility can be used as follows:

```ts
mockFetcher.path("/api/histories/deleted"").method("get").mock("my amazing history");
```

Now the following code:
```ts
const historyFechter = fetcher.path("/api/histories/deleted"").method("get").create();
const value = await historyFechter({});
console.log(value);
```

prints: `"my amazing history"`

`path` can also take a regular expression, to mock multiple paths at once.
The value passed to `mock` can be function, which will then be called with the arguments passed to the fetcher.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
