### PR TITLE
[23.0] Support ro crate 0.8.0 and 0.7.0

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2450,7 +2450,7 @@ class WriteCrates:
                     "encodingFormat": encoding_format,
                 }
                 ro_crate.add_file(
-                    file_name,
+                    os.path.join(self.export_directory, file_name),
                     dest_path=file_name,
                     properties=properties,
                 )

--- a/lib/galaxy/model/store/ro_crate_utils.py
+++ b/lib/galaxy/model/store/ro_crate_utils.py
@@ -6,6 +6,8 @@ from typing import (
     Optional,
 )
 
+from packaging.version import parse
+from rocrate import __version__ as rocrate_version
 from rocrate.model.computationalworkflow import (
     ComputationalWorkflow,
     WorkflowDescription,
@@ -102,13 +104,21 @@ class WorkflowRunCrateProfileBuilder:
         if dataset.dataset.id in self.model_store.dataset_id_to_path:
             filename, _ = self.model_store.dataset_id_to_path[dataset.dataset.id]
             if not filename:
+                # dataset was not serialized
                 filename = f"datasets/dataset_{dataset.dataset.uuid}"
+                if parse(rocrate_version) >= parse("0.8.0"):
+                    source = None
+                else:
+                    # Drop in 23.1
+                    source = filename
+            else:
+                source = os.path.join(self.model_store.export_directory, filename)
             name = dataset.name
             encoding_format = dataset.datatype.get_mime()
             properties["name"] = name
             properties["encodingFormat"] = encoding_format
             file_entity = crate.add_file(
-                filename,
+                source,
                 dest_path=filename,
                 properties=properties,
             )
@@ -272,7 +282,7 @@ class WorkflowRunCrateProfileBuilder:
                     "encodingFormat": "application/json",
                 }
                 crate.add_file(
-                    attrs,
+                    attrs_path,
                     dest_path=attrs,
                     properties=properties,
                 )

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -347,7 +347,6 @@ def validate_has_pl_galaxy(ro_crate: ROCrate):
     assert programming_language.id == "https://w3id.org/workflowhub/workflow-ro-crate#galaxy"
     assert programming_language.name == "Galaxy"
     assert programming_language.url == "https://galaxyproject.org/"
-    assert programming_language.version
 
 
 def validate_organize_action(ro_crate: ROCrate):


### PR DESCRIPTION
[ro-crate-py 0.8.0](https://github.com/ResearchObject/ro-crate-py/releases/tag/0.8.0) does some more verification of the source argument, it seems having the symlink in the export directory as source and target isn't enough here, we need to provide an absolute path to the source. version has been removed from computer language, and missing entries should have `None` as the source.

I guess there's a chance downstream users may run into version conflicts if we pin ro-cate to 0.7.0 in our packages, and we also don't really want to bump stable version dependencies, so I wrote this in a way that it works with 0.8.0 (as tested by the package tests) and 0.7.0 as tested in the unit/integration tests.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
