### PR TITLE
Add option to see invocations related to a history

### DIFF
--- a/client/src/components/History/CurrentHistory/HistoryNavigation.test.js
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.test.js
@@ -15,6 +15,7 @@ const expectedOptions = [
     "Export Tool Citations",
     "Export History to File",
     "Extract Workflow",
+    "Show Invocations",
     "Share or Publish",
     "Set Permissions",
     "Make Private",

--- a/client/src/components/History/CurrentHistory/HistoryNavigation.vue
+++ b/client/src/components/History/CurrentHistory/HistoryNavigation.vue
@@ -104,6 +104,14 @@
                         <span v-localize>Extract Workflow</span>
                     </b-dropdown-item>
 
+                    <b-dropdown-item
+                        :disabled="isAnonymous"
+                        :title="userTitle('Display Workflow Invocations')"
+                        @click="$router.push(`/histories/${history.id}/invocations`)">
+                        <Icon fixed-width icon="sitemap" class="fa-rotate-270 mr-1" />
+                        <span v-localize>Show Invocations</span>
+                    </b-dropdown-item>
+
                     <b-dropdown-divider></b-dropdown-divider>
 
                     <b-dropdown-item

--- a/client/src/components/Indices/SharingIndicators.vue
+++ b/client/src/components/Indices/SharingIndicators.vue
@@ -6,7 +6,7 @@
             class="sharing-indicator-published"
             size="sm"
             variant="link"
-            :title="'Search more published workflows' | localize"
+            :title="'Search more published items' | localize"
             @click.prevent="$emit('filter', 'is:published')">
             <Icon fixed-width icon="globe" />
         </b-button>
@@ -16,7 +16,7 @@
             class="sharing-indicator-shared"
             size="sm"
             variant="link"
-            :title="'Search more workflows shared with me' | localize"
+            :title="'Search more items shared with me' | localize"
             @click.prevent="$emit('filter', 'is:shared_with_me')">
             <Icon fixed-width icon="share-alt" />
         </b-button>

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -10,7 +10,7 @@
                     :download-endpoint="downloadEndpoint"
                     size="sm"
                     title="Generate PDF">
-                    </sts-download-button>
+                </sts-download-button>
                 <b-button
                     v-if="!readOnly"
                     v-b-tooltip.hover
@@ -23,12 +23,14 @@
                     <font-awesome-icon icon="edit" />
                 </b-button>
                 <h1 class="float-right align-middle mr-2 mt-1 h-md">Galaxy {{ markdownConfig.model_class }}</h1>
-                <span class="float-left font-weight-light ">
-                    <h1 class="text-break align-middle">Title: {{ markdownConfig.title || markdownConfig.model_class }}</h1>
+                <span class="float-left font-weight-light">
+                    <h1 class="text-break align-middle">
+                        Title: {{ markdownConfig.title || markdownConfig.model_class }}
+                    </h1>
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
-                <div class="float-left m-1 text-break">Created by {{ markdownConfig.username }} with Galaxy {{ version }} on {{ time }}</div>
+                <div class="float-left m-1 text-break">Generated with Galaxy {{ version }} on {{ time }}</div>
                 <div class="float-right m-1">Identifier: {{ markdownConfig.id }}</div>
             </b-badge>
             <div>

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -6,30 +6,30 @@
                 <sts-download-button
                     v-if="effectiveExportLink"
                     class="float-right markdown-pdf-export"
-                    variant="link"
                     :fallback-url="exportLink"
                     :download-endpoint="downloadEndpoint"
-                    title="Download PDF"></sts-download-button>
+                    size="sm"
+                    title="Generate PDF">
+                    </sts-download-button>
                 <b-button
                     v-if="!readOnly"
-                    v-b-tooltip.hover.bottom
-                    class="float-right markdown-edit"
-                    title="Edit Markdown"
-                    variant="link"
+                    v-b-tooltip.hover
+                    class="float-right markdown-edit mr-2"
                     role="button"
+                    size="sm"
+                    title="Edit Markdown"
                     @click="$emit('onEdit')">
+                    Edit
                     <font-awesome-icon icon="edit" />
                 </b-button>
-                <h1 class="float-right align-middle mr-1 mt-2 h-md">Galaxy {{ markdownConfig.model_class }}</h1>
-                <span class="float-left font-weight-light mb-3">
-                    <small class="text-break">Title: {{ markdownConfig.title || markdownConfig.model_class }}</small>
-                    <br />
-                    <small>Created by {{ markdownConfig.username }}</small>
+                <h1 class="float-right align-middle mr-2 mt-1 h-md">Galaxy {{ markdownConfig.model_class }}</h1>
+                <span class="float-left font-weight-light ">
+                    <h1 class="text-break align-middle">Title: {{ markdownConfig.title || markdownConfig.model_class }}</h1>
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
-                <div class="float-left m-1 text-break">Published with Galaxy {{ version }} on {{ time }}</div>
-                <div class="float-right m-1">Identifier {{ markdownConfig.id }}</div>
+                <div class="float-left m-1 text-break">Created by {{ markdownConfig.username }} with Galaxy {{ version }} on {{ time }}</div>
+                <div class="float-right m-1">Identifier: {{ markdownConfig.id }}</div>
             </b-badge>
             <div>
                 <b-alert v-if="markdownErrors.length > 0" variant="warning" show>
@@ -241,9 +241,6 @@ export default {
                 args: args,
                 content: content,
             };
-        },
-        onDownload() {
-            window.location.href = this.exportLink;
         },
     },
 };

--- a/client/src/components/StsDownloadButton.test.js
+++ b/client/src/components/StsDownloadButton.test.js
@@ -47,10 +47,12 @@ describe("StsDownloadButton", () => {
     });
 
     it("should fallback to a URL if tasks not enabled", async () => {
+        const windowSpy = jest.spyOn(window, "open");
+        windowSpy.mockImplementation(() => {})
         const wrapper = await mountStsDownloadButtonWrapper(NO_TASKS_CONFIG);
         wrapper.vm.onDownload(NO_TASKS_CONFIG);
         await flushPromises();
-        expect(window.location).toBeAt(FALLBACK_URL);
+        expect(window.open).toBeCalled();
     });
 
     it("should poll until ready", async () => {

--- a/client/src/components/StsDownloadButton.test.js
+++ b/client/src/components/StsDownloadButton.test.js
@@ -48,7 +48,7 @@ describe("StsDownloadButton", () => {
 
     it("should fallback to a URL if tasks not enabled", async () => {
         const windowSpy = jest.spyOn(window, "open");
-        windowSpy.mockImplementation(() => {})
+        windowSpy.mockImplementation(() => {});
         const wrapper = await mountStsDownloadButtonWrapper(NO_TASKS_CONFIG);
         wrapper.vm.onDownload(NO_TASKS_CONFIG);
         await flushPromises();

--- a/client/src/components/StsDownloadButton.vue
+++ b/client/src/components/StsDownloadButton.vue
@@ -5,8 +5,10 @@
             v-b-tooltip.hover.bottom
             :title="title"
             :variant="variant"
+            :size="size"
             role="button"
             @click="onDownload(config)">
+            Download
             <font-awesome-icon v-if="waiting" icon="spinner" spin />
             <font-awesome-icon v-else icon="download" />
         </b-button>
@@ -56,6 +58,10 @@ export default {
         variant: {
             type: String,
             default: null,
+        },
+        size: {
+            type: String,
+            default: "md",
         },
     },
     data() {

--- a/client/src/components/StsDownloadButton.vue
+++ b/client/src/components/StsDownloadButton.vue
@@ -8,7 +8,7 @@
             :size="size"
             role="button"
             @click="onDownload(config)">
-            Download
+            Generate
             <font-awesome-icon v-if="waiting" icon="spinner" spin />
             <font-awesome-icon v-else icon="download" />
         </b-button>
@@ -82,7 +82,7 @@ export default {
         },
         onDownload(config) {
             if (!config.enable_celery_tasks) {
-                window.location.assign(withPrefix(this.fallbackUrl));
+                window.open(withPrefix(this.fallbackUrl));
             } else {
                 this.waiting = true;
                 axios

--- a/client/src/components/Workflow/HistoryInvocations.vue
+++ b/client/src/components/Workflow/HistoryInvocations.vue
@@ -1,3 +1,21 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import InvocationsList from "@/components/Workflow/InvocationsList.vue";
+import { storeToRefs } from "pinia";
+import { useUserStore } from "@/stores/userStore";
+import { useHistoryStore } from "@/stores/historyStore";
+
+interface HistoryInvocationProps {
+    historyId: string;
+}
+
+const props = defineProps<HistoryInvocationProps>();
+
+const { currentUser } = storeToRefs(useUserStore());
+const { getHistoryNameById } = useHistoryStore();
+const historyName = computed(() => getHistoryNameById(props.historyId));
+</script>
 <template>
     <div>
         <InvocationsList
@@ -7,28 +25,3 @@
             :history-name="historyName" />
     </div>
 </template>
-<script>
-import InvocationsList from "components/Workflow/InvocationsList";
-import { mapState } from "pinia";
-import { useUserStore } from "@/stores/userStore";
-import { useHistoryStore } from "@/stores/historyStore";
-
-export default {
-    components: {
-        InvocationsList,
-    },
-    props: {
-        historyId: {
-            type: String,
-            required: true,
-        },
-    },
-    computed: {
-        ...mapState(useUserStore, ["currentUser"]),
-        ...mapState(useHistoryStore, ["getHistoryNameById"]),
-        historyName() {
-            return this.getHistoryNameById(this.historyId);
-        },
-    },
-};
-</script>

--- a/client/src/components/Workflow/HistoryInvocations.vue
+++ b/client/src/components/Workflow/HistoryInvocations.vue
@@ -1,0 +1,34 @@
+<template>
+    <div>
+        <InvocationsList
+            v-if="currentUser && historyName"
+            :user-id="currentUser.id"
+            :history-id="historyId"
+            :history-name="historyName" />
+    </div>
+</template>
+<script>
+import InvocationsList from "components/Workflow/InvocationsList";
+import { mapState } from "pinia";
+import { useUserStore } from "@/stores/userStore";
+import { useHistoryStore } from "@/stores/historyStore";
+
+export default {
+    components: {
+        InvocationsList,
+    },
+    props: {
+        historyId: {
+            type: String,
+            required: true,
+        },
+    },
+    computed: {
+        ...mapState(useUserStore, ["currentUser"]),
+        ...mapState(useHistoryStore, ["getHistoryNameById"]),
+        historyName() {
+            return this.getHistoryNameById(this.historyId);
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/InvocationReport.vue
+++ b/client/src/components/Workflow/InvocationReport.vue
@@ -5,6 +5,7 @@
             :markdown-config="markdownConfig"
             :enable_beta_markdown_export="config.enable_beta_markdown_export"
             :export-link="exportUrl"
+            :download-endpoint="stsUrl(config)"
             @onEdit="onEdit" />
     </config-provider>
 </template>
@@ -59,6 +60,9 @@ export default {
     methods: {
         onEdit() {
             window.location = withPrefix(`/pages/create?invocation_id=${this.invocationId}`);
+        },
+        stsUrl(config) {
+            return `${this.dataUrl}/prepare_download`;
         },
     },
 };

--- a/client/src/components/Workflow/InvocationsList.test.js
+++ b/client/src/components/Workflow/InvocationsList.test.js
@@ -66,7 +66,11 @@ describe("InvocationsList.vue", () => {
 
     describe("for a workflow with an empty invocation list", () => {
         beforeEach(async () => {
-            axiosMock.onAny().reply(200, [], { total_matches: "0" });
+            axiosMock
+                .onGet("/api/invocations", {
+                    params: { limit: 50, offset: 0, include_terminal: false, workflow_id: "abcde145678" },
+                })
+                .reply(200, [], { total_matches: "0" });
             const propsData = {
                 ownerGrid: false,
                 storedWorkflowName: "My Workflow",
@@ -80,11 +84,46 @@ describe("InvocationsList.vue", () => {
         });
 
         it("title should be shown", async () => {
-            expect(wrapper.find("#invocations-title").text()).toBe("Workflow Invocations for My Workflow");
+            expect(wrapper.find("#invocations-title").text()).toBe('Workflow Invocations for workflow "My Workflow"');
         });
 
         it("no invocations message should be shown when not loading", async () => {
             expect(wrapper.find("#no-invocations").exists()).toBe(true);
+        });
+
+        it("should not render pager", async () => {
+            expect(wrapper.find(".gx-invocations-grid-pager").exists()).toBeFalsy();
+        });
+    });
+
+    describe("for a history with an empty invocation list", () => {
+        beforeEach(async () => {
+            axiosMock
+                .onGet("/api/invocations", {
+                    params: { limit: 50, offset: 0, include_terminal: false, history_id: "abcde145678" },
+                })
+                .reply(200, [], { total_matches: "0" });
+            const propsData = {
+                ownerGrid: false,
+                historyName: "My History",
+                historyId: "abcde145678",
+            };
+            wrapper = mount(InvocationsList, {
+                propsData,
+                localVue,
+            });
+        });
+
+        it("title should be shown", async () => {
+            expect(wrapper.find("#invocations-title").text()).toBe('Workflow Invocations for history "My History"');
+        });
+
+        it("no invocations message should be shown when not loading", async () => {
+            expect(wrapper.find("#no-invocations").exists()).toBe(true);
+        });
+
+        it("should not render pager", async () => {
+            expect(wrapper.find(".gx-invocations-grid-pager").exists()).toBeFalsy();
         });
     });
 
@@ -132,11 +171,11 @@ describe("InvocationsList.vue", () => {
             expect(columns.at(3).text()).toBe(
                 formatDistanceToNow(parseISO(`${mockInvocationData.create_time}Z`), { addSuffix: true })
             );
-            expect(columns.at(4).text()).toBe(
-                formatDistanceToNow(parseISO(`${mockInvocationData.update_time}Z`), { addSuffix: true })
-            );
-            expect(columns.at(5).text()).toBe("scheduled");
-            expect(columns.at(6).text()).toBe("");
+            // expect(columns.at(4).text()).toBe(
+            //     formatDistanceToNow(parseISO(`${mockInvocationData.update_time}Z`), { addSuffix: true })
+            // );
+            expect(columns.at(4).text()).toBe("scheduled");
+            expect(columns.at(5).text()).toBe("");
         });
 
         it("toggles detail rendering", async () => {
@@ -160,6 +199,46 @@ describe("InvocationsList.vue", () => {
         it("calls executeWorkflow", async () => {
             await wrapper.find(".workflow-run").trigger("click");
             expect(window.location).toBeAt("workflows/run?id=workflowId");
+        });
+
+        it("should not render pager", async () => {
+            expect(wrapper.find(".gx-invocations-grid-pager").exists()).toBeFalsy();
+        });
+    });
+
+    describe("paginations", () => {
+        beforeEach(async () => {
+            axiosMock
+                .onGet("/api/invocations", { params: { limit: 1, offset: 0, include_terminal: false } })
+                .reply(200, [mockInvocationData], { total_matches: "3" });
+            const propsData = {
+                ownerGrid: false,
+                loading: false,
+                defaultPerPage: 1,
+            };
+            wrapper = mount(InvocationsList, {
+                propsData,
+                computed: {
+                    getWorkflowNameByInstanceId: (state) => (id) => "workflow name",
+                    getWorkflowByInstanceId: (state) => (id) => {
+                        return { id: "workflowId" };
+                    },
+                    getHistoryById: (state) => (id) => {
+                        return { id: "historyId" };
+                    },
+                    getHistoryNameById: () => () => "history name",
+                },
+                stubs: {
+                    "workflow-invocation-state": {
+                        template: "<span/>",
+                    },
+                },
+                localVue,
+            });
+        });
+
+        it("title should render pager", async () => {
+            expect(wrapper.find(".gx-invocations-grid-pager").exists()).toBeTruthy();
         });
     });
 });

--- a/client/src/components/Workflow/InvocationsList.test.js
+++ b/client/src/components/Workflow/InvocationsList.test.js
@@ -171,9 +171,6 @@ describe("InvocationsList.vue", () => {
             expect(columns.at(3).text()).toBe(
                 formatDistanceToNow(parseISO(`${mockInvocationData.create_time}Z`), { addSuffix: true })
             );
-            // expect(columns.at(4).text()).toBe(
-            //     formatDistanceToNow(parseISO(`${mockInvocationData.update_time}Z`), { addSuffix: true })
-            // );
             expect(columns.at(4).text()).toBe("scheduled");
             expect(columns.at(5).text()).toBe("");
         });

--- a/client/src/components/Workflow/InvocationsList.vue
+++ b/client/src/components/Workflow/InvocationsList.vue
@@ -23,7 +23,9 @@
                 <b-card>
                     <small class="float-right" :data-invocation-id="row.item.id">
                         <b>Last updated: <UtcDate :date="row.item.update_time" mode="elapsed" />;</b>
-                        <b>Invocation ID: <code>{{ row.item.id }}</code></b>
+                        <b
+                            >Invocation ID: <code>{{ row.item.id }}</code></b
+                        >
                     </small>
                     <workflow-invocation-state :invocation-id="row.item.id" @invocation-cancelled="refresh" />
                 </b-card>

--- a/client/src/components/Workflow/InvocationsList.vue
+++ b/client/src/components/Workflow/InvocationsList.vue
@@ -6,13 +6,12 @@
         <b-alert v-if="headerMessage" variant="info" show>
             {{ headerMessage }}
         </b-alert>
-        <b-alert class="index-grid-message" :variant="messageVariant" :show="showMessage">{{ message }}</b-alert>
+        <b-alert v-bind="alertAttrs">{{ message }}</b-alert>
         <b-table
             v-bind="indexTableAttrs"
             v-model="invocationItemsModel"
             no-sort-reset
             :fields="invocationFields"
-            :items="provider"
             class="invocations-table">
             <template v-slot:empty>
                 <loading-span v-if="loading" message="Loading workflow invocations" />
@@ -23,7 +22,8 @@
             <template v-slot:row-details="row">
                 <b-card>
                     <small class="float-right" :data-invocation-id="row.item.id">
-                        <b>Invocation: {{ row.item.id }}</b>
+                        <b>Last updated: <UtcDate :date="row.item.update_time" mode="elapsed" />;</b>
+                        <b>Invocation ID: <code>{{ row.item.id }}</code></b>
                     </small>
                     <workflow-invocation-state :invocation-id="row.item.id" @invocation-cancelled="refresh" />
                 </b-card>
@@ -32,14 +32,14 @@
                 <b-link
                     v-if="!data.detailsShowing"
                     v-b-tooltip.hover.top
-                    title="Show Invocation Details"
-                    class="btn-sm fa fa-chevron-down toggle-invocation-details"
+                    title="Show Details"
+                    class="btn-sm fa fa-lg fa-chevron-down toggle-invocation-details"
                     @click.stop="swapRowDetails(data)" />
                 <b-link
                     v-if="data.detailsShowing"
                     v-b-tooltip.hover.top
-                    title="Hide Invocation Details"
-                    class="btn-sm fa fa-chevron-up toggle-invocation-details"
+                    title="Hide Details"
+                    class="btn-sm fa fa-lg fa-chevron-up toggle-invocation-details"
                     @click.stop="swapRowDetails(data)" />
             </template>
             <template v-slot:cell(workflow_id)="data">
@@ -52,7 +52,7 @@
             <template v-slot:cell(history_id)="data">
                 <div
                     v-b-tooltip.hover.top.html
-                    :title="`<b>Switch to History:</b><br>${getHistoryNameById(data.item.history_id)}`"
+                    :title="`<b>Switch to</b><br>${getHistoryNameById(data.item.history_id)}`"
                     class="truncate">
                     <b-link id="switch-to-history" href="#" @click.stop="switchHistory(data.item.history_id)">
                         <b>{{ getHistoryNameById(data.item.history_id) }}</b>
@@ -73,7 +73,7 @@
             </template>
         </b-table>
         <b-pagination
-            v-show="rows >= perPage"
+            v-if="rows >= perPage"
             v-model="currentPage"
             class="gx-invocations-grid-pager"
             v-bind="paginationAttrs"></b-pagination>
@@ -82,7 +82,6 @@
 
 <script>
 import { mapActions, mapState } from "pinia";
-import { getAppRoot } from "onload/loadConfig";
 import { useHistoryStore } from "@/stores/historyStore";
 
 import { getGalaxyInstance } from "app";
@@ -105,26 +104,30 @@ export default {
         headerMessage: { type: String, default: "" },
         ownerGrid: { type: Boolean, default: true },
         userId: { type: String, default: null },
+        historyId: { type: String, default: null },
+        historyName: { type: String, default: null },
         storedWorkflowId: { type: String, default: null },
         storedWorkflowName: { type: String, default: null },
     },
     data() {
-        const fields = [
-            { key: "expand", label: "", class: "col-button" },
-            { key: "workflow_id", label: "Workflow", class: "col-name" },
-            { key: "history_id", label: "History", class: "col-history" },
+        const fields = [{ key: "expand", label: "", class: "col-button" }];
+        if (!this.storedWorkflowId) {
+            fields.push({ key: "workflow_id", label: "Workflow", class: "col-name" });
+        }
+        if (!this.historyId) {
+            fields.push({ key: "history_id", label: "History", class: "col-history" });
+        }
+        fields.push(
             { key: "create_time", label: "Invoked", class: "col-small", sortable: true },
-            { key: "update_time", label: "Updated", class: "col-small", sortable: true },
             { key: "state", class: "col-small" },
-            { key: "execute", label: "", class: "col-button" },
-        ];
+            { key: "execute", label: "Run", class: "col-button" }
+        );
         return {
             tableId: "invocation-list-table",
-            invocationItems: [],
+            dataProvider: invocationsProvider,
             invocationItemsModel: [],
             invocationFields: fields,
-            perPage: this.rowsPerPage(50),
-            root: getAppRoot(),
+            perPage: this.rowsPerPage(this.defaultPerPage || 50),
         };
     },
     computed: {
@@ -137,7 +140,10 @@ export default {
         title() {
             let title = `Workflow Invocations`;
             if (this.storedWorkflowName) {
-                title += ` for ${this.storedWorkflowName}`;
+                title += ` for workflow "${this.storedWorkflowName}"`;
+            }
+            if (this.historyName) {
+                title += ` for history "${this.historyName}"`;
             }
             return title;
         },
@@ -146,11 +152,27 @@ export default {
             if (this.storedWorkflowName) {
                 message += ` for ${this.storedWorkflowName}`;
             }
+            if (this.historyName) {
+                message += ` for ${this.historyName}`;
+            }
             return message;
+        },
+        dataProviderParameters() {
+            const extraParams = this.ownerGrid ? {} : { include_terminal: false };
+            if (this.storedWorkflowId) {
+                extraParams["workflow_id"] = this.storedWorkflowId;
+            }
+            if (this.historyId) {
+                extraParams["history_id"] = this.historyId;
+            }
+            if (this.userId) {
+                extraParams["user_id"] = this.userId;
+            }
+            return extraParams;
         },
     },
     watch: {
-        invocationItems: function (invocations) {
+        items: function (invocations) {
             if (invocations) {
                 const historyIds = new Set();
                 const workflowIds = new Set();
@@ -174,6 +196,9 @@ export default {
             const extraParams = this.ownerGrid ? {} : { include_terminal: false };
             if (this.storedWorkflowId) {
                 extraParams["workflow_id"] = this.storedWorkflowId;
+            }
+            if (this.historyId) {
+                extraParams["history_id"] = this.historyId;
             }
             if (this.userId) {
                 extraParams["user_id"] = this.userId;

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
@@ -2,14 +2,21 @@
     <div class="mb-3 workflow-invocation-state-component">
         <div v-if="invocationAndJobTerminal">
             <span>
-                <a class="invocation-report-link" :href="invocationLink">
-                    <b>View Report {{ indexStr }}</b>
-                </a>
-                <a
-                    v-b-tooltip
-                    class="fa fa-print ml-1 invocation-pdf-link"
+                <b-button
+                    v-b-tooltip.hover
+                    size="sm"
+                    class="invocation-report-link"
+                    :href="invocationLink">
+                    View Report
+                </b-button>
+                <b-button
+                    v-b-tooltip.hover
+                    size="sm"
+                    class="invocation-pdf-link"
                     :href="invocationPdfLink"
-                    title="Download PDF" />
+                    target="_blank">
+                    Generate PDF
+                </b-button>
             </span>
         </div>
         <div v-else-if="!invocationSchedulingTerminal">

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationSummary.vue
@@ -2,11 +2,7 @@
     <div class="mb-3 workflow-invocation-state-component">
         <div v-if="invocationAndJobTerminal">
             <span>
-                <b-button
-                    v-b-tooltip.hover
-                    size="sm"
-                    class="invocation-report-link"
-                    :href="invocationLink">
+                <b-button v-b-tooltip.hover size="sm" class="invocation-report-link" :href="invocationLink">
                     View Report
                 </b-button>
                 <b-button

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -34,6 +34,7 @@ import HistoryImport from "components/HistoryImport";
 import HistoryView from "components/History/HistoryView";
 import HistoryPublished from "components/History/HistoryPublished";
 import HistoryPublishedList from "components/History/HistoryPublishedList";
+import HistoryInvocations from "components/Workflow/HistoryInvocations";
 import HistoryMultipleView from "components/History/Multiple/MultipleView";
 import InteractiveTools from "components/InteractiveTools/InteractiveTools";
 import InvocationReport from "components/Workflow/InvocationReport";
@@ -265,6 +266,11 @@ export function getRouter(Galaxy) {
                         get component() {
                             return Galaxy.config.enable_celery_tasks ? HistoryExportTasks : HistoryExport;
                         },
+                        props: true,
+                    },
+                    {
+                        path: "histories/:historyId/invocations",
+                        component: HistoryInvocations,
                         props: true,
                     },
                     {

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -237,6 +237,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     webapp.add_client_route("/histories/list")
     webapp.add_client_route("/histories/import")
     webapp.add_client_route("/histories/{history_id}/export")
+    webapp.add_client_route("/histories/{history_id}/invocations")
     webapp.add_client_route("/histories/list_published")
     webapp.add_client_route("/histories/list_shared")
     webapp.add_client_route("/histories/rename")


### PR DESCRIPTION
plus minor UI tweaks

after vs before:

- ![Galaxy___martenson](https://github.com/galaxyproject/galaxy/assets/1814954/d7c2471e-693a-46dc-8d76-3a36eb134756)
- ![Galaxy](https://github.com/galaxyproject/galaxy/assets/1814954/2e2db37a-b2e2-45bb-8805-a4d1b38f4b5f)



## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
