### PR TITLE
[23.0] Fix job failure handling when condor indicates job failure

### DIFF
--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -211,7 +211,7 @@ class CondorJobRunner(AsynchronousJobRunner):
             if job_failed:
                 log.debug(f"({galaxy_id_tag}/{job_id}) job failed")
                 cjs.failed = True
-                self.work_queue.put((self.finish_job, cjs))
+                self.work_queue.put((self.fail_job, cjs))
                 continue
             cjs.runnning = job_running
             new_watched.append(cjs)


### PR DESCRIPTION
That's just doing what the other job handlers are doing, and it avoids

```
Could not find import model store for directory [/data/jwd02f/main/058/809/58809207/metadata/outputs_populated] (full path [/data/jwd02f/main/058/809/58809207/metadata/outputs_populated])
```
when the job fails in condor due to e.g. OOM errors.
other runners also set more specific states such as https://github.com/mvdbeek/galaxy/blob/a771c3a9918237d2558383c2310dee642c675e7f/lib/galaxy/jobs/runners/slurm.py#L168 ... that would probably make resubmission more useful.

I've not tested this, but it does seem like the right thing to do.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
