### PR TITLE
[23.0] Fix implicit converters with optional parameters

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -133,6 +133,8 @@ def get_params_and_input_name(
             params[value.name] = deps[value.name]
         elif value.type == "data":
             input_name = key
+        elif value.optional:
+            params[value.name] = None
 
     # add potentially required/common internal tool parameters e.g. '__job_resource'
     if target_context:

--- a/test/functional/tools/implicit_conversion_optional_param.xml
+++ b/test/functional/tools/implicit_conversion_optional_param.xml
@@ -1,0 +1,23 @@
+<tool id="implicit_conversion_optional_param" name="Test Implicit Conversion" version="0.1" profile="22.01">
+    <!-- test that optional parameter in bigwig to wig converter can be left unset -->
+    <command><![CDATA[cp '$input' '$output']]></command>
+    <inputs>
+        <param name="input" type="data" format="wig" label="Biom1 file" />
+    </inputs>
+    <outputs>
+        <data name="output" format="wig" />
+    </outputs>
+    <tests>
+        <!-- bigwig file for wig input triggers bigwig to wig conversion -->
+        <test>
+            <param name="input" ftype="bigwig" value="2.bigwig" />
+            <output name="output" ftype="wig">
+                <assert_contents>
+                    <has_text text="variableStep chrom" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -153,6 +153,7 @@
   <tool file="validation_empty_dataset.xml" />
   <tool file="implicit_conversion.xml" />
   <tool file="implicit_conversion_format_input.xml" />
+  <tool file="implicit_conversion_optional_param.xml" />
   <tool file="implicit_collection_conversion.xml" />
   <tool file="implicit_nested_list_conversion.xml" />
   <tool file="explicit_conversion.xml" />


### PR DESCRIPTION
In this case https://github.com/galaxyproject/galaxy/blob/1c8462db178fd19aaee04f6674e28d4ad5075812/lib/galaxy/datatypes/converters/bigwig_to_wig_converter.xml#L25

Fixes:
```
KeyError: 'chrom'
  File "galaxy/tools/__init__.py", line 1909, in handle_single_execution
    rval = self.execute(
  File "galaxy/tools/__init__.py", line 2005, in execute
    return self.tool_action.execute(
  File "galaxy/tools/actions/__init__.py", line 392, in execute
    ) = self._collect_inputs(tool, trans, incoming, history, current_user_roles, collection_info)
  File "galaxy/tools/actions/__init__.py", line 327, in _collect_inputs
    inp_data, all_permissions = self._collect_input_datasets(
  File "galaxy/tools/actions/__init__.py", line 268, in _collect_input_datasets
    tool.visit_inputs(param_values, visitor)
  File "galaxy/tools/__init__.py", line 1748, in visit_inputs
    visit_input_values(self.inputs, values, callback)
  File "galaxy/tools/parameters/__init__.py", line 224, in visit_input_values
    callback_helper(
  File "galaxy/tools/parameters/__init__.py", line 159, in callback_helper
    new_value = callback(**args)
  File "galaxy/tools/actions/__init__.py", line 191, in visitor
    input_datasets[prefix + input.name] = process_dataset(value)
  File "galaxy/tools/actions/__init__.py", line 126, in process_dataset
    data = data.get_converted_dataset(trans, target_ext, target_context=parent, history=history)
  File "galaxy/model/__init__.py", line 4211, in get_converted_dataset
    self.datatype.convert_dataset(
  File "galaxy/datatypes/data.py", line 795, in convert_dataset
    job, converted_datasets, *_ = converter.execute(trans, incoming=params, set_output_hid=visible, history=history)
  File "galaxy/tools/__init__.py", line 2005, in execute
    return self.tool_action.execute(
  File "galaxy/tools/actions/__init__.py", line 453, in execute
    params=wrapped_params.params,
  File "galaxy/tools/parameters/wrapped.py", line 43, in params
    self.wrap_values(self.tool.inputs, params, skip_missing_values=not self.tool.check_values)
  File "galaxy/tools/parameters/wrapped.py", line 58, in wrap_values
    value = input_values[input.name]
```

in https://sentry.galaxyproject.org/share/issue/4f2171798f214f7ba8b947eaaebe2776/

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
