### PR TITLE
[23.0] Verify existence of default value attribute for user forms fields

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8609,9 +8609,10 @@ class FormDefinition(Base, Dictifiable, RepresentById):
                     "WorkflowField": WorkflowField,
                 }
             ).get(field["type"], TextField)
+            default_value = field["default"] if "default" in field else None
             form_def["inputs"].append(
                 FieldClass(
-                    user=user, value=values.get(field["name"], field["default"]), security=security, **field
+                    user=user, value=values.get(field["name"], default_value), security=security, **field
                 ).to_dict()
             )
         return form_def

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8609,7 +8609,6 @@ class FormDefinition(Base, Dictifiable, RepresentById):
                     "WorkflowField": WorkflowField,
                 }
             ).get(field["type"], TextField)
-            default_value = field["default"] if "default" in field else None
             form_def["inputs"].append(
                 FieldClass(
                     user=user, value=values.get(field["name"], field.get("default")), security=security, **field

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -8612,7 +8612,7 @@ class FormDefinition(Base, Dictifiable, RepresentById):
             default_value = field["default"] if "default" in field else None
             form_def["inputs"].append(
                 FieldClass(
-                    user=user, value=values.get(field["name"], default_value), security=security, **field
+                    user=user, value=values.get(field["name"], field.get("default")), security=security, **field
                 ).to_dict()
             )
         return form_def


### PR DESCRIPTION
It seems that in the past some custom input fields for user forms might have been stored in the database without the default value attribute. This addition will ensure that the default value `None` is used if no default value is available. Thanks @dannon.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
