### PR TITLE
Improve histories and datasets immutability checks

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -177,6 +177,11 @@ class ItemOwnershipException(MessageException):
     err_code = error_codes_by_name["USER_DOES_NOT_OWN_ITEM"]
 
 
+class ItemImmutableException(MessageException):
+    status_code = 403
+    err_code = error_codes_by_name["ITEM_IS_IMMUTABLE"]
+
+
 class ConfigDoesNotAllowException(MessageException):
     status_code = 403
     err_code = error_codes_by_name["CONFIG_DOES_NOT_ALLOW"]

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -1,192 +1,197 @@
 [
-   {
-      "name": "UNKNOWN",
-      "code": 0,
-      "message": "Unknown error occurred while processing request."
-   },
-   {
-      "name": "ACCEPTED_RETRY_LATER",
-      "code": 202001,
-      "message": "Galaxy has accepted this request and is processing. A retry-after header indicates to the client when to retry."
-   },
-   {
-      "name": "NO_CONTENT_GENERIC",
-      "code": 204001,
-      "message": "Galaxy has no content to associate with this request."
-   },
-   {
-      "name": "USER_CANNOT_RUN_AS",
-      "code": 400001,
-      "message": "User does not have permissions to run jobs as another user."
-   },
-   {
-      "name": "USER_INVALID_RUN_AS",
-      "code": 400002,
-      "message": "Invalid run_as request - run_as user does not exist."
-   },
-   {
-      "name": "USER_INVALID_JSON",
-      "code": 400003,
-      "message": "Your request did not appear to be valid JSON, please consult the API documentation."
-   },
-   {
-      "name": "USER_OBJECT_ATTRIBUTE_INVALID",
-      "code": 400004,
-      "message": "Attempted to create or update object with invalid attribute value."
-   },
-   {
-      "name": "USER_OBJECT_ATTRIBUTE_MISSING",
-      "code": 400005,
-      "message": "Attempted to create or update object without required attribute."
-   },
-   {
-      "name": "USER_SLUG_DUPLICATE",
-      "code": 400006,
-      "message": "Slug must be unique per user."
-   },
-   {
-      "name": "USER_REQUEST_MISSING_PARAMETER",
-      "code": 400007,
-      "message": "Request is missing parameter required to complete desired action."
-   },
-   {
-      "name": "USER_REQUEST_INVALID_PARAMETER",
-      "code": 400008,
-      "message": "Request contained invalid parameter, action could not be completed."
-   },
-   {
-      "name": "MALFORMED_ID",
-      "code": 400009,
-      "message": "The id of the resource is malformed."
-   },
-   {
-      "name": "UNKNOWN_CONTENTS_TYPE",
-      "code": 400010,
-      "message": "The request contains unknown type of contents."
-   },
-   {
-      "name": "USER_IDENTIFIER_DUPLICATE",
-      "code": 400011,
-      "message": "Request contained a duplicated identifier that must be unique."
-   },
-   {
-      "name": "USER_TOOL_META_PARAMETER_PROBLEM",
-      "code": 400012,
-      "message": "Supplied incorrect or incompatible tool meta parameters."
-   },
-   {
-      "name": "MALFORMED_CONTENTS",
-      "code": 400013,
-      "message": "The contents of the request are malformed."
-   },
-   {
-      "name": "USER_TOOL_MISSING_PROBLEM",
-      "code": 400014,
-      "message": "Tool could not be found."
-   },
-   {
-      "name": "TOOL_INPUTS_NOT_READY",
-      "code": 400015,
-      "message": "Tool inputs not yet ready, try again later."
-   },
-   {
-      "name": "REAL_USER_REQUIRED",
-      "code": 400016,
-      "message": "Only real users can make this request."
-   },
-   {
-      "name": "USER_AUTHENTICATION_FAILED",
-      "code": 401001,
-      "message": "Authentication failed, invalid credentials supplied."
-   },
-   {
-      "name": "USER_NO_API_KEY",
-      "code": 403001,
-      "message": "Authentication required for this request"
-   },
-   {
-      "name": "USER_CANNOT_ACCESS_ITEM",
-      "code": 403002,
-      "message": "User cannot access specified item."
-   },
-   {
-      "name": "USER_DOES_NOT_OWN_ITEM",
-      "code": 403003,
-      "message": "User does not own specified item."
-   },
-   {
-      "name": "CONFIG_DOES_NOT_ALLOW",
-      "code": 403004,
-      "message": "The configuration of this Galaxy instance does not allow that operation"
-   },
-   {
-      "name": "INSUFFICIENT_PERMISSIONS",
-      "code": 403005,
-      "message": "You don't have proper permissions to perform the requested operation"
-   },
-   {
-      "name": "ADMIN_REQUIRED",
-      "code": 403006,
-      "message": "Action requires admin account."
-   },
-   {
-      "name": "USER_ACTIVATION_REQUIRED",
-      "code": 403007,
-      "message": "Action requires account activation."
-   },
-   {
-      "name": "USER_OBJECT_NOT_FOUND",
-      "code": 404001,
-      "message": "No such object found."
-   },
-   {
-      "name": "CONFLICT",
-      "code": 409001,
-      "message": "Database conflict prevented fulfilling the request."
-   },
-   {
-      "name": "DEPRECATED_API_CALL",
-      "code": 410001,
-      "message": "This API method or call signature has been deprecated and is no longer available"
-   },
-   {
-      "name": "INTERNAL_SERVER_ERROR",
-      "code": 500001,
-      "message": "Internal server error."
-   },
-   {
-      "name": "INCONSISTENT_DATABASE",
-      "code": 500002,
-      "message": "Inconsistent database prevented fulfilling the request."
-   },
-   {
-      "name": "CONFIG_ERROR",
-      "code": 500003,
-      "message": "Error in a configuration file."
-   },
-   {
-      "name": "TOOL_EXECUTION_ERROR",
-      "code": 500004,
-      "message": "Tool execution failed due to an internal server error."
-   },
-   {
-      "name": "INVALID_FILE_FORMAT",
-      "code": 500005,
-      "message": "File format not supported for this operation."
-   },
-   {
-      "name": "REFERENCE_DATA_ERROR",
-      "code": 500006,
-      "message": "Reference data required for program execution failed to load."
-   },
-   {
-      "name": "NOT_IMPLEMENTED",
-      "code": 501001,
-      "message": "Method is not implemented."
-   },
-   {
-      "name": "SERVER_NOT_CONFIGURED_FOR_REQUEST",
-      "code": 501002,
-      "message": "Server not configured for the request. The Galaxy admin may be able to resolve the problem by installing additional dependencies or setting up new infrastructure."
-   }
+    {
+        "name": "UNKNOWN",
+        "code": 0,
+        "message": "Unknown error occurred while processing request."
+    },
+    {
+        "name": "ACCEPTED_RETRY_LATER",
+        "code": 202001,
+        "message": "Galaxy has accepted this request and is processing. A retry-after header indicates to the client when to retry."
+    },
+    {
+        "name": "NO_CONTENT_GENERIC",
+        "code": 204001,
+        "message": "Galaxy has no content to associate with this request."
+    },
+    {
+        "name": "USER_CANNOT_RUN_AS",
+        "code": 400001,
+        "message": "User does not have permissions to run jobs as another user."
+    },
+    {
+        "name": "USER_INVALID_RUN_AS",
+        "code": 400002,
+        "message": "Invalid run_as request - run_as user does not exist."
+    },
+    {
+        "name": "USER_INVALID_JSON",
+        "code": 400003,
+        "message": "Your request did not appear to be valid JSON, please consult the API documentation."
+    },
+    {
+        "name": "USER_OBJECT_ATTRIBUTE_INVALID",
+        "code": 400004,
+        "message": "Attempted to create or update object with invalid attribute value."
+    },
+    {
+        "name": "USER_OBJECT_ATTRIBUTE_MISSING",
+        "code": 400005,
+        "message": "Attempted to create or update object without required attribute."
+    },
+    {
+        "name": "USER_SLUG_DUPLICATE",
+        "code": 400006,
+        "message": "Slug must be unique per user."
+    },
+    {
+        "name": "USER_REQUEST_MISSING_PARAMETER",
+        "code": 400007,
+        "message": "Request is missing parameter required to complete desired action."
+    },
+    {
+        "name": "USER_REQUEST_INVALID_PARAMETER",
+        "code": 400008,
+        "message": "Request contained invalid parameter, action could not be completed."
+    },
+    {
+        "name": "MALFORMED_ID",
+        "code": 400009,
+        "message": "The id of the resource is malformed."
+    },
+    {
+        "name": "UNKNOWN_CONTENTS_TYPE",
+        "code": 400010,
+        "message": "The request contains unknown type of contents."
+    },
+    {
+        "name": "USER_IDENTIFIER_DUPLICATE",
+        "code": 400011,
+        "message": "Request contained a duplicated identifier that must be unique."
+    },
+    {
+        "name": "USER_TOOL_META_PARAMETER_PROBLEM",
+        "code": 400012,
+        "message": "Supplied incorrect or incompatible tool meta parameters."
+    },
+    {
+        "name": "MALFORMED_CONTENTS",
+        "code": 400013,
+        "message": "The contents of the request are malformed."
+    },
+    {
+        "name": "USER_TOOL_MISSING_PROBLEM",
+        "code": 400014,
+        "message": "Tool could not be found."
+    },
+    {
+        "name": "TOOL_INPUTS_NOT_READY",
+        "code": 400015,
+        "message": "Tool inputs not yet ready, try again later."
+    },
+    {
+        "name": "REAL_USER_REQUIRED",
+        "code": 400016,
+        "message": "Only real users can make this request."
+    },
+    {
+        "name": "USER_AUTHENTICATION_FAILED",
+        "code": 401001,
+        "message": "Authentication failed, invalid credentials supplied."
+    },
+    {
+        "name": "USER_NO_API_KEY",
+        "code": 403001,
+        "message": "Authentication required for this request"
+    },
+    {
+        "name": "USER_CANNOT_ACCESS_ITEM",
+        "code": 403002,
+        "message": "User cannot access specified item."
+    },
+    {
+        "name": "USER_DOES_NOT_OWN_ITEM",
+        "code": 403003,
+        "message": "User does not own specified item."
+    },
+    {
+        "name": "ITEM_IS_IMMUTABLE",
+        "code": 403003,
+        "message": "The specified item is immutable."
+    },
+    {
+        "name": "CONFIG_DOES_NOT_ALLOW",
+        "code": 403004,
+        "message": "The configuration of this Galaxy instance does not allow that operation"
+    },
+    {
+        "name": "INSUFFICIENT_PERMISSIONS",
+        "code": 403005,
+        "message": "You don't have proper permissions to perform the requested operation"
+    },
+    {
+        "name": "ADMIN_REQUIRED",
+        "code": 403006,
+        "message": "Action requires admin account."
+    },
+    {
+        "name": "USER_ACTIVATION_REQUIRED",
+        "code": 403007,
+        "message": "Action requires account activation."
+    },
+    {
+        "name": "USER_OBJECT_NOT_FOUND",
+        "code": 404001,
+        "message": "No such object found."
+    },
+    {
+        "name": "CONFLICT",
+        "code": 409001,
+        "message": "Database conflict prevented fulfilling the request."
+    },
+    {
+        "name": "DEPRECATED_API_CALL",
+        "code": 410001,
+        "message": "This API method or call signature has been deprecated and is no longer available"
+    },
+    {
+        "name": "INTERNAL_SERVER_ERROR",
+        "code": 500001,
+        "message": "Internal server error."
+    },
+    {
+        "name": "INCONSISTENT_DATABASE",
+        "code": 500002,
+        "message": "Inconsistent database prevented fulfilling the request."
+    },
+    {
+        "name": "CONFIG_ERROR",
+        "code": 500003,
+        "message": "Error in a configuration file."
+    },
+    {
+        "name": "TOOL_EXECUTION_ERROR",
+        "code": 500004,
+        "message": "Tool execution failed due to an internal server error."
+    },
+    {
+        "name": "INVALID_FILE_FORMAT",
+        "code": 500005,
+        "message": "File format not supported for this operation."
+    },
+    {
+        "name": "REFERENCE_DATA_ERROR",
+        "code": 500006,
+        "message": "Reference data required for program execution failed to load."
+    },
+    {
+        "name": "NOT_IMPLEMENTED",
+        "code": 501001,
+        "message": "Method is not implemented."
+    },
+    {
+        "name": "SERVER_NOT_CONFIGURED_FOR_REQUEST",
+        "code": 501002,
+        "message": "Server not configured for the request. The Galaxy admin may be able to resolve the problem by installing additional dependencies or setting up new infrastructure."
+    }
 ]

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -143,6 +143,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         """
         Purge this history and all HDAs, Collections, and Datasets inside this history.
         """
+        self.error_unless_mutable(history)
         self.hda_manager.dataset_manager.error_unless_dataset_purge_allowed()
         # First purge all the datasets
         for hda in history.datasets:

--- a/lib/galaxy/managers/secured.py
+++ b/lib/galaxy/managers/secured.py
@@ -143,3 +143,25 @@ class OwnableManagerMixin:
         """
         # just alias to list_owned
         return self.list_owned(user, **kwargs)
+
+    def get_mutable(self, id: int, user: Optional[model.User], **kwargs: Any) -> Any:
+        """
+        Return the item with the given id if the user can mutate it,
+        otherwise raise an error. The user must be the owner of the item.
+
+        :raises exceptions.ItemOwnershipException:
+        """
+        item = self.get_owned(id, user, **kwargs)
+        self.error_unless_mutable(item)
+        return item
+
+    def error_unless_mutable(self, item):
+        """
+        Raise an error if the item is NOT mutable.
+
+        Items purged or archived are considered immutable.
+
+        :raises exceptions.ItemImmutableException:
+        """
+        if getattr(item, "purged", False) or getattr(item, "archived", False):
+            raise exceptions.ItemImmutableException(f"{self.model_class.__name__} is immutable")

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -498,6 +498,8 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
             else:
                 raise exceptions.RequestParameterInvalidException("Must run conversion on either hdca or hda.")
 
+        self.history_manager.error_unless_mutable(target_history)
+
         # Make the target datatype available to the converter
         params["__target_datatype__"] = target_type
         vars = converter.handle_input(trans, params, history=target_history)

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -825,6 +825,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         try:
             id = self.decode_id(dataset_id)
             hda = self.hda_manager.get_owned(id, trans.user, current_history=trans.history)
+            self.hda_manager.error_unless_mutable(hda.history)
             hda.mark_deleted()
             hda.clear_associated_files()
             trans.log_event(f"Dataset id {str(id)} marked as deleted")
@@ -844,6 +845,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         try:
             id = self.decode_id(dataset_id)
             item = self.hda_manager.get_owned(id, trans.user, current_history=trans.history)
+            self.hda_manager.error_unless_mutable(item.history)
             self.hda_manager.undelete(item)
             trans.log_event(f"Dataset id {str(id)} has been undeleted")
         except Exception:
@@ -858,6 +860,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         try:
             id = self.decode_id(dataset_id)
             item = self.hda_manager.get_owned(id, trans.user, current_history=trans.history)
+            self.hda_manager.error_unless_mutable(item.history)
             item.mark_unhidden()
             trans.sa_session.flush()
             trans.log_event(f"Dataset id {str(id)} has been unhidden")

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -124,7 +124,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         if payload.instance_type == "history":
             if payload.history_id is None:
                 raise exceptions.RequestParameterInvalidException("Parameter history_id is required.")
-            history = self.history_manager.get_owned(payload.history_id, trans.user, current_history=trans.history)
+            history = self.history_manager.get_mutable(payload.history_id, trans.user, current_history=trans.history)
             create_params["parent"] = history
             create_params["history"] = history
         elif payload.instance_type == "library" and payload.folder_id:

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -695,6 +695,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
             try:
                 manager = self.dataset_manager_by_type[dataset.src]
                 dataset_instance = manager.get_owned(dataset.id, trans.user)
+                manager.error_unless_mutable(dataset_instance.history)
                 if dataset.src == DatasetSourceType.hda:
                     self.hda_manager.error_if_uploading(dataset_instance)
                 if payload.purge:

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -388,7 +388,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             any values that were different from the original and, therefore, updated
         """
         # TODO: PUT /api/histories/{encoded_history_id} payload = { rating: rating } (w/ no security checks)
-        history = self.manager.get_owned(history_id, trans.user, current_history=trans.history)
+        history = self.manager.get_mutable(history_id, trans.user, current_history=trans.history)
         self.deserializer.deserialize(history, payload, user=trans.user, trans=trans)
         return self._serialize_history(trans, history, serialization_params)
 
@@ -406,7 +406,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         You can purge a history, removing all it's datasets from disk (if unshared),
         by passing in ``purge=True`` in the url.
         """
-        history = self.manager.get_owned(history_id, trans.user, current_history=trans.history)
+        history = self.manager.get_mutable(history_id, trans.user, current_history=trans.history)
         if purge:
             self.manager.purge(history)
         else:
@@ -427,7 +427,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
 
         :returns:   the undeleted history
         """
-        history = self.manager.get_owned(history_id, trans.user, current_history=trans.history)
+        history = self.manager.get_mutable(history_id, trans.user, current_history=trans.history)
         self.manager.undelete(history)
         return self._serialize_history(trans, history, serialization_params)
 

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -133,7 +133,7 @@ class ToolsService(ServiceBase):
         history_id = payload.get("history_id")
         if history_id:
             history_id = trans.security.decode_id(history_id) if isinstance(history_id, str) else history_id
-            target_history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
+            target_history = self.history_manager.get_mutable(history_id, trans.user, current_history=trans.history)
         else:
             target_history = None
 

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -253,7 +253,7 @@ def _get_target_history(
             history_name = history_param
     if history_id:
         history_manager = trans.app.history_manager
-        target_history = history_manager.get_owned(
+        target_history = history_manager.get_mutable(
             trans.security.decode_id(history_id), trans.user, current_history=trans.history
         )
     else:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -6484,6 +6484,18 @@ input_c:
         finally:
             shutil.rmtree(workflow_directory)
 
+    def test_cannot_run_workflow_on_immutable_history(self) -> None:
+        with self.dataset_populator.test_history() as history_id:
+            # once we purge the history, it becomes immutable
+            self._delete(f"histories/{history_id}", data={"purge": True}, json=True)
+
+            with self.assertRaisesRegex(AssertionError, "History is immutable"):
+                self.workflow_populator.run_workflow(
+                    WORKFLOW_INPUTS_AS_OUTPUTS,
+                    test_data={"input1": "hello world", "text_input": {"value": "A text variable", "type": "raw"}},
+                    history_id=history_id,
+                )
+
     def _invoke_paused_workflow(self, history_id):
         workflow = self.workflow_populator.load_workflow_from_resource("test_workflow_pause")
         workflow_id = self.workflow_populator.create_workflow(workflow)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -476,10 +476,11 @@ class BaseDatasetPopulator(BasePopulator):
         details = self.get_history_dataset_details(history_id, dataset=output)
         return details
 
-    def tag_dataset(self, history_id, hda_id, tags):
+    def tag_dataset(self, history_id, hda_id, tags, raise_on_error=True):
         url = f"histories/{history_id}/contents/{hda_id}"
         response = self._put(url, {"tags": tags}, json=True)
-        response.raise_for_status()
+        if raise_on_error:
+            response.raise_for_status()
         return response.json()
 
     def create_from_store_raw(self, payload: Dict[str, Any]) -> Response:


### PR DESCRIPTION
Extracted from #16003

Restricts some mutation operations through the API on items that are purged or archived. This is probably not enforced thoroughly enough, but it should work for a significant number of situations that are already inconsistent.

For example, you can no longer drag and drop or copy datasets to a purged history.

TODO:
- [x] add some tests

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
