### PR TITLE
reorganize user menu for consistency

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -5,7 +5,7 @@
             {{ message }}
         </b-alert>
         <p>
-            <span v-localize>You are logged in as</span>
+            <span v-localize>You are signed in as</span>
             <strong id="user-preferences-current-email">{{ email }}</strong>
             <span v-localize>and you are using</span>
             <strong>{{ diskUsage }}</strong>

--- a/client/src/entry/analysis/menu.js
+++ b/client/src/entry/analysis/menu.js
@@ -198,6 +198,7 @@ export function fetchMenu(options = {}) {
                     }`,
                     disabled: true,
                 },
+                { divider: true },
                 {
                     title: _l("Preferences"),
                     url: "/user",
@@ -206,12 +207,13 @@ export function fetchMenu(options = {}) {
                     title: _l("Custom Builds"),
                     url: "/custom_builds",
                 },
-                { divider: true },
                 {
-                    title: _l("Logout"),
-                    onclick: userLogout,
-                    hidden: Galaxy.config.single_user,
+                    title: _l("Show/Hide Activity Bar"),
+                    onclick: () => {
+                        userStore.toggleActivityBar();
+                    },
                 },
+                { divider: true },
                 {
                     title: _l("Datasets"),
                     url: "/datasets/list",
@@ -242,19 +244,16 @@ export function fetchMenu(options = {}) {
             });
         }
         if (Galaxy.config.interactivetools_enable) {
-            userTab.menu.push({ divider: true });
             userTab.menu.push({
                 title: _l("Active InteractiveTools"),
                 url: "/interactivetool_entry_points/list",
             });
         }
-
-        // beta switch for activity bar
+        userTab.menu.push({ divider: true });
         userTab.menu.push({
-            title: _l("Show/Hide Activity Bar"),
-            onclick: () => {
-                userStore.toggleActivityBar();
-            },
+            title: _l("Sign Out"),
+            onclick: userLogout,
+            hidden: Galaxy.config.single_user,
         });
     }
     menu.push(userTab);

--- a/client/src/entry/analysis/menu.js
+++ b/client/src/entry/analysis/menu.js
@@ -193,7 +193,7 @@ export function fetchMenu(options = {}) {
             tooltip: _l("Account and saved data"),
             menu: [
                 {
-                    title: `${_l("Logged in as")} ${
+                    title: `${_l("Signed in as")} ${
                         Galaxy.user.get("username") ? Galaxy.user.get("username") : Galaxy.user.get("email")
                     }`,
                     disabled: true,

--- a/client/src/entry/analysis/menu.js
+++ b/client/src/entry/analysis/menu.js
@@ -204,10 +204,6 @@ export function fetchMenu(options = {}) {
                     url: "/user",
                 },
                 {
-                    title: _l("Custom Builds"),
-                    url: "/custom_builds",
-                },
-                {
                     title: _l("Show/Hide Activity Bar"),
                     onclick: () => {
                         userStore.toggleActivityBar();

--- a/client/src/nls/de/locale.js
+++ b/client/src/nls/de/locale.js
@@ -24,7 +24,7 @@ define({
     Login: "Anmeldung",
     Register: "Neu registrieren",
     "Login or Register": "Einloggen oder Registrieren",
-    "Logged in as": "Angemeldet als",
+    "Signed in as": "Angemeldet als",
     Preferences: "Präferenzen",
     "Custom Builds": "Custom Builds",
     Logout: "Ausloggen",

--- a/client/src/nls/es/locale.js
+++ b/client/src/nls/es/locale.js
@@ -63,7 +63,7 @@ define({
     "Forgot password?": "¿Olvidó su contraseña?",
     "Register here.": "Regístrese aquí.",
     "Click here to reset your password.": "Haga clic aquí para restablecer su contraseña.",
-    "Logged in as": "Se ha conectado como",
+    "Signed in as": "Se ha conectado como",
 
     Preferences: "Preferencias",
 
@@ -585,7 +585,7 @@ define({
     "Edit your email, addresses and custom parameters or change your public name.":
         "Edita tus direcciones de correo y personaliza los parámetros o cambia tu nombre público.",
     "User preferences": "Preferencias de usuario",
-    "You are logged in as": "Iniciaste sesión como",
+    "You are signed in as": "Iniciaste sesión como",
     "Sign out": "Cerrar sesión",
     "Manage custom builds": "Administrar construcciones personalizadas",
     "Manage OpenIDs": "Administrar OpenIDs",

--- a/client/src/nls/fr/locale.js
+++ b/client/src/nls/fr/locale.js
@@ -25,7 +25,7 @@ define({
     Login: "Authentification",
     Register: "Enregistrement",
     "Login or Register": "Authentification et Enregistrement",
-    "Logged in as": "Authentifié en tant que",
+    "Signed in as": "Authentifié en tant que",
     Preferences: "Préférences",
     "Custom Builds": "Mes génomes Builds de référence",
     Logout: "Déconnexion",

--- a/client/src/nls/ja/locale.js
+++ b/client/src/nls/ja/locale.js
@@ -27,8 +27,6 @@ define({
     Login: "ログイン",
     Register: "登録",
     "Login or Register": "ログイン/登録",
-    //"Logged in as":
-    //    "",
     Preferences: "設定",
     "Custom Builds": "カスタムビルド",
     Logout: "ログアウト",

--- a/client/src/nls/locale.js
+++ b/client/src/nls/locale.js
@@ -26,7 +26,7 @@ define({
         Login: false,
         Register: false,
         "Login or Register": false,
-        "Logged in as": false,
+        "Signed in as": false,
         Preferences: false,
         "Custom Builds": false,
         Logout: false,

--- a/client/src/nls/zh/locale.js
+++ b/client/src/nls/zh/locale.js
@@ -27,7 +27,7 @@ define({
     Login: "登陆",
     Register: "注册",
     "Login or Register": "注册登陆",
-    "Logged in as": "您已登陆为",
+    "Signed in as": "您已登陆为",
     Preferences: "用户偏好性",
     "Custom Builds": "自定义构建集",
     Logout: "退出",

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -59,7 +59,7 @@ masthead:
     admin: 'Admin'
 
     # user menu
-    logout: 'Logout'
+    logout: 'Sign Out'
     custom_builds: 'Custom Builds'
     preferences: 'Preferences'
     histories: 'Histories'

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -60,7 +60,6 @@ masthead:
 
     # user menu
     logout: 'Sign Out'
-    custom_builds: 'Custom Builds'
     preferences: 'Preferences'
     histories: 'Histories'
     invocations: 'Workflow Invocations'
@@ -78,6 +77,7 @@ preferences:
     manage_information: '#edit-preferences-information'
     toolbox_filters: '#edit-preferences-toolbox-filters'
     manage_api_key: '#edit-preferences-api-key'
+    custom_builds: '#edit-preferences-custom-builds'
     current_email: "#user-preferences-current-email"
     get_new_key: '.create-button'
     api_key_input: '[data-test-id="api-key-input"]'

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -43,7 +43,7 @@ masthead:
 
     username:
       type: xpath
-      selector: '//a[contains(text(), "Logged in as")]'
+      selector: '//a[contains(text(), "Signed in as")]'
 
     logged_in_only: '.loggedin-only'
     logged_out_only: '.loggedout-only'

--- a/lib/galaxy_test/selenium/test_custom_builds.py
+++ b/lib/galaxy_test/selenium/test_custom_builds.py
@@ -78,8 +78,8 @@ class TestCustomBuilds(SharedStateSeleniumTestCase):
 
     def navigate_to_custom_builds_page(self):
         self.home()
-        self.click_masthead_user()  # Open masthead menu
-        self.components.masthead.custom_builds.wait_for_and_click()
+        self.navigate_to_user_preferences()
+        self.components.preferences.custom_builds.wait_for_and_click()
 
     def setup_shared_state(self):
         TestCustomBuilds.user_email = self._get_random_email()


### PR DESCRIPTION
I believe the last item is the standard position for signing out. Some other minor consistency changes.

before
![Screenshot 2023-04-25 at 10 09 18 AM](https://user-images.githubusercontent.com/1814954/234352177-c223b794-035f-4e99-a81e-b72d3c3e74c7.png)
after
![Screenshot 2023-04-25 at 12 19 16 PM](https://user-images.githubusercontent.com/1814954/234380872-c9d70720-5c32-4f2f-b761-44f129242a6e.png)



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
