### PR TITLE
Update carbon emissions calculations explanation page styling

### DIFF
--- a/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissionsCalculations.vue
+++ b/client/src/components/JobMetrics/CarbonEmissions/CarbonEmissionsCalculations.vue
@@ -100,14 +100,14 @@ const greenAlgorithmsUrl = "https://www.green-algorithms.org/";
             </p>
 
             <pre>
-              energy_needed_cpu = runtime * power_needed_cpu / 1000
-              energy_needed_memory = runtime * power_needed_memory / 1000
-              total_energy_needed = runtime * total_power_needed / 1000
+                energy_needed_cpu = runtime * power_needed_cpu / 1000
+                energy_needed_memory = runtime * power_needed_memory / 1000
+                total_energy_needed = runtime * total_power_needed / 1000
             </pre>
 
             <p>
                 Finally, we convert the energy usage into estimated carbon emissions (in metric units CO2e) by
-                multiplying the carbon intensity of the server location.
+                multiplying the carbon intensity of the server location:
             </p>
 
             <pre>
@@ -157,16 +157,20 @@ const greenAlgorithmsUrl = "https://www.green-algorithms.org/";
     </article>
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
+@import "scss/theme/blue.scss";
+
 pre {
     font-weight: bold;
     white-space: pre-line;
-    border-left: 4px solid lightgray;
+    line-height: 1.5rem;
+    background-color: $gray-100;
+    border: 1px solid $brand-secondary;
     border-radius: 4px;
-    padding-left: 1rem;
+    padding: 1rem;
 }
 
 section {
-    margin-top: 2rem;
+    margin-top: 4rem;
 }
 </style>


### PR DESCRIPTION
Addresses #15046. This PR updates the page explaining the carbon emissions to make everything nicer on the eyes and more readable.

Old UI:
[Screencast from 2023-05-31 11-17-57.webm](https://github.com/galaxyproject/galaxy/assets/57318507/adea054c-3f15-4831-8892-9a5e09bd4cdb)

New UI:
[Screencast from 2023-06-06 09-54-14.webm](https://github.com/galaxyproject/galaxy/assets/57318507/71373e60-9145-4de2-adfc-0092637c4028)

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
