### PR TITLE
[23.0] Fix converting Enum value to str for Python 3.11

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/invocations.py
+++ b/lib/galaxy/webapps/galaxy/services/invocations.py
@@ -199,7 +199,7 @@ class InvocationsService(ServiceBase):
         view = params.view or default_view
         step_details = params.step_details
         legacy_job_state = params.legacy_job_state
-        as_dict = invocation.to_dict(view, step_details=step_details, legacy_job_state=legacy_job_state)
+        as_dict = invocation.to_dict(view.value, step_details=step_details, legacy_job_state=legacy_job_state)
         as_dict = self.security.encode_all_ids(as_dict, recursive=True)
         as_dict["messages"] = [
             InvocationMessageResponseModel.parse_obj(message).__root__.dict() for message in invocation.messages


### PR DESCRIPTION
Fix the following traceback:

```
Traceback (most recent call last):
  File "/tmp/tmpiustglxt/galaxy-dev/lib/galaxy/util/dictifiable.py", line 57, in to_dict
    visible_keys = self.__getattribute__(f"dict_{view}_visible_keys")
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'WorkflowInvocation' object has no attribute 'dict_InvocationSerializationView.element_visible_keys'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/tmpiustglxt/galaxy-dev/lib/galaxy/web/framework/decorators.py", line 337, in decorator
    rval = func(self, trans, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmpiustglxt/galaxy-dev/lib/galaxy/webapps/galaxy/api/workflows.py", line 891, in show_invocation
    return self.__encode_invocation(workflow_invocation, **kwd)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmpiustglxt/galaxy-dev/lib/galaxy/webapps/galaxy/api/workflows.py", line 1108, in __encode_invocation
    return self.invocations_service.serialize_workflow_invocation(invocation, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmpiustglxt/galaxy-dev/lib/galaxy/webapps/galaxy/services/invocations.py", line 202, in serialize_workflow_invocation
    as_dict = invocation.to_dict(view, step_details=step_details, legacy_job_state=legacy_job_state)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmpiustglxt/galaxy-dev/lib/galaxy/model/__init__.py", line 7814, in to_dict
    rval = super().to_dict(view=view, value_mapper=value_mapper)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmpiustglxt/galaxy-dev/lib/galaxy/util/dictifiable.py", line 59, in to_dict
    raise Exception(f"Unknown Dictifiable view: {view}")
Exception: Unknown Dictifiable view: InvocationSerializationView.element
```

Broken in https://github.com/galaxyproject/galaxy/pull/13875 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run API tests under Python 3.11

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
