### PR TITLE
Fix font-awesome library types

### DIFF
--- a/client/src/components/Common/TextSummary.vue
+++ b/client/src/components/Common/TextSummary.vue
@@ -32,7 +32,6 @@ const propShowDetails = computed({
     },
 });
 
-//@ts-ignore bad library types
 library.add(faChevronUp, faChevronDown);
 const collapsedEnableIcon = "fas fa-chevron-down";
 const collapsedDisableIcon = "fas fa-chevron-up";

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -64,7 +64,6 @@ const emit = defineEmits<{
     (e: "change", shouldRefresh: boolean): void;
 }>();
 
-//@ts-ignore bad library types
 library.add(faExclamation, faTimes, faArrowsAltH, faCaretSquareDown, faCaretSquareUp);
 
 /** TODO: remove attrs computed.

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -40,7 +40,6 @@ const emit = defineEmits<{
     (e: "selectHistories", histories: HistorySummary[]): void;
 }>();
 
-// @ts-ignore bad library types
 library.add(faColumns, faSignInAlt, faListAlt);
 
 const filter = ref("");

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -12,7 +12,6 @@ import MultipleViewList from "./MultipleViewList.vue";
 
 const filter = ref("");
 
-//@ts-ignore bad library types
 library.add(faTimes);
 
 const { currentUser } = storeToRefs(useUserStore());

--- a/client/src/components/ObjectStore/badgeIcons.ts
+++ b/client/src/components/ObjectStore/badgeIcons.ts
@@ -1,7 +1,3 @@
-/* I can't get this to type properly in type script, so
-   handling it here in JavaScript. I get a variant of this
-   error (https://github.com/FortAwesome/Font-Awesome/issues/12575).
-*/
 import { library } from "@fortawesome/fontawesome-svg-core";
 
 import {

--- a/client/src/components/TagsMultiselect/StatelessTags.vue
+++ b/client/src/components/TagsMultiselect/StatelessTags.vue
@@ -32,7 +32,6 @@ const emit = defineEmits<{
     (e: "tag-click", tag: string): void;
 }>();
 
-//@ts-ignore bad library types
 library.add(faTags, faCheck, faTimes, faPlus);
 
 const { userTags, addLocalTag } = useUserTags();

--- a/client/src/components/TagsMultiselect/Tag.vue
+++ b/client/src/components/TagsMultiselect/Tag.vue
@@ -19,7 +19,6 @@ const emit = defineEmits<{
     (e: "deleted", tag: string): void;
 }>();
 
-//@ts-ignore bad types
 library.add(faTimes);
 
 const color = computed(() => keyedColorScheme(props.option));

--- a/client/src/components/Tool/ToolTutorialRecommendations.vue
+++ b/client/src/components/Tool/ToolTutorialRecommendations.vue
@@ -17,7 +17,6 @@ const props = defineProps<{
     owner?: string;
 }>();
 
-//@ts-ignore: bad library types
 library.add(faCaretDown);
 
 const { trainingAvailable, trainingCategories, tutorialDetails, allTutorialsUrl, versionAvailable } =

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -131,7 +131,6 @@ import type { OutputTerminals } from "./modules/terminals";
 
 Vue.use(BootstrapVue);
 
-// @ts-ignore
 library.add(faCodeBranch);
 
 const props = defineProps({

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -7,7 +7,10 @@
         "baseUrl": ".",
         "paths": {
             "@/*": ["src/*"],
-            "@tests/*": ["tests/*"]
+            "@tests/*": ["tests/*"],
+            "@fortawesome/fontawesome-common-types": [
+                "./node_modules/@fortawesome/fontawesome-common-types/index"
+            ]
         },
         "outDir": "./dist/build",
 


### PR DESCRIPTION
Fixed by pointing typescript to the correct definition file for a shared module. Found here: https://github.com/FortAwesome/Font-Awesome/issues/12575#issuecomment-437018110

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
