### PR TITLE
adjust grid sharing indicators

### DIFF
--- a/client/src/components/Indices/SharingIndicators.vue
+++ b/client/src/components/Indices/SharingIndicators.vue
@@ -1,7 +1,21 @@
+<script setup lang="ts">
+import { BButton, VBTooltip } from "bootstrap-vue";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faShareAlt, faGlobe, faLink } from "@fortawesome/free-solid-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+
+library.add(faGlobe, faShareAlt, faLink);
+
+interface SharingIndicatorsProps {
+    object: Object;
+}
+const props = defineProps<SharingIndicatorsProps>();
+</script>
+
 <template>
     <span>
         <b-button
-            v-if="object.published"
+            v-if="props.object.published"
             v-b-tooltip.hover
             class="sharing-indicator-published"
             size="sm"
@@ -11,7 +25,7 @@
             <font-awesome-icon icon="globe" />
         </b-button>
         <b-button
-            v-if="object.importable"
+            v-if="props.object.importable"
             v-b-tooltip.hover
             class="sharing-indicator-importable"
             size="sm"
@@ -21,7 +35,7 @@
             <font-awesome-icon icon="link" />
         </b-button>
         <b-button
-            v-if="object.shared"
+            v-if="props.object.shared"
             v-b-tooltip.hover
             class="sharing-indicator-shared"
             size="sm"
@@ -32,26 +46,3 @@
         </b-button>
     </span>
 </template>
-
-<script>
-import { VBTooltip } from "bootstrap-vue";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { faShareAlt, faGlobe, faLink } from "@fortawesome/free-solid-svg-icons";
-import { library } from "@fortawesome/fontawesome-svg-core";
-library.add(faGlobe, faShareAlt, faLink);
-
-export default {
-    components: {
-        FontAwesomeIcon,
-    },
-    directives: {
-        VBTooltip,
-    },
-    props: {
-        object: {
-            type: Object,
-            required: true,
-        },
-    },
-};
-</script>

--- a/client/src/components/Indices/SharingIndicators.vue
+++ b/client/src/components/Indices/SharingIndicators.vue
@@ -6,9 +6,19 @@
             class="sharing-indicator-published"
             size="sm"
             variant="link"
-            :title="'Search more published items' | localize"
+            :title="'Find all published items' | localize"
             @click.prevent="$emit('filter', 'is:published')">
-            <Icon fixed-width icon="globe" />
+            <font-awesome-icon icon="globe" />
+        </b-button>
+        <b-button
+            v-if="object.importable"
+            v-b-tooltip.hover
+            class="sharing-indicator-importable"
+            size="sm"
+            variant="link"
+            :title="'Find all importable items' | localize"
+            @click.prevent="$emit('filter', 'is:importable')">
+            <font-awesome-icon icon="link" />
         </b-button>
         <b-button
             v-if="object.shared"
@@ -16,20 +26,24 @@
             class="sharing-indicator-shared"
             size="sm"
             variant="link"
-            :title="'Search more items shared with me' | localize"
+            :title="'Find all items shared with me' | localize"
             @click.prevent="$emit('filter', 'is:shared_with_me')">
-            <Icon fixed-width icon="share-alt" />
+            <font-awesome-icon icon="share-alt" />
         </b-button>
     </span>
 </template>
 
 <script>
 import { VBTooltip } from "bootstrap-vue";
-import { faShareAlt, faGlobe } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faShareAlt, faGlobe, faLink } from "@fortawesome/free-solid-svg-icons";
 import { library } from "@fortawesome/fontawesome-svg-core";
-library.add(faGlobe, faShareAlt);
+library.add(faGlobe, faShareAlt, faLink);
 
 export default {
+    components: {
+        FontAwesomeIcon,
+    },
     directives: {
         VBTooltip,
     },

--- a/client/src/components/Indices/filtersMixin.js
+++ b/client/src/components/Indices/filtersMixin.js
@@ -43,8 +43,8 @@ export default {
         appendTagFilter(tag, text) {
             this.appendFilter(`${tag}:'${text}'`);
         },
-        appendFilter(text) {
-            const initialFilter = this.filter;
+        appendFilter(text, replace = false) {
+            const initialFilter = replace ? "" : this.filter;
             if (initialFilter.length === 0) {
                 this.filter = text;
             } else if (initialFilter.indexOf(text) < 0) {

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -30,9 +30,7 @@
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
-                <div class="float-left m-1 text-break">
-                    Created by {{ markdownConfig.username }} with Galaxy {{ version }} on {{ time }}
-                </div>
+                <div class="float-left m-1 text-break">Generated with Galaxy {{ version }} on {{ time }}</div>
                 <div class="float-right m-1">Identifier: {{ markdownConfig.id }}</div>
             </b-badge>
             <div>

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -30,7 +30,9 @@
                 </span>
             </div>
             <b-badge variant="info" class="w-100 rounded mb-3 white-space-normal">
-                <div class="float-left m-1 text-break">Generated with Galaxy {{ version }} on {{ time }}</div>
+                <div class="float-left m-1 text-break">
+                    Created by {{ markdownConfig.username }} with Galaxy {{ version }} on {{ time }}
+                </div>
                 <div class="float-right m-1">Identifier: {{ markdownConfig.id }}</div>
             </b-badge>
             <div>

--- a/client/src/components/Sharing/Sharing.vue
+++ b/client/src/components/Sharing/Sharing.vue
@@ -31,10 +31,7 @@
             </b-form-checkbox>
             <br />
             <div v-if="item.importable">
-                <div>
-                    This {{ modelClass }} is currently <strong>{{ itemStatus }}</strong
-                    >.
-                </div>
+                <div>This {{ modelClass }} is currently {{ itemStatus }}.</div>
                 <p>Anyone can view and import this {{ modelClass }} by visiting the following URL:</p>
                 <blockquote>
                     <b-button v-b-tooltip.hover title="Edit URL" variant="link" size="sm" @click="onEdit">

--- a/client/src/components/Workflow/WorkflowList.test.js
+++ b/client/src/components/Workflow/WorkflowList.test.js
@@ -122,7 +122,7 @@ describe("WorkflowList.vue", () => {
             expect(columns.at(2).text()).toBe(
                 formatDistanceToNow(parseISO(`${mockWorkflowsData[0].update_time}Z`), { addSuffix: true })
             );
-            expect(row.find(".fa-globe").exists()).toBe(true);
+            expect(row.find(".sharing-indicator-published").exists()).toBe(true);
 
             // test expand summary button for longer annotations
             const annotationHead = sampleLongAnnotation.substr(0, 75);
@@ -172,7 +172,7 @@ describe("WorkflowList.vue", () => {
         it("update filter when published icon is clicked", async () => {
             const rows = wrapper.findAll("tbody > tr").wrappers;
             const row = rows[0];
-            row.find(".fa-globe").trigger("click");
+            row.find(".sharing-indicator-published").trigger("click");
             flushPromises();
             expect(wrapper.vm.filter).toBe("is:published");
         });

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -50,7 +50,7 @@
                 <SharingIndicators
                     v-if="!row.item.deleted"
                     :object="row.item"
-                    @filter="(filter) => appendFilter(filter)" />
+                    @filter="(filter) => appendFilter(filter, true)" />
                 <div v-else>&#8212;</div>
             </template>
             <template v-slot:cell(show_in_tool_panel)="row">
@@ -127,11 +127,15 @@ const helpHtml = `<div>
         <dt><code>tag</code></dt>
         <dd>
             Shows workflows with the given workflow tag. You may also click
-            on a tag in your list of workflows to filter on that tag directly.
+            on a tag to filter on that tag directly.
         </dd>
         <dt><code>is:published</code></dt>
         <dd>
             Shows published workflows.
+        </dd>
+        <dt><code>is:importable</code></dt>
+        <dd>
+            Shows importable workflows (this also means they have URL generated).
         </dd>
         <dt><code>is:shared_with_me</code></dt>
         <dd>

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -199,6 +199,8 @@ class WorkflowsManager(sharable.SharableModelManager, deletable.DeletableManager
                     elif key == "is":
                         if q == "published":
                             query = query.filter(model.StoredWorkflow.published == true())
+                        elif q == "importable":
+                            query = query.filter(model.StoredWorkflow.importable == true())
                         elif q == "deleted":
                             query = query.filter(model.StoredWorkflow.deleted == true())
                             show_deleted = true

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -42,6 +42,9 @@ from galaxy.webapps.base.controller import (
 )
 from galaxy.webapps.galaxy.api import depends
 
+import logging
+log = logging.getLogger(__name__)
+
 
 def format_bool(b):
     if b:
@@ -451,8 +454,8 @@ class PageController(BaseUIController, SharableMixin, UsesStoredWorkflowMixin, U
                     {
                         "name": "content_format",
                         "label": "Content Format",
-                        "type": "hidden",
                         "value": "markdown",
+                        "hidden": True,
                     },
                     {
                         "name": "content",

--- a/lib/galaxy/webapps/galaxy/controllers/page.py
+++ b/lib/galaxy/webapps/galaxy/controllers/page.py
@@ -42,9 +42,6 @@ from galaxy.webapps.base.controller import (
 )
 from galaxy.webapps.galaxy.api import depends
 
-import logging
-log = logging.getLogger(__name__)
-
 
 def format_bool(b):
     if b:


### PR DESCRIPTION
+ add new indicator for "importable" object
+ fix a bug in pages where content_type would actually not be hidden
+ allow filtering on importable workflows

the icons are:
- `fa-globe` for "public" (as used in workflow list and data libraries)
- `fa-link` for "importable" (this means they have a url to share, hence the icon)
- `fa-share-alt` for "shared with me" (standard sharing icon with three nodes connected)

feedback welcome

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
