### PR TITLE
[23.0] Fix ``Text File Busy`` errors at the source

### DIFF
--- a/lib/galaxy/jobs/runners/util/fork_safe_write.py
+++ b/lib/galaxy/jobs/runners/util/fork_safe_write.py
@@ -1,0 +1,18 @@
+import fcntl
+
+from galaxy.util import unicodify
+
+
+def fork_safe_write(path: str, contents: str):
+    # The following write method looks a little funky and is inspired by https://twitter.com/_monoid/status/1317895053122150400.
+    # This should guarantee that we wait until all forks that inherit open FDs have proceeded to execve,
+    # because only then the shared lock can be acquired.
+    # This **should** entirely avoid the "Text File Busy" error that `_handle_script_integrity` attempts to deal with.
+    # The likelihood of "Text File Busy" happening increases as the load increases, and more work has to be done
+    # when forking to copy memory pages, making the fork slower and therefore more likely to happen while the script
+    # file is open for writing.
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(unicodify(contents))
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+    with open(path) as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_SH)

--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -17,6 +17,7 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.resources import resource_string
+from ..fork_safe_write import fork_safe_write
 
 log = logging.getLogger(__name__)
 DEFAULT_SHELL = "/bin/bash"
@@ -131,9 +132,7 @@ def write_script(path: str, contents, job_io: DescribesScriptIntegrityChecks, mo
     dir = os.path.dirname(path)
     if not os.path.exists(dir):
         os.makedirs(dir)
-
-    with open(path, "w", encoding="utf-8") as f:
-        f.write(unicodify(contents))
+    fork_safe_write(path, contents)
     os.chmod(path, mode)
     if job_io.check_job_script_integrity:
         assert job_io.check_job_script_integrity_count is not None


### PR DESCRIPTION
Comment in line explains the source of the errors. I've created https://gist.github.com/mvdbeek/682f3495e31275b5f8ed121fabd7103f to verify that we can reproduce the issue and that the additional locking fixes it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
