### PR TITLE
Use automated naming convention to generate indexes and constraints in database

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -69,6 +69,7 @@ from sqlalchemy import (
     inspect,
     Integer,
     join,
+    MetaData,
     not_,
     Numeric,
     or_,
@@ -215,6 +216,20 @@ else:
     _HasTable = object
 
 
+# Naming convention applied to database constraints and indexes.
+# All except "ix" are conventions used by PostgreSQL by default.
+# We keep the "ix" template consistent with historical Galaxy usage.
+#
+# NOTE: If editing, also update model.migrations.utils.DbObjectNames.
+NAMING_CONVENTION = {
+    "pk": "%(table_name)s_pkey",
+    "fk": "%(table_name)s_%(column_0_name)s_fkey",
+    "uq": "%(table_name)s_%(column_0_name)s_key",
+    "ck": "%(table_name)s_%(column_0_name)s_check",
+    "ix": "ix_%(table_name)s_%(column_0_name)s",
+}
+
+
 def get_uuid(uuid: Optional[Union[UUID, str]] = None) -> UUID:
     if isinstance(uuid, UUID):
         return uuid
@@ -225,8 +240,9 @@ def get_uuid(uuid: Optional[Union[UUID, str]] = None) -> UUID:
 
 class Base(_HasTable, metaclass=DeclarativeMeta):
     __abstract__ = True
+    metadata = MetaData(naming_convention=NAMING_CONVENTION)
+    mapper_registry.metadata = metadata
     registry = mapper_registry
-    metadata = mapper_registry.metadata
     __init__ = mapper_registry.constructor
 
     @classmethod

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -123,6 +123,7 @@ from galaxy.model.custom_types import (
     TrimmedString,
     UUIDType,
 )
+from galaxy.model.database_object_names import NAMING_CONVENTION
 from galaxy.model.item_attrs import (
     get_item_annotation_str,
     UsesAnnotations,
@@ -214,20 +215,6 @@ else:
     from sqlalchemy.orm.decl_api import DeclarativeMeta
 
     _HasTable = object
-
-
-# Naming convention applied to database constraints and indexes.
-# All except "ix" are conventions used by PostgreSQL by default.
-# We keep the "ix" template consistent with historical Galaxy usage.
-#
-# NOTE: If editing, also update model.migrations.utils.DbObjectNames.
-NAMING_CONVENTION = {
-    "pk": "%(table_name)s_pkey",
-    "fk": "%(table_name)s_%(column_0_name)s_fkey",
-    "uq": "%(table_name)s_%(column_0_name)s_key",
-    "ck": "%(table_name)s_%(column_0_name)s_check",
-    "ix": "ix_%(table_name)s_%(column_0_name)s",
-}
 
 
 def get_uuid(uuid: Optional[Union[UUID, str]] = None) -> UUID:

--- a/lib/galaxy/model/database_object_names.py
+++ b/lib/galaxy/model/database_object_names.py
@@ -21,21 +21,21 @@ NAMING_CONVENTION = {
 }
 
 
-def foreign_key(table_name: str, column_names: Union[str, List]) -> str:
+def build_foreign_key_name(table_name: str, column_names: Union[str, List]) -> str:
     columns = _as_str(column_names)
     return f"{table_name}_{columns}_fkey"
 
 
-def unique_constraint(table_name: str, column_names: Union[str, List]) -> str:
+def build_unique_constraint_name(table_name: str, column_names: Union[str, List]) -> str:
     columns = _as_str(column_names)
     return f"{table_name}_{columns}_key"
 
 
-def check_constraint(table_name: str, column_name: str) -> str:
+def build_check_constraint_name(table_name: str, column_name: str) -> str:
     return f"{table_name}_{column_name}_check"
 
 
-def index(table_name: str, column_names: Union[str, List]) -> str:
+def build_index_name(table_name: str, column_names: Union[str, List]) -> str:
     columns = _as_str(column_names)
     return f"ix_{table_name}_{columns}"
 

--- a/lib/galaxy/model/database_object_names.py
+++ b/lib/galaxy/model/database_object_names.py
@@ -1,0 +1,31 @@
+"""
+Naming convention and helper functions for generating names of database
+constraints and indexes.
+"""
+
+# Naming convention applied to database constraints and indexes.
+# All except "ix" are conventions used by PostgreSQL by default.
+# We keep the "ix" template consistent with historical Galaxy usage.
+NAMING_CONVENTION = {
+    "pk": "%(table_name)s_pkey",
+    "fk": "%(table_name)s_%(column_0_name)s_fkey",
+    "uq": "%(table_name)s_%(column_0_name)s_key",
+    "ck": "%(table_name)s_%(column_0_name)s_check",
+    "ix": "ix_%(table_name)s_%(column_0_name)s",
+}
+
+
+def foreign_key(table_name, column_name):
+    return f"{table_name}_{column_name}_fkey"
+
+
+def unique_constraint(table_name, column_name):
+    return f"{table_name}_{column_name}_key"
+
+
+def check_constraint(table_name, column_name):
+    return f"{table_name}_{column_name}_check"
+
+
+def index(table_name, column_name):
+    return f"ix_{table_name}_{column_name}"

--- a/lib/galaxy/model/database_object_names.py
+++ b/lib/galaxy/model/database_object_names.py
@@ -2,6 +2,12 @@
 Naming convention and helper functions for generating names of database
 constraints and indexes.
 """
+from typing import (
+    List,
+    Union,
+)
+
+from galaxy.util import listify
 
 # Naming convention applied to database constraints and indexes.
 # All except "ix" are conventions used by PostgreSQL by default.
@@ -15,17 +21,24 @@ NAMING_CONVENTION = {
 }
 
 
-def foreign_key(table_name, column_name):
-    return f"{table_name}_{column_name}_fkey"
+def foreign_key(table_name: str, column_names: Union[str, List]) -> str:
+    columns = _as_str(column_names)
+    return f"{table_name}_{columns}_fkey"
 
 
-def unique_constraint(table_name, column_name):
-    return f"{table_name}_{column_name}_key"
+def unique_constraint(table_name: str, column_names: Union[str, List]) -> str:
+    columns = _as_str(column_names)
+    return f"{table_name}_{columns}_key"
 
 
-def check_constraint(table_name, column_name):
+def check_constraint(table_name: str, column_name: str) -> str:
     return f"{table_name}_{column_name}_check"
 
 
-def index(table_name, column_name):
-    return f"ix_{table_name}_{column_name}"
+def index(table_name: str, column_names: Union[str, List]) -> str:
+    columns = _as_str(column_names)
+    return f"ix_{table_name}_{columns}"
+
+
+def _as_str(column_names: Union[str, List]) -> str:
+    return "_".join(listify(column_names))

--- a/lib/galaxy/model/migrations/alembic/env.py
+++ b/lib/galaxy/model/migrations/alembic/env.py
@@ -11,6 +11,7 @@ from alembic.script import ScriptDirectory
 from alembic.script.base import Script
 from sqlalchemy import create_engine
 
+from galaxy.model import Base
 from galaxy.model.migrations import (
     GXY,
     ModelId,
@@ -18,7 +19,7 @@ from galaxy.model.migrations import (
 )
 
 config = context.config
-target_metadata = None  # Not implemented: used for autogenerate, which we don't use here.
+target_metadata = Base.metadata
 log = logging.getLogger(__name__)
 
 

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
@@ -5,7 +5,7 @@ Revises: c39f1de47a04
 Create Date: 2023-03-07 15:06:55.682273
 
 """
-from galaxy.model.database_object_names import index
+from galaxy.model.database_object_names import build_index_name
 from galaxy.model.migrations.util import (
     create_index,
     drop_index,
@@ -19,7 +19,7 @@ depends_on = None
 
 table_name = "workflow_request_step_states"
 column_name = "workflow_invocation_id"
-index_name = index(table_name, column_name)
+index_name = build_index_name(table_name, column_name)
 
 
 def upgrade():

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
@@ -5,9 +5,9 @@ Revises: c39f1de47a04
 Create Date: 2023-03-07 15:06:55.682273
 
 """
+from galaxy.model.database_object_names import index
 from galaxy.model.migrations.util import (
     create_index,
-    DbObjectNames,
     drop_index,
 )
 
@@ -19,7 +19,7 @@ depends_on = None
 
 table_name = "workflow_request_step_states"
 column_name = "workflow_invocation_id"
-index_name = DbObjectNames.index(table_name, column_name)
+index_name = index(table_name, column_name)
 
 
 def upgrade():

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
@@ -7,6 +7,7 @@ Create Date: 2023-03-07 15:06:55.682273
 """
 from galaxy.model.migrations.util import (
     create_index,
+    DbObjectNames,
     drop_index,
 )
 
@@ -17,12 +18,12 @@ branch_labels = None
 depends_on = None
 
 table_name = "workflow_request_step_states"
-columns = ["workflow_invocation_id"]
-index_name = "ix_workflow_request_step_states_workflow_invocation_id"
+column_name = "workflow_invocation_id"
+index_name = DbObjectNames.index(table_name, column_name)
 
 
 def upgrade():
-    create_index(index_name, table_name, columns)
+    create_index(index_name, table_name, [column_name])
 
 
 def downgrade():

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
@@ -7,6 +7,7 @@ Create Date: 2023-03-07 15:10:44.943542
 """
 from galaxy.model.migrations.util import (
     create_index,
+    DbObjectNames,
     drop_index,
 )
 
@@ -18,12 +19,12 @@ depends_on = None
 
 
 table_name = "workflow_request_input_parameters"
-columns = ["workflow_invocation_id"]
-index_name = "ix_workflow_request_input_parameters_workflow_invocation_id"
+column_name = "workflow_invocation_id"
+index_name = DbObjectNames.index(table_name, column_name)
 
 
 def upgrade():
-    create_index(index_name, table_name, columns)
+    create_index(index_name, table_name, [column_name])
 
 
 def downgrade():

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
@@ -5,7 +5,7 @@ Revises: 3a2914d703ca
 Create Date: 2023-03-07 15:10:44.943542
 
 """
-from galaxy.model.database_object_names import index
+from galaxy.model.database_object_names import build_index_name
 from galaxy.model.migrations.util import (
     create_index,
     drop_index,
@@ -20,7 +20,7 @@ depends_on = None
 
 table_name = "workflow_request_input_parameters"
 column_name = "workflow_invocation_id"
-index_name = index(table_name, column_name)
+index_name = build_index_name(table_name, column_name)
 
 
 def upgrade():

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
@@ -5,9 +5,9 @@ Revises: 3a2914d703ca
 Create Date: 2023-03-07 15:10:44.943542
 
 """
+from galaxy.model.database_object_names import index
 from galaxy.model.migrations.util import (
     create_index,
-    DbObjectNames,
     drop_index,
 )
 
@@ -20,7 +20,7 @@ depends_on = None
 
 table_name = "workflow_request_input_parameters"
 column_name = "workflow_invocation_id"
-index_name = DbObjectNames.index(table_name, column_name)
+index_name = index(table_name, column_name)
 
 
 def upgrade():

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/d0583094c8cd_add_quota_source_labels.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/d0583094c8cd_add_quota_source_labels.py
@@ -13,7 +13,7 @@ from sqlalchemy import (
     String,
 )
 
-from galaxy.model.database_object_names import index
+from galaxy.model.database_object_names import build_index_name
 from galaxy.model.migrations.util import (
     add_column,
     create_index,
@@ -32,8 +32,8 @@ down_revision = "c39f1de47a04"
 branch_labels = None
 depends_on = None
 
-old_index_name = index("default_quota_association", "type")
-new_index_name = index("quota", "quota_source_label")
+old_index_name = build_index_name("default_quota_association", "type")
+new_index_name = build_index_name("quota", "quota_source_label")
 unique_constraint_name = "uqsu_unique_label_per_user"  # leave unchanged
 
 

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/d0583094c8cd_add_quota_source_labels.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/d0583094c8cd_add_quota_source_labels.py
@@ -18,6 +18,7 @@ from galaxy.model.migrations.util import (
     create_index,
     create_table,
     create_unique_constraint,
+    DbObjectNames,
     drop_column,
     drop_constraint,
     drop_index,
@@ -31,6 +32,10 @@ down_revision = "c39f1de47a04"
 branch_labels = None
 depends_on = None
 
+old_index_name = DbObjectNames.index("default_quota_association", "type")
+new_index_name = DbObjectNames.index("quota", "quota_source_label")
+unique_constraint_name = "uqsu_unique_label_per_user"  # leave unchanged
+
 
 def upgrade():
     with transaction():
@@ -43,17 +48,15 @@ def upgrade():
             # user had an index on disk_usage - does that make any sense? -John
             Column("disk_usage", Numeric(15, 0)),
         )
-        create_unique_constraint(
-            "uqsu_unique_label_per_user", "user_quota_source_usage", ["user_id", "quota_source_label"]
-        )
-        drop_index("ix_default_quota_association_type", "default_quota_association")
-        create_index("ix_quota_quota_source_label", "quota", ["quota_source_label"])
+        create_unique_constraint(unique_constraint_name, "user_quota_source_usage", ["user_id", "quota_source_label"])
+        drop_index(old_index_name, "default_quota_association")
+        create_index(new_index_name, "quota", ["quota_source_label"])
 
 
 def downgrade():
     with transaction():
-        drop_index("ix_quota_quota_source_label", "quota")
-        create_index("ix_default_quota_association_type", "default_quota_association", ["type"], unique=True)
-        drop_constraint("uqsu_unique_label_per_user", "user_quota_source_usage")
+        drop_index(new_index_name, "quota")
+        create_index(old_index_name, "default_quota_association", ["type"], unique=True)
+        drop_constraint(unique_constraint_name, "user_quota_source_usage")
         drop_table("user_quota_source_usage")
         drop_column("quota", "quota_source_label")

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/d0583094c8cd_add_quota_source_labels.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/d0583094c8cd_add_quota_source_labels.py
@@ -13,12 +13,12 @@ from sqlalchemy import (
     String,
 )
 
+from galaxy.model.database_object_names import index
 from galaxy.model.migrations.util import (
     add_column,
     create_index,
     create_table,
     create_unique_constraint,
-    DbObjectNames,
     drop_column,
     drop_constraint,
     drop_index,
@@ -32,8 +32,8 @@ down_revision = "c39f1de47a04"
 branch_labels = None
 depends_on = None
 
-old_index_name = DbObjectNames.index("default_quota_association", "type")
-new_index_name = DbObjectNames.index("quota", "quota_source_label")
+old_index_name = index("default_quota_association", "type")
+new_index_name = index("quota", "quota_source_label")
 unique_constraint_name = "uqsu_unique_label_per_user"  # leave unchanged
 
 

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/e0e3bb173ee6_add_column_deleted_to_api_keys.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/e0e3bb173ee6_add_column_deleted_to_api_keys.py
@@ -10,9 +10,9 @@ from sqlalchemy import (
     Column,
 )
 
+from galaxy.model.database_object_names import index
 from galaxy.model.migrations.util import (
     add_column,
-    DbObjectNames,
     drop_column,
     drop_index,
     transaction,
@@ -28,7 +28,7 @@ depends_on = None
 # database object names used in this revision
 table_name = "api_keys"
 column_name = "deleted"
-index_name = DbObjectNames.index(table_name, column_name)
+index_name = index(table_name, column_name)
 
 
 def upgrade():

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/e0e3bb173ee6_add_column_deleted_to_api_keys.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/e0e3bb173ee6_add_column_deleted_to_api_keys.py
@@ -10,7 +10,7 @@ from sqlalchemy import (
     Column,
 )
 
-from galaxy.model.database_object_names import index
+from galaxy.model.database_object_names import build_index_name
 from galaxy.model.migrations.util import (
     add_column,
     drop_column,
@@ -28,7 +28,7 @@ depends_on = None
 # database object names used in this revision
 table_name = "api_keys"
 column_name = "deleted"
-index_name = index(table_name, column_name)
+index_name = build_index_name(table_name, column_name)
 
 
 def upgrade():

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/e0e3bb173ee6_add_column_deleted_to_api_keys.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/e0e3bb173ee6_add_column_deleted_to_api_keys.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
 
 from galaxy.model.migrations.util import (
     add_column,
+    DbObjectNames,
     drop_column,
     drop_index,
     transaction,
@@ -27,6 +28,7 @@ depends_on = None
 # database object names used in this revision
 table_name = "api_keys"
 column_name = "deleted"
+index_name = DbObjectNames.index(table_name, column_name)
 
 
 def upgrade():
@@ -35,5 +37,5 @@ def upgrade():
 
 def downgrade():
     with transaction():
-        drop_index("ix_api_keys_deleted", table_name)
+        drop_index(index_name, table_name)
         drop_column(table_name, column_name)

--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -450,26 +450,3 @@ def transaction():
         except OperationalError:
             op.execute("ROLLBACK")
             raise
-
-
-class DbObjectNames:
-    """
-    Helper methods for generating names for database constraints and indexes.
-    This format is based on the naming convention specified in the galaxy.model module.
-    """
-
-    @staticmethod
-    def foreign_key(table_name, column_name):
-        return f"{table_name}_{column_name}_fkey"
-
-    @staticmethod
-    def unique_constraint(table_name, column_name):
-        return f"{table_name}_{column_name}_key"
-
-    @staticmethod
-    def check_constraint(table_name, column_name):
-        return f"{table_name}_{column_name}_check"
-
-    @staticmethod
-    def index(table_name, column_name):
-        return f"ix_{table_name}_{column_name}"

--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -450,3 +450,26 @@ def transaction():
         except OperationalError:
             op.execute("ROLLBACK")
             raise
+
+
+class DbObjectNames:
+    """
+    Helper methods for generating names for database constraints and indexes.
+    This format is based on the naming convention specified in the galaxy.model module.
+    """
+
+    @staticmethod
+    def foreign_key(table_name, column_name):
+        return f"{table_name}_{column_name}_fkey"
+
+    @staticmethod
+    def unique_constraint(table_name, column_name):
+        return f"{table_name}_{column_name}_key"
+
+    @staticmethod
+    def check_constraint(table_name, column_name):
+        return f"{table_name}_{column_name}_check"
+
+    @staticmethod
+    def index(table_name, column_name):
+        return f"ix_{table_name}_{column_name}"

--- a/test/unit/data/model/test_database_object_names.py
+++ b/test/unit/data/model/test_database_object_names.py
@@ -1,0 +1,32 @@
+import galaxy.model.database_object_names as names
+
+
+def test_foreign_key_single_column():
+    assert names.foreign_key("foo", "bar_id") == "foo_bar_id_fkey"
+
+
+def test_foreign_key_composite():
+    assert names.foreign_key("foo", ["bar_id", "buz_id"]) == "foo_bar_id_buz_id_fkey"
+    assert names.foreign_key("foo", ["bar_id", "buz_id", "bam_id"]) == "foo_bar_id_buz_id_bam_id_fkey"
+
+
+def test_unique_constraint_single_column():
+    assert names.unique_constraint("foo", "bar") == "foo_bar_key"
+
+
+def test_unique_constraint_composite():
+    assert names.unique_constraint("foo", ["bar", "buz"]) == "foo_bar_buz_key"
+    assert names.unique_constraint("foo", ["bar", "buz", "bam"]) == "foo_bar_buz_bam_key"
+
+
+def test_check_constraint():
+    assert names.check_constraint("foo", "bar") == "foo_bar_check"
+
+
+def test_index_single_column():
+    assert names.index("foo", "bar") == "ix_foo_bar"
+
+
+def test_index_composite():
+    assert names.index("foo", ["bar", "buz"]) == "ix_foo_bar_buz"
+    assert names.index("foo", ["bar", "buz", "bam"]) == "ix_foo_bar_buz_bam"

--- a/test/unit/data/model/test_database_object_names.py
+++ b/test/unit/data/model/test_database_object_names.py
@@ -1,32 +1,37 @@
-import galaxy.model.database_object_names as names
+from galaxy.model.database_object_names import (
+    build_check_constraint_name,
+    build_foreign_key_name,
+    build_index_name,
+    build_unique_constraint_name,
+)
 
 
 def test_foreign_key_single_column():
-    assert names.foreign_key("foo", "bar_id") == "foo_bar_id_fkey"
+    assert build_foreign_key_name("foo", "bar_id") == "foo_bar_id_fkey"
 
 
 def test_foreign_key_composite():
-    assert names.foreign_key("foo", ["bar_id", "buz_id"]) == "foo_bar_id_buz_id_fkey"
-    assert names.foreign_key("foo", ["bar_id", "buz_id", "bam_id"]) == "foo_bar_id_buz_id_bam_id_fkey"
+    assert build_foreign_key_name("foo", ["bar_id", "buz_id"]) == "foo_bar_id_buz_id_fkey"
+    assert build_foreign_key_name("foo", ["bar_id", "buz_id", "bam_id"]) == "foo_bar_id_buz_id_bam_id_fkey"
 
 
 def test_unique_constraint_single_column():
-    assert names.unique_constraint("foo", "bar") == "foo_bar_key"
+    assert build_unique_constraint_name("foo", "bar") == "foo_bar_key"
 
 
 def test_unique_constraint_composite():
-    assert names.unique_constraint("foo", ["bar", "buz"]) == "foo_bar_buz_key"
-    assert names.unique_constraint("foo", ["bar", "buz", "bam"]) == "foo_bar_buz_bam_key"
+    assert build_unique_constraint_name("foo", ["bar", "buz"]) == "foo_bar_buz_key"
+    assert build_unique_constraint_name("foo", ["bar", "buz", "bam"]) == "foo_bar_buz_bam_key"
 
 
 def test_check_constraint():
-    assert names.check_constraint("foo", "bar") == "foo_bar_check"
+    assert build_check_constraint_name("foo", "bar") == "foo_bar_check"
 
 
 def test_index_single_column():
-    assert names.index("foo", "bar") == "ix_foo_bar"
+    assert build_index_name("foo", "bar") == "ix_foo_bar"
 
 
 def test_index_composite():
-    assert names.index("foo", ["bar", "buz"]) == "ix_foo_bar_buz"
-    assert names.index("foo", ["bar", "buz", "bam"]) == "ix_foo_bar_buz_bam"
+    assert build_index_name("foo", ["bar", "buz"]) == "ix_foo_bar_buz"
+    assert build_index_name("foo", ["bar", "buz", "bam"]) == "ix_foo_bar_buz_bam"


### PR DESCRIPTION
Solves issue uncovered via work on #16003.

This adds an automated naming convention for database indexes and constraints added by SQLAlchemy and Alembic. This ensures that indexes and constraints will always have deterministic names regardless of the database (PostgreSQL, SQLite, etc.) and of whether they were explicitly named or not (e.g. added inline via Column parameters). This is needed for correct handling of downgrade revision scripts (as well as consistency of constraint and index naming in the database overall). 

The issue surfaced thanks to a failed test, which broke on a downgrade migration after a new index had been added to the model definition. The index was unnamed (added via `index=True`), and the name that was assigned to it by the database was different from the name used in the revision's downgrade script - hence, the test failed when the script tried to drop a nonexistent index. This bug will go unnoticed if the new migration is applied to an existing database (since the index is added via the revision script where it is explicitly named); however, if a new database is initialized, migrations are bypassed, which will trigger the bug on a subsequent downgrade.

Setting the object's name to match whatever is generated by the database by default is easy for postgres (e.g. `[table-name]_[column-name]_fkey`). However, SQLite does things differently: to quote Alembic's docs, "SQLite, unlike any other database, allows constraints to exist in the database that have no identifying name." [[ref](https://alembic.sqlalchemy.org/en/latest/batch.html#dropping-unnamed-or-named-foreign-key-constraints)]. The solution is to either (a) always give objects explicit names (which is tedious and error-prone: no more inline specification of indexes and foreign keys!); or (b) to use an automated naming convention, recommended by [SQLAlchemy](https://docs.sqlalchemy.org/en/14/core/constraints.html#configuring-constraint-naming-conventions) and Alembic (which has a whole section on [The Importance of Naming Constraints](https://alembic.sqlalchemy.org/en/latest/naming.html#the-importance-of-naming-constraints)).

This has been on my to-do list for a long while. It [finally bit me](https://github.com/galaxyproject/galaxy/pull/16003#issuecomment-1545824739) (thanks, @davelopez :smile:)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run `./manage_db.sh upgrade; ./manage_db.sh downgrade base; ./manage_db.sh upgrade`: this verifies that the helper methods in `migrations.utils.DbObjectNames` used in existing revision scripts do not affect the state of an existing database.
  2. Add a new revision that creates a NEW index via the `index=True` Column attribute (i.e., index is not explicitly named). Repeat step 1. This verifies that the naming convention specified in `galaxy.model` is automatically applied in a revision script. Remove the revision after testing.
  3. Repeat steps 1,2 on postgresql or sqlite (so both databases are tested).
  4. Run `pytest test/unit/app/test_migrate_database.py`. This verifies that the naming convention is automatically applied when initializing a new database (and bypassing migrations), and that the names generated by the model are identical to those generated by the migration utility `DbObjectNames`.
  

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
