### PR TITLE
Fix minor Switch to History bug in `HistoryView`

### DIFF
--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -8,7 +8,7 @@
                 variant="outline-info"
                 title="Switch to this history"
                 :disabled="currentHistory.id == history.id"
-                @click="setCurrentHistory(history)">
+                @click="setCurrentHistory(history.id)">
                 Switch to this history
             </b-button>
             <b-button v-else v-b-modal:copy-history-modal size="sm" variant="outline-info" title="Import this history">


### PR DESCRIPTION
In `HistoryView`, clicking _Switch to this history_ would produce an error for invalid id, because we were doing:
```
@click="setCurrentHistory(history)">
```
instead of:
```
@click="setCurrentHistory(history.id)">
```

https://github.com/galaxyproject/galaxy/assets/78516064/3dca41ff-699a-46cc-9fe6-cfc346bc3f6e

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
