### PR TITLE
Improve robustness of collection edit E2E test.

### DIFF
--- a/client/src/components/Collections/common/ChangeDatatypeTab.vue
+++ b/client/src/components/Collections/common/ChangeDatatypeTab.vue
@@ -3,16 +3,14 @@
         <div>
             <span class="float-left h-sm">Change Datatype/Extension of all elements in collection</span>
             <div class="text-right">
-                <button
-                    class="save-datatype-edit btn btn-primary"
-                    :disabled="selectedDatatype.id == currentDatatype"
-                    @click="clickedSave">
+                <button class="save-datatype-edit btn btn-primary" :disabled="!enableSave" @click="clickedSave">
                     {{ l("Save") }}
                 </button>
             </div>
         </div>
         <b>{{ l("New Type") }}: </b>
         <multiselect
+            v-if="hasSelectedDatatype"
             v-model="selectedDatatype"
             class="datatype-dropdown"
             deselect-label="Can't remove this value"
@@ -45,6 +43,14 @@ export default {
             selectedDatatype: {},
             currentDatatype: "",
         };
+    },
+    computed: {
+        hasSelectedDatatype() {
+            return Boolean(this.selectedDatatype);
+        },
+        enableSave() {
+            return this.hasSelectedDatatype && this.selectedDatatype.id != this.currentDatatype;
+        },
     },
     created() {
         this.selectedDatatype = this.datatypes.find((element) => element.id == this.datatypeFromElements);

--- a/client/src/components/Collections/common/CollectionEditView.vue
+++ b/client/src/components/Collections/common/CollectionEditView.vue
@@ -10,7 +10,9 @@
             </b-alert>
         </div>
         <b-tabs content-class="mt-3">
-            <b-tab @click="updateInfoMessage(newCollectionMessage + ' ' + noQuotaIncreaseMessage)">
+            <b-tab
+                title-link-class="collection-edit-change-genome-nav"
+                @click="updateInfoMessage(newCollectionMessage + ' ' + noQuotaIncreaseMessage)">
                 <template v-slot:title> <font-awesome-icon icon="table" /> &nbsp; {{ l("Database/Build") }}</template>
                 <db-key-provider v-slot="{ item, loading }">
                     <div v-if="loading"><b-spinner label="Loading Database/Builds..."></b-spinner></div>
@@ -24,13 +26,19 @@
                 </db-key-provider>
             </b-tab>
             <SuitableConvertersProvider :id="collection_id" v-slot="{ item }">
-                <b-tab v-if="item && item.length" @click="updateInfoMessage(newCollectionMessage)">
+                <b-tab
+                    v-if="item && item.length"
+                    title-link-class="collection-edit-convert-datatype-nav"
+                    @click="updateInfoMessage(newCollectionMessage)">
                     <template v-slot:title> <font-awesome-icon icon="cog" /> &nbsp; {{ l("Convert") }}</template>
                     <suitable-converters-tab :suitable-converters="item" @clicked-convert="clickedConvert" />
                 </b-tab>
             </SuitableConvertersProvider>
             <ConfigProvider v-slot="{ config }">
-                <b-tab v-if="config.enable_celery_tasks" @click="updateInfoMessage(expectWaitTimeMessage)">
+                <b-tab
+                    v-if="config.enable_celery_tasks"
+                    title-link-class="collection-edit-change-datatype-nav"
+                    @click="updateInfoMessage(expectWaitTimeMessage)">
                     <template v-slot:title>
                         <font-awesome-icon icon="database" /> &nbsp; {{ l("Datatypes") }}
                     </template>

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -332,15 +332,13 @@ edit_dataset_attributes:
 edit_collection_attributes:
   selectors:
     alert_info: 'div.alert-info'
-    database_genome_tab:
-      type: xpath
-      selector: '//a[contains(text(), "Database/Build")]'
-    datatypes_tab:
-      type: xpath
-      selector: '//a[contains(text(), "Datatypes")]'
+    database_genome_tab: '.collection-edit-change-genome-nav'
+    datatypes_tab: '.collection-edit-change-datatype-nav'
     data_value:
       type: xpath
       selector: '//span[contains(text(), "${data_change}")]'
+    genome_select_search: ".database-dropdown input.multiselect__input"
+    datatype_select_search: '.datatype-dropdown input.multiselect__input'
     save_dbkey_btn: '.save-dbkey-edit'
     save_datatype_btn: '.save-datatype-edit'
 

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -11,7 +11,7 @@ class TestCollectionEdit(SeleniumTestCase):
     @selenium_test
     @managed_history
     def test_change_dbkey_simple_list(self):
-        self.create_simple_list_collection()
+        self._create_simple_list_collection("1.fasta", "fasta")
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
         alert_element = self.components.edit_collection_attributes.alert_info.wait_for_visible()
@@ -28,7 +28,7 @@ class TestCollectionEdit(SeleniumTestCase):
     @selenium_test
     @managed_history
     def test_change_datatype_simple_list(self):
-        self.create_simple_list_collection_txt()
+        self._create_simple_list_collection("1.txt", "txt")
         self.open_collection_edit_view()
         self.navigate_to_datatype_tab()
         alert_element = self.components.edit_collection_attributes.alert_info.wait_for_visible()
@@ -42,30 +42,19 @@ class TestCollectionEdit(SeleniumTestCase):
         self.change_datatype_value_and_click_submit(dataValue, dataNew)
         self.check_current_data_value(dataNew)
         self.wait_for_history()
-        self.find_element_by_selector("span.content-title").click()
-        self.wait_for_selector_clickable("div.content-item")
-        self.find_element_by_selector("div.content-item").click()
+        self.history_panel_expand_collection(2)
+        self.history_panel_ensure_showing_item_details(1)
         item = self.history_panel_item_component(hid=1)
         item.datatype.wait_for_visible()
-        assert self.find_element_by_selector("span.datatype > span").text == dataNew
+        assert item.datatype.wait_for_text() == dataNew
 
-    def create_simple_list_collection(self):
-        self.perform_upload(self.get_filename("1.fasta"))
-        self._wait_for_and_select([1])
-        self._collection_dropdown("build list")
-        self.collection_builder_set_name("my cool list")
-        self.screenshot("collection_builder_list")
-        self.collection_builder_create()
-        self._wait_for_hid_visible(2)
-
-    def create_simple_list_collection_txt(self):
-        self.perform_upload(self.get_filename("1.txt"))
+    def _create_simple_list_collection(self, filename, ext):
+        self.perform_upload(self.get_filename(filename), ext=ext)
         self._wait_for_and_select([1])
 
         self._collection_dropdown("build list")
 
         self.collection_builder_set_name("my cool list")
-        self.screenshot("collection_builder_list")
         self.collection_builder_create()
         self._wait_for_hid_visible(2)
 
@@ -73,33 +62,29 @@ class TestCollectionEdit(SeleniumTestCase):
         self.components.history_panel.collection_menu_edit_attributes.wait_for_and_click()
 
     def navigate_to_database_tab(self):
-        self.components.edit_collection_attributes.database_genome_tab.wait_for_and_click()
+        self._edit_attributes.database_genome_tab.wait_for_and_click()
 
     def navigate_to_datatype_tab(self):
-        self.components.edit_collection_attributes.datatypes_tab.wait_for_and_click()
+        self._edit_attributes.datatypes_tab.wait_for_and_click()
 
     def check_current_data_value(self, dataValue):
-        self.components.edit_collection_attributes.data_value(data_change=dataValue).wait_for_visible()
+        self._edit_attributes.data_value(data_change=dataValue).wait_for_visible()
 
     def change_dbkey_value_and_click_submit(self, dataValue, dataNew):
-        self.components.edit_collection_attributes.data_value(data_change=dataValue).wait_for_and_click()
-        self.find_element_by_selector(
-            "div.database-dropdown > div.multiselect__tags > input.multiselect__input"
-        ).send_keys(dataNew)
-        self.find_element_by_selector(
-            "div.database-dropdown > div.multiselect__tags > input.multiselect__input"
-        ).send_keys(self.keys.ENTER)
-        self.components.edit_collection_attributes.save_dbkey_btn.wait_for_and_click()
+        self._edit_attributes.data_value(data_change=dataValue).wait_for_and_click()
+        self._edit_attributes.genome_select_search.wait_for_and_send_keys(dataNew)
+        self._edit_attributes.genome_select_search.wait_for_and_send_keys(self.keys.ENTER)
+        self._edit_attributes.save_dbkey_btn.wait_for_and_click()
 
     def change_datatype_value_and_click_submit(self, dataValue, dataNew):
-        self.components.edit_collection_attributes.data_value(data_change=dataValue).wait_for_and_click()
-        self.find_element_by_selector(
-            "div.datatype-dropdown > div.multiselect__tags > input.multiselect__input"
-        ).send_keys(dataNew)
-        self.find_element_by_selector(
-            "div.datatype-dropdown > div.multiselect__tags > input.multiselect__input"
-        ).send_keys(self.keys.ENTER)
-        self.components.edit_collection_attributes.save_datatype_btn.wait_for_and_click()
+        self._edit_attributes.data_value(data_change=dataValue).wait_for_and_click()
+        self._edit_attributes.datatype_select_search.wait_for_and_send_keys(dataNew)
+        self._edit_attributes.datatype_select_search.wait_for_and_send_keys(self.keys.ENTER)
+        self._edit_attributes.save_datatype_btn.wait_for_and_click()
+
+    @property
+    def _edit_attributes(self):
+        return self.components.edit_collection_attributes
 
     def _wait_for_and_select(self, hids):
         """


### PR DESCRIPTION
#16099 hopefully fixed the underlying error causing the flakiness in the test but I still have a bunch of refactorings here aimed at using improved abstractions, targeting more explicit, stable DOM elements, etc.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
