### PR TITLE
[23.0] Fix mypy error due to alembic 1.11.0

### DIFF
--- a/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/3a2914d703ca_add_index_wf_r_s_s__workflow_invocation_.py
@@ -26,4 +26,4 @@ def upgrade():
 
 
 def downgrade():
-    drop_index(index_name, table_name, columns)
+    drop_index(index_name, table_name)

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/caa7742f7bca_add_index_wf_r_i_p__workflow_invocation_.py
@@ -27,4 +27,4 @@ def upgrade():
 
 
 def downgrade():
-    drop_index(index_name, table_name, columns)
+    drop_index(index_name, table_name)

--- a/lib/galaxy/model/migrations/util.py
+++ b/lib/galaxy/model/migrations/util.py
@@ -25,9 +25,9 @@ def create_index(index_name, table_name, columns):
         op.create_index(index_name, table_name, columns)
 
 
-def drop_index(index_name, table_name, columns):
+def drop_index(index_name, table_name) -> None:
     if index_exists(index_name, table_name):
-        op.drop_index(index_name, table_name)
+        op.drop_index(index_name, table_name=table_name)
 
 
 def column_exists(table_name, column_name):


### PR DESCRIPTION
Alembic 1.11.0 made the `table_name` argument of `op.drop_index()` keyword-only, causing the following failure in the test_galaxy_packages build (where alembic is not pinned):

```
galaxy/model/migrations/util.py:30: error: Too many positional arguments for
"drop_index"  [misc]
            op.drop_index(index_name, table_name)
            ^
```

xref: https://github.com/sqlalchemy/alembic/issues/1243

Also drop the unused `columns` parameter from our wrapper method, as done already in the dev branch.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
