### PR TITLE
Fix history counter empty on initial load

### DIFF
--- a/client/src/components/History/Multiple/MultipleViewItem.vue
+++ b/client/src/components/History/Multiple/MultipleViewItem.vue
@@ -75,13 +75,16 @@ export default {
         };
     },
     computed: {
-        ...mapState(useHistoryStore, ["getHistoryById"]),
+        ...mapState(useHistoryStore, ["getHistoryById", "loadHistoryById"]),
         sameToCurrent() {
             return this.currentHistory.id === this.source.id;
         },
         getHistory() {
             return this.getHistoryById(this.source.id);
         },
+    },
+    mounted() {
+        this.loadHistoryById(this.source.id);
     },
     methods: {
         onViewCollection(collection) {


### PR DESCRIPTION
Fixes #15948
The history size is not included in the summary data that is stored in the store at the initial state and should be retrieved on the loading history panel.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
