### PR TITLE
Fix : Ignore error messages for admin created accounts

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -106,7 +106,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         if message:
             return None, message
         message, status = trans.app.auth_manager.check_registration_allowed(email, username, password, trans.request)
-        if message:
+        if message and not trans.user_is_admin: 
             return None, message
         if subscribe:
             message = self.send_subscription_email(email)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -106,7 +106,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         if message:
             return None, message
         message, status = trans.app.auth_manager.check_registration_allowed(email, username, password, trans.request)
-        if message and not trans.user_is_admin: 
+        if message and not trans.user_is_admin:
             return None, message
         if subscribe:
             message = self.send_subscription_email(email)


### PR DESCRIPTION
Always create account when admin request it, ignoring errors messages from 'check_registration_allowed'.
Fix the issue  #16067
Side effect :  Bypass the 'challenge' option of the authenticator if set, when an admin create an account (locally).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
 1.Reproduce the test steps included in the bug/issue report.
 2. Check that the new user account is create successfully.
 
## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
