### PR TITLE
Fixes the parcel2 build for hdf5 viz when using node18.  

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -157,7 +157,11 @@ function buildPlugins(callback, forceRebuild) {
                     };
                     // if node version is >16, set NODE_OPTIONS to use legacy openssl provider
                     if (process.versions.node.split(".")[0] > "16") {
-                        opts.env = { ...process.env, NODE_OPTIONS: "--openssl-legacy-provider" };
+                        opts.env = {
+                            ...process.env,
+                            PARCEL_WORKER_BACKEND: "process",
+                            NODE_OPTIONS: "--openssl-legacy-provider",
+                        };
                     }
                     if (child_process.spawnSync("yarn", ["build"], opts).status === 0) {
                         console.log(`Successfully built, saving build state to ${hashFilePath}`);


### PR DESCRIPTION
The underlying problem is that parcel passes through, unfiltered, the environment.  We could have a separate list to figure out which plugins need additional options, but this runs the risk of deployers having *other* potentially broken things in their ENV for node.  By telling parcel to just use the process backend, we avoid this issue completely and don't have to modify or maintain other changes to the build infra.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
