### PR TITLE
[23.0] Fix test search for mulled container hashes

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -297,7 +297,8 @@ def hashed_test_search(
         r.raise_for_status()
         p = "-".join(package)
         for line in r.text.split("\n"):
-            if p in line:
+            # include only linux-64 builds since that is hardcoded in get_anaconda_url and the only target for container builds
+            if p in line and "linux-64" in line:
                 build = line.split(p)[1].split(".tar.bz2")[0]
                 if build == "":
                     containers.append(f"{package[0]}:{package[1]}")


### PR DESCRIPTION
Fixes
```
FAILED test/unit/tool_util/mulled/test_get_tests.py::test_hashed_test_search - AssertionError: assert ['bamtools --help'] == ['bamtools --help', 'samtools --help']
  Right contains one more item: 'samtools --help'
  Full diff:
  - ['bamtools --help', 'samtools --help']
  + ['bamtools --help']
```
(again). The test broke with the addition of
`osx-64/samtools-1.3.1-h0840685_11.tar.bz2` 4 days ago.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
