### PR TITLE
Handle appending to a results file that does not exists.

### DIFF
--- a/lib/galaxy/tool_util/verify/script.py
+++ b/lib/galaxy/tool_util/verify/script.py
@@ -60,11 +60,12 @@ class Results:
         self.galaxy_url = galaxy_url
         test_results = []
         suitename = default_suitename
-        if append:
+        if append and os.path.exists(test_json):
             assert test_json != "-"
             with open(test_json) as f:
                 previous_results = json.load(f)
-                test_results = previous_results["tests"]
+                if "tests" in previous_results:
+                    test_results = previous_results["tests"]
                 if "suitename" in previous_results:
                     suitename = previous_results["suitename"]
         self.test_results = test_results

--- a/test/unit/tool_util/test_verify_script.py
+++ b/test/unit/tool_util/test_verify_script.py
@@ -270,7 +270,7 @@ def test_test_tools_records_retry_exception() -> None:
 
 
 def test_append_results() -> None:
-    tf = mktemp(dir='/tmp')
+    tf = mktemp(dir="/tmp")
     assert not os.path.exists(tf)
     # Now try to append to the non-existent file.
     results = Results("my suite", tf, True)

--- a/test/unit/tool_util/test_verify_script.py
+++ b/test/unit/tool_util/test_verify_script.py
@@ -1,6 +1,6 @@
 import json
 import os
-from tempfile import NamedTemporaryFile, mktemp
+from tempfile import NamedTemporaryFile
 from typing import (
     cast,
     NoReturn,
@@ -270,15 +270,16 @@ def test_test_tools_records_retry_exception() -> None:
 
 
 def test_append_results() -> None:
-    tf = mktemp(dir="/tmp")
-    assert not os.path.exists(tf)
+    tf = NamedTemporaryFile()
+    tf.close()
+    assert not os.path.exists(tf.name)
     # Now try to append to the non-existent file.
-    results = Results("my suite", tf, True)
+    results = Results("my suite", tf.name, True)
     results.register_result({"id": "foo", "has_data": True, "data": {"status": "success"}})
     try:
         results.write()
-        assert os.path.exists(tf)
-        with open(tf) as f:
+        assert os.path.exists(tf.name)
+        with open(tf.name) as f:
             report_obj = json.load(f)
         assert "tests" in report_obj
         assert len(report_obj["tests"]) == 1
@@ -286,8 +287,8 @@ def test_append_results() -> None:
         assert report_obj["results"]["errors"] == 0
         assert report_obj["results"]["skips"] == 0
     finally:
-        os.remove(tf)
-    assert not os.path.exists(tf)
+        os.remove(tf.name)
+    assert not os.path.exists(tf.name)
 
 
 def test_results():


### PR DESCRIPTION
Running `galaxy-tool-test -j results.json --append ...` will fail if the `results.json` file does not already exist. Appending to a file that does not exist should simply create the file.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
