### PR TITLE
Allow Default Filter to be set in Config

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -262,9 +262,13 @@
                                                 aria-haspopup="true"
                                                 aria-expanded="false"></button>
                                             <div class="dropdown-menu">
-                                                <a class="dropdown-item" @click="changeFilters('illumina')">_1</a>
-                                                <a class="dropdown-item" @click="changeFilters('Rs')">_R1</a>
-                                                <a class="dropdown-item" @click="changeFilters('dot12s')">.1.fastq</a>
+                                                <a
+                                                    class="dropdown-item"
+                                                    v-for="(value, key) in commonFilters"
+                                                    :key="key"
+                                                    @click="changeFilters(key)">
+                                                    {{ value[0] }}
+                                                </a>
                                             </div>
                                         </div>
                                     </div>
@@ -314,10 +318,14 @@
                                                 data-toggle="dropdown"
                                                 aria-haspopup="true"
                                                 aria-expanded="false"></button>
-                                            <div class="dropdown-menu">
-                                                <a class="dropdown-item" @click="changeFilters('illumina')">_2</a>
-                                                <a class="dropdown-item" @click="changeFilters('Rs')">_R2</a>
-                                                <a class="dropdown-item" @click="changeFilters('dot12s')">.2.fastq</a>
+                                                <div class="dropdown-menu">
+                                                <a
+                                                    class="dropdown-item"
+                                                    v-for="(value, key) in commonFilters"
+                                                    :key="key"
+                                                    @click="changeFilters(key)">
+                                                    {{ value[1] }}
+                                                </a>
                                             </div>
                                         </div>
                                     </div>
@@ -644,6 +652,7 @@ export default {
                 this.commonFilters[initialFilter].push(this.config.default_paired_list_forward_filter);
                 this.commonFilters[initialFilter].push(this.config.default_paired_list_reverse_filter);
             }
+
             this.changeFilters(initialFilter);
         },
         /** add ids to dataset objs in initial list if none */

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -419,6 +419,7 @@ import { Splitpanes, Pane } from "splitpanes";
 import draggable from "vuedraggable";
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
+import { getGalaxyInstance } from "app";
 
 Vue.use(BootstrapVue);
 export default {
@@ -432,6 +433,7 @@ export default {
     mixins: [mixin],
     data: function () {
         return {
+            config: getGalaxyInstance().config,
             state: "build", //error, duplicates
             dragToChangeTitle: _l("Drag to change"),
             chooseFilterTitle: _l("Choose from common filters"),
@@ -631,7 +633,18 @@ export default {
             }
         },
         initialFiltersSet: function () {
-            this.changeFilters("illumina");
+            let initialFilter = this.config.default_paired_list_filter_name
+                ? this.config.default_paired_list_filter_name
+                : this.DEFAULT_FILTERS;
+            if (this.config.default_paired_list_filter_name) {
+                //add initialFilter to commonFilters
+                this.commonFilters[initialFilter] = [];
+
+                // add the default filter to the list of common filters
+                this.commonFilters[initialFilter].push(this.config.default_paired_list_forward_filter);
+                this.commonFilters[initialFilter].push(this.config.default_paired_list_reverse_filter);
+            }
+            this.changeFilters(initialFilter);
         },
         /** add ids to dataset objs in initial list if none */
         _ensureElementIds: function () {

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1610,7 +1610,7 @@
 
 :Description:
     Name of filter set
-:Default: ``full_names``
+:Default: ``""``
 :Type: str
 
 
@@ -1620,7 +1620,7 @@
 
 :Description:
     Forward filter
-:Default: ``forward``
+:Default: ``""``
 :Type: str
 
 
@@ -1630,7 +1630,7 @@
 
 :Description:
     Reverse filter
-:Default: ``reverse``
+:Default: ``""``
 :Type: str
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1604,6 +1604,36 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``default_paired_list_filter_name``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Name of filter set
+:Default: ``full_names``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``default_paired_list_forward_filter``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Forward filter
+:Default: ``forward``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``default_paired_list_reverse_filter``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Reverse filter
+:Default: ``reverse``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``password_expiration_period``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1103,6 +1103,15 @@ galaxy:
   # only if activation_grace_period is set.
   #inactivity_box_content: Your account has not been activated yet.  Feel free to browse around and see what's available, but you won't be able to upload data or run jobs until you have verified your email address.
 
+  # Name of filter set
+  #default_paired_list_filter_name: full_names
+
+  # Forward filter
+  #default_paired_list_forward_filter: forward
+
+  # Reverse filter
+  #default_paired_list_reverse_filter: reverse
+
   # Password expiration period (in days). Users are required to change
   # their password every x days. Users will be redirected to the change
   # password screen when they log in after their password expires. Enter

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1104,13 +1104,13 @@ galaxy:
   #inactivity_box_content: Your account has not been activated yet.  Feel free to browse around and see what's available, but you won't be able to upload data or run jobs until you have verified your email address.
 
   # Name of filter set
-  #default_paired_list_filter_name: full_names
+  #default_paired_list_filter_name: ''
 
   # Forward filter
-  #default_paired_list_forward_filter: forward
+  #default_paired_list_forward_filter: ''
 
   # Reverse filter
-  #default_paired_list_reverse_filter: reverse
+  #default_paired_list_reverse_filter: ''
 
   # Password expiration period (in days). Users are required to change
   # their password every x days. Users will be redirected to the change

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1153,19 +1153,22 @@ mapping:
 
       default_paired_list_filter_name:
         type: str
-        default: "full_names"
+        default: ""
+        required: false
         desc: |
           Name of filter set
 
       default_paired_list_forward_filter:
         type: str
-        default: "forward"
+        default: ""
+        required: false
         desc: |
           Forward filter
 
       default_paired_list_reverse_filter:
         type: str
-        default: "reverse"
+        default: ""
+        required: false
         desc: |
           Reverse filter
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1151,6 +1151,24 @@ mapping:
           Shown in warning box to users that were not activated yet.
           In use only if activation_grace_period is set.
 
+      default_paired_list_filter_name:
+        type: str
+        default: "full_names"
+        desc: |
+          Name of filter set
+
+      default_paired_list_forward_filter:
+        type: str
+        default: "forward"
+        desc: |
+          Forward filter
+
+      default_paired_list_reverse_filter:
+        type: str
+        default: "reverse"
+        desc: |
+          Reverse filter
+
       password_expiration_period:
         type: int
         default: 0

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -207,6 +207,9 @@ class ConfigSerializer(base.ModelSerializer):
             "tool_training_recommendations": _use_config,
             "tool_training_recommendations_link": _use_config,
             "tool_training_recommendations_api_url": _use_config,
+            "default_paired_list_filter_name": _use_config,
+            "default_paired_list_forward_filter": _use_config,
+            "default_paired_list_reverse_filter": _use_config,
         }
 
 


### PR DESCRIPTION
Fix for #15937 

I added config options for a default filter name, forward, and reverse string. 
If there is a default set in config, it adds that option to the available dropdown options, so that users can access it again, if they try another filter. 


https://github.com/galaxyproject/galaxy/assets/26912553/0c4a426d-e5fa-44d5-9479-be93fdafdcdb



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. change `default_paired_list_filter_name`, `default_paired_list_forward_filter`, and `default_paired_list_reverse_filter` in `lib/galaxy/config/schemas/config_schema.yml`
  2. open up the Paired List Collection Creator to see that the default filters are whatever you set them to
  3. Also note that those default filters are available as filter to set in the dropdown options

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
