### PR TITLE
Workflow Connections Dynamic Radius

### DIFF
--- a/client/src/components/Workflow/Editor/SVGConnection.vue
+++ b/client/src/components/Workflow/Editor/SVGConnection.vue
@@ -20,7 +20,6 @@ const props = defineProps({
 });
 
 const ribbonMargin = 4;
-const lineShift = 30;
 
 const curve = line().curve(curveBasis);
 
@@ -60,7 +59,7 @@ const inputPos = computed(() => {
     }
 });
 
-const position = computed(() => {
+const connectionPosition = computed(() => {
     if (inputPos.value && outputPos.value) {
         return {
             startX: outputPos.value.startX,
@@ -91,22 +90,80 @@ const connectionIsValid = computed(() => {
     return !connectionStore.invalidConnections[getConnectionId(props.connection)];
 });
 
-const offsets = computed(() => getLineOffsets(inputIsMappedOver.value, outputIsMappedOver.value));
+const lineOffsets = computed(() => getLineOffsets(inputIsMappedOver.value, outputIsMappedOver.value));
+
+const baseLineShift = 15;
+const lineShiftGrowFactorX = 0.15;
+const lineShiftGrowFactorY = 0.1;
+const lineShiftX = computed(() => {
+    const position = connectionPosition.value;
+
+    if (!position) {
+        return baseLineShift;
+    }
+
+    const distanceX = position.endX - position.startX;
+    const distanceY = Math.abs(position.endY - position.startY);
+
+    const adjustedDistanceX = Math.max(distanceX - baseLineShift, 0);
+
+    const forward = position.endX >= position.startX;
+
+    if (forward) {
+        const growX = adjustedDistanceX * lineShiftGrowFactorX;
+        const growY = distanceY * lineShiftGrowFactorY;
+
+        return baseLineShift + growX + growY;
+    } else {
+        const growX = adjustedDistanceX * lineShiftGrowFactorX * 0.5;
+        const growY = distanceY * lineShiftGrowFactorY * 0.5;
+
+        return baseLineShift * 2 + growX + growY;
+    }
+});
+
+const lineShiftY = computed(() => {
+    const position = connectionPosition.value;
+
+    if (!position) {
+        return 0;
+    }
+
+    const distanceY = position.endY - position.startY;
+    return distanceY / 2;
+});
 
 const paths = computed(() => {
-    if (!position.value || !offsets.value) {
+    const position = connectionPosition.value;
+    const offsets = lineOffsets.value;
+
+    if (!position || !offsets) {
         return [];
     }
 
-    const lines = [...Array(offsets.value.numOffsets).keys()].map((offsetIndex) => {
-        const startOffset = offsets.value.startOffsets[offsetIndex] || 0;
-        const endOffset = offsets.value.endOffsets[offsetIndex] || 0;
-        return [
-            [position.value!.startX, position.value!.startY + startOffset],
-            [position.value!.startX + lineShift, position.value!.startY + startOffset],
-            [position.value!.endX - lineShift, position.value!.endY + endOffset],
-            [position.value!.endX, position.value!.endY + endOffset],
-        ] as [number, number][];
+    const forward = position.endX >= position.startX;
+
+    const lines = [...Array(offsets.numOffsets).keys()].map((offsetIndex) => {
+        const startOffset = offsets.startOffsets[offsetIndex] || 0;
+        const endOffset = offsets.endOffsets[offsetIndex] || 0;
+
+        if (forward) {
+            return [
+                [position.startX, position.startY + startOffset],
+                [position.startX + lineShiftX.value, position.startY + startOffset],
+                [position.endX - lineShiftX.value, position.endY + endOffset],
+                [position.endX, position.endY + endOffset],
+            ] as [number, number][];
+        } else {
+            return [
+                [position.startX, position.startY + startOffset],
+                [position.startX + lineShiftX.value, position.startY + startOffset],
+                [position.startX + lineShiftX.value, position.startY + lineShiftY.value + startOffset],
+                [position.endX - lineShiftX.value, position.endY - lineShiftY.value + endOffset],
+                [position.endX - lineShiftX.value, position.endY + endOffset],
+                [position.endX, position.endY + endOffset],
+            ] as [number, number][];
+        }
     });
 
     return lines.map((l) => curve(l)!);
@@ -135,23 +192,23 @@ const connectionClass = computed(() => {
 });
 
 function generateLineOffsets(inputIsMappedOver: boolean, outputIsMappedOver: boolean) {
-    const _offsets = [-2 * ribbonMargin, -ribbonMargin, 0, ribbonMargin, 2 * ribbonMargin];
+    const offsets = [-2 * ribbonMargin, -ribbonMargin, 0, ribbonMargin, 2 * ribbonMargin];
     let startOffsets = [0];
     let endOffsets = [0];
     let numOffsets = 1;
 
     if (outputIsMappedOver) {
-        startOffsets = _offsets;
-        numOffsets = _offsets.length;
+        startOffsets = offsets;
+        numOffsets = offsets.length;
     }
     if (inputIsMappedOver) {
-        endOffsets = _offsets;
-        numOffsets = _offsets.length;
+        endOffsets = offsets;
+        numOffsets = offsets.length;
     }
     return { numOffsets, startOffsets, endOffsets };
 }
 
-const lineOffsets = {
+const lineOffsetDictionary = {
     "false-false": generateLineOffsets(false, false),
     "true-false": generateLineOffsets(true, false),
     "false-true": generateLineOffsets(false, true),
@@ -159,7 +216,7 @@ const lineOffsets = {
 } as const;
 
 function getLineOffsets(inputIsMappedOver?: boolean, outputIsMappedOver?: boolean) {
-    return lineOffsets[`${inputIsMappedOver ?? false}-${outputIsMappedOver ?? false}`];
+    return lineOffsetDictionary[`${inputIsMappedOver ?? false}-${outputIsMappedOver ?? false}`];
 }
 
 function keyForIndex(index: number) {

--- a/client/src/components/Workflow/Editor/SVGConnection.vue
+++ b/client/src/components/Workflow/Editor/SVGConnection.vue
@@ -92,9 +92,15 @@ const connectionIsValid = computed(() => {
 
 const lineOffsets = computed(() => getLineOffsets(inputIsMappedOver.value, outputIsMappedOver.value));
 
+// minimum line shift
 const baseLineShift = 15;
+
+// how much the x distance influences line shift
 const lineShiftGrowFactorX = 0.15;
+
+// how much the y distance influences line shift
 const lineShiftGrowFactorY = 0.1;
+
 const lineShiftX = computed(() => {
     const position = connectionPosition.value;
 
@@ -115,22 +121,12 @@ const lineShiftX = computed(() => {
 
         return baseLineShift + growX + growY;
     } else {
+        // reverse variant had reduced growth, but a higher base
         const growX = adjustedDistanceX * lineShiftGrowFactorX * 0.5;
         const growY = distanceY * lineShiftGrowFactorY * 0.5;
 
         return baseLineShift * 2 + growX + growY;
     }
-});
-
-const lineShiftY = computed(() => {
-    const position = connectionPosition.value;
-
-    if (!position) {
-        return 0;
-    }
-
-    const distanceY = position.endY - position.startY;
-    return distanceY / 2;
 });
 
 const paths = computed(() => {
@@ -155,11 +151,14 @@ const paths = computed(() => {
                 [position.endX, position.endY + endOffset],
             ] as [number, number][];
         } else {
+            // reverse variant has two additional control points to smooth curve
+            const lineShiftY = (position.endY - position.startY) / 2;
+
             return [
                 [position.startX, position.startY + startOffset],
                 [position.startX + lineShiftX.value, position.startY + startOffset],
-                [position.startX + lineShiftX.value, position.startY + lineShiftY.value + startOffset],
-                [position.endX - lineShiftX.value, position.endY - lineShiftY.value + endOffset],
+                [position.startX + lineShiftX.value, position.startY + lineShiftY + startOffset],
+                [position.endX - lineShiftX.value, position.endY - lineShiftY + endOffset],
                 [position.endX - lineShiftX.value, position.endY + endOffset],
                 [position.endX, position.endY + endOffset],
             ] as [number, number][];

--- a/client/src/components/Workflow/Editor/SVGConnection.vue
+++ b/client/src/components/Workflow/Editor/SVGConnection.vue
@@ -99,7 +99,7 @@ const baseLineShift = 15;
 const lineShiftGrowFactorX = 0.15;
 
 // how much the y distance influences line shift
-const lineShiftGrowFactorY = 0.1;
+const lineShiftGrowFactorY = 0.08;
 
 const lineShiftX = computed(() => {
     const position = connectionPosition.value;
@@ -108,21 +108,19 @@ const lineShiftX = computed(() => {
         return baseLineShift;
     }
 
-    const distanceX = position.endX - position.startX;
+    const distanceX = Math.abs(position.endX - position.startX - baseLineShift);
     const distanceY = Math.abs(position.endY - position.startY);
-
-    const adjustedDistanceX = Math.max(distanceX - baseLineShift, 0);
 
     const forward = position.endX >= position.startX;
 
     if (forward) {
-        const growX = adjustedDistanceX * lineShiftGrowFactorX;
+        const growX = distanceX * lineShiftGrowFactorX;
         const growY = distanceY * lineShiftGrowFactorY;
 
         return baseLineShift + growX + growY;
     } else {
         // reverse variant had reduced growth, but a higher base
-        const growX = adjustedDistanceX * lineShiftGrowFactorX * 0.5;
+        const growX = distanceX * lineShiftGrowFactorX * 0.5;
         const growY = distanceY * lineShiftGrowFactorY * 0.5;
 
         return baseLineShift * 2 + growX + growY;


### PR DESCRIPTION
Makes the workflow connections radius dynamic, to make long and backwards connections easier to follow.
Adds two additional control points to reverse connections, to make them bend more cleanly.

Has little impact on short connections.

![image](https://github.com/galaxyproject/galaxy/assets/44241786/9dcd55e7-e087-4757-80e0-d82e29c393e3)

For comparison, the same connections currently look like this on dev:

![image](https://github.com/galaxyproject/galaxy/assets/44241786/bc1b123a-6354-4920-af34-66f0d88a11f0)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
