### PR TITLE
[22.05] Fix dropbox import to support newer versions

### DIFF
--- a/lib/galaxy/files/sources/dropbox.py
+++ b/lib/galaxy/files/sources/dropbox.py
@@ -1,7 +1,10 @@
 try:
-    from dropboxfs.dropboxfs import DropboxFS
+    from fs.dropboxfs import DropboxFS
 except ImportError:
-    DropboxFS = None
+    try:
+        from dropboxfs.dropboxfs import DropboxFS
+    except ImportError:
+        DropboxFS = None
 
 from ._pyfilesystem2 import PyFilesystem2FilesSource
 

--- a/lib/galaxy/files/sources/dropbox.py
+++ b/lib/galaxy/files/sources/dropbox.py
@@ -1,6 +1,7 @@
 try:
     from fs.dropboxfs import DropboxFS
 except ImportError:
+    # fs.dropboxfs < 0.3
     try:
         from dropboxfs.dropboxfs import DropboxFS
     except ImportError:


### PR DESCRIPTION
Closes: https://github.com/galaxyproject/galaxy/issues/15489

This is all very confusing, but it looks like the original fs.dropboxfs package was here: https://github.com/PyFilesystem/fs.dropboxfs but is now unmaintained. The new fs.dropboxfs package is maintained here by one of the original authors: https://github.com/rkhwaja/fs.dropboxfs

xref: https://github.com/galaxyproject/galaxy/pull/16229

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
