### PR TITLE
[22.05] Pin fs.dropboxfs to <0.3

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -16,7 +16,7 @@ total-perspective-vortex<2
 
 # For file sources plugins
 fs.webdavfs>=0.4.2  # type: webdav
-fs.dropboxfs  # type: dropbox
+fs.dropboxfs<0.3  # type: dropbox
 fs.sshfs  # type: ssh
 fs-s3fs  # type: s3
 s3fs  # type: s3fs


### PR DESCRIPTION
The import of DropboxFS in dropbox.py is different from version 0.3 onwards (<0.3: `from dropboxfs.dropboxfs import DropboxFS`, >=0.3 `from fs.dropboxfs import DropboxFS`).

For issue https://github.com/galaxyproject/galaxy/issues/15489

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
