### PR TITLE
Add count support for listing filters

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -395,7 +395,7 @@ class ModelManager(Generic[U]):
         If the filters include functional filters, this function will raise an exception as they might cause
         performance issues.
         """
-        # TODO: requires case sensitivity fix from https://github.com/galaxyproject/galaxy/pull/16036
+        self._handle_filters_case_sensitivity(filters)
         orm_filters, fn_filters = self._split_filters(filters)
         if fn_filters:
             raise exceptions.RequestParameterInvalidException("Counting with functional filters is not supported.")

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -961,22 +961,19 @@ class TestHistoryFilters(BaseTestCase):
         all_histories = [history1, history2, history3, history4]
         deleted = [history1, history2, history3]
 
-        self.log("no filters should work")
-        assert self.history_manager.count() == len(all_histories)
-        self.log("orm filtered should work")
+        assert self.history_manager.count() == len(all_histories), "having no filters should count all histories"
         filters = [model.History.deleted == true()]
-        assert self.history_manager.count(filters=filters) == len(deleted)
+        assert self.history_manager.count(filters=filters) == len(deleted), "counting with orm filters should work"
 
         raw_annotation_fn_filter = ("annotation", "has", test_annotation)
-        self.log("fn filtered is not supported")
-        with pytest.raises(exceptions.RequestParameterInvalidException) as exc:
+        # functional filtering is not supported
+        with pytest.raises(exceptions.RequestParameterInvalidException) as exc_info:
             filters = self.filter_parser.parse_filters([raw_annotation_fn_filter])
             self.history_manager.count(filters=filters)
-            assert "not supported" in str(exc)
+            assert "not supported" in str(exc_info)
 
         raw_deleted_orm_filter = ("deleted", "eq", "True")
-        self.log("mixin orm and fn filtered is not supported")
-        with pytest.raises(exceptions.RequestParameterInvalidException) as exc:
+        with pytest.raises(exceptions.RequestParameterInvalidException) as exc_info:
             filters = self.filter_parser.parse_filters([raw_deleted_orm_filter, raw_annotation_fn_filter])
             self.history_manager.count(filters=filters)
-            assert "not supported" in str(exc)
+            assert "not supported" in str(exc_info)


### PR DESCRIPTION
Extracted from https://github.com/galaxyproject/galaxy/pull/16003

I figured out that could be useful when trying to get the `total_matches` of a query using the current "dynamic filtering framework", not sure why it was not part of the API already, maybe because using functional filters could impact the performance in some extreme cases? We probably could fail the request as we do currently when listing history contents.

In draft until both TODOs are resolved.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
