### PR TITLE
[23.0] Allow skipping ``expect_num_outputs`` when ``expect_failure`` is set in tool test

### DIFF
--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -60,9 +60,11 @@ def lint_tests(tool_xml, lint_ctx):
         _check_asserts(test_idx, test.findall(".//assert_contents"), lint_ctx)
 
         # check if expect_num_outputs is set if there are outputs with filters
+        # (except for tests with expect_failure .. which can't have test outputs)
         filter = tool_xml.findall("./outputs//filter")
         if len(filter) > 0 and "expect_num_outputs" not in test.attrib:
-            lint_ctx.warn("Test should specify 'expect_num_outputs' if outputs have filters", node=test)
+            if not asbool(test.attrib.get("expect_failure", False)):
+                lint_ctx.warn("Test should specify 'expect_num_outputs' if outputs have filters", node=test)
 
         # really simple test that test parameters are also present in the inputs
         for param in test.findall("param"):
@@ -145,7 +147,7 @@ def lint_tests(tool_xml, lint_ctx):
                                 node=output,
                             )
 
-        if "expect_failure" in test.attrib and asbool(test.attrib["expect_failure"]):
+        if asbool(test.attrib.get("expect_failure", False)):
             if found_output_test:
                 lint_ctx.error(f"Test {test_idx}: Cannot specify outputs in a test expecting failure.", node=test)
                 continue

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -775,6 +775,10 @@ TESTS_DISCOVER_OUTPUTS = """
             <output name="data_name"/>
             <output_collection name="collection_name"/>
         </test>
+        <!-- no count or discovered_dataset/element
+             - no outputs can be given
+             - consequently also counts and expect_num_output need not to be given -->
+        <test expect_failure="true"/>
         <!-- no nested element and count at element -->
         <test>
             <output name="data_name" count="1"/>
@@ -1687,7 +1691,7 @@ def test_tests_discover_outputs(lint_ctx):
         in lint_ctx.error_messages
     )
     assert (
-        "Test 4: test collection 'collection_name' must contain nested 'element' tags and/or element childen with a 'count' attribute"
+        "Test 5: test collection 'collection_name' must contain nested 'element' tags and/or element childen with a 'count' attribute"
         in lint_ctx.error_messages
     )
     assert not lint_ctx.warn_messages


### PR DESCRIPTION
otherwise we contradict that failing tests must not have output assertions

fixes: https://github.com/galaxyproject/galaxy/issues/16235

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
