### PR TITLE
Fixes initial state of select all checkbox

### DIFF
--- a/client/src/components/Form/Elements/FormCheck.test.js
+++ b/client/src/components/Form/Elements/FormCheck.test.js
@@ -43,9 +43,8 @@ describe("FormCheck", () => {
             if (expectedValues.length === 0) {
                 expectedValues = null;
             }
-            expect(wrapper.emitted().input[i + 4][0]).toEqual(expectedValues);
+            expect(wrapper.emitted().input[i + 3][0]).toEqual(expectedValues);
         }
-        expect(wrapper.emitted().input[7][0]).toBe(null);
     });
 
     it("Confirm checkboxes are created when various 'empty values' are passed.", async () => {
@@ -95,6 +94,8 @@ describe("FormCheck", () => {
         }
         /* 3 - confirm corresponding options indeterminate-state */
         await inputs.at(1).setChecked(true);
-        expect(wrapper.find("input:indeterminate").exists()).toBe(true);
+        expect(wrapper.emitted().input[2][0]).toStrictEqual(["value_0"]);
+        await wrapper.setProps({ value: ["value_0"] });
+        expect(inputs.at(0).element.indeterminate).toBe(true);
     });
 });

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, type ComputedRef } from "vue";
+import { computed } from "vue";
 
 export interface FormCheckProps {
     value?: string | string[];
@@ -26,11 +26,9 @@ const currentValue = computed({
     },
 });
 
-const hasOptions: ComputedRef<boolean> = computed(() => props.options.length > 0);
-const indeterminate: ComputedRef<boolean> = computed(
-    () => ![0, props.options.length].includes(currentValue.value.length)
-);
-const selectAll: ComputedRef<boolean> = computed(() => currentValue.value.length === props.options.length);
+const hasOptions = computed(() => props.options.length > 0);
+const indeterminate = computed(() => ![0, props.options.length].includes(currentValue.value.length));
+const selectAll = computed(() => currentValue.value.length === props.options.length);
 
 function onSelectAll(selected: boolean): void {
     if (selected) {

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -32,7 +32,7 @@ const indeterminate: ComputedRef<boolean> = computed(
 );
 const selectAll: ComputedRef<boolean> = computed(() => currentValue.value.length === props.options.length);
 
-function onSelectAll(selected: boolean): void {
+function onSelectAll(selected) {
     if (selected) {
         const allValues = props.options.map((option) => option[1]);
         emit("input", allValues);

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -32,7 +32,7 @@ const indeterminate: ComputedRef<boolean> = computed(
 );
 const selectAll: ComputedRef<boolean> = computed(() => currentValue.value.length === props.options.length);
 
-function onSelectAll(selected) {
+function onSelectAll(selected: boolean): void {
     if (selected) {
         const allValues = props.options.map((option) => option[1]);
         emit("input", allValues);

--- a/client/src/components/Form/Elements/FormCheck.vue
+++ b/client/src/components/Form/Elements/FormCheck.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, type ComputedRef } from "vue";
 
 export interface FormCheckProps {
     value?: string | string[];
@@ -12,8 +12,6 @@ const emit = defineEmits<{
     (e: "input", value: string[] | null): void;
 }>();
 
-const indeterminate = ref(false);
-
 const currentValue = computed({
     get: () => {
         const val = props.value ?? [];
@@ -25,26 +23,17 @@ const currentValue = computed({
         } else {
             emit("input", null);
         }
-        if (newValue.length === 0) {
-            selectAll.value = false;
-            indeterminate.value = false;
-        } else if (newValue.length === props.options.length) {
-            selectAll.value = true;
-            indeterminate.value = false;
-        } else {
-            indeterminate.value = true;
-        }
     },
 });
 
-const hasOptions = computed(() => {
-    return props.options.length > 0;
-});
+const hasOptions: ComputedRef<boolean> = computed(() => props.options.length > 0);
+const indeterminate: ComputedRef<boolean> = computed(
+    () => ![0, props.options.length].includes(currentValue.value.length)
+);
+const selectAll: ComputedRef<boolean> = computed(() => currentValue.value.length === props.options.length);
 
-const selectAll = ref(false);
-
-function onSelectAll() {
-    if (selectAll.value) {
+function onSelectAll(selected: boolean): void {
+    if (selected) {
         const allValues = props.options.map((option) => option[1]);
         emit("input", allValues);
     } else {
@@ -56,11 +45,11 @@ function onSelectAll() {
 <template>
     <div v-if="hasOptions">
         <b-form-checkbox
-            v-model="selectAll"
             v-localize
             class="mb-1"
+            :checked="selectAll"
             :indeterminate="indeterminate"
-            @input="onSelectAll">
+            @change="onSelectAll">
             Select / Deselect all
         </b-form-checkbox>
         <b-form-checkbox-group v-model="currentValue" stacked class="pl-3">

--- a/client/src/components/Form/Elements/FormDrilldown/FormDrilldown.vue
+++ b/client/src/components/Form/Elements/FormDrilldown/FormDrilldown.vue
@@ -85,7 +85,7 @@ function onSelectAll(selected: boolean): void {
             :indeterminate="selectAllIndeterminate"
             class="d-inline select-all-checkbox"
             @change="onSelectAll">
-            Select/Unselect All
+            Select / Deselect All
         </b-form-checkbox>
         <form-drilldown-list
             :multiple="multiple"


### PR DESCRIPTION
The select all field for checkbox input fields does not react to initial values. This PR fixes this. In order to test this select the `wc_gnu` Line/Word/Character tool from the toolbox. Notice how, although all checkboxes are checked by default, the select all fields remains unchecked. PR also adjust the label to `Select / Deselect All` for consistency with the more recent drill down element.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
