### PR TITLE
[23.0] Extract HDA for code_file validate_input hook

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1809,7 +1809,12 @@ class Tool(Dictifiable):
                 # If the tool provides a `validate_input` hook, call it.
                 validate_input = self.get_hook("validate_input")
                 if validate_input:
-                    validate_input(request_context, errors, params, self.inputs)
+                    # hooks are so terrible ... this is specifically for https://github.com/galaxyproject/tools-devteam/blob/main/tool_collections/gops/basecoverage/operation_filter.py
+                    legacy_non_dce_params = {
+                        k: v.hda if isinstance(v, model.DatasetCollectionElement) and v.hda else v
+                        for k, v in params.items()
+                    }
+                    validate_input(request_context, errors, legacy_non_dce_params, self.inputs)
             all_errors.append(errors)
             all_params.append(params)
         unset_dataset_matcher_factory(request_context)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1570,14 +1570,14 @@ test_data:
                 wait=True,
             )
             history_contents = self.dataset_populator._get_contents_request(history_id=history_id).json()
-            first_input = history_contents[1]
-            assert first_input["history_content_type"] == "dataset"
+            input_collection = self.dataset_populator.get_history_collection_details(history_id, hid=1, assert_ok=False)
+            first_input = input_collection["elements"][0]
             paused_dataset = history_contents[-1]
             failed_dataset = self.dataset_populator.get_history_dataset_details(history_id, hid=5, assert_ok=False)
             assert paused_dataset["state"] == "paused", paused_dataset
             assert failed_dataset["state"] == "error", failed_dataset
             inputs = {
-                "input1": {"values": [{"src": "hda", "id": first_input["id"]}]},
+                "input1": {"values": [{"src": "dce", "id": first_input["id"]}]},
                 "failbool": "false",
                 "rerun_remap_job_id": failed_dataset["creating_job"],
             }


### PR DESCRIPTION
Guess code_files are still a thing ... https://github.com/galaxyproject/tools-devteam/blob/main/tool_collections/gops/basecoverage/operation_filter.py fails when accessing HDA attributes.

The adapted test just shows that rerun_remap_job_id works fine otherwise.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
🤷‍♂️ i don't know how to exercise this specifically with gops tools ... probably need to conditionally fail one tool run in the database. @wm75 @bgruening  do you think you can test this ?

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
