### PR TITLE
Workflow Editor Infinite Grid with Landmark-Lines

### DIFF
--- a/client/src/components/Workflow/Editor/AdaptiveGrid.vue
+++ b/client/src/components/Workflow/Editor/AdaptiveGrid.vue
@@ -1,21 +1,42 @@
 <script setup lang="ts">
 import { useAnimationFrame } from "@/composables/sensors/animationFrame";
 import type { UseElementBoundingReturn } from "@vueuse/core";
-import { computed, ref, type Ref } from "vue";
+import { computed, ref, watch, type Ref, onMounted } from "vue";
+import { Transform, type AxisAlignedBoundingBox } from "./modules/geometry";
+
+const lineGap = 10;
+const minorLandmarkFrequency = 10;
+const majorLandmarkFrequency = 20;
 
 const props = defineProps<{
     viewportBounds: UseElementBoundingReturn;
-    viewportPan: { x: number; y: number };
-    viewportScale: number;
+    viewportBoundingBox: AxisAlignedBoundingBox;
+    transform: { x: number; y: number; k: number };
 }>();
 
-//tmp
-props;
+const colors = {
+    grid: "black",
+    landmark: "black",
+};
+
+onMounted(() => {
+    const element = canvas.value!;
+    const style = getComputedStyle(element);
+
+    colors.grid = style.getPropertyValue("--grid-color");
+    colors.landmark = style.getPropertyValue("--landmark-color");
+});
 
 const canvas: Ref<HTMLCanvasElement | null> = ref(null);
 const context = computed(() => canvas.value?.getContext("2d") ?? null);
 
 let redraw = true;
+
+watch(
+    () => props.transform,
+    () => (redraw = true),
+    { deep: true }
+);
 
 useAnimationFrame(() => {
     const ctx = context.value;
@@ -23,6 +44,10 @@ useAnimationFrame(() => {
     if (ctx && redraw) {
         ctx.canvas.width = ctx.canvas.offsetWidth;
         ctx.canvas.height = ctx.canvas.offsetHeight;
+        ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+        ctx.resetTransform();
+
+        new Transform().scale([props.transform.k, props.transform.k]).applyToContext(ctx);
 
         renderGrid(ctx);
 
@@ -30,7 +55,79 @@ useAnimationFrame(() => {
     }
 });
 
-function renderGrid(ctx: CanvasRenderingContext2D) {}
+function renderGrid(ctx: CanvasRenderingContext2D) {
+    const zoom = props.transform.k;
+
+    const pan = {
+        x: props.transform.x / zoom,
+        y: props.transform.y / zoom,
+    } as const;
+
+    if (zoom > 0.5) {
+        ctx.strokeStyle = colors.grid;
+        ctx.lineWidth = 1;
+
+        ctx.beginPath();
+        traceGrid(ctx, lineGap, pan, props.viewportBoundingBox);
+        ctx.stroke();
+    }
+
+    if (zoom > 0.15) {
+        ctx.strokeStyle = colors.landmark;
+        ctx.lineWidth = 1;
+
+        const gap = lineGap * minorLandmarkFrequency;
+
+        ctx.beginPath();
+        traceGrid(ctx, gap, pan, props.viewportBoundingBox);
+        ctx.stroke();
+    }
+
+    {
+        ctx.strokeStyle = colors.landmark;
+        ctx.lineWidth = 2;
+
+        const gap = lineGap * majorLandmarkFrequency;
+
+        ctx.beginPath();
+        traceGrid(ctx, gap, pan, props.viewportBoundingBox);
+        ctx.stroke();
+    }
+}
+
+/**
+ * moves the contexts path along a grid with the specified parameters
+ */
+function traceGrid(
+    ctx: CanvasRenderingContext2D,
+    gap: number,
+    pan: { x: number; y: number },
+    bounds: AxisAlignedBoundingBox
+) {
+    const startOffset = {
+        x: (pan.x % gap) - gap,
+        y: (pan.y % gap) - gap,
+    } as const;
+
+    const xAmount = bounds.width / gap + 2;
+    const yAmount = bounds.height / gap + 2;
+
+    // vertical
+    for (let i = 0; i < xAmount; i++) {
+        const x = startOffset.x + i * gap;
+
+        ctx.moveTo(x, 0);
+        ctx.lineTo(x, bounds.height);
+    }
+
+    // horizontal
+    for (let i = 0; i < yAmount; i++) {
+        const y = startOffset.y + i * gap;
+
+        ctx.moveTo(0, y);
+        ctx.lineTo(bounds.width, y);
+    }
+}
 </script>
 
 <template>
@@ -38,7 +135,13 @@ function renderGrid(ctx: CanvasRenderingContext2D) {}
 </template>
 
 <style scoped lang="scss">
+@import "~bootstrap/scss/_functions.scss";
+@import "theme/blue.scss";
+
 .adaptive-grid-canvas {
+    --grid-color: #{$workflow-editor-grid-color};
+    --landmark-color: #{$workflow-editor-grid-color-landmark};
+
     position: absolute;
     top: 0;
     left: 0;
@@ -46,5 +149,7 @@ function renderGrid(ctx: CanvasRenderingContext2D) {}
     bottom: 0;
     width: 100%;
     height: 100%;
+
+    background-color: $workflow-editor-bg;
 }
 </style>

--- a/client/src/components/Workflow/Editor/AdaptiveGrid.vue
+++ b/client/src/components/Workflow/Editor/AdaptiveGrid.vue
@@ -23,7 +23,7 @@ const landmarkLines = [
         width: 4,
     },
     {
-        condition: (zoom: number) => zoom <= 0.15,
+        condition: (zoom: number) => zoom <= 0.2,
         frequency: 200,
         width: 8,
     },

--- a/client/src/components/Workflow/Editor/AdaptiveGrid.vue
+++ b/client/src/components/Workflow/Editor/AdaptiveGrid.vue
@@ -33,7 +33,7 @@ const context = computed(() => canvas.value?.getContext("2d") ?? null);
 let redraw = true;
 
 watch(
-    () => props.transform,
+    () => [props.transform, props.viewportBounds],
     () => (redraw = true),
     { deep: true }
 );

--- a/client/src/components/Workflow/Editor/AdaptiveGrid.vue
+++ b/client/src/components/Workflow/Editor/AdaptiveGrid.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { useAnimationFrame } from "@/composables/sensors/animationFrame";
+import type { UseElementBoundingReturn } from "@vueuse/core";
+import { computed, ref, type Ref } from "vue";
+
+const props = defineProps<{
+    viewportBounds: UseElementBoundingReturn;
+    viewportPan: { x: number; y: number };
+    viewportScale: number;
+}>();
+
+//tmp
+props;
+
+const canvas: Ref<HTMLCanvasElement | null> = ref(null);
+const context = computed(() => canvas.value?.getContext("2d") ?? null);
+
+let redraw = true;
+
+useAnimationFrame(() => {
+    const ctx = context.value;
+
+    if (ctx && redraw) {
+        ctx.canvas.width = ctx.canvas.offsetWidth;
+        ctx.canvas.height = ctx.canvas.offsetHeight;
+
+        renderGrid(ctx);
+
+        redraw = false;
+    }
+});
+
+function renderGrid(ctx: CanvasRenderingContext2D) {}
+</script>
+
+<template>
+    <canvas ref="canvas" class="adaptive-grid-canvas"></canvas>
+</template>
+
+<style scoped lang="scss">
+.adaptive-grid-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+}
+</style>

--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -7,8 +7,10 @@
             class="canvas-content position-relative"
             @drop.prevent
             @dragover.prevent>
-            <!-- canvas-background is sibling of node-area because it has a different transform origin, so can't be parent of node-area -->
-            <div class="canvas-background" :style="canvasStyle" />
+            <AdaptiveGrid
+                :viewport-bounds="elementBounding"
+                :viewport-bounding-box="viewportBoundingBox"
+                :transform="transform" />
             <div class="node-area" :style="canvasStyle">
                 <WorkflowEdges
                     :transform="transform"
@@ -61,6 +63,7 @@ import type { OutputTerminals } from "./modules/terminals";
 import { assertDefined } from "@/utils/assertions";
 import { minZoom, maxZoom } from "./modules/zoomLevels";
 import { useViewportBoundingBox } from "./composables/viewportBoundingBox";
+import AdaptiveGrid from "./AdaptiveGrid.vue";
 
 const emit = defineEmits(["transform", "graph-offset", "onRemove", "scrollTo"]);
 const props = defineProps({

--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -38,8 +38,7 @@
             v-if="elementBounding"
             :steps="steps"
             :viewport-bounds="elementBounding"
-            :viewport-scale="scale"
-            :viewport-pan="transform"
+            :viewport-bounding-box="viewportBoundingBox"
             @panBy="panBy"
             @moveTo="moveTo" />
     </div>
@@ -61,6 +60,7 @@ import type { XYPosition } from "@/stores/workflowEditorStateStore";
 import type { OutputTerminals } from "./modules/terminals";
 import { assertDefined } from "@/utils/assertions";
 import { minZoom, maxZoom } from "./modules/zoomLevels";
+import { useViewportBoundingBox } from "./composables/viewportBoundingBox";
 
 const emit = defineEmits(["transform", "graph-offset", "onRemove", "scrollTo"]);
 const props = defineProps({
@@ -78,6 +78,7 @@ const canvas: Ref<HTMLElement | null> = ref(null);
 const elementBounding = useElementBounding(canvas, { windowResize: false, windowScroll: false });
 const scroll = useScroll(canvas);
 const { transform, panBy, setZoom, moveTo } = useD3Zoom(1, minZoom, maxZoom, canvas, scroll, { x: 20, y: 20 });
+const { viewportBoundingBox } = useViewportBoundingBox(elementBounding, scale, transform);
 
 const isDragging = ref(false);
 provide("isDragging", isDragging);

--- a/client/src/components/Workflow/Editor/WorkflowMinimap.vue
+++ b/client/src/components/Workflow/Editor/WorkflowMinimap.vue
@@ -12,8 +12,7 @@ import type { Ref } from "vue";
 const props = defineProps<{
     steps: Steps;
     viewportBounds: UseElementBoundingReturn;
-    viewportPan: { x: number; y: number };
-    viewportScale: number;
+    viewportBoundingBox: AxisAlignedBoundingBox;
 }>();
 
 const emit = defineEmits<{
@@ -29,33 +28,12 @@ let redraw = false;
 
 // it is important these throttles are defined before useAnimationFrame,
 // so that they are executed first in the frame loop
-const { throttle: viewportThrottle } = useAnimationFrameThrottle();
 const { throttle: dragThrottle } = useAnimationFrameThrottle();
 
-/** bounding box following the viewport */
-const viewportBounds = ref(new AxisAlignedBoundingBox());
 watch(
-    () => ({
-        x: props.viewportPan.x,
-        y: props.viewportPan.y,
-        scale: props.viewportScale,
-        width: unref(props.viewportBounds.width),
-        height: unref(props.viewportBounds.height),
-    }),
-    ({ x, y, scale, width, height }) => {
-        redraw = true;
-
-        viewportThrottle(() => {
-            const bounds = viewportBounds.value;
-
-            bounds.x = -x / scale;
-            bounds.y = -y / scale;
-            bounds.width = width / scale;
-            bounds.height = height / scale;
-
-            viewportBounds.value = bounds;
-        });
-    }
+    () => props.viewportBoundingBox,
+    () => (redraw = true),
+    { deep: true }
 );
 
 /** bounding box encompassing all nodes in the workflow */
@@ -228,7 +206,12 @@ function renderMinimap() {
     ctx.strokeStyle = colors.viewOutline;
     ctx.fillStyle = colors.view;
     ctx.lineWidth = 1 / canvasTransform.scaleX;
-    ctx.rect(viewportBounds.value.x, viewportBounds.value.y, viewportBounds.value.width, viewportBounds.value.height);
+    ctx.rect(
+        props.viewportBoundingBox.x,
+        props.viewportBoundingBox.y,
+        props.viewportBoundingBox.width,
+        props.viewportBoundingBox.height
+    );
     ctx.fill();
     ctx.stroke();
 }
@@ -272,7 +255,7 @@ useDraggable(canvas, {
             .scale([scaleFactor.value, scaleFactor.value])
             .apply([event.offsetX, event.offsetY]);
 
-        if (viewportBounds.value.isPointInBounds({ x, y })) {
+        if (props.viewportBoundingBox.isPointInBounds({ x, y })) {
             dragViewport = true;
         }
     },

--- a/client/src/components/Workflow/Editor/composables/viewportBoundingBox.ts
+++ b/client/src/components/Workflow/Editor/composables/viewportBoundingBox.ts
@@ -17,7 +17,7 @@ export function useViewportBoundingBox(
     scale: Ref<number>,
     pan: Ref<{ x: number; y: number }>
 ) {
-    const { throttle } = useAnimationFrameThrottle();
+    const { throttle } = useAnimationFrameThrottle(100);
 
     const viewportBoundingBox = ref(new AxisAlignedBoundingBox());
     watch(

--- a/client/src/components/Workflow/Editor/composables/viewportBoundingBox.ts
+++ b/client/src/components/Workflow/Editor/composables/viewportBoundingBox.ts
@@ -1,0 +1,46 @@
+import { ref, unref, watch, type Ref } from "vue";
+import { AxisAlignedBoundingBox } from "../modules/geometry";
+import { useAnimationFrameThrottle } from "@/composables/throttle";
+import type { UseElementBoundingReturn } from "@vueuse/core";
+
+/**
+ * Constructs a bounding box following the editors pan and zoom in
+ * animation frame intervals.
+ *
+ * @param bounds vueuse bounding box
+ * @param scale scale to apply to bounding box
+ * @param pan pan to apply to bounding box
+ * @returns Axis Aligned Bounding Box following the viewport
+ */
+export function useViewportBoundingBox(
+    bounds: UseElementBoundingReturn,
+    scale: Ref<number>,
+    pan: Ref<{ x: number; y: number }>
+) {
+    const { throttle } = useAnimationFrameThrottle();
+
+    const viewportBoundingBox = ref(new AxisAlignedBoundingBox());
+    watch(
+        () => ({
+            x: unref(pan).x,
+            y: unref(pan).y,
+            scale: unref(scale),
+            width: unref(bounds.width),
+            height: unref(bounds.height),
+        }),
+        ({ x, y, scale, width, height }) => {
+            throttle(() => {
+                const bounds = viewportBoundingBox.value;
+
+                bounds.x = -x / scale;
+                bounds.y = -y / scale;
+                bounds.width = width / scale;
+                bounds.height = height / scale;
+
+                viewportBoundingBox.value = bounds;
+            });
+        }
+    );
+
+    return { viewportBoundingBox };
+}

--- a/client/src/composables/sensors/animationFrame.ts
+++ b/client/src/composables/sensors/animationFrame.ts
@@ -1,16 +1,40 @@
 import { onScopeDispose } from "vue";
 
 type CallbackFunction = (timestamp: number) => void;
+interface CallbackGroup {
+    priority: number;
+    callbacks: CallbackFunction[];
+}
 
-const callbacks: CallbackFunction[] = [];
+const callbackGroups: CallbackGroup[] = [];
 let loopActive = false;
 
 function animationFrameLoop(timestamp: number) {
-    callbacks.forEach((callback) => {
-        callback(timestamp);
+    callbackGroups.forEach((group) => {
+        group.callbacks.forEach((callback) => {
+            callback(timestamp);
+        });
     });
 
     window.requestAnimationFrame(animationFrameLoop);
+}
+
+function getCallbackGroup(priority: number): CallbackGroup {
+    let group = callbackGroups.find((g) => g.priority === priority);
+
+    if (group) {
+        return group;
+    } else {
+        group = {
+            priority,
+            callbacks: [],
+        };
+
+        callbackGroups.push(group);
+        callbackGroups.sort((a, b) => a.priority - b.priority);
+
+        return group;
+    }
 }
 
 /**
@@ -18,10 +42,13 @@ function animationFrameLoop(timestamp: number) {
  * This can serve as a performance effective alternative for frequently firing events (eg, scroll events)
  * @see https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
  * @param callback
+ * @param priority higher priority callbacks get called first
  * @returns a stop function, to remove the callback from the animation loop
  */
-export function useAnimationFrame(callback: CallbackFunction) {
-    callbacks.push(callback);
+export function useAnimationFrame(callback: CallbackFunction, priority = 0) {
+    const group = getCallbackGroup(priority);
+
+    group.callbacks.push(callback);
 
     if (!loopActive) {
         window.requestAnimationFrame(animationFrameLoop);
@@ -29,10 +56,10 @@ export function useAnimationFrame(callback: CallbackFunction) {
     }
 
     const stop = () => {
-        const index = callbacks.indexOf(callback);
+        const index = group.callbacks.indexOf(callback);
 
         if (index !== -1) {
-            callbacks.splice(index, 1);
+            group.callbacks.splice(index, 1);
         }
     };
 

--- a/client/src/composables/sensors/animationFrame.ts
+++ b/client/src/composables/sensors/animationFrame.ts
@@ -31,7 +31,7 @@ function getCallbackGroup(priority: number): CallbackGroup {
         };
 
         callbackGroups.push(group);
-        callbackGroups.sort((a, b) => a.priority - b.priority);
+        callbackGroups.sort((a, b) => b.priority - a.priority);
 
         return group;
     }

--- a/client/src/composables/throttle.ts
+++ b/client/src/composables/throttle.ts
@@ -1,6 +1,6 @@
 import { useAnimationFrame } from "./sensors/animationFrame";
 
-export function useAnimationFrameThrottle() {
+export function useAnimationFrameThrottle(animationFramePriority = 0) {
     let lastCallback: (() => void) | null = null;
 
     const throttle = (callback: () => void) => {
@@ -12,7 +12,7 @@ export function useAnimationFrameThrottle() {
             lastCallback();
             lastCallback = null;
         }
-    });
+    }, animationFramePriority);
 
     return {
         throttle,

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -154,8 +154,8 @@ $state-running-border: $border-color;
 
 // Workflow editor
 $workflow-editor-bg: $white;
-$workflow-editor-grid-size: 0.7rem;
 $workflow-editor-grid-color: lighten($brand-primary, 65%);
+$workflow-editor-grid-color-landmark: lighten($brand-primary, 60%);
 $workflow-overview-bg: $panel-bg-color;
 $workflow-node-width: 12.5rem;
 

--- a/client/src/style/scss/workflow.scss
+++ b/client/src/style/scss/workflow.scss
@@ -83,21 +83,6 @@
                 top: 0px;
                 overflow: hidden;
             }
-            .canvas-background {
-                @extend .rounded;
-                background: $workflow-editor-bg;
-                background-size: $workflow-editor-grid-size $workflow-editor-grid-size;
-                background-image: linear-gradient(to right, $workflow-editor-grid-color 1px, transparent 1px),
-                    linear-gradient(to bottom, $workflow-editor-grid-color 1px, transparent 1px);
-                // Set width and height to 10 times larger than canvas, so that we can zoom out and still see the grid
-                width: 1000%;
-                height: 1000%;
-                // Set the initial position to the center of the canvas, again so that we can zoom out and still see the grid in the top left direction
-                top: -500%;
-                left: -500%;
-                transform-origin: center;
-                position: relative;
-            }
             .base-terminal {
                 @extend .fa;
                 @extend .fa-circle;


### PR DESCRIPTION
Replaces the workflow editors background with an adaptive infinite gird.

The current grid is very large, but not infinite. Large workflows could not make full use of the grid. This grid extends infinitely instead.

Currently, when moving to a place where there are no nodes it can be hard to see movement when dragging the view-port, due to the small distance between the lines. While dragging the canvas at specific speeds, this effect can even lead to an optical illusion, where it looks like the canvas is moving in the opposite direction. This can be disorienting. The bolder landmark lines in the new background grid help with this, as well as with node-alignment.

This method of rendering the grid also removes the moire effect occurring on small zoom levels, which appears due to the current grid being rendered using a gradient.

Finally, the new grid displays only the landmark lines at small zoom levels, to reduce visual noise.

Current:
![Screenshot from 2023-05-16 12-42-27](https://github.com/galaxyproject/galaxy/assets/44241786/9de7758f-8804-4a01-90af-aac2372193d0)

New:
![Screenshot from 2023-05-16 12-42-11](https://github.com/galaxyproject/galaxy/assets/44241786/6710dda3-49f9-43c2-ac4a-3fa3811f2aeb)

Moire Effect in current:
![Screenshot from 2023-05-16 12-40-11](https://github.com/galaxyproject/galaxy/assets/44241786/e33fb047-1bb5-4a4f-b68f-3439193fa724)

Same zoom in new:
![Screenshot from 2023-05-16 12-42-02](https://github.com/galaxyproject/galaxy/assets/44241786/d113d308-4d7c-457b-a19d-a3da8e0b6461)

Movement in current:

https://github.com/galaxyproject/galaxy/assets/44241786/93207aff-cdc1-41f5-a25a-ef2977488815

Movement in new:

https://github.com/galaxyproject/galaxy/assets/44241786/4af7e378-369a-4dc7-b256-bfd9342d76aa

Zoom out showing the adaptive line rendering at different zoom levels:

https://github.com/galaxyproject/galaxy/assets/44241786/20d53ab1-afac-45a6-a3f9-2cd2816c7b78


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
