### PR TITLE
Attempt to fix mypy check

### DIFF
--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -151,7 +151,7 @@ class DropIndex(DDLOperation):
         self.table_name = table_name
 
     def execute(self) -> None:
-        op.drop_index(self.index_name, self.table_name)
+        op.drop_index(self.index_name, table_name=self.table_name)
 
     def pre_execute_check(self) -> bool:
         return index_exists(self.index_name, self.table_name, False)


### PR DESCRIPTION
I'm a bit confused by the mypy error consistently failing in all PRs. It doesn't look that this should happen.

```
galaxy/model/migrations/util.py:154: error: Too many positional arguments for "drop_index"  [misc]
            op.drop_index(self.index_name, self.table_name)
```

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
