### PR TITLE
Hide Activity Bar for anonymous users

### DIFF
--- a/client/src/entry/analysis/modules/Analysis.vue
+++ b/client/src/entry/analysis/modules/Analysis.vue
@@ -25,7 +25,7 @@ const showPanels = computed(() => {
 });
 
 const showActivityBar = computed(() => {
-    return userStore.showActivityBar;
+    return userStore.showActivityBar && !userStore.isAnonymous;
 });
 
 // methods


### PR DESCRIPTION
If a user would toggle their activity bar on, and then sign out, you would still be able to see the activity bar for anonymous users. This could expose links like workflows, visualizations, preferences to anon users and is unnecessary.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
