### PR TITLE
Paginate History Store

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -144,6 +144,7 @@
     "@types/d3": "^7.4.0",
     "@types/jquery": "^3.5.16",
     "@types/lodash": "^4.14.194",
+    "@types/lodash.isequal": "^4.5.6",
     "@types/markdown-it": "^12.2.3",
     "@types/underscore": "^1.11.4",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
@@ -194,9 +195,9 @@
     "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.12.0",
     "webpack-merge": "^5.8.0",
+    "xml-js": "^1.6.11",
     "yaml-jest": "^1.2.0",
-    "yaml-loader": "^0.8.0",
-    "xml-js": "^1.6.11"
+    "yaml-loader": "^0.8.0"
   },
   "peerDependencies": {
     "postcss": "^8.4.6"

--- a/client/src/components/Dataset/DatasetList.vue
+++ b/client/src/components/Dataset/DatasetList.vue
@@ -114,11 +114,10 @@ export default {
         },
     },
     created() {
-        this.loadHistories();
         this.load();
     },
     methods: {
-        ...mapActions(useHistoryStore, ["loadHistories", "applyFilters"]),
+        ...mapActions(useHistoryStore, ["applyFilters"]),
         load(concat = false) {
             this.loading = true;
             getDatasets({

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -19,13 +19,13 @@
                 </b-button>
 
                 <b-button
-                    v-b-modal.selector-history-modal
                     v-b-tooltip.bottom.hover
                     data-description="switch to another history"
                     size="sm"
                     variant="link"
                     :disabled="isAnonymous"
-                    :title="userTitle('Switch to history')">
+                    :title="userTitle('Switch to history')"
+                    @click="showSwitchModal = !showSwitchModal">
                     <Icon fixed-width icon="exchange-alt" />
                 </b-button>
 
@@ -143,9 +143,11 @@
         </nav>
 
         <SelectorModal
+            v-if="showSwitchModal"
             id="selector-history-modal"
             :histories="histories"
             :additional-options="['center', 'multi']"
+            :show-modal.sync="showSwitchModal"
             @selectHistory="setCurrentHistory($event.id)" />
 
         <CopyModal id="copy-current-history-modal" :history="history" />
@@ -191,6 +193,11 @@ export default {
         history: { type: Object, required: true },
         title: { type: String, default: "Histories" },
         historiesLoading: { type: Boolean, default: false },
+    },
+    data() {
+        return {
+            showSwitchModal: false,
+        };
     },
     computed: {
         ...mapState(useUserStore, ["isAnonymous"]),

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -143,7 +143,7 @@
         </nav>
 
         <SelectorModal
-            v-if="showSwitchModal"
+            v-show="showSwitchModal"
             id="selector-history-modal"
             :histories="histories"
             :additional-options="['center', 'multi']"

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -45,7 +45,7 @@
                             <b-spinner v-if="historiesLoading" small />
                             <span>Fetching histories from server</span>
                         </div>
-                        <span v-else>You have {{ histories.length }} histories.</span>
+                        <span v-else>You have {{ totalHistoryCount }} histories.</span>
                     </b-dropdown-text>
 
                     <b-dropdown-item
@@ -201,6 +201,7 @@ export default {
     },
     computed: {
         ...mapState(useUserStore, ["isAnonymous"]),
+        ...mapState(useHistoryStore, ["totalHistoryCount"]),
     },
     methods: {
         ...mapActions(useHistoryStore, ["createNewHistory", "deleteHistory", "secureHistory", "setCurrentHistory"]),

--- a/client/src/components/History/Modals/SelectorModal.test.js
+++ b/client/src/components/History/Modals/SelectorModal.test.js
@@ -1,3 +1,5 @@
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
 import { createPinia } from "pinia";
 import { mount } from "@vue/test-utils";
 import flushPromises from "flush-promises";
@@ -19,14 +21,14 @@ const getFakeHistorySummaries = (num, selectedIndex = 0) => {
     result[selectedIndex].id = CURRENT_HISTORY_ID;
     return result;
 };
-const PROPS_WITH_10_HISTORIES = {
+const PROPS_FOR_MODAL = {
     currentHistoryId: CURRENT_HISTORY_ID,
-    histories: getFakeHistorySummaries(10),
-    perPage: 3,
+    histories: [],
     static: true, // Force the modal visible for testing
+    showModal: true,
 };
-const PROPS_WITH_10_HISTORY_MULTIPLE_SELECT = {
-    ...PROPS_WITH_10_HISTORIES,
+const PROPS_FOR_MODAL_MULTIPLE_SELECT = {
+    ...PROPS_FOR_MODAL,
     multiple: true,
 };
 
@@ -34,6 +36,18 @@ const CURRENT_HISTORY_INDICATION_TEXT = "(Current)";
 
 describe("History SelectorModal.vue", () => {
     let wrapper;
+    let axiosMock;
+    let historyStore;
+    const allHistories = getFakeHistorySummaries(15);
+
+    function getUpdatedAxiosMock() {
+        const offset = historyStore.historiesOffset;
+        axiosMock
+            .onGet(`/api/histories?view=summary&order=update_time&offset=${offset}&limit=10`)
+            .reply(200, allHistories.slice(offset, offset + 10));
+
+        axiosMock.onGet(`/api/histories/count`).reply(200, 15);
+    }
 
     async function mountWith(props) {
         const pinia = createPinia();
@@ -42,35 +56,41 @@ describe("History SelectorModal.vue", () => {
             localVue,
             pinia,
         });
-        const historyStore = useHistoryStore();
-        historyStore.setHistories(props.histories);
+        historyStore = useHistoryStore();
+        axiosMock = new MockAdapter(axios);
+        getUpdatedAxiosMock();
+        await historyStore.loadHistories();
+        await wrapper.setProps({
+            histories: historyStore.histories,
+        });
         historyStore.setCurrentHistoryId(props.currentHistoryId);
 
         await flushPromises();
     }
 
     it("should indicate the currently selected history", async () => {
-        await mountWith(PROPS_WITH_10_HISTORIES);
+        await mountWith(PROPS_FOR_MODAL);
 
         const currentHistoryRow = wrapper.find(`[data-pk="${CURRENT_HISTORY_ID}"]`);
         expect(currentHistoryRow.html()).toContain(CURRENT_HISTORY_INDICATION_TEXT);
+        axiosMock.restore();
     });
 
     it("paginates the histories", async () => {
-        await mountWith(PROPS_WITH_10_HISTORIES);
+        await mountWith(PROPS_FOR_MODAL);
 
         const displayedRows = wrapper.findAllComponents(BListGroupItem).wrappers;
-        expect(displayedRows.length).toBe(3);
+        expect(displayedRows.length).toBe(10);
+        getUpdatedAxiosMock();
+        await historyStore.loadHistories();
+        expect(historyStore.histories.length).toBe(15);
+        expect(historyStore.historiesOffset).toBe(15);
 
-        // filter out all page buttons. e.g [1] [2] [3] etc...
-        const pages = wrapper
-            .findAll(".pagination > .page-item")
-            .wrappers.filter((item) => item.text().match(/[0-9]+/));
-        expect(pages.length).toBe(4);
+        axiosMock.restore();
     });
 
     it("emits selectHistory with the correct history ID when a row is clicked", async () => {
-        await mountWith(PROPS_WITH_10_HISTORIES);
+        await mountWith(PROPS_FOR_MODAL);
 
         expect(wrapper.emitted()["selectHistory"]).toBeUndefined();
 
@@ -80,11 +100,12 @@ describe("History SelectorModal.vue", () => {
 
         expect(wrapper.emitted()["selectHistory"]).toBeDefined();
         expect(wrapper.emitted()["selectHistory"][0][0].id).toBe(targetHistoryId);
+        axiosMock.restore();
     });
 
     describe("Multi-selection Mode", () => {
         it("should select multiple histories", async () => {
-            await mountWith(PROPS_WITH_10_HISTORY_MULTIPLE_SELECT);
+            await mountWith(PROPS_FOR_MODAL_MULTIPLE_SELECT);
 
             expect(wrapper.emitted()["selectHistories"]).toBeUndefined();
 
@@ -104,6 +125,7 @@ describe("History SelectorModal.vue", () => {
             await button.trigger("click");
 
             expect(wrapper.emitted()["selectHistories"][0][0][0].id).toBe(targetHistoryId1);
+            axiosMock.restore();
         });
     });
 });

--- a/client/src/components/History/Modals/SelectorModal.test.js
+++ b/client/src/components/History/Modals/SelectorModal.test.js
@@ -79,13 +79,19 @@ describe("History SelectorModal.vue", () => {
     it("paginates the histories", async () => {
         await mountWith(PROPS_FOR_MODAL);
 
-        const displayedRows = wrapper.findAllComponents(BListGroupItem).wrappers;
+        let displayedRows = wrapper.findAllComponents(BListGroupItem).wrappers;
         expect(displayedRows.length).toBe(10);
+        expect(wrapper.find(".load-more-hist-button").exists()).toBe(true);
+
         getUpdatedAxiosMock();
         await historyStore.loadHistories();
-        expect(historyStore.histories.length).toBe(15);
-        expect(historyStore.historiesOffset).toBe(15);
+        await wrapper.setProps({
+            histories: historyStore.histories,
+        });
 
+        displayedRows = wrapper.findAllComponents(BListGroupItem).wrappers;
+        expect(displayedRows.length).toBe(15);
+        expect(wrapper.find(".load-more-hist-button").exists()).toBe(false);
         axiosMock.restore();
     });
 

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -12,7 +12,7 @@ import {
 } from "bootstrap-vue";
 import StatelessTags from "@/components/TagsMultiselect/StatelessTags.vue";
 import UtcDate from "@/components/UtcDate.vue";
-import { computed, nextTick, onMounted, onUnmounted, ref, watch, type PropType, type Ref } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch, type PropType, type Ref } from "vue";
 import localize from "@/utils/localization";
 import Heading from "@/components/Common/Heading.vue";
 import type { components } from "@/schema";
@@ -79,7 +79,6 @@ const validFilter = computed(() => filter.value && filter.value.length > 2);
 const allLoaded = computed(() => totalHistoryCount.value <= filtered.value.length);
 
 onMounted(async () => {
-    await nextTick();
     useInfiniteScroll(scrollableDiv.value, () => loadMore());
 });
 

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -80,7 +80,6 @@ const allLoaded = computed(() => totalHistoryCount.value <= filtered.value.lengt
 
 onMounted(async () => {
     await nextTick();
-    scrollableDiv.value = document.querySelector(".history-selector-modal-list");
     useInfiniteScroll(scrollableDiv.value, () => loadMore());
 });
 
@@ -225,7 +224,7 @@ async function loadMore(noScroll = false) {
             <b-badge v-if="filter && !validFilter" class="alert-danger w-100">Search string too short!</b-badge>
             <b-alert v-else-if="!busy && hasNoResults" variant="danger" show>No histories found.</b-alert>
 
-            <div class="history-selector-modal-list">
+            <div ref="scrollableDiv" class="history-selector-modal-list">
                 <b-list-group>
                     <b-list-group-item
                         v-for="history in filtered"

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -205,9 +205,10 @@ async function loadMore(noScroll = false) {
                 <b-form-input v-model="filter" type="search" debounce="400" :placeholder="localize('Search Filter')" />
             </b-form-group>
 
+            <b-badge v-if="filter && !validFilter" class="alert-danger w-100">Search string too short!</b-badge>
+            <b-alert v-else-if="!busy && hasNoResults" variant="danger" show>No histories found.</b-alert>
+
             <div class="history-selector-modal-list">
-                <b-badge v-if="filter && !validFilter" class="alert-danger w-100">Search string too short!</b-badge>
-                <b-alert v-else-if="!busy && hasNoResults" variant="danger" show>No histories found.</b-alert>
                 <b-list-group>
                     <b-list-group-item
                         v-for="history in filtered"

--- a/client/src/components/History/Modals/SelectorModal.vue
+++ b/client/src/components/History/Modals/SelectorModal.vue
@@ -116,7 +116,7 @@ watch(
 
 const filtered: Ref<HistorySummary[]> = computed(() => {
     let filteredHistories: HistorySummary[] = [];
-    if (!filter.value) {
+    if (!validFilter.value) {
         filteredHistories = historiesProxy.value;
     } else {
         const filters = HistoriesFilters.getFiltersForText(filter.value);

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref, onMounted, type Ref } from "vue";
 import { storeToRefs } from "pinia";
 import localize from "@/utils/localization";
 import { useUserStore } from "@/stores/userStore";
@@ -9,13 +9,44 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 import MultipleViewList from "./MultipleViewList.vue";
+import SelectorModal from "@/components/History/Modals/SelectorModal.vue";
 
 const filter = ref("");
+const showSelectModal = ref(false);
 
 library.add(faTimes);
 
 const { currentUser } = storeToRefs(useUserStore());
 const { histories, historiesLoading, currentHistory } = storeToRefs(useHistoryStore());
+
+const historyStore = useHistoryStore();
+onMounted(() => {
+    historyStore.loadPinnedHistories();
+});
+
+const selectedHistories: Ref<{ id: string }[]> = computed(() => historyStore.pinnedHistories);
+
+if (!selectedHistories.value.length ?? histories.value.length > 0) {
+    historyStore.pinHistory(histories.value[0]!.id);
+}
+
+function addHistoriesToList(histories: { id: string }[]) {
+    // Unpin histories that are already pinned but not in the incoming list
+    const historiesToUnpin = selectedHistories.value.filter(
+        (pinnedHistory) => !histories.some((history) => history.id === pinnedHistory.id)
+    );
+    historiesToUnpin.forEach((history) => {
+        historyStore.unpinHistory(history.id);
+    });
+    // Pin histories that aren't already pinned and are in incoming list
+    histories.forEach((history) => {
+        const historyExists = selectedHistories.value.some((h) => h.id === history.id);
+        if (!historyExists) {
+            historyStore.pinHistory(history.id);
+            historyStore.loadHistoryById(history.id);
+        }
+    });
+}
 
 function updateFilter(newFilter: string) {
     filter.value = newFilter;
@@ -43,10 +74,23 @@ function updateFilter(newFilter: string) {
                     </b-button>
                 </b-input-group-append>
             </b-input-group>
-            <MultipleViewList :histories="histories" :filter="filter" :current-history="currentHistory" />
+            <MultipleViewList
+                :histories="histories"
+                :filter="filter"
+                :current-history="currentHistory"
+                :selected-histories="selectedHistories"
+                :show-modal.sync="showSelectModal" />
         </div>
         <b-alert v-else class="m-2" variant="danger" show>
             <span v-localize class="font-weight-bold">No History found.</span>
         </b-alert>
+        <SelectorModal
+            v-if="showSelectModal"
+            :multiple="true"
+            :histories="histories"
+            :additional-options="['center', 'set-current']"
+            :show-modal.sync="showSelectModal"
+            title="Select histories"
+            @selectHistories="addHistoriesToList" />
     </div>
 </template>

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -39,6 +39,12 @@ onMounted(async () => {
     loadingPinnedHistories.value = false;
 });
 
+/**
+ * From the incoming list, pin histories that are not already pinned and
+ * unpin histories that are not in the incoming list.
+ * This is a mechanism to allow users to select or deselect histories in modal.
+ * @param histories the incoming list of histories to pin
+ */
 function addHistoriesToList(histories: { id: string }[]) {
     // Unpin histories that are already pinned but not in the incoming list
     const historiesToUnpin = selectedHistories.value.filter(
@@ -94,7 +100,7 @@ function updateFilter(newFilter: string) {
             <span v-localize class="font-weight-bold">No History found.</span>
         </b-alert>
         <SelectorModal
-            v-if="showSelectModal"
+            v-show="showSelectModal"
             :multiple="true"
             :histories="histories"
             :additional-options="['center', 'set-current']"

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -30,7 +30,6 @@ onMounted(async () => {
     loadingPinnedHistories.value = true;
     stopStoreWatcher.value = watchEffect(() => {
         if (noHistoriesInView.value == true) {
-            console.log("WATCH: ", histories.value.length);
             historyStore.pinHistory(histories.value[0]!.id);
             if (stopStoreWatcher.value) {
                 stopStoreWatcher.value();

--- a/client/src/components/History/Multiple/MultipleView.vue
+++ b/client/src/components/History/Multiple/MultipleView.vue
@@ -36,11 +36,6 @@ onMounted(async () => {
             }
         }
     });
-    await Promise.all(
-        selectedHistories.value.map(async ({ id }) => {
-            await historyStore.loadHistoryById(id);
-        })
-    );
     loadingPinnedHistories.value = false;
 });
 

--- a/client/src/components/History/Multiple/MultipleViewItem.vue
+++ b/client/src/components/History/Multiple/MultipleViewItem.vue
@@ -1,5 +1,10 @@
 <template>
-    <div id="list-item" class="d-flex flex-column align-items-center w-100">
+    <div v-if="!getHistory" class="container">
+        <div class="row align-items-center h-100">
+            <LoadingSpan class="mx-auto" message="Loading History" />
+        </div>
+    </div>
+    <div v-else id="list-item" class="d-flex flex-column align-items-center w-100">
         <CollectionPanel
             v-if="selectedCollections.length && selectedCollections[0].history_id === source.id"
             :history="getHistory"
@@ -40,11 +45,13 @@ import { mapActions, mapState } from "pinia";
 import { useHistoryStore } from "@/stores/historyStore";
 import HistoryPanel from "components/History/CurrentHistory/HistoryPanel";
 import CollectionPanel from "components/History/CurrentCollection/CollectionPanel";
+import LoadingSpan from "components/LoadingSpan";
 
 export default {
     components: {
         HistoryPanel,
         CollectionPanel,
+        LoadingSpan,
     },
     props: {
         source: {

--- a/client/src/components/History/Multiple/MultipleViewList.vue
+++ b/client/src/components/History/Multiple/MultipleViewList.vue
@@ -3,16 +3,14 @@ import { computed, ref, type Ref } from "vue";
 //@ts-ignore missing typedefs
 import VirtualList from "vue-virtual-scroll-list";
 import MultipleViewItem from "./MultipleViewItem.vue";
-import { useHistoryStore, type HistorySummary } from "@/stores/historyStore";
-import SelectorModal from "@/components/History/Modals/SelectorModal.vue";
+import type { HistorySummary } from "@/stores/historyStore";
 import { useAnimationFrameScroll } from "@/composables/sensors/animationFrameScroll";
 import { useAnimationFrameResizeObserver } from "@/composables/sensors/animationFrameResizeObserver";
-
-const historyStore = useHistoryStore();
 
 const props = withDefaults(
     defineProps<{
         histories: HistorySummary[];
+        selectedHistories: { id: string }[];
         filter?: string;
     }>(),
     {
@@ -30,21 +28,6 @@ useAnimationFrameResizeObserver(scrollContainer, ({ clientSize, scrollSize }) =>
 
 const scrolledLeft = computed(() => !isScrollable.value || arrived.left);
 const scrolledRight = computed(() => !isScrollable.value || arrived.right);
-
-const selectedHistories = computed(() => historyStore.pinnedHistories);
-
-if (!selectedHistories.value.length ?? props.histories.length > 0) {
-    historyStore.pinHistory(props.histories[0]!.id);
-}
-
-function addHistoriesToList(histories: HistorySummary[]) {
-    histories.forEach((history) => {
-        const historyExists = selectedHistories.value.find((h) => h.id === history.id);
-        if (!historyExists) {
-            historyStore.pinHistory(history.id);
-        }
-    });
-}
 </script>
 
 <template>
@@ -65,18 +48,10 @@ function addHistoriesToList(histories: HistorySummary[]) {
             </virtual-list>
 
             <div
-                v-b-modal.select-histories-modal
-                class="history-picker text-primary d-flex m-3 p-5 align-items-center text-nowrap">
+                class="history-picker text-primary d-flex m-3 p-5 align-items-center text-nowrap"
+                @click.stop="$emit('update:show-modal', true)">
                 Select histories
             </div>
-
-            <SelectorModal
-                id="select-histories-modal"
-                :multiple="true"
-                :histories="histories"
-                :additional-options="['center', 'set-current']"
-                title="Select histories"
-                @selectHistories="addHistoriesToList" />
         </div>
     </div>
 </template>
@@ -85,6 +60,7 @@ function addHistoriesToList(histories: HistorySummary[]) {
 .list-container {
     .history-picker {
         border: dotted lightgray;
+        cursor: pointer;
     }
 
     position: relative;

--- a/client/src/components/History/Multiple/MultipleViewList.vue
+++ b/client/src/components/History/Multiple/MultipleViewList.vue
@@ -34,11 +34,11 @@ const scrolledRight = computed(() => !isScrollable.value || arrived.right);
     <div class="list-container h-100" :class="{ 'scrolled-left': scrolledLeft, 'scrolled-right': scrolledRight }">
         <div ref="scrollContainer" class="d-flex h-100 w-auto overflow-auto">
             <virtual-list
-                v-if="selectedHistories.length"
-                :estimate-size="selectedHistories.length"
+                v-if="props.selectedHistories.length"
+                :estimate-size="props.selectedHistories.length"
                 :data-key="'id'"
                 :data-component="MultipleViewItem"
-                :data-sources="selectedHistories"
+                :data-sources="props.selectedHistories"
                 :direction="'horizontal'"
                 :extra-props="{ filter }"
                 :item-style="{ width: '15rem' }"

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -95,7 +95,7 @@ export default {
         };
     },
     computed: {
-        ...mapState(useHistoryStore, ["currentHistoryId"]),
+        ...mapState(useHistoryStore, ["currentHistoryId", "getHistoryById"]),
         ...mapState(useHistoryItemsStore, ["getLastUpdateTime"]),
         historyStatusKey() {
             return `${this.currentHistoryId}_${this.getLastUpdateTime}`;
@@ -114,6 +114,10 @@ export default {
     methods: {
         handleInvocations(invocations) {
             this.invocations = invocations;
+            // make sure any new histories are added to historyStore
+            this.invocations.forEach((invocation) => {
+                this.getHistoryById(invocation.history_id);
+            });
         },
         handleSubmissionError(error) {
             this.submissionError = errorMessageAsString(error);

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -410,6 +410,10 @@ export interface paths {
          */
         post: operations["create_api_histories_post"];
     };
+    "/api/histories/count": {
+        /** Returns number of histories for the current user. */
+        get: operations["count_api_histories_count_get"];
+    };
     "/api/histories/deleted": {
         /** Returns deleted histories for the current user. */
         get: operations["index_deleted_api_histories_deleted_get"];
@@ -10643,6 +10647,29 @@ export interface operations {
                         | components["schemas"]["HistorySummary"]
                         | components["schemas"]["HistoryDetailed"]
                         | Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    count_api_histories_count_get: {
+        /** Returns number of histories for the current user. */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": number;
                 };
             };
             /** @description Validation Error */

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -25,6 +25,7 @@ const isLoadingHistory = new Set();
 export const useHistoryStore = defineStore("historyStore", () => {
     const historiesLoading = ref(false);
     const historiesOffset = ref(0);
+    const totalHistoryCount = ref(0);
     const pinnedHistories = useUserLocalStorage<{ id: string }[]>("history-store-pinned-histories", []);
     const storedCurrentHistoryId = ref<string | null>(null);
     const storedFilterTexts = ref<{ [key: string]: string }>({});
@@ -133,7 +134,9 @@ export const useHistoryStore = defineStore("historyStore", () => {
     }
 
     function pinHistory(historyId: string) {
-        pinnedHistories.value.push({ id: historyId });
+        if (pinnedHistories.value.findIndex((item) => item.id == historyId) == -1) {
+            pinnedHistories.value.push({ id: historyId });
+        }
     }
 
     function unpinHistory(historyId: string) {
@@ -155,11 +158,13 @@ export const useHistoryStore = defineStore("historyStore", () => {
 
     async function copyHistory(history: HistorySummary, name: string, copyAll: boolean) {
         const newHistory = (await cloneHistory(history, name, copyAll)) as HistorySummary;
+        await handleTotalCountChange(1);
         return setCurrentHistory(newHistory.id);
     }
 
     async function createNewHistory() {
         const newHistory = await createAndSelectNewHistory();
+        await handleTotalCountChange(1);
         return selectHistory(newHistory as HistorySummary);
     }
 
@@ -168,7 +173,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
         const filteredHistoryIds = historyIds.filter((id) => !excludedIds.includes(id));
         return filteredHistoryIds[0];
     }
-
+    
     async function deleteHistory(historyId: string, purge: boolean) {
         const deletedHistory = (await deleteHistoryById(historyId, purge)) as HistorySummary;
         const nextAvailableHistoryId = getNextAvailableHistoryId([deletedHistory.id]);
@@ -178,32 +183,53 @@ export const useHistoryStore = defineStore("historyStore", () => {
             await createNewHistory();
         }
         Vue.delete(storedHistories.value, deletedHistory.id);
+        await handleTotalCountChange(1, true);
     }
 
     async function loadCurrentHistory() {
         const history = await getCurrentHistoryFromServer();
         selectHistory(history as HistorySummary);
     }
-        
+
+    /**
+     * This function handles the cases where a history has been created
+     * or removed (to set pagination offset and updated history count)
+     *
+     * @param count How many histories have been added/removed
+     * @param reduction Whether it is a reduction or addition (default)
+     */
+    async function handleTotalCountChange(count = 0, reduction = false) {
+        historiesOffset.value += !reduction ? count : -count;
+        await loadTotalHistoryCount();
+    }
+
+    async function loadTotalHistoryCount() {
+        await getHistoryCount().then((count) => (totalHistoryCount.value = count));
+    }
+
     /** TODO:
-     * not handling filters with pagination for now
-     * "pausing" pagination at the existing offset if a filter exists
+     * - not handling filters with pagination for now
+     *   "pausing" pagination at the existing offset if a filter exists
      */
     async function loadHistories(paginate = true, queryString?: string) {
         if (!historiesLoading.value) {
+            setHistoriesLoading(true);
             let limit: number | null = null;
-            if (!queryString) {
+            if (!queryString || queryString == "") {
                 if (paginate) {
-                    const totalCount = await getTotalHistoryCount.value;
-                    if (historiesOffset.value >= totalCount) {
+                    await loadTotalHistoryCount();
+                    if (historiesOffset.value >= totalHistoryCount.value) {
+                        setHistoriesLoading(false);
                         return;
                     }
                     limit = PAGINATION_LENGTH;
                 } else {
                     historiesOffset.value = 0;
                 }
+                limit = PAGINATION_LENGTH;
+            } else {
+                historiesOffset.value = 0;
             }
-            setHistoriesLoading(true);
             const offset = queryString ? 0 : historiesOffset.value;
             await getHistoryList(offset, limit, queryString)
                 .then((histories) => {
@@ -247,7 +273,6 @@ export const useHistoryStore = defineStore("historyStore", () => {
         pinnedHistories,
         getHistoryById,
         getHistoryNameById,
-        getTotalHistoryCount,
         setCurrentHistory,
         setCurrentHistoryId,
         setFilterText,
@@ -267,5 +292,6 @@ export const useHistoryStore = defineStore("historyStore", () => {
         updateHistory,
         historiesLoading,
         historiesOffset,
+        totalHistoryCount,
     };
 });

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -19,7 +19,7 @@ import { useUserLocalStorage } from "@/composables/userLocalStorage";
 
 export type HistorySummary = components["schemas"]["HistorySummary"];
 
-const PAGINATION_LENGTH = 10;
+const PAGINATION_LIMIT = 10;
 const isLoadingHistory = new Set();
 
 export const useHistoryStore = defineStore("historyStore", () => {
@@ -206,7 +206,7 @@ export const useHistoryStore = defineStore("historyStore", () => {
     async function loadTotalHistoryCount() {
         await getHistoryCount().then((count) => (totalHistoryCount.value = count));
     }
-
+    
     /** TODO:
      * - not handling filters with pagination for now
      *   "pausing" pagination at the existing offset if a filter exists
@@ -222,13 +222,10 @@ export const useHistoryStore = defineStore("historyStore", () => {
                         setHistoriesLoading(false);
                         return;
                     }
-                    limit = PAGINATION_LENGTH;
+                    limit = PAGINATION_LIMIT;
                 } else {
                     historiesOffset.value = 0;
                 }
-                limit = PAGINATION_LENGTH;
-            } else {
-                historiesOffset.value = 0;
             }
             const offset = queryString ? 0 : historiesOffset.value;
             await getHistoryList(offset, limit, queryString)

--- a/client/src/stores/services/history.services.js
+++ b/client/src/stores/services/history.services.js
@@ -112,15 +112,16 @@ export async function setCurrentHistoryOnServer(historyId) {
  * @param {Number | null} limit
  * @return {Promise.<Array>} list of histories
  */
-export async function getHistoryList(offset = 0, limit = null) {
-    const url = "api/histories";
-    const paginatedParams = {
-        view: "summary",
-        offset: offset,
-        limit: limit,
-        order: "update_time",
-    };
-    const response = await axios.get(prependPath(url), { params: paginatedParams });
+export async function getHistoryList(offset = 0, limit = null, queryString = "") {
+    const params = `view=summary&order=update_time&offset=${offset}`;
+    let url = `api/histories?${params}`;
+    if (limit !== null) {
+        url += `&limit=${limit}`;
+    }
+    if (queryString !== "") {
+        url += `&${queryString}`;
+    }
+    const response = await axios.get(prependPath(url));
     return doResponse(response);
 }
 

--- a/client/src/stores/services/history.services.js
+++ b/client/src/stores/services/history.services.js
@@ -130,6 +130,8 @@ export async function getHistoryList(offset = 0, limit = null, queryString = "")
  * @return {Promise.<Number>} number of histories
  */
 export async function getHistoryCount() {
+    // This url is temp. for this PR, waiting on:
+    // https://github.com/galaxyproject/galaxy/pull/16075
     const url = "api/histories/count";
     const response = await axios.get(prependPath(url));
     return doResponse(response);

--- a/client/src/stores/services/history.services.js
+++ b/client/src/stores/services/history.services.js
@@ -108,11 +108,29 @@ export async function setCurrentHistoryOnServer(historyId) {
 
 /**
  * Get list of histories from server and return them.
+ * @param {Number} offset
+ * @param {Number | null} limit
  * @return {Promise.<Array>} list of histories
  */
-export async function getHistoryList() {
+export async function getHistoryList(offset = 0, limit = null) {
     const url = "api/histories";
-    const response = await axios.get(prependPath(url), { params: stdHistoryParams });
+    const paginatedParams = {
+        view: "summary",
+        offset: offset,
+        limit: limit,
+        order: "update_time",
+    };
+    const response = await axios.get(prependPath(url), { params: paginatedParams });
+    return doResponse(response);
+}
+
+/**
+ * Get number of histories from server and return them.
+ * @return {Promise.<Number>} number of histories
+ */
+export async function getHistoryCount() {
+    const url = "api/histories/count";
+    const response = await axios.get(prependPath(url));
     return doResponse(response);
 }
 

--- a/client/src/stores/services/history.services.js
+++ b/client/src/stores/services/history.services.js
@@ -108,8 +108,9 @@ export async function setCurrentHistoryOnServer(historyId) {
 
 /**
  * Get list of histories from server and return them.
- * @param {Number} offset
- * @param {Number | null} limit
+ * @param {Number} offset to start from (default = 0)
+ * @param {Number | null} limit of histories to load (default = null; in which case no limit)
+ * @param {String} queryString to append to url in the form `q=filter&qv=val&q=...`
  * @return {Promise.<Array>} list of histories
  */
 export async function getHistoryList(offset = 0, limit = null, queryString = "") {
@@ -126,7 +127,7 @@ export async function getHistoryList(offset = 0, limit = null, queryString = "")
 }
 
 /**
- * Get number of histories from server and return them.
+ * Get number of histories for current user from server and return them.
  * @return {Promise.<Number>} number of histories
  */
 export async function getHistoryCount() {

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -52,7 +52,7 @@ export const useUserStore = defineStore(
         function loadUser() {
             if (!loadPromise) {
                 loadPromise = getCurrentUser()
-                    .then((user) => {
+                    .then(async (user) => {
                         const historyStore = useHistoryStore();
                         currentUser.value = { ...user, isAnonymous: !user.email };
                         currentPreferences.value = user?.preferences ?? null;
@@ -62,8 +62,9 @@ export const useUserStore = defineStore(
                                 user?.preferences?.favorites ?? { tools: [] }
                             );
                         }
-                        historyStore.loadCurrentHistory();
-                        historyStore.loadHistories();
+                        await historyStore.loadCurrentHistory();
+                        // load first few histories for user to start pagination
+                        await historyStore.loadHistories();
                     })
                     .catch((e) => {
                         console.error("Failed to load user", e);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2382,6 +2382,18 @@
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
   integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
 
+"@types/lodash.isequal@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz#ff42a1b8e20caa59a97e446a77dc57db923bc02b"
+  integrity sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.195"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
+  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
+
 "@types/lodash@^4.14.194":
   version "4.14.194"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -131,6 +131,17 @@ class FastAPIHistories:
             trans, serialization_params, filter_query_params, deleted_only=deleted, all_histories=all
         )
 
+    # THIS IS JUST A DUMMY ROUTE FOR WIP testing
+    @router.get(
+        "/api/histories/count",
+        summary="Returns number of histories for the current user.",
+    )
+    def count(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> int:
+        return self.service.count(trans)
+
     @router.get(
         "/api/histories/deleted",
         summary="Returns deleted histories for the current user.",

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -131,7 +131,6 @@ class FastAPIHistories:
             trans, serialization_params, filter_query_params, deleted_only=deleted, all_histories=all
         )
 
-    # THIS IS JUST A DUMMY ROUTE FOR WIP testing
     @router.get(
         "/api/histories/count",
         summary="Returns number of histories for the current user.",

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -462,6 +462,23 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         ]
         return rval
 
+    # THIS IS JUST A DUMMY FN FOR WIP testing
+    def count(
+        self,
+        trans: ProvidesHistoryContext,
+    ):
+        """
+        Returns number of histories for the current user.
+        """
+        # bail early with current history if user is anonymous
+        current_user = self.user_manager.current_user(trans)
+        if self.user_manager.is_anonymous(current_user):
+            current_history = self.manager.get_current(trans)
+            if not current_history:
+                return 0
+            return 1
+        return len(current_user.active_histories)
+
     def published(
         self,
         trans: ProvidesHistoryContext,

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -462,7 +462,6 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         ]
         return rval
 
-    # THIS IS JUST A DUMMY FN FOR WIP testing
     def count(
         self,
         trans: ProvidesHistoryContext,
@@ -470,7 +469,6 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         """
         Returns number of histories for the current user.
         """
-        # bail early with current history if user is anonymous
         current_user = self.user_manager.current_user(trans)
         if self.user_manager.is_anonymous(current_user):
             current_history = self.manager.get_current(trans)


### PR DESCRIPTION
Paginating histories instead of loading all in the `userStore`. Scrolling in the Switch to History modal will load more histories. Fixes #14317 

https://github.com/galaxyproject/galaxy/assets/78516064/43c6e70b-25b1-45f2-8838-4ee5154ffcae

### Key changes:
- In `SelectorModal`, the b-pagination has been replaced with `vue-infinite-scroll` pagination and a load more button. We can also see the number of histories loaded / total histories.
- In `historyStore`, whenever an instance of the `loadHistories()` function is called, instead of loading all histories (`histories?view=summary`), we load starting from the `historyStore.historiesOffset` up to the pagination limit (set = 10) (e.g.: `histories?view=summary&order=update_time&offset=20&limit=10`)
- `historyStore.loadHistories` takes two parameters: `loadHistories(paginate=true, queryString?)`. `paginate` decides whether to paginate by the offset+limit or load all histories if needed. `queryString` is the query being added to the url which then pauses pagination at the offset and instead just loads histories for the current query: `histories?view=summary&order=update_time&offset=0&q=name-contains&qv=genomics`. When the filter is removed, we go back to the previous offset and paginate from where we left off.
- In the `MultipleView` selector modal, we can now also deselect histories and apply the changes if needed.
- Added a route for `api/histories/count` which returns the number of total histories for the current user, by: `len(current_user.active_histories)`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
