### PR TITLE
Localization naming adjustment/standardization.

### DIFF
--- a/client/src/app/base-mvc.js
+++ b/client/src/app/base-mvc.js
@@ -1,7 +1,7 @@
 import $ from "jquery";
 import _ from "underscore";
 import Backbone from "backbone";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 //==============================================================================
 /** Backbone model that syncs to the browser's sessionStorage API.
@@ -503,14 +503,14 @@ var SelectableViewMixin = {
  *
  *  The template strings can access:
  *      the json/model hash using model ("<%- model.myAttr %>) using the jsonNamespace above
- *      _l: the localizer function
+ *      localize: the localizer function
  *      view (if passed): ostensibly, the view using the template (handy for view instance vars)
  *      Because they're namespaced, undefined attributes will not throw an error.
  *
  *  @example:
  *      templateBler : BASE_MVC.wrapTemplate([
  *          '<div class="myclass <%- mynamespace.modelClass %>">',
- *              '<span><% print( _l( mynamespace.message ) ); %>:<%= view.status %></span>'
+ *              '<span><% print( localize( mynamespace.message ) ); %>:<%= view.status %></span>'
  *          '</div>'
  *      ], 'mynamespace' )
  *
@@ -521,7 +521,7 @@ function wrapTemplate(template, jsonNamespace) {
     jsonNamespace = jsonNamespace || "model";
     var templateFn = _.template(template.join(""));
     return (json, view) => {
-        var templateVars = { view: view || {}, _l: _l };
+        var templateVars = { view: view || {}, localize: localize };
         templateVars[jsonNamespace] = json || {};
         return templateFn(templateVars);
     };

--- a/client/src/app/user-model.js
+++ b/client/src/app/user-model.js
@@ -1,6 +1,6 @@
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 //==============================================================================
 /** @class Model for a Galaxy user (including anonymous users).
@@ -19,7 +19,7 @@ var User = Backbone.Model.extend(
          */
         defaults: /** @lends User.prototype */ {
             id: null,
-            username: `(${_l("anonymous user")})`,
+            username: `(${localize("anonymous user")})`,
             email: "",
             total_disk_usage: 0,
             nice_total_disk_usage: "",

--- a/client/src/app/user-model.js
+++ b/client/src/app/user-model.js
@@ -1,11 +1,13 @@
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
+
 import { localize } from "utils/localization";
 
 //==============================================================================
 /** @class Model for a Galaxy user (including anonymous users).
  *  @name User
  */
+
 var User = Backbone.Model.extend(
     /** @lends User.prototype */ {
         /** API location for this resource */

--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -51,7 +51,7 @@ function onClick(): void {
                     :id="id"
                     class="position-relative mb-1"
                     :class="{ 'nav-item-active': isActive }"
-                    :aria-label="title | l"
+                    :aria-label="title | localize"
                     @click="onClick">
                     <span v-if="progressStatus" class="progress">
                         <div
@@ -73,7 +73,7 @@ function onClick(): void {
                 </b-nav-item>
             </template>
             <div class="px-2 py-1">
-                <small v-if="tooltip">{{ tooltip | l }}</small>
+                <small v-if="tooltip">{{ tooltip | localize }}</small>
                 <small v-else>No tooltip available for this item</small>
                 <div v-if="options" class="nav-options p-1">
                     <router-link v-for="(option, index) in options" :key="index" :to="option.value">

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -199,7 +199,7 @@
 <script>
 import mixin from "./common/mixin";
 import DatasetCollectionElementView from "./ListDatasetCollectionElementView";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import STATES from "mvc/dataset/states";
 import "ui/hoverhighlight";
 import Vue from "vue";
@@ -218,17 +218,17 @@ export default {
     data: function () {
         return {
             state: "build", //error
-            titleUndoButton: _l("Undo all reordering and discards"),
-            titleSortButton: _l("Sort datasets by name"),
-            titleDeselectButton: _l("De-select all selected datasets"),
-            noElementsHeader: _l("No datasets were selected"),
-            discardedElementsHeader: _l("No elements left. Would you like to"),
-            invalidHeader: _l("The following selections could not be included due to problems:"),
-            allInvalidElementsPartOne: _l("At least one element is needed for the collection. You may need to"),
-            cancelText: _l("cancel"),
-            startOverText: _l("start over"),
-            allInvalidElementsPartTwo: _l("and reselect new elements."),
-            errorText: _l("Galaxy could not be reached and may be updating.  Try again in a few minutes."),
+            titleUndoButton: localize("Undo all reordering and discards"),
+            titleSortButton: localize("Sort datasets by name"),
+            titleDeselectButton: localize("De-select all selected datasets"),
+            noElementsHeader: localize("No datasets were selected"),
+            discardedElementsHeader: localize("No elements left. Would you like to"),
+            invalidHeader: localize("The following selections could not be included due to problems:"),
+            allInvalidElementsPartOne: localize("At least one element is needed for the collection. You may need to"),
+            cancelText: localize("cancel"),
+            startOverText: localize("start over"),
+            allInvalidElementsPartTwo: localize("and reselect new elements."),
+            errorText: localize("Galaxy could not be reached and may be updating.  Try again in a few minutes."),
             workingElements: [],
             originalNamedElements: [],
             invalidElements: [],
@@ -277,7 +277,7 @@ export default {
     methods: {
         l(str) {
             // _l conflicts private methods of Vue internals, expose as l instead
-            return _l(str);
+            return localize(str);
         },
         /** set up instance vars */
         _instanceSetUp: function () {
@@ -321,14 +321,14 @@ export default {
         /** describe what is wrong with a particular element if anything */
         _isElementInvalid: function (element) {
             if (element.history_content_type === "dataset_collection") {
-                return _l("is a collection, this is not allowed");
+                return localize("is a collection, this is not allowed");
             }
             var validState = element.state === STATES.OK || STATES.NOT_READY_STATES.includes(element.state);
             if (!validState) {
-                return _l("has errored, is paused, or is not accessible");
+                return localize("has errored, is paused, or is not accessible");
             }
             if (element.deleted || element.purged) {
-                return _l("has been deleted or purged");
+                return localize("has been deleted or purged");
             }
             return null;
         },

--- a/client/src/components/Collections/ListCollectionCreatorModal.js
+++ b/client/src/components/Collections/ListCollectionCreatorModal.js
@@ -1,10 +1,10 @@
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Vue from "vue";
 import { collectionCreatorModalSetup } from "./common/modal";
 
 function listCollectionCreatorModal(elements, options) {
     options = options || {};
-    options.title = _l("Create a collection from a list of datasets");
+    options.title = localize("Create a collection from a list of datasets");
     const { promise, showEl } = collectionCreatorModalSetup(options);
     return import(/* webpackChunkName: "ListCollectionCreator" */ "./ListCollectionCreator.vue").then((module) => {
         const listCollectionCreatorInstance = Vue.extend(module.default);

--- a/client/src/components/Collections/ListDatasetCollectionElementView.vue
+++ b/client/src/components/Collections/ListDatasetCollectionElementView.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import ClickToEdit from "./common/ClickToEdit";
 export default {
     components: { ClickToEdit },
@@ -19,8 +19,8 @@ export default {
     },
     data: function () {
         return {
-            titleDiscardButton: _l("Remove this dataset from the list"),
-            titleElementName: _l("Click to rename"),
+            titleDiscardButton: localize("Remove this dataset from the list"),
+            titleElementName: localize("Click to rename"),
             isSelected: false,
             elementName: "",
         };
@@ -36,7 +36,7 @@ export default {
     methods: {
         l(str) {
             // _l conflicts private methods of Vue internals, expose as l instead
-            return _l(str);
+            return localize(str);
         },
         clickDiscard: function () {
             this.$emit("element-is-discarded", this.element);

--- a/client/src/components/Collections/PairCollectionCreator.vue
+++ b/client/src/components/Collections/PairCollectionCreator.vue
@@ -151,7 +151,7 @@
 <script>
 import mixin from "./common/mixin";
 import STATES from "mvc/dataset/states";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
 
@@ -161,14 +161,16 @@ export default {
     data: function () {
         return {
             state: "build", //error
-            errorText: _l("Galaxy could not be reached and may be updating.  Try again in a few minutes."),
-            noElementsHeader: _l("No datasets were selected."),
-            allInvalidElementsPartOne: _l("Exactly two elements needed for the collection. You may need to"),
-            cancelText: _l("cancel"),
-            allInvalidElementsPartTwo: _l("and reselect new elements."),
-            exactlyTwoValidElementsPartOne: _l("Two (and only two) elements are needed for the pair. You may need to "),
-            exactlyTwoValidElementsPartTwo: _l("and reselect new elements."),
-            invalidHeader: _l("The following selections could not be included due to problems:"),
+            errorText: localize("Galaxy could not be reached and may be updating.  Try again in a few minutes."),
+            noElementsHeader: localize("No datasets were selected."),
+            allInvalidElementsPartOne: localize("Exactly two elements needed for the collection. You may need to"),
+            cancelText: localize("cancel"),
+            allInvalidElementsPartTwo: localize("and reselect new elements."),
+            exactlyTwoValidElementsPartOne: localize(
+                "Two (and only two) elements are needed for the pair. You may need to "
+            ),
+            exactlyTwoValidElementsPartTwo: localize("and reselect new elements."),
+            invalidHeader: localize("The following selections could not be included due to problems:"),
             minElements: 2,
             workingElements: [],
             invalidElements: [],
@@ -204,7 +206,7 @@ export default {
     methods: {
         l(str) {
             // _l conflicts private methods of Vue internals, expose as l instead
-            return _l(str);
+            return localize(str);
         },
         _elementsSetUp: function () {
             /** a list of invalid elements and the reasons they aren't valid */
@@ -240,14 +242,14 @@ export default {
         /** describe what is wrong with a particular element if anything */
         _isElementInvalid: function (element) {
             if (element.history_content_type === "dataset_collection") {
-                return _l("is a collection, this is not allowed");
+                return localize("is a collection, this is not allowed");
             }
             var validState = element.state === STATES.OK || STATES.NOT_READY_STATES.includes(element.state);
             if (!validState) {
-                return _l("has errored, is paused, or is not accessible");
+                return localize("has errored, is paused, or is not accessible");
             }
             if (element.deleted || element.purged) {
-                return _l("has been deleted or purged");
+                return localize("has been deleted or purged");
             }
             return null;
         },

--- a/client/src/components/Collections/PairCollectionCreatorModal.js
+++ b/client/src/components/Collections/PairCollectionCreatorModal.js
@@ -1,10 +1,10 @@
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Vue from "vue";
 import { collectionCreatorModalSetup } from "./common/modal";
 
 function pairCollectionCreatorModal(elements, options) {
     options = options || {};
-    options.title = _l("Create a collection from a pair of datasets");
+    options.title = localize("Create a collection from a pair of datasets");
     const { promise, showEl } = collectionCreatorModalSetup(options);
     return import(/* webpackChunkName: "PairCollectionCreator" */ "./PairCollectionCreator.vue").then((module) => {
         var pairCollectionCreatorInstance = Vue.extend(module.default);

--- a/client/src/components/Collections/PairedElementView.vue
+++ b/client/src/components/Collections/PairedElementView.vue
@@ -16,7 +16,7 @@
 </template>
 <script>
 import ClickToEdit from "./common/ClickToEdit.vue";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 export default {
     components: { ClickToEdit },
     props: {
@@ -30,8 +30,8 @@ export default {
     },
     data: function () {
         return {
-            unpairButtonTitle: _l("Unpair"),
-            titlePairName: _l("Click to rename"),
+            unpairButtonTitle: localize("Unpair"),
+            titlePairName: localize("Click to rename"),
             name: "",
         };
     },
@@ -49,7 +49,7 @@ export default {
     methods: {
         l(str) {
             // _l conflicts private methods of Vue internals, expose as l instead
-            return _l(str);
+            return localize(str);
         },
     },
 };

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -407,7 +407,7 @@
     </div>
 </template>
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import mixin from "./common/mixin";
 import UnpairedDatasetElementView from "./UnpairedDatasetElementView";
 import levenshteinDistance from "utils/levenshtein";
@@ -433,10 +433,10 @@ export default {
     data: function () {
         return {
             state: "build", //error, duplicates
-            dragToChangeTitle: _l("Drag to change"),
-            chooseFilterTitle: _l("Choose from common filters"),
-            filterTextPlaceholder: _l("Filter text"),
-            filterTextTitle: _l("Use this box to filter elements, using simple matching or regular expressions."),
+            dragToChangeTitle: localize("Drag to change"),
+            chooseFilterTitle: localize("Choose from common filters"),
+            filterTextPlaceholder: localize("Filter text"),
+            filterTextTitle: localize("Use this box to filter elements, using simple matching or regular expressions."),
             pairedElements: [],
             unpairedElements: [],
             commonFilters: {
@@ -516,12 +516,12 @@ export default {
                 },
             }),
             strategy: null,
-            errorText: _l("Galaxy could not be reached and may be updating.  Try again in a few minutes."),
-            invalidHeader: _l("The following selections could not be included due to problems:"),
-            allInvalidElementsPartOne: _l("At least two elements are needed for the collection. You may need to"),
-            noElementsHeader: _l("No datasets were selected"),
-            cancelText: _l("cancel"),
-            allInvalidElementsPartTwo: _l("and reselect new elements."),
+            errorText: localize("Galaxy could not be reached and may be updating.  Try again in a few minutes."),
+            invalidHeader: localize("The following selections could not be included due to problems:"),
+            allInvalidElementsPartOne: localize("At least two elements are needed for the collection. You may need to"),
+            noElementsHeader: localize("No datasets were selected"),
+            cancelText: localize("cancel"),
+            allInvalidElementsPartTwo: localize("and reselect new elements."),
             duplicatePairNames: [],
         };
     },
@@ -601,7 +601,7 @@ export default {
     methods: {
         l(str) {
             // _l conflicts private methods of Vue internals, expose as l instead
-            return _l(str);
+            return localize(str);
         },
         removeExtensionsToggle: function () {
             this.removeExtensions = !this.removeExtensions;
@@ -656,14 +656,14 @@ export default {
         /** describe what is wrong with a particular element if anything */
         _isElementInvalid: function (element) {
             if (element.history_content_type === "dataset_collection") {
-                return _l("is a collection, this is not allowed");
+                return localize("is a collection, this is not allowed");
             }
             var validState = element.state === STATES.OK || STATES.NOT_READY_STATES.includes(element.state);
             if (!validState) {
-                return _l("has errored, is paused, or is not accessible");
+                return localize("has errored, is paused, or is not accessible");
             }
             if (element.deleted || element.purged) {
-                return _l("has been deleted or purged");
+                return localize("has been deleted or purged");
             }
             return null;
         },

--- a/client/src/components/Collections/PairedListCollectionCreatorModal.js
+++ b/client/src/components/Collections/PairedListCollectionCreatorModal.js
@@ -1,11 +1,11 @@
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Vue from "vue";
 import { collectionCreatorModalSetup } from "./common/modal";
 import PairedListCollectionCreator from "./PairedListCollectionCreator.vue";
 
 function pairedListCollectionCreatorModal(elements, options) {
     options = options || {};
-    options.title = _l("Create a collection of paired datasets");
+    options.title = localize("Create a collection of paired datasets");
     const { promise, showEl } = collectionCreatorModalSetup(options);
     var pairedListCollectionCreatorInstance = Vue.extend(PairedListCollectionCreator);
     var vm = document.createElement("div");

--- a/client/src/components/Collections/RuleBasedCollectionCreatorModal.js
+++ b/client/src/components/Collections/RuleBasedCollectionCreatorModal.js
@@ -1,4 +1,4 @@
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Vue from "vue";
 import { collectionCreatorModalSetup } from "./common/modal";
 
@@ -7,13 +7,13 @@ function ruleBasedCollectionCreatorModal(elements, elementsType, importType, opt
     // elementsType in [raw, ftp, datasets]
     let title;
     if (importType == "datasets") {
-        title = _l("Build Rules for Uploading Datasets");
+        title = localize("Build Rules for Uploading Datasets");
     } else if (elementsType == "collection_contents") {
-        title = _l("Build Rules for Applying to Existing Collection");
+        title = localize("Build Rules for Applying to Existing Collection");
     } else if (elementsType == "datasets" || elementsType == "library_datasets") {
-        title = _l("Build Rules for Creating Collection(s)");
+        title = localize("Build Rules for Creating Collection(s)");
     } else {
-        title = _l("Build Rules for Uploading Collections");
+        title = localize("Build Rules for Uploading Collections");
     }
     options.title = title;
     // Prevents user from accidentally closing the modal by clicking outside the bounds

--- a/client/src/components/Collections/UnpairedDatasetElementView.vue
+++ b/client/src/components/Collections/UnpairedDatasetElementView.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 export default {
     props: {
         element: {
@@ -16,14 +16,14 @@ export default {
     },
     data: function () {
         return {
-            titleElementName: _l("Click to rename"),
+            titleElementName: localize("Click to rename"),
             isSelected: false,
         };
     },
     methods: {
         l(str) {
             // _l conflicts private methods of Vue internals, expose as l instead
-            return _l(str);
+            return localize(str);
         },
         /** string rep */
         toString() {

--- a/client/src/components/Collections/common/CollectionCreator.vue
+++ b/client/src/components/Collections/common/CollectionCreator.vue
@@ -77,7 +77,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 export default {
     props: {
         oncancel: {
@@ -100,11 +100,11 @@ export default {
     },
     data: function () {
         return {
-            titleForHelp: _l("Expand or Close Help"),
-            hideOriginalsText: _l("Hide original elements?"),
-            titleMoreHelp: _l("Close and show more help"),
-            placeholderEnterName: _l("Enter a name for your new collection"),
-            dropdownText: _l("Create a <i>single</> pair"),
+            titleForHelp: localize("Expand or Close Help"),
+            hideOriginalsText: localize("Hide original elements?"),
+            titleMoreHelp: localize("Close and show more help"),
+            placeholderEnterName: localize("Enter a name for your new collection"),
+            dropdownText: localize("Create a <i>single</> pair"),
             isExpanded: false,
             collectionName: this.suggestedName,
             removeFileExtensionsText: "Remove file extensions?",
@@ -124,7 +124,7 @@ export default {
     methods: {
         l(str) {
             // _l conflicts private methods of Vue internals, expose as l instead
-            return _l(str);
+            return localize(str);
         },
         _clickForHelp: function () {
             this.isExpanded = !this.isExpanded;

--- a/client/src/components/Collections/common/modal.js
+++ b/client/src/components/Collections/common/modal.js
@@ -1,6 +1,6 @@
 import { getGalaxyInstance } from "app";
 import UI_MODAL from "mvc/ui/ui-modal";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 export function collectionCreatorModalSetup(options, Galaxy = null) {
     Galaxy = Galaxy || getGalaxyInstance();
@@ -18,7 +18,7 @@ export function collectionCreatorModalSetup(options, Galaxy = null) {
     const showEl = function (el) {
         const close_event = options.closing_events === undefined || options.closing_events;
         modal.show({
-            title: options.title || _l("Create a collection"),
+            title: options.title || localize("Create a collection"),
             body: el,
             width: "85%",
             height: "100%",

--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -18,7 +18,7 @@
                 size="sm"
                 :pressed="showAdvanced"
                 :variant="showAdvanced ? 'info' : 'secondary'"
-                :title="titleAdvanced | l"
+                :title="titleAdvanced | localize"
                 data-description="toggle advanced search"
                 @click="onToggle">
                 <icon v-if="showAdvanced" icon="angle-double-up" />
@@ -29,7 +29,7 @@
                 aria-haspopup="true"
                 class="search-clear"
                 size="sm"
-                :title="titleClear | l"
+                :title="titleClear | localize"
                 data-description="reset query"
                 @click="clearBox">
                 <icon v-if="loading" icon="spinner" spin />

--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -51,7 +51,9 @@
                                 <FormDisplay :inputs="result['conversion_inputs']" @onChange="onConversion" />
                                 <div class="mt-2">
                                     <b-button variant="primary" @click="submit('conversion', 'conversion')">
-                                        <font-awesome-icon icon="exchange-alt" class="mr-1" />{{ "Create Dataset" | localize }}
+                                        <font-awesome-icon icon="exchange-alt" class="mr-1" />{{
+                                            "Create Dataset" | localize
+                                        }}
                                     </b-button>
                                 </div>
                             </div>

--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -2,14 +2,14 @@
     <div aria-labelledby="dataset-attributes-heading">
         <h1 id="dataset-attributes-heading" v-localize class="h-lg">Edit Dataset Attributes</h1>
         <b-alert v-if="messageText" :variant="messageVariant" show>
-            {{ messageText | l }}
+            {{ messageText | localize }}
         </b-alert>
         <DatasetAttributesProvider :id="datasetId" v-slot="{ result, loading }" @error="onError">
             <div v-if="!loading" class="mt-3">
                 <b-tabs>
                     <b-tab v-if="!result['attribute_disable']">
                         <template v-slot:title>
-                            <font-awesome-icon icon="bars" class="mr-1" />{{ "Attributes" | l }}
+                            <font-awesome-icon icon="bars" class="mr-1" />{{ "Attributes" | localize }}
                         </template>
                         <FormDisplay :inputs="result['attribute_inputs']" @onChange="onAttribute" />
                         <div class="mt-2">
@@ -18,10 +18,10 @@
                                 variant="primary"
                                 class="mr-1"
                                 @click="submit('attribute', 'attributes')">
-                                <font-awesome-icon icon="save" class="mr-1" />{{ "Save" | l }}
+                                <font-awesome-icon icon="save" class="mr-1" />{{ "Save" | localize }}
                             </b-button>
                             <b-button v-if="!result['metadata_disable']" @click="submit('attribute', 'autodetect')">
-                                <font-awesome-icon icon="redo" class="mr-1" />{{ "Auto-detect" | l }}
+                                <font-awesome-icon icon="redo" class="mr-1" />{{ "Auto-detect" | localize }}
                             </b-button>
                         </div>
                     </b-tab>
@@ -32,10 +32,10 @@
                         ">
                         <template v-slot:title>
                             <span v-if="!result['conversion_disable']">
-                                <font-awesome-icon icon="cog" class="mr-1" />{{ "Convert" | l }}
+                                <font-awesome-icon icon="cog" class="mr-1" />{{ "Convert" | localize }}
                             </span>
                             <span v-else>
-                                <font-awesome-icon icon="database" class="mr-1" />{{ "Datatypes" | l }}
+                                <font-awesome-icon icon="database" class="mr-1" />{{ "Datatypes" | localize }}
                             </span>
                         </template>
                         <div v-if="!result['conversion_disable']" class="ui-portlet-section">
@@ -43,7 +43,7 @@
                                 <div class="portlet-title">
                                     <font-awesome-icon icon="cog" class="portlet-title-icon fa-fw mr-1" />
                                     <span class="portlet-title-text">
-                                        <b itemprop="name">{{ "Convert" | l }}</b>
+                                        <b itemprop="name">{{ "Convert" | localize }}</b>
                                     </span>
                                 </div>
                             </div>
@@ -51,7 +51,7 @@
                                 <FormDisplay :inputs="result['conversion_inputs']" @onChange="onConversion" />
                                 <div class="mt-2">
                                     <b-button variant="primary" @click="submit('conversion', 'conversion')">
-                                        <font-awesome-icon icon="exchange-alt" class="mr-1" />{{ "Create Dataset" | l }}
+                                        <font-awesome-icon icon="exchange-alt" class="mr-1" />{{ "Create Dataset" | localize }}
                                     </b-button>
                                 </div>
                             </div>
@@ -61,7 +61,7 @@
                                 <div class="portlet-title">
                                     <font-awesome-icon icon="database" class="portlet-title-icon fa-fw mr-1" />
                                     <span class="portlet-title-text">
-                                        <b itemprop="name">{{ "Datatypes" | l }}</b>
+                                        <b itemprop="name">{{ "Datatypes" | localize }}</b>
                                     </span>
                                 </div>
                             </div>
@@ -69,10 +69,10 @@
                                 <FormDisplay :inputs="result['datatype_inputs']" @onChange="onDatatype" />
                                 <div class="mt-2">
                                     <b-button variant="primary" class="mr-1" @click="submit('datatype', 'datatype')">
-                                        <font-awesome-icon icon="save" class="mr-1" />{{ "Save" | l }}
+                                        <font-awesome-icon icon="save" class="mr-1" />{{ "Save" | localize }}
                                     </b-button>
                                     <b-button @click="submit('datatype', 'datatype_detect')">
-                                        <font-awesome-icon icon="redo" class="mr-1" />{{ "Auto-detect" | l }}
+                                        <font-awesome-icon icon="redo" class="mr-1" />{{ "Auto-detect" | localize }}
                                     </b-button>
                                 </div>
                             </div>
@@ -80,12 +80,12 @@
                     </b-tab>
                     <b-tab v-if="!result['permission_disable']">
                         <template v-slot:title>
-                            <font-awesome-icon icon="user" class="mr-1" />{{ "Permissions" | l }}
+                            <font-awesome-icon icon="user" class="mr-1" />{{ "Permissions" | localize }}
                         </template>
                         <FormDisplay :inputs="result['permission_inputs']" @onChange="onPermission" />
                         <div class="mt-2">
                             <b-button variant="primary" @click="submit('permission', 'permission')">
-                                <font-awesome-icon icon="save" class="mr-1" />{{ "Save" | l }}
+                                <font-awesome-icon icon="save" class="mr-1" />{{ "Save" | localize }}
                             </b-button>
                         </div>
                     </b-tab>

--- a/client/src/components/DatasetInformation/DatasetError.vue
+++ b/client/src/components/DatasetInformation/DatasetError.vue
@@ -64,7 +64,7 @@
                     <div v-if="showForm" id="fieldsAndButton">
                         <span class="mr-2 font-weight-bold">{{ emailTitle }}</span>
                         <span v-if="!!currentUser?.email">{{ currentUser?.email }}</span>
-                        <span v-else>{{ "You must be logged in to receive emails" | l }}</span>
+                        <span v-else>{{ "You must be logged in to receive emails" | localize }}</span>
                         <FormElement
                             id="dataset-error-message"
                             v-model="message"
@@ -95,6 +95,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faBug } from "@fortawesome/free-solid-svg-icons";
 import { sendErrorReport } from "./services";
+import { localize } from "utils/localization";
 
 library.add(faBug);
 
@@ -118,7 +119,7 @@ export default {
             message: null,
             errorMessage: null,
             resultMessages: [],
-            emailTitle: this.l("Your email address"),
+            emailTitle: localize("Your email address"),
         };
     },
     computed: {

--- a/client/src/components/DatasetInformation/DatasetSource.vue
+++ b/client/src/components/DatasetInformation/DatasetSource.vue
@@ -21,7 +21,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCopy, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 import { copy } from "utils/clipboard";
 import DatasetSourceTransform from "./DatasetSourceTransform";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 library.add(faCopy, faExternalLinkAlt);
 
@@ -47,7 +47,7 @@ export default {
     },
     methods: {
         copyLink() {
-            copy(this.sourceUri, _l("Link copied to your clipboard"));
+            copy(this.sourceUri, localize("Link copied to your clipboard"));
         },
     },
 };

--- a/client/src/components/Form/Elements/FormDirectory.vue
+++ b/client/src/components/Form/Elements/FormDirectory.vue
@@ -41,7 +41,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faFolder, faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { FilesDialog } from "components/FilesDialog";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 library.add(faFolder, faFolderOpen);
 
@@ -58,7 +58,7 @@ export default {
         FilesDialog,
     },
     data() {
-        return { ...getDefaultValues(), modalKey: 0, selectText: _l("Select") };
+        return { ...getDefaultValues(), modalKey: 0, selectText: localize("Select") };
     },
     computed: {
         isValidName() {

--- a/client/src/components/Form/FormGeneric.vue
+++ b/client/src/components/Form/FormGeneric.vue
@@ -14,10 +14,10 @@
             </FormCard>
             <div class="mt-3">
                 <b-button id="submit" variant="primary" class="mr-1" @click="onSubmit()">
-                    <span :class="submitIconClass" />{{ submitTitle | l }}
+                    <span :class="submitIconClass" />{{ submitTitle | localize }}
                 </b-button>
                 <b-button v-if="cancelRedirect" @click="onCancel()">
-                    <span class="mr-1 fa fa-times" />{{ "Cancel" | l }}
+                    <span class="mr-1 fa fa-times" />{{ "Cancel" | localize }}
                 </b-button>
             </div>
         </div>

--- a/client/src/components/Form/FormMessage.vue
+++ b/client/src/components/Form/FormMessage.vue
@@ -1,6 +1,6 @@
 <template>
     <b-alert class="mt-2" :variant="variant" :show="showAlert">
-        {{ message | l }}
+        {{ message | localize }}
     </b-alert>
 </template>
 <script>

--- a/client/src/components/Grid/history-list.js
+++ b/client/src/components/Grid/history-list.js
@@ -3,7 +3,7 @@ import $ from "jquery";
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import AjaxQueue from "utils/ajax-queue";
 import Utils from "utils/utils";
 import GridView from "mvc/grid/grid-view";
@@ -58,7 +58,7 @@ var HistoryGridView = GridView.extend({
 });
 
 var View = Backbone.View.extend({
-    title: _l("Histories"),
+    title: localize("Histories"),
     initialize: function (options) {
         const Galaxy = getGalaxyInstance();
         LoadingIndicator.markViewAsLoading(this);

--- a/client/src/components/History/CurrentHistory/HistoryEmpty.vue
+++ b/client/src/components/History/CurrentHistory/HistoryEmpty.vue
@@ -2,7 +2,7 @@
     <b-alert show>
         <h4 class="mb-1">
             <i class="fa fa-info-circle empty-message"></i>
-            <span>{{ message | l }}</span>
+            <span>{{ message | localize }}</span>
         </h4>
         <p>
             <a v-localize href="#" @click.prevent="openGlobalUploadModal">You can load your own data</a>

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -60,7 +60,7 @@
                     <b-dropdown-divider></b-dropdown-divider>
 
                     <b-dropdown-item
-                        :title="l('Resume all Paused Jobs in this History')"
+                        :title="localize('Resume all Paused Jobs in this History')"
                         @click="iframeRedirect('/history/resume_paused_jobs?current=True')">
                         <Icon fixed-width icon="play" class="mr-1" />
                         <span v-localize>Resume Paused Jobs</span>
@@ -76,13 +76,13 @@
                         <span v-localize>Copy this History</span>
                     </b-dropdown-item>
 
-                    <b-dropdown-item v-b-modal:delete-history-modal :title="l('Permanently Delete History')">
+                    <b-dropdown-item v-b-modal:delete-history-modal :title="localize('Permanently Delete History')">
                         <Icon fixed-width icon="trash" class="mr-1" />
                         <span v-localize>Delete this History</span>
                     </b-dropdown-item>
 
                     <b-dropdown-item
-                        :title="l('Export Citations for all Tools used in this History')"
+                        :title="localize('Export Citations for all Tools used in this History')"
                         @click="$router.push(`/histories/citations?id=${history.id}`)">
                         <Icon fixed-width icon="stream" class="mr-1" />
                         <span v-localize>Export Tool Citations</span>
@@ -90,7 +90,7 @@
 
                     <b-dropdown-item
                         data-description="export to file"
-                        :title="l('Export and Download History as a File')"
+                        :title="localize('Export and Download History as a File')"
                         @click="$router.push(`/histories/${history.id}/export`)">
                         <Icon fixed-width icon="file-archive" class="mr-1" />
                         <span v-localize>Export History to File</span>
@@ -172,6 +172,7 @@
 import { mapState } from "pinia";
 import { useUserStore } from "@/stores/userStore";
 import { legacyNavigationMixin } from "components/plugins/legacyNavigation";
+import { localize } from "utils/localization";
 import CopyModal from "components/History/Modals/CopyModal";
 import SelectorModal from "components/History/Modals/SelectorModal";
 
@@ -193,11 +194,12 @@ export default {
     methods: {
         userTitle(title) {
             if (this.isAnonymous) {
-                return this.l("Log in to") + " " + this.l(title);
+                return localize("Log in to") + " " + localize(title);
             } else {
-                return this.l(title);
+                return localize(title);
             }
         },
+        localize,
     },
 };
 </script>

--- a/client/src/components/History/Layout/DetailsLayout.vue
+++ b/client/src/components/History/Layout/DetailsLayout.vue
@@ -69,6 +69,7 @@
 <script>
 import { mapState } from "pinia";
 import { useUserStore } from "@/stores/userStore";
+import { localize } from "@/utils/localization";
 import short from "components/directives/v-short";
 import StatelessTags from "components/TagsMultiselect/StatelessTags";
 
@@ -97,12 +98,12 @@ export default {
         ...mapState(useUserStore, ["isAnonymous"]),
         editButtonTitle() {
             if (this.isAnonymous) {
-                return this.l("Log in to Rename History");
+                return localize("Log in to Rename History");
             } else {
                 if (this.writeable) {
-                    return this.l("Edit");
+                    return localize("Edit");
                 } else {
-                    return this.l("Not Editable");
+                    return localize("Not Editable");
                 }
             }
         },

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -1,5 +1,10 @@
 <template>
-    <b-modal ref="modal" v-bind="$attrs" :title="title | localize" footer-class="justify-content-between" v-on="$listeners">
+    <b-modal
+        ref="modal"
+        v-bind="$attrs"
+        :title="title | localize"
+        footer-class="justify-content-between"
+        v-on="$listeners">
         <b-form-group :description="'Filter histories' | localize">
             <b-form-input v-model="filter" type="search" :placeholder="'Search Filter' | localize" />
         </b-form-group>

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -1,7 +1,7 @@
 <template>
-    <b-modal ref="modal" v-bind="$attrs" :title="title | l" footer-class="justify-content-between" v-on="$listeners">
-        <b-form-group :description="'Filter histories' | l">
-            <b-form-input v-model="filter" type="search" :placeholder="'Search Filter' | l" />
+    <b-modal ref="modal" v-bind="$attrs" :title="title | localize" footer-class="justify-content-between" v-on="$listeners">
+        <b-form-group :description="'Filter histories' | localize">
+            <b-form-input v-model="filter" type="search" :placeholder="'Search Filter' | localize" />
         </b-form-group>
 
         <b-table

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -38,7 +38,7 @@ function updateFilter(newFilter: string) {
                             size="sm"
                             :class="filter && 'font-weight-bold'"
                             :value="value"
-                            :placeholder="'search datasets in selected histories' | l"
+                            :placeholder="'search datasets in selected histories' | localize"
                             data-description="filter text input"
                             @input="input"
                             @keyup.esc="updateFilter('')" />

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -180,7 +180,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Vue from "vue";
 import { mapState } from "pinia";
 import { useUserStore } from "@/stores/userStore";
@@ -226,17 +226,17 @@ export default {
                 description: "",
                 synopsis: "",
             },
-            titleLibrary: _l("Library"),
-            titleName: _l("Name"),
-            titleDescription: _l("Description"),
-            titleSynopsis: _l("Synopsis"),
-            titleSave: _l("Save"),
-            titleUndelete: _l("Undelete"),
-            titleEdit: _l("Edit"),
-            titleCancel: _l("Cancel"),
-            titleDelete: _l("Delete"),
-            titlePerPage: _l("per page"),
-            titleTotal: _l("total"),
+            titleLibrary: localize("Library"),
+            titleName: localize("Name"),
+            titleDescription: localize("Description"),
+            titleSynopsis: localize("Synopsis"),
+            titleSave: localize("Save"),
+            titleUndelete: localize("Undelete"),
+            titleEdit: localize("Edit"),
+            titleCancel: localize("Cancel"),
+            titleDelete: localize("Delete"),
+            titlePerPage: localize("per page"),
+            titleTotal: localize("total"),
         };
     },
     computed: {

--- a/client/src/components/Libraries/LibraryFolder/FolderDetails/FolderDetails.vue
+++ b/client/src/components/Libraries/LibraryFolder/FolderDetails/FolderDetails.vue
@@ -61,7 +61,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
@@ -94,10 +94,10 @@ export default {
     },
     data() {
         return {
-            detailsCaption: _l("Details"),
-            folderHeader: _l("Folder"),
-            libraryHeader: _l("Library"),
-            titleLocationDetails: _l("Location Details"),
+            detailsCaption: localize("Details"),
+            folderHeader: localize("Folder"),
+            libraryHeader: localize("Library"),
+            titleLocationDetails: localize("Location Details"),
             fields: [
                 {
                     key: "name",
@@ -105,12 +105,12 @@ export default {
                 },
                 { key: "value" },
             ],
-            folderFieldTitles: { folder_name: _l("Name"), folder_description: _l("Description"), id: "ID" },
+            folderFieldTitles: { folder_name: localize("Name"), folder_description: localize("Description"), id: "ID" },
             libraryFieldTitles: {
-                name: _l("Name"),
-                description: _l("Description"),
-                synopsis: _l("Synopsis"),
-                create_time_pretty: _l("Created"),
+                name: localize("Name"),
+                description: localize("Description"),
+                synopsis: localize("Synopsis"),
+                create_time_pretty: localize("Created"),
                 id: "ID",
             },
             libraryDetails: null,
@@ -138,7 +138,7 @@ export default {
                 const response = await axios.get(url);
                 return buildFields(this.libraryFieldTitles, response.data);
             } catch (e) {
-                this.error = `${_l("Failed to retrieve library details.")} ${e}`;
+                this.error = `${localize("Failed to retrieve library details.")} ${e}`;
                 return null;
             }
         },

--- a/client/src/components/Libraries/LibraryFolder/SearchField.vue
+++ b/client/src/components/Libraries/LibraryFolder/SearchField.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 export default {
     name: "SearchField",
@@ -26,7 +26,7 @@ export default {
         return {
             search: "",
             awaitingSearch: false,
-            titleSearch: _l("Search"),
+            titleSearch: localize("Search"),
         };
     },
     watch: {

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/add-datasets.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/add-datasets.js
@@ -1,6 +1,6 @@
 import { getGalaxyInstance } from "app";
 import { Toast } from "composables/toast";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import mod_library_model from "./library-model";
 import _ from "underscore";
 import Backbone from "backbone";
@@ -184,7 +184,7 @@ var AddDatasets = Backbone.View.extend({
                 var template_modal = this.templateAddFilesFromHistory();
                 this.modal.show({
                     closing_events: true,
-                    title: _l("Adding datasets from your history"),
+                    title: localize("Adding datasets from your history"),
                     body: template_modal({
                         histories: this.histories.models,
                     }),
@@ -224,7 +224,7 @@ var AddDatasets = Backbone.View.extend({
         this.modal = Galaxy.modal;
         this.modal.show({
             closing_events: true,
-            title: _l("Please select folders or files"),
+            title: localize("Please select folders or files"),
             body: template_modal({}),
             buttons: {
                 Import: () => {
@@ -430,7 +430,7 @@ var AddDatasets = Backbone.View.extend({
         var template_modal = this.templateImportPathModal();
         this.modal.show({
             closing_events: true,
-            title: _l("Please enter paths to import"),
+            title: localize("Please enter paths to import"),
             body: template_modal({}),
             buttons: {
                 Import: () => {

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/delete-selected.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/delete-selected.js
@@ -1,6 +1,6 @@
 import { getGalaxyInstance } from "app";
 import { Toast } from "composables/toast";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import mod_library_model from "./library-model";
 import _ from "underscore";
 import $ from "jquery";
@@ -24,7 +24,7 @@ export function deleteSelectedItems(checkedRows, onRemove, refreshTable, refresh
         const modal = Galaxy.modal;
         modal.show({
             closing_events: true,
-            title: _l("Deleting selected items"),
+            title: localize("Deleting selected items"),
             body: template({}),
             buttons: {
                 Close: () => {

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/import-to-history/import-dataset.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/import-to-history/import-dataset.js
@@ -1,6 +1,6 @@
 import { getGalaxyInstance } from "app";
 import { Toast } from "composables/toast";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import mod_library_model from "../library-model";
 import _ from "underscore";
 import Backbone from "backbone";
@@ -35,7 +35,7 @@ var ImportDatasetModal = Backbone.View.extend({
                     this.modal = Galaxy.modal;
                     this.modal.show({
                         closing_events: true,
-                        title: _l("Import into History"),
+                        title: localize("Import into History"),
                         body: template({
                             histories: this.histories.models,
                         }),

--- a/client/src/components/Login/LoginForm.vue
+++ b/client/src/components/Login/LoginForm.vue
@@ -86,7 +86,7 @@ import BootstrapVue from "bootstrap-vue";
 import { withPrefix } from "utils/redirect";
 import NewUserConfirmation from "./NewUserConfirmation";
 import ExternalLogin from "components/User/ExternalIdentities/ExternalLogin";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 Vue.use(BootstrapVue);
 
@@ -136,9 +136,9 @@ export default {
             url: null,
             messageText: null,
             messageVariant: null,
-            headerWelcome: _l("Welcome to Galaxy, please log in"),
-            labelNameAddress: _l("Public Name or Email Address"),
-            labelPassword: _l("Password"),
+            headerWelcome: localize("Welcome to Galaxy, please log in"),
+            labelNameAddress: localize("Public Name or Email Address"),
+            labelPassword: localize("Password"),
         };
     },
     computed: {

--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -86,7 +86,7 @@ import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
 import { withPrefix } from "utils/redirect";
 import ExternalLogin from "components/User/ExternalIdentities/ExternalLogin";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 Vue.use(BootstrapVue);
 
@@ -142,11 +142,11 @@ export default {
             subscribe: null,
             messageText: null,
             messageVariant: null,
-            labelEmailAddress: _l("Email address"),
-            labelPassword: _l("Password"),
-            labelConfirmPassword: _l("Confirm password"),
-            labelPublicName: _l("Public name"),
-            labelSubscribe: _l("Subscribe to mailing list"),
+            labelEmailAddress: localize("Email address"),
+            labelPassword: localize("Password"),
+            labelConfirmPassword: localize("Confirm password"),
+            labelPublicName: localize("Public name"),
+            labelSubscribe: localize("Subscribe to mailing list"),
         };
     },
     computed: {

--- a/client/src/components/Masthead/QuotaMeter.vue
+++ b/client/src/components/Masthead/QuotaMeter.vue
@@ -21,12 +21,13 @@ import { mapState } from "pinia";
 import { bytesToString } from "utils/utils";
 import { useUserStore } from "@/stores/userStore";
 import { mapGetters } from "vuex";
+import { localize } from "@/utils/localization";
 
 export default {
     name: "QuotaMeter",
     data() {
         return {
-            usingString: this.l("Using"),
+            usingString: localize("Using"),
         };
     },
     computed: {
@@ -52,9 +53,9 @@ export default {
         title() {
             let details = "";
             if (this.isAnonymous) {
-                details = this.l("Log in for details.");
+                details = localize("Log in for details.");
             } else {
-                details = this.l("Click for details.");
+                details = localize("Click for details.");
             }
 
             if (this.hasQuota) {

--- a/client/src/components/ObjectStore/showTargetPopoverMixin.js
+++ b/client/src/components/ObjectStore/showTargetPopoverMixin.js
@@ -1,4 +1,5 @@
 import ShowSelectedObjectStore from "./ShowSelectedObjectStore";
+import { localize } from "utils/localization";
 
 export default {
     components: {
@@ -12,7 +13,7 @@ export default {
     },
     computed: {
         title() {
-            return this.l(`Preferred Target Object Store ${this.titleSuffix || ""}`);
+            return localize(`Preferred Target Object Store ${this.titleSuffix || ""}`);
         },
     },
 };

--- a/client/src/components/PageEditor/util.js
+++ b/client/src/components/PageEditor/util.js
@@ -1,11 +1,11 @@
 import axios from "axios";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { getAppRoot } from "onload/loadConfig";
 import { show_modal, hide_modal } from "layout/modal";
 import { rethrowSimple } from "utils/simple-error";
 
 export async function save(pageId, content, showProgress = true) {
-    showProgress && show_modal(_l("Saving page"), _l("progress"));
+    showProgress && show_modal(localize("Saving page"), localize("progress"));
     try {
         const response = await axios
             .post(`${getAppRoot()}api/pages/${pageId}/revisions`, { content: content })

--- a/client/src/components/Panels/Buttons/FavoritesButton.vue
+++ b/client/src/components/Panels/Buttons/FavoritesButton.vue
@@ -16,6 +16,7 @@
 <script>
 import { mapState } from "pinia";
 import { useUserStore } from "@/stores/userStore";
+import { localize } from "@/utils/localization";
 
 export default {
     name: "FavoritesButton",
@@ -34,12 +35,12 @@ export default {
         ...mapState(useUserStore, ["isAnonymous"]),
         tooltipText() {
             if (this.isAnonymous) {
-                return this.l("Log in to Favorite Tools");
+                return localize("Log in to Favorite Tools");
             } else {
                 if (this.toggle) {
-                    return this.l("Clear");
+                    return localize("Clear");
                 } else {
-                    return this.l("Show favorites");
+                    return localize("Show favorites");
                 }
             }
         },

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -76,7 +76,7 @@ import PanelViewButton from "./Buttons/PanelViewButton";
 import { filterToolSections, filterTools, hasResults, hideToolsSection } from "./utilities";
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 export default {
     components: {
@@ -112,7 +112,7 @@ export default {
             showAdvanced: false,
             buttonText: "",
             buttonIcon: "",
-            titleSearchTools: _l("search tools"),
+            titleSearchTools: localize("search tools"),
         };
     },
     computed: {
@@ -141,7 +141,7 @@ export default {
             if (storedWorkflowMenuEntries) {
                 return [
                     {
-                        title: _l("All workflows"),
+                        title: localize("All workflows"),
                         href: `${getAppRoot()}workflows/list`,
                         id: "list",
                     },
@@ -189,7 +189,7 @@ export default {
             this.setButtonText();
         },
         setButtonText() {
-            this.buttonText = this.showSections ? _l("Hide Sections") : _l("Show Sections");
+            this.buttonText = this.showSections ? localize("Hide Sections") : localize("Show Sections");
             this.buttonIcon = this.showSections ? "fa fa-eye-slash" : "fa fa-eye";
         },
         updatePanelView(panelView) {

--- a/client/src/components/Panels/ToolBoxWorkflow.vue
+++ b/client/src/components/Panels/ToolBoxWorkflow.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import ToolSection from "./Common/ToolSection";
 import ToolSearch from "./Common/ToolSearch";
 import { filterToolSections, removeDisabledTools } from "./utilities";
@@ -129,7 +129,7 @@ export default {
         },
         workflowSection() {
             return {
-                name: _l("Workflows"),
+                name: localize("Workflows"),
                 elems: this.workflows,
             };
         },
@@ -138,7 +138,7 @@ export default {
         },
         dataManagerSection() {
             return {
-                name: _l("Data Managers"),
+                name: localize("Data Managers"),
                 elems: this.dataManagers,
             };
         },

--- a/client/src/components/RuleBuilder/ColumnSelector.vue
+++ b/client/src/components/RuleBuilder/ColumnSelector.vue
@@ -41,7 +41,7 @@
 
 <script>
 import Vue from "vue";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Select2 from "components/Select2";
 export default {
     components: {
@@ -54,7 +54,7 @@ export default {
         label: {
             required: false,
             type: String,
-            default: _l("From Column"),
+            default: localize("From Column"),
         },
         help: {
             required: false,
@@ -99,7 +99,7 @@ export default {
             return remaining;
         },
         title() {
-            return _l("Select a column");
+            return localize("Select a column");
         },
     },
     methods: {

--- a/client/src/components/RuleBuilder/IdentifierDisplay.vue
+++ b/client/src/components/RuleBuilder/IdentifierDisplay.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import RuleDefs from "./rule-definitions";
 const MAPPING_TARGETS = RuleDefs.MAPPING_TARGETS;
 
@@ -33,10 +33,10 @@ export default {
             return MAPPING_TARGETS[this.type].help || "";
         },
         titleEdit() {
-            return _l("Edit column definition");
+            return localize("Edit column definition");
         },
         titleRemove() {
-            return _l("Remove this column definition");
+            return localize("Remove this column definition");
         },
         columnsLabel() {
             return RuleDefs.columnDisplay(this.columns, this.colHeaders);

--- a/client/src/components/RuleBuilder/RegularExpressionInput.vue
+++ b/client/src/components/RuleBuilder/RegularExpressionInput.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 export default {
     props: {
@@ -24,16 +24,16 @@ export default {
     },
     computed: {
         label() {
-            return _l("Regular Expression");
+            return localize("Regular Expression");
         },
         title() {
-            return _l("Enter a regular expression.");
+            return localize("Enter a regular expression.");
         },
         popoverTitle() {
-            return _l("Regular Expressions");
+            return localize("Regular Expressions");
         },
         popoverContent() {
-            return _l(
+            return localize(
                 `Regular expressions are patterns used to match character combinations in strings. This input accepts Python-style regular expressions, find more information about these in <a href="https://pythonforbiologists.com/tutorial/regex.html">this Python for Biologists tutorial</a>.`
             );
         },

--- a/client/src/components/RuleBuilder/RuleComponent.vue
+++ b/client/src/components/RuleBuilder/RuleComponent.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 export default {
     props: {
@@ -23,8 +23,8 @@ export default {
     },
     data: function () {
         return {
-            applyLabel: _l("Apply"),
-            cancelLabel: _l("Cancel"),
+            applyLabel: localize("Apply"),
+            cancelLabel: localize("Cancel"),
         };
     },
     computed: {

--- a/client/src/components/RuleBuilder/RuleDisplay.vue
+++ b/client/src/components/RuleBuilder/RuleDisplay.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import RuleDefs from "./rule-definitions";
 const RULES = RuleDefs.RULES;
 
@@ -36,10 +36,10 @@ export default {
             return RULES[ruleType].display(this.rule, this.colHeaders);
         },
         editTitle() {
-            return _l("Edit this rule.");
+            return localize("Edit this rule.");
         },
         removeTitle() {
-            return _l("Remove this rule.");
+            return localize("Remove this rule.");
         },
     },
     methods: {

--- a/client/src/components/RuleBuilder/SavedRulesSelector.vue
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.vue
@@ -24,7 +24,7 @@
 
 <script>
 import Vue from "vue";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import BootstrapVue from "bootstrap-vue";
 import { RULES, MAPPING_TARGETS } from "./rule-definitions";
 import UtcDate from "components/UtcDate";
@@ -42,7 +42,7 @@ export default {
     },
     data: function () {
         return {
-            savedRulesMenu: _l("Recently used rules"),
+            savedRulesMenu: localize("Recently used rules"),
             // Get the 61 character values for ASCII 65 (A) to 126 (~), which is how handson table labels its columns
             // This ensures the handson table headers are available for passing to the display method in formatPreview
             hotHeaders: [...new Array(61).keys()].map((i) => String.fromCharCode(i + 65)),

--- a/client/src/components/RuleBuilder/rule-definitions.js
+++ b/client/src/components/RuleBuilder/rule-definitions.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import pyre from "pyre-to-regexp";
 
 const NEW_COLUMN = "new";
@@ -69,7 +69,7 @@ const flatMap = (f, xs) => {
 
 const RULES = {
     add_column_basename: {
-        title: _l("Basename of Path of URL"),
+        title: localize("Basename of Path of URL"),
         display: (rule, colHeaders) => {
             return `Add column using basename of column ${colHeaders[rule.target_column]}`;
         },
@@ -96,7 +96,7 @@ const RULES = {
         },
     },
     add_column_rownum: {
-        title: _l("Row Number"),
+        title: localize("Row Number"),
         display: (rule, colHeaders) => {
             return `Add column for the current row number.`;
         },
@@ -124,7 +124,7 @@ const RULES = {
         },
     },
     add_column_value: {
-        title: _l("Fixed Value"),
+        title: localize("Fixed Value"),
         display: (rule, colHeaders) => {
             return `Add column for the constant value of ${rule.value}.`;
         },
@@ -151,7 +151,7 @@ const RULES = {
         },
     },
     add_column_metadata: {
-        title: _l("Add Column from Metadata"),
+        title: localize("Add Column from Metadata"),
         display: (rule, colHeaders) => {
             return `Add column for ${rule.value}.`;
         },
@@ -198,7 +198,7 @@ const RULES = {
         },
     },
     add_column_group_tag_value: {
-        title: _l("Add Column from Group Tag Value"),
+        title: localize("Add Column from Group Tag Value"),
         display: (rule, colHeaders) => {
             return `Add column for value of group tag ${rule.value}.`;
         },
@@ -239,7 +239,7 @@ const RULES = {
         },
     },
     add_column_regex: {
-        title: _l("Using a Regular Expression"),
+        title: localize("Using a Regular Expression"),
         display: (rule, colHeaders) => {
             return `Add new column using ${rule.expression} applied to column ${colHeaders[rule.target_column]}`;
         },
@@ -292,7 +292,7 @@ const RULES = {
         },
     },
     add_column_concatenate: {
-        title: _l("Concatenate Columns"),
+        title: localize("Concatenate Columns"),
         display: (rule, colHeaders) => {
             return `Concatenate column ${colHeaders[rule.target_column_0]} and column ${
                 colHeaders[rule.target_column_1]
@@ -325,7 +325,7 @@ const RULES = {
         },
     },
     add_column_substr: {
-        title: _l("Keep or Trim Prefix or Suffix"),
+        title: localize("Keep or Trim Prefix or Suffix"),
         display: (rule, colHeaders) => {
             const type = rule.substr_type;
             let display;
@@ -393,7 +393,7 @@ const RULES = {
         },
     },
     remove_columns: {
-        title: _l("Remove Column(s)"),
+        title: localize("Remove Column(s)"),
         display: (rule, colHeaders) => {
             const targetColumns = rule.target_columns;
             return `Remove ${multiColumnsToString(targetColumns, colHeaders)}`;
@@ -425,7 +425,7 @@ const RULES = {
         },
     },
     add_filter_regex: {
-        title: _l("Using a Regular Expression"),
+        title: localize("Using a Regular Expression"),
         display: (rule, colHeaders) => {
             return `Filter rows using regular expression ${rule.expression} on column ${
                 colHeaders[rule.target_column]
@@ -467,7 +467,7 @@ const RULES = {
         },
     },
     add_filter_count: {
-        title: _l("First or Last N Rows"),
+        title: localize("First or Last N Rows"),
         display: (rule, colHeaders) => {
             const which = rule.which;
             const invert = rule.invert;
@@ -517,7 +517,7 @@ const RULES = {
         },
     },
     add_filter_empty: {
-        title: _l("On Emptiness"),
+        title: localize("On Emptiness"),
         display: (rule, colHeaders) => {
             return `Filter rows if no value for column ${colHeaders[rule.target_column]}`;
         },
@@ -547,7 +547,7 @@ const RULES = {
         },
     },
     add_filter_matches: {
-        title: _l("Matching a Supplied Value"),
+        title: localize("Matching a Supplied Value"),
         display: (rule, colHeaders) => {
             return `Filter rows with value ${rule.value} for column ${colHeaders[rule.target_column]}`;
         },
@@ -581,7 +581,7 @@ const RULES = {
         },
     },
     add_filter_compare: {
-        title: _l("By Comparing to a Numeric Value"),
+        title: localize("By Comparing to a Numeric Value"),
         display: (rule, colHeaders) => {
             return `Filter rows with value ${rule.compare_type} ${rule.value} for column ${
                 colHeaders[rule.target_column]
@@ -628,7 +628,7 @@ const RULES = {
         },
     },
     sort: {
-        title: _l("Sort"),
+        title: localize("Sort"),
         display: (rule, colHeaders) => {
             return `Sort on column ${colHeaders[rule.target_column]}`;
         },
@@ -681,7 +681,7 @@ const RULES = {
         },
     },
     swap_columns: {
-        title: _l("Swap Column(s)"),
+        title: localize("Swap Column(s)"),
         display: (rule, colHeaders) => {
             return `Swap ${multiColumnsToString([rule.target_column_0, rule.target_column_1], colHeaders)}`;
         },
@@ -715,7 +715,7 @@ const RULES = {
         },
     },
     split_columns: {
-        title: _l("Split Column(s)"),
+        title: localize("Split Column(s)"),
         display: (rule, colHeaders) => {
             return `Duplicate each row and split up columns`;
         },
@@ -763,87 +763,87 @@ const RULES = {
 const MAPPING_TARGETS = {
     list_identifiers: {
         multiple: true,
-        label: _l("List Identifier(s)"),
-        columnHeader: _l("List Identifier"),
-        help: _l(
+        label: localize("List Identifier(s)"),
+        columnHeader: localize("List Identifier"),
+        help: localize(
             "This should be a short description of the replicate, sample name, condition, etc... that describes each level of the list structure."
         ),
         importType: "collections",
     },
     paired_identifier: {
-        label: _l("Paired-end Indicator"),
-        columnHeader: _l("Paired Indicator"),
-        help: _l(
+        label: localize("Paired-end Indicator"),
+        columnHeader: localize("Paired Indicator"),
+        help: localize(
             "This should be set to '1', 'R1', 'forward', 'f', or 'F' to indicate forward reads, and '2', 'r', 'reverse', 'R2', 'R', or 'R2' to indicate reverse reads."
         ),
         importType: "collections",
     },
     collection_name: {
-        label: _l("Collection Name"),
-        help: _l(
+        label: localize("Collection Name"),
+        help: localize(
             "If this is set, all rows with the same collection name will be joined into a collection and it is possible to create multiple collections at once."
         ),
         modes: ["raw", "ftp", "datasets", "library_datasets"],
         importType: "collections",
     },
     name_tag: {
-        label: _l("Name Tag"),
-        help: _l("Add a name tag or hash tag based on the specified column value for imported datasets."),
+        label: localize("Name Tag"),
+        help: localize("Add a name tag or hash tag based on the specified column value for imported datasets."),
         importType: "datasets",
         modes: ["raw", "ftp"],
     },
     tags: {
         multiple: true,
-        label: _l("General Purpose Tag(s)"),
-        help: _l(
+        label: localize("General Purpose Tag(s)"),
+        help: localize(
             "Add a general purpose tag based on the specified column value, use : to separate key-value pairs if desired. These tags are not propagated to derived datasets the way name and group tags are."
         ),
         modes: ["raw", "ftp", "datasets", "library_datasets", "collection_contents"],
     },
     group_tags: {
         multiple: true,
-        label: _l("Group Tag(s)"),
-        help: _l(
+        label: localize("Group Tag(s)"),
+        help: localize(
             "Add a group tag based on the specified column value, use : to separate key-value pairs. These tags are propagated to derived datasets and may be useful for factorial experiments."
         ),
         modes: ["raw", "ftp", "datasets", "library_datasets", "collection_contents"],
     },
     name: {
-        label: _l("Name"),
+        label: localize("Name"),
         importType: "datasets",
     },
     dbkey: {
-        label: _l("Genome"),
+        label: localize("Genome"),
         modes: ["raw", "ftp"],
     },
     file_type: {
-        label: _l("Type"),
+        label: localize("Type"),
         modes: ["raw", "ftp"],
-        help: _l("This should be the Galaxy file type corresponding to this file."),
+        help: localize("This should be the Galaxy file type corresponding to this file."),
     },
     url: {
-        label: _l("URL"),
+        label: localize("URL"),
         modes: ["raw"],
-        help: _l("This should be a URL (or Galaxy-aware URI) the file can be downloaded from."),
+        help: localize("This should be a URL (or Galaxy-aware URI) the file can be downloaded from."),
     },
     url_deferred: {
-        label: _l("Deferred URL"),
+        label: localize("Deferred URL"),
         modes: ["raw"],
-        help: _l(
+        help: localize(
             "This should be a URL (or Galaxy-aware URI) th efile can be downloaded from - the file will not be downloaded until it used by a tool."
         ),
     },
     info: {
-        label: _l("Info"),
-        help: _l(
+        label: localize("Info"),
+        help: localize(
             "Unstructured text associated with the dataset that shows up in the history panel, this is optional and can be whatever you would like."
         ),
         modes: ["raw", "ftp"],
     },
     ftp_path: {
-        label: _l("FTP Path"),
+        label: localize("FTP Path"),
         modes: ["raw", "ftp"],
-        help: _l(
+        help: localize(
             "This should be the path to the target file to include relative to your FTP directory on the Galaxy server"
         ),
         requiresFtp: true,
@@ -887,7 +887,7 @@ const applyRules = function (data, sources, columns, rules, headersPerRule = [])
         rule.error = null;
         rule.warn = null;
         if (hasRuleError) {
-            rule.warn = _l("Skipped due to previous errors.");
+            rule.warn = localize("Skipped due to previous errors.");
             continue;
         }
         var ruleType = rule.type;

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -581,7 +581,7 @@ import _ from "underscore";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import axios from "axios";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { refreshContentsWrapper } from "utils/data";
 import HotTable from "@handsontable/vue";
 import UploadUtils from "mvc/upload/upload-utils";
@@ -760,26 +760,28 @@ export default {
             errorMessage: "",
             jaggedData: false,
             waitingJobState: "new",
-            titleReset: _l("Undo all reordering and discards"),
-            titleNumericSort: _l(
+            titleReset: localize("Undo all reordering and discards"),
+            titleNumericSort: localize(
                 "By default columns will be sorted lexicographically, check this option if the columns are numeric values and should be sorted as numbers"
             ),
-            titleInvertFilterRegex: _l("Remove rows not matching the specified regular expression at specified column"),
-            titleInvertFilterEmpty: _l("Remove rows that have non-empty values at specified column"),
-            titleInvertFilterMatches: _l("Remove rows matching supplied value"),
-            titleViewSource: _l(
+            titleInvertFilterRegex: localize(
+                "Remove rows not matching the specified regular expression at specified column"
+            ),
+            titleInvertFilterEmpty: localize("Remove rows that have non-empty values at specified column"),
+            titleInvertFilterMatches: localize("Remove rows matching supplied value"),
+            titleViewSource: localize(
                 "Advanced Option: View and or edit the JSON representation of the rules to apply to this tabular data"
             ),
-            titleSourceCancel: _l("Stop editing rules and dismiss changes"),
-            titleSourceReset: _l("Reset text area to current set of rules"),
-            titleSourceApply: _l("Apply changes to rule source and return to rule preview"),
-            titleRulesMenu: _l("General rules to apply"),
-            titleFilterMenu: _l("Rules that filter rows from the data"),
-            titleColumMenu: _l("Rules that generate new columns"),
-            titleRemoveMapping: _l("Remove column definition assignment"),
-            titleApplyColumnDefinitions: _l("Apply these column definitions and return to rules preview"),
-            titleErrorOkay: _l("Dismiss this error and return to the rule builder to try again with new rules"),
-            namePlaceholder: _l("Enter a name for your new collection"),
+            titleSourceCancel: localize("Stop editing rules and dismiss changes"),
+            titleSourceReset: localize("Reset text area to current set of rules"),
+            titleSourceApply: localize("Apply changes to rule source and return to rule preview"),
+            titleRulesMenu: localize("General rules to apply"),
+            titleFilterMenu: localize("Rules that filter rows from the data"),
+            titleColumMenu: localize("Rules that generate new columns"),
+            titleRemoveMapping: localize("Remove column definition assignment"),
+            titleApplyColumnDefinitions: localize("Apply these column definitions and return to rules preview"),
+            titleErrorOkay: localize("Dismiss this error and return to the rule builder to try again with new rules"),
+            namePlaceholder: localize("Enter a name for your new collection"),
             activeRuleIndex: null,
             addColumnRegexTarget: 0,
             addColumnBasenameTarget: 0,
@@ -827,7 +829,7 @@ export default {
             hideSourceItems: this.defaultHideSourceItems,
             addNameTag: false,
             orientation: orientation,
-            validityErrorHeader: _l("These issues must be resolved to proceed:"),
+            validityErrorHeader: localize("These issues must be resolved to proceed:"),
         };
     },
     computed: {
@@ -860,29 +862,29 @@ export default {
         },
         titleFinish() {
             if (this.validityErrorMessages.length != 0) {
-                return _l("Button is disabled due to validation errors. Please see alerts above.");
+                return localize("Button is disabled due to validation errors. Please see alerts above.");
             } else if (this.elementsType == "datasets" || this.elementsType == "library_datasets") {
-                return _l("Create new collection from specified rules and datasets");
+                return localize("Create new collection from specified rules and datasets");
             } else if (this.elementsType == "collection_contents") {
-                return _l("Save rules and return to tool form");
+                return localize("Save rules and return to tool form");
             } else {
-                return _l("Upload collection using specified rules");
+                return localize("Upload collection using specified rules");
             }
         },
         titleCancel() {
             if (this.importType == "datasets") {
-                return _l("Close this modal and do not upload any datasets");
+                return localize("Close this modal and do not upload any datasets");
             } else {
-                return _l("Close this modal and do not create any collections");
+                return localize("Close this modal and do not create any collections");
             }
         },
         finishButtonTitle() {
             if (this.elementsType == "datasets" || this.elementsType == "library_datasets") {
-                return _l("Create");
+                return localize("Create");
             } else if (this.elementsType == "collection_contents") {
-                return _l("Save");
+                return localize("Save");
             } else {
-                return _l("Upload");
+                return localize("Upload");
             }
         },
         hasActiveMappingEdit() {
@@ -982,22 +984,22 @@ export default {
                     const collectionTypeRank = collectionTypeRanks[index];
                     if (collectionTypeRank == "list") {
                         // TODO: drop the numeral at the end if only flat list
-                        metadataOptions["identifier" + index] = _l("List Identifier ") + (parseInt(index) + 1);
+                        metadataOptions["identifier" + index] = localize("List Identifier ") + (parseInt(index) + 1);
                     } else {
-                        metadataOptions["identifier" + index] = _l("Paired Identifier");
+                        metadataOptions["identifier" + index] = localize("Paired Identifier");
                     }
                 }
-                metadataOptions["tags"] = _l("Tags");
+                metadataOptions["tags"] = localize("Tags");
             } else if (this.elementsType == "ftp") {
-                metadataOptions["path"] = _l("Path");
+                metadataOptions["path"] = localize("Path");
             } else if (this.elementsType == "remote_files") {
-                metadataOptions["url"] = _l("URL");
-                metadataOptions["url_deferred"] = _l("URL (deferred)");
+                metadataOptions["url"] = localize("URL");
+                metadataOptions["url_deferred"] = localize("URL (deferred)");
             } else if (this.elementsType == "library_datasets") {
-                metadataOptions["name"] = _l("Name");
+                metadataOptions["name"] = localize("Name");
             } else if (this.elementsType == "datasets") {
-                metadataOptions["hid"] = _l("History ID (hid)");
-                metadataOptions["name"] = _l("Name");
+                metadataOptions["hid"] = localize("History ID (hid)");
+                metadataOptions["name"] = localize("Name");
             } else {
                 metadataOptions = null;
             }
@@ -1227,7 +1229,7 @@ export default {
         },
         l(str) {
             // _l conflicts private methods of Vue internals, expose as l instead
-            return _l(str);
+            return localize(str);
         },
         cancel() {
             this.oncancel();

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -9,7 +9,7 @@
                 <div v-if="showEntryPoints">
                     <ToolEntryPoints v-for="job in entryPoints" :key="job.id" :job-id="job.id" />
                 </div>
-                <b-modal v-model="showError" size="sm" :title="errorTitle | l" scrollable ok-only>
+                <b-modal v-model="showError" size="sm" :title="errorTitle | localize" scrollable ok-only>
                     <b-alert v-if="errorMessage" show variant="danger">
                         {{ errorMessage }}
                     </b-alert>

--- a/client/src/components/Toolshed/Index.vue
+++ b/client/src/components/Toolshed/Index.vue
@@ -27,7 +27,7 @@
     </div>
 </template>
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import SearchList from "./SearchList/Index.vue";
 import InstalledList from "./InstalledList/Index.vue";
 
@@ -52,7 +52,7 @@ export default {
                 { text: "Search All", value: true },
                 { text: "Installed Only", value: false },
             ],
-            titleClearSearch: _l("clear search (esc)"),
+            titleClearSearch: localize("clear search (esc)"),
         };
     },
     computed: {

--- a/client/src/components/Tour/TourList.vue
+++ b/client/src/components/Tour/TourList.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { getAppRoot } from "onload/loadConfig";
 import { urlData } from "utils/url";
 import DelayedInput from "components/Common/DelayedInput";
@@ -42,7 +42,7 @@ export default {
             tours: [],
             search: "",
             error: null,
-            searchTours: _l("search tours"),
+            searchTours: localize("search tours"),
         };
     },
     created() {

--- a/client/src/components/Upload/Collection.vue
+++ b/client/src/components/Upload/Collection.vue
@@ -117,7 +117,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import _ from "underscore";
 import { getGalaxyInstance } from "app";
 import { refreshContentsWrapper } from "utils/data";
@@ -153,13 +153,13 @@ export default {
             enableBuild: false,
             highlightBox: false,
             rowUploadModel: UploadRow,
-            btnLocalTitle: _l("Choose local files"),
-            btnCreateTitle: _l("Paste/Fetch data"),
-            btnFtpTitle: _l("Choose FTP files"),
-            btnStartTitle: _l("Start"),
-            btnBuildTitle: _l("Build"),
-            btnStopTitle: _l("Pause"),
-            btnResetTitle: _l("Reset"),
+            btnLocalTitle: localize("Choose local files"),
+            btnCreateTitle: localize("Paste/Fetch data"),
+            btnFtpTitle: localize("Choose FTP files"),
+            btnStartTitle: localize("Start"),
+            btnBuildTitle: localize("Build"),
+            btnStopTitle: localize("Pause"),
+            btnResetTitle: localize("Reset"),
         };
     },
     computed: {

--- a/client/src/components/Upload/Composite.vue
+++ b/client/src/components/Upload/Composite.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import _ from "underscore";
 import { refreshContentsWrapper } from "utils/data";
 import UploadRow from "mvc/upload/composite/composite-row";
@@ -77,8 +77,8 @@ export default {
             listGenomes: [],
             running: false,
             showHelper: true,
-            btnResetTitle: _l("Reset"),
-            btnStartTitle: _l("Start"),
+            btnResetTitle: localize("Reset"),
+            btnStartTitle: localize("Start"),
             readyStart: false,
         };
     },

--- a/client/src/components/Upload/Default.vue
+++ b/client/src/components/Upload/Default.vue
@@ -101,7 +101,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import _ from "underscore";
 import UploadRow from "mvc/upload/default/default-row";
 import UploadBoxMixin from "./UploadBoxMixin";
@@ -138,11 +138,11 @@ export default {
             enableReset: false,
             enableStart: false,
             enableSources: false,
-            btnLocalTitle: _l("Choose local files"),
-            btnCreateTitle: _l("Paste/Fetch data"),
-            btnStartTitle: _l("Start"),
-            btnStopTitle: _l("Pause"),
-            btnResetTitle: _l("Reset"),
+            btnLocalTitle: localize("Choose local files"),
+            btnCreateTitle: localize("Paste/Fetch data"),
+            btnStartTitle: localize("Start"),
+            btnStopTitle: localize("Pause"),
+            btnResetTitle: localize("Reset"),
         };
     },
     computed: {

--- a/client/src/components/Upload/RulesInput.vue
+++ b/client/src/components/Upload/RulesInput.vue
@@ -1,8 +1,8 @@
 <template>
-    <upload-wrapper ref="wrapper" :top-info="topInfo | l">
+    <upload-wrapper ref="wrapper" :top-info="topInfo | localize">
         <span style="width: 25%; display: inline; height: 100%" class="float-left">
             <div class="upload-rule-option">
-                <div class="upload-rule-option-title">{{ "Upload data as" | l }}</div>
+                <div class="upload-rule-option-title">{{ "Upload data as" | localize }}</div>
                 <div class="rule-data-type">
                     <select2 v-model="dataType" container-class="upload-footer-selection">
                         <option value="datasets">Datasets</option>
@@ -11,13 +11,13 @@
                 </div>
             </div>
             <div class="upload-rule-option">
-                <div class="upload-rule-option-title">{{ "Load tabular data from" | l }}</div>
+                <div class="upload-rule-option-title">{{ "Load tabular data from" | localize }}</div>
                 <div class="rule-select-type">
                     <select2 v-model="selectionType" container-class="upload-footer-selection">
-                        <option value="paste">{{ "Pasted Table" | l }}</option>
-                        <option value="dataset">{{ "History Dataset" | l }}</option>
-                        <option v-if="ftpUploadSite" value="ftp">{{ "FTP Directory" | l }}</option>
-                        <option value="remote_files">{{ "Remote Files Directory" | l }}</option>
+                        <option value="paste">{{ "Pasted Table" | localize }}</option>
+                        <option value="dataset">{{ "History Dataset" | localize }}</option>
+                        <option v-if="ftpUploadSite" value="ftp">{{ "FTP Directory" | localize }}</option>
+                        <option value="remote_files">{{ "Remote Files Directory" | localize }}</option>
                     </select2>
                 </div>
             </div>
@@ -25,7 +25,7 @@
                 <div class="upload-rule-option-title">History dataset</div>
                 <div>
                     <b-link v-if="selectedDatasetName == null" @click="onSelectDataset">
-                        {{ "Select" | l }}
+                        {{ "Select" | localize }}
                     </b-link>
                     <span v-else>
                         {{ selectedDatasetName }} <font-awesome-icon icon="edit" @click="onSelectDataset" />
@@ -47,7 +47,7 @@
                 class="ui-button-default"
                 :title="btnCloseTitle"
                 @click="$emit('dismiss')">
-                {{ btnCloseTitle | l }}
+                {{ btnCloseTitle | localize }}
             </b-button>
             <b-button
                 id="btn-build"
@@ -57,7 +57,7 @@
                 :title="btnBuildTitle"
                 :variant="sourceContent ? 'primary' : ''"
                 @click="_eventBuild">
-                {{ btnBuildTitle | l }}
+                {{ btnBuildTitle | localize }}
             </b-button>
             <b-button
                 id="btn-reset"
@@ -66,7 +66,7 @@
                 :title="btnResetTitle"
                 :disabled="!enableReset"
                 @click="_eventReset">
-                {{ btnResetTitle | l }}
+                {{ btnResetTitle | localize }}
             </b-button>
         </template>
     </upload-wrapper>

--- a/client/src/components/Upload/UploadBoxMixin.js
+++ b/client/src/components/Upload/UploadBoxMixin.js
@@ -1,6 +1,6 @@
-import _l from "utils/localization";
 import $ from "jquery";
 import Select2 from "components/Select2";
+import { localize } from "utils/localization";
 import Popover from "mvc/ui/ui-popover";
 import UploadExtension from "mvc/upload/upload-extension";
 import UploadModel from "mvc/upload/upload-model";
@@ -13,8 +13,6 @@ import { filesDialog, refreshContentsWrapper } from "utils/data";
 import { getAppRoot } from "onload";
 import { UploadQueue } from "utils/uploadbox";
 import axios from "axios";
-
-const localize = _l;
 
 export default {
     components: {
@@ -335,7 +333,7 @@ export default {
         initFtpPopover() {
             // add ftp file viewer
             this.ftp = new Popover({
-                title: _l("FTP files"),
+                title: localize("FTP files"),
                 class: "ftp-upload",
                 container: $(this.$refs.btnFtp),
             });

--- a/client/src/components/User/DiskUsage/DiskUsageSummary.vue
+++ b/client/src/components/User/DiskUsage/DiskUsageSummary.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { mapActions, mapState } from "pinia";
 import { useUserStore } from "@/stores/userStore";
 import { bytesToString } from "utils/utils";
@@ -58,7 +58,7 @@ export default {
     },
     data() {
         return {
-            errorMessageTitle: _l("Failed to access disk usage details."),
+            errorMessageTitle: localize("Failed to access disk usage details."),
             errorMessage: null,
             isRecalculating: false,
             dismissCountDown: 0,

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -117,7 +117,7 @@ import BootstrapVue from "bootstrap-vue";
 import ThemeSelector from "./ThemeSelector.vue";
 import { getGalaxyInstance } from "app";
 import { withPrefix } from "utils/redirect";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import axios from "axios";
 import QueryStringParsing from "utils/query-string-parsing";
 import { getUserPreferencesModel } from "components/User/UserPreferencesModel";
@@ -212,7 +212,7 @@ export default {
             const Galaxy = getGalaxyInstance();
             if (
                 confirm(
-                    _l(
+                    localize(
                         "WARNING: This will make all datasets (excluding library datasets) for which you have " +
                             "'management' permissions, in all of your histories " +
                             "private, and will set permissions such that all " +
@@ -225,7 +225,7 @@ export default {
             ) {
                 axios.post(withPrefix(`/history/make_private?all_histories=true`)).then((response) => {
                     Galaxy.modal.show({
-                        title: _l("Datasets are now private"),
+                        title: localize("Datasets are now private"),
                         body: `All of your histories and datsets have been made private.  If you'd like to make all *future* histories private please use the <a href="${withPrefix(
                             "/user/permissions"
                         )}">User Permissions</a> interface.`,
@@ -241,7 +241,7 @@ export default {
         signOut() {
             const Galaxy = getGalaxyInstance();
             Galaxy.modal.show({
-                title: _l("Sign out"),
+                title: localize("Sign out"),
                 body: "Do you want to continue and sign out of all active sessions?",
                 buttons: {
                     Cancel: function () {

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -1,5 +1,5 @@
 import { getGalaxyInstance } from "app";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 export const getUserPreferencesModel = (user_id) => {
     const Galaxy = getGalaxyInstance();
@@ -7,20 +7,20 @@ export const getUserPreferencesModel = (user_id) => {
     user_id = user_id || Galaxy.user.id;
     return {
         information: {
-            title: _l("Manage Information"),
+            title: localize("Manage Information"),
             id: "edit-preferences-information",
             description: config.enable_account_interface
-                ? _l("Edit your email, addresses and custom parameters or change your public name.")
-                : _l("Edit your custom parameters."),
+                ? localize("Edit your email, addresses and custom parameters or change your public name.")
+                : localize("Edit your custom parameters."),
             url: `/api/users/${user_id}/information/inputs`,
             icon: "fa-user",
             redirect: "/user",
             disabled: config.use_remote_user,
         },
         password: {
-            title: _l("Change Password"),
+            title: localize("Change Password"),
             id: "edit-preferences-password",
-            description: _l("Allows you to change your login credentials."),
+            description: localize("Allows you to change your login credentials."),
             icon: "fa-unlock-alt",
             url: `/api/users/${user_id}/password/inputs`,
             submit_title: "Save Password",
@@ -28,9 +28,9 @@ export const getUserPreferencesModel = (user_id) => {
             disabled: config.use_remote_user || !config.enable_account_interface,
         },
         permissions: {
-            title: _l("Set Dataset Permissions for New Histories"),
+            title: localize("Set Dataset Permissions for New Histories"),
             id: "edit-preferences-permissions",
-            description: _l(
+            description: localize(
                 "Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored."
             ),
             url: `/api/users/${user_id}/permissions/inputs`,
@@ -40,9 +40,9 @@ export const getUserPreferencesModel = (user_id) => {
             disabled: config.single_user,
         },
         toolbox_filters: {
-            title: _l("Manage Toolbox Filters"),
+            title: localize("Manage Toolbox Filters"),
             id: "edit-preferences-toolbox-filters",
-            description: _l("Customize your Toolbox by displaying or omitting sets of Tools."),
+            description: localize("Customize your Toolbox by displaying or omitting sets of Tools."),
             url: `/api/users/${user_id}/toolbox_filters/inputs`,
             icon: "fa-filter",
             submitTitle: "Save Filters",

--- a/client/src/components/Visualizations/PluginList.vue
+++ b/client/src/components/Visualizations/PluginList.vue
@@ -53,7 +53,7 @@
     </div>
 </template>
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import axios from "axios";
@@ -78,9 +78,9 @@ export default {
             name: null,
             error: null,
             fixed: false,
-            titleSearchVisualizations: _l("search visualizations"),
-            titleCreateVisualization: _l("Create Visualization"),
-            titleSelectDataset: _l("Select a dataset to visualize:"),
+            titleSearchVisualizations: localize("search visualizations"),
+            titleCreateVisualization: localize("Create Visualization"),
+            titleSelectDataset: localize("Select a dataset to visualize:"),
         };
     },
     created() {

--- a/client/src/components/Workflow/Editor/Recommendations.vue
+++ b/client/src/components/Workflow/Editor/Recommendations.vue
@@ -21,7 +21,7 @@
 import { getToolPredictions } from "./modules/services";
 import { getCompatibleRecommendations } from "./modules/utilities";
 import LoadingSpan from "components/LoadingSpan";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 
 export default {
@@ -46,8 +46,8 @@ export default {
         return {
             compatibleTools: [],
             isDeprecated: false,
-            popoverHeaderText: _l("Tool recommendations"),
-            noRecommendationsMessage: _l("No tool recommendations"),
+            popoverHeaderText: localize("Tool recommendations"),
+            noRecommendationsMessage: localize("No tool recommendations"),
             deprecatedMessage: "",
             showLoading: true,
         };

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -84,7 +84,7 @@
     </div>
 </template>
 <script>
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { Services } from "./services";
 import { getAppRoot } from "onload/loadConfig";
 import { storedWorkflowsProvider } from "components/providers/StoredWorkflowsProvider";
@@ -176,26 +176,26 @@ export default {
             fields: [
                 {
                     key: "name",
-                    label: _l("Name"),
+                    label: localize("Name"),
                     sortable: true,
                 },
                 {
                     key: "tags",
-                    label: _l("Tags"),
+                    label: localize("Tags"),
                     sortable: false,
                 },
                 {
-                    label: _l("Updated"),
+                    label: localize("Updated"),
                     key: "update_time",
                     sortable: true,
                 },
                 {
-                    label: _l("Sharing"),
+                    label: localize("Sharing"),
                     key: "published",
                     sortable: false,
                 },
                 {
-                    label: _l("Bookmarked"),
+                    label: localize("Bookmarked"),
                     key: "show_in_tool_panel",
                     sortable: false,
                 },
@@ -204,7 +204,7 @@ export default {
                     label: "",
                 },
             ],
-            titleSearch: _l("Search Workflows"),
+            titleSearch: localize("Search Workflows"),
             workflowItemsModel: [],
             workflowItems: [],
             helpHtml: helpHtml,

--- a/client/src/components/plugins/localization.js
+++ b/client/src/components/plugins/localization.js
@@ -2,7 +2,7 @@
  * Makes localization directives and filters available
  */
 
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 
 const newlineMatch = /\r?\n|\r/g;
 const doublespaces = /\s\s+/g;

--- a/client/src/components/plugins/localization.js
+++ b/client/src/components/plugins/localization.js
@@ -24,7 +24,7 @@ function localizeDirective(localize) {
 
 export const localizationPlugin = {
     install(Vue, l = localize) {
-        Vue.filter("localize", l)
+        Vue.filter("localize", l);
         Vue.directive("localize", localizeDirective(l));
     },
 };

--- a/client/src/components/plugins/localization.js
+++ b/client/src/components/plugins/localization.js
@@ -7,7 +7,7 @@ import { localize } from "utils/localization";
 const newlineMatch = /\r?\n|\r/g;
 const doublespaces = /\s\s+/g;
 
-function localizeDirective(l) {
+function localizeDirective(localize) {
     return {
         // TODO consider using a different hook if we need dynamic updates in content translation
         bind(el, binding, vnode) {
@@ -16,27 +16,14 @@ function localizeDirective(l) {
                     .replace(newlineMatch, " ")
                     .replace(doublespaces, " ")
                     .trim();
-                node.textContent = l(standardizedContent);
+                node.textContent = localize(standardizedContent);
             });
         },
     };
 }
 
-// adds localizeText mixin
-function localizeMixin(l) {
-    return {
-        methods: {
-            l: l,
-            localize: l,
-        },
-    };
-}
-
 export const localizationPlugin = {
-    install(Vue, l = _l) {
-        Vue.filter("localize", l);
-        Vue.filter("l", l);
-        Vue.directive("localize", localizeDirective(l));
-        Vue.mixin(localizeMixin(l));
+    install(Vue, localize = localize) {
+        Vue.directive("localize", localizeDirective(localize));
     },
 };

--- a/client/src/components/plugins/localization.js
+++ b/client/src/components/plugins/localization.js
@@ -23,7 +23,8 @@ function localizeDirective(localize) {
 }
 
 export const localizationPlugin = {
-    install(Vue, localize = localize) {
-        Vue.directive("localize", localizeDirective(localize));
+    install(Vue, l = localize) {
+        Vue.filter("localize", l)
+        Vue.directive("localize", localizeDirective(l));
     },
 };

--- a/client/src/entry/analysis/menu.js
+++ b/client/src/entry/analysis/menu.js
@@ -1,5 +1,5 @@
 import { getGalaxyInstance } from "app";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { userLogout } from "utils/logout";
 import { useUserStore } from "@/stores/userStore";
 
@@ -13,7 +13,7 @@ export function fetchMenu(options = {}) {
     menu.push({
         id: "analysis",
         url: "/",
-        tooltip: _l("Tools and Current History"),
+        tooltip: localize("Tools and Current History"),
         icon: "fa-home",
         target: "_top",
     });
@@ -23,8 +23,8 @@ export function fetchMenu(options = {}) {
     //
     menu.push({
         id: "workflow",
-        title: _l("Workflow"),
-        tooltip: _l("Chain tools into workflows"),
+        title: localize("Workflow"),
+        tooltip: localize("Chain tools into workflows"),
         disabled: !Galaxy.user.id,
         url: "/workflows/list",
     });
@@ -35,8 +35,8 @@ export function fetchMenu(options = {}) {
     if (Galaxy.config.visualizations_visible) {
         menu.push({
             id: "visualization",
-            title: _l("Visualize"),
-            tooltip: _l("Visualize datasets"),
+            title: localize("Visualize"),
+            tooltip: localize("Visualize datasets"),
             disabled: !Galaxy.user.id,
             url: "/visualizations",
         });
@@ -50,36 +50,36 @@ export function fetchMenu(options = {}) {
         // functionality as a representation for external data.  The rest is
         // hidden though.
         menu.push({
-            title: _l("Data Libraries"),
+            title: localize("Data Libraries"),
             url: "/libraries",
             id: "libraries",
         });
     } else {
         menu.push({
             id: "shared",
-            title: _l("Shared Data"),
+            title: localize("Shared Data"),
             url: "javascript:void(0)",
-            tooltip: _l("Access published resources"),
+            tooltip: localize("Access published resources"),
             menu: [
                 {
-                    title: _l("Data Libraries"),
+                    title: localize("Data Libraries"),
                     url: "/libraries",
                     target: "_top",
                 },
                 {
-                    title: _l("Histories"),
+                    title: localize("Histories"),
                     url: "/histories/list_published",
                 },
                 {
-                    title: _l("Workflows"),
+                    title: localize("Workflows"),
                     url: "/workflows/list_published",
                 },
                 {
-                    title: _l("Visualizations"),
+                    title: localize("Visualizations"),
                     url: "/visualizations/list_published",
                 },
                 {
-                    title: _l("Pages"),
+                    title: localize("Pages"),
                     url: "/pages/list_published",
                 },
             ],
@@ -92,9 +92,9 @@ export function fetchMenu(options = {}) {
     if (Galaxy.user.get("is_admin")) {
         menu.push({
             id: "admin",
-            title: _l("Admin"),
+            title: localize("Admin"),
             url: "/admin",
-            tooltip: _l("Administer this Galaxy"),
+            tooltip: localize("Administer this Galaxy"),
             cls: "admin-only",
             target: "_top",
         });
@@ -105,53 +105,53 @@ export function fetchMenu(options = {}) {
     //
     const helpTab = {
         id: "help",
-        title: _l("Help"),
+        title: localize("Help"),
         url: "javascript:void(0)",
-        tooltip: _l("Support, contact, and community"),
+        tooltip: localize("Support, contact, and community"),
         menu: [
             {
-                title: _l("Galaxy Help"),
+                title: localize("Galaxy Help"),
                 url: options.helpsite_url,
                 target: "_blank",
                 hidden: !options.helpsite_url,
             },
             {
-                title: _l("Support"),
+                title: localize("Support"),
                 url: options.support_url,
                 target: "_blank",
                 hidden: !options.support_url,
             },
             {
-                title: _l("Videos"),
+                title: localize("Videos"),
                 url: options.screencasts_url,
                 target: "_blank",
                 hidden: !options.screencasts_url,
             },
             {
-                title: _l("Community Hub"),
+                title: localize("Community Hub"),
                 url: options.wiki_url,
                 target: "_blank",
                 hidden: !options.wiki_url,
             },
             {
-                title: _l("How to Cite Galaxy"),
+                title: localize("How to Cite Galaxy"),
                 url: options.citation_url,
                 target: "_blank",
             },
             {
-                title: _l("Interactive Tours"),
+                title: localize("Interactive Tours"),
                 url: "/tours",
             },
             {
-                title: _l("Introduction to Galaxy"),
+                title: localize("Introduction to Galaxy"),
                 url: "/welcome/new",
             },
             {
-                title: _l("About"),
+                title: localize("About"),
                 url: "/about",
             },
             {
-                title: _l("Terms and Conditions"),
+                title: localize("Terms and Conditions"),
                 url: options.terms_url,
                 target: "_blank",
                 hidden: !options.terms_url,
@@ -168,18 +168,18 @@ export function fetchMenu(options = {}) {
         if (options.allow_user_creation) {
             userTab = {
                 id: "user",
-                title: _l("Login or Register"),
+                title: localize("Login or Register"),
                 cls: "loggedout-only",
                 url: "/login",
-                tooltip: _l("Log in or register a new account"),
+                tooltip: localize("Log in or register a new account"),
                 target: "_top",
             };
         } else {
             userTab = {
                 id: "user",
-                title: _l("Login"),
+                title: localize("Login"),
                 cls: "loggedout-only",
-                tooltip: _l("Login"),
+                tooltip: localize("Login"),
                 url: "/login",
                 target: "_top",
             };
@@ -187,67 +187,67 @@ export function fetchMenu(options = {}) {
     } else {
         userTab = {
             id: "user",
-            title: _l("User"),
+            title: localize("User"),
             cls: "loggedin-only",
             url: "javascript:void(0)",
-            tooltip: _l("Account and saved data"),
+            tooltip: localize("Account and saved data"),
             menu: [
                 {
-                    title: `${_l("Signed in as")} ${
+                    title: `${localize("Signed in as")} ${
                         Galaxy.user.get("username") ? Galaxy.user.get("username") : Galaxy.user.get("email")
                     }`,
                     disabled: true,
                 },
                 { divider: true },
                 {
-                    title: _l("Preferences"),
+                    title: localize("Preferences"),
                     url: "/user",
                 },
                 {
-                    title: _l("Show/Hide Activity Bar"),
+                    title: localize("Show/Hide Activity Bar"),
                     onclick: () => {
                         userStore.toggleActivityBar();
                     },
                 },
                 { divider: true },
                 {
-                    title: _l("Datasets"),
+                    title: localize("Datasets"),
                     url: "/datasets/list",
                 },
                 {
-                    title: _l("Histories"),
+                    title: localize("Histories"),
                     url: "/histories/list",
                 },
                 {
-                    title: _l("Histories shared with me"),
+                    title: localize("Histories shared with me"),
                     url: "/histories/list_shared",
                     hidden: Galaxy.config.single_user,
                 },
                 {
-                    title: _l("Pages"),
+                    title: localize("Pages"),
                     url: "/pages/list",
                 },
                 {
-                    title: _l("Workflow Invocations"),
+                    title: localize("Workflow Invocations"),
                     url: "/workflows/invocations",
                 },
             ],
         };
         if (Galaxy.config.visualizations_visible) {
             userTab.menu.push({
-                title: _l("Visualizations"),
+                title: localize("Visualizations"),
                 url: "/visualizations/list",
             });
         }
         if (Galaxy.config.interactivetools_enable) {
             userTab.menu.push({
-                title: _l("Active InteractiveTools"),
+                title: localize("Active InteractiveTools"),
                 url: "/interactivetool_entry_points/list",
             });
         }
         userTab.menu.push({ divider: true });
         userTab.menu.push({
-            title: _l("Sign Out"),
+            title: localize("Sign Out"),
             onclick: userLogout,
             hidden: Galaxy.config.single_user,
         });

--- a/client/src/layout/window-manager.js
+++ b/client/src/layout/window-manager.js
@@ -1,5 +1,5 @@
 /** Adds window manager masthead icon and functionality **/
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import WinBox from "winbox/src/js/winbox.js";
 import "winbox/dist/css/winbox.min.css";
 import { withPrefix } from "utils/redirect";
@@ -16,7 +16,7 @@ export class WindowManager {
         return {
             id: "enable-window-manager",
             icon: "fa-th",
-            tooltip: _l("Enable/Disable Window Manager"),
+            tooltip: localize("Enable/Disable Window Manager"),
             visible: true,
             onclick: () => {
                 this.active = !this.active;

--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -1,7 +1,7 @@
 import _ from "underscore";
 import $ from "jquery";
 import Backbone from "backbone";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Utils from "utils/utils";
 import Ui from "mvc/ui/ui-misc";
 import Select from "mvc/ui/ui-select-default";
@@ -16,7 +16,7 @@ const Configurations = {
         {
             src: "hda",
             icon: "fa-file-o",
-            tooltip: _l("Single dataset"),
+            tooltip: localize("Single dataset"),
             library: true,
             multiple: false,
             batch: Batch.DISABLED,
@@ -24,14 +24,14 @@ const Configurations = {
         {
             src: "hda",
             icon: "fa-files-o",
-            tooltip: _l("Multiple datasets"),
+            tooltip: localize("Multiple datasets"),
             multiple: true,
             batch: Batch.LINKED,
         },
         {
             src: "hdca",
             icon: "fa-folder-o",
-            tooltip: _l("Dataset collection"),
+            tooltip: localize("Dataset collection"),
             multiple: false,
             batch: Batch.LINKED,
         },
@@ -40,14 +40,14 @@ const Configurations = {
         {
             src: "hda",
             icon: "fa-files-o",
-            tooltip: _l("Multiple datasets"),
+            tooltip: localize("Multiple datasets"),
             multiple: true,
             batch: Batch.DISABLED,
         },
         {
             src: "hdca",
             icon: "fa-folder-o",
-            tooltip: _l("Dataset collections"),
+            tooltip: localize("Dataset collections"),
             multiple: true,
             batch: Batch.DISABLED,
         },
@@ -56,7 +56,7 @@ const Configurations = {
         {
             src: "hdca",
             icon: "fa-folder-o",
-            tooltip: _l("Dataset collection"),
+            tooltip: localize("Dataset collection"),
             multiple: false,
             batch: Batch.DISABLED,
         },
@@ -65,7 +65,7 @@ const Configurations = {
         {
             src: "hda",
             icon: "fa-file-o",
-            tooltip: _l("Single dataset"),
+            tooltip: localize("Single dataset"),
             multiple: false,
             batch: Batch.DISABLED,
         },
@@ -74,7 +74,7 @@ const Configurations = {
         {
             src: "hda",
             icon: "fa-files-o",
-            tooltip: _l("Multiple datasets"),
+            tooltip: localize("Multiple datasets"),
             multiple: true,
             batch: Batch.DISABLED,
         },
@@ -83,7 +83,7 @@ const Configurations = {
         {
             src: "hdca",
             icon: "fa-folder-o",
-            tooltip: _l("Dataset collection"),
+            tooltip: localize("Dataset collection"),
             multiple: false,
             batch: Batch.DISABLED,
         },
@@ -92,14 +92,14 @@ const Configurations = {
         {
             src: "hda",
             icon: "fa-file-o",
-            tooltip: _l("Single dataset"),
+            tooltip: localize("Single dataset"),
             multiple: false,
             batch: Batch.DISABLED,
         },
         {
             src: "hda",
             icon: "fa-files-o",
-            tooltip: _l("Multiple datasets"),
+            tooltip: localize("Multiple datasets"),
             multiple: true,
             batch: Batch.ENABLED,
         },
@@ -108,14 +108,14 @@ const Configurations = {
         {
             src: "hdca",
             icon: "fa-folder-o",
-            tooltip: _l("Dataset collection"),
+            tooltip: localize("Dataset collection"),
             multiple: false,
             batch: Batch.DISABLED,
         },
         {
             src: "hdca",
             icon: "fa-folder",
-            tooltip: _l("Multiple collections"),
+            tooltip: localize("Multiple collections"),
             multiple: true,
             batch: Batch.ENABLED,
         },

--- a/client/src/mvc/upload/composite/composite-row.js
+++ b/client/src/mvc/upload/composite/composite-row.js
@@ -2,7 +2,7 @@
 import $ from "jquery";
 import _ from "underscore";
 import Backbone from "backbone";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Utils from "utils/utils";
 import UploadSettings from "mvc/upload/upload-settings";
 import UploadFtp from "mvc/upload/upload-ftp";
@@ -61,13 +61,13 @@ export default Backbone.View.extend({
         // source selection popup
         this.button_menu = new Ui.ButtonMenu({
             icon: "fa-caret-down",
-            title: _l("Select"),
+            title: localize("Select"),
             pull: "left",
         });
         this.$source.append(this.button_menu.$el);
         this.button_menu.addMenu({
             icon: "fa-laptop",
-            title: _l("Choose local file"),
+            title: localize("Choose local file"),
             onclick: function () {
                 self.uploadinput.dialog();
             },
@@ -75,7 +75,7 @@ export default Backbone.View.extend({
         if (this.app.ftpUploadSite) {
             this.button_menu.addMenu({
                 icon: "fa-folder-open-o",
-                title: _l("Choose FTP file"),
+                title: localize("Choose FTP file"),
                 onclick: function () {
                     self._showFtp();
                 },
@@ -101,7 +101,7 @@ export default Backbone.View.extend({
 
         // append popup to settings icon
         this.settings = new Popover({
-            title: _l("Upload configuration"),
+            title: localize("Upload configuration"),
             container: this.$settings,
             placement: "bottom",
         });

--- a/client/src/mvc/upload/uploadbox-row.js
+++ b/client/src/mvc/upload/uploadbox-row.js
@@ -1,7 +1,7 @@
 /**
  * shared functionality between default-row and collection-row.
  */
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import Backbone from "backbone";
 import Utils from "utils/utils";
 import Popover from "mvc/ui/ui-popover";
@@ -19,7 +19,7 @@ export default Backbone.View.extend({
     _setupSettings: function () {
         // append popup to settings icon
         this.settings = new Popover({
-            title: _l("Upload configuration"),
+            title: localize("Upload configuration"),
             container: this.$(".upload-settings"),
             placement: "bottom",
         });

--- a/client/src/mvc/visualization/chart/views/repeat.js
+++ b/client/src/mvc/visualization/chart/views/repeat.js
@@ -1,5 +1,5 @@
 /** This class creates a ui component which enables the dynamic creation of portlets */
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import _ from "underscore";
 import $ from "jquery";
 import Backbone from "backbone";
@@ -11,7 +11,7 @@ export var View = Backbone.View.extend({
     initialize: function (options) {
         this.list = {};
         this.options = Utils.merge(options, {
-            title: _l("Repeat"),
+            title: localize("Repeat"),
             empty_text: "Not available.",
             max: null,
             min: null,
@@ -47,7 +47,7 @@ export var View = Backbone.View.extend({
         }
         var button_delete = new Ui.Button({
             icon: "fa-trash-o",
-            tooltip: _l("Delete this repeat block"),
+            tooltip: localize("Delete this repeat block"),
             cls: "ui-button-icon-plain form-repeat-delete",
             onclick: function () {
                 if (options.ondel) {
@@ -57,7 +57,7 @@ export var View = Backbone.View.extend({
         });
         var portlet = new Portlet.View({
             id: options.id,
-            title: _l("placeholder"),
+            title: localize("placeholder"),
             cls: options.cls || "ui-portlet-section",
             operations: { button_delete: button_delete },
         });

--- a/client/src/utils/utils.ts
+++ b/client/src/utils/utils.ts
@@ -7,7 +7,7 @@ import axios, { type AxiosError, type AxiosResponse } from "axios";
 
 import { getAppRoot } from "@/onload/loadConfig";
 import { getGalaxyInstance } from "@/app";
-import _l from "@/utils/localization";
+import { localize } from "@/utils/localization";
 
 /** Object with any internal structure. More specific key than built-in Object type */
 export type AnyObject = Record<string | number | symbol, any>;
@@ -304,7 +304,7 @@ export function appendScriptStyle(data: Readonly<{ script?: string; styles?: str
 export function setWindowTitle(title: string): void {
     const Galaxy = getGalaxyInstance();
     if (title) {
-        window.document.title = `Galaxy ${Galaxy.config.brand ? ` | ${Galaxy.config.brand}` : ""} | ${_l(title)}`;
+        window.document.title = `Galaxy ${Galaxy.config.brand ? ` | ${Galaxy.config.brand}` : ""} | ${localize(title)}`;
     } else {
         window.document.title = `Galaxy ${Galaxy.config.brand ? ` | ${Galaxy.config.brand}` : ""}`;
     }

--- a/client/src/viz/circster.js
+++ b/client/src/viz/circster.js
@@ -3,7 +3,7 @@ import $ from "jquery";
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import * as d3 from "d3v3";
 import { event as currentEvent } from "d3v3";
 import visualization from "viz/visualization";
@@ -1131,7 +1131,7 @@ var Circster = Backbone.View.extend({
             [
                 {
                     icon_class: "plus-button",
-                    title: _l("Add tracks"),
+                    title: localize("Add tracks"),
                     on_click: function () {
                         visualization.select_datasets({ dbkey: vis.get("dbkey") }, (tracks) => {
                             vis.add_tracks(tracks);
@@ -1140,7 +1140,7 @@ var Circster = Backbone.View.extend({
                 },
                 {
                     icon_class: "gear",
-                    title: _l("Settings"),
+                    title: localize("Settings"),
                     on_click: function () {
                         var view = new config.ConfigSettingCollectionView({
                             collection: vis.get("config"),
@@ -1150,13 +1150,13 @@ var Circster = Backbone.View.extend({
                 },
                 {
                     icon_class: "disk--arrow",
-                    title: _l("Save"),
+                    title: localize("Save"),
                     on_click: function () {
                         const Galaxy = getGalaxyInstance();
 
                         // show saving dialog box
                         Galaxy.modal.show({
-                            title: _l("Saving..."),
+                            title: localize("Saving..."),
                             body: "progress",
                         });
 
@@ -1180,7 +1180,7 @@ var Circster = Backbone.View.extend({
                             .error(() => {
                                 // show dialog
                                 Galaxy.modal.show({
-                                    title: _l("Could Not Save"),
+                                    title: localize("Could Not Save"),
                                     body: "Could not save visualization. Please try again later.",
                                     buttons: {
                                         Cancel: function () {
@@ -1193,7 +1193,7 @@ var Circster = Backbone.View.extend({
                 },
                 {
                     icon_class: "cross-circle",
-                    title: _l("Close"),
+                    title: localize("Close"),
                     on_click: function () {
                         window.top.location = `${getAppRoot()}visualizations/list`;
                     },

--- a/client/src/viz/phyloviz.js
+++ b/client/src/viz/phyloviz.js
@@ -1,6 +1,6 @@
 import $ from "jquery";
 import Backbone from "backbone";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import * as d3 from "d3v3";
 import visualization_mod from "viz/visualization";
 import { Dataset } from "mvc/dataset/data";
@@ -226,7 +226,7 @@ var PhyloTree = visualization_mod.Visualization.extend({
         separation: 250, // px dist between nodes of different depth to represent 1 evolutionary until
         leafHeight: 18,
         type: "phyloviz", // visualization type
-        title: _l("Title"),
+        title: localize("Title"),
         scaleFactor: 1,
         translate: [0, 0],
         fontSize: 12, //fontSize of node label
@@ -775,7 +775,7 @@ var HeaderButtons = Backbone.View.extend({
             [
                 {
                     icon_class: "gear",
-                    title: _l("PhyloViz Settings"),
+                    title: localize("PhyloViz Settings"),
                     on_click: function () {
                         $("#SettingsMenu").show();
                         self.settingsMenu.updateUI();
@@ -783,7 +783,7 @@ var HeaderButtons = Backbone.View.extend({
                 },
                 {
                     icon_class: "disk",
-                    title: _l("Save visualization"),
+                    title: localize("Save visualization"),
                     on_click: function () {
                         var nexSelected = $("#phylovizNexSelector option:selected").text();
                         if (nexSelected) {
@@ -801,7 +801,7 @@ var HeaderButtons = Backbone.View.extend({
                 },
                 {
                     icon_class: "information",
-                    title: _l("Phyloviz Help"),
+                    title: localize("Phyloviz Help"),
                     on_click: function () {
                         window.open("https://galaxyproject.org/learn/visualization/phylogenetic-tree/");
                         // https://docs.google.com/document/d/1AXFoJgEpxr21H3LICRs3EyMe1B1X_KFPouzIgrCz3zk/edit
@@ -822,14 +822,14 @@ var HeaderButtons = Backbone.View.extend({
             [
                 {
                     icon_class: "zoom-in",
-                    title: _l("Zoom in"),
+                    title: localize("Zoom in"),
                     on_click: function () {
                         self.phylovizView.zoomAndPan({ zoom: "+" });
                     },
                 },
                 {
                     icon_class: "zoom-out",
-                    title: _l("Zoom out"),
+                    title: localize("Zoom out"),
                     on_click: function () {
                         self.phylovizView.zoomAndPan({ zoom: "-" });
                     },

--- a/client/src/viz/sweepster.js
+++ b/client/src/viz/sweepster.js
@@ -7,7 +7,7 @@ import _ from "underscore";
 import $ from "jquery";
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import * as d3 from "d3v3";
 import visualization from "viz/visualization";
 import tracks from "viz/trackster/tracks";
@@ -406,14 +406,14 @@ var SweepsterTrackView = Backbone.View.extend({
 
         var icon_menu = mod_icon_btn.create_icon_buttons_menu([
             {
-                title: _l("Settings"),
+                title: localize("Settings"),
                 icon_class: "gear track-settings",
                 on_click: function () {
                     settings_div.toggle();
                 },
             },
             {
-                title: _l("Remove"),
+                title: localize("Remove"),
                 icon_class: "cross-circle",
                 on_click: function () {
                     self.$el.remove();
@@ -522,7 +522,7 @@ var ToolInputValOrSweepView = Backbone.View.extend({
         var menu = mod_icon_btn.create_icon_buttons_menu(
             [
                 {
-                    title: _l("Add parameter to tree"),
+                    title: localize("Add parameter to tree"),
                     icon_class: "plus-button",
                     on_click: function () {
                         input.set("in_ptree", true);
@@ -533,7 +533,7 @@ var ToolInputValOrSweepView = Backbone.View.extend({
                     },
                 },
                 {
-                    title: _l("Remove parameter from tree"),
+                    title: localize("Remove parameter from tree"),
                     icon_class: "toggle",
                     on_click: function () {
                         // Remove parameter from tree params where name matches clicked paramter.
@@ -806,7 +806,7 @@ export var SweepsterVisualizationView = Backbone.View.extend({
 
         var close_button = mod_icon_btn.create_icon_buttons_menu([
             {
-                title: _l("Close"),
+                title: localize("Close"),
                 icon_class: "cross-circle",
                 on_click: function () {
                     $(".tooltip").remove();
@@ -855,7 +855,7 @@ export var SweepsterVisualizationView = Backbone.View.extend({
                 // Close viz.
                 {
                     icon_class: "cross-circle",
-                    title: _l("Close"),
+                    title: localize("Close"),
                     on_click: function () {
                         window.top.location = `${getAppRoot()}visualizations/list`;
                     },

--- a/client/src/viz/trackster.js
+++ b/client/src/viz/trackster.js
@@ -7,7 +7,7 @@ import $ from "jquery";
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import tracks from "viz/trackster/tracks";
 import visualization from "viz/visualization";
 import IconButton from "mvc/ui/icon-button";
@@ -98,7 +98,7 @@ export class TracksterUI extends Backbone.Model {
             .error(() => {
                 // show dialog
                 Galaxy.modal.show({
-                    title: _l("Could Not Save"),
+                    title: localize("Could Not Save"),
                     body: "Could not save visualization. Please try again later.",
                     buttons: {
                         Cancel: () => {
@@ -117,7 +117,7 @@ export class TracksterUI extends Backbone.Model {
             [
                 {
                     icon_class: "plus-button",
-                    title: _l("Add tracks"),
+                    title: localize("Add tracks"),
                     on_click: () => {
                         visualization.select_datasets({ dbkey: this.view.dbkey }, (new_tracks) => {
                             _.each(new_tracks, (track) => {
@@ -128,7 +128,7 @@ export class TracksterUI extends Backbone.Model {
                 },
                 {
                     icon_class: "block--plus",
-                    title: _l("Add group"),
+                    title: localize("Add group"),
                     on_click: () => {
                         this.view.add_drawable(
                             new tracks.DrawableGroup(this.view, this.view, {
@@ -139,7 +139,7 @@ export class TracksterUI extends Backbone.Model {
                 },
                 {
                     icon_class: "globe",
-                    title: _l("Circster"),
+                    title: localize("Circster"),
                     on_click: () => {
                         const vis_id = this.view.vis_id;
                         var circster_q = "id=" + vis_id;
@@ -151,14 +151,14 @@ export class TracksterUI extends Backbone.Model {
                 },
                 {
                     icon_class: "disk--arrow",
-                    title: _l("Save"),
+                    title: localize("Save"),
                     on_click: () => {
                         this.save_viz();
                     },
                 },
                 {
                     icon_class: "cross-circle",
-                    title: _l("Close"),
+                    title: localize("Close"),
                     on_click: () => {
                         this.handle_unsaved_changes(this.view);
                     },
@@ -334,7 +334,7 @@ export class TracksterUI extends Backbone.Model {
         const Galaxy = getGalaxyInstance();
         if (view.has_changes) {
             Galaxy.modal.show({
-                title: _l("Close visualization"),
+                title: localize("Close visualization"),
                 body: "There are unsaved changes to your visualization which will be lost if you do not save them.",
                 buttons: {
                     Cancel: () => {
@@ -440,7 +440,7 @@ export class TracksterUIView extends Backbone.View {
             embedded: true,
         });
         Galaxy.modal.show({
-            title: _l("Add Data to Saved Visualization"),
+            title: localize("Add Data to Saved Visualization"),
             body: tracks_grid.$el,
             buttons: {
                 Cancel: () => {
@@ -494,7 +494,7 @@ export class TracksterUIView extends Backbone.View {
             success: (response) => {
                 // show dialog
                 Galaxy.modal.show({
-                    title: _l("New Visualization"),
+                    title: localize("New Visualization"),
                     body: this.template_view_new(response),
                     buttons: {
                         Cancel: () => {

--- a/client/src/viz/trackster/filters.js
+++ b/client/src/viz/trackster/filters.js
@@ -1,5 +1,5 @@
 import $ from "jquery";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import _ from "underscore";
 import { getGalaxyInstance } from "app";
 
@@ -639,14 +639,14 @@ _.extend(FiltersManager.prototype, {
                 if (response.error) {
                     // General error.
                     Galaxy.modal.show({
-                        title: _l("Filter Dataset"),
+                        title: localize("Filter Dataset"),
                         body: `Error running tool ${tool_id}`,
                         buttons: { Close: Galaxy.modal.hide() },
                     });
                 } else if (filters.length === 0) {
                     // No more filters to run.
                     Galaxy.modal.show({
-                        title: _l("Filtering Dataset"),
+                        title: localize("Filtering Dataset"),
                         body: "Filter(s) are running on the complete dataset. Outputs are in dataset's history.",
                         buttons: { Close: Galaxy.modal.hide() },
                     });

--- a/client/src/viz/trackster/tracks.js
+++ b/client/src/viz/trackster/tracks.js
@@ -3,7 +3,7 @@ import $ from "jquery";
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import visualization from "viz/visualization";
 import viz_views from "viz/viz_views";
 import util from "viz/trackster/util";
@@ -316,7 +316,7 @@ Drawable.prototype.action_icons_def = [
     // Edit settings.
     {
         name: "settings_icon",
-        title: _l("Edit settings"),
+        title: localize("Edit settings"),
         css_class: "gear",
         on_click_fn: function (drawable) {
             var view = new config_mod.ConfigSettingCollectionView({
@@ -328,7 +328,7 @@ Drawable.prototype.action_icons_def = [
     // Remove.
     {
         name: "remove_icon",
-        title: _l("Remove"),
+        title: localize("Remove"),
         css_class: "remove-icon",
         on_click_fn: function (drawable) {
             // Tooltip for remove icon must be deleted when drawable is deleted.
@@ -648,7 +648,7 @@ extend(DrawableGroup.prototype, Drawable.prototype, DrawableCollection.prototype
         // Replace group with composite track.
         {
             name: "composite_icon",
-            title: _l("Show composite track"),
+            title: localize("Show composite track"),
             css_class: "layers-stack",
             on_click_fn: function (group) {
                 $(".tooltip").remove();
@@ -658,7 +658,7 @@ extend(DrawableGroup.prototype, Drawable.prototype, DrawableCollection.prototype
         // Toggle track filters.
         {
             name: "filters_icon",
-            title: _l("Filters"),
+            title: localize("Filters"),
             css_class: "ui-slider-050",
             on_click_fn: function (group) {
                 // TODO: update Tooltip text.
@@ -2348,7 +2348,7 @@ extend(Track.prototype, Drawable.prototype, {
         // Change track mode.
         {
             name: "mode_icon",
-            title: _l("Set display mode"),
+            title: localize("Set display mode"),
             css_class: "chevron-expand",
             on_click_fn: function () {},
         },
@@ -2357,7 +2357,7 @@ extend(Track.prototype, Drawable.prototype, {
         // Set track as overview.
         {
             name: "overview_icon",
-            title: _l("Set as overview"),
+            title: localize("Set as overview"),
             css_class: "application-dock-270",
             on_click_fn: function (track) {
                 track.view.set_overview(track);
@@ -2368,7 +2368,7 @@ extend(Track.prototype, Drawable.prototype, {
         // Toggle track filters.
         {
             name: "filters_icon",
-            title: _l("Filters"),
+            title: localize("Filters"),
             css_class: "ui-slider-050",
             on_click_fn: function (drawable) {
                 // TODO: update Tooltip text.
@@ -2383,7 +2383,7 @@ extend(Track.prototype, Drawable.prototype, {
         // Toggle track tool.
         {
             name: "tools_icon",
-            title: _l("Tool"),
+            title: localize("Tool"),
             css_class: "hammer",
             on_click_fn: function (track) {
                 // TODO: update Tooltip text.
@@ -2403,7 +2403,7 @@ extend(Track.prototype, Drawable.prototype, {
         // Go to parameter exploration visualization.
         {
             name: "param_space_viz_icon",
-            title: _l("Tool parameter space visualization"),
+            title: localize("Tool parameter space visualization"),
             css_class: "arrow-split",
             on_click_fn: (track) => {
                 const Galaxy = getGalaxyInstance();
@@ -2666,7 +2666,7 @@ extend(Track.prototype, Drawable.prototype, {
                             .click(() => {
                                 const Galaxy = getGalaxyInstance();
                                 Galaxy.modal.show({
-                                    title: _l("Trackster Error"),
+                                    title: localize("Trackster Error"),
                                     body: `<pre>${result.message}</pre>`,
                                     buttons: {
                                         Close: function () {
@@ -3630,7 +3630,7 @@ extend(CompositeTrack.prototype, TiledTrack.prototype, {
         // Create composite track from group's tracks.
         {
             name: "composite_icon",
-            title: _l("Show individual tracks"),
+            title: localize("Show individual tracks"),
             css_class: "layers-stack",
             on_click_fn: function (track) {
                 $(".tooltip").remove();

--- a/client/src/viz/visualization.js
+++ b/client/src/viz/visualization.js
@@ -2,7 +2,7 @@ import _ from "underscore";
 import $ from "jquery";
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { Dataset } from "mvc/dataset/data";
 import util_mod from "viz/trackster/util";
 import config_mod from "utils/config";
@@ -63,19 +63,19 @@ var select_datasets = (filters, success_fn) => {
     var tabs = new Tabs.View();
     tabs.add({
         id: "histories",
-        title: _l("Histories"),
+        title: localize("Histories"),
         $el: $("<div/>").append(history_grid.$el),
     });
     tabs.add({
         id: "libraries",
-        title: _l("Libraries"),
+        title: localize("Libraries"),
         $el: $("<div/>").append(library_grid.$el),
     });
 
     // modal
     const Galaxy = getGalaxyInstance();
     Galaxy.modal.show({
-        title: _l("Select datasets for new tracks"),
+        title: localize("Select datasets for new tracks"),
         body: tabs.$el,
         closing_events: true,
         buttons: {

--- a/client/tests/jest/__mocks__/localization.js
+++ b/client/tests/jest/__mocks__/localization.js
@@ -6,6 +6,8 @@ export function _getUserLocale(user, config) {
     return "en";
 }
 
-export default function localize(l) {
+export function localize(l) {
     return l;
 }
+
+export default localize;

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -10,7 +10,7 @@ import { eventHubPlugin } from "components/plugins/eventHub";
 import { iconPlugin } from "components/plugins/icons";
 import BootstrapVue from "bootstrap-vue";
 import Vuex from "vuex";
-import _l from "utils/localization";
+import { localize } from "utils/localization";
 import { PiniaVuePlugin } from "pinia";
 
 const defaultComparator = (a, b) => a == b;

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -181,7 +181,7 @@ export function getLocalVue(instrumentLocalization = false) {
     localVue.use(PiniaVuePlugin);
     localVue.use(Vuex);
     localVue.use(BootstrapVue);
-    const l = instrumentLocalization ? testLocalize : _l;
+    const l = instrumentLocalization ? testLocalize : localize;
     localVue.use(localizationPlugin, l);
     localVue.use(vueRxShortcutPlugin);
     localVue.use(eventHubPlugin);

--- a/doc/source/dev/translating.rst
+++ b/doc/source/dev/translating.rst
@@ -21,7 +21,7 @@ The last three lines contain a mapping of English text to their Spanish equivale
 
 - Find untranslated text in the UI
 - Find the corresponding text in the codebase
-- Ensure that it uses `_l()` localisation statements
+- Ensure that it uses `localize()` localization statements
 - Add the translation for that text to the `locale.js` file.
 
 A quick example.
@@ -123,7 +123,7 @@ What you're looking for is the ``data()`` block which returns a dictionary. Ther
      </template>
 
      <script>
-    +import _l from "utils/localization";
+    +import { localize } from "utils/localization";
      import { VBTooltip } from "bootstrap-vue";
      import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
      import { library } from "@fortawesome/fontawesome-svg-core";
@@ -135,7 +135,7 @@ What you're looking for is the ``data()`` block which returns a dictionary. Ther
              return {
                  status: "",
                  percentage: 0,
-    +            titleUploadData: _l("Upload Data"),
+    +            titleUploadData: localize("Upload Data"),
              };
          },
 


### PR DESCRIPTION
In composition API components `_l` has a conflict with the internal vue template helpers.  This manifests as a really fun to track down problem where vue breaks upon adding the localization import, which we've hit twice now while converting over older components.  Just using `localize` as we have been in some spots works fine, so this standardizes to localize to avoid this happening again.

WIP, also looking at potentially hooking in vue-i18n or other solutions since we're already touching all this.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
