### PR TITLE
Set Initial Filter for Paired List Collection Creator Based on Initial Elements 

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -631,17 +631,17 @@ export default {
             }
         },
         initialFiltersSet: function () {
-            var illumina = 0;
-            var dot12s = 0;
-            var Rs = 0;
+            let illumina = 0;
+            let dot12s = 0;
+            let Rs = 0;
             //should we limit the forEach? What if there are 1000s of elements?
             this.initialElements.forEach((element) => {
-                if (element.name.includes("_1") || element.name.includes("_2")) {
-                    illumina++;
-                } else if (element.name.includes(".1.fastq") || element.name.includes(".2.fastq")) {
+                if (element.name.includes(".1.fastq") || element.name.includes(".2.fastq")) {
                     dot12s++;
                 } else if (element.name.includes("_R1") || element.name.includes("_R2")) {
                     Rs++;
+                } else if (element.name.includes("_1") || element.name.includes("_2")) {
+                    illumina++;
                 }
             });
 

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -631,7 +631,29 @@ export default {
             }
         },
         initialFiltersSet: function () {
-            this.changeFilters("illumina");
+            var illumina = 0;
+            var dot12s = 0;
+            var Rs = 0;
+            //should we limit the forEach? What if there are 1000s of elements?
+            this.initialElements.forEach((element) => {
+                if (element.name.includes("_1") || element.name.includes("_2")) {
+                    illumina++;
+                } else if (element.name.includes(".1.fastq") || element.name.includes(".2.fastq")) {
+                    dot12s++;
+                } else if (element.name.includes("_R1") || element.name.includes("_R2")) {
+                    Rs++;
+                }
+            });
+
+            if (illumina > dot12s && illumina > Rs) {
+                this.changeFilters("illumina");
+            } else if (dot12s > illumina && dot12s > Rs) {
+                this.changeFilters("dot12s");
+            } else if (Rs > illumina && Rs > dot12s) {
+                this.changeFilters("Rs");
+            } else {
+                this.changeFilters("illumina");
+            }
         },
         /** add ids to dataset objs in initial list if none */
         _ensureElementIds: function () {


### PR DESCRIPTION
Fix for #15937 
Instead of setting the default as a config, the paired list collection creator picks the best initial filter based on what elements are incoming.  


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Edit your dataset names to have various common paired endings (_1/_2, _R1/_R2, .1.fastq/.2.fastq)
  2. Select _R1/_R2 pairs, and create a paired list collection.
  3. Note that the initial filter matches the incoming endings
  4. Select .1.fastq/.2.fastq pairs, and create a paried list collection.
  5. Note that the initial filter matches the incoming endings.
  6. Select _1/_2 pairs OR select a random assortment.
  7. Note that the inital filter matches illumina (_1/_2).
 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
