### PR TITLE
Refine activity bar dragging behavior

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.test.js
+++ b/client/src/components/ActivityBar/ActivityBar.test.js
@@ -4,7 +4,14 @@ import { shallowMount } from "@vue/test-utils";
 import { getLocalVue } from "tests/jest/helpers";
 import { useActivityStore } from "@/stores/activityStore";
 import { useEventStore } from "@/stores/eventStore";
+import { useConfig } from "@/composables/config";
 import mountTarget from "./ActivityBar.vue";
+
+jest.mock("composables/config");
+useConfig.mockReturnValue({
+    config: {},
+    isLoaded: true,
+});
 
 jest.mock("vue-router/composables", () => ({
     useRoute: jest.fn(() => ({})),

--- a/client/src/components/ActivityBar/ActivityBar.test.js
+++ b/client/src/components/ActivityBar/ActivityBar.test.js
@@ -1,0 +1,49 @@
+import { createTestingPinia } from "@pinia/testing";
+import { PiniaVuePlugin } from "pinia";
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "tests/jest/helpers";
+import { useActivityStore } from "@/stores/activityStore";
+import mountTarget from "./ActivityBar.vue";
+
+jest.mock("vue-router/composables", () => ({
+    useRoute: jest.fn(() => ({})),
+}));
+
+const localVue = getLocalVue();
+localVue.use(PiniaVuePlugin);
+
+function testActivity(id, newOptions = {}) {
+    const defaultOptions = {
+        id: `test-${id}`,
+        description: "test-description",
+        icon: "test-icon",
+        mutable: true,
+        optional: false,
+        title: "test-title",
+        to: "test-to",
+        tooltip: "test-tooltip",
+        visible: true,
+    };
+    return { ...defaultOptions, ...newOptions };
+}
+
+describe("ActivityBar", () => {
+    let activityStore;
+    let wrapper;
+
+    beforeEach(async () => {
+        const pinia = createTestingPinia({ stubActions: false });
+        activityStore = useActivityStore();
+        wrapper = shallowMount(mountTarget, {
+            localVue,
+            pinia,
+        });
+    });
+
+    it("rendering", async () => {
+        activityStore.setAll([testActivity("1"), testActivity("2"), testActivity("3")]);
+        await wrapper.vm.$nextTick();
+        const items = wrapper.findAll("[title='test-title']");
+        expect(items.length).toBe(3);
+    });
+});

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -26,6 +26,8 @@ const eventStore = useEventStore();
 const activityStore = useActivityStore();
 const { isAnonymous } = storeToRefs(userStore);
 
+const emit = defineEmits(["dragstart"]);
+
 // sync built-in activities with cached activities
 activityStore.sync();
 
@@ -66,6 +68,7 @@ function onDragEnter(evt) {
     if (eventData) {
         dragTarget.value = evt.target;
         dragItem.value = convertDropData(eventData);
+        emit("dragstart", dragItem.value);
     } else {
         dragItem.value = null;
     }
@@ -125,6 +128,7 @@ function toggleContextMenu(evt) {
     <div class="d-flex">
         <div
             class="activity-bar d-flex flex-column no-highlight"
+            data-description="activity bar"
             @contextmenu="toggleContextMenu"
             @dragover.prevent="onDragOver"
             @dragenter.prevent="onDragEnter"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -128,14 +128,14 @@ function toggleContextMenu(evt) {
 </script>
 
 <template>
-    <div
-        class="d-flex"
-        @contextmenu="toggleContextMenu"
-        @drop.prevent="onChange"
-        @dragover.prevent="onDragOver"
-        @dragenter.prevent="onDragEnter"
-        @dragleave.prevent="onDragLeave">
-        <div class="activity-bar d-flex flex-column no-highlight">
+    <div class="d-flex">
+        <div
+            class="activity-bar d-flex flex-column no-highlight"
+            @contextmenu="toggleContextMenu"
+            @drop.prevent="onChange"
+            @dragover.prevent="onDragOver"
+            @dragenter.prevent="onDragEnter"
+            @dragleave.prevent="onDragLeave">
             <b-nav vertical class="flex-nowrap p-1 h-100 vertical-overflow">
                 <draggable
                     :list="activities"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -2,6 +2,7 @@
 import { storeToRefs } from "pinia";
 import draggable from "vuedraggable";
 import { ref } from "vue";
+import { storeToRefs } from "pinia";
 import { useUserStore } from "@/stores/userStore";
 import { useActivityStore } from "@/stores/activityStore";
 import { useRoute } from "vue-router/composables";
@@ -29,7 +30,7 @@ const { isAnonymous } = storeToRefs(userStore);
 activityStore.sync();
 
 // activities from store
-const activities = ref(activityStore.getAll());
+const { activities } = storeToRefs(activityStore);
 
 // context menu references
 const contextMenuVisible = ref(false);
@@ -55,13 +56,6 @@ function isActiveRoute(activityTo) {
  */
 function isActiveSideBar(menuKey) {
     return userStore.toggledSideBar === menuKey;
-}
-
-/**
- * Triggered by vue-draggable when the list of activities has changed or an item has been dropped
- */
-function onChange() {
-    activityStore.setAll(activities);
 }
 
 /**
@@ -132,7 +126,6 @@ function toggleContextMenu(evt) {
         <div
             class="activity-bar d-flex flex-column no-highlight"
             @contextmenu="toggleContextMenu"
-            @drop.prevent="onChange"
             @dragover.prevent="onDragOver"
             @dragenter.prevent="onDragEnter"
             @dragleave.prevent="onDragLeave">
@@ -144,7 +137,6 @@ function toggleContextMenu(evt) {
                     chosen-class="activity-chosen-class"
                     drag-class="activity-drag-class"
                     ghost-class="activity-chosen-class"
-                    @change="onChange"
                     @start="isDragging = true"
                     @end="isDragging = false">
                     <div v-for="(activity, activityIndex) in activities" :key="activityIndex">

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -1,13 +1,12 @@
-<script setup>
-import { storeToRefs } from "pinia";
+<script setup lang="ts">
 import draggable from "vuedraggable";
-import { ref } from "vue";
+import { ref, type Ref } from "vue";
 import { storeToRefs } from "pinia";
 import { useUserStore } from "@/stores/userStore";
-import { useActivityStore } from "@/stores/activityStore";
+import { useActivityStore, type Activity } from "@/stores/activityStore";
 import { useRoute } from "vue-router/composables";
-import { convertDropData } from "@/stores/activitySetup.js";
-import { useEventStore } from "@/stores/eventStore";
+import { convertDropData } from "@/stores/activitySetup";
+import { useEventStore, type EventData } from "@/stores/eventStore";
 import ContextMenu from "@/components/Common/ContextMenu.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";
 import { useConfig } from "@/composables/config";
@@ -40,8 +39,8 @@ const contextMenuX = ref(0);
 const contextMenuY = ref(0);
 
 // drag references
-const dragTarget = ref(null);
-const dragItem = ref(null);
+const dragTarget: Ref<EventTarget | null> = ref(null);
+const dragItem: Ref<Activity | null> = ref(null);
 
 // drag state
 const isDragging = ref(false);
@@ -49,21 +48,21 @@ const isDragging = ref(false);
 /**
  * Checks if the route of an activitiy is currently being visited and panels are collapsed
  */
-function isActiveRoute(activityTo) {
+function isActiveRoute(activityTo: string) {
     return route.path === activityTo && isActiveSideBar("");
 }
 
 /**
  * Checks if a panel has been expanded
  */
-function isActiveSideBar(menuKey) {
+function isActiveSideBar(menuKey: string) {
     return userStore.toggledSideBar === menuKey;
 }
 
 /**
  * Evaluates the drop data and keeps track of the drop area
  */
-function onDragEnter(evt) {
+function onDragEnter(evt: Event) {
     const eventData = eventStore.getDragData();
     if (eventData) {
         dragTarget.value = evt.target;
@@ -77,23 +76,25 @@ function onDragEnter(evt) {
 /**
  * Removes the dragged activity when exiting the drop area
  */
-function onDragLeave(evt) {
+function onDragLeave(evt: Event) {
     if (dragItem.value && dragTarget.value == evt.target) {
-        activities.value = activities.value.filter((a) => a.id !== dragItem.value.id);
+        const dragId = dragItem.value.id;
+        activities.value = activities.value.filter((a) => a.id !== dragId);
     }
 }
 
 /**
  * Insert the dragged item into the activities list
  */
-function onDragOver(evt) {
-    const target = evt.target.closest(".activity-item");
+function onDragOver(evt: Event) {
+    const target = (evt.target as HTMLElement).closest(".activity-item");
     if (target && dragItem.value) {
         const targetId = target.id;
         const targetIndex = activities.value.findIndex((a) => `activity-${a.id}` === targetId);
         if (targetIndex !== -1) {
-            const dragId = dragItem.value.id;
-            if (activities.value[targetIndex].id !== dragId) {
+            const dragId: string = dragItem.value.id;
+            const targetActivity = activities.value[targetIndex];
+            if (targetActivity && targetActivity.id !== dragId) {
                 const activitiesTemp = activities.value.filter((a) => a.id !== dragId);
                 activitiesTemp.splice(targetIndex, 0, dragItem.value);
                 activities.value = activitiesTemp;
@@ -105,14 +106,14 @@ function onDragOver(evt) {
 /**
  * Tracks the state of activities which expand or collapse the sidepanel
  */
-function onToggleSidebar(toggle) {
+function onToggleSidebar(toggle: string) {
     userStore.toggleSideBar(toggle);
 }
 
 /**
  * Positions and displays the context menu
  */
-function toggleContextMenu(evt) {
+function toggleContextMenu(evt: MouseEvent) {
     if (evt && !contextMenuVisible.value) {
         evt.preventDefault();
         contextMenuVisible.value = true;

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -6,7 +6,7 @@ import { useUserStore } from "@/stores/userStore";
 import { useActivityStore, type Activity } from "@/stores/activityStore";
 import { useRoute } from "vue-router/composables";
 import { convertDropData } from "@/stores/activitySetup";
-import { useEventStore, type EventData } from "@/stores/eventStore";
+import { useEventStore } from "@/stores/eventStore";
 import ContextMenu from "@/components/Common/ContextMenu.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";
 import { useConfig } from "@/composables/config";
@@ -62,7 +62,7 @@ function isActiveSideBar(menuKey: string) {
 /**
  * Evaluates the drop data and keeps track of the drop area
  */
-function onDragEnter(evt: Event) {
+function onDragEnter(evt: MouseEvent) {
     const eventData = eventStore.getDragData();
     if (eventData) {
         dragTarget.value = evt.target;
@@ -76,7 +76,7 @@ function onDragEnter(evt: Event) {
 /**
  * Removes the dragged activity when exiting the drop area
  */
-function onDragLeave(evt: Event) {
+function onDragLeave(evt: MouseEvent) {
     if (dragItem.value && dragTarget.value == evt.target) {
         const dragId = dragItem.value.id;
         activities.value = activities.value.filter((a) => a.id !== dragId);
@@ -86,7 +86,7 @@ function onDragLeave(evt: Event) {
 /**
  * Insert the dragged item into the activities list
  */
-function onDragOver(evt: Event) {
+function onDragOver(evt: MouseEvent) {
     const target = (evt.target as HTMLElement).closest(".activity-item");
     if (target && dragItem.value) {
         const targetId = target.id;

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -183,9 +183,11 @@ function toggleContextMenu(evt: MouseEvent) {
                 <ActivityItem
                     id="activity-settings"
                     icon="cog"
+                    :is-active="isActiveRoute('/user')"
                     title="Settings"
                     tooltip="Edit preferences"
-                    to="/user" />
+                    to="/user"
+                    @click="onToggleSidebar()" />
             </b-nav>
         </div>
         <FlexPanel v-if="isActiveSideBar('tools')" key="tools" side="left" :collapsible="false">

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -58,7 +58,7 @@ function isActiveSideBar(menuKey) {
 }
 
 /**
- * Triggered by vue-draggable when the list of activities has changed
+ * Triggered by vue-draggable when the list of activities has changed or an item has been dropped
  */
 function onChange() {
     activityStore.setAll(activities);
@@ -72,6 +72,8 @@ function onDragEnter(evt) {
     if (eventData) {
         dragTarget.value = evt.target;
         dragItem.value = convertDropData(eventData);
+    } else {
+        dragItem.value = null;
     }
 }
 
@@ -80,9 +82,7 @@ function onDragEnter(evt) {
  */
 function onDragLeave(evt) {
     if (dragItem.value && dragTarget.value == evt.target) {
-        const dragId = dragItem.value.id;
-        const activitiesTemp = activities.value.filter((a) => a.id !== dragId);
-        activities.value = activitiesTemp;
+        activities.value = activities.value.filter((a) => a.id !== dragItem.value.id);
     }
 }
 

--- a/client/src/components/History/Content/ContentItem.vue
+++ b/client/src/components/History/Content/ContentItem.vue
@@ -7,7 +7,7 @@
         tabindex="0"
         role="button"
         @keydown="onKeyDown">
-        <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @click.stop="onClick">
+        <div class="p-1 cursor-pointer" draggable @dragstart="onDragStart" @dragend="onDragEnd" @click.stop="onClick">
             <div class="d-flex justify-content-between">
                 <span class="p-1 font-weight-bold">
                     <b-button v-if="selectable" class="selector p-0" @click.stop="$emit('update:selected', !selected)">

--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -6,7 +6,8 @@
             data-toggle="dropdown"
             :data-workflow-dropdown="workflow.id"
             draggable
-            @dragstart="onDragStart">
+            @dragstart="onDragStart"
+            @dragend="onDragEnd">
             <Icon icon="caret-down" class="fa-lg" />
             <span class="workflow-dropdown-name">{{ workflow.name }}</span>
         </b-link>

--- a/client/src/stores/activitySetup.ts
+++ b/client/src/stores/activitySetup.ts
@@ -1,6 +1,8 @@
 /**
  * List of built-in activities
  */
+import { type Activity } from "@/stores/activityStore";
+import { type EventData } from "@/stores/eventStore";
 
 export const Activities = [
     {
@@ -82,7 +84,7 @@ export const Activities = [
     },
 ];
 
-export function convertDropData(data) {
+export function convertDropData(data: EventData): Activity | null {
     if (data.history_content_type === "dataset") {
         return {
             description: "Displays this dataset.",
@@ -90,7 +92,7 @@ export function convertDropData(data) {
             id: `dataset-${data.id}`,
             mutable: true,
             optional: true,
-            title: data.name,
+            title: data.name as string,
             tooltip: "View your dataset",
             to: `/datasets/${data.id}/preview`,
             visible: true,
@@ -98,15 +100,16 @@ export function convertDropData(data) {
     }
     if (data.model_class === "StoredWorkflow") {
         return {
-            description: data.description,
+            description: data.description as string,
             icon: "fa-play",
             id: `workflow-${data.id}`,
             mutable: true,
             optional: true,
-            title: data.name,
-            tooltip: data.name,
+            title: data.name as string,
+            tooltip: data.name as string,
             to: `/workflows/run?id=${data.id}`,
             visible: true,
         };
     }
+    return null;
 }

--- a/client/src/stores/eventStore.ts
+++ b/client/src/stores/eventStore.ts
@@ -6,7 +6,7 @@
 import { ref, type Ref } from "vue";
 import { defineStore } from "pinia";
 
-type EventData = { [key: string]: unknown };
+export type EventData = { [key: string]: unknown };
 
 export const useEventStore = defineStore("eventStore", () => {
     const dragData: Ref<EventData | null> = ref(null);


### PR DESCRIPTION
Contains some minor cleanup ensuring that the dragged data is properly cleared when the drag event ends. Additionally it avoids triggering drag/drop events when moving over the side panels. Also contains some new unit tests, unfortunately there seems to be an ongoing issue with stubbing in Vue2.7. When using `shallowMount` the `stub` property is ignored, otherwise I would have added more tests regarding the other drag event handlers. Finally, switches remaining modules to typescript.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
