### PR TITLE
Missing outputs should be recorded as test errors

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1484,7 +1484,6 @@ def _handle_def_errors(testdef):
 
 
 def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, galaxy_interactor, quiet=False):
-    assert data_list or data_collection_list, "Tool produced no output data"
     assert len(jobs) == 1, "Test framework logic error, somehow tool test resulted in more than one job."
     job = jobs[0]
 
@@ -1497,6 +1496,10 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                 if stream in job_stdio:
                     print(_format_stream(job_stdio[stream], stream=stream, format=True), file=sys.stderr)
         found_exceptions.append(e)
+
+    if not (data_list or data_collection_list):
+        error = AssertionError("Tool produced no output datasets or collections")
+        register_exception(error)
 
     if testdef.expect_failure:
         if testdef.outputs:

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1497,10 +1497,6 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                     print(_format_stream(job_stdio[stream], stream=stream, format=True), file=sys.stderr)
         found_exceptions.append(e)
 
-    if not (data_list or data_collection_list):
-        error = AssertionError("Tool produced no output datasets or collections")
-        register_exception(error)
-
     if testdef.expect_failure:
         if testdef.outputs:
             raise Exception("Cannot specify outputs in a test expecting failure.")
@@ -1517,6 +1513,10 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
             found_exceptions.append(e)
 
     job_stdio = galaxy_interactor.get_job_stdio(job["id"])
+
+    if not (data_list or data_collection_list):
+        error = AssertionError("Tool produced no output datasets or collections")
+        register_exception(error)
 
     if testdef.num_outputs is not None:
         expected = testdef.num_outputs

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1538,6 +1538,7 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
         outfile = output_dict["value"]
         attributes = output_dict["attributes"]
         output_testdef = Bunch(name=name, outfile=outfile, attributes=attributes)
+        output_data = None
         try:
             output_data = data_list[name]
         except (TypeError, KeyError):
@@ -1550,7 +1551,8 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                 else:
                     output_data = data_list[len(data_list) - len(testdef.outputs) + output_index]
             except IndexError:
-                pass
+                error = AssertionError(f"Tool did not produce an output with name '{name}' (or at index {output_index})")
+                register_exception(error)
         if output_data:
             try:
                 galaxy_interactor.verify_output(
@@ -1564,9 +1566,6 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                 )
             except Exception as e:
                 register_exception(e)
-        else:
-            error = AssertionError(f"Tool did not produce an output with name '{name}' (or at index {output_index})")
-            register_exception(error)
 
     other_checks = {
         "command_line": "Command produced by the job",

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1551,7 +1551,9 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
                 else:
                     output_data = data_list[len(data_list) - len(testdef.outputs) + output_index]
             except IndexError:
-                error = AssertionError(f"Tool did not produce an output with name '{name}' (or at index {output_index})")
+                error = AssertionError(
+                    f"Tool did not produce an output with name '{name}' (or at index {output_index})"
+                )
                 register_exception(error)
         if output_data:
             try:

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1500,9 +1500,6 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
         if testdef.outputs:
             raise Exception("Cannot specify outputs in a test expecting failure.")
 
-    if not data_list and not data_collection_list:
-        Exception("Job did not produce any outputs")
-
     maxseconds = testdef.maxseconds
     # Wait for the job to complete and register expections if the final
     # status was not what test was expecting.
@@ -1516,9 +1513,7 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
 
     job_stdio = galaxy_interactor.get_job_stdio(job["id"])
 
-    if not (data_list or data_collection_list):
-        error = AssertionError("Tool produced no output datasets or collections")
-        register_exception(error)
+    assert data_list or data_collection_list, "Tool produced no output datasets or collections"
 
     if testdef.num_outputs is not None:
         expected = testdef.num_outputs

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1486,7 +1486,6 @@ def _handle_def_errors(testdef):
 def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, galaxy_interactor, quiet=False):
     assert len(jobs) == 1, "Test framework logic error, somehow tool test resulted in more than one job."
     job = jobs[0]
-
     found_exceptions: List[Exception] = []
 
     def register_exception(e: Exception):
@@ -1500,6 +1499,9 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
     if testdef.expect_failure:
         if testdef.outputs:
             raise Exception("Cannot specify outputs in a test expecting failure.")
+
+    if not data_list and not data_collection_list:
+        Exception("Job did not produce any outputs")
 
     maxseconds = testdef.maxseconds
     # Wait for the job to complete and register expections if the final

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1429,8 +1429,6 @@ def verify_tool(
             raise e
 
         if not expected_failure_occurred:
-            assert data_list or data_collection_list
-
             try:
                 job_stdio = _verify_outputs(
                     testdef, test_history, jobs, data_list, data_collection_list, galaxy_interactor, quiet=quiet
@@ -1486,6 +1484,7 @@ def _handle_def_errors(testdef):
 
 
 def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, galaxy_interactor, quiet=False):
+    assert data_list or data_collection_list, "Tool produced no output data"
     assert len(jobs) == 1, "Test framework logic error, somehow tool test resulted in more than one job."
     job = jobs[0]
 

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1513,8 +1513,6 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
 
     job_stdio = galaxy_interactor.get_job_stdio(job["id"])
 
-    assert data_list or data_collection_list, "Tool produced no output datasets or collections"
-
     if testdef.num_outputs is not None:
         expected = testdef.num_outputs
         actual = len(data_list) + len(data_collection_list)
@@ -1546,23 +1544,29 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
             # Legacy - fall back on ordered data list access if data_list is
             # just a list (case with twill variant or if output changes its
             # name).
-            if hasattr(data_list, "values"):
-                output_data = list(data_list.values())[output_index]
-            else:
-                output_data = data_list[len(data_list) - len(testdef.outputs) + output_index]
-        assert output_data is not None
-        try:
-            galaxy_interactor.verify_output(
-                history,
-                jobs,
-                output_data,
-                output_testdef=output_testdef,
-                tool_id=job["tool_id"],
-                maxseconds=maxseconds,
-                tool_version=testdef.tool_version,
-            )
-        except Exception as e:
-            register_exception(e)
+            try:
+                if hasattr(data_list, "values"):
+                    output_data = list(data_list.values())[output_index]
+                else:
+                    output_data = data_list[len(data_list) - len(testdef.outputs) + output_index]
+            except IndexError:
+                pass
+        if output_data:
+            try:
+                galaxy_interactor.verify_output(
+                    history,
+                    jobs,
+                    output_data,
+                    output_testdef=output_testdef,
+                    tool_id=job["tool_id"],
+                    maxseconds=maxseconds,
+                    tool_version=testdef.tool_version,
+                )
+            except Exception as e:
+                register_exception(e)
+        else:
+            error = AssertionError(f"Tool did not produce an output with name '{name}' (or at index {output_index})")
+            register_exception(error)
 
     other_checks = {
         "command_line": "Command produced by the job",

--- a/test/functional/tools/output_filter.xml
+++ b/test/functional/tools/output_filter.xml
@@ -1,15 +1,15 @@
 <tool id="output_filter" name="output_filter" version="1.0.0">
     <description>test for output filtering and expect_num_outputs</description>
     <command><![CDATA[
-echo 'test' > 1 &&
-echo 'test' > 2 &&
-echo 'test' > 3 &&
-echo 'test' > 4 &&
-echo 'test' > 5 &&
-echo 'test' > p1.forward &&
-echo 'test' > p1.reverse &&
-echo 'test' > p2.forward &&
-echo 'test' > p2.reverse 
+echo '1' > 1 &&
+echo '2' > 2 &&
+echo '3' > 3 &&
+echo '4' > 4 &&
+echo '5' > 5 &&
+echo 'p1.forward' > p1.forward &&
+echo 'p1.reverse' > p1.reverse &&
+echo 'p2.forward' > p2.forward &&
+echo 'p2.reverse' > p2.reverse 
     ]]></command>
     <inputs>
         <param name="produce_out_1" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Do Filter 1" />
@@ -41,12 +41,12 @@ echo 'test' > p2.reverse
             <param name="filter_text_1" value="foo" />
             <output name="out_1">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="1" />
                 </assert_contents>
             </output>
             <output name="out_2">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="2" />
                 </assert_contents>
             </output>
         </test>
@@ -55,7 +55,7 @@ echo 'test' > p2.reverse
             <param name="filter_text_1" value="bar" /> <!-- fails second filter in out2 -->
             <output name="out_1">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="1" />
                 </assert_contents>
             </output>
         </test>
@@ -73,23 +73,23 @@ echo 'test' > p2.reverse
             <param name="produce_collection" value="true" />
             <output name="out_1">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="1" />
                 </assert_contents>
             </output>
             <output name="out_2">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="2" />
                 </assert_contents>
             </output>
             <output_collection name="list_output" type="list" count="2">
                 <element name="4">
                     <assert_contents>
-                        <has_line line="test" />
+                        <has_line line="4" />
                     </assert_contents>
                 </element>
                 <element name="5">
                     <assert_contents>
-                        <has_line line="test" />
+                        <has_line line="5" />
                     </assert_contents>
                 </element>
             </output_collection>
@@ -101,23 +101,23 @@ echo 'test' > p2.reverse
             <param name="produce_paired_collection" value="true" />
             <output name="out_1">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="1" />
                 </assert_contents>
             </output>
             <output name="out_2">
                 <assert_contents>
-                    <has_line line="test" />
+                    <has_line line="2" />
                 </assert_contents>
             </output>
             <output_collection name="list_output" type="list" count="2">
                 <element name="4">
                     <assert_contents>
-                        <has_line line="test" />
+                        <has_line line="4" />
                     </assert_contents>
                 </element>
                 <element name="5">
                     <assert_contents>
-                        <has_line line="test" />
+                        <has_line line="5" />
                     </assert_contents>
                 </element>
             </output_collection>
@@ -125,24 +125,24 @@ echo 'test' > p2.reverse
                 <element name="p1">
                     <element name="forward">
                         <assert_contents>
-                            <has_line line="test" />
+                            <has_line line="p1.forward" />
                         </assert_contents>
                     </element>
                     <element name="reverse">
                         <assert_contents>
-                            <has_line line="test" />
+                            <has_line line="p1.reverse" />
                         </assert_contents>
                     </element>
                 </element>
                 <element name="p2">
                     <element name="forward">
                         <assert_contents>
-                            <has_line line="test" />
+                            <has_line line="p2.forward" />
                         </assert_contents>
                     </element>
                     <element name="reverse">
                         <assert_contents>
-                            <has_line line="test" />
+                            <has_line line="p2.reverse" />
                         </assert_contents>
                     </element>
                 </element>

--- a/test/functional/tools/output_filter.xml
+++ b/test/functional/tools/output_filter.xml
@@ -63,7 +63,14 @@ echo 'p2.reverse' > p2.reverse
         <test expect_num_outputs="0" expect_test_failure="true">
             <param name="produce_out_1" value="false" />
             <param name="filter_text_1" value="not_foo_or_bar" />
+            <output name="out_3">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
             <assert_stdout>
+                <has_n_lines n="0"/>
+            </assert_stdout>
                 <has_n_lines n="0"/>
             </assert_stdout>
         </test>

--- a/test/functional/tools/output_filter.xml
+++ b/test/functional/tools/output_filter.xml
@@ -26,7 +26,6 @@ echo 'test' > p2.reverse
             <!-- Must pass all filters... -->
             <filter>filter_text_1 == "foo"</filter>
         </data>
-        <data name="out_3" format="txt" from_work_dir="3"/>
         <collection name="list_output" type="list" label="List">
             <discover_datasets pattern="(?P&lt;identifier_0&gt;[45])" ext="txt" visible="true" />
             <filter>produce_collection is True</filter>
@@ -37,7 +36,7 @@ echo 'test' > p2.reverse
         </collection>
     </outputs>
     <tests>
-        <test expect_num_outputs="3">
+        <test expect_num_outputs="2">
             <param name="produce_out_1" value="true" />
             <param name="filter_text_1" value="foo" />
             <output name="out_1">
@@ -50,13 +49,8 @@ echo 'test' > p2.reverse
                     <has_line line="test" />
                 </assert_contents>
             </output>
-            <output name="out_3">
-                <assert_contents>
-                    <has_line line="test" />
-                </assert_contents>
-            </output>
         </test>
-        <test expect_num_outputs="2">
+        <test expect_num_outputs="1">
             <param name="produce_out_1" value="true" />
             <param name="filter_text_1" value="bar" /> <!-- fails second filter in out2 -->
             <output name="out_1">
@@ -64,22 +58,16 @@ echo 'test' > p2.reverse
                     <has_line line="test" />
                 </assert_contents>
             </output>
-            <output name="out_3">
-                <assert_contents>
-                    <has_line line="test" />
-                </assert_contents>
-            </output>
         </test>
-        <test expect_num_outputs="1">
+        <!-- tool runs with no outputs should fail -->
+        <test expect_num_outputs="0" expect_test_failure="true">
             <param name="produce_out_1" value="false" />
             <param name="filter_text_1" value="not_foo_or_bar" />
-            <output name="out_3">
-                <assert_contents>
-                    <has_line line="test" />
-                </assert_contents>
-            </output>
+            <assert_stdout>
+                <has_n_lines n="0"/>
+            </assert_stdout>
         </test>
-        <test expect_num_outputs="4">
+        <test expect_num_outputs="3">
             <param name="produce_out_1" value="true" />
             <param name="filter_text_1" value="foo" />
             <param name="produce_collection" value="true" />
@@ -89,11 +77,6 @@ echo 'test' > p2.reverse
                 </assert_contents>
             </output>
             <output name="out_2">
-                <assert_contents>
-                    <has_line line="test" />
-                </assert_contents>
-            </output>
-            <output name="out_3">
                 <assert_contents>
                     <has_line line="test" />
                 </assert_contents>
@@ -111,7 +94,7 @@ echo 'test' > p2.reverse
                 </element>
             </output_collection>
         </test>
-        <test expect_num_outputs="5">
+        <test expect_num_outputs="4">
             <param name="produce_out_1" value="true" />
             <param name="filter_text_1" value="foo" />
             <param name="produce_collection" value="true" />
@@ -122,11 +105,6 @@ echo 'test' > p2.reverse
                 </assert_contents>
             </output>
             <output name="out_2">
-                <assert_contents>
-                    <has_line line="test" />
-                </assert_contents>
-            </output>
-            <output name="out_3">
                 <assert_contents>
                     <has_line line="test" />
                 </assert_contents>

--- a/test/functional/tools/output_filter.xml
+++ b/test/functional/tools/output_filter.xml
@@ -71,8 +71,6 @@ echo 'p2.reverse' > p2.reverse
             <assert_stdout>
                 <has_n_lines n="0"/>
             </assert_stdout>
-                <has_n_lines n="0"/>
-            </assert_stdout>
         </test>
         <test expect_num_outputs="3">
             <param name="produce_out_1" value="true" />


### PR DESCRIPTION
from `planemo` the `verify_tool` function is called from [within an try-except block](https://github.com/galaxyproject/planemo/blob/1aa3eb05a97ad20c0be6f6560ab5cec090e76612/planemo/engine/galaxy.py#L109) which silently catches any exception.

Thus any exception raised from within verify_tool will not be detected, i.e. the assertion needs to be moved into `_verify_outputs` (which also seems to make sense by name) in order to make verify_tool record the problem properly.

This only affects tool tests. Guess we do not want to actually forbid tool runs with no outputs.. Even if I don't know what they are used for. 
## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
