### PR TITLE
[webhook/gtn] Expand query selector list to encompass 'a'

### DIFF
--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -130,7 +130,7 @@
 
                     const gtnToolElements = document
                         .getElementById("gtn-embed")
-                        .contentDocument.querySelectorAll("span[data-tool]");
+                        .contentDocument.querySelectorAll("span[data-tool],a[data-tool]");
 
                     // Buttonify
                     gtnToolElements.forEach(function (el) {
@@ -139,7 +139,7 @@
                             let target = e.target;
 
                             // Sometimes we get the i or the strong, not the parent.
-                            if (e.target.tagName.toLowerCase() !== "span") {
+                            if (e.target.tagName.toLowerCase() !== "span" && e.target.tagName.toLowerCase() !== "a") {
                                 target = e.target.parentElement;
                             }
 
@@ -156,7 +156,7 @@
 
                     const gtnWorkflowElements = document
                         .getElementById("gtn-embed")
-                        .contentDocument.querySelectorAll("span[data-workflow]");
+                        .contentDocument.querySelectorAll("span[data-workflow],a[data-workflow]");
 
                     // Buttonify
                     gtnWorkflowElements.forEach(function (el) {
@@ -165,7 +165,7 @@
                             let target = e.target;
 
                             // Sometimes we get the i or the strong, not the parent.
-                            if (e.target.tagName.toLowerCase() !== "span") {
+                            if (e.target.tagName.toLowerCase() !== "span" && e.target.tagName.toLowerCase() !== "a") {
                                 target = e.target.parentElement;
                             }
 

--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -134,7 +134,6 @@
 
                     // Buttonify
                     gtnToolElements.forEach(function (el) {
-                        el.classList.add("galaxy-proxy-active");
                         el.addEventListener("click", function (e) {
                             let target = e.target;
 
@@ -160,7 +159,6 @@
 
                     // Buttonify
                     gtnWorkflowElements.forEach(function (el) {
-                        el.classList.add("galaxy-proxy-active");
                         el.addEventListener("click", (e) => {
                             let target = e.target;
 


### PR DESCRIPTION
Previously we were not using proper semantic elements for the tool links, this corrects that to also accept `a` which we'll deploy at some point in the future after the next release.

Additionally this removes the 'galaxy-proxy-active' class changes to each individual element, we just leave the application to the body element, and can make CSS decisions based primarily off of that.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
