### PR TITLE
Adjust notifications activity item

### DIFF
--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -2,6 +2,7 @@
 import draggable from "vuedraggable";
 import { ref, type Ref } from "vue";
 import { storeToRefs } from "pinia";
+import { useConfig } from "@/composables/config";
 import { useUserStore } from "@/stores/userStore";
 import { useActivityStore, type Activity } from "@/stores/activityStore";
 import { useRoute } from "vue-router/composables";
@@ -9,13 +10,12 @@ import { convertDropData } from "@/stores/activitySetup";
 import { useEventStore } from "@/stores/eventStore";
 import ContextMenu from "@/components/Common/ContextMenu.vue";
 import FlexPanel from "@/components/Panels/FlexPanel.vue";
-import { useConfig } from "@/composables/config";
-import ActivityItem from "./ActivityItem.vue";
-import UploadItem from "./Items/UploadItem.vue";
-import ActivitySettings from "./ActivitySettings.vue";
-import WorkflowBox from "@/components/Panels/WorkflowBox.vue";
 import ToolBox from "@/components/Panels/ProviderAwareToolBox.vue";
-import NotificationsBell from "@/components/Notifications/NotificationsBell.vue";
+import WorkflowBox from "@/components/Panels/WorkflowBox.vue";
+import ActivityItem from "./ActivityItem.vue";
+import ActivitySettings from "./ActivitySettings.vue";
+import UploadItem from "./Items/UploadItem.vue";
+import NotificationItem from "./Items/NotificationItem.vue";
 
 const { config } = useConfig();
 
@@ -179,7 +179,7 @@ function toggleContextMenu(evt: MouseEvent) {
                 </draggable>
             </b-nav>
             <b-nav vertical class="flex-nowrap p-1">
-                <NotificationsBell v-if="!isAnonymous && config.enable_notification_system" tooltip-placement="right" />
+                <NotificationItem v-if="!isAnonymous && config.enable_notification_system" tooltip-placement="right" />
                 <ActivityItem
                     id="activity-settings"
                     icon="cog"

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -185,7 +185,6 @@ function toggleContextMenu(evt: MouseEvent) {
                     icon="bell"
                     :is-active="isActiveRoute('/user/notifications')"
                     title="Notifications"
-                    tooltip="Show notifications"
                     to="/user/notifications"
                     @click="onToggleSidebar()" />
                 <ActivityItem

--- a/client/src/components/ActivityBar/ActivityBar.vue
+++ b/client/src/components/ActivityBar/ActivityBar.vue
@@ -179,7 +179,15 @@ function toggleContextMenu(evt: MouseEvent) {
                 </draggable>
             </b-nav>
             <b-nav vertical class="flex-nowrap p-1">
-                <NotificationItem v-if="!isAnonymous && config.enable_notification_system" tooltip-placement="right" />
+                <NotificationItem
+                    v-if="!isAnonymous && config.enable_notification_system"
+                    id="activity-notifications"
+                    icon="bell"
+                    :is-active="isActiveRoute('/user/notifications')"
+                    title="Notifications"
+                    tooltip="Show notifications"
+                    to="/user/notifications"
+                    @click="onToggleSidebar()" />
                 <ActivityItem
                     id="activity-settings"
                     icon="cog"

--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -14,8 +14,8 @@ interface Option {
 export interface Props {
     id: string;
     title?: string;
-    indicator?: boolean;
     icon?: string | object;
+    indicator?: boolean;
     isActive?: boolean;
     tooltip?: string;
     tooltipPlacement?: string;
@@ -28,6 +28,7 @@ export interface Props {
 const props = withDefaults(defineProps<Props>(), {
     title: undefined,
     icon: "question",
+    indicator: false,
     isActive: false,
     options: undefined,
     progressPercentage: 0,
@@ -70,7 +71,7 @@ function onClick(evt: MouseEvent): void {
                     </span>
                     <span class="position-relative">
                         <div class="nav-icon">
-                            <span v-if="indicator" class="indicator"> </span>
+                            <span v-if="indicator" class="indicator" />
                             <FontAwesomeIcon :icon="icon" />
                         </div>
                         <TextShort v-if="title" :text="title" class="nav-title" />

--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -128,6 +128,16 @@ function onClick(evt: MouseEvent): void {
     font-size: 0.7rem;
 }
 
+.indicator {
+    position: absolute;
+    top: -0.2rem;
+    right: -0.1rem;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    background: $brand-danger;
+}
+
 .progress {
     background: transparent;
     border-radius: $border-radius-extralarge;

--- a/client/src/components/ActivityBar/ActivityItem.vue
+++ b/client/src/components/ActivityBar/ActivityItem.vue
@@ -71,7 +71,7 @@ function onClick(evt: MouseEvent): void {
                     </span>
                     <span class="position-relative">
                         <div class="nav-icon">
-                            <span v-if="indicator" class="indicator" />
+                            <span v-if="indicator" class="nav-indicator" />
                             <FontAwesomeIcon :icon="icon" />
                         </div>
                         <TextShort v-if="title" :text="title" class="nav-title" />
@@ -101,6 +101,16 @@ function onClick(evt: MouseEvent): void {
     font-size: 1rem;
 }
 
+.nav-indicator {
+    position: absolute;
+    top: 0px;
+    left: 2.2rem;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    background: $brand-danger;
+}
+
 .nav-item {
     display: flex;
     align-items: center;
@@ -127,16 +137,6 @@ function onClick(evt: MouseEvent): void {
     width: 4rem;
     margin-top: 0.5rem;
     font-size: 0.7rem;
-}
-
-.indicator {
-    position: absolute;
-    top: -0.2rem;
-    right: -0.1rem;
-    width: 0.6rem;
-    height: 0.6rem;
-    border-radius: 50%;
-    background: $brand-danger;
 }
 
 .progress {

--- a/client/src/components/ActivityBar/Items/NotificationItem.vue
+++ b/client/src/components/ActivityBar/Items/NotificationItem.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { BNavItem } from "bootstrap-vue";
+import Popper from "components/Popper/Popper.vue";
+import { useRouter } from "vue-router/composables";
+import { faBell } from "@fortawesome/free-solid-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { useNotificationsStore } from "@/stores/notificationsStore";
+
+library.add(faBell);
+
+defineProps({
+    tooltipPlacement: {
+        type: String,
+        default: "right",
+    },
+});
+
+const router = useRouter();
+const { totalUnreadCount } = storeToRefs(useNotificationsStore());
+
+function onClick() {
+    router.push("/user/notifications");
+}
+</script>
+
+<template>
+    <Popper :placement="tooltipPlacement">
+        <template v-slot:reference>
+            <BNavItem id="activity-notifications" @click="onClick">
+                <span class="position-relative">
+                    <span v-if="!!totalUnreadCount" class="indicator"> </span>
+                    <FontAwesomeIcon class="nav-icon" :icon="faBell" />
+                </span>
+            </BNavItem>
+        </template>
+        <div class="px-2 py-1">
+            {{
+                totalUnreadCount
+                    ? `You have ${totalUnreadCount} unread notifications`
+                    : "You have no unread notifications"
+            }}
+        </div>
+    </Popper>
+</template>
+
+<style scoped lang="scss">
+@import "theme/blue.scss";
+
+.nav-item {
+    display: flex;
+    align-items: center;
+    align-content: center;
+    justify-content: center;
+}
+
+.nav-icon {
+    @extend .nav-item;
+    font-size: 1rem;
+}
+
+.indicator {
+    position: absolute;
+    top: -0.2rem;
+    right: -0.1rem;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    background: $brand-danger;
+}
+</style>

--- a/client/src/components/ActivityBar/Items/NotificationItem.vue
+++ b/client/src/components/ActivityBar/Items/NotificationItem.vue
@@ -1,64 +1,39 @@
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { BNavItem } from "bootstrap-vue";
-import Popper from "components/Popper/Popper.vue";
-import { useRouter } from "vue-router/composables";
-import { faBell } from "@fortawesome/free-solid-svg-icons";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { useNotificationsStore } from "@/stores/notificationsStore";
+import ActivityItem from "components/ActivityBar/ActivityItem.vue";
 
-library.add(faBell);
-
-defineProps({
-    tooltipPlacement: {
-        type: String,
-        default: "right",
-    },
-});
-
-const router = useRouter();
 const { totalUnreadCount } = storeToRefs(useNotificationsStore());
 
-function onClick() {
-    router.push("/user/notifications");
+export interface Props {
+    id: string;
+    title: string;
+    icon: string;
+    isActive: boolean;
+    tooltip: string;
+    to: string;
 }
+
+defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "click"): void;
+}>();
 </script>
 
 <template>
-    <Popper :placement="tooltipPlacement">
-        <template v-slot:reference>
-            <BNavItem id="activity-notifications" @click="onClick">
-                <span class="position-relative">
-                    <span v-if="!!totalUnreadCount" class="indicator"> </span>
-                    <FontAwesomeIcon class="nav-icon" :icon="faBell" />
-                </span>
-            </BNavItem>
-        </template>
-        <div class="px-2 py-1">
-            {{
-                totalUnreadCount
-                    ? `You have ${totalUnreadCount} unread notifications`
-                    : "You have no unread notifications"
-            }}
-        </div>
-    </Popper>
+    <ActivityItem
+        :id="id"
+        :icon="icon"
+        :is-active="isActive"
+        :title="title"
+        :tooltip="tooltip"
+        :to="to"
+        @click="emit('click')" />
 </template>
 
 <style scoped lang="scss">
 @import "theme/blue.scss";
-
-.nav-item {
-    display: flex;
-    align-items: center;
-    align-content: center;
-    justify-content: center;
-}
-
-.nav-icon {
-    @extend .nav-item;
-    font-size: 1rem;
-}
 
 .indicator {
     position: absolute;

--- a/client/src/components/ActivityBar/Items/NotificationItem.vue
+++ b/client/src/components/ActivityBar/Items/NotificationItem.vue
@@ -25,23 +25,10 @@ const emit = defineEmits<{
     <ActivityItem
         :id="id"
         :icon="icon"
+        :indicator="totalUnreadCount"
         :is-active="isActive"
         :title="title"
         :tooltip="tooltip"
         :to="to"
         @click="emit('click')" />
 </template>
-
-<style scoped lang="scss">
-@import "theme/blue.scss";
-
-.indicator {
-    position: absolute;
-    top: -0.2rem;
-    right: -0.1rem;
-    width: 0.6rem;
-    height: 0.6rem;
-    border-radius: 50%;
-    background: $brand-danger;
-}
-</style>

--- a/client/src/components/ActivityBar/Items/NotificationItem.vue
+++ b/client/src/components/ActivityBar/Items/NotificationItem.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from "vue";
 import { storeToRefs } from "pinia";
 import { useNotificationsStore } from "@/stores/notificationsStore";
 import ActivityItem from "components/ActivityBar/ActivityItem.vue";
@@ -10,7 +11,6 @@ export interface Props {
     title: string;
     icon: string;
     isActive: boolean;
-    tooltip: string;
     to: string;
 }
 
@@ -19,13 +19,17 @@ defineProps<Props>();
 const emit = defineEmits<{
     (e: "click"): void;
 }>();
+
+const tooltip = computed(() =>
+    totalUnreadCount ? `You have ${totalUnreadCount} unread notifications` : "You have no unread notifications"
+);
 </script>
 
 <template>
     <ActivityItem
         :id="id"
         :icon="icon"
-        :indicator="totalUnreadCount"
+        :indicator="!!totalUnreadCount"
         :is-active="isActive"
         :title="title"
         :tooltip="tooltip"

--- a/client/src/components/ActivityBar/Items/NotificationItem.vue
+++ b/client/src/components/ActivityBar/Items/NotificationItem.vue
@@ -21,7 +21,9 @@ const emit = defineEmits<{
 }>();
 
 const tooltip = computed(() =>
-    totalUnreadCount ? `You have ${totalUnreadCount} unread notifications` : "You have no unread notifications"
+    totalUnreadCount.value > 0
+        ? `You have ${totalUnreadCount.value} unread notifications`
+        : "You have no unread notifications"
 );
 </script>
 

--- a/client/src/components/plugins/icons.js
+++ b/client/src/components/plugins/icons.js
@@ -2,6 +2,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import {
     faArrowUp,
+    faBell,
     faBolt,
     faBurn,
     faChartArea,
@@ -51,6 +52,7 @@ import {
 
 library.add(
     faArrowUp,
+    faBell,
     faBolt,
     faBurn,
     faChartArea,


### PR DESCRIPTION
Follow-up for #15663. Adjusts the notifications activity item and brings it into alignment with existing activities by using the shared `ActivityItem` component. This ensures a consistent title, tooltip, color, and highlighting appearance and behavior.

Image shows, highlighted notifications icon with indicator and tooltip, together with the settings activity:

Before:
<img width="277" alt="image" src="https://github.com/galaxyproject/galaxy/assets/2105447/c76df373-6fd2-4ad2-8e00-47a0f7289537">

Now:
<img width="277" alt="image" src="https://github.com/galaxyproject/galaxy/assets/2105447/50127a18-e24b-420c-8848-bd8ecb6a3e75">


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
