### PR TITLE
Scope pinned histories by user ID

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -62,7 +62,7 @@
     "ignorePatterns": ["dist", "src/libs", "src/nls", "src/legacy"],
     "overrides": [
         {
-            "files": ["**/*.test.js", "**/*.test.ts"],
+            "files": ["**/*.test.js", "**/*.test.ts", "**/tests/jest/**"],
             "env": {
                 "jest": true
             }

--- a/client/src/composables/__mocks__/hashedUserId.ts
+++ b/client/src/composables/__mocks__/hashedUserId.ts
@@ -1,0 +1,8 @@
+import { computed } from "vue";
+
+// set to always mock in jest.setup.js
+export function useHashedUserId() {
+    const hashedUserId = computed(() => "fake-hashed-id");
+
+    return { hashedUserId };
+}

--- a/client/src/composables/hashedUserId.ts
+++ b/client/src/composables/hashedUserId.ts
@@ -1,0 +1,64 @@
+import { computed, ref, watch } from "vue";
+import { useCurrentUser } from "./user";
+import { useLocalStorage } from "@vueuse/core";
+
+async function hash32(value: string): Promise<string> {
+    const valueUtf8 = new TextEncoder().encode(value);
+    const hashBuffer = await crypto.subtle.digest("SHA-256", valueUtf8);
+
+    return bufferToString(hashBuffer);
+}
+
+function bufferToString(buffer: ArrayBuffer): string {
+    const u8Array = new Uint8Array(buffer);
+    const hashString = window.btoa(String.fromCharCode(...u8Array));
+
+    return hashString;
+}
+
+function createSalt(): string {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+
+    return bufferToString(bytes);
+}
+
+const currentHash = ref<string | null>(null);
+let unhashedId: string | null = null;
+
+/**
+ * One way hashed ID of the current User
+ */
+export function useHashedUserId() {
+    const { currentUser } = useCurrentUser(true);
+
+    // salt the local store, to make a user untraceable by id across different clients
+    const localStorageSalt = useLocalStorage("local-storage-salt", createSalt());
+
+    watch(
+        () => currentUser.value,
+        () => {
+            if (currentUser.value && currentUser.value.id !== "") {
+                hashUserId(currentUser.value.id + localStorageSalt.value);
+            }
+        },
+        {
+            immediate: true,
+        }
+    );
+
+    async function hashUserId(id: string) {
+        if (unhashedId !== id) {
+            unhashedId = id;
+            currentHash.value = null;
+
+            const hashed = await hash32(id);
+
+            currentHash.value = hashed;
+        }
+    }
+
+    const hashedUserId = computed(() => currentHash.value);
+
+    return { hashedUserId };
+}

--- a/client/src/composables/user.ts
+++ b/client/src/composables/user.ts
@@ -15,7 +15,7 @@ export function useCurrentUser(noFetch: boolean | Ref<boolean> = false, fetchOnc
     const currentUser = computed(() => userStore.currentUser);
     const currentFavorites = computed(() => userStore.currentFavorites);
     onMounted(() => {
-        if (!unref(noFetch) && !(Object.keys(currentUser).length > 0) && unref(fetchOnce)) {
+        if (!unref(noFetch) && !(Object.keys(currentUser).length > 0 && unref(fetchOnce))) {
             userStore.loadUser();
         }
     });

--- a/client/src/composables/userLocalStorage.ts
+++ b/client/src/composables/userLocalStorage.ts
@@ -1,0 +1,33 @@
+import { ref, watch, type Ref, computed, customRef } from "vue";
+import { useHashedUserId } from "./hashedUserId";
+import { useLocalStorage, type RemovableRef, resolveUnref } from "@vueuse/core";
+
+/**
+ * Local storage composable specific to current user.
+ * @param key
+ * @param initialValue
+ */
+export function useUserLocalStorage<T>(key: string, initialValue: T) {
+    const { hashedUserId } = useHashedUserId();
+
+    const storedRef = computed(() => {
+        if (hashedUserId.value) {
+            return useLocalStorage(`${key}-${hashedUserId.value}`, initialValue);
+        } else {
+            return ref(initialValue);
+        }
+    });
+
+    const currentValue = customRef((track, trigger) => ({
+        get() {
+            track();
+            return storedRef.value.value;
+        },
+        set(newValue) {
+            storedRef.value.value = newValue;
+            trigger();
+        },
+    }));
+
+    return currentValue;
+}

--- a/client/src/stores/historyStore.ts
+++ b/client/src/stores/historyStore.ts
@@ -14,231 +14,224 @@ import {
     setCurrentHistoryOnServer,
     updateHistoryFields,
 } from "@/stores/services/history.services";
+import { useUserLocalStorage } from "@/composables/userLocalStorage";
 
 export type HistorySummary = components["schemas"]["HistorySummary"];
 
 const isLoadingHistory = new Set();
 
-export const useHistoryStore = defineStore(
-    "historyStore",
-    () => {
-        const historiesLoading = ref(false);
-        const pinnedHistories = ref<{ id: string }[]>([]);
-        const storedCurrentHistoryId = ref<string | null>(null);
-        const storedFilterTexts = ref<{ [key: string]: string }>({});
-        const storedHistories = ref<{ [key: string]: HistorySummary }>({});
+export const useHistoryStore = defineStore("historyStore", () => {
+    const historiesLoading = ref(false);
+    const pinnedHistories = useUserLocalStorage<{ id: string }[]>("history-store-pinned-histories", []);
+    const storedCurrentHistoryId = ref<string | null>(null);
+    const storedFilterTexts = ref<{ [key: string]: string }>({});
+    const storedHistories = ref<{ [key: string]: HistorySummary }>({});
 
-        const histories = computed(() => {
-            return Object.values(storedHistories.value).sort(sortByObjectProp("name"));
-        });
+    const histories = computed(() => {
+        return Object.values(storedHistories.value).sort(sortByObjectProp("name"));
+    });
 
-        const getFirstHistoryId = computed(() => {
-            return histories.value[0]?.id ?? null;
-        });
+    const getFirstHistoryId = computed(() => {
+        return histories.value[0]?.id ?? null;
+    });
 
-        const currentHistory = computed(() => {
-            if (storedCurrentHistoryId.value !== null) {
-                return storedHistories.value[storedCurrentHistoryId.value];
-            }
-            return null;
-        });
-
-        const currentHistoryId = computed(() => {
-            if (storedCurrentHistoryId.value === null || !(storedCurrentHistoryId.value in storedHistories.value)) {
-                return getFirstHistoryId.value;
-            } else {
-                return storedCurrentHistoryId.value;
-            }
-        });
-
-        const currentFilterText = computed(() => {
-            if (currentHistoryId.value) {
-                return storedFilterTexts.value[currentHistoryId.value];
-            } else {
-                return "";
-            }
-        });
-
-        const getHistoryById = computed(() => {
-            return (historyId: string) => {
-                return storedHistories.value[historyId] ?? null;
-            };
-        });
-
-        const getHistoryNameById = computed(() => {
-            return (historyId: string) => {
-                const history = storedHistories.value[historyId];
-                if (history) {
-                    return history.name;
-                } else {
-                    return "...";
-                }
-            };
-        });
-
-        async function setCurrentHistory(historyId: string) {
-            const currentHistory = await setCurrentHistoryOnServer(historyId);
-            selectHistory(currentHistory as HistorySummary);
-            setFilterText(historyId, "");
+    const currentHistory = computed(() => {
+        if (storedCurrentHistoryId.value !== null) {
+            return storedHistories.value[storedCurrentHistoryId.value];
         }
+        return null;
+    });
 
-        function setCurrentHistoryId(historyId: string) {
-            storedCurrentHistoryId.value = historyId;
+    const currentHistoryId = computed(() => {
+        if (storedCurrentHistoryId.value === null || !(storedCurrentHistoryId.value in storedHistories.value)) {
+            return getFirstHistoryId.value;
+        } else {
+            return storedCurrentHistoryId.value;
         }
+    });
 
-        function setFilterText(historyId: string, filterText: string) {
-            Vue.set(storedFilterTexts.value, historyId, filterText);
+    const currentFilterText = computed(() => {
+        if (currentHistoryId.value) {
+            return storedFilterTexts.value[currentHistoryId.value];
+        } else {
+            return "";
         }
+    });
 
-        function setHistory(history: HistorySummary) {
-            Vue.set(storedHistories.value, history.id, history);
-        }
-
-        function setHistories(histories: HistorySummary[]) {
-            // The incoming history list may contain less information than the already stored
-            // histories, so we ensure that already available details are not getting lost.
-            const enrichedHistories = histories.map((history) => {
-                const historyState = storedHistories.value[history.id] || {};
-                return Object.assign({}, historyState, history);
-            });
-            // Histories are provided as list but stored as map.
-            const newMap = enrichedHistories.reduce((acc, h) => ({ ...acc, [h.id]: h }), {}) as {
-                [key: string]: HistorySummary;
-            };
-            // Ensure that already stored histories, which are not available in the incoming array,
-            // are not lost. This happens e.g. with shared histories since they have different owners.
-            Object.values(storedHistories.value).forEach((history) => {
-                const historyId = history.id;
-                if (!newMap[historyId]) {
-                    newMap[historyId] = history;
-                }
-            });
-            // Update stored histories
-            storedHistories.value = newMap;
-        }
-
-        function setHistoriesLoading(loading: boolean) {
-            historiesLoading.value = loading;
-        }
-
-        function pinHistory(historyId: string) {
-            pinnedHistories.value.push({ id: historyId });
-        }
-
-        function unpinHistory(historyId: string) {
-            pinnedHistories.value = pinnedHistories.value.filter((h) => h.id !== historyId);
-        }
-
-        function selectHistory(history: HistorySummary) {
-            setHistory(history);
-            setCurrentHistoryId(history.id);
-        }
-
-        async function applyFilters(historyId: string, filters: Record<string, string | boolean>) {
-            if (currentHistoryId.value !== historyId) {
-                await setCurrentHistory(historyId);
-            }
-            const filterText = HistoryFilters.getFilterText(HistoryFilters.getValidFilterSettings(filters));
-            setFilterText(historyId, filterText);
-        }
-
-        async function copyHistory(history: HistorySummary, name: string, copyAll: boolean) {
-            const newHistory = (await cloneHistory(history, name, copyAll)) as HistorySummary;
-            return setCurrentHistory(newHistory.id);
-        }
-
-        async function createNewHistory() {
-            const newHistory = await createAndSelectNewHistory();
-            return selectHistory(newHistory as HistorySummary);
-        }
-
-        function getNextAvailableHistoryId(excludedIds: string[]) {
-            const historyIds = Object.keys(storedHistories.value);
-            const filteredHistoryIds = historyIds.filter((id) => !excludedIds.includes(id));
-            return filteredHistoryIds[0];
-        }
-
-        async function deleteHistory(historyId: string, purge: boolean) {
-            const deletedHistory = (await deleteHistoryById(historyId, purge)) as HistorySummary;
-            const nextAvailableHistoryId = getNextAvailableHistoryId([deletedHistory.id]);
-            if (nextAvailableHistoryId) {
-                await setCurrentHistory(nextAvailableHistoryId);
-            } else {
-                await createNewHistory();
-            }
-            Vue.delete(storedHistories.value, deletedHistory.id);
-        }
-
-        async function loadCurrentHistory() {
-            const history = await getCurrentHistoryFromServer();
-            selectHistory(history as HistorySummary);
-        }
-
-        async function loadHistories() {
-            if (!historiesLoading.value) {
-                setHistoriesLoading(true);
-                await getHistoryList()
-                    .then((histories) => setHistories(histories))
-                    .catch((error) => console.warn(error))
-                    .finally(() => {
-                        setHistoriesLoading(false);
-                    });
-            }
-        }
-
-        async function loadHistoryById(historyId: string) {
-            if (!isLoadingHistory.has(historyId)) {
-                await getHistoryByIdFromServer(historyId)
-                    .then((history) => setHistory(history as HistorySummary))
-                    .catch((error: Error) => console.warn(error))
-                    .finally(() => {
-                        isLoadingHistory.delete(historyId);
-                    });
-                isLoadingHistory.add(historyId);
-            }
-        }
-
-        async function secureHistory(history: HistorySummary) {
-            const securedHistory = await secureHistoryOnServer(history);
-            setHistory(securedHistory as HistorySummary);
-        }
-
-        async function updateHistory({ id, ...update }: HistorySummary) {
-            const savedHistory = await updateHistoryFields(id, update);
-            setHistory(savedHistory as HistorySummary);
-        }
-
-        return {
-            histories,
-            currentHistory,
-            currentHistoryId,
-            currentFilterText,
-            pinnedHistories,
-            getHistoryById,
-            getHistoryNameById,
-            setCurrentHistory,
-            setCurrentHistoryId,
-            setFilterText,
-            setHistory,
-            setHistories,
-            pinHistory,
-            unpinHistory,
-            selectHistory,
-            applyFilters,
-            copyHistory,
-            createNewHistory,
-            deleteHistory,
-            loadCurrentHistory,
-            loadHistories,
-            loadHistoryById,
-            secureHistory,
-            updateHistory,
-            historiesLoading,
+    const getHistoryById = computed(() => {
+        return (historyId: string) => {
+            return storedHistories.value[historyId] ?? null;
         };
-    },
-    {
-        persist: {
-            paths: ["pinnedHistories"],
-        },
+    });
+
+    const getHistoryNameById = computed(() => {
+        return (historyId: string) => {
+            const history = storedHistories.value[historyId];
+            if (history) {
+                return history.name;
+            } else {
+                return "...";
+            }
+        };
+    });
+
+    async function setCurrentHistory(historyId: string) {
+        const currentHistory = await setCurrentHistoryOnServer(historyId);
+        selectHistory(currentHistory as HistorySummary);
+        setFilterText(historyId, "");
     }
-);
+
+    function setCurrentHistoryId(historyId: string) {
+        storedCurrentHistoryId.value = historyId;
+    }
+
+    function setFilterText(historyId: string, filterText: string) {
+        Vue.set(storedFilterTexts.value, historyId, filterText);
+    }
+
+    function setHistory(history: HistorySummary) {
+        Vue.set(storedHistories.value, history.id, history);
+    }
+
+    function setHistories(histories: HistorySummary[]) {
+        // The incoming history list may contain less information than the already stored
+        // histories, so we ensure that already available details are not getting lost.
+        const enrichedHistories = histories.map((history) => {
+            const historyState = storedHistories.value[history.id] || {};
+            return Object.assign({}, historyState, history);
+        });
+        // Histories are provided as list but stored as map.
+        const newMap = enrichedHistories.reduce((acc, h) => ({ ...acc, [h.id]: h }), {}) as {
+            [key: string]: HistorySummary;
+        };
+        // Ensure that already stored histories, which are not available in the incoming array,
+        // are not lost. This happens e.g. with shared histories since they have different owners.
+        Object.values(storedHistories.value).forEach((history) => {
+            const historyId = history.id;
+            if (!newMap[historyId]) {
+                newMap[historyId] = history;
+            }
+        });
+        // Update stored histories
+        storedHistories.value = newMap;
+    }
+
+    function setHistoriesLoading(loading: boolean) {
+        historiesLoading.value = loading;
+    }
+
+    function pinHistory(historyId: string) {
+        pinnedHistories.value.push({ id: historyId });
+    }
+
+    function unpinHistory(historyId: string) {
+        pinnedHistories.value = pinnedHistories.value.filter((h) => h.id !== historyId);
+    }
+
+    function selectHistory(history: HistorySummary) {
+        setHistory(history);
+        setCurrentHistoryId(history.id);
+    }
+
+    async function applyFilters(historyId: string, filters: Record<string, string | boolean>) {
+        if (currentHistoryId.value !== historyId) {
+            await setCurrentHistory(historyId);
+        }
+        const filterText = HistoryFilters.getFilterText(HistoryFilters.getValidFilterSettings(filters));
+        setFilterText(historyId, filterText);
+    }
+
+    async function copyHistory(history: HistorySummary, name: string, copyAll: boolean) {
+        const newHistory = (await cloneHistory(history, name, copyAll)) as HistorySummary;
+        return setCurrentHistory(newHistory.id);
+    }
+
+    async function createNewHistory() {
+        const newHistory = await createAndSelectNewHistory();
+        return selectHistory(newHistory as HistorySummary);
+    }
+
+    function getNextAvailableHistoryId(excludedIds: string[]) {
+        const historyIds = Object.keys(storedHistories.value);
+        const filteredHistoryIds = historyIds.filter((id) => !excludedIds.includes(id));
+        return filteredHistoryIds[0];
+    }
+
+    async function deleteHistory(historyId: string, purge: boolean) {
+        const deletedHistory = (await deleteHistoryById(historyId, purge)) as HistorySummary;
+        const nextAvailableHistoryId = getNextAvailableHistoryId([deletedHistory.id]);
+        if (nextAvailableHistoryId) {
+            await setCurrentHistory(nextAvailableHistoryId);
+        } else {
+            await createNewHistory();
+        }
+        Vue.delete(storedHistories.value, deletedHistory.id);
+    }
+
+    async function loadCurrentHistory() {
+        const history = await getCurrentHistoryFromServer();
+        selectHistory(history as HistorySummary);
+    }
+
+    async function loadHistories() {
+        if (!historiesLoading.value) {
+            setHistoriesLoading(true);
+            await getHistoryList()
+                .then((histories) => setHistories(histories))
+                .catch((error) => console.warn(error))
+                .finally(() => {
+                    setHistoriesLoading(false);
+                });
+        }
+    }
+
+    async function loadHistoryById(historyId: string) {
+        if (!isLoadingHistory.has(historyId)) {
+            await getHistoryByIdFromServer(historyId)
+                .then((history) => setHistory(history as HistorySummary))
+                .catch((error: Error) => console.warn(error))
+                .finally(() => {
+                    isLoadingHistory.delete(historyId);
+                });
+            isLoadingHistory.add(historyId);
+        }
+    }
+
+    async function secureHistory(history: HistorySummary) {
+        const securedHistory = await secureHistoryOnServer(history);
+        setHistory(securedHistory as HistorySummary);
+    }
+
+    async function updateHistory({ id, ...update }: HistorySummary) {
+        const savedHistory = await updateHistoryFields(id, update);
+        setHistory(savedHistory as HistorySummary);
+    }
+
+    return {
+        histories,
+        currentHistory,
+        currentHistoryId,
+        currentFilterText,
+        pinnedHistories,
+        getHistoryById,
+        getHistoryNameById,
+        setCurrentHistory,
+        setCurrentHistoryId,
+        setFilterText,
+        setHistory,
+        setHistories,
+        pinHistory,
+        unpinHistory,
+        selectHistory,
+        applyFilters,
+        copyHistory,
+        createNewHistory,
+        deleteHistory,
+        loadCurrentHistory,
+        loadHistories,
+        loadHistoryById,
+        secureHistory,
+        updateHistory,
+        historiesLoading,
+    };
+});

--- a/client/tests/jest/jest.setup.js
+++ b/client/tests/jest/jest.setup.js
@@ -9,3 +9,6 @@ Vue.config.devtools = false;
 and this makes the tag tests work correctly */
 global.XMLHttpRequest = undefined;
 global.setImmediate = global.setTimeout;
+
+// Always mock the following imports
+jest.mock("@/composables/hashedUserId");


### PR DESCRIPTION
fixes #16134 by scoping the pinned sessions to a salted hash of the user id.
Adds a composable which makes it easy to apply the same scoping to other locally persisted values.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
