### PR TITLE
Mock fetcher followup

### DIFF
--- a/client/src/schema/__mocks__/fetcher.ts
+++ b/client/src/schema/__mocks__/fetcher.ts
@@ -62,7 +62,9 @@ function setMockReturn(path: Path | RegExp, method: Method, value: any) {
 /**
  * Mock implementation for the fetcher found in `@/schema/fetcher`
  *
- * Importing this will mock fetcher automatically.
+ * You need to call `jest.mock("@/schema")` and/or `jest.mock("@/schema/fetcher")`
+ * (depending on what module the file you are testing imported)
+ * in order for this mock to take effect.
  *
  * To specify return values for the mock, use
  * `mockFetcher.path(...).method(...).mock(desiredReturnValue)`
@@ -88,3 +90,5 @@ export const mockFetcher = {
         mockValues.length = 0;
     },
 };
+
+export const fetcher = mockFetcher;

--- a/client/src/schema/__mocks__/index.ts
+++ b/client/src/schema/__mocks__/index.ts
@@ -1,0 +1,1 @@
+export { fetcher, mockFetcher } from "./fetcher";

--- a/client/src/schema/mockFetcher.test.ts
+++ b/client/src/schema/mockFetcher.test.ts
@@ -1,5 +1,7 @@
-import { mockFetcher } from "../mockFetcher";
+import { mockFetcher } from "./__mocks__/fetcher";
 import { fetcher } from "@/schema";
+
+jest.mock("@/schema");
 
 mockFetcher.path("/api/configuration").method("get").mock("CONFIGURATION");
 

--- a/client/tsconfig.webpack.json
+++ b/client/tsconfig.webpack.json
@@ -1,4 +1,4 @@
 {
     "extends": "./tsconfig.json",
-    "exclude": ["./src/**/*.test.ts", "./tests/**/*.ts"]
+    "exclude": ["./src/**/*.test.ts", "./tests/**/*.ts", "**/__mocks__/**"]
 }


### PR DESCRIPTION
Followup for the fetcher mock utility.
The old version required a specific import order, which is a side effect prone to breaking.

This restructuring requires to call `jest.mock("@/schema")` and/or `jest.mock("@/schema/fetcher")` in tests,
however it should work regardless of import order.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
