### PR TITLE
[23.0] Make ``ctx_rev`` optional in InstalledToolShedRepository response model

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -4564,7 +4564,7 @@ export interface components {
              * Changeset revision number
              * @description The linearized 0-based index of the changeset on the tool shed (0, 1, 2,...)
              */
-            ctx_rev: string;
+            ctx_rev?: string;
             /** Deleted */
             deleted: boolean;
             /** Dist To Shed */

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2329,7 +2329,7 @@ class InstalledToolShedRepository(Model):
     owner: str = Field(title="Owner", description="Owner of repository")
     deleted: bool
     # This should be an int... but it would break backward compatiblity. Probably switch it at some point anyway?
-    ctx_rev: str = Field(
+    ctx_rev: Optional[str] = Field(
         title="Changeset revision number",
         description="The linearized 0-based index of the changeset on the tool shed (0, 1, 2,...)",
     )


### PR DESCRIPTION
It feels like we should have this info, but in practice this is not always defined and should be treated as optional?  xref https://github.com/galaxyproject/galaxy/issues/16135

Maybe someone with some more insight knows why this might be the case?  There are other fields that seem like they might be optional in practice as well, in the linked issue.

(wanted to smoke test this, will regenerate schema and retarget to 23.0...)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
