### PR TITLE
Add hdf4 datatype

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -179,6 +179,7 @@
       <display file="igb/gtf.xml"/>
     </datatype>
     <datatype extension="toolshed.gz" type="galaxy.datatypes.binary:Binary" mimetype="multipart/x-gzip" subclass="true"/>
+    <datatype extension="hdf4" type="galaxy.datatypes.binary:Binary" subclass="true" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="h5" type="galaxy.datatypes.binary:H5" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="scool" type="galaxy.datatypes.binary:H5" mimetype="application/octet-stream" display_in_upload="true" subclass="true"/>
     <datatype extension="grib" type="galaxy.datatypes.binary:Grib" mimetype="application/octet-stream" display_in_upload="true"/>


### PR DESCRIPTION
In the context of a galaxy-eu workshop related to the FAIR-EASE project, I added a HDFView interactive tool that can handle hdf4 files along with hdf5 and netcdf. See https://github.com/usegalaxy-eu/galaxy/pull/163.

Therefore this adds a hdf4 entry in the list of datatypes.

Maybe later I'll contribute to create a dedicate class with a sniff function etc.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
