### PR TITLE
[23.0] Update pulsar to 0.15.2

### DIFF
--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -118,7 +118,7 @@ pkgutil-resolve-name==1.3.10 ; python_version >= "3.7" and python_version < "3.9
 prompt-toolkit==3.0.36 ; python_version >= "3.7" and python_version < "3.12"
 prov==1.5.1 ; python_version >= "3.7" and python_version < "3.12"
 psutil==5.9.4 ; python_version >= "3.7" and python_version < "3.12"
-pulsar-galaxy-lib==0.15.0.dev2 ; python_version >= "3.7" and python_version < "3.12"
+pulsar-galaxy-lib==0.15.2 ; python_version >= "3.7" and python_version < "3.12"
 pyasn1==0.4.8 ; python_version >= "3.7" and python_version < "3.12"
 pycparser==2.21 ; python_version >= "3.7" and python_version < "3.12"
 pycryptodome==3.16.0 ; python_version >= "3.7" and python_version < "3.12"


### PR DESCRIPTION
Which includes fixes for lost and timed out connections to the message queue.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
