### PR TITLE
Migrate display applications API to Fast API

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -242,6 +242,20 @@ export interface paths {
          */
         get: operations["types_and_mapping_api_datatypes_types_and_mapping_get"];
     };
+    "/api/display_applications": {
+        /**
+         * Returns the list of display applications.
+         * @description Returns the list of display applications.
+         */
+        get: operations["display_applications_index_api_display_applications_get"];
+    };
+    "/api/display_applications/reload": {
+        /**
+         * Reloads the list of display applications.
+         * @description Reloads the list of display applications.
+         */
+        post: operations["display_applications_reload_api_display_applications_reload_post"];
+    };
     "/api/drs_download/{object_id}": {
         /** Download */
         get: operations["download_api_drs_download__object_id__get"];
@@ -2951,6 +2965,19 @@ export interface components {
              */
             links: components["schemas"]["Hyperlink"][];
         };
+        /** DisplayApplication */
+        DisplayApplication: {
+            /** Filename */
+            filename_: string;
+            /** Id */
+            id: string;
+            /** Links */
+            links: components["schemas"]["Link"][];
+            /** Name */
+            name: string;
+            /** Version */
+            version: string;
+        };
         /**
          * ElementsFromType
          * @description An enumeration.
@@ -5644,6 +5671,11 @@ export interface components {
              */
             url: string;
         };
+        /** Link */
+        Link: {
+            /** Name */
+            name: string;
+        };
         /**
          * MaterializeDatasetInstanceAPIRequest
          * @description Base model definition with common configuration used by all derived models.
@@ -6394,6 +6426,15 @@ export interface components {
          * @default []
          */
         QuotaSummaryList: components["schemas"]["QuotaSummary"][];
+        /** ReloadFeedback */
+        ReloadFeedback: {
+            /** Failed */
+            failed: string[];
+            /** Message */
+            message: string;
+            /** Reloaded */
+            reloaded: string[];
+        };
         /**
          * RemoteFilesDisableMode
          * @description An enumeration.
@@ -8841,6 +8882,53 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["DatatypesCombinedMap"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    display_applications_index_api_display_applications_get: {
+        /**
+         * Returns the list of display applications.
+         * @description Returns the list of display applications.
+         */
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["DisplayApplication"][];
+                };
+            };
+        };
+    };
+    display_applications_reload_api_display_applications_reload_post: {
+        /**
+         * Reloads the list of display applications.
+         * @description Reloads the list of display applications.
+         */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    [key: string]: string[] | undefined;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["ReloadFeedback"];
                 };
             };
             /** @description Validation Error */

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -766,26 +766,6 @@ def populate_api_routes(webapp, app):
         "update_step", "/steps/{step_id}", action="update_invocation_step", conditions=dict(method=["PUT"])
     )
 
-    # ======================================
-    # ====== DISPLAY APPLICATIONS API ======
-    # ======================================
-
-    webapp.mapper.connect(
-        "index",
-        "/api/display_applications",
-        controller="display_applications",
-        action="index",
-        conditions=dict(method=["GET"]),
-    )
-
-    webapp.mapper.connect(
-        "reload",
-        "/api/display_applications/reload",
-        controller="display_applications",
-        action="reload",
-        conditions=dict(method=["POST"]),
-    )
-
     # ================================
     # ===== USERS API =====
     # ================================

--- a/lib/galaxy_test/api/test_display_applications.py
+++ b/lib/galaxy_test/api/test_display_applications.py
@@ -28,7 +28,7 @@ class TestDisplayApplicationsApi(ApiTestCase):
         all_ids = [display_app["id"] for display_app in display_apps]
         input_ids = self._get_half_random_items(all_ids)
         payload = {"ids": input_ids}
-        response = self._post("display_applications/reload", payload, admin=True)
+        response = self._post("display_applications/reload", payload, admin=True, json=True)
         self._assert_status_code_is(response, 200)
         reloaded = response.json()["reloaded"]
         assert len(reloaded) == len(input_ids)
@@ -38,7 +38,7 @@ class TestDisplayApplicationsApi(ApiTestCase):
     def test_reload_unknown_returns_as_failed(self):
         unknown_id = "unknown"
         payload = {"ids": [unknown_id]}
-        response = self._post("display_applications/reload", payload, admin=True)
+        response = self._post("display_applications/reload", payload, admin=True, json=True)
         self._assert_status_code_is(response, 200)
         reloaded = response.json()["reloaded"]
         failed = response.json()["failed"]


### PR DESCRIPTION
This is a part of #10889.


## Summary
- [x] Add pydantic models
- [x]  Operations now return pydanctic models
- [x] Removed the mapping to the legacy route and add FastAPI routes


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
    You can find the interactive API documentation here: [http://127.0.0.1:8080/api/docs#/display_applications](url) 


![manual_testing_display_applications](https://github.com/galaxyproject/galaxy/assets/117033448/5dcd16d8-f993-4665-aecd-a813eed56e24)



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
