### PR TITLE
[23.0] Make Expression Tools searchable in `ToolBoxWorkflow`

### DIFF
--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -44,7 +44,7 @@
 <script>
 import { getGalaxyInstance } from "app";
 import DelayedInput from "components/Common/DelayedInput";
-import { normalizeTools, searchToolsByKeys } from "../utilities.js";
+import { flattenTools, searchToolsByKeys } from "../utilities.js";
 
 export default {
     name: "ToolSearch",
@@ -98,7 +98,7 @@ export default {
             return this.currentPanelView === "default" ? "section" : "ontology";
         },
         toolsList() {
-            return normalizeTools(this.toolbox);
+            return flattenTools(this.toolbox);
         },
     },
     methods: {

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -25,7 +25,7 @@
                 :current-panel-view="currentPanelView"
                 :placeholder="titleSearchTools"
                 :show-advanced.sync="showAdvanced"
-                :toolbox="toolbox"
+                :toolbox="tools"
                 :query="query"
                 @onQuery="onQuery"
                 @onResults="onResults" />
@@ -125,6 +125,9 @@ export default {
         };
     },
     computed: {
+        tools() {
+            return hideToolsSection(this.toolbox);
+        },
         queryTooShort() {
             return this.query && this.query.length < 3;
         },
@@ -133,11 +136,9 @@ export default {
         },
         sections() {
             if (this.showSections) {
-                return filterToolSections(this.toolbox, this.results);
+                return filterToolSections(this.tools, this.results);
             } else {
-                return hasResults(this.results)
-                    ? filterTools(this.toolbox, this.results)
-                    : hideToolsSection(this.toolbox);
+                return hasResults(this.results) ? filterTools(this.tools, this.results) : this.tools;
             }
         },
         isUser() {

--- a/client/src/components/Panels/ToolBoxWorkflow.vue
+++ b/client/src/components/Panels/ToolBoxWorkflow.vue
@@ -120,7 +120,7 @@ export default {
             return this.query && this.query.length < 3;
         },
         noResults() {
-            return this.query && this.results.length === 0;
+            return this.query && (!this.results || this.results.length === 0);
         },
         hasWorkflowSection() {
             return this.workflows.length > 0;

--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -51,7 +51,7 @@ export function createWhooshQuery(filterSettings, panelView, toolbox) {
 // Given toolbox and search results, returns filtered tool results
 export function filterTools(tools, results) {
     let toolsResults = [];
-    tools = normalizeTools(tools);
+    tools = flattenTools(tools);
     toolsResults = mapToolsResults(tools, results);
     toolsResults = sortToolsResults(toolsResults);
     toolsResults = removeDuplicateResults(toolsResults);
@@ -110,10 +110,12 @@ export function searchToolsByKeys(tools, keys, query) {
     return orderBy(returnedTools, ["order"], ["desc"]).map((tool) => tool.id);
 }
 
-export function normalizeTools(tools) {
-    tools = hideToolsSection(tools);
-    tools = flattenTools(tools);
-    return tools;
+export function flattenTools(tools) {
+    let normalizedTools = [];
+    tools.forEach((section) => {
+        normalizedTools = normalizedTools.concat(flattenToolsSection(section));
+    });
+    return normalizedTools;
 }
 
 export function hideToolsSection(tools) {
@@ -197,12 +199,4 @@ function deleteEmptyToolsSections(tools, results) {
         });
 
     return tools;
-}
-
-function flattenTools(tools) {
-    let normalizedTools = [];
-    tools.forEach((section) => {
-        normalizedTools = normalizedTools.concat(flattenToolsSection(section));
-    });
-    return normalizedTools;
 }

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -1,5 +1,5 @@
 import toolsList from "components/ToolsView/testData/toolsList";
-import { createWhooshQuery, filterTools, filterToolSections, normalizeTools, searchToolsByKeys } from "./utilities";
+import { createWhooshQuery, filterTools, filterToolSections, flattenTools, searchToolsByKeys } from "./utilities";
 
 describe("test helpers in tool searching utilities", () => {
     it("test parsing helper that converts settings to whoosh query", async () => {
@@ -25,7 +25,7 @@ describe("test helpers in tool searching utilities", () => {
             "__ZIP_COLLECTION__",
         ];
         let keys = { description: 1, name: 0 };
-        let results = searchToolsByKeys(normalizeTools(toolsList), keys, q);
+        let results = searchToolsByKeys(flattenTools(toolsList), keys, q);
         expect(results).toEqual(expectedResults);
 
         expectedResults = [
@@ -35,14 +35,14 @@ describe("test helpers in tool searching utilities", () => {
             "__FILTER_EMPTY_DATASETS__",
         ];
         keys = { description: 0, name: 1 };
-        results = searchToolsByKeys(normalizeTools(toolsList), keys, q);
+        results = searchToolsByKeys(flattenTools(toolsList), keys, q);
         expect(results).toEqual(expectedResults);
 
         // whitespace precedes to ensure query.trim() works
         q = " filter empty datasets";
         expectedResults = ["__FILTER_EMPTY_DATASETS__"];
         keys = { description: 1, name: 2, combined: 0 };
-        results = searchToolsByKeys(normalizeTools(toolsList), keys, q);
+        results = searchToolsByKeys(flattenTools(toolsList), keys, q);
         expect(results).toEqual(expectedResults);
 
         const tempToolsList = [
@@ -64,7 +64,7 @@ describe("test helpers in tool searching utilities", () => {
         q = "uMi tools extract ";
         expectedResults = ["toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/1.1.2+galaxy2"];
         keys = { description: 1, name: 2, hyphenated: 0 };
-        results = searchToolsByKeys(normalizeTools(tempToolsList), keys, q);
+        results = searchToolsByKeys(flattenTools(tempToolsList), keys, q);
         expect(results).toEqual(expectedResults);
     });
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/15932
Bug where Expression Tools were removed from searchable tools in the Workflow Tool box

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
