### PR TITLE
Add Repository owner field to ToolSearch

### DIFF
--- a/client/src/components/Panels/Common/ToolSearch.test.js
+++ b/client/src/components/Panels/Common/ToolSearch.test.js
@@ -29,6 +29,8 @@ describe("ToolSearch", () => {
             name: "name-filter",
             "[placeholder='any section']": "section-filter",
             "[placeholder='any id']": "id-filter",
+            "[placeholder='any repository']": "repo-filter",
+            "[placeholder='any owner']": "owner-filter",
             "[placeholder='any help text']": "help-filter",
         };
 

--- a/client/src/components/Panels/Common/ToolSearch.test.js
+++ b/client/src/components/Panels/Common/ToolSearch.test.js
@@ -29,7 +29,6 @@ describe("ToolSearch", () => {
             name: "name-filter",
             "[placeholder='any section']": "section-filter",
             "[placeholder='any id']": "id-filter",
-            "[placeholder='any repository']": "repo-filter",
             "[placeholder='any owner']": "owner-filter",
             "[placeholder='any help text']": "help-filter",
         };

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -26,7 +26,7 @@
             <small class="mt-1">Filter by id:</small>
             <b-form-input v-model="filterSettings['id']" size="sm" placeholder="any id" />
             <small class="mt-1">Filter by repository name:</small>
-            <b-form-input v-model="filterSettings['repository']" size="sm" placeholder="any name" />
+            <b-form-input v-model="filterSettings['repository']" size="sm" placeholder="any repository" />
             <small class="mt-1">Filter by repository owner:</small>
             <b-form-input v-model="filterSettings['owner']" size="sm" placeholder="any owner" />
             <small class="mt-1">Filter by help text:</small>
@@ -40,12 +40,73 @@
                     <icon icon="redo" />
                     <span>{{ "Cancel" | localize }}</span>
                 </b-button>
+                <b-button title="Search Help" size="sm" @click="showHelp = true">
+                    <icon icon="question" />
+                </b-button>
+                <b-modal v-model="showHelp" title="Tool Advanced Search Help" ok-only>
+                    <div v-html="helpHtml"></div>
+                </b-modal>
             </div>
         </div>
     </div>
 </template>
 
 <script>
+const helpHtml = `<div>
+    <p>
+        You can use this Advanced Tool Search Panel to find tools by applying
+        search filters, with the results showing up in the center panel.
+    </p>
+
+    <p><i>(Clicking on the Section, Repo or Owner labels in the 
+        Search Results will activate the according filter)</i></p>
+
+    <p>The available tool search filters are:</p>
+    <dl>
+        <dt><code>name</code></dt>
+        <dd>
+            The tool name (stored as tool.name + tool.description in the XML)
+        </dd>
+        <dt><code>section</code></dt>
+        <dd>
+            The tool section is based on the current view you have selected 
+            for the panel. <br />
+            When this field is active, you will be able to see a datalist
+            showing the available sections you can filter from. <br />
+            By default, Galaxy tool panel sections are filterable if you are
+            currently on the <i>Full Tool Panel</i> view, and it will show
+            EDAM ontologies or EDAM topics if you have either of those
+            options selected. <br />
+            Change panel views by clicking on the down-arrow icon at the top
+            right of the tool panel.
+        </dd>
+        <dt><code>id</code></dt>
+        <dd>
+            The tool id (taken from its XML)
+        </dd>
+        <dt><code>repository</code></dt>
+        <dd>
+            Some tools have been installed from 
+            <a href="https://toolshed.g2.bx.psu.edu/" target="_blank">ToolShed</a>
+            repos. This <i>repository</i> filter allows you to search for tools from
+            a specific repository.
+        </dd>
+        <dt><code>owner</code></dt>
+        <dd>
+            For the tools that have been installed from the
+            <a href="https://toolshed.g2.bx.psu.edu/" target="_blank">ToolShed</a>
+            , this <i>owner</i> filter allows you to search for tools from
+            a specific ToolShed repository <b>owner</b>.
+        </dd>
+        <dt><code>help text</code></dt>
+        <dd>
+            This is like a keyword search: you can search for keywords that
+            might exist in a tool's help text. An example input:
+            <i>"genome, RNA, minimap"</i>
+        </dd>
+    </dl>
+</div>`;
+
 import { getGalaxyInstance } from "app";
 import DelayedInput from "components/Common/DelayedInput";
 import { normalizeTools, searchToolsByKeys } from "../utilities.js";
@@ -86,6 +147,8 @@ export default {
             favorites: ["#favs", "#favorites", "#favourites"],
             minQueryLength: 3,
             filterSettings: {},
+            helpHtml: helpHtml,
+            showHelp: false,
         };
     },
     computed: {

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -25,6 +25,10 @@
             <b-form-datalist id="sectionSelect" :options="sectionNames"></b-form-datalist>
             <small class="mt-1">Filter by id:</small>
             <b-form-input v-model="filterSettings['id']" size="sm" placeholder="any id" />
+            <small class="mt-1">Filter by repository name:</small>
+            <b-form-input v-model="filterSettings['repository']" size="sm" placeholder="any name" />
+            <small class="mt-1">Filter by repository owner:</small>
+            <b-form-input v-model="filterSettings['owner']" size="sm" placeholder="any owner" />
             <small class="mt-1">Filter by help text:</small>
             <b-form-input v-model="filterSettings['help']" size="sm" placeholder="any help text" />
             <div class="mt-3">

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -25,8 +25,6 @@
             <b-form-datalist id="sectionSelect" :options="sectionNames"></b-form-datalist>
             <small class="mt-1">Filter by id:</small>
             <b-form-input v-model="filterSettings['id']" size="sm" placeholder="any id" />
-            <small class="mt-1">Filter by repository name:</small>
-            <b-form-input v-model="filterSettings['repository']" size="sm" placeholder="any repository" />
             <small class="mt-1">Filter by repository owner:</small>
             <b-form-input v-model="filterSettings['owner']" size="sm" placeholder="any owner" />
             <small class="mt-1">Filter by help text:</small>
@@ -75,13 +73,6 @@
                             </dd>
                             <dt><code>id</code></dt>
                             <dd>The tool id (taken from its XML)</dd>
-                            <dt><code>repository</code></dt>
-                            <dd>
-                                Some tools have been installed from
-                                <a href="https://toolshed.g2.bx.psu.edu/" target="_blank">ToolShed</a>
-                                repos. This <i>repository</i> filter allows you to search for tools from a specific
-                                repository.
-                            </dd>
                             <dt><code>owner</code></dt>
                             <dd>
                                 For the tools that have been installed from the

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -44,7 +44,59 @@
                     <icon icon="question" />
                 </b-button>
                 <b-modal v-model="showHelp" title="Tool Advanced Search Help" ok-only>
-                    <div v-html="helpHtml"></div>
+                    <div>
+                        <p>
+                            You can use this Advanced Tool Search Panel to find tools by applying search filters, with
+                            the results showing up in the center panel.
+                        </p>
+
+                        <p>
+                            <i>
+                                (Clicking on the Section, Repo or Owner labels in the Search Results will activate the
+                                according filter)
+                            </i>
+                        </p>
+
+                        <p>The available tool search filters are:</p>
+                        <dl>
+                            <dt><code>name</code></dt>
+                            <dd>The tool name (stored as tool.name + tool.description in the XML)</dd>
+                            <dt><code>section</code></dt>
+                            <dd>
+                                The tool section is based on the current view you have selected for the panel. <br />
+                                When this field is active, you will be able to see a datalist showing the available
+                                sections you can filter from. <br />
+                                By default, Galaxy tool panel sections are filterable if you are currently on the
+                                <i>Full Tool Panel</i> view, and it will show EDAM ontologies or EDAM topics if you have
+                                either of those options selected. <br />
+                                Change panel views by clicking on the
+                                <icon icon="caret-down" />
+                                icon at the top right of the tool panel.
+                            </dd>
+                            <dt><code>id</code></dt>
+                            <dd>The tool id (taken from its XML)</dd>
+                            <dt><code>repository</code></dt>
+                            <dd>
+                                Some tools have been installed from
+                                <a href="https://toolshed.g2.bx.psu.edu/" target="_blank">ToolShed</a>
+                                repos. This <i>repository</i> filter allows you to search for tools from a specific
+                                repository.
+                            </dd>
+                            <dt><code>owner</code></dt>
+                            <dd>
+                                For the tools that have been installed from the
+                                <a href="https://toolshed.g2.bx.psu.edu/" target="_blank">ToolShed</a>
+                                , this <i>owner</i> filter allows you to search for tools from a specific ToolShed
+                                repository <b>owner</b>.
+                            </dd>
+                            <dt><code>help text</code></dt>
+                            <dd>
+                                This is like a keyword search: you can search for keywords that might exist in a tool's
+                                help text. An example input:
+                                <i>"genome, RNA, minimap"</i>
+                            </dd>
+                        </dl>
+                    </div>
                 </b-modal>
             </div>
         </div>
@@ -52,61 +104,6 @@
 </template>
 
 <script>
-const helpHtml = `<div>
-    <p>
-        You can use this Advanced Tool Search Panel to find tools by applying
-        search filters, with the results showing up in the center panel.
-    </p>
-
-    <p><i>(Clicking on the Section, Repo or Owner labels in the 
-        Search Results will activate the according filter)</i></p>
-
-    <p>The available tool search filters are:</p>
-    <dl>
-        <dt><code>name</code></dt>
-        <dd>
-            The tool name (stored as tool.name + tool.description in the XML)
-        </dd>
-        <dt><code>section</code></dt>
-        <dd>
-            The tool section is based on the current view you have selected 
-            for the panel. <br />
-            When this field is active, you will be able to see a datalist
-            showing the available sections you can filter from. <br />
-            By default, Galaxy tool panel sections are filterable if you are
-            currently on the <i>Full Tool Panel</i> view, and it will show
-            EDAM ontologies or EDAM topics if you have either of those
-            options selected. <br />
-            Change panel views by clicking on the down-arrow icon at the top
-            right of the tool panel.
-        </dd>
-        <dt><code>id</code></dt>
-        <dd>
-            The tool id (taken from its XML)
-        </dd>
-        <dt><code>repository</code></dt>
-        <dd>
-            Some tools have been installed from 
-            <a href="https://toolshed.g2.bx.psu.edu/" target="_blank">ToolShed</a>
-            repos. This <i>repository</i> filter allows you to search for tools from
-            a specific repository.
-        </dd>
-        <dt><code>owner</code></dt>
-        <dd>
-            For the tools that have been installed from the
-            <a href="https://toolshed.g2.bx.psu.edu/" target="_blank">ToolShed</a>
-            , this <i>owner</i> filter allows you to search for tools from
-            a specific ToolShed repository <b>owner</b>.
-        </dd>
-        <dt><code>help text</code></dt>
-        <dd>
-            This is like a keyword search: you can search for keywords that
-            might exist in a tool's help text. An example input:
-            <i>"genome, RNA, minimap"</i>
-        </dd>
-    </dl>
-</div>`;
-
 import { getGalaxyInstance } from "app";
 import DelayedInput from "components/Common/DelayedInput";
 import { normalizeTools, searchToolsByKeys } from "../utilities.js";
@@ -147,7 +144,6 @@ export default {
             favorites: ["#favs", "#favorites", "#favourites"],
             minQueryLength: 3,
             filterSettings: {},
-            helpHtml: helpHtml,
             showHelp: false,
         };
     },

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -21,13 +21,18 @@ describe("test helpers in tool searching utilities and panel handling", () => {
             name: "Filter",
             id: "__FILTER_FAILED_DATASETS__",
             help: "downstream",
+            owner: "devteam",
         };
         const q = createWhooshQuery(settings, "default", []);
 
         // OrGroup (at backend) on name, name_exact, description
         expect(q).toContain("name:(Filter) name_exact:(Filter) description:(Filter)");
         // AndGroup (explicit at frontend) on all other settings
-        expect(q).toContain("id_exact:(__FILTER_FAILED_DATASETS__) AND help:(downstream)");
+        expect(q).toContain("id_exact:(__FILTER_FAILED_DATASETS__) AND help:(downstream) AND owner:(devteam)");
+        // Combined query results in:
+        expect(q).toEqual(
+            "(name:(Filter) name_exact:(Filter) description:(Filter)) AND (id_exact:(__FILTER_FAILED_DATASETS__) AND help:(downstream) AND owner:(devteam) AND )"
+        );
     });
 
     it("test tool search helper that searches for tools given keys", async () => {

--- a/client/src/components/ToolsList/ToolsList.vue
+++ b/client/src/components/ToolsList/ToolsList.vue
@@ -81,6 +81,14 @@ export default {
             type: String,
             default: "",
         },
+        repository: {
+            type: String,
+            default: "",
+        },
+        owner: {
+            type: String,
+            default: "",
+        },
         help: {
             type: String,
             default: "",

--- a/client/src/components/ToolsList/ToolsList.vue
+++ b/client/src/components/ToolsList/ToolsList.vue
@@ -81,10 +81,6 @@ export default {
             type: String,
             default: "",
         },
-        repository: {
-            type: String,
-            default: "",
-        },
         owner: {
             type: String,
             default: "",

--- a/client/src/components/ToolsList/ToolsListItem.vue
+++ b/client/src/components/ToolsList/ToolsListItem.vue
@@ -14,6 +14,8 @@ const props = defineProps({
     link: { type: String, default: null },
     workflowCompatible: { type: Boolean, default: false },
     local: { type: Boolean, default: false },
+    repository: { type: String, default: null },
+    owner: { type: String, default: null },
 });
 
 const emit = defineEmits(["open"]);
@@ -40,9 +42,21 @@ import {
     faAngleDown,
     faAngleUp,
     faExclamationTriangle,
+    faUser,
+    faToolbox,
 } from "@fortawesome/free-solid-svg-icons";
 
-library.add(faWrench, faExternalLinkAlt, faCheck, faTimes, faAngleDown, faAngleUp, faExclamationTriangle);
+library.add(
+    faWrench,
+    faExternalLinkAlt,
+    faCheck,
+    faTimes,
+    faAngleDown,
+    faAngleUp,
+    faExclamationTriangle,
+    faUser,
+    faToolbox
+);
 </script>
 
 <template>
@@ -96,6 +110,17 @@ library.add(faWrench, faExternalLinkAlt, faCheck, faTimes, faAngleDown, faAngleU
                 <span v-if="!props.workflowCompatible" class="tag warn">
                     <FontAwesomeIcon icon="fa-exclamation-triangle" />
                     Not Workflow compatible
+                </span>
+
+                <span v-if="props.repository" class="tag info">
+                    <FontAwesomeIcon icon="fa-toolbox" />
+                    <b>Repo:</b>
+                    <b-link :to="`/tools/list?repository=${props.repository}`">{{ props.repository }}</b-link>
+                </span>
+
+                <span v-if="props.owner" class="tag success">
+                    <FontAwesomeIcon icon="fa-user" />
+                    <b>Owner:</b> <b-link :to="`/tools/list?owner=${props.owner}`">{{ props.owner }}</b-link>
                 </span>
             </div>
 

--- a/client/src/components/ToolsList/ToolsListItem.vue
+++ b/client/src/components/ToolsList/ToolsListItem.vue
@@ -14,7 +14,6 @@ const props = defineProps({
     link: { type: String, default: null },
     workflowCompatible: { type: Boolean, default: false },
     local: { type: Boolean, default: false },
-    repository: { type: String, default: null },
     owner: { type: String, default: null },
 });
 
@@ -43,20 +42,9 @@ import {
     faAngleUp,
     faExclamationTriangle,
     faUser,
-    faToolbox,
 } from "@fortawesome/free-solid-svg-icons";
 
-library.add(
-    faWrench,
-    faExternalLinkAlt,
-    faCheck,
-    faTimes,
-    faAngleDown,
-    faAngleUp,
-    faExclamationTriangle,
-    faUser,
-    faToolbox
-);
+library.add(faWrench, faExternalLinkAlt, faCheck, faTimes, faAngleDown, faAngleUp, faExclamationTriangle, faUser);
 </script>
 
 <template>
@@ -110,12 +98,6 @@ library.add(
                 <span v-if="!props.workflowCompatible" class="tag warn">
                     <FontAwesomeIcon icon="fa-exclamation-triangle" />
                     Not Workflow compatible
-                </span>
-
-                <span v-if="props.repository" class="tag info">
-                    <FontAwesomeIcon icon="fa-toolbox" />
-                    <b>Repo:</b>
-                    <b-link :to="`/tools/list?repository=${props.repository}`">{{ props.repository }}</b-link>
                 </span>
 
                 <span v-if="props.owner" class="tag success">

--- a/client/src/components/ToolsList/ToolsListTable.vue
+++ b/client/src/components/ToolsList/ToolsListTable.vue
@@ -15,7 +15,6 @@
             :help="item.help"
             :local="item.target === 'galaxy_main'"
             :link="item.link"
-            :repository="item.tool_shed_repository && item.tool_shed_repository.name"
             :owner="item.tool_shed_repository && item.tool_shed_repository.owner"
             :workflow-compatible="item.is_workflow_compatible"
             :version="item.version"

--- a/client/src/components/ToolsList/ToolsListTable.vue
+++ b/client/src/components/ToolsList/ToolsListTable.vue
@@ -15,6 +15,8 @@
             :help="item.help"
             :local="item.target === 'galaxy_main'"
             :link="item.link"
+            :repository="item.tool_shed_repository && item.tool_shed_repository.name"
+            :owner="item.tool_shed_repository && item.tool_shed_repository.owner"
             :workflow-compatible="item.is_workflow_compatible"
             :version="item.version"
             @open="() => onOpen(item)" />

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -137,9 +137,10 @@ class ToolPanelViewSearch:
             # The stored ID field is not searchable
             "id": ID(stored=True, unique=True),
             # This exact field is searchable by exact matches only
-            "id_exact": TEXT(
+            "id_exact": NGRAMWORDS(
+                minsize=config.tool_ngram_minsize,
+                maxsize=config.tool_ngram_maxsize,
                 field_boost=(config.tool_id_boost * config.tool_name_exact_multiplier),
-                analyzer=analysis.IDTokenizer() | analysis.LowercaseFilter(),
             ),
             # The primary name field is searchable by exact match only, and is
             # eligible for massive score boosting. A secondary ngram or text
@@ -156,6 +157,10 @@ class ToolPanelViewSearch:
             "edam_operations": TEXT(field_boost=float(config.tool_section_boost)),
             # The edam topics section where the tool is listed in the tool panel
             "edam_topics": TEXT(field_boost=float(config.tool_section_boost)),
+            # The name of the repository the tool belongs to
+            "repository": TEXT(field_boost=float(config.tool_section_boost)),
+            # The owner id of the repository the tool belongs to
+            "owner": TEXT(field_boost=float(config.tool_section_boost)),
             # Short description defined in the tool XML
             "description": TEXT(
                 field_boost=config.tool_description_boost,
@@ -289,6 +294,8 @@ class ToolPanelViewSearch:
             "section": to_unicode(tool.get_panel_section()[1] if len(tool.get_panel_section()) == 2 else ""),
             "edam_operations": clean(tool.edam_operations),
             "edam_topics": clean(tool.edam_topics),
+            "repository": to_unicode(tool.repository_name),
+            "owner": to_unicode(tool.repository_owner),
             "help": to_unicode(""),
         }
         if tool.guid:
@@ -335,6 +342,8 @@ class ToolPanelViewSearch:
             "section",
             "edam_operations",
             "edam_topics",
+            "repository",
+            "owner",
             "help",
             "labels",
             "stub",


### PR DESCRIPTION
Also made tool_id searchable by partial match (Fixes #15804 and xref [#15855-comment](https://github.com/galaxyproject/galaxy/pull/15855#issuecomment-1518341411))

### All changes in this PR:
- ~~Two new fields~~ One new field added to the search: `owner` ~~and `repository`~~ which is taken from the tool.id in the backend (e.g.: `id = toolshed_url/repos/owner/repository/tool_name/version`)
- Added the owner ~~and repository~~ labels to the `ToolListItem`s in the `ToolsListTable`
- Made tool id searchable by partial match (e.g.: `id=grep1` and `q=grep` should now get results)
- Added a help modal for Tool Search that explains the usage (as requested in #15804)

https://user-images.githubusercontent.com/78516064/236968928-625546f0-8c17-42d8-b630-a44c89b899ab.mov

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
