### PR TITLE
Disable invalid link for anonymous users.

### DIFF
--- a/client/src/components/Masthead/QuotaMeter.vue
+++ b/client/src/components/Masthead/QuotaMeter.vue
@@ -1,12 +1,12 @@
 <template>
     <div>
         <div v-if="!hasQuota" class="quota-text d-flex align-items-center">
-            <b-link v-b-tooltip.hover.left to="/storage" class="ml-auto" :title="title">
+            <b-link v-b-tooltip.hover.left to="/storage" :disabled="isAnonymous" class="ml-auto" :title="title">
                 {{ usingString + " " + totalUsageString }}
             </b-link>
         </div>
         <div v-else class="quota-meter d-flex align-items-center">
-            <b-link v-b-tooltip.hover.left class="quota-progress" to="/storage" :title="title">
+            <b-link v-b-tooltip.hover.left class="quota-progress" :disabled="isAnonymous" to="/storage" :title="title">
                 <b-progress :max="100">
                     <b-progress-bar aria-label="Quota usage" :value="usage" :variant="variant" />
                 </b-progress>


### PR DESCRIPTION
Previously would just lead to a page with no information and big scary red box. The title text also currently makes it clear you need to login to very quota breakdown.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Click link as anonymous user without this change and see scary box, apply change and see the scary message goes away.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
