### PR TITLE
Ensure session is request-scoped for legacy endpoints

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -82,6 +82,7 @@ from galaxy.util import (
     compression_utils,
     nice_size,
     sqlite,
+    UNKNOWN,
 )
 from galaxy.util.checkers import (
     is_bz2,
@@ -2516,7 +2517,7 @@ class GeminiSQLite(SQlite):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = "Gemini SQLite Database, version %s" % (dataset.metadata.gemini_version or "unknown")
+            dataset.peek = "Gemini SQLite Database, version %s" % (dataset.metadata.gemini_version or UNKNOWN)
             dataset.blurb = nice_size(dataset.get_size())
         else:
             dataset.peek = "file does not exist"
@@ -2526,7 +2527,7 @@ class GeminiSQLite(SQlite):
         try:
             return dataset.peek
         except Exception:
-            return "Gemini SQLite Database, version %s" % (dataset.metadata.gemini_version or "unknown")
+            return "Gemini SQLite Database, version %s" % (dataset.metadata.gemini_version or UNKNOWN)
 
 
 class ChiraSQLite(SQlite):
@@ -2603,7 +2604,7 @@ class CuffDiffSQlite(SQlite):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = "CuffDiff SQLite Database, version %s" % (dataset.metadata.cuffdiff_version or "unknown")
+            dataset.peek = "CuffDiff SQLite Database, version %s" % (dataset.metadata.cuffdiff_version or UNKNOWN)
             dataset.blurb = nice_size(dataset.get_size())
         else:
             dataset.peek = "file does not exist"
@@ -2613,7 +2614,7 @@ class CuffDiffSQlite(SQlite):
         try:
             return dataset.peek
         except Exception:
-            return "CuffDiff SQLite Database, version %s" % (dataset.metadata.cuffdiff_version or "unknown")
+            return "CuffDiff SQLite Database, version %s" % (dataset.metadata.cuffdiff_version or UNKNOWN)
 
 
 class MzSQlite(SQlite):
@@ -3033,8 +3034,8 @@ class NcbiTaxonomySQlite(SQlite):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             dataset.peek = "NCBI Taxonomy SQLite Database, version {} ({} taxons)".format(
-                getattr(dataset.metadata, "ncbitaxonomy_schema_version", "unknown"),
-                getattr(dataset.metadata, "taxon_count", "unknown"),
+                getattr(dataset.metadata, "ncbitaxonomy_schema_version", UNKNOWN),
+                getattr(dataset.metadata, "taxon_count", UNKNOWN),
             )
             dataset.blurb = nice_size(dataset.get_size())
         else:
@@ -3046,8 +3047,8 @@ class NcbiTaxonomySQlite(SQlite):
             return dataset.peek
         except Exception:
             return "NCBI Taxonomy SQLite Database, version {} ({} taxons)".format(
-                getattr(dataset.metadata, "ncbitaxonomy_schema_version", "unknown"),
-                getattr(dataset.metadata, "taxon_count", "unknown"),
+                getattr(dataset.metadata, "ncbitaxonomy_schema_version", UNKNOWN),
+                getattr(dataset.metadata, "taxon_count", UNKNOWN),
             )
 
 
@@ -3504,7 +3505,7 @@ class PostgresqlArchive(CompressedArchive):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             dataset.peek = f"PostgreSQL Archive ({nice_size(dataset.get_size())})"
-            dataset.blurb = "PostgreSQL version %s" % (dataset.metadata.version or "unknown")
+            dataset.blurb = "PostgreSQL version %s" % (dataset.metadata.version or UNKNOWN)
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"
@@ -3558,7 +3559,7 @@ class Fast5Archive(CompressedArchive):
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
             dataset.peek = f"FAST5 Archive ({nice_size(dataset.get_size())})"
-            dataset.blurb = "%s sequences" % (dataset.metadata.fast5_count or "unknown")
+            dataset.blurb = "%s sequences" % (dataset.metadata.fast5_count or UNKNOWN)
         else:
             dataset.peek = "file does not exist"
             dataset.blurb = "file purged from disk"
@@ -3666,7 +3667,7 @@ class SearchGuiArchive(CompressedArchive):
 
     def set_peek(self, dataset: DatasetProtocol, **kwd) -> None:
         if not dataset.dataset.purged:
-            dataset.peek = "SearchGUI Archive, version %s" % (dataset.metadata.searchgui_version or "unknown")
+            dataset.peek = "SearchGUI Archive, version %s" % (dataset.metadata.searchgui_version or UNKNOWN)
             dataset.blurb = nice_size(dataset.get_size())
         else:
             dataset.peek = "file does not exist"
@@ -3676,7 +3677,7 @@ class SearchGuiArchive(CompressedArchive):
         try:
             return dataset.peek
         except Exception:
-            return "SearchGUI Archive, version %s" % (dataset.metadata.searchgui_version or "unknown")
+            return "SearchGUI Archive, version %s" % (dataset.metadata.searchgui_version or UNKNOWN)
 
 
 @build_sniff_from_prefix

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -50,6 +50,7 @@ from galaxy.util import (
     inflector,
     iter_start_of_line,
     unicodify,
+    UNKNOWN,
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.compression_utils import FileObjType
@@ -106,7 +107,7 @@ class DatatypeValidation:
 
     @staticmethod
     def unvalidated() -> "DatatypeValidation":
-        return DatatypeValidation("unknown", "Dataset validation unimplemented for this datatype.")
+        return DatatypeValidation(UNKNOWN, "Dataset validation unimplemented for this datatype.")
 
     def __repr__(self) -> str:
         return f"DatatypeValidation[state={self.state},message={self.message}]"
@@ -713,7 +714,7 @@ class Data(metaclass=DataMeta):
         try:
             return self.supported_display_apps[type]["label"]
         except Exception:
-            return "unknown"
+            return UNKNOWN
 
     def as_display_type(self, dataset: DatasetProtocol, type: str, **kwd) -> Union[FileObjType, str]:
         """Returns modified file contents for a particular display type"""

--- a/lib/galaxy/datatypes/ngsindex.py
+++ b/lib/galaxy/datatypes/ngsindex.py
@@ -8,6 +8,7 @@ from galaxy.datatypes.protocols import (
     DatasetProtocol,
     HasExtraFilesAndMetadata,
 )
+from galaxy.util import UNKNOWN
 from .metadata import MetadataElement
 from .text import Html
 
@@ -30,7 +31,7 @@ class BowtieIndex(Html):
     MetadataElement(
         name="sequence_space",
         desc="sequence_space for this index set",
-        default="unknown",
+        default=UNKNOWN,
         set_in_upload=True,
         readonly=True,
     )

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -43,6 +43,7 @@ from galaxy.util import (
     ParamsWithSpecs,
     shrink_stream_by_size,
     unicodify,
+    UNKNOWN,
 )
 from galaxy.util.custom_logging import get_logger
 from galaxy.util.monitors import Monitors
@@ -146,11 +147,11 @@ class BaseJobRunner:
                     # arg should be a JobWrapper/TaskWrapper
                     job_id = arg.get_id_tag()
             except Exception:
-                job_id = "unknown"
+                job_id = UNKNOWN
             try:
                 name = method.__name__
             except Exception:
-                name = "unknown"
+                name = UNKNOWN
             try:
                 action_str = f"galaxy.jobs.runners.{self.__class__.__name__.lower()}.{name}"
                 action_timer = self.app.execution_timer_factory.get_timer(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4181,7 +4181,7 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
         deleted=False,
         designation=None,
         parent_id=None,
-        validated_state="unknown",
+        validated_state=DatasetValidatedState.UNKNOWN,
         validated_state_message=None,
         visible=True,
         create_dataset=False,

--- a/lib/galaxy/tool_shed/util/dependency_display.py
+++ b/lib/galaxy/tool_shed/util/dependency_display.py
@@ -3,6 +3,7 @@ import os
 
 from galaxy import util
 from galaxy.tool_shed.util import utility_container_manager
+from galaxy.util import UNKNOWN
 from galaxy.util.tool_shed.common_util import parse_repository_dependency_tuple
 
 log = logging.getLogger(__name__)
@@ -24,9 +25,9 @@ class DependencyDisplayer:
         for dependency_key, requirements_dict in tool_dependencies.items():
             if dependency_key in ["set_environment"]:
                 continue
-            repository_name = requirements_dict.get("repository_name", "unknown")
-            repository_owner = requirements_dict.get("repository_owner", "unknown")
-            changeset_revision = requirements_dict.get("changeset_revision", "unknown")
+            repository_name = requirements_dict.get("repository_name", UNKNOWN)
+            repository_owner = requirements_dict.get("repository_owner", UNKNOWN)
+            changeset_revision = requirements_dict.get("changeset_revision", UNKNOWN)
             dependency_name = requirements_dict["name"]
             version = requirements_dict["version"]
             if self.app.tool_dependency_dir:

--- a/lib/galaxy/tool_shed/util/utility_container_manager.py
+++ b/lib/galaxy/tool_shed/util/utility_container_manager.py
@@ -9,6 +9,7 @@ from galaxy.tool_shed.util.repository_util import (
     extract_components_from_tuple,
     get_tool_shed_repository_by_id,
 )
+from galaxy.util import UNKNOWN
 from galaxy.util.tool_shed.common_util import parse_repository_dependency_tuple
 
 log = logging.getLogger(__name__)
@@ -253,8 +254,8 @@ class UtilityContainerManager:
                     data_tables = ", ".join(data_manager_dict.get("data_tables", ""))
                 except Exception as e:
                     name = str(e)
-                    version = "unknown"
-                    data_tables = "unknown"
+                    version = UNKNOWN
+                    data_tables = UNKNOWN
                 data_manager = DataManager(id=data_manager_id, name=name, version=version, data_tables=data_tables)
                 folder.valid_data_managers.append(data_manager)
         else:
@@ -442,28 +443,28 @@ class UtilityContainerManager:
                     requirements_str = ""
                     for requirement_dict in requirements:
                         try:
-                            requirement_name = str(requirement_dict.get("name", "unknown"))
-                            requirement_type = str(requirement_dict.get("type", "unknown"))
+                            requirement_name = str(requirement_dict.get("name", UNKNOWN))
+                            requirement_type = str(requirement_dict.get("type", UNKNOWN))
                         except Exception as e:
                             requirement_name = str(e)
-                            requirement_type = "unknown"
+                            requirement_type = UNKNOWN
                         requirements_str += f"{requirement_name} ({requirement_type}), "
                     requirements_str = requirements_str.rstrip(", ")
                 else:
                     requirements_str = "none"
                 try:
                     tool_config = str(tool_dict.get("tool_config", "missing"))
-                    tool_id = str(tool_dict.get("id", "unknown"))
-                    name = str(tool_dict.get("name", "unknown"))
+                    tool_id = str(tool_dict.get("id", UNKNOWN))
+                    name = str(tool_dict.get("name", UNKNOWN))
                     description = str(tool_dict.get("description", ""))
-                    version = str(tool_dict.get("version", "unknown"))
+                    version = str(tool_dict.get("version", UNKNOWN))
                     profile = str(tool_dict.get("profile", "any"))
                 except Exception as e:
                     tool_config = str(e)
-                    tool_id = "unknown"
-                    name = "unknown"
+                    tool_id = UNKNOWN
+                    name = UNKNOWN
                     description = ""
-                    version = "unknown"
+                    version = UNKNOWN
                 tool = Tool(
                     id=container_object_tool_id,
                     tool_config=tool_config,
@@ -547,9 +548,9 @@ class UtilityContainerManager:
                             td_id = set_environment_dict.get("tool_dependency_id", None)
                         except Exception as e:
                             name = str(e)
-                            type = "unknown"
-                            repository_id = "unknown"
-                            td_id = "unknown"
+                            type = UNKNOWN
+                            repository_id = UNKNOWN
+                            td_id = UNKNOWN
                         if self.app.name == "galaxy":
                             try:
                                 installation_status = set_environment_dict.get("status", "Never installed")
@@ -577,10 +578,10 @@ class UtilityContainerManager:
                         td_id = requirements_dict.get("tool_dependency_id", None)
                     except Exception as e:
                         name = str(e)
-                        version = "unknown"
-                        type = "unknown"
-                        repository_id = "unknown"
-                        td_id = "unknown"
+                        version = UNKNOWN
+                        type = UNKNOWN
+                        repository_id = UNKNOWN
+                        td_id = UNKNOWN
                     if self.app.name == "galaxy":
                         try:
                             installation_status = requirements_dict.get("status", "Never installed")
@@ -672,7 +673,7 @@ class UtilityContainerManager:
             repository_dependency = repository_dependency[0:6]
         else:
             tool_shed_repository_id = None
-            installation_status = "unknown"
+            installation_status = UNKNOWN
         if tool_shed_repository_id:
             tool_shed_repository = get_tool_shed_repository_by_id(
                 self.app, self.app.security.encode_id(tool_shed_repository_id)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -140,6 +140,7 @@ from galaxy.util import (
     rst_to_html,
     string_as_bool,
     unicodify,
+    UNKNOWN,
     XML,
 )
 from galaxy.util.bunch import Bunch
@@ -2158,7 +2159,7 @@ class Tool(Dictifiable):
             )
         except exceptions.ToolExecutionError as exc:
             job = exc.job
-            job_id = "unknown"
+            job_id = UNKNOWN
             if job is not None:
                 job.mark_failed(info=exc.err_msg, blurb=exc.err_code.default_error_message)
                 job_id = job.id

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -139,6 +139,8 @@ XML = etree.XML
 
 defaultdict = collections.defaultdict
 
+UNKNOWN = "unknown"
+
 
 def str_removeprefix(s: str, prefix: str):
     """

--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -5,7 +5,9 @@ import io
 import json
 import logging
 import os
+import random
 import socket
+import string
 import tarfile
 import tempfile
 import time
@@ -26,7 +28,10 @@ import webob.exc as httpexceptions
 # We will use some very basic HTTP/wsgi utilities from the paste library
 from paste.response import HeaderDict
 
-from galaxy.util import smart_str
+from galaxy.util import (
+    smart_str,
+    UNKNOWN,
+)
 from galaxy.util.resources import resource_string
 
 log = logging.getLogger(__name__)
@@ -200,9 +205,13 @@ class WebApplication:
 
     def handle_request(self, environ, start_response, body_renderer=None):
         # Grab the request_id (should have been set by middleware)
-        request_id = environ.get("request_id", "unknown")
-        # Map url using routes
+        request_id = environ.get("request_id", UNKNOWN)
         path_info = environ.get("PATH_INFO", "")
+
+        unique_request_id = self._make_unique_request_id(request_id, path_info)
+        self._model.set_request_id(unique_request_id)  # Start SQLAlchemy session scope
+
+        # Map url using routes
         client_match = self.clientside_routes.match(path_info, environ)
         map_match = self.mapper.match(path_info, environ) or client_match
         if path_info.startswith("/api"):
@@ -255,7 +264,19 @@ class WebApplication:
             if not body:
                 raise
         body_renderer = body_renderer or self._render_body
+        self._model.unset_request_id(unique_request_id)  # End SQLAlchemy session scope
         return body_renderer(trans, body, environ, start_response)
+
+    def _make_unique_request_id(self, request_id, path_info):
+        """
+        If request_id is insufficiently unique, construct a reasonably unique identifier.
+        """
+        if not request_id or request_id == UNKNOWN:
+            path_hash = hash(path_info)
+            # Add a pseudo-random suffix to account for identical paths
+            suffix = "".join(random.choices(string.ascii_lowercase, k=5))
+            request_id = f"{request_id}_{path_hash}_{suffix}"
+        return request_id
 
     def _render_body(self, trans, body, environ, start_response):
         # Now figure out what we got back and try to get it to the browser in

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -113,6 +113,10 @@ class WebApplication(base.WebApplication):
         # Security helper
         self.security = galaxy_app.security
 
+        # We need this to set the REQUEST_ID contextvar in model.base *BEFORE* a GalaxyWebTransaction is created.
+        # This will ensure a SQLAlchemy session is request-scoped for legacy (non-fastapi) endpoints.
+        self._model = galaxy_app.model
+
     def build_apispec(self):
         """
         Traverse all route paths starting with "api" and create an APISpec instance.

--- a/lib/galaxy/webapps/reports/buildapp.py
+++ b/lib/galaxy/webapps/reports/buildapp.py
@@ -13,6 +13,9 @@ import galaxy.model.mapping
 import galaxy.webapps.base.webapp
 from galaxy.util import asbool
 from galaxy.util.properties import load_app_properties
+from galaxy.web.framework.middleware.error import ErrorMiddleware
+from galaxy.web.framework.middleware.request_id import RequestIDMiddleware
+from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
 from galaxy.webapps.base.webapp import build_url_map
 from galaxy.webapps.util import wrap_if_allowed
 
@@ -91,16 +94,14 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         app = wrap_if_allowed(app, stack, recursive.RecursiveMiddleware, args=(conf,))
 
     # Error middleware
-    import galaxy.web.framework.middleware.error
-
-    app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
+    app = wrap_if_allowed(app, stack, ErrorMiddleware, args=(conf,))
     # Transaction logging (apache access.log style)
     if asbool(conf.get("use_translogger", True)):
         from paste.translogger import TransLogger
 
         app = wrap_if_allowed(app, stack, TransLogger)
     # X-Forwarded-Host handling
-    from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
-
     app = wrap_if_allowed(app, stack, XForwardedHostMiddleware)
+    # Request ID handling
+    app = wrap_if_allowed(app, stack, RequestIDMiddleware)
     return app

--- a/lib/galaxy/webapps/reports/controllers/workflows.py
+++ b/lib/galaxy/webapps/reports/controllers/workflows.py
@@ -20,6 +20,7 @@ from galaxy import (
     model,
     util,
 )
+from galaxy.util import UNKNOWN
 from galaxy.web.legacy_framework import grids
 from galaxy.webapps.base.controller import (
     BaseUIController,
@@ -47,7 +48,7 @@ class SpecifiedDateListGrid(grids.Grid):
         def get_value(self, trans, grid, stored_workflow):
             if stored_workflow.user:
                 return escape(stored_workflow.user.email)
-            return "unknown"
+            return UNKNOWN
 
     class EmailColumn(grids.GridColumn):
         def filter(self, trans, user, query, column_filter):

--- a/lib/galaxy_test/api/test_display_applications.py
+++ b/lib/galaxy_test/api/test_display_applications.py
@@ -1,6 +1,7 @@
 import random
 from typing import List
 
+from galaxy.util import UNKNOWN
 from galaxy_test.base.decorators import requires_admin
 from ._framework import ApiTestCase
 
@@ -36,7 +37,7 @@ class TestDisplayApplicationsApi(ApiTestCase):
 
     @requires_admin
     def test_reload_unknown_returns_as_failed(self):
-        unknown_id = "unknown"
+        unknown_id = UNKNOWN
         payload = {"ids": [unknown_id]}
         response = self._post("display_applications/reload", payload, admin=True, json=True)
         self._assert_status_code_is(response, 200)

--- a/lib/galaxy_test/api/test_licenses.py
+++ b/lib/galaxy_test/api/test_licenses.py
@@ -1,3 +1,4 @@
+from galaxy.util import UNKNOWN
 from ._framework import ApiTestCase
 
 
@@ -13,7 +14,7 @@ class TestLicensesApi(ApiTestCase):
         self._assert_matches_license_id(licenseId, response.json())
 
     def test_404_on_unknown_license(self):
-        licenseId = "unknown"
+        licenseId = UNKNOWN
         response = self._get(f"licenses/{licenseId}")
         self._assert_status_code_is(response, 404)
 

--- a/lib/galaxy_test/api/test_tool_data.py
+++ b/lib/galaxy_test/api/test_tool_data.py
@@ -7,6 +7,7 @@ since these tests can mutate the server config state.
 
 import operator
 
+from galaxy.util import UNKNOWN
 from ._framework import ApiTestCase
 
 
@@ -75,7 +76,7 @@ class TestToolDataApi(ApiTestCase):
         self._assert_status_code_is(delete_response, 400)
 
     def test_delete_without_values_raises_400(self):
-        payload = {"unknown": "test"}
+        payload = {UNKNOWN: "test"}
         delete_response = self._delete("tool_data/testbeta", data=payload, admin=True)
         self._assert_status_code_is(delete_response, 400)
 

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -6,6 +6,7 @@ import pytest
 from tusclient import client
 
 from galaxy.tool_util.verify.test_data import TestDataResolver
+from galaxy.util import UNKNOWN
 from galaxy.util.unittest_utils import (
     skip_if_github_down,
     skip_if_site_down,
@@ -909,7 +910,7 @@ class TestToolsUpload(ApiTestCase):
         with open(path, "rb") as fh:
             metadata = self._upload_and_get_details(fh, file_type="fastqcssanger")
         assert "validated_state" in metadata
-        assert metadata["validated_state"] == "unknown"
+        assert metadata["validated_state"] == UNKNOWN
         history_id = metadata["history_id"]
         dataset_id = metadata["id"]
         terminal_validated_state = self.dataset_populator.validate_dataset_and_wait(history_id, dataset_id)
@@ -920,7 +921,7 @@ class TestToolsUpload(ApiTestCase):
         with open(path, "rb") as fh:
             metadata = self._upload_and_get_details(fh, file_type="fastqsanger")
         assert "validated_state" in metadata
-        assert metadata["validated_state"] == "unknown"
+        assert metadata["validated_state"] == UNKNOWN
         history_id = metadata["history_id"]
         dataset_id = metadata["id"]
         terminal_validated_state = self.dataset_populator.validate_dataset_and_wait(history_id, dataset_id)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -25,6 +25,7 @@ from requests import (
 )
 
 from galaxy.exceptions import error_codes
+from galaxy.util import UNKNOWN
 from galaxy_test.base import rules_test_data
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
@@ -5740,7 +5741,7 @@ steps:
                 history_id=history_id,
             )
             hda2 = self.dataset_populator.get_history_dataset_details(history_id, hid=2)
-            assert hda2["validated_state"] == "unknown"
+            assert hda2["validated_state"] == UNKNOWN
 
     @skip_without_tool("cat1")
     def test_validated_post_job_action_invalid(self):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -98,6 +98,7 @@ from galaxy.tool_util.verify.wait import (
 from galaxy.util import (
     DEFAULT_SOCKET_TIMEOUT,
     galaxy_root_path,
+    UNKNOWN,
 )
 from galaxy.util.resources import resource_string
 from galaxy.util.unittest_utils import skip_if_site_down
@@ -1195,7 +1196,7 @@ class BaseDatasetPopulator(BasePopulator):
         def validated():
             metadata = self.get_history_dataset_details(history_id, dataset_id=dataset_id)
             validated_state = metadata["validated_state"]
-            if validated_state == "unknown":
+            if validated_state == UNKNOWN:
                 return
             else:
                 return validated_state

--- a/lib/tool_shed/utility_containers/__init__.py
+++ b/lib/tool_shed/utility_containers/__init__.py
@@ -7,6 +7,7 @@ from galaxy.tool_shed.util.container_util import (
     generate_repository_dependencies_key_for_repository,
     STRSEP,
 )
+from galaxy.util import UNKNOWN
 from galaxy.util.tool_shed.common_util import parse_repository_dependency_tuple
 from tool_shed.util.readme_util import build_readme_files_dict
 
@@ -221,9 +222,9 @@ class ToolShedUtilityContainerManager(utility_container_manager.UtilityContainer
                     version = requirements_dict["version"]
                     error = requirements_dict["error"]
                 except Exception as e:
-                    name = "unknown"
-                    type = "unknown"
-                    version = "unknown"
+                    name = UNKNOWN
+                    type = UNKNOWN
+                    version = UNKNOWN
                     error = str(e)
                 key = self.generate_tool_dependencies_key(name, version, type)
                 label = f"Version <b>{version}</b> of the <b>{name}</b> <b>{type}</b>"

--- a/lib/tool_shed/webapp/api/groups.py
+++ b/lib/tool_shed/webapp/api/groups.py
@@ -13,7 +13,10 @@ from galaxy.exceptions import (
     ObjectNotFound,
     RequestParameterMissingException,
 )
-from galaxy.util import pretty_print_time_interval
+from galaxy.util import (
+    pretty_print_time_interval,
+    UNKNOWN,
+)
 from galaxy.web import (
     expose_api,
     expose_api_anonymous_and_sessionless,
@@ -155,7 +158,7 @@ class GroupsController(BaseAPIController):
                 "username": user.username,
                 "user_repos_url": user_repos_url,
                 "user_repos_count": user_repos_count,
-                "user_tools_count": "unknown",
+                "user_tools_count": UNKNOWN,
                 "time_created": time_created,
             }
             group_members.append(member_dict)

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -15,6 +15,9 @@ import galaxy.webapps.base.webapp
 from galaxy import util
 from galaxy.util import asbool
 from galaxy.util.properties import load_app_properties
+from galaxy.web.framework.middleware.error import ErrorMiddleware
+from galaxy.web.framework.middleware.request_id import RequestIDMiddleware
+from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
 from galaxy.webapps.base.webapp import build_url_map
 from galaxy.webapps.util import wrap_if_allowed
 
@@ -269,14 +272,11 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         app = wrap_if_allowed(app, stack, TransLogger)
 
     # X-Forwarded-Host handling
-    from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
-
     app = wrap_if_allowed(app, stack, XForwardedHostMiddleware)
-
+    # Request ID handling
+    app = wrap_if_allowed(app, stack, RequestIDMiddleware)
     # Error middleware
-    import galaxy.web.framework.middleware.error
-
-    app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
+    app = wrap_if_allowed(app, stack, ErrorMiddleware, args=(conf,))
     return app
 
 

--- a/test/unit/webapps/test_routes.py
+++ b/test/unit/webapps/test_routes.py
@@ -25,7 +25,7 @@ class MockWebApplication(WebApplication):
 
 def test_galaxy_routes():
     test_config = Bunch(template_cache_path="/tmp")
-    app = cast(MinimalApp, Bunch(config=test_config, security=object(), trace_logger=None, name="galaxy"))
+    app = cast(MinimalApp, Bunch(config=test_config, security=object(), trace_logger=None, name="galaxy", model=None))
     test_webapp = MockWebApplication(app)
 
     galaxy_buildapp.populate_api_routes(test_webapp, app)


### PR DESCRIPTION
Some of this is factored out from #15421.

These are fixes for several bugs that break galaxy under `autocommit=False`.

1. Our SQLAlchemy sessions are supposed to be request-scoped (see the `set_request_id/unset_request_id` calls [here](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/api/__init__.py#L88); for context see #11411). However, this happens only for FastAPI endpoints. Any call to a non-FastAPI endpoint results in a session left open with an idle transaction with database locks; new sessions+transactions are created for each subsequent connection, psycopg2 raises "too many clients" error soon after. 

    Without the `autocommit=False` setting, the bug is dormant, but still a bug. This PR fixes it.

2. The legacy `handle_request()` method allows for `request_id = "unknown"`. This does not work as a unique key for a scoped session. Here I generate a unique-enough identifier instead.

3. In some cases we never reach the end of the `handle_request()` method; as a result, the request-scoped SQLAlchemy session was never closed, causing database transactions being stuck in idle state.

    This is fixed by setting/unsetting the request_id on the scoped session within a try/finally block, thus ensuring the session will be always closed.

4. Minor refactoring: replace the string `"unknown"` with a constant defined in `galaxy.util` across code base.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
