### PR TITLE
Vueify Select field

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -99,7 +99,7 @@
     "util": "^0.12.4",
     "vue": "^2.7.14",
     "vue-infinite-scroll": "^2.0.2",
-    "vue-multiselect": "^2.1.6",
+    "vue-multiselect": "^2.1.7",
     "vue-observe-visibility": "^1.0.0",
     "vue-prismjs": "^1.2.0",
     "vue-router": "^3.6.5",

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -62,6 +62,7 @@ describe("FormSelect", () => {
     it("multiple values", async () => {
         const wrapper = createTarget({
             multiple: true,
+            optional: true,
             options: defaultOptions,
             value: ["value_1", ""],
         });
@@ -70,5 +71,16 @@ describe("FormSelect", () => {
         expect(selectedValue.length).toBe(2);
         expect(selectedValue.at(0).text()).toBe("label_1");
         expect(selectedValue.at(1).text()).toBe("label_3");
+        selectedValue.at(0).trigger("click");
+        const newValue = wrapper.emitted().input[0][0][0];
+        expect(newValue).toBe("");
+        await wrapper.setProps({ value: newValue });
+        selectedValue.at(1).trigger("click");
+        const nullValue = wrapper.emitted().input[1][0];
+        expect(nullValue).toBe(null);
+        await wrapper.setProps({ value: nullValue });
+        selectedValue.at(0).trigger("click");
+        const finalValue = wrapper.emitted().input[2][0][0];
+        expect(finalValue).toBe("value_1");
     });
 });

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -6,20 +6,22 @@ const localVue = getLocalVue(true);
 
 function createTarget(propsData) {
     return mount(MountTarget, {
-        propsData,
         localVue,
+        propsData,
     });
 }
+
+const defaultOptions = [
+    ["label_1", "value_1"],
+    ["label_2", "value_2"],
+    ["label_3", "value_3"],
+];
 
 describe("FormSelect", () => {
     it("basics", async () => {
         const wrapper = createTarget({
+            options: defaultOptions,
             value: "value_1",
-            options: [
-                ["label_1", "value_1"],
-                ["label_2", "value_2"],
-                ["label_3", "value_3"],
-            ],
         });
         const target = wrapper.findComponent(MountTarget);
         const options = target.findAll("li > span > span");
@@ -27,5 +29,44 @@ describe("FormSelect", () => {
         for (let i = 0; i < options.length; i++) {
             expect(options.at(i).text()).toBe(`label_${i + 1}`);
         }
+        const selectedValue = wrapper.find(".multiselect__option--selected");
+        expect(selectedValue.text()).toBe("label_1");
+    });
+
+    it("optional values", async () => {
+        const wrapper = createTarget({
+            options: defaultOptions,
+            optional: true,
+        });
+        const target = wrapper.findComponent(MountTarget);
+        const options = target.findAll("li > span > span");
+        expect(options.length).toBe(4);
+        expect(options.at(0).text()).toBe("Nothing selected");
+        const selectedDefault = wrapper.find(".multiselect__option--selected");
+        expect(selectedDefault.text()).toBe("Nothing selected");
+        await wrapper.setProps({ value: "value_1" });
+        const selectedValue = wrapper.find(".multiselect__option--selected");
+        expect(selectedValue.text()).toBe("label_1");
+        await wrapper.setProps({ value: null });
+        const unselectDefault = wrapper.find(".multiselect__option--selected");
+        expect(unselectDefault.text()).toBe("Nothing selected");
+    });
+
+    it("multiple values", async () => {
+        const wrapper = createTarget({
+            multiple: true,
+            options: defaultOptions,
+            value: ["value_1", "value_3"],
+        });
+        const target = wrapper.findComponent(MountTarget);
+        const options = target.findAll("li > span > span");
+        expect(options.length).toBe(3);
+        for (let i = 0; i < options.length; i++) {
+            expect(options.at(i).text()).toBe(`label_${i + 1}`);
+        }
+        const selectedValue = wrapper.findAll(".multiselect__option--selected");
+        expect(selectedValue.length).toBe(2);
+        expect(selectedValue.at(0).text()).toBe("label_1");
+        expect(selectedValue.at(1).text()).toBe("label_3");
     });
 });

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -1,0 +1,31 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "tests/jest/helpers";
+import MountTarget from "./FormSelect";
+
+const localVue = getLocalVue(true);
+
+function createTarget(propsData) {
+    return mount(MountTarget, {
+        propsData,
+        localVue,
+    });
+}
+
+describe("FormSelect", () => {
+    it("basics", async () => {
+        const wrapper = createTarget({
+            value: "value_1",
+            options: [
+                ["label_1", "value_1"],
+                ["label_2", "value_2"],
+                ["label_3", "value_3"],
+            ],
+        });
+        const target = wrapper.findComponent(MountTarget);
+        const options = target.findAll("li > span > span");
+        expect(options.length).toBe(3);
+        for (let i = 0; i < options.length; i++) {
+            expect(options.at(i).text()).toBe(`label_${i + 1}`);
+        }
+    });
+});

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -14,7 +14,7 @@ function createTarget(propsData) {
 const defaultOptions = [
     ["label_1", "value_1"],
     ["label_2", "value_2"],
-    ["label_3", "value_3"],
+    ["label_3", ""],
 ];
 
 function testDefaultOptions(wrapper) {
@@ -63,7 +63,7 @@ describe("FormSelect", () => {
         const wrapper = createTarget({
             multiple: true,
             options: defaultOptions,
-            value: ["value_1", "value_3"],
+            value: ["value_1", ""],
         });
         testDefaultOptions(wrapper);
         const selectedValue = wrapper.findAll(".multiselect__option--selected");

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -17,18 +17,25 @@ const defaultOptions = [
     ["label_3", "value_3"],
 ];
 
+function testDefaultOptions(wrapper) {
+    const target = wrapper.findComponent(MountTarget);
+    const options = target.findAll("li > span > span");
+    expect(options.length).toBe(3);
+    for (let i = 0; i < options.length; i++) {
+        expect(options.at(i).text()).toBe(`label_${i + 1}`);
+    }
+}
+
 describe("FormSelect", () => {
     it("basics", async () => {
         const wrapper = createTarget({
             options: defaultOptions,
-            value: "value_1",
         });
-        const target = wrapper.findComponent(MountTarget);
-        const options = target.findAll("li > span > span");
-        expect(options.length).toBe(3);
-        for (let i = 0; i < options.length; i++) {
-            expect(options.at(i).text()).toBe(`label_${i + 1}`);
-        }
+        testDefaultOptions(wrapper);
+        const noValue = wrapper.find(".multiselect__option--selected");
+        expect(noValue.exists()).toBe(false);
+        expect(wrapper.emitted().input[0][0]).toBe("value_1");
+        await wrapper.setProps({ value: "value_1" });
         const selectedValue = wrapper.find(".multiselect__option--selected");
         expect(selectedValue.text()).toBe("label_1");
     });
@@ -58,12 +65,7 @@ describe("FormSelect", () => {
             options: defaultOptions,
             value: ["value_1", "value_3"],
         });
-        const target = wrapper.findComponent(MountTarget);
-        const options = target.findAll("li > span > span");
-        expect(options.length).toBe(3);
-        for (let i = 0; i < options.length; i++) {
-            expect(options.at(i).text()).toBe(`label_${i + 1}`);
-        }
+        testDefaultOptions(wrapper);
         const selectedValue = wrapper.findAll(".multiselect__option--selected");
         expect(selectedValue.length).toBe(2);
         expect(selectedValue.at(0).text()).toBe("label_1");

--- a/client/src/components/Form/Elements/FormSelect.test.js
+++ b/client/src/components/Form/Elements/FormSelect.test.js
@@ -62,7 +62,6 @@ describe("FormSelect", () => {
     it("multiple values", async () => {
         const wrapper = createTarget({
             multiple: true,
-            optional: true,
             options: defaultOptions,
             value: ["value_1", ""],
         });

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -28,6 +28,13 @@ const emit = defineEmits<{
 }>();
 
 /**
+ * Configure deselect label
+ */
+const deselectLabel: ComputedRef<string> = computed(() => {
+    return props.multiple ? "Press enter to remove" : "";
+});
+
+/**
  * Translates input options for consumption by the
  * select component into an array of objects
  */
@@ -108,6 +115,7 @@ onMounted(() => {
         v-model="currentValue"
         :allow-empty="optional"
         :close-on-select="!multiple"
+        :deselect-label="deselectLabel"
         :options="formattedOptions"
         :multiple="multiple"
         placeholder="Select value"

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -34,16 +34,15 @@ const hasOptions = computed(() => {
 
 const currentValue = computed({
     get: () => {
-        if (props.value === null) {
-            if (!props.optional && hasOptions) {
-                const initialValue = formattedOptions.value[0];
-                emit("input", initialValue.value);
-                return initialValue;
-            }
-        } else {
+        if (props.value) {
             const selectedValues = Array.isArray(props.value) ? props.value : [props.value];
-            return formattedOptions.value.filter((option) => selectedValues.indexOf(option.value) > -1);
+            return formattedOptions.value.filter((option) => selectedValues.includes(option.value));
+        } else if (!props.optional && hasOptions) {
+            const initialValue = formattedOptions.value[0];
+            emit("input", initialValue.value);
+            return initialValue;
         }
+        return null;
     },
     set: (val) => {
         emit("input", val.value);
@@ -55,10 +54,10 @@ const currentValue = computed({
     <multiselect
         v-if="hasOptions"
         v-model="currentValue"
+        :allow-empty="optional"
         :close-on-select="!multiple"
         :options="formattedOptions"
         :multiple="multiple"
-        :allow-empty="optional"
         placeholder="Select value"
         track-by="value"
         label="label" />

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -1,0 +1,57 @@
+<script setup>
+import { computed } from "vue";
+import Multiselect from "vue-multiselect";
+
+const emit = defineEmits(["input"]);
+const props = defineProps({
+    value: {
+        default: null,
+    },
+    multiple: {
+        type: Boolean,
+        default: false,
+    },
+    options: {
+        type: Array,
+        required: true,
+    },
+    optional: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const formattedOptions = computed(() => {
+    return props.options.map((option) => ({
+        label: option[0],
+        value: option[1],
+    }));
+});
+
+const currentValue = computed({
+    get: () => {
+        const selectedValues = !Array.isArray(props.value) ? [props.value] : props.value;
+        return formattedOptions.value.filter((option) => selectedValues.indexOf(option.value) > -1);
+    },
+    set: (val) => {
+        emit("input", val.value);
+    },
+});
+
+const hasOptions = computed(() => {
+    return props.options.length > 0;
+});
+</script>
+
+<template>
+    <multiselect
+        v-if="hasOptions"
+        v-model="currentValue"
+        :options="formattedOptions"
+        :multiple="multiple"
+        :allow-empty="optional"
+        placeholder="Select value"
+        track-by="value"
+        label="label" />
+    <b-alert v-else v-localize variant="warning" show> No options available. </b-alert>
+</template>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -63,10 +63,7 @@ const selectedValues: ComputedRef<Array<SelectValue>> = computed(() => {
  * Tracks current value and emits changes
  */
 const currentValue = computed({
-    get: () =>
-        formattedOptions.value.filter(
-            (option: SelectOption) => option.value !== null && selectedValues.value.includes(option.value)
-        ),
+    get: () => formattedOptions.value.filter((option: SelectOption) => selectedValues.value.includes(option.value)),
     set: (val: Array<SelectOption> | SelectOption): void => {
         if (Array.isArray(val)) {
             const values: SelectValue[] = val.map((v: SelectOption) => v.value);

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, watch } from "vue";
+import { computed, onMounted, watch, type ComputedRef } from "vue";
 import Multiselect from "vue-multiselect";
 
 type SelectValue = string | null;
@@ -31,7 +31,7 @@ const emit = defineEmits<{
  * Translates input options for consumption by the
  * select component into an array of objects
  */
-const formattedOptions = computed(() => {
+const formattedOptions: ComputedRef<Array<SelectOption>> = computed(() => {
     const result: Array<SelectOption> = props.options.map((option: [string, string]) => ({
         label: option[0],
         value: option[1],
@@ -48,14 +48,14 @@ const formattedOptions = computed(() => {
 /**
  * Tracks if the select field has options
  */
-const hasOptions = computed(() => {
+const hasOptions: ComputedRef<Boolean> = computed(() => {
     return formattedOptions.value.length > 0;
 });
 
 /**
  * Tracks selected values
  */
-const selectedValues = computed(() => {
+const selectedValues: ComputedRef<Array<SelectValue>> = computed(() => {
     return Array.isArray(props.value) ? props.value : [props.value];
 });
 
@@ -67,7 +67,7 @@ const currentValue = computed({
         formattedOptions.value.filter(
             (option: SelectOption) => option.value !== null && selectedValues.value.includes(option.value)
         ),
-    set: (val: Array<SelectOption> | SelectOption) => {
+    set: (val: Array<SelectOption> | SelectOption): void => {
         if (Array.isArray(val)) {
             const values: SelectValue[] = val.map((v: SelectOption) => v.value);
             emit("input", values);
@@ -80,7 +80,7 @@ const currentValue = computed({
 /**
  * Ensures that an initial value is selected for non-optional inputs
  */
-function setInitialValue() {
+function setInitialValue(): void {
     if (props.value === null && !props.optional && hasOptions.value) {
         const initialValue = formattedOptions.value[0];
         if (initialValue) {

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -38,7 +38,7 @@ const cls: ComputedRef<string> = computed(() => {
  * Configure deselect label
  */
 const deselectLabel: ComputedRef<string> = computed(() => {
-    return props.multiple ? "Press enter to remove" : "";
+    return props.multiple ? "Click to remove" : "";
 });
 
 /**

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -28,6 +28,13 @@ const emit = defineEmits<{
 }>();
 
 /**
+ * Determine dom wrapper class
+ */
+const cls: ComputedRef<string> = computed(() => {
+    return props.multiple ? "form-select-multiple" : "form-select";
+});
+
+/**
  * Configure deselect label
  */
 const deselectLabel: ComputedRef<string> = computed(() => {
@@ -57,6 +64,13 @@ const formattedOptions: ComputedRef<Array<SelectOption>> = computed(() => {
  */
 const hasOptions: ComputedRef<Boolean> = computed(() => {
     return formattedOptions.value.length > 0;
+});
+
+/**
+ * Configure selected label
+ */
+const selectedLabel: ComputedRef<string> = computed(() => {
+    return props.multiple ? "Selected" : "";
 });
 
 /**
@@ -114,12 +128,26 @@ onMounted(() => {
         v-if="hasOptions"
         v-model="currentValue"
         :allow-empty="optional"
+        :class="cls"
         :close-on-select="!multiple"
         :deselect-label="deselectLabel"
         :options="formattedOptions"
         :multiple="multiple"
+        :selected-label="selectedLabel"
         placeholder="Select value"
         track-by="value"
         label="label" />
     <b-alert v-else v-localize variant="warning" show> No options available. </b-alert>
 </template>
+
+<style lang="scss">
+@import "theme/blue.scss";
+.form-select
+    > .multiselect__content-wrapper
+    > .multiselect__content
+    > .multiselect__element
+    > .multiselect__option--selected {
+    background: $brand-primary;
+    color: $brand-light;
+}
+</style>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -67,6 +67,19 @@ const hasOptions: ComputedRef<Boolean> = computed(() => {
 });
 
 /**
+ * Provides initial value if necessary
+ */
+const initialValue: ComputedRef<SelectValue> = computed(() => {
+    if (props.value === null && !props.optional && hasOptions.value) {
+        const v = formattedOptions.value[0];
+        if (v) {
+            return v.value;
+        }
+    }
+    return null;
+});
+
+/**
  * Configure selected label
  */
 const selectedLabel: ComputedRef<string> = computed(() => {
@@ -103,11 +116,8 @@ const currentValue = computed({
  * Ensures that an initial value is selected for non-optional inputs
  */
 function setInitialValue(): void {
-    if (props.value === null && !props.optional && hasOptions.value) {
-        const initialValue = formattedOptions.value[0];
-        if (initialValue) {
-            emit("input", initialValue.value);
-        }
+    if (initialValue.value) {
+        emit("input", initialValue.value);
     }
 }
 

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -131,7 +131,7 @@ onMounted(() => {
     <multiselect
         v-if="hasOptions"
         v-model="currentValue"
-        :allow-empty="optional"
+        :allow-empty="true"
         :class="['form-select', cls]"
         :close-on-select="!multiple"
         :deselect-label="deselectLabel"

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -22,10 +22,17 @@ const props = defineProps({
 });
 
 const formattedOptions = computed(() => {
-    return props.options.map((option) => ({
+    const result = props.options.map((option) => ({
         label: option[0],
         value: option[1],
     }));
+    if (props.optional && !props.multiple) {
+        result.unshift({
+            label: "Nothing selected",
+            value: null,
+        });
+    }
+    return result;
 });
 
 const hasOptions = computed(() => {

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -87,8 +87,12 @@ const currentValue = computed({
     get: () => formattedOptions.value.filter((option: SelectOption) => selectedValues.value.includes(option.value)),
     set: (val: Array<SelectOption> | SelectOption): void => {
         if (Array.isArray(val)) {
-            const values: Array<SelectValue> = val.map((v: SelectOption) => v.value);
-            emit("input", values);
+            if (val.length > 0) {
+                const values: Array<SelectValue> = val.map((v: SelectOption) => v.value);
+                emit("input", values);
+            } else {
+                emit("input", null);
+            }
         } else {
             emit("input", val.value);
         }

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -28,18 +28,26 @@ const formattedOptions = computed(() => {
     }));
 });
 
+const hasOptions = computed(() => {
+    return props.options.length > 0;
+});
+
 const currentValue = computed({
     get: () => {
-        const selectedValues = !Array.isArray(props.value) ? [props.value] : props.value;
-        return formattedOptions.value.filter((option) => selectedValues.indexOf(option.value) > -1);
+        if (props.value === null) {
+            if (!props.optional && hasOptions) {
+                const initialValue = formattedOptions.value[0];
+                emit("input", initialValue.value);
+                return initialValue;
+            }
+        } else {
+            const selectedValues = Array.isArray(props.value) ? props.value : [props.value];
+            return formattedOptions.value.filter((option) => selectedValues.indexOf(option.value) > -1);
+        }
     },
     set: (val) => {
         emit("input", val.value);
     },
-});
-
-const hasOptions = computed(() => {
-    return props.options.length > 0;
 });
 </script>
 

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -45,7 +45,12 @@ const currentValue = computed({
         return null;
     },
     set: (val) => {
-        emit("input", val.value);
+        if (props.multiple) {
+            const values = val.map((v) => v.value);
+            emit("input", values);
+        } else {
+            emit("input", val.value);
+        }
     },
 });
 </script>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -135,6 +135,7 @@ onMounted(() => {
         :multiple="multiple"
         :selected-label="selectedLabel"
         placeholder="Select value"
+        select-label="Click to select"
         track-by="value"
         label="label" />
     <b-alert v-else v-localize variant="warning" show> No options available. </b-alert>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -55,6 +55,7 @@ const currentValue = computed({
     <multiselect
         v-if="hasOptions"
         v-model="currentValue"
+        :close-on-select="!multiple"
         :options="formattedOptions"
         :multiple="multiple"
         :allow-empty="optional"

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -31,7 +31,7 @@ const emit = defineEmits<{
  * Determine dom wrapper class
  */
 const cls: ComputedRef<string> = computed(() => {
-    return props.multiple ? "form-select-multiple" : "form-select";
+    return props.multiple ? "form-select-multiple" : "form-select-single";
 });
 
 /**
@@ -132,7 +132,7 @@ onMounted(() => {
         v-if="hasOptions"
         v-model="currentValue"
         :allow-empty="optional"
-        :class="cls"
+        :class="['form-select', cls]"
         :close-on-select="!multiple"
         :deselect-label="deselectLabel"
         :options="formattedOptions"
@@ -147,12 +147,36 @@ onMounted(() => {
 
 <style lang="scss">
 @import "theme/blue.scss";
-.form-select
-    > .multiselect__content-wrapper
-    > .multiselect__content
-    > .multiselect__element
-    > .multiselect__option--selected {
-    background: $brand-primary;
-    color: $brand-light;
+.form-select {
+    > .multiselect__content-wrapper {
+        > .multiselect__content {
+            > .multiselect__element {
+                > .multiselect__option {
+                    font-size: $font-size-base;
+                }
+            }
+        }
+    }
+    > .multiselect__tags {
+        border: $border-default;
+    }
+}
+.form-select-single {
+    > .multiselect__content-wrapper {
+        > .multiselect__content {
+            > .multiselect__element {
+                > .multiselect__option--selected {
+                    background: $brand-primary;
+                    color: $brand-light;
+                }
+            }
+        }
+    }
+    > .multiselect__tags {
+        min-height: 0;
+        > .multiselect__single {
+            font-size: $font-size-base;
+        }
+    }
 }
 </style>

--- a/client/src/components/Form/Elements/FormSelect.vue
+++ b/client/src/components/Form/Elements/FormSelect.vue
@@ -14,7 +14,7 @@ const props = withDefaults(
         multiple?: boolean;
         optional?: boolean;
         options: Array<[string, string]>;
-        value?: string[] | string;
+        value?: Array<string> | string;
     }>(),
     {
         multiple: false,
@@ -24,7 +24,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-    (e: "input", value: SelectValue | SelectValue[]): void;
+    (e: "input", value: SelectValue | Array<SelectValue>): void;
 }>();
 
 /**
@@ -66,7 +66,7 @@ const currentValue = computed({
     get: () => formattedOptions.value.filter((option: SelectOption) => selectedValues.value.includes(option.value)),
     set: (val: Array<SelectOption> | SelectOption): void => {
         if (Array.isArray(val)) {
-            const values: SelectValue[] = val.map((v: SelectOption) => v.value);
+            const values: Array<SelectValue> = val.map((v: SelectOption) => v.value);
             emit("input", values);
         } else {
             emit("input", val.value);

--- a/client/src/components/Form/Elements/FormSelection.vue
+++ b/client/src/components/Form/Elements/FormSelection.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 import FormCheck from "./FormCheck";
 import FormRadio from "./FormRadio";
+import FormSelect from "./FormSelect";
 
 const $emit = defineEmits(["input"]);
 const props = defineProps({
@@ -15,6 +16,10 @@ const props = defineProps({
     display: {
         type: String,
         default: null,
+    },
+    optional: {
+        type: Boolean,
+        default: false,
     },
     options: {
         type: Array,
@@ -53,4 +58,5 @@ const currentOptions = computed(() => {
 <template>
     <form-check v-if="display === 'checkboxes'" v-model="currentValue" :options="currentOptions" />
     <form-radio v-else-if="display === 'radio'" v-model="currentValue" :options="currentOptions" />
+    <form-select v-else v-model="currentValue" :multiple="multiple" :optional="optional" :options="currentOptions" />
 </template>

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -256,7 +256,10 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
                 :datalist="attrs.datalist"
                 :type="props.type" />
             <FormSelection
-                v-else-if="['data_column', 'genomebuild', 'group_tag', 'select'].includes(props.type)"
+                v-else-if="
+                    (props.type === undefined && attrs.options) ||
+                    ['data_column', 'genomebuild', 'group_tag', 'select'].includes(props.type)
+                "
                 :id="id"
                 v-model="currentValue"
                 :data="attrs.data"

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -256,7 +256,7 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
                 :datalist="attrs.datalist"
                 :type="props.type" />
             <FormSelection
-                v-else-if="props.type === 'select'"
+                v-else-if="['data_column', 'genomebuild', 'group_tag', 'select'].includes(props.type)"
                 :id="id"
                 v-model="currentValue"
                 :data="attrs.data"

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -256,7 +256,7 @@ const isOptional = computed(() => !isRequired.value && attrs.value["optional"] !
                 :datalist="attrs.datalist"
                 :type="props.type" />
             <FormSelection
-                v-else-if="props.type === 'select' && ['radio', 'checkboxes'].includes(attrs.display)"
+                v-else-if="props.type === 'select'"
                 :id="id"
                 v-model="currentValue"
                 :data="attrs.data"

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -810,7 +810,7 @@ admin:
   quota:
     selectors:
       add_new: '.quotas .manage-table-actions .action-button'
-      items: '.quotas tbody tr td'
+      items: '.quotas #grid-table-body tr'
       add_form: "[url='/admin/create_quota']"
       add_form_submit: "[url='/admin/create_quota'] #submit"
 

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -610,7 +610,7 @@ workflow_run:
     runtime_setting_target: '.workflow-run-settings-target'
     input_select_field:
       type: xpath
-      selector: '//div[@data-label="${label}"]//span[@class="select2-chosen"]'
+      selector: '//div[@data-label="${label}"]//span[@class="multiselect__single"]'
     primary_storage_indciator: '.workflow-storage-indicator-primary'
     intermediate_storage_indciator: '.workflow-storage-indicator-intermediate'
 
@@ -681,15 +681,15 @@ workflow_editor:
     change_datatype:
       type: xpath
       selector: >
-        //div[@data-label='Change datatype' and not(ancestor::div[contains(@style,'display: none')])]//span[contains(@class, 'select2-chosen')]
+        //div[@data-label='Change datatype' and not(ancestor::div[contains(@style,'display: none')])]//span[contains(@class, 'multiselect__single')]
     select_datatype_text_search:
       type: xpath
       selector: >
-        //div[@class="select2-search" and not(ancestor::div[contains(@style,'display: none')])]//input
+        //input[@class="multiselect__input"]
     select_datatype:
       type: xpath
       selector: >
-        //div[@class="select2-result-label" and contains(text(), "${datatype}") and not(ancestor::div[contains(@style,'display: none')])]
+        //li[@class="multiselect__element"]//span[text()="${datatype}"]
     add_tags:
       type: xpath
       selector: >

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -610,7 +610,7 @@ workflow_run:
     runtime_setting_target: '.workflow-run-settings-target'
     input_select_field:
       type: xpath
-      selector: '//div[@data-label="${label}"]//span[@class="multiselect__single"]'
+      selector: '//div[@data-label="${label}"]//div[contains(@class, "multiselect")]'
     primary_storage_indciator: '.workflow-storage-indicator-primary'
     intermediate_storage_indciator: '.workflow-storage-indicator-intermediate'
 
@@ -681,7 +681,7 @@ workflow_editor:
     change_datatype:
       type: xpath
       selector: >
-        //div[@data-label='Change datatype' and not(ancestor::div[contains(@style,'display: none')])]//span[contains(@class, 'multiselect__single')]
+        //div[@data-label='Change datatype']//div[contains(@class, 'multiselect')]
     select_datatype_text_search:
       type: xpath
       selector: >

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11187,10 +11187,10 @@ vue-loader@^15.10.1:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
-vue-multiselect@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.6.tgz"
-  integrity sha512-s7jmZPlm9FeueJg1RwJtnE9KNPtME/7C8uRWSfp9/yEN4M8XcS/d+bddoyVwVnvFyRh9msFo0HWeW0vTL8Qv+w==
+vue-multiselect@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/vue-multiselect/-/vue-multiselect-2.1.7.tgz#f27afe3d46482b94810382af7a4826219255c47d"
+  integrity sha512-KIegcN+Ntwg3cbkY/jhw2s/+XJUM0Lpi/LcKFYCS8PrZHcWBl2iKCVze7ZCnRj3w8H7/lUJ9v7rj9KQiNxApBw==
 
 vue-observe-visibility@^1.0.0:
   version "1.0.0"

--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -171,7 +171,7 @@ class HasDriver:
     def wait_for_element_count_of_at_least(self, selector_template: Target, n: int, **kwds) -> WebElement:
         element = self._wait_on(
             lambda driver: len(driver.find_elements(*selector_template.element_locator)) >= n,
-            f"{selector_template.description} to become absent",
+            f"{selector_template.description} to become visible",
             **kwds,
         )
         return element

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1133,7 +1133,7 @@ class NavigatesGalaxy(HasDriver):
         if quota_source_label:
             self.select_set_value("#quota_source_label", quota_source_label)
         if user:
-            self.select_set_value("#in_users", user)
+            self.select_set_value("#in_users", user, multiple=True)
         quota_component.add_form_submit.wait_for_and_click()
 
     def select_dataset_from_lib_import_modal(self, filenames):
@@ -1991,7 +1991,7 @@ class NavigatesGalaxy(HasDriver):
         if annotation_area.is_absent or not annotation_area.is_displayed:
             annotation_icon.wait_for_and_click()
 
-    def select_set_value(self, container_selector_or_elem, value):
+    def select_set_value(self, container_selector_or_elem, value, multiple=False):
         if hasattr(container_selector_or_elem, "selector"):
             container_selector_or_elem = container_selector_or_elem.selector
         if not hasattr(container_selector_or_elem, "find_element"):
@@ -2002,6 +2002,8 @@ class NavigatesGalaxy(HasDriver):
         text_input = container_elem.find_element(By.CSS_SELECTOR, "input[class='multiselect__input']")
         text_input.send_keys(value)
         self.send_enter(text_input)
+        if multiple:
+            self.send_escape(text_input)
 
     def select2_set_value(self, container_selector_or_elem, value, with_click=True, clear_value=False):
         # There are two hacky was to select things from the select2 widget -

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1131,9 +1131,9 @@ class NavigatesGalaxy(HasDriver):
             },
         )
         if quota_source_label:
-            self.select2_set_value("#quota_source_label", quota_source_label)
+            self.select_set_value("#quota_source_label", quota_source_label)
         if user:
-            self.select2_set_value("#in_users", user)
+            self.select_set_value("#in_users", user)
         quota_component.add_form_submit.wait_for_and_click()
 
     def select_dataset_from_lib_import_modal(self, filenames):
@@ -1990,6 +1990,18 @@ class NavigatesGalaxy(HasDriver):
 
         if annotation_area.is_absent or not annotation_area.is_displayed:
             annotation_icon.wait_for_and_click()
+
+    def select_set_value(self, container_selector_or_elem, value):
+        if hasattr(container_selector_or_elem, "selector"):
+            container_selector_or_elem = container_selector_or_elem.selector
+        if not hasattr(container_selector_or_elem, "find_element"):
+            container_elem = self.wait_for_selector(container_selector_or_elem)
+        else:
+            container_elem = container_selector_or_elem
+        container_elem.click()
+        text_input = container_elem.find_element(By.CSS_SELECTOR, "input[class='multiselect__input']")
+        text_input.send_keys(value)
+        self.send_enter(text_input)
 
     def select2_set_value(self, container_selector_or_elem, value, with_click=True, clear_value=False):
         # There are two hacky was to select things from the select2 widget -


### PR DESCRIPTION
Replaces the backbone-based regular select field module with a Vue component using `vue-multiselect`. Requirement to replace the data field selector. xref: #12872

https://user-images.githubusercontent.com/2105447/236805327-067b1e18-e0c1-4b39-80c4-69763df6bdb0.mov

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
