### PR TITLE
[23.0] Tool filtering fix for label handling

### DIFF
--- a/client/src/components/Panels/utilities.js
+++ b/client/src/components/Panels/utilities.js
@@ -138,15 +138,27 @@ export function removeDisabledTools(tools) {
     });
 }
 
+function isToolObject(tool) {
+    // toolbox overhaul with typing will simplify this dramatically...
+    // Right now, our shorthand is that tools have no 'text', and don't match
+    // the model_class of the section/label.
+    if (!tool.text && tool.model_class !== "ToolSectionLabel" && tool.model_class !== "ToolSection") {
+        return true;
+    }
+    return false;
+}
+
 function flattenToolsSection(section) {
     const flattenTools = [];
     if (section.elems) {
         section.elems.forEach((tool) => {
-            if (!tool.text) {
+            if (isToolObject(tool)) {
                 flattenTools.push(tool);
             }
         });
-    } else if (!section.text) {
+    } else if (isToolObject(section)) {
+        // This might be a top-level section-less tool and not actually a
+        // section.
         flattenTools.push(section);
     }
     return flattenTools;

--- a/client/src/components/ToolsView/testData/toolsList.json
+++ b/client/src/components/ToolsView/testData/toolsList.json
@@ -114,5 +114,13 @@
     "version": "",
     "id": "liftOver",
     "name": "Lift-Over"
+  },
+  {
+    "model_class": "ToolSectionLabel",
+    "id": "testlabel3",
+    "text": null,
+    "version": "",
+    "description": null,
+    "links": null
   }
 ]

--- a/client/tests/jest/jest.config.js
+++ b/client/tests/jest/jest.config.js
@@ -39,6 +39,7 @@ module.exports = {
     roots: ["<rootDir>/src/", "<rootDir>/tests/jest/standalone/"],
     setupFilesAfterEnv: ["<rootDir>/tests/jest/jest.setup.js"],
     testEnvironment: "jsdom",
+    testPathIgnorePatterns: ["/node_modules/", "/dist/"],
     transform: {
         "^.+\\.js$": "babel-jest",
         "^.*\\.(vue)$": "@vue/vue2-jest",


### PR DESCRIPTION
Better testing of whether or not a thing is a tool for toolbox normalzation/flattening.

Fixes #16164 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Add a toplevel label or point your client at usegalaxy.fr; search.
  2. I'll add a test in the morning.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
