### PR TITLE
Limit number of celery task executions per second per user

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5121,6 +5121,30 @@
 :Type: bool
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+``celery_user_rate_limit``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    If set to a non-0 value, upper limit on number of tasks that can
+    be executed per user per second.
+:Default: ``0.0``
+:Type: float
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``celery_user_rate_limit_standard_before_start``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Applies if `celery_user_rate_limit` is non-zero. Used for
+    testing against a postgres db. Forces use of standard sql
+    code rather than postgres specific dialect for database
+    access code.
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~
 ``use_pbkdf2``
 ~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5132,18 +5132,6 @@
 :Type: float
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``celery_user_rate_limit_standard_before_start``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Applies if celery_user_rate_limit is non-zero. Used for testing
-    against a postgres db. Forces use of standard sql code rather than
-    postgres specific dialect for database access code.
-:Default: ``false``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~
 ``use_pbkdf2``
 ~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -5137,10 +5137,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Applies if `celery_user_rate_limit` is non-zero. Used for
-    testing against a postgres db. Forces use of standard sql
-    code rather than postgres specific dialect for database
-    access code.
+    Applies if celery_user_rate_limit is non-zero. Used for testing
+    against a postgres db. Forces use of standard sql code rather than
+    postgres specific dialect for database access code.
 :Default: ``false``
 :Type: bool
 

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -599,7 +599,7 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
         """
         task_before_start: GalaxyTaskBeforeStart
         if self.config.celery_user_rate_limit:
-            if is_postgres(self.config.database_connection):
+            if is_postgres(self.config.database_connection):  # type: ignore[arg-type]
                 task_before_start = GalaxyTaskBeforeStartUserRateLimitPostgres(
                     self.config.celery_user_rate_limit, self.model.session
                 )

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -28,6 +28,10 @@ from galaxy import (
     jobs,
     tools,
 )
+from galaxy.celery.base_task import (
+    GalaxyTaskBeforeStart,
+    GalaxyTaskUserRateLimitBeforeStart,
+)
 from galaxy.config_watchers import ConfigWatchers
 from galaxy.datatypes.registry import Registry
 from galaxy.files import ConfiguredFileSources
@@ -57,6 +61,8 @@ from galaxy.managers.workflows import (
     WorkflowsManager,
 )
 from galaxy.model import (
+    CeleryUserRateLimitPostgres,
+    CeleryUserRateLimitStandard,
     custom_types,
     mapping,
 )
@@ -581,8 +587,27 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
 
         self._configure_tool_shed_registry()
         self._register_singleton(tool_shed_registry.Registry, self.tool_shed_registry)
-        # Tool Data Tables
+        #  Tool Data Tables
         self._configure_tool_data_tables(from_shed_config=False)
+        self._register_celery_galaxy_task_components()
+
+    def _register_celery_galaxy_task_components(self):
+        """
+        Register subtype class instance to support implementation of a user rate limit for execution of celery tasks.
+        The default supertype class does not enforce a user rate limit. This is the case if the celery_user_rate_limit
+        config param is default value of 0.0
+        """
+        if self.config.celery_user_rate_limit:
+            force_standard_before_start = self.config.get("celery_user_rate_limit_standard_before_start", False)
+            if not force_standard_before_start and self.config.database_connection.startswith("postgres"):
+                task_before_start = GalaxyTaskUserRateLimitBeforeStart(
+                    self.config.celery_user_rate_limit, CeleryUserRateLimitPostgres(), self.model.session
+                )
+            else:
+                task_before_start = GalaxyTaskUserRateLimitBeforeStart(
+                    self.config.celery_user_rate_limit, CeleryUserRateLimitStandard(), self.model.session
+                )
+            self._register_singleton(GalaxyTaskBeforeStart, task_before_start)
 
     def _configure_tool_shed_registry(self) -> None:
         # Set up the tool sheds registry

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -15,6 +15,7 @@ import pebble
 from celery import (
     Celery,
     shared_task,
+    Task,
 )
 from celery.signals import (
     worker_init,
@@ -22,6 +23,7 @@ from celery.signals import (
 )
 from kombu import serialization
 
+from galaxy.celery.base_task import GalaxyTaskBeforeStart
 from galaxy.config import Configuration
 from galaxy.main_config import find_config
 from galaxy.util import ExecutionTimer
@@ -65,6 +67,21 @@ class GalaxyCelery(Celery):
         if module.startswith("galaxy.celery.tasks"):
             module = f"galaxy{module[19:]}"
         return module
+
+
+class GalaxyTask(Task):
+    """
+    Custom celery task used to limit number of tasks executions per user
+    per second.
+    """
+
+    def before_start(self, task_id, args, kwargs):
+        """
+        Set appropriate before start object from DI container.
+        """
+        app = get_galaxy_app()
+        assert app
+        app[GalaxyTaskBeforeStart](self, task_id, args, kwargs)
 
 
 def set_thread_app(app):
@@ -144,7 +161,7 @@ def galaxy_task(*args, action=None, **celery_task_kwd):
         celery_task_kwd["serializer"] = PYDANTIC_AWARE_SERIALIZER_NAME
 
     def decorate(func: Callable):
-        @shared_task(**celery_task_kwd)
+        @shared_task(base=GalaxyTask, **celery_task_kwd)
         @wraps(func)
         def wrapper(*args, **kwds):
             app = get_galaxy_app()

--- a/lib/galaxy/celery/base_task.py
+++ b/lib/galaxy/celery/base_task.py
@@ -1,0 +1,69 @@
+import datetime
+
+from celery import Task
+
+from galaxy.model import CeleryUserRateLimit
+from galaxy.model.scoped_session import galaxy_scoped_session
+
+
+class GalaxyTaskBeforeStart:
+    """
+    Class used by the custom celery task, GalaxyTask, to implement
+    logic to limit number of task executions per user per second.
+    This superclass is used directly when no user rate limit logic
+    is to be enforced based on value of config param,
+    celery_user_rate_limit.
+    """
+
+    def __call__(self, task: Task, task_id, args, kwargs):
+        pass
+
+
+class GalaxyTaskUserRateLimitBeforeStart(GalaxyTaskBeforeStart):
+    """
+    Used when we wish to enforce a user rate limit based on
+    celery_user_rate_limit config setting.
+    The user_rate_limit constructor parameter is a class instance
+    that implements logic specific to the type of database
+    configured. i.e. For postgres we take advantage of efficiencies
+    in its dialect.
+    We limit executions by keeping track of the last scheduled
+    time for the execution of a task by user. When a new task
+    is to be executed we schedule it a certain time interval
+    after the last scheduled execution of a task by this user
+    by doing a task.retry.
+    If the last scheduled execution was far enough in the past
+    then we allow the task to run immediately.
+    """
+
+    user_rate_limit: CeleryUserRateLimit
+
+    def __init__(
+        self,
+        tasks_per_user_per_sec: float,
+        user_rate_limit: CeleryUserRateLimit,
+        ga_scoped_session: galaxy_scoped_session,
+    ):
+        self.user_rate_limit = user_rate_limit
+        self.task_exec_countdown_secs = 1 / tasks_per_user_per_sec
+        self.ga_scoped_session = ga_scoped_session
+
+    def __call__(self, task: Task, task_id, args, kwargs):
+        if task.request.retries > 0:
+            return
+        usr = kwargs.get("task_user_id")
+        if not usr:
+            return
+        now = datetime.datetime.now()
+        sa_session = None
+        try:
+            sa_session = self.ga_scoped_session
+            next_scheduled_time = self.user_rate_limit.calculate_task_start_time(
+                usr, sa_session, self.task_exec_countdown_secs, now
+            )
+        finally:
+            if sa_session:
+                sa_session.remove()
+        if next_scheduled_time > now:
+            count_down = next_scheduled_time - now
+            task.retry(countdown=count_down.total_seconds())

--- a/lib/galaxy/celery/base_task.py
+++ b/lib/galaxy/celery/base_task.py
@@ -1,8 +1,20 @@
 import datetime
+from abc import abstractmethod
 
 from celery import Task
+from sqlalchemy import (
+    bindparam,
+    insert,
+    select,
+    text,
+    update,
+)
+from sqlalchemy.dialects.postgresql import insert as ps_insert
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from galaxy.model import CeleryUserRateLimit
+from galaxy.model.base import transaction
 from galaxy.model.scoped_session import galaxy_scoped_session
 
 
@@ -19,15 +31,11 @@ class GalaxyTaskBeforeStart:
         pass
 
 
-class GalaxyTaskUserRateLimitBeforeStart(GalaxyTaskBeforeStart):
+class GalaxyTaskBeforeStartUserRateLimit(GalaxyTaskBeforeStart):
     """
     Used when we wish to enforce a user rate limit based on
-    celery_user_rate_limit config setting.
-    The user_rate_limit constructor parameter is a class instance
-    that implements logic specific to the type of database
-    configured. i.e. For postgres we take advantage of efficiencies
-    in its dialect.
-    We limit executions by keeping track of the last scheduled
+    non-default value of celery_user_rate_limit config setting.
+    We limit executions by keeping track in a table of the last scheduled
     time for the execution of a task by user. When a new task
     is to be executed we schedule it a certain time interval
     after the last scheduled execution of a task by this user
@@ -36,15 +44,11 @@ class GalaxyTaskUserRateLimitBeforeStart(GalaxyTaskBeforeStart):
     then we allow the task to run immediately.
     """
 
-    user_rate_limit: CeleryUserRateLimit
-
     def __init__(
         self,
         tasks_per_user_per_sec: float,
-        user_rate_limit: CeleryUserRateLimit,
         ga_scoped_session: galaxy_scoped_session,
     ):
-        self.user_rate_limit = user_rate_limit
         self.task_exec_countdown_secs = 1 / tasks_per_user_per_sec
         self.ga_scoped_session = ga_scoped_session
 
@@ -55,15 +59,105 @@ class GalaxyTaskUserRateLimitBeforeStart(GalaxyTaskBeforeStart):
         if not usr:
             return
         now = datetime.datetime.now()
-        sa_session = None
-        try:
-            sa_session = self.ga_scoped_session
-            next_scheduled_time = self.user_rate_limit.calculate_task_start_time(
-                usr, sa_session, self.task_exec_countdown_secs, now
-            )
-        finally:
-            if sa_session:
-                sa_session.remove()
+        sa_session = self.ga_scoped_session
+        next_scheduled_time = self.calculate_task_start_time(usr, sa_session, self.task_exec_countdown_secs, now)
         if next_scheduled_time > now:
             count_down = next_scheduled_time - now
             task.retry(countdown=count_down.total_seconds())
+
+    @abstractmethod
+    def calculate_task_start_time(
+        self, user_id: int, sa_session: Session, task_interval_secs: float, now: datetime.datetime
+    ) -> datetime.datetime:
+        return now
+
+
+class GalaxyTaskBeforeStartUserRateLimitPostgres(GalaxyTaskBeforeStartUserRateLimit):
+    """
+    Postgres specific implementation that overrides the calculate_task_start_time method.
+    We take advantage of efficiencies in its dialect.
+    """
+
+    _update_stmt = (
+        update(CeleryUserRateLimit)
+        .where(CeleryUserRateLimit.user_id == bindparam("userid"))
+        .values(last_scheduled_time=text("greatest(last_scheduled_time + ':interval second', " ":now) "))
+        .returning(CeleryUserRateLimit.last_scheduled_time)
+    )
+
+    _insert_stmt = (
+        ps_insert(CeleryUserRateLimit)
+        .values(user_id=bindparam("userid"), last_scheduled_time=bindparam("now"))
+        .returning(CeleryUserRateLimit.last_scheduled_time)
+    )
+
+    _upsert_stmt = _insert_stmt.on_conflict_do_update(
+        index_elements=["user_id"], set_=dict(last_scheduled_time=bindparam("sched_time"))
+    )
+
+    def calculate_task_start_time(  # type: ignore
+        self, user_id: int, sa_session: Session, task_interval_secs: float, now: datetime.datetime
+    ) -> datetime.datetime:
+        with transaction(sa_session):
+            result = sa_session.execute(
+                self._update_stmt, {"userid": user_id, "interval": task_interval_secs, "now": now}
+            )
+            if result.rowcount == 0:
+                sched_time = now + datetime.timedelta(seconds=task_interval_secs)
+                result = sa_session.execute(
+                    self._upsert_stmt, {"userid": user_id, "now": now, "sched_time": sched_time}
+                )
+            for row in result:
+                return row[0]
+            sa_session.commit()
+
+
+class GalaxyTaskBeforeStartUserRateLimitStandard(GalaxyTaskBeforeStartUserRateLimit):
+    """
+    Generic but slower implementation supported by most databases that overrides
+    the calculate_task_start_time method.
+    """
+
+    _select_stmt = (
+        select(CeleryUserRateLimit.last_scheduled_time)
+        .with_for_update(of=CeleryUserRateLimit.last_scheduled_time)
+        .where(CeleryUserRateLimit.user_id == bindparam("userid"))
+    )
+
+    _update_stmt = (
+        update(CeleryUserRateLimit)
+        .where(CeleryUserRateLimit.user_id == bindparam("userid"))
+        .values(last_scheduled_time=bindparam("sched_time"))
+    )
+
+    _insert_stmt = insert(CeleryUserRateLimit).values(
+        user_id=bindparam("userid"), last_scheduled_time=bindparam("sched_time")
+    )
+
+    def calculate_task_start_time(
+        self, user_id: int, sa_session: Session, task_interval_secs: float, now: datetime.datetime
+    ) -> datetime.datetime:
+        last_scheduled_time = None
+        with transaction(sa_session):
+            last_scheduled_time = sa_session.scalars(self._select_stmt, {"userid": user_id}).first()
+            if last_scheduled_time:
+                sched_time = last_scheduled_time + datetime.timedelta(seconds=task_interval_secs)
+                if sched_time < now:
+                    sched_time = now
+                sa_session.execute(self._update_stmt, {"userid": user_id, "sched_time": sched_time})
+            sa_session.commit()
+        if not last_scheduled_time:
+            try:
+                with transaction(sa_session):
+                    sched_time = now
+                    sa_session.execute(self._insert_stmt, {"userid": user_id, "sched_time": sched_time})
+                    sa_session.commit()
+            except IntegrityError:
+                #  Row was inserted by another thread since we tried the update above.
+                with transaction(sa_session):
+                    sched_time = now + datetime.timedelta(seconds=task_interval_secs)
+                    result = sa_session.execute(self._update_stmt, {"userid": user_id, "sched_time": sched_time})
+                    if result.rowcount == 0:
+                        raise Exception(f"Failed to update a celery_user_rate_limit row for user id {user_id}")
+                    sa_session.commit()
+        return sched_time

--- a/lib/galaxy/celery/base_task.py
+++ b/lib/galaxy/celery/base_task.py
@@ -49,7 +49,10 @@ class GalaxyTaskBeforeStartUserRateLimit(GalaxyTaskBeforeStart):
         tasks_per_user_per_sec: float,
         ga_scoped_session: galaxy_scoped_session,
     ):
-        self.task_exec_countdown_secs = 1 / tasks_per_user_per_sec
+        try:
+            self.task_exec_countdown_secs = 1 / tasks_per_user_per_sec
+        except ZeroDivisionError:
+            raise Exception("tasks_per_user_per_sec was zero in celery GalaxyTask before_start")
         self.ga_scoped_session = ga_scoped_session
 
     def __call__(self, task: Task, task_id, args, kwargs):

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2740,11 +2740,6 @@ galaxy:
   # executed per user per second.
   #celery_user_rate_limit: 0.0
 
-  # Applies if celery_user_rate_limit is non-zero. Used for testing
-  # against a postgres db. Forces use of standard sql code rather than
-  # postgres specific dialect for database access code.
-  #celery_user_rate_limit_standard_before_start: false
-
   # Allow disabling pbkdf2 hashing of passwords for legacy situations.
   # This should normally be left enabled unless there is a specific
   # reason to disable it.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2736,6 +2736,15 @@ galaxy:
   # https://docs.galaxyproject.org/en/master/admin/production.html
   #enable_celery_tasks: false
 
+  # If set to a non-0 value, upper limit on number of
+  # tasks that can be executed per user per second.
+  #celery_user_rate_limit: 0.0
+
+  # Applies if celery_user_rate_limit is non-zero. Used for testing against
+  # a postgres db. Forces use of standard sql code rather than
+  # postgres specific dialect for database access code.
+  #celery_user_rate_limit_standard_before_start: false
+
   # Allow disabling pbkdf2 hashing of passwords for legacy situations.
   # This should normally be left enabled unless there is a specific
   # reason to disable it.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2736,12 +2736,12 @@ galaxy:
   # https://docs.galaxyproject.org/en/master/admin/production.html
   #enable_celery_tasks: false
 
-  # If set to a non-0 value, upper limit on number of
-  # tasks that can be executed per user per second.
+  # If set to a non-0 value, upper limit on number of tasks that can be
+  # executed per user per second.
   #celery_user_rate_limit: 0.0
 
-  # Applies if celery_user_rate_limit is non-zero. Used for testing against
-  # a postgres db. Forces use of standard sql code rather than
+  # Applies if celery_user_rate_limit is non-zero. Used for testing
+  # against a postgres db. Forces use of standard sql code rather than
   # postgres specific dialect for database access code.
   #celery_user_rate_limit_standard_before_start: false
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3742,15 +3742,6 @@ mapping:
           If set to a non-0 value, upper limit on number of
           tasks that can be executed per user per second.
 
-      celery_user_rate_limit_standard_before_start:
-        type: bool
-        default: false
-        required: false
-        desc: |
-          Applies if celery_user_rate_limit is non-zero. Used for testing against
-          a postgres db. Forces use of standard sql code rather than
-          postgres specific dialect for database access code.
-
       use_pbkdf2:
         type: bool
         default: true

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3734,6 +3734,23 @@ mapping:
           Activate this only if you have setup a Celery worker for Galaxy.
           For details, see https://docs.galaxyproject.org/en/master/admin/production.html
 
+      celery_user_rate_limit:
+        type: float
+        default: 0.0
+        required: false
+        desc: |
+          If set to a non-0 value, upper limit on number of
+          tasks that can be executed per user per second.
+
+      celery_user_rate_limit_standard_before_start:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Applies if celery_user_rate_limit is non-zero. Used for testing against
+          a postgres db. Forces use of standard sql code rather than
+          postgres specific dialect for database access code.
+
       use_pbkdf2:
         type: bool
         default: true

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -425,7 +425,7 @@ class DatasetCollectionManager:
                     dataset.deleted = True
 
                 if purge and not dataset.purged:
-                    async_result = self.hda_manager.purge(dataset)
+                    async_result = self.hda_manager.purge(dataset, user=trans.user)
 
         with transaction(trans.sa_session):
             trans.sa_session.commit()

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -222,10 +222,11 @@ class HDAManager(
         return ldda.to_history_dataset_association(history, add_to_history=True)
 
     # .... deletion and purging
-    def purge(self, hda, flush=True, user: Optional[model.User] = None):
+    def purge(self, hda, flush=True, **kwargs):
         if self.app.config.enable_celery_tasks:
             from galaxy.celery.tasks import purge_hda
 
+            user = kwargs.get("user")
             return purge_hda.delay(hda_id=hda.id, task_user_id=getattr(user, "id", None))
         else:
             self._purge(hda, flush=flush)

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -222,11 +222,11 @@ class HDAManager(
         return ldda.to_history_dataset_association(history, add_to_history=True)
 
     # .... deletion and purging
-    def purge(self, hda, flush=True):
+    def purge(self, hda, flush=True, user: Optional[model.User] = None):
         if self.app.config.enable_celery_tasks:
             from galaxy.celery.tasks import purge_hda
 
-            return purge_hda.delay(hda_id=hda.id)
+            return purge_hda.delay(hda_id=hda.id, task_user_id=getattr(user, "id", None))
         else:
             self._purge(hda, flush=flush)
 
@@ -439,7 +439,7 @@ class HDAStorageCleanerManager(base.StorageCleanerManager):
             with transaction(session):
                 session.commit()
 
-        self._request_full_delete_all(dataset_ids_to_remove)
+        self._request_full_delete_all(dataset_ids_to_remove, user)
 
         return StorageItemsCleanupResult(
             total_item_count=len(item_ids),
@@ -448,13 +448,13 @@ class HDAStorageCleanerManager(base.StorageCleanerManager):
             errors=errors,
         )
 
-    def _request_full_delete_all(self, dataset_ids_to_remove: Set[int]):
+    def _request_full_delete_all(self, dataset_ids_to_remove: Set[int], user: Optional[model.User]):
         use_tasks = self.dataset_manager.app.config.enable_celery_tasks
         request = PurgeDatasetsTaskRequest(dataset_ids=list(dataset_ids_to_remove))
         if use_tasks:
             from galaxy.celery.tasks import purge_datasets
 
-            purge_datasets.delay(request=request)
+            purge_datasets.delay(request=request, task_user_id=getattr(user, "id", None))
         else:
             self.dataset_manager.purge_datasets(request)
 

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -140,7 +140,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         return self.query(filters=filters, order_by=desc_update_time, limit=1, **kwargs).first()
 
     # .... purgable
-    def purge(self, history, flush=True, user: Optional[model.User] = None, **kwargs):
+    def purge(self, history, flush=True, **kwargs):
         """
         Purge this history and all HDAs, Collections, and Datasets inside this history.
         """
@@ -149,7 +149,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         # First purge all the datasets
         for hda in history.datasets:
             if not hda.purged:
-                self.hda_manager.purge(hda, flush=True, user=user)
+                self.hda_manager.purge(hda, flush=True, **kwargs)
 
         # Now mark the history as purged
         super().purge(history, flush=flush, **kwargs)

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -140,7 +140,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         return self.query(filters=filters, order_by=desc_update_time, limit=1, **kwargs).first()
 
     # .... purgable
-    def purge(self, history, flush=True, **kwargs):
+    def purge(self, history, flush=True, user: Optional[model.User] = None, **kwargs):
         """
         Purge this history and all HDAs, Collections, and Datasets inside this history.
         """
@@ -149,7 +149,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         # First purge all the datasets
         for hda in history.datasets:
             if not hda.purged:
-                self.hda_manager.purge(hda, flush=True)
+                self.hda_manager.purge(hda, flush=True, user=user)
 
         # Now mark the history as purged
         super().purge(history, flush=flush, **kwargs)
@@ -456,7 +456,7 @@ class HistoryStorageCleanerManager(StorageCleanerManager):
         for history_id in item_ids:
             try:
                 history = self.history_manager.get_owned(history_id, user)
-                self.history_manager.purge(history, flush=False)
+                self.history_manager.purge(history, flush=False, user=user)
                 success_item_count += 1
                 total_free_bytes += int(history.disk_size)
             except BaseException as e:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6,7 +6,6 @@ the relationship cardinalities are obvious (e.g. prefer Dataset to Data)
 """
 import abc
 import base64
-import datetime
 import errno
 import json
 import logging
@@ -67,7 +66,6 @@ from sqlalchemy import (
     ForeignKey,
     func,
     Index,
-    insert,
     inspect,
     Integer,
     join,
@@ -90,7 +88,6 @@ from sqlalchemy import (
     update,
     VARCHAR,
 )
-from sqlalchemy.dialects.postgresql import insert as ps_insert
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext import hybrid
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -105,7 +102,6 @@ from sqlalchemy.orm import (
     reconstructor,
     registry,
     relationship,
-    Session,
 )
 from sqlalchemy.orm.attributes import flag_modified
 from sqlalchemy.orm.collections import attribute_mapped_collection
@@ -10400,98 +10396,11 @@ class CeleryUserRateLimit(Base):
     user_id = Column(Integer, ForeignKey("galaxy_user.id", ondelete="CASCADE"), primary_key=True)
     last_scheduled_time = Column(DateTime, nullable=False)
 
-    def calculate_task_start_time(
-        self, user_id: int, sa_session: Session, task_interval_secs: float, now: datetime.datetime
-    ) -> datetime.datetime:
-        """
-        Calculates the next time a task should be scheduled to run for the user_id.
-        It looks up the latest time a task has already been scheduled to run
-        for this user in a database table and then adds task_interval_secs seconds
-        to it to come up with the next scheduled time.
-        """
-        return now
-
     def __repr__(self):
         return (
             f"CeleryUserRateLimit(id_type={self.id_type!r}, "
             f"id={self.id!r}, last_scheduled_time={self.last_scheduled_time!r})"
         )
-
-
-class CeleryUserRateLimitStandard(CeleryUserRateLimit):
-    """
-    Generic but slower implementation supported by most databases
-    """
-
-    _select_stmt = (
-        select(CeleryUserRateLimit.last_scheduled_time)
-        .with_for_update(of=CeleryUserRateLimit.last_scheduled_time)
-        .where(CeleryUserRateLimit.user_id == bindparam("userid"))
-    )
-
-    _update_stmt = (
-        update(CeleryUserRateLimit)
-        .where(CeleryUserRateLimit.user_id == bindparam("userid"))
-        .values(last_scheduled_time=bindparam("sched_time"))
-    )
-
-    _insert_stmt = insert(CeleryUserRateLimit).values(
-        user_id=bindparam("userid"), last_scheduled_time=bindparam("sched_time")
-    )
-
-    def calculate_task_start_time(
-        self, user_id: int, sa_session: Session, task_interval_secs: float, now: datetime.datetime
-    ) -> datetime.datetime:
-        last_scheduled_time = sa_session.scalars(self._select_stmt, {"userid": user_id}).first()
-        if last_scheduled_time:
-            sched_time = last_scheduled_time + datetime.timedelta(seconds=task_interval_secs)
-            if sched_time < now:
-                sched_time = now
-            sa_session.execute(self._update_stmt, {"userid": user_id, "sched_time": sched_time})
-        else:
-            try:
-                sched_time = now
-                sa_session.execute(self._insert_stmt, {"userid": user_id, "sched_time": sched_time})
-            except Exception:
-                sched_time = now + datetime.timedelta(seconds=task_interval_secs)
-                sa_session.execute(self._update_stmt, {"userid": user_id, "sched_time": sched_time})
-        return sched_time
-
-
-class CeleryUserRateLimitPostgres(CeleryUserRateLimit):
-    """
-    Postgres specific implementation that takes advantage of the
-    returning option to do an update and return a column value from the
-    updated row in a single statement. It also takes advantage
-    of the upsert feature of postgres.
-    """
-
-    _update_stmt = (
-        update(CeleryUserRateLimit)
-        .where(CeleryUserRateLimit.user_id == bindparam("userid"))
-        .values(last_scheduled_time=text("greatest(last_scheduled_time + ':interval second', " ":now) "))
-        .returning(CeleryUserRateLimit.last_scheduled_time)
-    )
-
-    _insert_stmt = (
-        ps_insert(CeleryUserRateLimit)
-        .values(user_id=bindparam("userid"), last_scheduled_time=bindparam("now"))
-        .returning(CeleryUserRateLimit.last_scheduled_time)
-    )
-
-    _upsert_stmt = _insert_stmt.on_conflict_do_update(
-        index_elements=["user_id"], set_=dict(last_scheduled_time=bindparam("sched_time"))
-    )
-
-    def calculate_task_start_time(  # type: ignore
-        self, user_id: int, sa_session: Session, task_interval_secs: float, now: datetime.datetime
-    ) -> datetime.datetime:
-        result = sa_session.execute(self._update_stmt, {"userid": user_id, "interval": task_interval_secs, "now": now})
-        if result.rowcount == 0:
-            sched_time = now + datetime.timedelta(seconds=task_interval_secs)
-            result = sa_session.execute(self._upsert_stmt, {"userid": user_id, "now": now, "sched_time": sched_time})
-        for row in result:
-            return row[0]
 
 
 # The following models (HDA, LDDA) are mapped imperatively (for details see discussion in PR #12064)

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -1,6 +1,9 @@
 import sqlite3
 from contextlib import contextmanager
-from typing import Optional
+from typing import (
+    NewType,
+    Optional,
+)
 
 from sqlalchemy import (
     create_engine,
@@ -17,6 +20,8 @@ from sqlalchemy.sql.expression import (
 
 from galaxy.exceptions import ConfigurationError
 from galaxy.model import Job
+
+DbUrl = NewType("DbUrl", str)
 
 
 def database_exists(db_url, database=None):
@@ -166,3 +171,7 @@ def _statement_executed_without_error(statement: ClauseElement, engine: Engine) 
             return True
     except Exception:
         return False
+
+
+def is_postgres(url: DbUrl) -> bool:
+    return url.startswith("postgres")

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/987ce9839ecb_create_celery_user_rate_limit_table.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/987ce9839ecb_create_celery_user_rate_limit_table.py
@@ -1,0 +1,31 @@
+"""create celery_user_rate_limit_table
+
+Revision ID: 987ce9839ecb
+Revises: b855b714e8b8
+Create Date: 2023-05-17 15:08:28.467938
+
+"""
+import sqlalchemy as sa
+
+from galaxy.model.migrations.util import (
+    create_table,
+    drop_table,
+)
+
+# revision identifiers, used by Alembic.
+revision = "987ce9839ecb"
+down_revision = "e0561d5fc8c7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    create_table(
+        "celery_user_rate_limit",
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("galaxy_user.id"), primary_key=True),
+        sa.Column("last_scheduled_time", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade():
+    drop_table("celery_user_rate_limit")

--- a/lib/galaxy/model/unittest_utils/model_testing_utils.py
+++ b/lib/galaxy/model/unittest_utils/model_testing_utils.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from typing import (
     Callable,
     Iterator,
-    NewType,
     Optional,
 )
 
@@ -20,7 +19,11 @@ from sqlalchemy.engine import (
 )
 from sqlalchemy.sql.compiler import IdentifierPreparer
 
-from galaxy.model.database_utils import create_database
+from galaxy.model.database_utils import (
+    create_database,
+    DbUrl,
+    is_postgres,
+)
 
 # GALAXY_TEST_CONNECT_POSTGRES_URI='postgresql://postgres@localhost:5432/postgres' pytest test/unit/model
 skip_if_not_postgres_uri = pytest.mark.skipif(
@@ -31,8 +34,6 @@ skip_if_not_postgres_uri = pytest.mark.skipif(
 skip_if_not_mysql_uri = pytest.mark.skipif(
     not os.environ.get("GALAXY_TEST_CONNECT_MYSQL_URI"), reason="GALAXY_TEST_CONNECT_MYSQL_URI not set"
 )
-
-DbUrl = NewType("DbUrl", str)
 
 
 @contextmanager
@@ -219,10 +220,6 @@ def get_stored_obj(session, cls, obj_id=None, where_clause=None, unique=False):
 def get_stored_instance_by_id(session, cls_, id):
     statement = select(cls_).where(cls_.__table__.c.id == id)
     return session.execute(statement).scalar_one()
-
-
-def is_postgres(url: DbUrl) -> bool:
-    return url.startswith("postgres")
 
 
 def _is_mysql(url: DbUrl) -> bool:

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -178,6 +178,7 @@ class ExportHistoryToolAction(ToolAction):
             include_hidden=incoming["include_hidden"],
             include_deleted=incoming["include_deleted"],
             compressed=compressed,
+            user=trans.user,
         )
 
         return job, {}

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -194,8 +194,13 @@ def execute(
             )
 
             raw_tool_source = tool.tool_source.to_string()
+            #  task_user_id parameter is used to do task user rate limiting. It is only passed
+            #  to first task in chain because it is only necessary to rate limit the first
+            #  task in a chain.
             async_result = (
-                setup_fetch_data.s(job_id, raw_tool_source=raw_tool_source)
+                setup_fetch_data.s(
+                    job_id, raw_tool_source=raw_tool_source, task_user_id=getattr(trans.user, "id", None)
+                )
                 | fetch_data.s(job_id=job_id)
                 | set_job_metadata.s(
                     extended_metadata_collection="extended" in tool.app.config.metadata_strategy,

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -2,6 +2,7 @@ import getpass
 import logging
 import os
 import shutil
+from typing import Optional
 
 from galaxy import model
 from galaxy.model import store
@@ -96,7 +97,15 @@ class JobExportHistoryArchiveWrapper:
         self.job_id = job_id
         self.sa_session = self.app.model.context
 
-    def setup_job(self, history, store_directory, include_hidden=False, include_deleted=False, compressed=True):
+    def setup_job(
+        self,
+        history,
+        store_directory,
+        include_hidden=False,
+        include_deleted=False,
+        compressed=True,
+        user: Optional[model.User] = None,
+    ):
         """
         Perform setup for job to export a history into an archive.
         """
@@ -115,6 +124,6 @@ class JobExportHistoryArchiveWrapper:
         )
         if app.config.enable_celery_tasks:
             # symlink files on export, on worker files will tarred up in a dereferenced manner.
-            export_history.delay(request=request)
+            export_history.delay(request=request, task_user_id=getattr(user, "id", None))
         else:
             export_history(request=request)

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -304,7 +304,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
                         f"History ({history.name}) has been shared with others, unshare it before deleting it."
                     )
                 if purge:
-                    self.history_manager.purge(history)
+                    self.history_manager.purge(history, user=trans.user)
                 else:
                     self.history_manager.delete(history)
                 if history == current_history:

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -456,7 +456,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
             hash_function=payload.hash_function,
             user=trans.async_request_user,
         )
-        result = compute_dataset_hash.delay(request=request)
+        result = compute_dataset_hash.delay(request=request, task_user_id=getattr(trans.user, "id", None))
         return async_task_summary(result)
 
     def drs_dataset_instance(self, object_id: str) -> Tuple[int, DatasetSourceType]:
@@ -497,7 +497,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                 hash_function=hash_funciton,
                 user=None,
             )
-            compute_dataset_hash.delay(request=request)
+            compute_dataset_hash.delay(request=request, task_user_id=getattr(trans.user, "id", None))
             raise galaxy_exceptions.AcceptedRetryLater(
                 "required checksum task for DRS object response launched.", retry_after=60
             )

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -291,7 +291,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             for_library=False,
             model_store_format=payload.model_store_format,
         )
-        result = import_model_store.delay(request=request)
+        result = import_model_store.delay(request=request, task_user_id=getattr(trans.user, "id", None))
         return async_task_summary(result)
 
     def _ensure_can_create_history(self, trans):
@@ -352,7 +352,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             export_association_id=export_association.id,
             **payload.dict(),
         )
-        result = prepare_history_download.delay(request=request)
+        result = prepare_history_download.delay(request=request, task_user_id=getattr(trans.user, "id", None))
         task_summary = async_task_summary(result)
         export_association.task_uuid = task_summary.id
         with transaction(trans.sa_session):
@@ -370,7 +370,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
             export_association_id=export_association.id,
             **payload.dict(),
         )
-        result = write_history_to.delay(request=request)
+        result = write_history_to.delay(request=request, task_user_id=getattr(trans.user, "id", None))
         task_summary = async_task_summary(result)
         export_association.task_uuid = task_summary.id
         with transaction(trans.sa_session):

--- a/lib/galaxy/webapps/galaxy/services/invocations.py
+++ b/lib/galaxy/webapps/galaxy/services/invocations.py
@@ -170,7 +170,7 @@ class InvocationsService(ServiceBase):
             galaxy_url=trans.request.url_path,
             **payload.dict(),
         )
-        result = prepare_invocation_download.delay(request=request)
+        result = prepare_invocation_download.delay(request=request, task_user_id=getattr(trans.user, "id", None))
         return AsyncFile(storage_request_id=short_term_storage_target.request_id, task=async_task_summary(result))
 
     def write_store(
@@ -186,7 +186,7 @@ class InvocationsService(ServiceBase):
             invocation_id=workflow_invocation.id,
             **payload.dict(),
         )
-        result = write_invocation_to.delay(request=request)
+        result = write_invocation_to.delay(request=request, task_user_id=getattr(trans.user, "id", None))
         rval = async_task_summary(result)
         return rval
 

--- a/lib/galaxy/webapps/galaxy/services/pages.py
+++ b/lib/galaxy/webapps/galaxy/services/pages.py
@@ -149,5 +149,5 @@ class PagesService(ServiceBase):
             document_type=PdfDocumentType.page,
             short_term_storage_request_id=request_id,
         )
-        result = prepare_pdf_download.delay(request=pdf_download_request)
+        result = prepare_pdf_download.delay(request=pdf_download_request, task_user_id=getattr(trans.user, "id", None))
         return AsyncFile(storage_request_id=request_id, task=async_task_summary(result))

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -34,7 +34,7 @@ class UsersService(ServiceBase):
         if trans.app.config.enable_celery_tasks:
             from galaxy.celery.tasks import recalculate_user_disk_usage
 
-            result = recalculate_user_disk_usage.delay(user_id=trans.user.id)
+            result = recalculate_user_disk_usage.delay(task_user_id=getattr(trans.user, "id", None))
             return async_task_summary(result)
         else:
             send_local_control_task(

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -342,6 +342,13 @@ def copy_database_template(source, db_path):
         raise Exception(f"Failed to copy database template from source {source}")
 
 
+def init_database(database_connection):
+    # We pass by migrations and instantiate the current table
+    create_database(database_connection)
+    mapping.init("/tmp", database_connection, create_tables=True, map_install_models=True)
+    toolshed_mapping.init(database_connection, create_tables=True)
+
+
 def database_conf(db_path, prefix="GALAXY", prefer_template_database=False):
     """Find (and populate if needed) Galaxy database connection."""
     database_auto_migrate = False
@@ -359,10 +366,7 @@ def database_conf(db_path, prefix="GALAXY", prefer_template_database=False):
             actual_database_parsed = database_template_parsed._replace(path=f"/{actual_db}")
             database_connection = actual_database_parsed.geturl()
             if not database_exists(database_connection):
-                # We pass by migrations and instantiate the current table
-                create_database(database_connection)
-                mapping.init("/tmp", database_connection, create_tables=True, map_install_models=True)
-                toolshed_mapping.init(database_connection, create_tables=True)
+                init_database(database_connection)
                 check_migrate_databases = False
     else:
         default_db_filename = f"{prefix.lower()}.sqlite"

--- a/test/integration/test_celery_user_rate_limit.py
+++ b/test/integration/test_celery_user_rate_limit.py
@@ -1,0 +1,169 @@
+import datetime
+import tempfile
+from functools import lru_cache
+from typing import (
+    Dict,
+    Iterable,
+    List,
+)
+
+from celery.result import AsyncResult
+from sqlalchemy import text
+
+from galaxy.celery import galaxy_task
+from galaxy.model.database_utils import sqlalchemy_engine
+from galaxy.util import ExecutionTimer
+from galaxy_test.driver.driver_util import init_database
+from galaxy_test.driver.integration_util import IntegrationTestCase
+
+
+@galaxy_task(bind=True)
+def mock_user_id_task(self, task_user_id: int):
+    return task_user_id
+
+
+@lru_cache()
+def sqlite_url():
+    path = tempfile.NamedTemporaryFile().name
+    dburl = f"sqlite:///{path}"
+    init_database(dburl)
+    return dburl
+
+
+@lru_cache()
+def setup_users(dburl: str, num_users: int = 2):
+    """
+    Setup test users in galaxy_user table with user id's starting from 2 because
+    we assume there always exists a user with id = 1.
+    This is because the new celery_user_rate_limit table has
+    a user_id with a foreign key pointing to galaxy_user table.
+    """
+    expected_user_ids = [i for i in range(2, num_users + 1)]
+    with sqlalchemy_engine(dburl) as engine:
+        with engine.begin() as conn:
+            found_user_ids = conn.scalars(
+                text("select id from galaxy_user where id between 1 and :high"), {"high": num_users}
+            ).all()
+            if len(expected_user_ids) > len(found_user_ids):
+                user_ids_to_add = set(expected_user_ids).difference(found_user_ids)
+                for user_id in user_ids_to_add:
+                    conn.execute(
+                        text("insert into galaxy_user(id, active, email, password) values (:id, :active, :email, :pw)"),
+                        [{"id": user_id, "active": True, "email": "e", "pw": "p"}],
+                    )
+
+
+class TestCeleryUserRateLimitIntegration(IntegrationTestCase):
+    """
+    Test feature that limits the number of celery task executions
+    per user per second. This is implemented by the celery_user_rate_limit
+    config parameter whose default value is 0.0 meaning no rate limit.
+    For each of a set of users it submits runs a task num_calls times.
+    For the test to succeed the total duration of completion of all task
+    executions should be equal to the tasks_per_user_per_sec times
+    num_calls-1. This is because tasks for different users should be
+    executed in parallel. In addition, we verify that the total
+    duration for execution of tasks for each user equals the total
+    task duration, again because tasks for different users should
+    run in parallel.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+    def _test_mock_pass_user_id_task(self, users: Iterable[int], num_calls: int, tasks_per_user_per_sec: float):
+        expected_duration: float
+        if tasks_per_user_per_sec == 0.0:
+            expected_duration = 0.0
+            expected_duration_lbound = 0.0
+        else:
+            secs_between_tasks_per_user = 1 / tasks_per_user_per_sec
+            expected_duration = secs_between_tasks_per_user * (num_calls - 1)
+            expected_duration_lbound = expected_duration - 4
+        expected_duration_hbound = expected_duration + 4
+        start_time = datetime.datetime.utcnow()
+        timer = ExecutionTimer()
+        results: Dict[int, List[AsyncResult]] = {}
+        for user in users:
+            user_results: List[AsyncResult] = []
+            for _i in range(num_calls):  # type: ignore
+                user_results.append(mock_user_id_task.delay(task_user_id=user))
+            results[user] = user_results
+        for user, user_results in results.items():
+            for result in user_results:
+                val = result.get(timeout=1000)
+                assert val == user
+        elapsed = timer.elapsed
+        assert elapsed >= expected_duration_lbound and elapsed <= expected_duration_hbound
+        for user_results in results.values():
+            last_task_end_time = start_time
+            for result in user_results:
+                if result.date_done > last_task_end_time:
+                    last_task_end_time = result.date_done
+            user_elapsed = (last_task_end_time - start_time).total_seconds()
+            assert user_elapsed >= expected_duration_lbound and user_elapsed <= expected_duration_hbound
+
+
+class TestCeleryUserRateLimitIntegrationPostgres(TestCeleryUserRateLimitIntegration):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        dburl = config["database_connection"]
+        setup_users(dburl)
+
+
+class TestCeleryUserRateLimitIntegrationPostgres1(TestCeleryUserRateLimitIntegrationPostgres):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        TestCeleryUserRateLimitIntegrationPostgres.handle_galaxy_config_kwds(config)
+        config["celery_user_rate_limit"] = 0.1
+
+    def test_mock_pass_user_id_task(self):
+        self._test_mock_pass_user_id_task([1, 2], 3, 0.1)
+
+
+class TestCeleryUserRateLimitIntegrationPostgresStandard(TestCeleryUserRateLimitIntegrationPostgres1):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        TestCeleryUserRateLimitIntegrationPostgres1.handle_galaxy_config_kwds(config)
+        config["celery_user_rate_limit_standard_before_start"] = True
+
+
+class TestCeleryUserRateLimitIntegrationPostgresNoLimit(TestCeleryUserRateLimitIntegration):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        TestCeleryUserRateLimitIntegrationPostgres.handle_galaxy_config_kwds(config)
+        # config["celery_user_rate_limit"] = 0.0
+
+    def test_mock_pass_user_id_task(self):
+        self._test_mock_pass_user_id_task([1, 2], 3, 0)
+
+
+class TestCeleryUserRateLimitIntegrationSqlite(TestCeleryUserRateLimitIntegration):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["database_connection"] = sqlite_url()
+        if config.get("database_engine_option_pool_size"):
+            config.pop("database_engine_option_pool_size")
+        if config.get("database_engine_option_max_overflow"):
+            config.pop("database_engine_option_max_overflow")
+        setup_users(config["database_connection"])
+
+
+class TestCeleryUserRateLimitIntegrationSqlite1(TestCeleryUserRateLimitIntegrationSqlite):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        TestCeleryUserRateLimitIntegrationSqlite.handle_galaxy_config_kwds(config)
+        config["celery_user_rate_limit"] = 0.1
+
+    def test_mock_pass_user_id_task(self):
+        self._test_mock_pass_user_id_task([1, 2], 3, 0.1)
+
+
+class TestCeleryUserRateLimitIntegrationSqliteNoLimit(TestCeleryUserRateLimitIntegrationSqlite):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        TestCeleryUserRateLimitIntegrationSqlite.handle_galaxy_config_kwds(config)
+        # config["celery_user_rate_limit"] = 0.0
+
+    def test_mock_pass_user_id_task(self):
+        self._test_mock_pass_user_id_task([1, 2], 3, 0)

--- a/test/unit/app/test_migrate_database.py
+++ b/test/unit/app/test_migrate_database.py
@@ -1,5 +1,6 @@
 import pytest
 
+from galaxy.model.database_utils import is_postgres
 from galaxy.model.migrations import AlembicManager
 from galaxy.model.unittest_utils.migration_scripts_testing_utils import (  # noqa: F401 - contains fixtures we have to import explicitly
     run_command,
@@ -8,7 +9,6 @@ from galaxy.model.unittest_utils.migration_scripts_testing_utils import (  # noq
 from galaxy.model.unittest_utils.model_testing_utils import (  # noqa: F401 - url_factory is a fixture we have to import explicitly
     create_and_drop_database,
     disposing_engine,
-    is_postgres,
     sqlite_url_factory,
     url_factory,
 )


### PR DESCRIPTION
Closes #14411

Introduce a celery_user_rate_limit config parameter which specifies how many tasks per second a user can execute. Create a custom celery Task class called GalaxyTask with a before_start hook that implements the rate limiting logic. Add a new table, celery_user_rate_limit that tracks the last scheduled execution time
by user id. Add new integration test, test_celery_user_rate_limit.py.

A task function must include the keyword parameter task_user_id for user rate limiting to work.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
