### PR TITLE
[23.0] Fix sort error when re-running job with DCE collection input

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2493,7 +2493,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
             d["options"]["hdca"].append(
                 {
                     "id": trans.security.encode_id(dce.id),
-                    "hid": None,
+                    "hid": -1,
                     "name": dce.element_identifier,
                     "src": "dce",
                     "tags": [],


### PR DESCRIPTION
Otherwise fails with
```
TypeError: '<' not supported between instances of 'NoneType' and 'int'
  File "galaxy/tools/__init__.py", line 2542, in populate_model
    tool_dict = input.to_dict(request_context, other_values=other_values)
  File "galaxy/tools/parameters/basic.py", line 2536, in to_dict
    d["options"]["hdca"] = sorted(d["options"]["hdca"], key=lambda k: k.get("hid", -1), reverse=True)
```

From https://sentry.galaxyproject.org/share/issue/1b0bcc83846b4b1891824776b0099545/

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
