### PR TITLE
[23.0] When importing tool data bundles, use the first loc file for the matching table

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -6398,9 +6398,9 @@ export interface components {
              * Share Option
              * @description User choice for sharing resources which its contents may be restricted:
              *  - None: The user did not choose anything yet or no option is needed.
-             *  - SharingOptions.make_public: The contents of the resource will be made publicly accessible.
-             *  - SharingOptions.make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
-             *  - SharingOptions.no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
+             *  - make_public: The contents of the resource will be made publicly accessible.
+             *  - make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
+             *  - no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
              */
             share_option?: components["schemas"]["SharingOptions"];
             /**
@@ -8789,7 +8789,7 @@ export interface operations {
          * @description Sets the permissions to manage a library folder.
          */
         parameters: {
-            /** @description Indicates what action should be performed on the Library. Currently only `LibraryFolderPermissionAction.set_permissions` is supported. */
+            /** @description Indicates what action should be performed on the Library. Currently only `set_permissions` is supported. */
             query?: {
                 action?: components["schemas"]["LibraryFolderPermissionAction"];
             };

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -6398,9 +6398,9 @@ export interface components {
              * Share Option
              * @description User choice for sharing resources which its contents may be restricted:
              *  - None: The user did not choose anything yet or no option is needed.
-             *  - make_public: The contents of the resource will be made publicly accessible.
-             *  - make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
-             *  - no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
+             *  - SharingOptions.make_public: The contents of the resource will be made publicly accessible.
+             *  - SharingOptions.make_accessible_to_shared: This will automatically create a new `sharing role` allowing protected contents to be accessed only by the desired users.
+             *  - SharingOptions.no_changes: This won't change the current permissions for the contents. The user which this resource will be shared may not be able to access all its contents.
              */
             share_option?: components["schemas"]["SharingOptions"];
             /**
@@ -8789,7 +8789,7 @@ export interface operations {
          * @description Sets the permissions to manage a library folder.
          */
         parameters: {
-            /** @description Indicates what action should be performed on the Library. Currently only `set_permissions` is supported. */
+            /** @description Indicates what action should be performed on the Library. Currently only `LibraryFolderPermissionAction.set_permissions` is supported. */
             query?: {
                 action?: components["schemas"]["LibraryFolderPermissionAction"];
             };
@@ -13340,6 +13340,9 @@ export interface operations {
     create_api_tool_data_post: {
         /** Import a data manager bundle */
         parameters?: {
+            query?: {
+                tool_data_file_path?: Record<string, never>;
+            };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
                 "run-as"?: string;

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -376,10 +376,11 @@ def import_data_bundle(
     src: str,
     uri: Optional[str] = None,
     id: Optional[int] = None,
+    tool_data_file_path: Optional[str] = None,
 ):
     if src == "uri":
         assert uri
-        tool_data_import_manager.import_data_bundle_by_uri(config, uri)
+        tool_data_import_manager.import_data_bundle_by_uri(config, uri, tool_data_file_path=tool_data_file_path)
     else:
         assert id
         dataset: model.DatasetInstance
@@ -387,7 +388,7 @@ def import_data_bundle(
             dataset = hda_manager.by_id(id)
         else:
             dataset = ldda_manager.by_id(id)
-        tool_data_import_manager.import_data_bundle_by_dataset(config, dataset)
+        tool_data_import_manager.import_data_bundle_by_dataset(config, dataset, tool_data_file_path=tool_data_file_path)
 
 
 @galaxy_task(action="pruning history audit table")

--- a/lib/galaxy/managers/tool_data.py
+++ b/lib/galaxy/managers/tool_data.py
@@ -113,7 +113,7 @@ class ToolDataImportManager:
         self.file_sources = app.file_sources
         self.tool_data_tables = app.tool_data_tables
 
-    def import_data_bundle_by_uri(self, config, uri: str):
+    def import_data_bundle_by_uri(self, config, uri: str, tool_data_file_path=None):
         # an admin-only task - so allow file:// uris
         if uri.startswith("file://"):
             target = uri[len("file://") :]
@@ -126,17 +126,19 @@ class ToolDataImportManager:
             what="data import",  # An alternative to this is sticking this in the bundle, only used for logging.
             data_manager_path=config.galaxy_data_manager_data_path,
             target_config_file=config.data_manager_config_file,
+            tool_data_file_path=tool_data_file_path,
         )
         self.tool_data_tables.import_bundle(
             target,
             options,
         )
 
-    def import_data_bundle_by_dataset(self, config, dataset: DatasetInstance):
+    def import_data_bundle_by_dataset(self, config, dataset: DatasetInstance, tool_data_file_path=None):
         options = BundleProcessingOptions(
             what="data import",  # An alternative to this is sticking this in the bundle, only used for logging.
             data_manager_path=config.galaxy_data_manager_data_path,
             target_config_file=config.data_manager_config_file,
+            tool_data_file_path=tool_data_file_path,
         )
         self.tool_data_tables.import_bundle(
             dataset.extra_files_path,

--- a/lib/galaxy/webapps/galaxy/api/tool_data.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_data.py
@@ -65,9 +65,11 @@ class FastAPIToolData:
         summary="Import a data manager bundle",
         require_admin=True,
     )
-    async def create(self, import_bundle_model: ImportToolDataBundle = Body(...)) -> AsyncTaskResultSummary:
+    async def create(
+        self, tool_data_file_path=None, import_bundle_model: ImportToolDataBundle = Body(...)
+    ) -> AsyncTaskResultSummary:
         source = import_bundle_model.source
-        result = import_data_bundle.delay(**source.dict())
+        result = import_data_bundle.delay(tool_data_file_path=tool_data_file_path, **source.dict())
         summary = async_task_summary(result)
         return summary
 


### PR DESCRIPTION
unless an explicit file path is passed via the API.

In the initial implementation (#15129), the bundle would only be importable if the exact same version of the exact same DM that was used to build the bundle was installed on the server where the bundle was being imported.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).