### PR TITLE
Ensure that unselected checkbox inputs emit null instead of an empty array

### DIFF
--- a/client/src/components/Form/Elements/FormCheck.test.js
+++ b/client/src/components/Form/Elements/FormCheck.test.js
@@ -29,7 +29,7 @@ describe("FormCheck", () => {
         const inputs = wrapper.findAll("[type='checkbox']");
         const labels = wrapper.findAll(".custom-control-label");
         expect(inputs.length).toBe(n + 1);
-        const expectedValues = [];
+        let expectedValues = [];
         for (let i = 0; i < n; i++) {
             await inputs.at(i + 1).setChecked();
             expect(labels.at(i + 1).text()).toBe(`label_${i}`);
@@ -37,6 +37,15 @@ describe("FormCheck", () => {
             expectedValues.push(`value_${i}`);
             expect(wrapper.emitted()["input"][i][0]).toEqual(expectedValues);
         }
+        for (let i = 0; i < n; i++) {
+            await inputs.at(i + 1).setChecked(false);
+            expectedValues = expectedValues.slice(1);
+            if (expectedValues.length === 0) {
+                expectedValues = null;
+            }
+            expect(wrapper.emitted().input[i + 4][0]).toEqual(expectedValues);
+        }
+        expect(wrapper.emitted().input[7][0]).toBe(null);
     });
 
     it("Confirm checkboxes are created when various 'empty values' are passed.", async () => {

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -48,7 +48,7 @@ function onSelectAll() {
         const allValues = props.options.map((option) => option[1]);
         emit("input", allValues);
     } else {
-        emit("input", []);
+        emit("input", null);
     }
 }
 </script>
@@ -63,7 +63,6 @@ function onSelectAll() {
             @input="onSelectAll">
             Select / Deselect all
         </b-form-checkbox>
-
         <b-form-checkbox-group v-model="currentValue" stacked class="pl-3">
             <b-form-checkbox v-for="(option, index) in options" :key="index" :value="option[1]">
                 {{ option[0] }}

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -9,7 +9,7 @@ export interface FormCheckProps {
 const props = defineProps<FormCheckProps>();
 
 const emit = defineEmits<{
-    (e: "input", value: string[]): void;
+    (e: "input", value: string[] | null): void;
 }>();
 
 const indeterminate = ref(false);
@@ -20,8 +20,11 @@ const currentValue = computed({
         return Array.isArray(val) ? val : [val];
     },
     set: (newValue) => {
-        emit("input", newValue);
-
+        if (newValue.length > 0) {
+            emit("input", newValue);
+        } else {
+            emit("input", null);
+        }
         if (newValue.length === 0) {
             selectAll.value = false;
             indeterminate.value = false;


### PR DESCRIPTION
To simplify the validation process, we commonly expect input fields with undefined values to submit `null`. This is currently expected by the tool form validation script in order to highlight missing values for non-optional inputs. The checkbox field currently submits an empty array instead which is not recognized by the validation mechanism as a missing value. This PR fixes that.

https://user-images.githubusercontent.com/2105447/236791160-f552e2e7-cf0d-4888-b24e-bd21a9ac2b8f.mov


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
