### PR TITLE
Place admin panel section data into computed prop

### DIFF
--- a/client/src/components/admin/AdminPanel.test.js
+++ b/client/src/components/admin/AdminPanel.test.js
@@ -1,0 +1,36 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "tests/jest/helpers";
+import MountTarget from "./AdminPanel.vue";
+
+const localVue = getLocalVue(true);
+
+function createTarget(propsData = {}) {
+    return mount(MountTarget, {
+        localVue,
+        propsData,
+        stubs: {
+            routerLink: true,
+        },
+    });
+}
+
+describe("AdminPanel", () => {
+    it("ensure reactivity to prop changes", async () => {
+        const wrapper = createTarget();
+        const sections = {
+            isToolshedInstalled: "#admin-link-toolshed",
+            enableQuotas: "#admin-link-quotas",
+        };
+        for (const elementId of Object.values(sections)) {
+            expect(wrapper.find(elementId).exists()).toBe(false);
+        }
+        for (const available of [true, false]) {
+            for (const [propId, elementId] of Object.entries(sections)) {
+                const props = {};
+                props[propId] = available;
+                await wrapper.setProps(props);
+                expect(wrapper.find(elementId).exists()).toBe(available);
+            }
+        }
+    });
+});

--- a/client/src/components/admin/AdminPanel.vue
+++ b/client/src/components/admin/AdminPanel.vue
@@ -43,9 +43,9 @@ export default {
             default: "",
         },
     },
-    data() {
-        return {
-            sections: [
+    computed: {
+        sections() {
+            return [
                 {
                     title: "Server",
                     items: [
@@ -148,8 +148,8 @@ export default {
                         },
                     ],
                 },
-            ],
-        };
+            ];
+        },
     },
 };
 </script>


### PR DESCRIPTION
This PR moves the admin panel section data into a computed prop to ensure reactivity with regard to configuration data. Without this there is a race condition i.e. if the configuration data is not immediately available upon mounting the component, subsequent updates to the configuration data are not reflected in the ui.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
