### PR TITLE
More extensive slugification of username

### DIFF
--- a/lib/galaxy/auth/util.py
+++ b/lib/galaxy/auth/util.py
@@ -9,6 +9,7 @@ from galaxy.util import (
     parse_xml,
     parse_xml_string,
     plugin_config,
+    ready_name_for_url,
     string_as_bool,
 )
 
@@ -76,7 +77,7 @@ def get_authenticators(auth_config_file, auth_config_file_set):
 def parse_auth_results(trans, auth_results, options):
     auth_return = {}
     auth_result, auto_email, auto_username = auth_results[:3]
-    auto_username = str(auto_username).lower()
+    auto_username = ready_name_for_url(str(auto_username).lower())
     # make username unique
     max_retries = int(options.get("max-retries", "10"))
     try_number = 0

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -98,6 +98,7 @@ from sqlalchemy.orm import (
     reconstructor,
     registry,
     relationship,
+    validates,
 )
 from sqlalchemy.orm.collections import attribute_mapped_collection
 from sqlalchemy.orm.decl_api import DeclarativeMeta
@@ -618,6 +619,11 @@ class User(Base, Dictifiable, RepresentById):
         self.purged = False
         self.active = False
         self.username = username
+
+    @validates('username')
+    def validate_username(self, key, username):
+        if not username == ready_name_for_url(username):
+            raise ValueError(f"Username '{username}' contains unsupported characters.")
 
     @property
     def extra_preferences(self):

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -741,8 +741,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
             user.set_random_password(length=12)
             user.external = True
             # Replace invalid characters in the username
-            for char in [x for x in username if x not in f"{string.ascii_lowercase + string.digits}-."]:
-                username = username.replace(char, "-")
+            username = util.ready_name_for_url(username)
             # Find a unique username - user can change it later
             if self.sa_session.query(self.app.model.User).filter_by(username=username).first():
                 i = 1

--- a/test/unit/auth/test_auth.py
+++ b/test/unit/auth/test_auth.py
@@ -1,3 +1,5 @@
+import pytest
+
 from galaxy.auth.providers.alwaysreject import AlwaysReject
 from galaxy.auth.providers.localdb import LocalDB
 from galaxy.model import User
@@ -23,3 +25,15 @@ def test_localdb():
         pass
     else:
         raise Exception("Password policy validation failed")
+
+
+def test_invalid_chars_in_username():
+    with pytest.raises(ValueError) as e:
+        User(email="testmail@somewhere.com", username="tester@")
+    with pytest.raises(ValueError) as e:
+        User(email="testmail@somewhere.com", username="tester+something")
+    with pytest.raises(ValueError) as e:
+        User(email="testmail@somewhere.com", username="tester.something")
+    with pytest.raises(ValueError) as e:
+        User(email="testmail@somewhere.com", username="tester_test")
+    User(email="testmail@somewhere.com", username="tester-test")


### PR DESCRIPTION
This is a somewhat more invasive change than: https://github.com/galaxyproject/galaxy/pull/16251

Specifically, it uses sqlalchemy validates to assert that the username does not contain invalid chars.

However, once major departure is that `ready_name_for_url` does not accept the period, which I think makes sense to be invalid in a slug. However, the period has thus far been allowed in usernames.

Yet another approach could be to silently slugify the username property, instead of validating it, but I suppose that has drawbacks of its own. Just throwing this out there for discussion.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
