### PR TITLE
Show search in `HistoryView`

### DIFF
--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -9,7 +9,7 @@
         @keydown="onKeyDown">
         <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @click.stop="onClick">
             <div class="d-flex justify-content-between">
-                <span class="p-1 font-weight-bold">
+                <span class="p-1 font-weight-bold" data-description="content item header info">
                     <b-button v-if="selectable" class="selector p-0" @click.stop="$emit('update:selected', !selected)">
                         <icon v-if="selected" fixed-width size="lg" :icon="['far', 'check-square']" />
                         <icon v-else fixed-width size="lg" :icon="['far', 'square']" />

--- a/client/src/components/History/CurrentHistory/HistoryCounter.vue
+++ b/client/src/components/History/CurrentHistory/HistoryCounter.vue
@@ -120,6 +120,7 @@ function onUpdatePreferredObjectStoreId(preferredObjectStoreId: string) {
             size="sm"
             class="rounded-0 text-decoration-none"
             :disabled="!showControls"
+            data-description="storage dashboard button"
             @click="onDashboard">
             <icon icon="database" />
             <span>{{ niceHistorySize }}</span>
@@ -148,6 +149,7 @@ function onUpdatePreferredObjectStoreId(preferredObjectStoreId: string) {
                     variant="link"
                     size="sm"
                     class="rounded-0 text-decoration-none"
+                    data-description="show active items button"
                     @click="setFilter('')">
                     <span class="fa fa-map-marker" />
                     <span>{{ numItemsActive }}</span>
@@ -160,6 +162,7 @@ function onUpdatePreferredObjectStoreId(preferredObjectStoreId: string) {
                     size="sm"
                     class="rounded-0 text-decoration-none"
                     :pressed="getCurrentFilterVal('deleted') !== false"
+                    data-description="include deleted items button"
                     @click="setFilter('deleted')">
                     <icon icon="trash" />
                     <span>{{ numItemsDeleted }}</span>
@@ -172,6 +175,7 @@ function onUpdatePreferredObjectStoreId(preferredObjectStoreId: string) {
                     size="sm"
                     class="rounded-0 text-decoration-none"
                     :pressed="getCurrentFilterVal('visible') !== true"
+                    data-description="include hidden items button"
                     @click="setFilter('visible')">
                     <icon icon="eye-slash" />
                     <span>{{ numItemsHidden }}</span>

--- a/client/src/components/History/CurrentHistory/HistoryPanel.vue
+++ b/client/src/components/History/CurrentHistory/HistoryPanel.vue
@@ -28,7 +28,7 @@
                 @dragleave.prevent="onDragLeave">
                 <slot name="navigation" :history="history" />
                 <HistoryFilters
-                    v-if="showControls"
+                    v-if="filterable"
                     class="content-operations-filters mx-3"
                     :filter-text.sync="filterText"
                     :show-advanced.sync="showAdvanced"

--- a/client/src/components/History/HistoryView.test.js
+++ b/client/src/components/History/HistoryView.test.js
@@ -1,0 +1,175 @@
+import { createPinia } from "pinia";
+import { mount } from "@vue/test-utils";
+import { useUserStore } from "stores/userStore";
+import { useHistoryStore } from "stores/historyStore";
+import { getLocalVue } from "tests/jest/helpers";
+import flushPromises from "flush-promises";
+import HistoryView from "./HistoryView";
+import { getHistoryByIdFromServer, setCurrentHistoryOnServer } from "stores/services/history.services";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+
+const localVue = getLocalVue();
+jest.mock("stores/services/history.services");
+
+function create_history(historyId, userId, purged = false) {
+    const historyName = `${userId}'s History ${historyId}`;
+    return {
+        model_class: "History",
+        id: historyId,
+        name: historyName,
+        purged: purged,
+        count: 10,
+        annotation: "This is a history",
+        tags: ["tag_1", "tag_2"],
+        user_id: userId,
+        contents_active: {
+            deleted: 1,
+            hidden: 2,
+            active: 8,
+        },
+    };
+}
+
+function create_datasets(historyId, count) {
+    const contents = [];
+    for (let index = 1; index <= count; index++) {
+        contents.push({
+            id: `dataset_${index}`,
+            name: `Dataset ${index}`,
+            history_id: historyId,
+            hid: index,
+            history_content_type: "dataset",
+            deleted: false,
+            visible: true,
+        });
+    }
+    return {
+        stats: {
+            total_matches: count,
+        },
+        contents: contents,
+    };
+}
+
+async function createWrapper(localVue, currentUserId, history) {
+    const pinia = createPinia();
+    getHistoryByIdFromServer.mockResolvedValue(history);
+    setCurrentHistoryOnServer.mockResolvedValue(history);
+    const axiosMock = new MockAdapter(axios);
+    const history_contents_url = `/api/histories/${history.id}/contents?v=dev&order=hid&offset=0&limit=100&q=deleted&qv=false&q=visible&qv=true`;
+    const history_contents_result = create_datasets(history.id, history.count);
+    axiosMock.onGet(history_contents_url).reply(200, history_contents_result);
+    const wrapper = mount(HistoryView, {
+        propsData: { id: history.id },
+        localVue,
+        stubs: {
+            icon: { template: "<div></div>" },
+        },
+        provide: {
+            store: {
+                dispatch: jest.fn,
+                getters: {},
+            },
+        },
+        pinia,
+    });
+    const userStore = useUserStore();
+    const userData = {
+        id: currentUserId,
+    };
+    userStore.currentUser = { ...userStore.currentUser, ...userData };
+    await flushPromises();
+    return wrapper;
+}
+
+describe("History center panel View", () => {
+    function expectCorrectLayout(wrapper) {
+        // HistoryFilters should exist in HistoryView
+        expect(wrapper.find("[data-description='filter text input']").exists()).toBe(true);
+        // annotation
+        expect(wrapper.find("[data-description='annotation value']").text()).toBe("This is a history");
+        // StatelessTags
+        const tags = wrapper.find(".stateless-tags");
+        expect(tags.text()).toContain("tag_1");
+        expect(tags.text()).toContain("tag_2");
+        // HistoryCounter
+        expect(wrapper.find("[data-description='storage dashboard button']").attributes("disabled")).toBeTruthy();
+        expect(wrapper.find("[data-description='show active items button']").text()).toEqual("8");
+        expect(wrapper.find("[data-description='include deleted items button']").text()).toEqual("1");
+        expect(wrapper.find("[data-description='include hidden items button']").text()).toEqual("2");
+    }
+
+    it("current user's current history", async () => {
+        const history = create_history("history_1", "user_1", false);
+        const wrapper = await createWrapper(localVue, "user_1", history);
+        expect(wrapper.vm.history).toEqual(history);
+
+        const historyStore = useHistoryStore();
+        await historyStore.setCurrentHistory(history.id);
+
+        // switch/import buttons: current history, should be a disabled switch
+        const switchButton = wrapper.find("[data-description='switch to history button']");
+        const importButton = wrapper.find("[data-description='import history button']");
+        expect(switchButton.attributes("disabled")).toBeTruthy();
+        expect(importButton.exists()).toBe(false);
+
+        // parts of the layout that should be similar for all cases
+        expectCorrectLayout(wrapper);
+
+        // all history items, make sure all show up with hids and names
+        const historyItems = wrapper.findAll(".content-item");
+        expect(historyItems.length).toBe(10);
+        for (let i = 0; i < historyItems.length; i++) {
+            const hid = historyItems.length - i;
+            const itemHeader = historyItems.at(i).find("[data-description='content item header info']");
+            const headerText = `${hid}: Dataset ${hid}`;
+            expect(itemHeader.text()).toBe(headerText);
+        }
+    });
+
+    it("other user's history", async () => {
+        const history = create_history("history_2", "user_2", false);
+        const wrapper = await createWrapper(localVue, "user_1", history);
+        expect(wrapper.vm.history).toEqual(history);
+
+        // switch/import buttons: external history so should be importable
+        const switchButton = wrapper.find("[data-description='switch to history button']");
+        const importButton = wrapper.find("[data-description='import history button']");
+        expect(switchButton.exists()).toBe(false);
+        expect(importButton.attributes("disabled")).toBeFalsy();
+
+        // parts of the layout that should be similar for all cases
+        expectCorrectLayout(wrapper);
+    });
+
+    it("same user, not current history", async () => {
+        const history = create_history("history_3", "user_1", false);
+        const wrapper = await createWrapper(localVue, "user_1", history);
+        expect(wrapper.vm.history).toEqual(history);
+
+        // switch/import buttons: not current history, switchable
+        const switchButton = wrapper.find("[data-description='switch to history button']");
+        const importButton = wrapper.find("[data-description='import history button']");
+        expect(switchButton.attributes("disabled")).toBeFalsy();
+        expect(importButton.exists()).toBe(false);
+
+        // parts of the layout that should be similar for all cases
+        expectCorrectLayout(wrapper);
+    });
+
+    it("same user, purged history", async () => {
+        const history = create_history("history_4", "user_1", true);
+        const wrapper = await createWrapper(localVue, "user_1", history);
+        expect(wrapper.vm.history).toEqual(history);
+
+        // switch/import buttons: purged they don't exist
+        const switchButton = wrapper.find("[data-description='switch to history button']");
+        const importButton = wrapper.find("[data-description='import history button']");
+        expect(switchButton.exists()).toBe(false);
+        expect(importButton.exists()).toBe(false);
+
+        // instead we have an alert
+        expect(wrapper.find("[data-description='history is purged']").text()).toBe("This history has been purged.");
+    });
+});

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="currentUser && history" class="d-flex flex-column h-100">
         <b-alert v-if="history.purged" variant="info" show>This history has been purged.</b-alert>
-        <div v-else class="flex-row flex-grow-0">
+        <div v-else class="flex-row flex-grow-0 pb-3">
             <b-button
                 v-if="currentUser.id == history.user_id"
                 size="sm"
@@ -26,6 +26,7 @@
             :history="history"
             :writable="currentUser.id == history.user_id"
             :show-controls="false"
+            filterable
             @view-collection="onViewCollection" />
         <CopyModal id="copy-history-modal" :history="history" />
     </div>

--- a/client/src/components/History/HistoryView.vue
+++ b/client/src/components/History/HistoryView.vue
@@ -1,17 +1,26 @@
 <template>
     <div v-if="currentUser && history" class="d-flex flex-column h-100">
-        <b-alert v-if="history.purged" variant="info" show>This history has been purged.</b-alert>
+        <b-alert v-if="history.purged" variant="info" show data-description="history is purged">
+            This history has been purged.
+        </b-alert>
         <div v-else class="flex-row flex-grow-0 pb-3">
             <b-button
                 v-if="currentUser.id == history.user_id"
                 size="sm"
                 variant="outline-info"
                 title="Switch to this history"
-                :disabled="currentHistory.id == history.id"
+                :disabled="currentHistory?.id == history?.id"
+                data-description="switch to history button"
                 @click="setCurrentHistory(history.id)">
                 Switch to this history
             </b-button>
-            <b-button v-else v-b-modal:copy-history-modal size="sm" variant="outline-info" title="Import this history">
+            <b-button
+                v-else
+                v-b-modal:copy-history-modal
+                size="sm"
+                variant="outline-info"
+                title="Import this history"
+                data-description="import history button">
                 Import this history
             </b-button>
         </div>


### PR DESCRIPTION
Added the `HistoryFilters` field/menu to the `HistoryView` component.

| Before |
| ------ |
| ![image](https://github.com/galaxyproject/galaxy/assets/78516064/1ead4573-eca7-4f62-91f3-5c3a5b1d0ea9) |

| After |
| ------- |
| ![image](https://github.com/galaxyproject/galaxy/assets/78516064/b191cbd5-05b1-48e6-9aa7-36059fd00f00) |


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
