### PR TITLE
Rename object stores in config.

### DIFF
--- a/lib/galaxy/config/sample/object_store_conf.xml.sample
+++ b/lib/galaxy/config/sample/object_store_conf.xml.sample
@@ -127,12 +127,12 @@
 -->
 
 <!--
-    Sample S3 Object Store
+    Sample AWS S3 Object Store
 
     The "size" attribute of <cache> is in gigabytes.
 -->
 <!--
-<object_store type="s3">
+<object_store type="aws_s3">
      <auth access_key="...." secret_key="....." />
      <bucket name="unique_bucket_name_all_lowercase" use_reduced_redundancy="False" />
      <cache path="database/object_store_cache" size="1000" />
@@ -157,12 +157,12 @@
 -->
 
 <!--
-    Sample Swift Object Store
+    Sample non-AWS S3 Object Store (e.g. swift)
 
     The "size" attribute of <cache> is in gigabytes.
 -->
 <!--
-<object_store type="swift">
+<object_store type="generic_s3">
     <auth access_key="...." secret_key="....." />
     <bucket name="unique_bucket_name" use_reduced_redundancy="False" max_chunk_size="250"/>
     <connection host="" port="" is_secure="" conn_path="" multipart="True"/>

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1324,7 +1324,7 @@ def type_to_object_store_class(store: str, fsmon: bool = False) -> Tuple[Type[Ba
     objectstore_constructor_kwds = {}
     if store == "disk":
         objectstore_class = DiskObjectStore
-    elif store == "s3":
+    elif store in ["s3", "aws_s3"]:
         from .s3 import S3ObjectStore
 
         objectstore_class = S3ObjectStore
@@ -1332,10 +1332,10 @@ def type_to_object_store_class(store: str, fsmon: bool = False) -> Tuple[Type[Ba
         from .cloud import Cloud
 
         objectstore_class = Cloud
-    elif store == "swift":
-        from .s3 import SwiftObjectStore
+    elif store in ["swift", "generic_s3"]:
+        from .s3 import GenericS3ObjectStore
 
-        objectstore_class = SwiftObjectStore
+        objectstore_class = GenericS3ObjectStore
     elif store == "distributed":
         objectstore_class = DistributedObjectStore
         objectstore_constructor_kwds["fsmon"] = fsmon

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -146,7 +146,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
     Galaxy and S3.
     """
 
-    store_type = "s3"
+    store_type = "aws_s3"
 
     def __init__(self, config, config_dict):
         super().__init__(config, config_dict)
@@ -776,17 +776,17 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
             thread.join(5)
 
 
-class SwiftObjectStore(S3ObjectStore):
+class GenericS3ObjectStore(S3ObjectStore):
     """
-    Object store that stores objects as items in a Swift bucket. A local
-    cache exists that is used as an intermediate location for files between
-    Galaxy and Swift.
+    Object store that stores objects as items in a generic S3 (non AWS) bucket.
+    A local cache exists that is used as an intermediate location for files between
+    Galaxy and the S3 storage service.
     """
 
-    store_type = "swift"
+    store_type = "generic_s3"
 
     def _configure_connection(self):
-        log.debug("Configuring Swift Connection")
+        log.debug("Configuring generic S3 Connection")
         self.conn = boto.connect_s3(
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -13,7 +13,7 @@ OBJECT_STORE_CONFIG = string.Template(
     """
 <object_store type="hierarchical" id="primary">
     <backends>
-        <object_store id="swifty" type="swift" weight="1" order="0">
+        <object_store id="swifty" type="generic_s3" weight="1" order="0">
             <auth access_key="${access_key}" secret_key="${secret_key}" />
             <bucket name="galaxy" use_reduced_redundancy="False" max_chunk_size="250"/>
             <connection host="${host}" port="${port}" is_secure="False" conn_path="" multipart="True"/>

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -735,7 +735,7 @@ def test_config_parse_s3():
             as_dict = object_store.to_dict()
             _assert_has_keys(as_dict, ["auth", "bucket", "connection", "cache", "extra_dirs", "type"])
 
-            _assert_key_has_value(as_dict, "type", "s3")
+            _assert_key_has_value(as_dict, "type", "aws_s3")
 
             auth_dict = as_dict["auth"]
             bucket_dict = as_dict["bucket"]


### PR DESCRIPTION
Per @bgruening's request - ``s3`` -> ``aws_s3`` and ``swift`` -> ``generic_s3``.

I think we only construct object stores with the one method - so this should be backward compatible.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
