### PR TITLE
Dataset error preview

### DIFF
--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -18,14 +18,16 @@
                         }}</b-link>
                     </span>
                     <!-- Include Job Detail Provider and Dataset Error Details here -->
-                    <JobDetailsProvider>
-                        <div class="info">
-                            <span class="value">{{ toolStderr }}</span>
-                        </div>
+                    <JobDetailsProvider
+                        v-slot="{ result: jobDetails, loading }"
+                        :job-id="result.creating_job" >
+                            <div v-if="!loading && jobDetails.tool_stderr" class="info">
+                                <span class="value">{{ jobDetails.tool_stderr }}</span>
+                            </div>
+                            <div v-else-if="result.misc_info" class="info">
+                                <span class="value">{{ result.misc_info }}</span>
+                            </div>
                     </JobDetailsProvider>
-                    <div v-if="result.misc_info" class="info">
-                        <span class="value">{{ result.misc_info }}</span>
-                    </div>
                 </div>
                 <DatasetActions
                     :item="result"

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -19,13 +19,13 @@
                     </span>
                     <!-- Include Job Detail Provider and Dataset Error Details here -->
                     <JobDetailsProvider>
-                        <div v-if="toolStderr" class="info">
+                        <div class="info">
                             <span class="value">{{ toolStderr }}</span>
                         </div>
                     </JobDetailsProvider>
-                    <!-- <div v-if="result.misc_info" class="info">
+                    <div v-if="result.misc_info" class="info">
                         <span class="value">{{ result.misc_info }}</span>
-                    </div> -->
+                    </div>
                 </div>
                 <DatasetActions
                     :item="result"

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -17,6 +17,7 @@
                             result.genome_build
                         }}</b-link>
                     </span>
+                    <!-- Include Job Detail Provider and Dataset Error Details here -->
                     <div v-if="result.misc_info" class="info">
                         <span class="value">{{ result.misc_info }}</span>
                     </div>

--- a/client/src/components/History/Content/Dataset/DatasetDetails.vue
+++ b/client/src/components/History/Content/Dataset/DatasetDetails.vue
@@ -18,9 +18,14 @@
                         }}</b-link>
                     </span>
                     <!-- Include Job Detail Provider and Dataset Error Details here -->
-                    <div v-if="result.misc_info" class="info">
+                    <JobDetailsProvider>
+                        <div v-if="toolStderr" class="info">
+                            <span class="value">{{ toolStderr }}</span>
+                        </div>
+                    </JobDetailsProvider>
+                    <!-- <div v-if="result.misc_info" class="info">
                         <span class="value">{{ result.misc_info }}</span>
-                    </div>
+                    </div> -->
                 </div>
                 <DatasetActions
                     :item="result"
@@ -89,19 +94,22 @@
 import { STATES } from "components/History/Content/model/states";
 import { DatasetProvider } from "components/providers/storeProviders";
 import DatasetActions from "./DatasetActions";
-import { BLink } from "bootstrap-vue";
+import { BLink } from "bootstrap-vue"; 
+import { JobDetailsProvider} from "components/providers/JobProvider";
 
 export default {
     components: {
         DatasetActions,
         DatasetProvider,
         BLink,
+        JobDetailsProvider,
     },
     props: {
         dataset: { type: Object, required: true },
         writable: { type: Boolean, default: true },
         showHighlight: { type: Boolean, default: false },
         itemUrls: { type: Object, required: true },
+        toolStderr: {type: String, default: null},
     },
     computed: {
         stateText() {


### PR DESCRIPTION
This PR Modifies the data set preview to now display the standard error message instead of just the info. Fixes #15910. 

**All changes in this PR:**

Added a conditional check to see if a standard error message exists and to display that preferentially to the misc.blurb for dataset error previews.

![image](https://github.com/galaxyproject/galaxy/assets/62220253/31af2202-ae0f-4ed0-b7aa-6d26d647e628)


## How to test the changes?
- [ ] Instructions for manual testing are as follows:

1. Import a history with an errored dataset. 
2. Expand the dataset and look at the preview error message.



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
