### PR TITLE
Fix tool remote test data

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -631,7 +631,8 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
             DependencyResolversView, DependencyResolversView(self)
         )
         self.test_data_resolver = self._register_singleton(
-            TestDataResolver, TestDataResolver(file_dirs=self.config.tool_test_data_directories)
+            TestDataResolver,
+            TestDataResolver(file_dirs=",".join([self.config.tool_test_data_directories, "url-location"])),
         )
         self.api_keys_manager = self._register_singleton(ApiKeyManager)
 

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1696,6 +1696,7 @@ def test_data_iter(required_files):
             dbkey=extra.get("dbkey", DEFAULT_DBKEY),
             location=extra.get("location", None),
             md5=extra.get("md5", None),
+            checksum=extra.get("checksum", None),
         )
         edit_attributes = extra.get("edit_attributes", [])
 


### PR DESCRIPTION
Follow up on #15510

The `RemoteLocationDataResolver` was never used when running Galaxy outside of the functional test framework because it was explicitly omitted when instancing Galaxy. Now it is included as a fallback in 6bb2788a6a69f1a97273e9d930344b45e5b1a943

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - With a tool with inputs using `location` and optionally `checksum` like in #15510 description
  - Run: `planemo test <your_tool.xml> --galaxy_root=<path to galaxy using this branch>`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
