### PR TITLE
Fix pasting file fails if text starts with `file `

### DIFF
--- a/client/src/components/Upload/helpers.js
+++ b/client/src/components/Upload/helpers.js
@@ -1,6 +1,15 @@
 export const defaultNewFileName = "New File";
 
-const URI_PREFIXES = ["http", "https", "ftp", "file", "gxfiles", "gximport", "gxuserimport", "gxftp"];
+const URI_PREFIXES = [
+    "http://",
+    "https://",
+    "ftp://",
+    "file://",
+    "gxfiles://",
+    "gximport://",
+    "gxuserimport://",
+    "gxftp://",
+];
 function itemIsUrl(item) {
     return URI_PREFIXES.some((prefix) => item.get("url_paste").startsWith(prefix));
 }


### PR DESCRIPTION
Closes  #15960 by appending `://` to the prefixes which identify URIs

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
