### PR TITLE
remove inherited title from masthead dropdown items

### DIFF
--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -117,6 +117,7 @@ function open(tab, event) {
                 :href="withPrefix(item.url)"
                 :target="item.target || '_parent'"
                 role="menuitem"
+                title=""
                 :active="item.disabled"
                 :disabled="item.disabled"
                 @click="open(item, $event)">


### PR DESCRIPTION
seemingly without this change the title is inherited from parent `b-nav-item-dropdown` (the actual masthed item/icon) which
1. is not useful because all items have the same title
2. is not wanted (?) on dropdown items
3. causes weird behavior where if you hover on the dropdown menu it will change cursor together with showing title after a second or two

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
