### PR TITLE
Change confusing pulsar logs message

### DIFF
--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -311,7 +311,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
         return job_state
 
     def _update_job_state_for_status(self, job_state, pulsar_status, full_status=None):
-        log.debug("(%s) Received status update: %s %s", job_state.job_id, type(pulsar_status), pulsar_status)
+        log.debug("(%s) Received status update: %s", job_state.job_id, pulsar_status)
         if pulsar_status in ["complete", "cancelled"] or job_state.job_wrapper.get_state() == model.Job.states.STOPPED:
             self.mark_as_finished(job_state)
             return None


### PR DESCRIPTION
Do not print the type of `pulsar_status` (a string) alongside its contents.

This is meant to address this confusing log message where the type of `pulsar_status` is printed alongside its content- From the reader's perspective it is difficult to guess what is the object whose type is being printed (so it may seem that he/she is missing important information) plus if `pulsar_status` is expected to always be a string then this information is not relevant.

> May 03 23:18:10 sn06.galaxyproject.eu python[917866]: galaxy.jobs.runners.pulsar DEBUG 2023-05-03 23:18:10,095 [pN:handler_sn06_1,p:917866,tN:PulsarJobRunner.monitor_thread] (59489430) Received status update: <class 'str'> running

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run a job using Pulsar

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
