### PR TITLE
[23.0] Fix rank calculation for jobs waiting to be run by anonymous users

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -426,7 +426,10 @@ class JobHandlerQueue(Monitors):
                 )
                 .subquery()
             )
-            rank = func.rank().over(partition_by=model.Job.table.c.user_id, order_by=model.Job.table.c.id).label("rank")
+            coalesce_exp = func.coalesce(
+                model.Job.table.c.user_id, model.Job.table.c.session_id
+            )  # accommodate jobs by anonymous users
+            rank = func.rank().over(partition_by=coalesce_exp, order_by=model.Job.table.c.id).label("rank")
             job_filter_conditions = (
                 (model.Job.state == model.Job.states.NEW),
                 (model.Job.handler == self.app.config.server_name),


### PR DESCRIPTION
As per discussion on galaxyadmin slack from May 22, 2023:

Issue: some jobs run by anonymous users get lots.
Cause: as per @natefoo:
```
Ok, I suspect it might be the windowed query. This would treat all anonymous users (user_id is null) as a single user: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/jobs/handler.py#L432

If the number of new state anonymous jobs on a given handler is larger than the window size, the ones past the cutoff would never be seen.
...
Basically we just need that rank function to use user_id if not null or session_id if user_id is null.
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
