### PR TITLE
[23.0] Load data tables in Celery worker

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -576,6 +576,8 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
 
         self._configure_tool_shed_registry()
         self._register_singleton(tool_shed_registry.Registry, self.tool_shed_registry)
+        # Tool Data Tables
+        self._configure_tool_data_tables(from_shed_config=False)
 
     def _configure_tool_shed_registry(self) -> None:
         # Set up the tool sheds registry
@@ -628,8 +630,6 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         )
         self.api_keys_manager = self._register_singleton(ApiKeyManager)
 
-        # Tool Data Tables
-        self._configure_tool_data_tables(from_shed_config=False)
         # Load dbkey / genome build manager
         self._configure_genome_builds(data_table_name="__dbkeys__", load_old_style=True)
 


### PR DESCRIPTION
This is needed so that data bundle imports will work. The test case covering this will just receive the full integration app and thus didn't have this problem.
Should fix:
```
[2023-06-13 21:33:38,899: ERROR/main] Task galaxy.import_data_bundle[0853f72f-c8ce-4e59-b6e8-25e208ce79f7] raised unexpected: AttributeError("'GalaxyManagerApplication' object has no attribute 'tool_data_tables'")
Traceback (most recent call last):
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/celery/__init__.py", line 163, in wrapper
    rval = app.magic_partial(func)(*args, **kwds)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.8/site-packages/lagom/wrapping.py", line 27, in _bound_func
    bound_args, bound_kwargs = argument_updater(args, kwargs)
  File "lagom/container.py", line 350, in _update_args
  File "lagom/container.py", line 425, in _infer_dependencies
  File "lagom/container.py", line 265, in resolve
  File "lagom/container.py", line 392, in _reflection_build_with_err_handling
  File "lagom/container.py", line 408, in _reflection_build
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/managers/tool_data.py", line 114, in __init__
    self.tool_data_tables = app.tool_data_tables
AttributeError: 'GalaxyManagerApplication' object has no attribute 'tool_data_tables'
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
