### PR TITLE
Selenium test for displaying workflows with problems in pages.

### DIFF
--- a/client/src/components/Panels/Common/Tool.vue
+++ b/client/src/components/Panels/Common/Tool.vue
@@ -1,10 +1,10 @@
 <template>
     <div class="toolTitle">
-        <a v-if="tool.disabled" class="title-link name text-muted">
+        <a v-if="tool.disabled" :data-tool-id="tool.id" class="title-link name text-muted">
             <span v-if="!hideName">{{ tool.name }}</span>
             <span class="description">{{ tool.description }}</span>
         </a>
-        <a v-else :class="targetClass" :href="tool.link" :target="tool.target" @click="onClick">
+        <a v-else :class="targetClass" :data-tool-id="tool.id" :href="tool.link" :target="tool.target" @click="onClick">
             <img v-if="tool.logo" class="logo" :src="tool.logo" :alt="tool.name" />
             <span class="labels">
                 <span

--- a/client/src/components/SelectionDialog/DataDialogTable.vue
+++ b/client/src/components/SelectionDialog/DataDialogTable.vue
@@ -11,6 +11,7 @@
             :per-page="perPage"
             :current-page="currentPage"
             :busy.sync="isBusy"
+            primary-key="id"
             @row-clicked="clicked"
             @filtered="filtered">
             <template v-slot:head(select_icon)="">

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -489,12 +489,12 @@ pages:
   editor:
     selectors:
       save: '#save-button'
-      embed_dataset:
-        type: xpath
-        selector: '//span[text() = "Embedded Dataset"]'
+      embed_dataset: '.toolTitle .title-link[data-tool-id="history_dataset_embedded"]'
+      embed_workflow_display: '.toolTitle .title-link[data-tool-id="workflow_display"]'
       dataset_selector:
         type: xpath
         selector: '//span[text() = "1: 1.fasta"]'
+      workflow_selection: .selection-dialog-modal [role="row"][data-pk="${id}"]
       embed_dialog_add_button: '.pages-embed .buttons #button-0'
       markdown_editor: '.markdown-textarea'
 

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1159,6 +1159,14 @@ class NavigatesGalaxy(HasDriver):
         self.libraries_index_search_for(name)
         self.libraries_index_table_elements()[0].find_element(By.CSS_SELECTOR, "td a").click()
 
+    def page_open_with_name(self, name, screenshot_name):
+        self.home()
+        self.navigate_to_pages()
+        self.click_grid_popup_option(name, "View")
+        if screenshot_name:
+            self.sleep_for(self.wait_types.UX_RENDER)
+            self.screenshot(screenshot_name)
+
     @retry_during_transitions
     def libraries_index_table_elements(self):
         container = self.components.libraries._.wait_for_visible()


### PR DESCRIPTION
Implements a selenium test to create a page with two embedded workflows with different errors and display them. I'm trying to figure out how the error display stuff in WorkflowDisplay.vue is exercised but I've failed to exercise that code.
 
## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
