### PR TITLE
Export tool citations configurable message

### DIFF
--- a/client/src/components/Citation/Citations.vue
+++ b/client/src/components/Citation/Citations.vue
@@ -16,9 +16,19 @@
                 </b-nav>
             </template>
             <div v-if="source === 'histories'" class="infomessage">
-                When writing up your analysis, remember to include all references that should be cited in order to
-                completely describe your work. Also, please remember to
-                <a href="https://galaxyproject.org/citing-galaxy">cite Galaxy</a>.
+                <ConfigProvider v-slot="{ config }">
+                    <div v-if="config.citations_export_message_australia">
+                        Please cite <b>Galaxy Australia</b> (below) in any publication resulting for analysis you performed on this service.<br><br>
+                        When acknowledging Galaxy Australia in any publication or presentation, we recommend the following acknowledgement statement:<br><br>
+                        “This work was conducted on Galaxy Australia, supported by the Australian BioCommons which is enabled by NCRIS via Bioplatforms Australia funding, the University of Melbourne, QCIF, AARNet, ARDC and the Queensland Government”.<br><br>
+                        You are also welcome to use our logo. A variety of logo formats are available for <a href="https://galaxyproject.org/images/galaxy-logos/">download</a>, and the accompanying usage guidelines are <a href="https://galaxyproject.org/citing-galaxy">here</a>.
+                    </div>
+                    <div v-else>
+                        When writing up your analysis, remember to include all references that should be cited in order to
+                        completely describe your work. Also, please remember to
+                        <a href="https://galaxyproject.org/citing-galaxy">cite Galaxy</a>.
+                    </div>
+                </ConfigProvider>
             </div>
             <div class="citations-formatted">
                 <Citation
@@ -55,6 +65,7 @@ import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
 import { getCitations } from "./services";
 import Citation from "./Citation";
+import ConfigProvider from "components/providers/ConfigProvider";
 
 Vue.use(BootstrapVue);
 
@@ -67,6 +78,7 @@ const outputFormats = Object.freeze({
 export default {
     components: {
         Citation,
+        ConfigProvider
     },
     props: {
         source: {
@@ -105,7 +117,7 @@ export default {
             .catch((e) => {
                 console.error(e);
             });
-    },
+    }
 };
 </script>
 <style>

--- a/client/src/components/Citation/Citations.vue
+++ b/client/src/components/Citation/Citations.vue
@@ -17,17 +17,7 @@
             </template>
             <div v-if="source === 'histories'" class="infomessage">
                 <ConfigProvider v-slot="{ config }">
-                    <div v-if="config.citations_export_message_australia">
-                        Please cite <b>Galaxy Australia</b> (below) in any publication resulting for analysis you performed on this service.<br><br>
-                        When acknowledging Galaxy Australia in any publication or presentation, we recommend the following acknowledgement statement:<br><br>
-                        “This work was conducted on Galaxy Australia, supported by the Australian BioCommons which is enabled by NCRIS via Bioplatforms Australia funding, the University of Melbourne, QCIF, AARNet, ARDC and the Queensland Government”.<br><br>
-                        You are also welcome to use our logo. A variety of logo formats are available for <a href="https://galaxyproject.org/images/galaxy-logos/">download</a>, and the accompanying usage guidelines are <a href="https://galaxyproject.org/citing-galaxy">here</a>.
-                    </div>
-                    <div v-else>
-                        When writing up your analysis, remember to include all references that should be cited in order to
-                        completely describe your work. Also, please remember to
-                        <a href="https://galaxyproject.org/citing-galaxy">cite Galaxy</a>.
-                    </div>
+                    <div v-html="config.citations_export_message_html"></div>
                 </ConfigProvider>
             </div>
             <div class="citations-formatted">

--- a/client/src/components/Citation/Citations.vue
+++ b/client/src/components/Citation/Citations.vue
@@ -16,9 +16,7 @@
                 </b-nav>
             </template>
             <div v-if="source === 'histories'" class="infomessage">
-                <ConfigProvider v-slot="{ config }">
-                    <div v-html="config.citations_export_message_html"></div>
-                </ConfigProvider>
+                <div v-html="config.citations_export_message_html"></div>
             </div>
             <div class="citations-formatted">
                 <Citation
@@ -55,7 +53,7 @@ import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
 import { getCitations } from "./services";
 import Citation from "./Citation";
-import ConfigProvider from "components/providers/ConfigProvider";
+import { useConfig } from "@/composables/config";
 
 Vue.use(BootstrapVue);
 
@@ -68,7 +66,6 @@ const outputFormats = Object.freeze({
 export default {
     components: {
         Citation,
-        ConfigProvider
     },
     props: {
         source: {
@@ -84,6 +81,10 @@ export default {
             required: false,
             default: false,
         },
+    },
+    setup() {
+        const { config } = useConfig(true);
+        return { config };
     },
     data() {
         return {
@@ -107,7 +108,7 @@ export default {
             .catch((e) => {
                 console.error(e);
             });
-    }
+    },
 };
 </script>
 <style>

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5126,3 +5126,17 @@
     CORS is used, make sure to add this host.
 :Default: ``https://training.galaxyproject.org/training-material/api/top-tools.json``
 :Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``citations_export_message_australia``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Optional bool to display a different message on the export
+    citations tool page, used by Galaxy Australia
+:Default: ``false``
+:Type: bool
+
+
+

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5128,15 +5128,14 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``citations_export_message_australia``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``citations_export_message_html``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Optional bool to display a different message on the export
-    citations tool page, used by Galaxy Australia
-:Default: ``false``
-:Type: bool
+    Message to display on the export citations tool page
+:Default: ``When writing up your analysis, remember to include all references that should be cited in order to completely describe your work. Also, please remember to <a href="https://galaxyproject.org/citing-galaxy">cite Galaxy</a>.``
+:Type: str
 
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1,21 +1,21 @@
 # Galaxy is configured by default to be usable in a single-user development
 # environment.  To tune the application for a multi-user production
 # environment, see the documentation at:
-#
+# 
 #  https://docs.galaxyproject.org/en/master/admin/production.html
-#
+# 
 # Throughout this sample configuration file, except where stated otherwise,
 # uncommented values override the default if left unset, whereas commented
 # values are set to the default value.  Relative paths are relative to the root
 # Galaxy directory.
-#
+# 
 # Examples of many of these options are explained in more detail in the Galaxy
 # Community Hub.
-#
+# 
 #   https://galaxyproject.org/admin/config
-#
+# 
 # Config hackers are encouraged to check there before asking for help.
-#
+# 
 # Configuration for Gravity process manager.
 # ``uwsgi:`` section will be ignored if Galaxy is started via Gravity commands (e.g ``./run.sh``, ``galaxy`` or ``galaxyctl``).
 gravity:
@@ -2729,3 +2729,8 @@ galaxy:
   # URL to API describing tutorials containing specific tools. When CORS
   # is used, make sure to add this host.
   #tool_training_recommendations_api_url: https://training.galaxyproject.org/training-material/api/top-tools.json
+
+  # Optional bool to display a different message on the export citations
+  # tool page, used by Galaxy Australia
+  #citations_export_message_australia: false
+

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2730,7 +2730,6 @@ galaxy:
   # is used, make sure to add this host.
   #tool_training_recommendations_api_url: https://training.galaxyproject.org/training-material/api/top-tools.json
 
-  # Optional bool to display a different message on the export citations
-  # tool page, used by Galaxy Australia
-  #citations_export_message_australia: false
+  # Message to display on the export citations tool page
+  #citations_export_message_html: When writing up your analysis, remember to include all references that should be cited in order to completely describe your work. Also, please remember to <a href="https://galaxyproject.org/citing-galaxy">cite Galaxy</a>.
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3735,3 +3735,11 @@ mapping:
         desc: |
           URL to API describing tutorials containing specific tools.
           When CORS is used, make sure to add this host.
+
+      citations_export_message_australia:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Optional bool to display a different message on the export citations tool
+          page, used by Galaxy Australia

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3736,10 +3736,12 @@ mapping:
           URL to API describing tutorials containing specific tools.
           When CORS is used, make sure to add this host.
 
-      citations_export_message_australia:
-        type: bool
-        default: false
+      citations_export_message_html:
+        type: str
+        default: >-
+          When writing up your analysis, remember to include all references that should be cited in order to
+          completely describe your work. Also, please remember to
+          <a href="https://galaxyproject.org/citing-galaxy">cite Galaxy</a>.
         required: false
         desc: |
-          Optional bool to display a different message on the export citations tool
-          page, used by Galaxy Australia
+          Message to display on the export citations tool page

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -124,7 +124,7 @@ class ConfigSerializer(base.ModelSerializer):
             "wiki_url": _use_config,
             "screencasts_url": _use_config,
             "citation_url": _use_config,
-            "citations_export_message_australia": _use_config,
+            "citations_export_message_html": _use_config,
             "support_url": _use_config,
             "quota_url": _use_config,
             "helpsite_url": _use_config,

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -124,6 +124,7 @@ class ConfigSerializer(base.ModelSerializer):
             "wiki_url": _use_config,
             "screencasts_url": _use_config,
             "citation_url": _use_config,
+            "citations_export_message_australia": _use_config,
             "support_url": _use_config,
             "quota_url": _use_config,
             "helpsite_url": _use_config,


### PR DESCRIPTION
At Galaxy Australia we wanted the ability to display a different message for the export tool citations page to better include our funders, so I changed the hard-coded message on the page to a configurable that different Galaxy region's infrastructure teams can set in the config file. Normally it still defaults to the original message on the current Galaxy US export tool citations page.

@neoformit 
 
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
