### PR TITLE
Updates MGnify interactive tool to v1.1.0

### DIFF
--- a/tools/interactive/interactivetool_mgnify_notebook.xml
+++ b/tools/interactive/interactivetool_mgnify_notebook.xml
@@ -1,6 +1,6 @@
-<tool id="interactive_tool_mgnify_notebook" tool_type="interactive" name="Interactive MGnify Notebook" version="0.0.1" profile="22.01">
+<tool id="interactive_tool_mgnify_notebook" tool_type="interactive" name="Interactive MGnify Notebook" version="1.1.0" profile="22.01">
     <requirements>
-        <container type="docker">quay.io/microbiome-informatics/emg-notebooks.dev:v1.0.1</container>
+        <container type="docker">quay.io/microbiome-informatics/emg-notebooks.dev:v1.1.0</container>
     </requirements>
     <entry_points>
         <entry_point name="MGnify Interactive Tool" requires_domain="True">


### PR DESCRIPTION
This PR updates the docker tag for the MGnify Interactive Tool to v1.1.0. This newer tag is [the latest stable release of the MGnify notebooks](https://github.com/EBI-Metagenomics/notebooks/releases/tag/v1.1.0), and includes some notebook improvements as well as better handling of R/Python dependencies.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
