### PR TITLE
Small test decorator improvements.

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -179,7 +179,7 @@ class GalaxyInteractorApi:
         self.api_url = f"{kwds['galaxy_url'].rstrip('/')}/api"
         self.cookies = None
         self.master_api_key = kwds["master_api_key"]
-        self.api_key = self.__get_user_key(
+        self.api_key = self._get_user_key(
             kwds.get("api_key"), kwds.get("master_api_key"), test_user=kwds.get("test_user")
         )
         if kwds.get("user_api_key_is_admin_key", False):
@@ -204,7 +204,9 @@ class GalaxyInteractorApi:
     def supports_test_data_download(self):
         return self.target_galaxy_version >= Version("19.01")
 
-    def __get_user_key(self, user_key: Optional[str], admin_key: Optional[str], test_user: Optional[str] = None) -> str:
+    def _get_user_key(
+        self, user_key: Optional[str], admin_key: Optional[str], test_user: Optional[str] = None
+    ) -> Optional[str]:
         if not test_user:
             test_user = "test@bx.psu.edu"
         if user_key:

--- a/lib/galaxy/webapps/galaxy/api/plugins.py
+++ b/lib/galaxy/webapps/galaxy/api/plugins.py
@@ -9,7 +9,10 @@ from galaxy.managers import (
     histories,
 )
 from galaxy.util import asbool
-from galaxy.web import expose_api
+from galaxy.web import (
+    expose_api,
+    expose_api_anonymous_and_sessionless,
+)
 from . import (
     BaseGalaxyAPIController,
     depends,
@@ -26,12 +29,12 @@ class PluginsController(BaseGalaxyAPIController):
     hda_manager: hdas.HDAManager = depends(hdas.HDAManager)
     history_manager: histories.HistoryManager = depends(histories.HistoryManager)
 
-    @expose_api
+    @expose_api_anonymous_and_sessionless
     def index(self, trans, **kwargs):
         """
         GET /api/plugins:
         """
-        registry = self._get_registry(trans)
+        registry = self._get_registry()
         dataset_id = kwargs.get("dataset_id")
         if dataset_id is not None:
             hda = self.hda_manager.get_accessible(self.decode_id(dataset_id), trans.user)
@@ -45,7 +48,7 @@ class PluginsController(BaseGalaxyAPIController):
         """
         GET /api/plugins/{id}:
         """
-        registry = self._get_registry(trans)
+        registry = self._get_registry()
         history_id = kwargs.get("history_id")
         if history_id is not None:
             history = self.history_manager.get_owned(
@@ -59,7 +62,7 @@ class PluginsController(BaseGalaxyAPIController):
             result = registry.get_plugin(id).to_dict()
         return result
 
-    def _get_registry(self, trans):
-        if not trans.app.visualizations_registry:
+    def _get_registry(self):
+        if not self.app.visualizations_registry:
             raise exceptions.MessageException("The visualization registry has not been configured.")
-        return trans.app.visualizations_registry
+        return self.app.visualizations_registry

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -12,6 +12,7 @@ from urllib.parse import (
 
 import pytest
 import requests
+from typing_extensions import Protocol
 
 from galaxy.util.properties import get_from_env
 from .api_asserts import (
@@ -84,6 +85,12 @@ class UsesCeleryTasks:
         }
 
 
+class HasAnonymousGalaxyInteractor(Protocol):
+    @property
+    def anonymous_galaxy_interactor(self) -> "ApiTestInteractor":
+        """Return an optionally anonymous galaxy interactor."""
+
+
 class UsesApiTestCaseMixin:
     url: str
     _galaxy_interactor: Optional["ApiTestInteractor"] = None
@@ -113,12 +120,23 @@ class UsesApiTestCaseMixin:
         self._galaxy_interactor = self._get_interactor()
 
     @property
+    def anonymous_galaxy_interactor(self) -> "ApiTestInteractor":
+        """Return an optionally anonymous galaxy interactor.
+
+        Lighter requirements for use with API requests that may not required an API key.
+        """
+        return self.galaxy_interactor
+
+    @property
     def galaxy_interactor(self) -> "ApiTestInteractor":
         assert self._galaxy_interactor is not None
         return self._galaxy_interactor
 
-    def _get_interactor(self, api_key=None) -> "ApiTestInteractor":
-        return ApiTestInteractor(self, api_key=api_key)
+    def _get_interactor(self, api_key=None, allow_anonymous=False) -> "ApiTestInteractor":
+        if allow_anonymous and api_key is None:
+            return AnonymousGalaxyInteractor(self)
+        else:
+            return ApiTestInteractor(self, api_key=api_key)
 
     def _setup_user(self, email, password=None):
         return self.galaxy_interactor.ensure_user_with_email(email, password=password)
@@ -226,3 +244,13 @@ class ApiTestInteractor(BaseInteractor):
 
     def put(self, *args, **kwds):
         return self._put(*args, **kwds)
+
+
+class AnonymousGalaxyInteractor(ApiTestInteractor):
+    def __init__(self, test_case):
+        super().__init__(test_case)
+
+    def _get_user_key(
+        self, user_key: Optional[str], admin_key: Optional[str], test_user: Optional[str] = None
+    ) -> Optional[str]:
+        return None

--- a/lib/galaxy_test/base/api_asserts.py
+++ b/lib/galaxy_test/base/api_asserts.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     cast,
     Dict,
+    Optional,
     Union,
 )
 
@@ -15,33 +16,37 @@ ASSERT_FAIL_ERROR_CODE = "Expected Galaxy error code %d, obtained %d"
 ASSERT_FAIL_STATUS_CODE = "Request status code (%d) was not expected value %s. Body was %s"
 
 
-def assert_status_code_is(response: Response, expected_status_code: int):
+def assert_status_code_is(response: Response, expected_status_code: int, failure_message: Optional[str] = None):
     """Assert that the supplied response has the expect status code."""
     response_status_code = response.status_code
     if expected_status_code != response_status_code:
-        _report_status_code_error(response, expected_status_code)
+        _report_status_code_error(response, expected_status_code, failure_message)
 
 
-def assert_status_code_is_ok(response: Response):
+def assert_status_code_is_ok(response: Response, failure_message: Optional[str] = None):
     """Assert that the supplied response is okay.
 
     The easier alternative ``response.raise_for_status()`` might be
-    perferable generally.
+    preferable generally.
 
     .. seealso:: :py:meth:`requests.Response.raise_for_status()`
     """
     response_status_code = response.status_code
     is_two_hundred_status_code = response_status_code >= 200 and response_status_code <= 300
     if not is_two_hundred_status_code:
-        _report_status_code_error(response, "2XX")
+        _report_status_code_error(response, "2XX", failure_message)
 
 
-def _report_status_code_error(response: Response, expected_status_code: Union[str, int]):
+def _report_status_code_error(
+    response: Response, expected_status_code: Union[str, int], failure_message: Optional[str]
+):
     try:
         body = response.json()
     except Exception:
         body = f"INVALID JSON RESPONSE <{response.text}>"
     assertion_message = ASSERT_FAIL_STATUS_CODE % (response.status_code, expected_status_code, body)
+    if failure_message:
+        assertion_message = f"{failure_message}. {assertion_message}"
     raise AssertionError(assertion_message)
 
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -108,7 +108,10 @@ from galaxy_test.base.decorators import (
 )
 from galaxy_test.base.json_schema_utils import JsonSchemaValidator
 from . import api_asserts
-from .api import ApiTestInteractor
+from .api import (
+    ApiTestInteractor,
+    HasAnonymousGalaxyInteractor,
+)
 from .api_util import random_name
 
 FILE_URL = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed"
@@ -143,15 +146,17 @@ def flakey(method):
     return wrapped_method
 
 
-def skip_without_tool(tool_id):
+def skip_without_tool(tool_id: str):
     """Decorate an API test method as requiring a specific tool.
 
     Have test framework skip the test case if the tool is unavailable.
     """
 
     def method_wrapper(method):
-        def get_tool_ids(api_test_case):
-            index = api_test_case.galaxy_interactor.get("tools", data=dict(in_panel=False))
+        def get_tool_ids(api_test_case: HasAnonymousGalaxyInteractor):
+            interactor = api_test_case.anonymous_galaxy_interactor
+            index = interactor.get("tools", data=dict(in_panel=False))
+            api_asserts.assert_status_code_is_ok(index, "Failed to fetch toolbox for target Galaxy.")
             tools = index.json()
             # In panels by default, so flatten out sections...
             tool_ids = [itemgetter("id")(_) for _ in tools]
@@ -169,8 +174,11 @@ def skip_without_tool(tool_id):
 
 def skip_without_asgi(method):
     @wraps(method)
-    def wrapped_method(api_test_case, *args, **kwd):
-        config = api_test_case.galaxy_interactor.get("configuration").json()
+    def wrapped_method(api_test_case: HasAnonymousGalaxyInteractor, *args, **kwd):
+        interactor = api_test_case.anonymous_galaxy_interactor
+        config_response = interactor.get("configuration")
+        api_asserts.assert_status_code_is_ok(config_response, "Failed to fetch configuration for target Galaxy.")
+        config = config_response.json()
         asgi_enabled = config.get("asgi_enabled", False)
         if not asgi_enabled:
             raise unittest.SkipTest("ASGI not enabled, skipping test")
@@ -179,15 +187,16 @@ def skip_without_asgi(method):
     return wrapped_method
 
 
-def skip_without_datatype(extension):
+def skip_without_datatype(extension: str):
     """Decorate an API test method as requiring a specific datatype.
 
     Have test framework skip the test case if the datatype is unavailable.
     """
 
-    def has_datatype(api_test_case):
-        index_response = api_test_case.galaxy_interactor.get("datatypes")
-        assert index_response.status_code == 200, "Failed to fetch datatypes for target Galaxy."
+    def has_datatype(api_test_case: HasAnonymousGalaxyInteractor):
+        interactor = api_test_case.anonymous_galaxy_interactor
+        index_response = interactor.get("datatypes", anon=True)
+        api_asserts.assert_status_code_is_ok(index_response, "Failed to fetch datatypes for target Galaxy.")
         datatypes = index_response.json()
         assert isinstance(datatypes, list)
         return extension in datatypes
@@ -196,6 +205,26 @@ def skip_without_datatype(extension):
         @wraps(method)
         def wrapped_method(api_test_case, *args, **kwargs):
             _raise_skip_if(not has_datatype(api_test_case))
+            method(api_test_case, *args, **kwargs)
+
+        return wrapped_method
+
+    return method_wrapper
+
+
+def skip_without_visualization_plugin(plugin_name: str):
+    def has_plugin(api_test_case: HasAnonymousGalaxyInteractor):
+        interactor = api_test_case.anonymous_galaxy_interactor
+        index_response = interactor.get("plugins", anon=True)
+        api_asserts.assert_status_code_is_ok(index_response, "Failed to fetch visualizations for target Galaxy.")
+        plugins = index_response.json()
+        assert isinstance(plugins, list)
+        return plugin_name in [p["name"] for p in plugins]
+
+    def method_wrapper(method):
+        @wraps(method)
+        def wrapped_method(api_test_case, *args, **kwargs):
+            _raise_skip_if(not has_plugin(api_test_case))
             method(api_test_case, *args, **kwargs)
 
         return wrapped_method

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -343,6 +343,12 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin, Use
         """Returns default download path"""
         return DEFAULT_DOWNLOAD_PATH
 
+    @property
+    def anonymous_galaxy_interactor(self):
+        api_key = self.get_api_key(force=False)
+        interactor = self._get_interactor(api_key=api_key, allow_anonymous=True)
+        return interactor
+
     def api_interactor_for_logged_in_user(self):
         api_key = self.get_api_key(force=True)
         interactor = self._get_interactor(api_key=api_key)

--- a/lib/galaxy_test/selenium/test_history_sharing.py
+++ b/lib/galaxy_test/selenium/test_history_sharing.py
@@ -135,7 +135,7 @@ class TestHistoryRequiresLoginSelenium(SeleniumTestCase):
 
     @selenium_test
     def test_share_history_login_redirect(self):
-        user_email = self.get_logged_in_user()["email"]
+        user_email = self.get_user_email()
         history_id = self.current_history_id()
         self.logout()
         self.go_to_history_sharing(history_id)

--- a/lib/galaxy_test/selenium/test_visualizations.py
+++ b/lib/galaxy_test/selenium/test_visualizations.py
@@ -1,20 +1,49 @@
+from galaxy_test.base.populators import (
+    skip_without_datatype,
+    skip_without_visualization_plugin,
+)
 from .framework import (
+    managed_history,
     selenium_test,
     SeleniumTestCase,
 )
 
 
 class TestVisualizations(SeleniumTestCase):
+    ensure_registered = True
+
+    @skip_without_datatype("png")
+    @skip_without_visualization_plugin("annotate_image")
     @selenium_test
-    def test_charts_framework(self):
-        self.register()
-        self.perform_upload(self.get_filename("1.sam"))
-        self.history_panel_wait_for_hid_ok(1)
-        dataset_component = self.history_panel_click_item_title(1, wait=True)
+    @managed_history
+    def test_charts_image_annotate(self):
+        hid = 1
+        self.perform_upload(self.get_filename("454Score.png"))
+        self.wait_for_history()
+        dataset_component = self.history_panel_click_item_title(hid, wait=True)
         dataset_component.visualize_button.wait_for_and_click()
 
+        self.components.visualization.plugin_item(id="annotate_image").wait_for_visible()
+        self.screenshot("visualization_plugins_png")
+        self.components.visualization.plugin_item(id="annotate_image").wait_for_and_click()
+
+        with self.main_panel():
+            self.wait_for_selector("#image-annotate")
+            self.screenshot("visualization_plugin_charts_image_annotate")
+
+    @managed_history
+    @selenium_test
+    @skip_without_visualization_plugin("nvd3_bar")
+    def test_charts_nvd3_bar(self):
+        hid = 1
+        self.perform_upload(self.get_filename("1.sam"))
+        dataset_component = self.history_panel_click_item_title(hid, wait=True)
+        dataset_component.visualize_button.wait_for_and_click()
+
+        self.components.visualization.plugin_item(id="nvd3_bar").wait_for_visible()
+        self.screenshot("visualization_plugins_sam")
         self.components.visualization.plugin_item(id="nvd3_bar").wait_for_and_click()
 
         with self.main_panel():
             self.wait_for_selector("g.nvd3")
-            self.screenshot("test_charts_framework -- nvd3_bar")
+            self.screenshot("visualization_plugin_charts_nvd3_bar_landing")

--- a/lib/galaxy_test/selenium/test_workflow_sharing.py
+++ b/lib/galaxy_test/selenium/test_workflow_sharing.py
@@ -11,7 +11,7 @@ class TestWorkflowSharingRedirect(SeleniumTestCase):
 
     @selenium_test
     def test_share_workflow_with_login_redirect(self):
-        user_email = self.get_logged_in_user()["email"]
+        user_email = self.get_user_email()
         workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
         self.logout()
         self.go_to_workflow_sharing(workflow_id)
@@ -24,7 +24,7 @@ class TestWorkflowSharingRedirect(SeleniumTestCase):
 
     @selenium_test
     def test_export_workflow_with_login_redirect(self):
-        user_email = self.get_logged_in_user()["email"]
+        user_email = self.get_user_email()
         workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
         self.logout()
         self.go_to_workflow_export(workflow_id)

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -26,7 +26,7 @@ class TestHistoryImportExportFtpSeleniumIntegrationBase(SeleniumIntegrationTestC
         return cls.temp_config_dir("ftp")
 
     def create_user_ftp_dir(self):
-        email = self.get_logged_in_user()["email"]
+        email = self.get_user_email()
         user_ftp_dir = os.path.join(self.ftp_dir(), email)
         os.makedirs(user_ftp_dir)
 

--- a/test/integration_selenium/test_upload_ftp.py
+++ b/test/integration_selenium/test_upload_ftp.py
@@ -35,7 +35,7 @@ class TestUploadFtpSeleniumIntegration(SeleniumIntegrationTestCase):
         self.wait_for_history()
 
     def _create_ftp_dir(self):
-        email = self.get_logged_in_user()["email"]
+        email = self.get_user_email()
         user_ftp_dir = os.path.join(self.ftp_dir(), email)
         os.makedirs(user_ftp_dir)
         return user_ftp_dir

--- a/test/integration_selenium/test_user_library_permissions.py
+++ b/test/integration_selenium/test_user_library_permissions.py
@@ -24,7 +24,7 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
     @selenium_test
     def test_user_library_import_dir(self):
         # create new user, create user_library_import_dir, create new email-dir, insert a random text file
-        email = self.get_logged_in_user()["email"]
+        email = self.get_user_email()
         current_user_import_dir = os.path.join(self.user_import_dir(), email)
         os.makedirs(current_user_import_dir)
         random_filename = self._get_random_name()
@@ -46,7 +46,7 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
     @selenium_test
     def test_user_library_import_dir_warning(self):
         # do not create email-dir, assert just warning
-        email = self.get_logged_in_user()["email"]
+        email = self.get_user_email()
         self.create_lib_and_permit_adding(email)
 
         self.libraries_open_with_name(self.name)


### PR DESCRIPTION
- Add some basic typing.
- Include more information in assertion errors thrown when they target an incorrectly configured server.
- Allow for explicit anonymous interactor creation so we can cleanly apply these decorators to Selenium tests (Selenium test interactors use API keys that can be created from the UI - so they don't have complete user information available upfront).
- Add decorator ``skip_without_visualization_plugin`` to parallel other ones - fix plugin API endpoint to allow anonymous indexing.
- Add some decorators to the visualization tests and implement a second test.
- Use ``managed_history`` decorator to ensure existing test has an hid of 1 as assumed.
- A spelling fix for a comment I otherwise no longer endorse.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
