### PR TITLE
Fix and Improve Workflow Editor Panning

### DIFF
--- a/client/src/components/Workflow/Editor/Draggable.vue
+++ b/client/src/components/Workflow/Editor/Draggable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, inject, reactive } from "vue";
+import { ref, inject, reactive, PropType } from "vue";
 import type { Ref } from "vue";
 import { useAnimationFrameSize } from "@/composables/sensors/animationFrameSize";
 import { useAnimationFrameThrottle } from "@/composables/throttle";
@@ -8,7 +8,7 @@ import type { ZoomTransform } from "d3-zoom";
 
 const props = defineProps({
     rootOffset: {
-        type: Object,
+        type: Object as PropType<Position>,
         required: true,
     },
     preventDefault: {
@@ -37,9 +37,12 @@ type Position = { x: number; y: number };
 
 const { throttle } = useAnimationFrameThrottle();
 
+let dragging = false;
+
 const onStart = (position: Position, event: DragEvent) => {
     emit("start");
     emit("mousedown", event);
+
     if (event.type == "dragstart") {
         dragImg = document.createElement("img");
         dragImg.src = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
@@ -59,18 +62,22 @@ const onStart = (position: Position, event: DragEvent) => {
 };
 
 const onMove = (position: Position, event: DragEvent) => {
+    dragging = true;
+
     if (event.type == "drag" && event.x == 0 && event.y == 0) {
         // the last drag event has no coordinate ... this is obviously a hack!
         return;
     }
 
     throttle(() => {
-        const newPosition = {
-            unscaled: { ...position, ...size },
-            x: (position.x - props.rootOffset.x - transform!.value.x) / transform!.value.k,
-            y: (position.y - props.rootOffset.y - transform!.value.y) / transform!.value.k,
-        };
-        emit("move", newPosition, event);
+        if (dragging) {
+            const newPosition = {
+                unscaled: { ...position, ...size },
+                x: (position.x - props.rootOffset.x - transform!.value.x) / transform!.value.k,
+                y: (position.y - props.rootOffset.y - transform!.value.y) / transform!.value.k,
+            };
+            emit("move", newPosition, event);
+        }
     });
 };
 
@@ -78,8 +85,10 @@ const onEnd = (position: Position, event: DragEvent) => {
     if (dragImg) {
         document.body.removeChild(dragImg);
     }
-    emit("stop");
+
+    dragging = false;
     emit("mouseup");
+    emit("stop");
 };
 
 useDraggable(draggable, {


### PR DESCRIPTION
Fixes and issue with workflow editor panning, where letting go of a node in the right moment caused panning to continue indefinitely.

Also makes panning speed refresh rate independent, and adaptive (within limits) depending on how far an element is dragged beyond the editors border.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
