### PR TITLE
Change release note icon

### DIFF
--- a/config/plugins/webhooks/news/config.yml
+++ b/config/plugins/webhooks/news/config.yml
@@ -3,5 +3,5 @@ type:
   - masthead
 activate: true
 
-icon: fa-bell
+icon: fa-bullhorn
 tooltip: See the Galaxy Release Notes

--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -8,17 +8,15 @@
 
     function newsSeen() {
         // When it's seen, remove fa, add far.
-        const newsIconSpan = document.querySelector("#news .fa-bell");
-        newsIconSpan.classList.remove("fa");
-        newsIconSpan.classList.add("far");
+        const newsIconSpan = document.querySelector("#news .fa-bullhorn");
+        newsIconSpan.classList.remove("fa-fade");
         window.localStorage.setItem("galaxy-news-seen-release", Galaxy.config.version_major);
     }
 
     function newsUnseen() {
         // When there is news, remove far, add fa for (default -- same as fas) solid style.
-        const newsIconSpan = document.querySelector("#news .fa-bell");
-        newsIconSpan.classList.remove("far");
-        newsIconSpan.classList.add("fa");
+        const newsIconSpan = document.querySelector("#news .fa-bullhorn");
+        newsIconSpan.classList.add("fa-fade");
     }
 
     /* The masthead icon may not exist yet when this webhook executes; we need this to wait for that to happen.


### PR DESCRIPTION
This PR is a part of #15663 and changes the release note (news hook) icon in the masthead to [bullhorn](https://fontawesome.com/icons/bullhorn?f=classic&s=solid&an=fade) and adds blinking animation when there is a new release note that a user has not seen, and It's blinking until the user clicks on the icon to view the new release note.


https://user-images.githubusercontent.com/8046843/236832311-6cd8e760-e2b8-4642-9fc2-5cd73b12b1da.mp4


## How to test the changes?
1- To see the blinking animation, remove the  `galaxy-news-seen-release` key from the browser's local storage and refresh

(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
