### PR TITLE
[23.1] Open latest version of tool from tool panel link

### DIFF
--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -193,8 +193,7 @@ export default {
                 evt.preventDefault();
                 // encode spaces in tool.id
                 const toolId = tool.id;
-                const toolVersion = tool.version;
-                this.$router.push(`/?tool_id=${encodeURIComponent(toolId)}&version=${toolVersion}`);
+                this.$router.push(`/?tool_id=${encodeURIComponent(toolId)}&version=latest`);
             }
         },
         onToggle() {


### PR DESCRIPTION
Bit of a simpler alternative to https://github.com/galaxyproject/galaxy/pull/16238, with the added benefit that you should still be able to find older versions ?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
