### PR TITLE
Don't build Docker image when pushing to release branches

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -2,7 +2,6 @@ name: Build Container Image
 on:
   push:
     branches:
-      - 'release*'
       - dev
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Disable building Docker images when code is pushed to `release_*` branches.  See #16053 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
