### PR TITLE
De-duplicate code around object store caches. 

### DIFF
--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1432,29 +1432,6 @@ def local_extra_dirs(func):
     return wraps
 
 
-def convert_bytes(bytes):
-    """A helper function used for pretty printing disk usage."""
-    if bytes is None:
-        bytes = 0
-    bytes = float(bytes)
-
-    if bytes >= 1099511627776:
-        terabytes = bytes / 1099511627776
-        size = f"{terabytes:.2f}TB"
-    elif bytes >= 1073741824:
-        gigabytes = bytes / 1073741824
-        size = f"{gigabytes:.2f}GB"
-    elif bytes >= 1048576:
-        megabytes = bytes / 1048576
-        size = f"{megabytes:.2f}MB"
-    elif bytes >= 1024:
-        kilobytes = bytes / 1024
-        size = f"{kilobytes:.2f}KB"
-    else:
-        size = f"{bytes:.2f}b"
-    return size
-
-
 def config_to_dict(config):
     """Dict-ify the portion of a config object consumed by the ObjectStore class and its subclasses."""
     return {

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -23,15 +23,13 @@ from galaxy.exceptions import (
 )
 from galaxy.util import (
     directory_hash_id,
+    nice_size,
     umask_fix_perms,
     unlink,
 )
 from galaxy.util.path import safe_relpath
 from galaxy.util.sleeper import Sleeper
-from . import (
-    ConcreteObjectStore,
-    convert_bytes,
-)
+from . import ConcreteObjectStore
 
 NO_BLOBSERVICE_ERROR_MESSAGE = (
     "ObjectStore configured, but no azure.storage.blob dependency available."
@@ -603,8 +601,8 @@ class AzureBlobObjectStore(ConcreteObjectStore):
             if total_size > cache_limit:
                 log.info(
                     "Initiating cache cleaning: current cache size: %s; clean until smaller than: %s",
-                    convert_bytes(total_size),
-                    convert_bytes(cache_limit),
+                    nice_size(total_size),
+                    nice_size(cache_limit),
                 )
                 # How much to delete? If simply deleting up to the cache-10% limit,
                 # is likely to be deleting frequently and may run the risk of hitting
@@ -626,6 +624,6 @@ class AzureBlobObjectStore(ConcreteObjectStore):
                         #     % (i, file_name, convert_bytes(f[2]), file_date, \
                         #     convert_bytes(deleted_amount), convert_bytes(delete_this_much)))
                     else:
-                        log.debug("Cache cleaning done. Total space freed: %s", convert_bytes(deleted_amount))
+                        log.debug("Cache cleaning done. Total space freed: %s", nice_size(deleted_amount))
 
             self.sleeper.sleep(30)  # Test cache size every 30 seconds?

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -23,13 +23,16 @@ from galaxy.exceptions import (
 )
 from galaxy.util import (
     directory_hash_id,
-    nice_size,
     umask_fix_perms,
     unlink,
 )
 from galaxy.util.path import safe_relpath
 from galaxy.util.sleeper import Sleeper
 from . import ConcreteObjectStore
+from .caching import (
+    CacheTarget,
+    check_cache,
+)
 
 NO_BLOBSERVICE_ERROR_MESSAGE = (
     "ObjectStore configured, but no azure.storage.blob dependency available."
@@ -578,52 +581,16 @@ class AzureBlobObjectStore(ConcreteObjectStore):
     # Secret Methods #
     ##################
 
+    @property
+    def cache_target(self) -> CacheTarget:
+        return CacheTarget(
+            self.staging_path,
+            self.cache_size,
+            0.9,
+        )
+
     def __cache_monitor(self):
         time.sleep(2)  # Wait for things to load before starting the monitor
         while self.running:
-            total_size = 0
-            # Is this going to be too expensive of an operation to be done frequently?
-            file_list = []
-            for dirpath, _, filenames in os.walk(self.staging_path):
-                for filename in filenames:
-                    filepath = os.path.join(dirpath, filename)
-                    file_size = os.path.getsize(filepath)
-                    total_size += file_size
-                    # Get the time given file was last accessed
-                    last_access_time = time.localtime(os.stat(filepath)[7])
-                    # Compose a tuple of the access time and the file path
-                    file_tuple = last_access_time, filepath, file_size
-                    file_list.append(file_tuple)
-            # Sort the file list (based on access time)
-            file_list.sort()
-            # Initiate cleaning once within 10% of the defined cache size?
-            cache_limit = self.cache_size * 0.9
-            if total_size > cache_limit:
-                log.info(
-                    "Initiating cache cleaning: current cache size: %s; clean until smaller than: %s",
-                    nice_size(total_size),
-                    nice_size(cache_limit),
-                )
-                # How much to delete? If simply deleting up to the cache-10% limit,
-                # is likely to be deleting frequently and may run the risk of hitting
-                # the limit - maybe delete additional #%?
-                # For now, delete enough to leave at least 10% of the total cache free
-                delete_this_much = total_size - cache_limit
-                # Keep deleting datasets from file_list until deleted_amount does not
-                # exceed delete_this_much; start deleting from the front of the file list,
-                # which assumes the oldest files come first on the list.
-                deleted_amount = 0
-                for entry in enumerate(file_list):
-                    if deleted_amount < delete_this_much:
-                        deleted_amount += entry[2]
-                        os.remove(entry[1])
-                        # Debugging code for printing deleted files' stats
-                        # folder, file_name = os.path.split(f[1])
-                        # file_date = time.strftime("%m/%d/%y %H:%M:%S", f[0])
-                        # log.debug("%s. %-25s %s, size %s (deleted %s/%s)" \
-                        #     % (i, file_name, convert_bytes(f[2]), file_date, \
-                        #     convert_bytes(deleted_amount), convert_bytes(delete_this_much)))
-                    else:
-                        log.debug("Cache cleaning done. Total space freed: %s", nice_size(deleted_amount))
-
+            check_cache(self.cache_target)
             self.sleeper.sleep(30)  # Test cache size every 30 seconds?

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -1,0 +1,95 @@
+"""
+"""
+import os
+import logging
+import time
+from typing import (
+    List,
+    Tuple,
+)
+
+from typing_extensions import NamedTuple
+
+from galaxy.util import nice_size
+
+log = logging.getLogger(__name__)
+
+
+ONE_GIGA_BYTE = 1024 * 1024 * 1024
+
+
+FileListT = List[Tuple[time.struct_time, str, int]]
+
+
+class CacheTarget(NamedTuple):
+    path: str
+    size: int  # cache size in gigabytes
+    limit: float  # cache limit as a percent
+
+
+def check_cache(cache_target: CacheTarget):
+    """Run a step of the cache monitor."""
+    total_size, file_list = _get_cache_size_files(cache_target.path)
+    # Sort the file list (based on access time)
+    file_list.sort()
+    # Initiate cleaning once we reach cache_monitor_cache_limit percentage of the defined cache size?
+    # Convert GBs to bytes for comparison
+    cache_size_in_gb = cache_target.size * ONE_GIGA_BYTE
+    cache_limit = cache_size_in_gb * cache_target.limit
+    if total_size > cache_limit:
+        log.debug(
+            "Initiating cache cleaning: current cache size: %s; clean until smaller than: %s",
+            nice_size(total_size),
+            nice_size(cache_limit),
+        )
+        # How much to delete? If simply deleting up to the cache-10% limit,
+        # is likely to be deleting frequently and may run the risk of hitting
+        # the limit - maybe delete additional #%?
+        # For now, delete enough to leave at least 10% of the total cache free
+        delete_this_much = total_size - cache_limit
+        _clean_cache(file_list, delete_this_much)
+
+
+def _clean_cache(file_list: FileListT, delete_this_much: float) -> None:
+    """Keep deleting files from the file_list until the size of the deleted
+    files is greater than the value in delete_this_much parameter.
+    :param file_list: List of candidate files that can be deleted. This method
+        will start deleting files from the beginning of the list so the list
+        should be sorted accordingly. The list must contains 3-element tuples,
+        positioned as follows: position 0 holds file last accessed timestamp
+        (as time.struct_time), position 1 holds file path, and position 2 has
+        file size (e.g., (<access time>, /mnt/data/dataset_1.dat), 472394)
+    :param delete_this_much: Total size of files, in bytes, that should be deleted.
+    """
+    # Keep deleting datasets from file_list until deleted_amount does not
+    # exceed delete_this_much; start deleting from the front of the file list,
+    # which assumes the oldest files come first on the list.
+    deleted_amount = 0
+    for entry in file_list:
+        if deleted_amount < delete_this_much:
+            deleted_amount += entry[2]
+            os.remove(entry[1])
+        else:
+            log.debug("Cache cleaning done. Total space freed: %s", nice_size(deleted_amount))
+            return
+
+
+def _get_cache_size_files(cache_path) -> Tuple[int, FileListT]:
+    """Returns cache size and cache files.
+
+    For each file, we get last access time, file path, and file size.
+    """
+    cache_size = 0
+    file_list = []
+
+    for dirpath, _, filenames in os.walk(cache_path):
+        for filename in filenames:
+            file_path = os.path.join(dirpath, filename)
+            file_size = os.path.getsize(file_path)
+            cache_size += file_size
+            # Get the time given file was last accessed
+            last_access_time = time.localtime(os.stat(file_path)[7])
+            # Compose a tuple of the access time and the file path
+            file_tuple = last_access_time, file_path, file_size
+            file_list.append(file_tuple)
+    return cache_size, file_list

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -1,7 +1,7 @@
 """
 """
-import os
 import logging
+import os
 import time
 from typing import (
     List,

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -18,13 +18,16 @@ from galaxy.exceptions import (
 )
 from galaxy.util import (
     directory_hash_id,
-    nice_size,
     safe_relpath,
     umask_fix_perms,
     unlink,
 )
 from galaxy.util.sleeper import Sleeper
 from . import ConcreteObjectStore
+from .caching import (
+    CacheTarget,
+    check_cache,
+)
 from .s3 import parse_config_xml
 
 try:
@@ -248,72 +251,19 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         as_dict.update(self._config_to_dict())
         return as_dict
 
+    @property
+    def cache_target(self) -> CacheTarget:
+        return CacheTarget(
+            self.staging_path,
+            self.cache_size,
+            0.9,
+        )
+
     def __cache_monitor(self):
         time.sleep(2)  # Wait for things to load before starting the monitor
         while self.running:
-            total_size = 0
-            # Is this going to be too expensive of an operation to be done frequently?
-            file_list = []
-            for dirpath, _, filenames in os.walk(self.staging_path):
-                for filename in filenames:
-                    filepath = os.path.join(dirpath, filename)
-                    file_size = os.path.getsize(filepath)
-                    total_size += file_size
-                    # Get the time given file was last accessed
-                    last_access_time = time.localtime(os.stat(filepath)[7])
-                    # Compose a tuple of the access time and the file path
-                    file_tuple = last_access_time, filepath, file_size
-                    file_list.append(file_tuple)
-            # Sort the file list (based on access time)
-            file_list.sort()
-            # Initiate cleaning once within 10% of the defined cache size?
-            cache_limit = self.cache_size * 0.9
-            if total_size > cache_limit:
-                log.info(
-                    "Initiating cache cleaning: current cache size: %s; clean until smaller than: %s",
-                    nice_size(total_size),
-                    nice_size(cache_limit),
-                )
-                # How much to delete? If simply deleting up to the cache-10% limit,
-                # is likely to be deleting frequently and may run the risk of hitting
-                # the limit - maybe delete additional #%?
-                # For now, delete enough to leave at least 10% of the total cache free
-                delete_this_much = total_size - cache_limit
-                self.__clean_cache(file_list, delete_this_much)
+            check_cache(self.cache_target)
             self.sleeper.sleep(30)  # Test cache size every 30 seconds?
-
-    def __clean_cache(self, file_list, delete_this_much):
-        """Keep deleting files from the file_list until the size of the deleted
-        files is greater than the value in delete_this_much parameter.
-
-        :type file_list: list
-        :param file_list: List of candidate files that can be deleted. This method
-            will start deleting files from the beginning of the list so the list
-            should be sorted accordingly. The list must contains 3-element tuples,
-            positioned as follows: position 0 holds file last accessed timestamp
-            (as time.struct_time), position 1 holds file path, and position 2 has
-            file size (e.g., (<access time>, /mnt/data/dataset_1.dat), 472394)
-
-        :type delete_this_much: int
-        :param delete_this_much: Total size of files, in bytes, that should be deleted.
-        """
-        # Keep deleting datasets from file_list until deleted_amount does not
-        # exceed delete_this_much; start deleting from the front of the file list,
-        # which assumes the oldest files come first on the list.
-        deleted_amount = 0
-        for entry in enumerate(file_list):
-            if deleted_amount < delete_this_much:
-                deleted_amount += entry[2]
-                os.remove(entry[1])
-                # Debugging code for printing deleted files' stats
-                # folder, file_name = os.path.split(f[1])
-                # file_date = time.strftime("%m/%d/%y %H:%M:%S", f[0])
-                # log.debug("%s. %-25s %s, size %s (deleted %s/%s)" \
-                #     % (i, file_name, convert_bytes(f[2]), file_date, \
-                #     convert_bytes(deleted_amount), convert_bytes(delete_this_much)))
-            else:
-                log.debug("Cache cleaning done. Total space freed: %s", nice_size(deleted_amount))
-                return
 
     def _get_bucket(self, bucket_name):
         try:

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -18,15 +18,13 @@ from galaxy.exceptions import (
 )
 from galaxy.util import (
     directory_hash_id,
+    nice_size,
     safe_relpath,
     umask_fix_perms,
     unlink,
 )
 from galaxy.util.sleeper import Sleeper
-from . import (
-    ConcreteObjectStore,
-    convert_bytes,
-)
+from . import ConcreteObjectStore
 from .s3 import parse_config_xml
 
 try:
@@ -273,8 +271,8 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
             if total_size > cache_limit:
                 log.info(
                     "Initiating cache cleaning: current cache size: %s; clean until smaller than: %s",
-                    convert_bytes(total_size),
-                    convert_bytes(cache_limit),
+                    nice_size(total_size),
+                    nice_size(cache_limit),
                 )
                 # How much to delete? If simply deleting up to the cache-10% limit,
                 # is likely to be deleting frequently and may run the risk of hitting
@@ -314,7 +312,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
                 #     % (i, file_name, convert_bytes(f[2]), file_date, \
                 #     convert_bytes(deleted_amount), convert_bytes(delete_this_much)))
             else:
-                log.debug("Cache cleaning done. Total space freed: %s", convert_bytes(deleted_amount))
+                log.debug("Cache cleaning done. Total space freed: %s", nice_size(deleted_amount))
                 return
 
     def _get_bucket(self, bucket_name):

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -25,7 +25,6 @@ from galaxy.exceptions import (
 )
 from galaxy.util import (
     directory_hash_id,
-    nice_size,
     string_as_bool,
     umask_fix_perms,
     unlink,
@@ -34,6 +33,10 @@ from galaxy.util import (
 from galaxy.util.path import safe_relpath
 from galaxy.util.sleeper import Sleeper
 from . import ConcreteObjectStore
+from .caching import (
+    CacheTarget,
+    check_cache,
+)
 from .s3_multipart_upload import multipart_upload
 
 NO_BOTO_ERROR_MESSAGE = (
@@ -231,72 +234,19 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
         as_dict.update(self._config_to_dict())
         return as_dict
 
+    @property
+    def cache_target(self) -> CacheTarget:
+        return CacheTarget(
+            self.staging_path,
+            self.cache_size,
+            0.9,
+        )
+
     def __cache_monitor(self):
         time.sleep(2)  # Wait for things to load before starting the monitor
         while self.running:
-            total_size = 0
-            # Is this going to be too expensive of an operation to be done frequently?
-            file_list = []
-            for dirpath, _, filenames in os.walk(self.staging_path):
-                for filename in filenames:
-                    filepath = os.path.join(dirpath, filename)
-                    file_size = os.path.getsize(filepath)
-                    total_size += file_size
-                    # Get the time given file was last accessed
-                    last_access_time = time.localtime(os.stat(filepath)[7])
-                    # Compose a tuple of the access time and the file path
-                    file_tuple = last_access_time, filepath, file_size
-                    file_list.append(file_tuple)
-            # Sort the file list (based on access time)
-            file_list.sort()
-            # Initiate cleaning once within 10% of the defined cache size?
-            cache_limit = self.cache_size * 0.9
-            if total_size > cache_limit:
-                log.info(
-                    "Initiating cache cleaning: current cache size: %s; clean until smaller than: %s",
-                    nice_size(total_size),
-                    nice_size(cache_limit),
-                )
-                # How much to delete? If simply deleting up to the cache-10% limit,
-                # is likely to be deleting frequently and may run the risk of hitting
-                # the limit - maybe delete additional #%?
-                # For now, delete enough to leave at least 10% of the total cache free
-                delete_this_much = total_size - cache_limit
-                self.__clean_cache(file_list, delete_this_much)
+            check_cache(self.cache_target)
             self.sleeper.sleep(30)  # Test cache size every 30 seconds?
-
-    def __clean_cache(self, file_list, delete_this_much):
-        """Keep deleting files from the file_list until the size of the deleted
-        files is greater than the value in delete_this_much parameter.
-
-        :type file_list: list
-        :param file_list: List of candidate files that can be deleted. This method
-            will start deleting files from the beginning of the list so the list
-            should be sorted accordingly. The list must contains 3-element tuples,
-            positioned as follows: position 0 holds file last accessed timestamp
-            (as time.struct_time), position 1 holds file path, and position 2 has
-            file size (e.g., (<access time>, /mnt/data/dataset_1.dat), 472394)
-
-        :type delete_this_much: int
-        :param delete_this_much: Total size of files, in bytes, that should be deleted.
-        """
-        # Keep deleting datasets from file_list until deleted_amount does not
-        # exceed delete_this_much; start deleting from the front of the file list,
-        # which assumes the oldest files come first on the list.
-        deleted_amount = 0
-        for entry in file_list:
-            if deleted_amount < delete_this_much:
-                deleted_amount += entry[2]
-                os.remove(entry[1])
-                # Debugging code for printing deleted files' stats
-                # folder, file_name = os.path.split(f[1])
-                # file_date = time.strftime("%m/%d/%y %H:%M:%S", f[0])
-                # log.debug("%s. %-25s %s, size %s (deleted %s/%s)" \
-                #     % (i, file_name, convert_bytes(f[2]), file_date, \
-                #     convert_bytes(deleted_amount), convert_bytes(delete_this_much)))
-            else:
-                log.debug("Cache cleaning done. Total space freed: %s", nice_size(deleted_amount))
-                return
 
     def _get_bucket(self, bucket_name):
         """Sometimes a handle to a bucket is not established right away so try

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -25,6 +25,7 @@ from galaxy.exceptions import (
 )
 from galaxy.util import (
     directory_hash_id,
+    nice_size,
     string_as_bool,
     umask_fix_perms,
     unlink,
@@ -32,10 +33,7 @@ from galaxy.util import (
 )
 from galaxy.util.path import safe_relpath
 from galaxy.util.sleeper import Sleeper
-from . import (
-    ConcreteObjectStore,
-    convert_bytes,
-)
+from . import ConcreteObjectStore
 from .s3_multipart_upload import multipart_upload
 
 NO_BOTO_ERROR_MESSAGE = (
@@ -256,8 +254,8 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
             if total_size > cache_limit:
                 log.info(
                     "Initiating cache cleaning: current cache size: %s; clean until smaller than: %s",
-                    convert_bytes(total_size),
-                    convert_bytes(cache_limit),
+                    nice_size(total_size),
+                    nice_size(cache_limit),
                 )
                 # How much to delete? If simply deleting up to the cache-10% limit,
                 # is likely to be deleting frequently and may run the risk of hitting
@@ -297,7 +295,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
                 #     % (i, file_name, convert_bytes(f[2]), file_date, \
                 #     convert_bytes(deleted_amount), convert_bytes(delete_this_much)))
             else:
-                log.debug("Cache cleaning done. Total space freed: %s", convert_bytes(deleted_amount))
+                log.debug("Cache cleaning done. Total space freed: %s", nice_size(deleted_amount))
                 return
 
     def _get_bucket(self, bucket_name):

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -1071,18 +1071,10 @@ def test_check_cache_sanity(tmp_path):
     cache_dir = tmp_path
     path = cache_dir / "a_file_0"
     path.write_text("this is an example file")
-    big_cache_target = CacheTarget(
-        cache_dir,
-        1,
-        .2
-    )
+    big_cache_target = CacheTarget(cache_dir, 1, 0.2)
     check_cache(big_cache_target)
     assert path.exists()
-    small_cache_target = CacheTarget(
-        cache_dir,
-        1,
-        .000000001
-    )
+    small_cache_target = CacheTarget(cache_dir, 1, 0.000000001)
     check_cache(small_cache_target)
     assert not path.exists()
 

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -727,8 +727,9 @@ def test_config_parse_s3():
             assert object_store.is_secure is True
             assert object_store.conn_path == "/"
 
-            assert object_store.cache_size == 1000
-            assert object_store.staging_path == "database/object_store_cache"
+            cache_target = object_store.cache_target
+            assert cache_target.size == 1000
+            assert cache_target.path == "database/object_store_cache"
             assert object_store.extra_dirs["job_work"] == "database/job_working_directory_s3"
             assert object_store.extra_dirs["temp"] == "database/tmp_s3"
 
@@ -885,8 +886,9 @@ def test_config_parse_cloud():
             assert object_store.is_secure is True
             assert object_store.conn_path == "/"
 
-            assert object_store.cache_size == 1000.0
-            assert object_store.staging_path == "database/object_store_cache"
+            cache_target = object_store.cache_target
+            assert cache_target.size == 1000.0
+            assert cache_target.path == "database/object_store_cache"
             assert object_store.extra_dirs["job_work"] == "database/job_working_directory_cloud"
             assert object_store.extra_dirs["temp"] == "database/tmp_cloud"
 
@@ -951,8 +953,9 @@ def test_config_parse_cloud_noauth_for_aws():
             assert object_store.is_secure is True
             assert object_store.conn_path == "/"
 
-            assert object_store.cache_size == 1000.0
-            assert object_store.staging_path == "database/object_store_cache"
+            cache_target = object_store.cache_target
+            assert cache_target.size == 1000.0
+            assert cache_target.path == "database/object_store_cache"
             assert object_store.extra_dirs["job_work"] == "database/job_working_directory_cloud"
             assert object_store.extra_dirs["temp"] == "database/tmp_cloud"
 
@@ -1028,8 +1031,9 @@ def test_config_parse_azure():
             assert object_store.container_name == "unique_container_name"
             assert object_store.max_chunk_size == 250
 
-            assert object_store.cache_size == 100
-            assert object_store.staging_path == "database/object_store_cache"
+            cache_target = object_store.cache_target
+            assert cache_target.size == 100
+            assert cache_target.path == "database/object_store_cache"
             assert object_store.extra_dirs["job_work"] == "database/job_working_directory_azure"
             assert object_store.extra_dirs["temp"] == "database/tmp_azure"
 


### PR DESCRIPTION
An atomic couple of refactorings to get the ball rolling ahead of tackling object store caching improvements. This doesn't touch the monitor code but does de-duplicate the actual cache removal code ahead of that.

This PR nets a decent removal of total number of lines of code (complex code) despite adding some unit tests of previously uncovered code and bringing in nice comments, constants, etc... from @kxk302's first cut at this in https://github.com/galaxyproject/galaxy/pull/14533/files.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
