### PR TITLE
Raise configuration error if connection URL is unparseable

### DIFF
--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -4,6 +4,7 @@ import pytest
 
 from galaxy import config
 from galaxy.config import DEFAULT_EMAIL_FROM_LOCAL_PART
+from galaxy.exceptions import ConfigurationError
 from galaxy.util.properties import running_from_source
 
 
@@ -50,6 +51,20 @@ def test_assign_email_from(monkeypatch):
         override_tempdir=False, galaxy_infrastructure_url="http://myhost:8080/galaxy/"
     )
     assert appconfig.email_from == f"{DEFAULT_EMAIL_FROM_LOCAL_PART}@myhost"
+
+
+@pytest.mark.parametrize("bracket", ["[", "]"])
+def test_error_if_database_connection_contains_brackets(bracket):
+    uri = f"dbscheme://user:pass{bracket}word@host/db"
+
+    with pytest.raises(ConfigurationError):
+        config.GalaxyAppConfiguration(override_tempdir=False, database_connection=uri)
+
+    with pytest.raises(ConfigurationError):
+        config.GalaxyAppConfiguration(override_tempdir=False, install_database_connection=uri)
+
+    with pytest.raises(ConfigurationError):
+        config.GalaxyAppConfiguration(override_tempdir=False, amqp_internal_connection=uri)
 
 
 class TestIsFetchWithCeleryEnabled:


### PR DESCRIPTION
Fixes #16083.

This does not address the issue caused by characters `#/?` that prevent masking of passwords, discussed in https://github.com/galaxyproject/galaxy/issues/16083#issuecomment-1562201983. That problem appears to be more complicated and will be addressed in a separate PR.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
