### PR TITLE
[23.0] Port selenium setup to non-deprecated selenium options

### DIFF
--- a/lib/galaxy/selenium/driver_factory.py
+++ b/lib/galaxy/selenium/driver_factory.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Union
 
 try:
     from pyvirtualdisplay import Display
@@ -8,7 +9,6 @@ except ImportError:
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.remote.webdriver import WebDriver
 
 logger = logging.getLogger("selenium.webdriver.remote.remote_connection")
@@ -90,36 +90,42 @@ def get_local_driver(browser=DEFAULT_BROWSER, headless=False) -> WebDriver:
     }
     driver_class = driver_to_class[browser]
     if browser == "CHROME":
-        options = ChromeOptions()
+        chrome_options = ChromeOptions()
         if headless:
-            options.add_argument("--headless")
+            chrome_options.add_argument("--headless")
         prefs = {"download.default_directory": DEFAULT_DOWNLOAD_PATH}
-        options.add_experimental_option("prefs", prefs)
-        return driver_class(desired_capabilities={"loggingPrefs": LOGGING_PREFS}, chrome_options=options)
-    elif browser == "FIREFOX":
-        fp = webdriver.FirefoxProfile()
-        fp.set_preference("network.proxy.type", 2)
-        fp.set_preference("network.proxy.autoconfig_url", "http://127.0.0.1:9675")
-        fp.set_preference("browser.download.folderList", 2)
-        fp.set_preference("browser.download.dir", DEFAULT_DOWNLOAD_PATH)
-        fp.set_preference("browser.helperApps.neverAsk.saveToDisk", "application/octet-stream")
-        return driver_class(firefox_profile=fp)
-
+        chrome_options.add_experimental_option("prefs", prefs)
+        chrome_options.set_capability("goog:loggingPrefs", LOGGING_PREFS)
+        return driver_class(options=chrome_options)
     else:
-        return driver_class(desired_capabilities={"loggingPrefs": LOGGING_PREFS})
+        firefox_options = webdriver.FirefoxOptions()
+        firefox_options.set_preference("network.proxy.type", 2)
+        firefox_options.set_preference("network.proxy.autoconfig_url", "http://127.0.0.1:9675")
+        firefox_options.set_preference("browser.download.folderList", 2)
+        firefox_options.set_preference("browser.download.dir", DEFAULT_DOWNLOAD_PATH)
+        firefox_options.set_preference("browser.helperApps.neverAsk.saveToDisk", "application/octet-stream")
+        return driver_class(options=firefox_options)
 
 
 def get_remote_driver(host, port, browser=DEFAULT_BROWSER) -> WebDriver:
     # docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:3.0.1-aluminum
-    if browser == "auto":
-        browser = "CHROME"
-    assert browser in ["CHROME", "EDGE", "ANDROID", "FIREFOX", "INTERNETEXPLORER", "IPAD", "IPHONE", "SAFARI"]
-    desired_capabilities = getattr(DesiredCapabilities, browser)
-    desired_capabilities["loggingPrefs"] = LOGGING_PREFS
+    options: Union[webdriver.ChromeOptions, webdriver.FirefoxOptions, webdriver.EdgeOptions, None] = None
+    if browser == "auto" or browser == "CHROME":
+        options = webdriver.ChromeOptions()
+    elif browser == "FIREFOX":
+        options = webdriver.FirefoxOptions()
+    elif browser == "EDGE":
+        options = webdriver.EdgeOptions()
+    elif browser == "SAFARI":
+        pass
+    else:
+        raise Exception(f"Browser '{browser}' not supported.")
+    if options:
+        options.set_capability("goog:loggingPrefs", LOGGING_PREFS)
     executor = f"http://{host}:{port}/wd/hub"
     driver = webdriver.Remote(
         command_executor=executor,
-        desired_capabilities=desired_capabilities,
+        options=options,
     )
     return driver
 

--- a/lib/galaxy/selenium/driver_factory.py
+++ b/lib/galaxy/selenium/driver_factory.py
@@ -112,6 +112,7 @@ def get_remote_driver(host, port, browser=DEFAULT_BROWSER) -> WebDriver:
     options: Union[webdriver.ChromeOptions, webdriver.FirefoxOptions, webdriver.EdgeOptions, None] = None
     if browser == "auto" or browser == "CHROME":
         options = webdriver.ChromeOptions()
+        options.set_capability("goog:loggingPrefs", LOGGING_PREFS)
     elif browser == "FIREFOX":
         options = webdriver.FirefoxOptions()
     elif browser == "EDGE":
@@ -120,8 +121,6 @@ def get_remote_driver(host, port, browser=DEFAULT_BROWSER) -> WebDriver:
         pass
     else:
         raise Exception(f"Browser '{browser}' not supported.")
-    if options:
-        options.set_capability("goog:loggingPrefs", LOGGING_PREFS)
     executor = f"http://{host}:{port}/wd/hub"
     driver = webdriver.Remote(
         command_executor=executor,

--- a/lib/galaxy/selenium/driver_factory.py
+++ b/lib/galaxy/selenium/driver_factory.py
@@ -10,6 +10,7 @@ except ImportError:
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.safari.options import Options as SafariOptions
 
 logger = logging.getLogger("selenium.webdriver.remote.remote_connection")
 logger.setLevel(logging.WARNING)
@@ -109,7 +110,7 @@ def get_local_driver(browser=DEFAULT_BROWSER, headless=False) -> WebDriver:
 
 def get_remote_driver(host, port, browser=DEFAULT_BROWSER) -> WebDriver:
     # docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:3.0.1-aluminum
-    options: Union[webdriver.ChromeOptions, webdriver.FirefoxOptions, webdriver.EdgeOptions, None] = None
+    options: Union[webdriver.ChromeOptions, webdriver.FirefoxOptions, webdriver.EdgeOptions, SafariOptions]
     if browser == "auto" or browser == "CHROME":
         options = webdriver.ChromeOptions()
         options.set_capability("goog:loggingPrefs", LOGGING_PREFS)
@@ -118,7 +119,7 @@ def get_remote_driver(host, port, browser=DEFAULT_BROWSER) -> WebDriver:
     elif browser == "EDGE":
         options = webdriver.EdgeOptions()
     elif browser == "SAFARI":
-        pass
+        options = SafariOptions()
     else:
         raise Exception(f"Browser '{browser}' not supported.")
     executor = f"http://{host}:{port}/wd/hub"


### PR DESCRIPTION
Should be compatible with new and old selenium package (4.7.2 and 4.10.0). 4.10.0 removed some deprecated interfaces, which fails our packaging tests.

I've only followed https://www.selenium.dev/documentation/webdriver/drivers/options/ and it seems to work in a quick test.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
