### PR TITLE
[23.0] Fix build collection not resetting selection

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
+++ b/client/src/components/History/CurrentHistory/HistoryOperations/SelectionOperations.vue
@@ -320,8 +320,8 @@ export default {
             // have to hide the source items if that was requested
             if (modalResult.hide_source_items) {
                 this.$emit("hide-selection", this.contentSelection);
-                this.$emit("reset-selection");
             }
+            this.$emit("reset-selection");
         },
     },
 };


### PR DESCRIPTION
Fixes #15946

The selection was reset only if we requested the source items of the collection to be hidden.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow the steps on #15946


    https://user-images.githubusercontent.com/46503462/234596276-02be287d-cde5-4e98-b2fa-aad01c58a94a.mp4




## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
