### PR TITLE
Dataset chunking tests (and small fixes)

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -8498,11 +8498,15 @@ export interface operations {
             /** @description If non-null, get the specified filename from the extra files for this dataset. */
             /** @description The file extension when downloading the display data. Use the value `data` to let the server infer it from the data type. */
             /** @description The query parameter 'raw' should be considered experimental and may be dropped at some point in the future without warning. Generally, data should be processed by its datatype prior to display. */
+            /** @description Set this for datatypes that allow chunked display through the display_data method to enable chunking. This specifies a byte offset into the target dataset's display. */
+            /** @description If offset is set, this recommends 'how large' the next chunk should be. This is not respected or interpreted uniformly and should be interpreted as a very loose recommendation. Different datatypes interpret 'largeness' differently - for bam datasets this is a number of lines whereas for tabular datatypes this is interpreted as a number of bytes. */
             query?: {
                 preview?: boolean;
                 filename?: string;
                 to_ext?: string;
                 raw?: boolean;
+                offset?: number;
+                ck_size?: number;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -8534,11 +8538,15 @@ export interface operations {
             /** @description If non-null, get the specified filename from the extra files for this dataset. */
             /** @description The file extension when downloading the display data. Use the value `data` to let the server infer it from the data type. */
             /** @description The query parameter 'raw' should be considered experimental and may be dropped at some point in the future without warning. Generally, data should be processed by its datatype prior to display. */
+            /** @description Set this for datatypes that allow chunked display through the display_data method to enable chunking. This specifies a byte offset into the target dataset's display. */
+            /** @description If offset is set, this recommends 'how large' the next chunk should be. This is not respected or interpreted uniformly and should be interpreted as a very loose recommendation. Different datatypes interpret 'largeness' differently - for bam datasets this is a number of lines whereas for tabular datatypes this is interpreted as a number of bytes. */
             query?: {
                 preview?: boolean;
                 filename?: string;
                 to_ext?: string;
                 raw?: boolean;
+                offset?: number;
+                ck_size?: number;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -10641,11 +10649,15 @@ export interface operations {
             /** @description If non-null, get the specified filename from the extra files for this dataset. */
             /** @description The file extension when downloading the display data. Use the value `data` to let the server infer it from the data type. */
             /** @description The query parameter 'raw' should be considered experimental and may be dropped at some point in the future without warning. Generally, data should be processed by its datatype prior to display. */
+            /** @description Set this for datatypes that allow chunked display through the display_data method to enable chunking. This specifies a byte offset into the target dataset's display. */
+            /** @description If offset is set, this recommends 'how large' the next chunk should be. This is not respected or interpreted uniformly and should be interpreted as a very loose recommendation. Different datatypes interpret 'largeness' differently - for bam datasets this is a number of lines whereas for tabular datatypes this is interpreted as a number of bytes. */
             query?: {
                 preview?: boolean;
                 filename?: string;
                 to_ext?: string;
                 raw?: boolean;
+                offset?: number;
+                ck_size?: number;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -10679,11 +10691,15 @@ export interface operations {
             /** @description If non-null, get the specified filename from the extra files for this dataset. */
             /** @description The file extension when downloading the display data. Use the value `data` to let the server infer it from the data type. */
             /** @description The query parameter 'raw' should be considered experimental and may be dropped at some point in the future without warning. Generally, data should be processed by its datatype prior to display. */
+            /** @description Set this for datatypes that allow chunked display through the display_data method to enable chunking. This specifies a byte offset into the target dataset's display. */
+            /** @description If offset is set, this recommends 'how large' the next chunk should be. This is not respected or interpreted uniformly and should be interpreted as a very loose recommendation. Different datatypes interpret 'largeness' differently - for bam datasets this is a number of lines whereas for tabular datatypes this is interpreted as a number of bytes. */
             query?: {
                 preview?: boolean;
                 filename?: string;
                 to_ext?: string;
                 raw?: boolean;
+                offset?: number;
+                ck_size?: number;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -617,7 +617,8 @@ class BamNative(CompressedArchive, _BamOrSam):
         if not offset == -1:
             try:
                 with pysam.AlignmentFile(dataset.file_name, "rb", check_sq=False) as bamfile:
-                    ck_size = 300  # 300 lines
+                    if ck_size is None:
+                        ck_size = 300  # 300 lines
                     if offset == 0:
                         offset = bamfile.tell()
                         ck_lines = bamfile.text.strip().replace("\t", " ").splitlines()  # type: ignore[attr-defined]

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -628,7 +628,7 @@ class BamNative(CompressedArchive, _BamOrSam):
                     for line_number, alignment in enumerate(bamfile, len(ck_lines)):
                         # return only Header lines if 'header_line_count' exceeds 'ck_size'
                         # FIXME: Can be problematic if bam has million lines of header
-                        if line_number > ck_size:
+                        if line_number >= ck_size:
                             break
 
                         offset = bamfile.tell()

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -565,6 +565,8 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         filename: Optional[str] = None,
         to_ext: Optional[str] = None,
         raw: bool = False,
+        offset: Optional[int] = None,
+        ck_size: Optional[int] = None,
         **kwd,
     ):
         """
@@ -572,7 +574,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
 
         The query parameter 'raw' should be considered experimental and may be dropped at
         some point in the future without warning. Generally, data should be processed by its
-        datatype prior to display (the defult if raw is unspecified or explicitly false.
+        datatype prior to display (the default if raw is unspecified or explicitly false.
         """
         headers = {}
         rval: Any = ""
@@ -589,6 +591,10 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                     file_path = dataset_instance.file_name
                 rval = open(file_path, "rb")
             else:
+                if offset is not None:
+                    kwd["offset"] = offset
+                if ck_size is not None:
+                    kwd["ck_size"] = ck_size
                 rval, headers = dataset_instance.datatype.display_data(
                     trans, dataset_instance, preview, filename, to_ext, **kwd
                 )

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -415,9 +415,7 @@ class ImportExportTests(BaseHistories):
             raise SkipTest("skipping test_import_metadata_regeneration for task based...")
         history_name = f"for_import_metadata_regeneration_{uuid4()}"
         history_id = self.dataset_populator.new_history(name=history_name)
-        self.dataset_populator.new_dataset(
-            history_id, content=open(self.test_data_resolver.get_filename("1.bam"), "rb"), file_type="bam", wait=True
-        )
+        self.dataset_populator.new_bam_dataset(history_id, self.test_data_resolver)
         imported_history_id = self._reimport_history(history_id, history_name)
         self._assert_history_length(imported_history_id, 1)
         self._check_imported_dataset(history_id=imported_history_id, hid=1)

--- a/test/unit/data/datatypes/test_bam.py
+++ b/test/unit/data/datatypes/test_bam.py
@@ -1,3 +1,5 @@
+import json
+
 from pysam import (  # type: ignore[attr-defined]
     AlignmentFile,
     view,
@@ -63,3 +65,31 @@ def test_set_meta_header_info():
             "SQ": [{"SN": "ref", "LN": 45}, {"SN": "ref2", "LN": 40}],
         }
         assert dataset.metadata.reference_names == ["ref", "ref2"]
+
+
+def test_get_chunk():
+    with get_dataset("bam_from_sam.bam") as dataset:
+        chunk = _get_chunk_response(dataset, 0, 1)
+        offset = chunk["offset"]
+
+        chunk2 = _get_chunk_response(dataset, offset, 1)
+
+        offset2 = chunk2["offset"]
+        chunk3 = _get_chunk_response(dataset, offset2, 1)
+        offset3 = chunk3["offset"]
+
+        assert offset < offset2
+        assert offset2 < offset3
+
+        double_chunk = _get_chunk_response(dataset, offset, 2)
+        double_chunk["ck_data"].startswith(chunk2["ck_data"])
+        double_chunk["ck_data"].endswith(chunk3["ck_data"])
+
+        double_chunk_offset = double_chunk["offset"]
+        assert offset3 == double_chunk_offset
+
+
+def _get_chunk_response(dataset, offset, chunk_size):
+    b = Bam()
+    chunk = b.get_chunk(None, dataset, offset, chunk_size)
+    return json.loads(chunk)


### PR DESCRIPTION
See the commit message on the individual atomic commits.

Fixes #15997

For future John - past you believed the next steps here are:
- Swap the UI to use ``/api/datasets/<id>/display`` instead of ``/dataset/display`` in ``TabularChunkedView.vue``.
- Drop any costume parsing or support for ``offset`` as a parameter in the legacy dataset controller so we can be comfortable everything is coming in through the tested API endpoint.
- If offset is sent to services.Dataset.display  - use a data provider the way show would instead if possible? See if we can mimic the external interface while coalescing around data providers internally. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
