### PR TITLE
[23.0] Reports app fixes

### DIFF
--- a/client/src/libs/jquery.custom.js
+++ b/client/src/libs/jquery.custom.js
@@ -23,4 +23,7 @@ require("imports-loader?imports=default|jqueryVendor|jQuery!jquery-migrate");
 
 // require("imports-loader?jQuery=jqueryVendor!../ui/autocom_tagging");
 
+// Only used in reports
+require("imports-loader?imports=default|jqueryVendor|jQuery!libs/jquery.sparklines");
+
 module.exports = jQuery;

--- a/client/src/reports/run_stats.js
+++ b/client/src/reports/run_stats.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
-import * as d3 from "d3";
+import * as d3 from "d3v3";
+import { event as currentEvent } from "d3v3";
 
 function date_by_subtracting_days(date, days) {
     return new Date(
@@ -125,14 +126,14 @@ export function create_chart(inp_data, name, time, title) {
             }
 
             var wdth = i * 4 + 10;
-            d3.select(d.target.parentElement)
+            d3.select(currentEvent.target.parentElement)
                 .select(".tool_tip")
                 .select("text")
                 .attr("transform", `translate( ${margin.left - 5}, ${height - d * zoom + margin.top + 10} )`)
                 .attr("visibility", "visible")
                 .text(d);
 
-            d3.select(d.target.parentElement)
+            d3.select(currentEvent.target.parentElement)
                 .select(".tool_tip")
                 .attr("width", `${wdth}px`)
                 .attr("height", "15px")
@@ -144,9 +145,12 @@ export function create_chart(inp_data, name, time, title) {
         })
         .on("mouseleave", (d) => {
             // Remove tool tip
-            d3.select(d.target.parentElement).select(".tool_tip").select("text").attr("visibility", "hidden");
+            d3.select(currentEvent.target.parentElement)
+                .select(".tool_tip")
+                .select("text")
+                .attr("visibility", "hidden");
 
-            d3.select(d.target.parentElement)
+            d3.select(currentEvent.target.parentElement)
                 .select(".tool_tip")
                 .select("rect")
                 .attr("width", "0")
@@ -178,14 +182,14 @@ export function create_chart(inp_data, name, time, title) {
         });
 
     // Declare how high the y axis goes
-    var y = d3.curveLinear().range([height, 0]);
+    var y = d3.scale.linear().range([height, 0]);
 
     // Create a yAxis object
     var yAxis = d3.svg
         .axis()
         .scale(y)
         .orient("left")
-        .tickFormat((d) => Math.round(d * d3.max(data), 0));
+        .tickFormat((d) => d3.round(d * d3.max(data), 0));
 
     // Put the y axis on the chart
     chart
@@ -438,13 +442,13 @@ export function create_histogram(inp_data, name, title) {
 
     // Cereate x axis metadata
     // Used for x axis, histogram creation, and bar initialization
-    var x = d3
-        .curveLinear()
+    var x = d3.scale
+        .linear()
         .domain([0, d3.max(data)])
         .range([0, width]);
 
     // Generate a histogram using twenty uniformly-spaced bins.
-    data = d3.histogram().bins(x.ticks(20))(data);
+    data = d3.layout.histogram().bins(x.ticks(20))(data);
 
     // Create an array of the sizes of the bars
     var lengths = [];
@@ -462,8 +466,8 @@ export function create_histogram(inp_data, name, title) {
 
     // Create y axis metadata
     // Used for y axis and bar initialization
-    var y = d3
-        .curveLinear()
+    var y = d3.scale
+        .linear()
         .domain([0, d3.max(data, (d) => d.y)])
         .range([height, 0]);
 
@@ -538,14 +542,14 @@ export function create_histogram(inp_data, name, title) {
                 i++;
             }
             var wdth = i * 4 + 10;
-            d3.select(d.target.parentElement)
+            d3.select(currentEvent.target.parentElement)
                 .select(".tool_tip")
                 .select("text")
                 .attr("transform", `translate( ${margin.left - 5}, ${height - d.length * zoom + margin.top + 10} )`)
                 .attr("visibility", "visible")
                 .text(d.length);
 
-            d3.select(d.target.parentElement)
+            d3.select(currentEvent.target.parentElement)
                 .select(".tool_tip")
                 .attr("width", `${wdth}px`)
                 .attr("height", "15px")
@@ -555,11 +559,14 @@ export function create_histogram(inp_data, name, title) {
                 .attr("height", "15px")
                 .attr("fill", "#ebd9b2");
         })
-        .on("mouseleave", (d) => {
+        .on("mouseleave", () => {
             // Remove tool tip
-            d3.select(d.target.parentElement).select(".tool_tip").select("text").attr("visibility", "hidden");
+            d3.select(currentEvent.target.parentElement)
+                .select(".tool_tip")
+                .select("text")
+                .attr("visibility", "hidden");
 
-            d3.select(d.target.parentElement)
+            d3.select(currentEvent.target.parentElement)
                 .select(".tool_tip")
                 .select("rect")
                 .attr("width", "0")

--- a/templates/base/base_panels.mako
+++ b/templates/base/base_panels.mako
@@ -147,9 +147,7 @@
             <div id="background"></div>
             
             ## Layer iframes over backgrounds
-            <div id="masthead" class="navbar navbar-fixed-top navbar-inverse">
-                ${self.masthead()}
-            </div>
+            ${self.masthead()}
             
             %if self.message_box_visible:
                 <div id="messagebox" class="alert alert-${app.config.message_box_class} rounded-0 m-0 p-2">

--- a/templates/webapps/reports/base_panels.mako
+++ b/templates/webapps/reports/base_panels.mako
@@ -17,32 +17,17 @@
 
 ## Masthead
 <%def name="masthead()">
-    ## Tab area, fills entire width
-    <div style="position: absolute; top: 0; left: 0; width: 100%; text-align: center">
-        <table class="tab-group" border="0" cellspacing="0" style="margin: auto;">
-            <tr>
-                <%def name="tab( id, display, href, target='_parent', visible=True, extra_class='' )">
-                    <%
-                    cls = "tab"
-                    if extra_class:
-                        cls += " " + extra_class
-                    if self.active_view == id:
-                        cls += " active"
-                    style = ""
-                    if not visible:
-                        style = "display: none;"
-                    %>
-                    <td class="${cls}" style="${style}"><a target="${target}" href="${href}">${display}</a></td>
-                </%def>
-            </tr>
-        </table>
-    </div>
-    ## Logo, layered over tabs to be clickable
-    <a class="navbar-brand" href="${h.url_for( app.config.get( 'logo_url', '/' ) )}">
-        <img class="navbar-brand-image" src="${h.url_for('/static/favicon.svg')}" />
-        <span class="navbar-brand-title">Galaxy Reports</span>
-        %if app.config.brand:
-            <span class='brand'>/ ${app.config.brand}</span>
-        %endif
-    </a>
+    <!-- This has the class masthead-toolshed for 23.0, but will be masthead-simple merged forward -->
+    <nav id="masthead" class="masthead-toolshed navbar navbar-expand navbar-fixed-top justify-content-center navbar-dark">
+        <a href="${h.url_for( app.config.get( 'logo_url', '/' ) )}" aria-label="homepage" class="navbar-brand">
+            <img alt="logo" class="navbar-brand-image" src="${h.url_for('/static/favicon.svg')}">
+            <span class="navbar-brand-title">
+                Reports
+                %if app.config.brand:
+                    / ${app.config.brand}
+                %endif
+            </span>
+        </a>
+         <ul class="navbar-nav"/>
+    </nav>
 </%def>


### PR DESCRIPTION
Fixes sparklines, closing #15965 
Swaps back to d3v3 until we know what we really want to do here -- this fixes the exception in #15964, which was not actually the reason for the unstyled contents.
Fixes the masthead structure, which got left behind in refactoring for 23.0.  This needs care when merging forward.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
