### PR TITLE
[23.0] Allow setting auto_decompress property in staging interface

### DIFF
--- a/lib/galaxy/tool_util/client/staging.py
+++ b/lib/galaxy/tool_util/client/staging.py
@@ -40,6 +40,7 @@ LOAD_TOOLS_FROM_PATH = True
 DEFAULT_USE_FETCH_API = True
 DEFAULT_FILE_TYPE = "auto"
 DEFAULT_DBKEY = "?"
+DEFAULT_DECOMPRESS = False
 
 
 class StagingInterface(metaclass=abc.ABCMeta):
@@ -104,6 +105,7 @@ class StagingInterface(metaclass=abc.ABCMeta):
                     file_type=file_type,
                     dbkey=dbkey,
                     to_posix_lines=to_posix_lines,
+                    decompress=upload_target.properties.get("decompress") or DEFAULT_DECOMPRESS,
                 )
                 name = _file_path_to_name(file_path)
                 if file_path is not None:
@@ -333,6 +335,8 @@ def _fetch_payload(history_id, file_type=DEFAULT_FILE_TYPE, dbkey=DEFAULT_DBKEY,
             element[arg] = kwd[arg]
     if "file_name" in kwd:
         element["name"] = kwd["file_name"]
+    if "decompress" in kwd:
+        element["auto_decompress"] = kwd["decompress"]
     target = {
         "destination": {"type": "hdas"},
         "elements": [element],

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -232,6 +232,8 @@ def galactic_job_json(
             kwd["tags"] = value.get("tags")
         if "dbkey" in value:
             kwd["dbkey"] = value.get("dbkey")
+        if "decompress" in value:
+            kwd["decompress"] = value["decompress"]
         if composite_data_raw:
             composite_data = []
             for entry in composite_data_raw:

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -281,6 +281,40 @@ class TestToolsUpload(ApiTestCase):
         assert details["genome_build"] == "hg19"
 
     @skip_if_github_down
+    def test_stage_fetch_decompress_true(self, history_id: str) -> None:
+        job = {
+            "input1": {
+                "class": "File",
+                "format": "fasta",
+                "location": "https://github.com/galaxyproject/galaxy/blob/dev/test-data/1.fasta.gz?raw=true",
+                "decompress": True,
+            }
+        }
+        inputs, datasets = stage_inputs(
+            self.galaxy_interactor, history_id, job, use_path_paste=False, to_posix_lines=False
+        )
+        dataset = datasets[0]
+        content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=dataset)
+        assert content.startswith(">hg17")
+
+    @skip_if_github_down
+    def test_stage_fetch_decompress_false(self, history_id: str) -> None:
+        job = {
+            "input1": {
+                "class": "File",
+                "format": "fasta",
+                "location": "https://github.com/galaxyproject/galaxy/blob/dev/test-data/1.fasta.gz?raw=true",
+                "decompress": False,
+            }
+        }
+        inputs, datasets = stage_inputs(
+            self.galaxy_interactor, history_id, job, use_path_paste=False, to_posix_lines=False
+        )
+        dataset = datasets[0]
+        content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=dataset)
+        assert not content.startswith(">hg17")
+
+    @skip_if_github_down
     def test_upload_multiple_mixed_success(self, history_id):
         destination = {"type": "hdas"}
         targets = [


### PR DESCRIPTION
This allows defining inputs such as
```yaml
     Drosophila_melanogaster.BDGP6.32.109_UCSC.gtf.gz:
       class: File
       location: https://zenodo.org/record/6457007/files/Drosophila_melanogaster.BDGP6.32.109_UCSC.gtf.gz
       filetype: gtf
       decompress: true
```

without needing to know what the server side default of auto_compress is.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
