### PR TITLE
`tool_util` only ever add latest tool to `AbstractToolBox`

### DIFF
--- a/lib/galaxy/tool_util/toolbox/base.py
+++ b/lib/galaxy/tool_util/toolbox/base.py
@@ -546,7 +546,9 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 # older tool is in same section, just replace it with newer
                 else:
                     panel_dict.replace_tool(
-                        previous_tool_id=related_tool.id, new_tool_id=tool_id, tool=tool,
+                        previous_tool_id=related_tool.id,
+                        new_tool_id=tool_id,
+                        tool=tool,
                     )
                 log_msg = f"Loaded tool id: {tool.id}, version: {tool.version} into tool panel."
 


### PR DESCRIPTION
Previously, we would only check if older/newer (related) version existed in current `ToolSection`. Fixed it so we check if related version exists in any `ToolSection` of the currently loaded `self._tool_panel`. Fixes https://github.com/galaxyproject/galaxy/issues/16145

This bug would only occur if a Tool had one version in one `ToolSection`, and another in another/different `ToolSection`.

### For e.g.: 
Take the Tool with id `Add_a_column1`.
Its latest version is `2.0` with the name: `Compute on rows`. An older version `1.4` also exists in the server, and has the name `Compute
an expression on every row`. If both versions of this tool are placed in the same section, only the latest version will appear in the ToolPanel, based on the current implementation in the backend. Instead, if both versions of this tool are placed in 2 different sections (like in usegalaxy.eu as of now), they will appear in both places, as seen below:

![image](https://github.com/galaxyproject/galaxy/assets/78516064/7ba951c4-494f-4f13-ab92-2892330936e1)

This has now been fixed so that instead of only checking if other versions exist in the current section, we also check all other sections of the ToolBox as well, to get the expected result:

![image](https://github.com/galaxyproject/galaxy/assets/78516064/7a33c69a-cb67-4323-90f9-3846eda38d02)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
