### PR TITLE
[23.0] Fix gcsfs test discovery

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -266,6 +266,9 @@ class ConditionalDependencies:
     def check_fs_gcsfs(self):
         return "googlecloudstorage" in self.file_sources
 
+    def check_google_cloud_storage(self):
+        return "googlecloudstorage" in self.file_sources
+
     def check_fs_onedatafs(self):
         return "onedata" in self.file_sources
 

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -24,6 +24,8 @@ s3fs  # type: s3fs
 fs.anvilfs # type: anvil
 fs.googledrivefs # type: googledrive
 fs-gcsfs # type: googlecloudstorage
+# fs-gcsfs doesn't pin google-cloud-storage, and old versions log noisy exceptions and break test discovery
+google-cloud-storage>=2.8.0  # type: googlecloudstorage
 fs-onedatafs # type: onedata
 fs-basespace # type: basespace
 


### PR DESCRIPTION
When google-cloud-storage is installed in an old version. Fixes https://github.com/galaxyproject/galaxy/issues/16012

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
