### PR TITLE
Improved Cache Monitoring for Object Stores

### DIFF
--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -215,6 +215,9 @@ def setup_periodic_tasks(config, celery_app):
     schedule_task("prune_history_audit_table", config.history_audit_table_prune_interval)
     schedule_task("cleanup_short_term_storage", config.short_term_storage_cleanup_interval)
 
+    if config.object_store_cache_monitor_driver in ["auto", "celery"]:
+        schedule_task("clean_object_store_caches", config.object_store_cache_monitor_interval)
+
     if beat_schedule:
         celery_app.conf.beat_schedule = beat_schedule
 

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -35,6 +35,7 @@ from galaxy.managers.tool_data import ToolDataImportManager
 from galaxy.metadata.set_metadata import set_metadata_portable
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.objectstore import BaseObjectStore
+from galaxy.objectstore.caching import check_caches
 from galaxy.schema.tasks import (
     ComputeDatasetHashTaskRequest,
     GenerateHistoryContentDownload,
@@ -406,3 +407,8 @@ def prune_history_audit_table(sa_session: galaxy_scoped_session):
 def cleanup_short_term_storage(storage_monitor: ShortTermStorageMonitor):
     """Cleanup short term storage."""
     storage_monitor.cleanup()
+
+
+@galaxy_task(action="prune object store cache directories")
+def clean_object_store_caches(object_store: BaseObjectStore):
+    check_caches(object_store.cache_targets())

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -974,6 +974,35 @@ mapping:
           Configuration file for the object store
           If this is set and exists, it overrides any other objectstore settings.
 
+      object_store_cache_monitor_driver:
+        type: str
+        default: 'auto'
+        required: false
+        enum: ['auto', 'inprocess', 'celery', 'external']
+        desc: |
+          Specify where cache monitoring is driven for caching object stores
+          such as S3, Azure, and iRODS. This option has no affect on disk object stores.
+          For production instances, the cache should be monitored by external tools such
+          as tmpwatch and this value should be set to 'external'. This will disable all
+          cache monitoring in Galaxy. Alternatively, 'celery' can monitor caches using
+          a periodic task or an 'inprocess' thread can be used - but this last option
+          seriously limits Galaxy's ability to scale. The default of 'auto' will use
+          'celery' if 'enable_celery_tasks' is set to true or 'inprocess' otherwise.
+          This option serves as the default for all object stores and can be overridden
+          on a per object store basis (but don't - just setup tmpwatch for all relevant
+          cache paths).
+
+      object_store_cache_monitor_interval:
+        type: int
+        default: 600
+        required: false
+        desc: |
+          For object store cache monitoring done by Galaxy, this is the interval between
+          cache checking steps. This is used by both inprocess cache monitors (which we
+          recommend you do not use) and by the celery task if it is configured (by setting
+          enable_celery_tasks to true and not setting object_store_cache_monitor_driver to
+          external).
+
       object_store_cache_path:
         type: str
         default: object_store_cache

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -145,7 +145,9 @@ def get_object_store(tool_job_working_directory, object_store=None):
         with open(object_store_conf_path) as f:
             config_dict = json.load(f)
         assert config_dict is not None
-        object_store = build_object_store_from_config(None, config_dict=config_dict)
+        # build an object store but disable any process management associated with it
+        # we're using it as a library - not as a service.
+        object_store = build_object_store_from_config(None, config_dict=config_dict, disable_process_management=True)
     Dataset.object_store = object_store
     return object_store
 

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1364,7 +1364,9 @@ def type_to_object_store_class(store: str, fsmon: bool = False) -> Tuple[Type[Ba
     return objectstore_class, objectstore_constructor_kwds
 
 
-def build_object_store_from_config(config, fsmon=False, config_xml=None, config_dict=None):
+def build_object_store_from_config(
+    config, fsmon=False, config_xml=None, config_dict=None, disable_process_management=False
+):
     """
     Invoke the appropriate object store.
 
@@ -1378,8 +1380,8 @@ def build_object_store_from_config(config, fsmon=False, config_xml=None, config_
     from_object = "xml"
 
     if config is None and config_dict is not None and "config" in config_dict:
-        # Build a config object from to_dict of an ObjectStore.
-        config = Bunch(**config_dict["config"])
+        # Build an application config object from to_dict of an ObjectStore.
+        config = Bunch(disable_process_management=disable_process_management, **config_dict["config"])
     elif config is None:
         raise Exception(
             "build_object_store_from_config sent None as config parameter and one cannot be recovered from config_dict"

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -48,6 +48,7 @@ from .badges import (
     serialize_badges,
     StoredBadgeDict,
 )
+from .caching import CacheTarget
 
 NO_SESSION_ERROR_MESSAGE = (
     "Attempted to 'create' object store entity in configuration with no database session present."
@@ -302,8 +303,13 @@ class ObjectStore(metaclass=abc.ABCMeta):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def cache_targets(self) -> List[CacheTarget]:
+        """Return a list of CacheTargets used by this object store."""
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def to_dict(self) -> Dict[str, Any]:
-        raise NotImplementedError
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def get_quota_source_map(self):
@@ -445,6 +451,9 @@ class BaseObjectStore(ObjectStore):
     def is_private(self, obj):
         return self._invoke("is_private", obj)
 
+    def cache_targets(self) -> List[CacheTarget]:
+        return []
+
     @classmethod
     def parse_private_from_config_xml(clazz, config_xml):
         private = DEFAULT_PRIVATE
@@ -545,6 +554,14 @@ class ConcreteObjectStore(BaseObjectStore):
 
     def _is_private(self, obj):
         return self.private
+
+    @property
+    def cache_target(self) -> Optional[CacheTarget]:
+        return None
+
+    def cache_targets(self) -> List[CacheTarget]:
+        cache_target = self.cache_target
+        return [cache_target] if cache_target is not None else []
 
     def get_quota_source_map(self):
         quota_source_map = QuotaSourceMap(
@@ -898,6 +915,13 @@ class NestedObjectStore(BaseObjectStore):
         """Create a backing file in a random backend."""
         objectstore = random.choice(list(self.backends.values()))
         return objectstore.create(obj, **kwargs)
+
+    def cache_targets(self) -> List[CacheTarget]:
+        cache_targets = []
+        for backend in self.backends.values():
+            cache_targets.extend(backend.cache_targets())
+        # TODO: merge more intelligently - de-duplicate paths and handle conflicting sizes/percents
+        return cache_targets
 
     def _empty(self, obj, **kwargs):
         """For the first backend that has this `obj`, determine if it is empty."""

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -99,7 +99,7 @@ class AzureBlobObjectStore(ConcreteObjectStore):
         auth_dict = config_dict["auth"]
         container_dict = config_dict["container"]
         cache_dict = config_dict.get("cache") or {}
-        self.enable_cache_monitor = enable_cache_monitor(config, config_dict)
+        self.enable_cache_monitor, self.cache_monitor_interval = enable_cache_monitor(config, config_dict)
 
         self.account_name = auth_dict.get("account_name")
         self.account_key = auth_dict.get("account_key")
@@ -122,7 +122,7 @@ class AzureBlobObjectStore(ConcreteObjectStore):
         if self.cache_size != -1 and self.enable_cache_monitor:
             # Convert GBs to bytes for comparison
             self.cache_size = self.cache_size * 1073741824
-            self.cache_monitor = InProcessCacheMonitor(self.cache_target, 30)
+            self.cache_monitor = InProcessCacheMonitor(self.cache_target, self.cache_monitor_interval)
 
     def to_dict(self):
         as_dict = super().to_dict()

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -29,6 +29,7 @@ from galaxy.util.path import safe_relpath
 from . import ConcreteObjectStore
 from .caching import (
     CacheTarget,
+    enable_cache_monitor,
     InProcessCacheMonitor,
     parse_caching_config_dict_from_xml,
 )
@@ -98,7 +99,7 @@ class AzureBlobObjectStore(ConcreteObjectStore):
         auth_dict = config_dict["auth"]
         container_dict = config_dict["container"]
         cache_dict = config_dict.get("cache") or {}
-        self.enable_cache_monitor = config_dict.get("enable_cache_monitor", True)
+        self.enable_cache_monitor = enable_cache_monitor(config, config_dict)
 
         self.account_name = auth_dict.get("account_name")
         self.account_key = auth_dict.get("account_key")

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -115,6 +115,13 @@ def parse_caching_config_dict_from_xml(config_xml):
     return cache_dict
 
 
+def enable_cache_monitor(config, config_dict):
+    if getattr(config, "disable_process_management", False):
+        return True
+    return config_dict.get("enable_cache_monitor", True)
+
+
+
 class InProcessCacheMonitor:
     def __init__(self, cache_target: CacheTarget, interval: int = 30, initial_sleep: Optional[int] = 2):
         # This Event object is initialized to False

--- a/lib/galaxy/objectstore/caching.py
+++ b/lib/galaxy/objectstore/caching.py
@@ -126,8 +126,9 @@ def enable_cache_monitor(config, config_dict) -> Tuple[bool, int]:
     default_interval = getattr(config, "object_store_cache_monitor_interval", 600)
     interval = cache_config_dict.get("monitor_interval") or default_interval
 
-    if getattr(config, "disable_process_management", False):
-        return True, interval
+    disable_process_management = getattr(config, "disable_process_management", None)
+    if disable_process_management is True:
+        return False, interval
 
     if config_dict.get("enable_cache_monitor", False) is False:
         return False, interval

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -24,6 +24,7 @@ from galaxy.util import (
 from . import ConcreteObjectStore
 from .caching import (
     CacheTarget,
+    enable_cache_monitor,
     InProcessCacheMonitor,
 )
 from .s3 import parse_config_xml
@@ -66,7 +67,6 @@ class CloudConfigMixin:
                 "size": self.cache_size,
                 "path": self.staging_path,
             },
-            "enable_cache_monitor": False,
         }
 
 
@@ -87,7 +87,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         bucket_dict = config_dict["bucket"]
         connection_dict = config_dict.get("connection", {})
         cache_dict = config_dict.get("cache") or {}
-        self.enable_cache_monitor = config_dict.get("enable_cache_monitor", True)
+        self.enable_cache_monitor = enable_cache_monitor(config, config_dict)
 
         self.provider = config_dict["provider"]
         self.credentials = config_dict["auth"]

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -87,7 +87,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         bucket_dict = config_dict["bucket"]
         connection_dict = config_dict.get("connection", {})
         cache_dict = config_dict.get("cache") or {}
-        self.enable_cache_monitor = enable_cache_monitor(config, config_dict)
+        self.enable_cache_monitor, self.cache_monitor_interval = enable_cache_monitor(config, config_dict)
 
         self.provider = config_dict["provider"]
         self.credentials = config_dict["auth"]
@@ -125,7 +125,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         if self.cache_size != -1 and self.enable_cache_monitor:
             # Convert GBs to bytes for comparison
             self.cache_size = self.cache_size * 1073741824
-            self.cache_monitor = InProcessCacheMonitor(self.cache_target, 30)
+            self.cache_monitor = InProcessCacheMonitor(self.cache_target, self.cache_monitor_interval)
 
     @staticmethod
     def _get_connection(provider, credentials):

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -154,7 +154,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
         bucket_dict = config_dict["bucket"]
         connection_dict = config_dict.get("connection", {})
         cache_dict = config_dict.get("cache") or {}
-        self.enable_cache_monitor = enable_cache_monitor(config, config_dict)
+        self.enable_cache_monitor, self.cache_monitor_interval = enable_cache_monitor(config, config_dict)
 
         self.access_key = auth_dict.get("access_key")
         self.secret_key = auth_dict.get("secret_key")
@@ -207,7 +207,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
         if self.cache_size != -1 and self.enable_cache_monitor:
             # Convert GBs to bytes for comparison
             self.cache_size = self.cache_size * 1073741824
-            self.cache_monitor = InProcessCacheMonitor(self.cache_target, 30)
+            self.cache_monitor = InProcessCacheMonitor(self.cache_target, self.cache_monitor_interval)
 
     def _configure_connection(self):
         log.debug("Configuring S3 Connection")

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -34,6 +34,7 @@ from galaxy.util.path import safe_relpath
 from . import ConcreteObjectStore
 from .caching import (
     CacheTarget,
+    enable_cache_monitor,
     InProcessCacheMonitor,
     parse_caching_config_dict_from_xml,
 )
@@ -130,7 +131,6 @@ class CloudConfigMixin:
                 "size": self.cache_size,
                 "path": self.staging_path,
             },
-            "enable_cache_monitor": False,
         }
 
 
@@ -154,7 +154,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
         bucket_dict = config_dict["bucket"]
         connection_dict = config_dict.get("connection", {})
         cache_dict = config_dict.get("cache") or {}
-        self.enable_cache_monitor = config_dict.get("enable_cache_monitor", True)
+        self.enable_cache_monitor = enable_cache_monitor(config, config_dict)
 
         self.access_key = auth_dict.get("access_key")
         self.secret_key = auth_dict.get("secret_key")

--- a/test/unit/app/test_tasks.py
+++ b/test/unit/app/test_tasks.py
@@ -1,0 +1,53 @@
+from contextlib import contextmanager
+from typing import (
+    Iterator,
+    List,
+)
+
+from galaxy.celery import set_thread_app
+from galaxy.celery.tasks import clean_object_store_caches
+from galaxy.di import Container
+from galaxy.objectstore import BaseObjectStore
+from galaxy.objectstore.caching import CacheTarget
+
+
+class MockObjectStore:
+    def __init__(self, cache_targets: List[CacheTarget]):
+        self._cache_targets = cache_targets
+
+    def cache_targets(self) -> List[CacheTarget]:
+        return self._cache_targets
+
+
+def test_clean_object_store_caches(tmp_path):
+    with celery_injected_app_container() as container:
+        cache_targets: List[CacheTarget] = []
+        container[BaseObjectStore] = MockObjectStore(cache_targets)  # type: ignore[assignment]
+
+        # similar code used in object store unit tests
+        cache_dir = tmp_path
+        path = cache_dir / "a_file_0"
+        path.write_text("this is an example file")
+
+        # works fine on an empty list of cache targets...
+        clean_object_store_caches()
+
+        assert path.exists()
+
+        # place the file in mock object store's cache targets and
+        # run the task again and the above file should be gone.
+        cache_targets.append(CacheTarget(cache_dir, 1, 0.000000001))
+        # works fine on an empty list of cache targets...
+        clean_object_store_caches()
+
+        assert not path.exists()
+
+
+@contextmanager
+def celery_injected_app_container() -> Iterator[Container]:
+    container = Container()
+    set_thread_app(container)
+    try:
+        yield container
+    finally:
+        set_thread_app(None)

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -1212,6 +1212,16 @@ def test_check_cache_sanity(tmp_path):
     assert not path.exists()
 
 
+def test_fits_in_cache_check(tmp_path):
+    cache_dir = tmp_path
+    big_cache_target = CacheTarget(cache_dir, 1, 0.2)
+    assert not big_cache_target.fits_in_cache(int(1024 * 1024 * 1024 * 0.3))
+    assert big_cache_target.fits_in_cache(int(1024 * 1024 * 1024 * 0.1))
+
+    noop_cache_target = CacheTarget(cache_dir, -1, 0.2)
+    assert noop_cache_target.fits_in_cache(1024 * 1024 * 1024 * 100)
+
+
 AZURE_BLOB_NO_CACHE_TEST_CONFIG = """<object_store type="azure_blob">
     <auth account_name="azureact" account_key="password123" />
     <container name="unique_container_name" max_chunk_size="250"/>

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -4,6 +4,7 @@ from tempfile import (
     mkdtemp,
     mkstemp,
 )
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -27,6 +28,29 @@ from galaxy.util import (
     directory_hash_id,
     unlink,
 )
+
+
+# Unit testing the cloud and advanced infrastructure object stores is difficult, but
+# we can at least stub out initializing and test the configuration of these things from
+# XML and dicts.
+class UninitializedPithosObjectStore(PithosObjectStore):
+    def _initialize(self):
+        pass
+
+
+class UninitializedS3ObjectStore(S3ObjectStore):
+    def _initialize(self):
+        pass
+
+
+class UninitializedAzureBlobObjectStore(AzureBlobObjectStore):
+    def _initialize(self):
+        pass
+
+
+class UninitializedCloudObjectStore(Cloud):
+    def _initialize(self):
+        pass
 
 
 def test_unlink_path():
@@ -389,6 +413,14 @@ def test_mixed_private():
         assert as_dict["private"] is True
 
 
+def test_empty_cache_targets_for_disk_nested_stores():
+    with TestConfig(MIXED_STORE_BY_DISTRIBUTED_TEST_CONFIG) as (directory, object_store):
+        assert len(object_store.cache_targets()) == 0
+
+    with TestConfig(MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG) as (directory, object_store):
+        assert len(object_store.cache_targets()) == 0
+
+
 BADGES_TEST_1_CONFIG_XML = """<?xml version="1.0"?>
 <object_store type="disk">
     <files_dir path="${temp_directory}/files1"/>
@@ -567,6 +599,57 @@ def test_distributed_store():
             assert len(extra_dirs) == 2
 
 
+def test_distributed_store_empty_cache_targets():
+    for config_str in [DISTRIBUTED_TEST_CONFIG, DISTRIBUTED_TEST_CONFIG_YAML]:
+        with TestConfig(config_str) as (directory, object_store):
+            assert len(object_store.cache_targets()) == 0
+
+
+DISTRIBUTED_TEST_S3_CONFIG_YAML = """
+type: distributed
+backends:
+  - id: files1
+    weight: 1
+    type: s3
+    auth:
+      access_key: access_moo
+      secret_key: secret_cow
+
+    bucket:
+      name: unique_bucket_name_all_lowercase
+      use_reduced_redundancy: false
+
+    extra_dirs:
+    - type: job_work
+      path: ${temp_directory}/job_working_directory_s3
+    - type: temp
+      path: ${temp_directory}/tmp_s3
+  - id: files2
+    weight: 1
+    type: s3
+    auth:
+      access_key: access_moo
+      secret_key: secret_cow
+
+    bucket:
+      name: unique_bucket_name_all_lowercase_2
+      use_reduced_redundancy: false
+
+    extra_dirs:
+    - type: job_work
+      path: ${temp_directory}/job_working_directory_s3_2
+    - type: temp
+      path: ${temp_directory}/tmp_s3_2
+"""
+
+
+@patch("galaxy.objectstore.s3.S3ObjectStore", UninitializedS3ObjectStore)
+def test_distributed_store_with_cache_targets():
+    for config_str in [DISTRIBUTED_TEST_S3_CONFIG_YAML]:
+        with TestConfig(config_str) as (directory, object_store):
+            assert len(object_store.cache_targets()) == 2
+
+
 HIERARCHICAL_MUST_HAVE_UNIFIED_QUOTA_SOURCE = """<?xml version="1.0"?>
 <object_store type="hierarchical" private="true">
     <backends>
@@ -595,29 +678,6 @@ def test_hiercachical_backend_must_share_quota_source():
         except Exception as e:
             the_exception = e
     assert the_exception is not None
-
-
-# Unit testing the cloud and advanced infrastructure object stores is difficult, but
-# we can at least stub out initializing and test the configuration of these things from
-# XML and dicts.
-class UninitializedPithosObjectStore(PithosObjectStore):
-    def _initialize(self):
-        pass
-
-
-class UninitializedS3ObjectStore(S3ObjectStore):
-    def _initialize(self):
-        pass
-
-
-class UninitializedAzureBlobObjectStore(AzureBlobObjectStore):
-    def _initialize(self):
-        pass
-
-
-class UninitializedCloudObjectStore(Cloud):
-    def _initialize(self):
-        pass
 
 
 PITHOS_TEST_CONFIG = """<?xml version="1.0"?>
@@ -965,8 +1025,6 @@ def test_config_parse_cloud():
 
             _assert_key_has_value(cache_dict, "size", 1000.0)
             _assert_key_has_value(cache_dict, "path", "database/object_store_cache")
-
-            _assert_key_has_value(as_dict, "enable_cache_monitor", False)
 
             extra_dirs = as_dict["extra_dirs"]
             assert len(extra_dirs) == 2


### PR DESCRIPTION
This implements the entire first half of issue https://github.com/galaxyproject/galaxy/issues/16052.

- Make all the cache directives in the XML optional and default to a single cache directory for all caching object stores with un-configured caches (simplifies setup of S3, etc...) (25061fc00fbafb44712b49002770e9f926453c89)
- Rework the cache monitor to allow it to be used as a scheduled Celery task. (cabe41d2ed6207764a174e0c3575ad0b6c2497e2) 
- Default enable_cache_monitor to false if celery is enabled, assume the scheduled task will deal with this task. (cabe41d2ed6207764a174e0c3575ad0b6c2497e2). (This also extends that allowing Galaxy-managed monitoring to be disabled all together by setting the relevant configuration options to "external" to indicate an external application is monitoring the cache.

It also brings in more of the de-duplication started by @kxk302 in https://github.com/galaxyproject/galaxy/pull/14533 including his swapping to threading Events and reworks how we disable cache monitoring (in 201bbd7a2d115d29c05ebfb19006ec138cc9e3ac outlined in my argument in https://github.com/galaxyproject/galaxy/pull/14533#discussion_r1197979489).

All the de-duplication and merging on abstractions makes the actual Celery implementation quite trivial.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
