### PR TITLE
Use `_.+` for unused variables

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -14,7 +14,7 @@
     "rules": {
         // Standard rules
         "no-console": "off",
-        "no-unused-vars": ["error", { "args": "none", "varsIgnorePattern": "[iI]gnoreUnused.*" }],
+        "no-unused-vars": ["error", { "args": "none", "varsIgnorePattern": "_.+" }],
         "prefer-const": "error",
         "one-var": ["error", "never"],
         "curly": "error",

--- a/client/docs/styleguide.md
+++ b/client/docs/styleguide.md
@@ -273,7 +273,7 @@ Do not add space between elements connected by conditionals.
 >     <span v-if="conditional">
 >         condition met
 >     </span>
-> 
+>
 >     <span v-else>
 >         condition not met
 >     </span>
@@ -289,7 +289,7 @@ Add space between non-connected elements.
 >     <span>
 >         First span.
 >     </span>
-> 
+>
 >     <span>
 >         Second span.
 >     </span>
@@ -321,7 +321,7 @@ Add space between logical blocks of elements.
 >     <span v-else>
 >         condition 1 not met
 >     </span>
-> 
+>
 >     <span v-if="otherConditional">
 >         condition 2 met
 >     </span>
@@ -427,11 +427,3 @@ Use `??` to assign default values.
 > The `??` operator uses the right hand value, when the left hand one is unassigned (`undefined` or `null`), while `||` does this on all falsely values (eg. `false` or `0`). This can lead to unexpected bugs in edge cases.
 >
 > [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing#assigning_a_default_value_to_a_variable)
-
-### Working with unused variables
-
-Unused variables are marked as errors in eslint, however when destructuring objects to remove
-certain keys you may be left with a variable you will not use further. You can
-name the unused variable `ignoredUnused`. The `no-unused-vars` config setting in `client/.eslintrc`
-contains `"varsIgnorePattern": "[iI]gnoreUnused.*"}` to ignore unused variables if they
-start with `ignoredUnused` or `IgnoredUnused`.

--- a/client/docs/styleguide.md
+++ b/client/docs/styleguide.md
@@ -273,7 +273,7 @@ Do not add space between elements connected by conditionals.
 >     <span v-if="conditional">
 >         condition met
 >     </span>
->
+> 
 >     <span v-else>
 >         condition not met
 >     </span>
@@ -289,7 +289,7 @@ Add space between non-connected elements.
 >     <span>
 >         First span.
 >     </span>
->
+> 
 >     <span>
 >         Second span.
 >     </span>
@@ -321,7 +321,7 @@ Add space between logical blocks of elements.
 >     <span v-else>
 >         condition 1 not met
 >     </span>
->
+> 
 >     <span v-if="otherConditional">
 >         condition 2 met
 >     </span>

--- a/client/docs/unused-variables.md
+++ b/client/docs/unused-variables.md
@@ -1,0 +1,21 @@
+# Working with unused variables
+
+Unused variables are marked as errors in eslint, however when destructuring objects to remove
+certain keys you may be left with a variable you will not use further.
+Prefix the unused variable with an underscore: `_unused`.
+The `no-unused-vars` config setting in `client/.eslintrc` contains `"varsIgnorePattern": "_.+"}`
+to ignore unused variables if they start with `_`.
+
+Example:
+
+```js
+const myObject = {
+    name: "history",
+    count: 5,
+    values: ["a", "b", "c"],
+};
+
+const { values: _discarded, ...otherObject } = myObject;
+
+console.log(otherObject); // Object { name: "history", count: 5 }
+```

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -142,7 +142,7 @@ function onToggleVisible() {
         };
     } else {
         if (step.post_job_actions) {
-            const { [actionKey]: ignoreUnused, ...newPostJobActions } = step.post_job_actions;
+            const { [actionKey]: _unused, ...newPostJobActions } = step.post_job_actions;
             step.post_job_actions = newPostJobActions;
         } else {
             step.post_job_actions = {};


### PR DESCRIPTION
Switches the unused variables ignore pattern from `[iI]gnoreUnused.*` to `_.+` to follow js convention.
Adapts the docs to reflect this change.

Also moves this info to a separate md file, as it is not just a style concern, but affects eslint checks.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
