### PR TITLE
[23.0] Fix minor error in `WorkflowList` help modal

### DIFF
--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -127,7 +127,7 @@ const helpHtml = `<div>
             "published" icon of a workflow in your list to filter on this
             directly.
         </dd>
-        <dt><code>is:shared</code></dt>
+        <dt><code>is:shared_with_me</code></dt>
         <dd>
             Shows workflows shared by another user directly with you. You may
             also just click on the "shared with me" icon of a workflow in your


### PR DESCRIPTION
Very minor mistake in the `WorkflowList` search help modal: we indicate there is a valid `filterText="is:shared"`, whereas, the actual valid filter is `"is:shared_with_me"`:

https://user-images.githubusercontent.com/78516064/236640911-de9a6d77-b2a9-4eca-9114-e1b9548a3126.mov

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
