### PR TITLE
Fix "database is locked" error (occurring in the context of workflow testing under SQLite)

### DIFF
--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -325,7 +325,7 @@ class WorkflowRequestMonitor(Monitors):
                 return
 
     def __attempt_schedule(self, invocation_id, workflow_scheduler):
-        with self.app.model.context() as session, session.begin():
+        with self.app.model.context() as session:
             workflow_invocation = session.get(model.WorkflowInvocation, invocation_id)
 
             try:


### PR DESCRIPTION
Factored out from #15421.

This solves :crossed_fingers: the sqlite database locking error that occurred in the context of testing workflows.

This also solves the workflow transaction error that happened on every workflow scheduling attempt with `autocommit=False`. Rationale for the `autocommit=False` fix: this transaction is not needed: every flush that was called in the context of a workflow execution will be wrapped in a transaction that commits.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
    Run this test: `lib/galaxy_test/api/test_jobs.py::TestJobsApi::test_index_workflow_filter_implicit_jobs` under sqlite (i.e., default connection) on the dev branch (will fail with the `sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) database is locked` error. Then switch to this branch and rerun. Observe no error.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
