### PR TITLE
Migrate cloud API to Fast API

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -8,6 +8,18 @@ export interface paths {
         /** Returns returns an API key for authenticated user based on BaseAuth headers. */
         get: operations["get_api_key_api_authenticate_baseauth_get"];
     };
+    "/api/cloud/storage": {
+        /** Lists cloud-based buckets (e.g., S3 bucket, Azure blob) user has defined. Is not yet implemented */
+        get: operations["index_api_cloud_storage_get"];
+    };
+    "/api/cloud/storage/get": {
+        /** Gets given objects from a given cloud-based bucket to a Galaxy history. */
+        post: operations["get_api_cloud_storage_get_post"];
+    };
+    "/api/cloud/storage/send": {
+        /** Sends given dataset(s) in a given history to a given cloud-based bucket. Each dataset is named using the label assigned to the dataset in the given history (see `HistoryDatasetAssociation.name`). If no dataset ID is given, this API sends all the datasets belonging to a given history to a given cloud-based bucket. */
+        post: operations["send_api_cloud_storage_send_post"];
+    };
     "/api/configuration": {
         /**
          * Return an object containing exposable configuration settings
@@ -2202,6 +2214,73 @@ export interface components {
         CleanupStorageItemsRequest: {
             /** Item Ids */
             item_ids: string[];
+        };
+        /**
+         * CloudDatasets
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CloudDatasets: {
+            /**
+             * Authentication ID
+             * @description The ID of CloudAuthz to be used for authorizing access to the resource provider. You may get a list of the defined authorizations via `/api/cloud/authz`. Also, you can use `/api/cloud/authz/create` to define a new authorization.
+             * @example 0123456789ABCDEF
+             */
+            authz_id: string;
+            /**
+             * Bucket
+             * @description The name of a bucket to which data should be sent (e.g., a bucket name on AWS S3).
+             */
+            bucket: string;
+            /**
+             * Objects
+             * @description A list of dataset IDs belonging to the specified history that should be sent to the given bucket. If not provided, Galaxy sends all the datasets belonging the specified history.
+             */
+            dataset_ids?: string[];
+            /**
+             * History ID
+             * @description The ID of history from which the object should be downloaded
+             * @example 0123456789ABCDEF
+             */
+            history_id: string;
+            /**
+             * Spaces to tabs
+             * @description A boolean value. If set to 'True', and an object with same name of the dataset to be sent already exist in the bucket, Galaxy replaces the existing object with the dataset to be sent. If set to 'False', Galaxy appends datetime to the dataset name to prevent overwriting an existing object.
+             * @default false
+             */
+            overwrite_existing?: boolean;
+        };
+        /**
+         * CloudObjects
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CloudObjects: {
+            /**
+             * Authentication ID
+             * @description The ID of CloudAuthz to be used for authorizing access to the resource provider. You may get a list of the defined authorizations via `/api/cloud/authz`. Also, you can use `/api/cloud/authz/create` to define a new authorization.
+             * @example 0123456789ABCDEF
+             */
+            authz_id: string;
+            /**
+             * Bucket
+             * @description The name of a bucket from which data should be fetched from (e.g., a bucket name on AWS S3).
+             */
+            bucket: string;
+            /**
+             * History ID
+             * @description The ID of history to which the object should be received to.
+             * @example 0123456789ABCDEF
+             */
+            history_id: string;
+            /**
+             * Input arguments
+             * @description A summary of the input arguments, which is optional and will default to {}.
+             */
+            input_args?: components["schemas"]["InputArguments"];
+            /**
+             * Objects
+             * @description A list of the names of objects to be fetched.
+             */
+            objects: string[];
         };
         /**
          * CollectionElementIdentifier
@@ -5367,6 +5446,36 @@ export interface components {
              * @description URI to fetch tool data bundle from (file:// URIs are fine because this is an admin-only operation)
              */
             uri: string;
+        };
+        /**
+         * InputArguments
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        InputArguments: {
+            /**
+             * Genome
+             * @description Sets the genome (e.g., `hg19`) of the objects being fetched to Galaxy.
+             * @default ?
+             */
+            dbkey?: string;
+            /**
+             * File Type
+             * @description Sets the Galaxy datatype (e.g., `bam`) for the objects being fetched to Galaxy. See the following link for a complete list of Galaxy data types: https://galaxyproject.org/learn/datatypes/.
+             * @default auto
+             */
+            file_type?: string;
+            /**
+             * Spaces to tabs
+             * @description A boolean value ('true' or 'false') that sets if spaces should be converted to tab in the objects being fetched to Galaxy. Applicable only if `to_posix_lines` is True
+             * @default false
+             */
+            space_to_tab?: boolean;
+            /**
+             * POSIX line endings
+             * @description A boolean value ('true' or 'false'); if 'Yes', converts universal line endings to POSIX line endings. Set to 'False' if you upload a gzip, bz2 or zip archive containing a binary file.
+             * @default Yes
+             */
+            to_posix_lines?: "Yes" | boolean;
         };
         /**
          * InstalledRepositoryToolShedStatus
@@ -8856,6 +8965,75 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["APIKeyResponse"];
+                };
+            };
+        };
+    };
+    index_api_cloud_storage_get: {
+        /** Lists cloud-based buckets (e.g., S3 bucket, Azure blob) user has defined. Is not yet implemented */
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
+    get_api_cloud_storage_get_post: {
+        /** Gets given objects from a given cloud-based bucket to a Galaxy history. */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CloudObjects"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    send_api_cloud_storage_send_post: {
+        /** Sends given dataset(s) in a given history to a given cloud-based bucket. Each dataset is named using the label assigned to the dataset in the given history (see `HistoryDatasetAssociation.name`). If no dataset ID is given, this API sends all the datasets belonging to a given history to a given cloud-based bucket. */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CloudDatasets"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": {
+                        [key: string]: (Record<string, never>[] | string) | undefined;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -17,7 +17,7 @@ export interface paths {
         post: operations["get_api_cloud_storage_get_post"];
     };
     "/api/cloud/storage/send": {
-        /** Sends given dataset(s) in a given history to a given cloud-based bucket. Each dataset is named using the label assigned to the dataset in the given history (see `HistoryDatasetAssociation.name`). If no dataset ID is given, this API sends all the datasets belonging to a given history to a given cloud-based bucket. */
+        /** Sends given dataset(s) in a given history to a given cloud-based bucket. */
         post: operations["send_api_cloud_storage_send_post"];
     };
     "/api/configuration": {
@@ -3755,6 +3755,22 @@ export interface components {
             /** Items From */
             items_from?: string;
             src: components["schemas"]["Src"];
+        };
+        /**
+         * FailedJob
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        FailedJob: {
+            /**
+             * Error
+             * @description A descriptive error message.
+             */
+            error: string;
+            /**
+             * Object
+             * @description The name of object is queued to be created
+             */
+            object: string;
         };
         /**
          * FetchDataPayload
@@ -8013,6 +8029,22 @@ export interface components {
          */
         StoredItemOrderBy: "name-asc" | "name-dsc" | "size-asc" | "size-dsc" | "update_time-asc" | "update_time-dsc";
         /**
+         * SuccessfulJob
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        SuccessfulJob: {
+            /**
+             * Job ID
+             * @description The ID of the queued send job.
+             */
+            job_id: string;
+            /**
+             * Object
+             * @description The name of object is queued to be created
+             */
+            object: string;
+        };
+        /**
          * SuitableConverter
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -8043,6 +8075,38 @@ export interface components {
          * @description Collection of converters that can be used on a particular dataset collection.
          */
         SuitableConverters: components["schemas"]["SuitableConverter"][];
+        /**
+         * SummaryGetObjects
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        SummaryGetObjects: {
+            /**
+             * Datasets
+             * @description A list of datasets created for the fetched files.
+             */
+            datasets: Record<string, never>[];
+        };
+        /**
+         * SummarySendDatasets
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        SummarySendDatasets: {
+            /**
+             * Bucket
+             * @description The name of bucket to which the listed datasets are queued to be sent
+             */
+            bucket_name: string;
+            /**
+             * Failed datasets
+             * @description The datasets for which Galaxy failed to create (and queue) send job
+             */
+            failed_dataset_labels: components["schemas"]["FailedJob"][];
+            /**
+             * Send datasets
+             * @description The datasets for which Galaxy succeeded to create (and queue) send job
+             */
+            sent_dataset_labels: components["schemas"]["SuccessfulJob"][];
+        };
         /**
          * TagCollection
          * @description The collection of tags associated with an item.
@@ -8997,7 +9061,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json": components["schemas"]["SummaryGetObjects"];
                 };
             };
             /** @description Validation Error */
@@ -9009,7 +9073,7 @@ export interface operations {
         };
     };
     send_api_cloud_storage_send_post: {
-        /** Sends given dataset(s) in a given history to a given cloud-based bucket. Each dataset is named using the label assigned to the dataset in the given history (see `HistoryDatasetAssociation.name`). If no dataset ID is given, this API sends all the datasets belonging to a given history to a given cloud-based bucket. */
+        /** Sends given dataset(s) in a given history to a given cloud-based bucket. */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -9025,9 +9089,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": {
-                        [key: string]: (Record<string, never>[] | string) | undefined;
-                    };
+                    "application/json": components["schemas"]["SummarySendDatasets"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -3049,6 +3049,32 @@ export interface components {
             )[];
         };
         /**
+         * Dataset
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        Dataset: {
+            /** Create time */
+            create_time?: Record<string, never>;
+            /** Deleted */
+            deleted?: Record<string, never>;
+            /** File size */
+            file_size?: Record<string, never>;
+            /** ID */
+            id?: Record<string, never>;
+            /** Purgable */
+            purgable?: Record<string, never>;
+            /** Purged */
+            purged?: Record<string, never>;
+            /** State */
+            state?: Record<string, never>;
+            /** Total size */
+            total_size?: Record<string, never>;
+            /** Update time */
+            update_time?: Record<string, never>;
+            /** UUID */
+            uuid?: Record<string, never>;
+        };
+        /**
          * DatasetAssociationRoles
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -3764,22 +3790,6 @@ export interface components {
             /** Items From */
             items_from?: string;
             src: components["schemas"]["Src"];
-        };
-        /**
-         * FailedJob
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        FailedJob: {
-            /**
-             * Error
-             * @description A descriptive error message.
-             */
-            error: string;
-            /**
-             * Object
-             * @description The name of object is queued to be created
-             */
-            object: string;
         };
         /**
          * FetchDataPayload
@@ -5478,8 +5488,8 @@ export interface components {
          */
         InputArguments: {
             /**
-             * Genome
-             * @description Sets the genome (e.g., `hg19`) of the objects being fetched to Galaxy.
+             * Database Key
+             * @description Sets the database key of the objects being fetched to Galaxy.
              * @default ?
              */
             dbkey?: string;
@@ -8038,22 +8048,6 @@ export interface components {
          */
         StoredItemOrderBy: "name-asc" | "name-dsc" | "size-asc" | "size-dsc" | "update_time-asc" | "update_time-dsc";
         /**
-         * SuccessfulJob
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        SuccessfulJob: {
-            /**
-             * Job ID
-             * @description The ID of the queued send job.
-             */
-            job_id: string;
-            /**
-             * Object
-             * @description The name of object is queued to be created
-             */
-            object: string;
-        };
-        /**
          * SuitableConverter
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -8085,17 +8079,6 @@ export interface components {
          */
         SuitableConverters: components["schemas"]["SuitableConverter"][];
         /**
-         * SummaryGetObjects
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        SummaryGetObjects: {
-            /**
-             * Datasets
-             * @description A list of datasets created for the fetched files.
-             */
-            datasets: Record<string, never>[];
-        };
-        /**
          * SummarySendDatasets
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -8109,12 +8092,12 @@ export interface components {
              * Failed datasets
              * @description The datasets for which Galaxy failed to create (and queue) send job
              */
-            failed_dataset_labels: components["schemas"]["FailedJob"][];
+            failed_dataset_labels: string[];
             /**
              * Send datasets
              * @description The datasets for which Galaxy succeeded to create (and queue) send job
              */
-            sent_dataset_labels: components["schemas"]["SuccessfulJob"][];
+            sent_dataset_labels: string[];
         };
         /**
          * TagCollection
@@ -9076,7 +9059,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["SummaryGetObjects"];
+                    "application/json": components["schemas"]["Dataset"][];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -2259,6 +2259,27 @@ export interface components {
             overwrite_existing?: boolean;
         };
         /**
+         * CloudDatasetsResponse
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CloudDatasetsResponse: {
+            /**
+             * Bucket
+             * @description The name of bucket to which the listed datasets are queued to be sent
+             */
+            bucket_name: string;
+            /**
+             * Failed datasets
+             * @description The datasets for which Galaxy failed to create (and queue) send job
+             */
+            failed_dataset_labels: string[];
+            /**
+             * Send datasets
+             * @description The datasets for which Galaxy succeeded to create (and queue) send job
+             */
+            sent_dataset_labels: string[];
+        };
+        /**
          * CloudObjects
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -3049,32 +3070,6 @@ export interface components {
             )[];
         };
         /**
-         * Dataset
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        Dataset: {
-            /** Create time */
-            create_time?: Record<string, never>;
-            /** Deleted */
-            deleted?: Record<string, never>;
-            /** File size */
-            file_size?: Record<string, never>;
-            /** ID */
-            id?: Record<string, never>;
-            /** Purgable */
-            purgable?: Record<string, never>;
-            /** Purged */
-            purged?: Record<string, never>;
-            /** State */
-            state?: Record<string, never>;
-            /** Total size */
-            total_size?: Record<string, never>;
-            /** Update time */
-            update_time?: Record<string, never>;
-            /** UUID */
-            uuid?: Record<string, never>;
-        };
-        /**
          * DatasetAssociationRoles
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -3297,6 +3292,56 @@ export interface components {
              */
             sources: Record<string, never>[];
         };
+        /**
+         * DatasetSummary
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        DatasetSummary: {
+            /**
+             * Create Time
+             * Format: date-time
+             * @description The time and date this item was created.
+             */
+            create_time?: string;
+            /** Deleted */
+            deleted: boolean;
+            /** File Size */
+            file_size: number;
+            /**
+             * ID
+             * @description The encoded ID of this entity.
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /** Purgable */
+            purgable: boolean;
+            /** Purged */
+            purged: boolean;
+            /**
+             * State
+             * @description The current state of this dataset.
+             */
+            state: components["schemas"]["DatasetState"];
+            /** Total Size */
+            total_size: number;
+            /**
+             * Update Time
+             * Format: date-time
+             * @description The last time and date this item was updated.
+             */
+            update_time?: string;
+            /**
+             * UUID
+             * Format: uuid4
+             * @description Universal unique identifier for this dataset.
+             */
+            uuid: string;
+        };
+        /**
+         * DatasetSummaryList
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        DatasetSummaryList: components["schemas"]["DatasetSummary"][];
         /**
          * DatasetTextContentDetails
          * @description Base model definition with common configuration used by all derived models.
@@ -8079,27 +8124,6 @@ export interface components {
          */
         SuitableConverters: components["schemas"]["SuitableConverter"][];
         /**
-         * SummarySendDatasets
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        SummarySendDatasets: {
-            /**
-             * Bucket
-             * @description The name of bucket to which the listed datasets are queued to be sent
-             */
-            bucket_name: string;
-            /**
-             * Failed datasets
-             * @description The datasets for which Galaxy failed to create (and queue) send job
-             */
-            failed_dataset_labels: string[];
-            /**
-             * Send datasets
-             * @description The datasets for which Galaxy succeeded to create (and queue) send job
-             */
-            sent_dataset_labels: string[];
-        };
-        /**
          * TagCollection
          * @description The collection of tags associated with an item.
          */
@@ -9059,7 +9083,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["Dataset"][];
+                    "application/json": components["schemas"]["DatasetSummaryList"];
                 };
             };
             /** @description Validation Error */
@@ -9090,7 +9114,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["SummarySendDatasets"];
+                    "application/json": components["schemas"]["CloudDatasetsResponse"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -9,15 +9,24 @@ export interface paths {
         get: operations["get_api_key_api_authenticate_baseauth_get"];
     };
     "/api/cloud/storage": {
-        /** Lists cloud-based buckets (e.g., S3 bucket, Azure blob) user has defined. Is not yet implemented */
+        /**
+         * Lists cloud-based buckets (e.g., S3 bucket, Azure blob) user has defined. Is not yet implemented
+         * @deprecated
+         */
         get: operations["index_api_cloud_storage_get"];
     };
     "/api/cloud/storage/get": {
-        /** Gets given objects from a given cloud-based bucket to a Galaxy history. */
+        /**
+         * Gets given objects from a given cloud-based bucket to a Galaxy history.
+         * @deprecated
+         */
         post: operations["get_api_cloud_storage_get_post"];
     };
     "/api/cloud/storage/send": {
-        /** Sends given dataset(s) in a given history to a given cloud-based bucket. */
+        /**
+         * Sends given dataset(s) in a given history to a given cloud-based bucket.
+         * @deprecated
+         */
         post: operations["send_api_cloud_storage_send_post"];
     };
     "/api/configuration": {
@@ -9034,7 +9043,10 @@ export interface operations {
         };
     };
     index_api_cloud_storage_get: {
-        /** Lists cloud-based buckets (e.g., S3 bucket, Azure blob) user has defined. Is not yet implemented */
+        /**
+         * Lists cloud-based buckets (e.g., S3 bucket, Azure blob) user has defined. Is not yet implemented
+         * @deprecated
+         */
         responses: {
             /** @description Successful Response */
             200: {
@@ -9045,7 +9057,10 @@ export interface operations {
         };
     };
     get_api_cloud_storage_get_post: {
-        /** Gets given objects from a given cloud-based bucket to a Galaxy history. */
+        /**
+         * Gets given objects from a given cloud-based bucket to a Galaxy history.
+         * @deprecated
+         */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -9073,7 +9088,10 @@ export interface operations {
         };
     };
     send_api_cloud_storage_send_post: {
-        /** Sends given dataset(s) in a given history to a given cloud-based bucket. */
+        /**
+         * Sends given dataset(s) in a given history to a given cloud-based bucket.
+         * @deprecated
+         */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/lib/galaxy/schema/cloud.py
+++ b/lib/galaxy/schema/cloud.py
@@ -1,4 +1,5 @@
 from typing import (
+    Any,
     List,
     Optional,
     Union,
@@ -10,6 +11,7 @@ from pydantic import (
 )
 from typing_extensions import Literal
 
+# from galaxy.model import Dataset
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import Model
 
@@ -90,4 +92,69 @@ class CloudDatasets(Model):
         default=False,
         title="Spaces to tabs",
         description="A boolean value. If set to 'True', and an object with same name of the dataset to be sent already exist in the bucket, Galaxy replaces the existing object with the dataset to be sent. If set to 'False', Galaxy appends datetime to the dataset name to prevent overwriting an existing object.",
+    )
+
+
+class FailedJob(Model):
+    object: str = Field(
+        default=Required,
+        title="Object",
+        description="The name of object is queued to be created",
+    )
+    error: str = Field(
+        default=Required,
+        title="Error",
+        description="A descriptive error message.",
+    )
+
+
+class SuccessfulJob(Model):
+    object: str = Field(
+        default=Required,
+        title="Object",
+        description="The name of object is queued to be created",
+    )
+    job_id: str = Field(
+        default=Required,
+        title="Job ID",
+        description="The ID of the queued send job.",
+    )
+
+
+class SummarySendDatasets(Model):
+    sent_dataset_labels: List[SuccessfulJob] = Field(
+        default=Required,
+        title="Send datasets",
+        description="The datasets for which Galaxy succeeded to create (and queue) send job",
+    )
+    failed_dataset_labels: List[FailedJob] = Field(
+        default=Required,
+        title="Failed datasets",
+        description="The datasets for which Galaxy failed to create (and queue) send job",
+    )
+    bucket_name: str = Field(
+        default=Required,
+        title="Bucket",
+        description="The name of bucket to which the listed datasets are queued to be sent",
+    )
+
+
+class SummaryGetObjects(Model):
+    datasets: List[Any] = Field(
+        default=Required,
+        title="Datasets",
+        description="A list of datasets created for the fetched files.",
+    )
+
+
+class StatusCode(Model):
+    detail: str = Field(
+        default=Required,
+        title="Detail",
+        description="The detail to expand on the status code",
+    )
+    status: int = Field(
+        default=Required,
+        title="Code",
+        description="The actual status code",
     )

--- a/lib/galaxy/schema/cloud.py
+++ b/lib/galaxy/schema/cloud.py
@@ -112,11 +112,57 @@ class SummarySendDatasets(Model):
     )
 
 
-class SummaryGetObjects(Model):
-    datasets: List[Any] = Field(
-        default=Required,
-        title="Datasets",
-        description="A list of datasets created for the fetched files.",
+class Dataset(Model):
+    # TODO Add descriptions for fields
+    id: Optional[Any] = Field(
+        default=None,
+        title="ID",
+        description="",
+    )
+    create_time: Optional[Any] = Field(
+        default=None,
+        title="Create time",
+        description="",
+    )
+    update_time: Optional[Any] = Field(
+        default=None,
+        title="Update time",
+        description="",
+    )
+    state: Optional[Any] = Field(
+        default=None,
+        title="State",
+        description="",
+    )
+    deleted: Optional[Any] = Field(
+        default=None,
+        title="Deleted",
+        description="",
+    )
+    purged: Optional[Any] = Field(
+        default=None,
+        title="Purged",
+        description="",
+    )
+    purgable: Optional[Any] = Field(
+        default=None,
+        title="Purgable",
+        description="",
+    )
+    file_size: Optional[Any] = Field(
+        default=None,
+        title="File size",
+        description="",
+    )
+    total_size: Optional[Any] = Field(
+        default=None,
+        title="Total size",
+        description="",
+    )
+    uuid: Optional[Any] = Field(
+        default=None,
+        title="UUID",
+        description="",
     )
 
 

--- a/lib/galaxy/schema/cloud.py
+++ b/lib/galaxy/schema/cloud.py
@@ -94,39 +94,13 @@ class CloudDatasets(Model):
     )
 
 
-class FailedJob(Model):
-    object: str = Field(
-        default=Required,
-        title="Object",
-        description="The name of object is queued to be created",
-    )
-    error: str = Field(
-        default=Required,
-        title="Error",
-        description="A descriptive error message.",
-    )
-
-
-class SuccessfulJob(Model):
-    object: str = Field(
-        default=Required,
-        title="Object",
-        description="The name of object is queued to be created",
-    )
-    job_id: str = Field(
-        default=Required,
-        title="Job ID",
-        description="The ID of the queued send job.",
-    )
-
-
 class SummarySendDatasets(Model):
-    sent_dataset_labels: List[SuccessfulJob] = Field(
+    sent_dataset_labels: List[str] = Field(
         default=Required,
         title="Send datasets",
         description="The datasets for which Galaxy succeeded to create (and queue) send job",
     )
-    failed_dataset_labels: List[FailedJob] = Field(
+    failed_dataset_labels: List[str] = Field(
         default=Required,
         title="Failed datasets",
         description="The datasets for which Galaxy failed to create (and queue) send job",

--- a/lib/galaxy/schema/cloud.py
+++ b/lib/galaxy/schema/cloud.py
@@ -1,0 +1,93 @@
+from typing import (
+    List,
+    Optional,
+    Union,
+)
+
+from pydantic import (
+    Field,
+    Required,
+)
+from typing_extensions import Literal
+
+from galaxy.schema.fields import DecodedDatabaseIdField
+from galaxy.schema.schema import Model
+
+
+class InputArguments(Model):
+    dbkey: Optional[str] = Field(
+        default="?",
+        title="Genome",
+        description="Sets the genome (e.g., `hg19`) of the objects being fetched to Galaxy.",
+    )
+    file_type: Optional[str] = Field(
+        default="auto",
+        title="File Type",
+        description="Sets the Galaxy datatype (e.g., `bam`) for the objects being fetched to Galaxy. See the following link for a complete list of Galaxy data types: https://galaxyproject.org/learn/datatypes/.",
+    )
+    to_posix_lines: Optional[Union[Literal["Yes"], bool]] = Field(
+        default="Yes",
+        title="POSIX line endings",
+        description="A boolean value ('true' or 'false'); if 'Yes', converts universal line endings to POSIX line endings. Set to 'False' if you upload a gzip, bz2 or zip archive containing a binary file.",
+    )
+    space_to_tab: Optional[bool] = Field(
+        default=False,
+        title="Spaces to tabs",
+        description="A boolean value ('true' or 'false') that sets if spaces should be converted to tab in the objects being fetched to Galaxy. Applicable only if `to_posix_lines` is True",
+    )
+
+
+class CloudObjects(Model):
+    history_id: DecodedDatabaseIdField = Field(
+        default=Required,
+        title="History ID",
+        description="The ID of history to which the object should be received to.",
+    )
+    bucket: str = Field(
+        default=Required,
+        title="Bucket",
+        description="The name of a bucket from which data should be fetched from (e.g., a bucket name on AWS S3).",
+    )
+    objects: List[str] = Field(
+        default=Required,
+        title="Objects",
+        description="A list of the names of objects to be fetched.",
+    )
+    authz_id: DecodedDatabaseIdField = Field(
+        default=Required,
+        title="Authentication ID",
+        description="The ID of CloudAuthz to be used for authorizing access to the resource provider. You may get a list of the defined authorizations via `/api/cloud/authz`. Also, you can use `/api/cloud/authz/create` to define a new authorization.",
+    )
+    input_args: Optional[InputArguments] = Field(
+        default=None,
+        title="Input arguments",
+        description="A summary of the input arguments, which is optional and will default to {}.",
+    )
+
+
+class CloudDatasets(Model):
+    history_id: DecodedDatabaseIdField = Field(
+        default=Required,
+        title="History ID",
+        description="The ID of history from which the object should be downloaded",
+    )
+    bucket: str = Field(
+        default=Required,
+        title="Bucket",
+        description="The name of a bucket to which data should be sent (e.g., a bucket name on AWS S3).",
+    )
+    authz_id: DecodedDatabaseIdField = Field(
+        default=Required,
+        title="Authentication ID",
+        description="The ID of CloudAuthz to be used for authorizing access to the resource provider. You may get a list of the defined authorizations via `/api/cloud/authz`. Also, you can use `/api/cloud/authz/create` to define a new authorization.",
+    )
+    dataset_ids: Optional[List[DecodedDatabaseIdField]] = Field(
+        default=None,
+        title="Objects",
+        description="A list of dataset IDs belonging to the specified history that should be sent to the given bucket. If not provided, Galaxy sends all the datasets belonging the specified history.",
+    )
+    overwrite_existing: Optional[bool] = Field(
+        default=False,
+        title="Spaces to tabs",
+        description="A boolean value. If set to 'True', and an object with same name of the dataset to be sent already exist in the bucket, Galaxy replaces the existing object with the dataset to be sent. If set to 'False', Galaxy appends datetime to the dataset name to prevent overwriting an existing object.",
+    )

--- a/lib/galaxy/schema/cloud.py
+++ b/lib/galaxy/schema/cloud.py
@@ -1,5 +1,4 @@
 from typing import (
-    Any,
     List,
     Optional,
     Union,
@@ -12,7 +11,10 @@ from pydantic import (
 from typing_extensions import Literal
 
 from galaxy.schema.fields import DecodedDatabaseIdField
-from galaxy.schema.schema import Model
+from galaxy.schema.schema import (
+    DatasetSummary,
+    Model,
+)
 
 
 class InputArguments(Model):
@@ -94,7 +96,7 @@ class CloudDatasets(Model):
     )
 
 
-class SummarySendDatasets(Model):
+class CloudDatasetsResponse(Model):
     sent_dataset_labels: List[str] = Field(
         default=Required,
         title="Send datasets",
@@ -112,60 +114,6 @@ class SummarySendDatasets(Model):
     )
 
 
-class Dataset(Model):
-    # TODO Add descriptions for fields
-    id: Optional[Any] = Field(
-        default=None,
-        title="ID",
-        description="",
-    )
-    create_time: Optional[Any] = Field(
-        default=None,
-        title="Create time",
-        description="",
-    )
-    update_time: Optional[Any] = Field(
-        default=None,
-        title="Update time",
-        description="",
-    )
-    state: Optional[Any] = Field(
-        default=None,
-        title="State",
-        description="",
-    )
-    deleted: Optional[Any] = Field(
-        default=None,
-        title="Deleted",
-        description="",
-    )
-    purged: Optional[Any] = Field(
-        default=None,
-        title="Purged",
-        description="",
-    )
-    purgable: Optional[Any] = Field(
-        default=None,
-        title="Purgable",
-        description="",
-    )
-    file_size: Optional[Any] = Field(
-        default=None,
-        title="File size",
-        description="",
-    )
-    total_size: Optional[Any] = Field(
-        default=None,
-        title="Total size",
-        description="",
-    )
-    uuid: Optional[Any] = Field(
-        default=None,
-        title="UUID",
-        description="",
-    )
-
-
 class StatusCode(Model):
     detail: str = Field(
         default=Required,
@@ -177,3 +125,7 @@ class StatusCode(Model):
         title="Code",
         description="The actual status code",
     )
+
+
+class DatasetSummaryList(Model):
+    __root__: List[DatasetSummary]

--- a/lib/galaxy/schema/cloud.py
+++ b/lib/galaxy/schema/cloud.py
@@ -11,7 +11,6 @@ from pydantic import (
 )
 from typing_extensions import Literal
 
-# from galaxy.model import Dataset
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import Model
 
@@ -19,8 +18,8 @@ from galaxy.schema.schema import Model
 class InputArguments(Model):
     dbkey: Optional[str] = Field(
         default="?",
-        title="Genome",
-        description="Sets the genome (e.g., `hg19`) of the objects being fetched to Galaxy.",
+        title="Database Key",
+        description="Sets the database key of the objects being fetched to Galaxy.",
     )
     file_type: Optional[str] = Field(
         default="auto",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -3463,3 +3463,16 @@ class PageSummaryList(Model):
         default=[],
         title="List with summary information of Pages.",
     )
+
+
+class DatasetSummary(Model):
+    id: EncodedDatabaseIdField = EntityIdField
+    create_time: Optional[datetime] = CreateTimeField
+    update_time: Optional[datetime] = UpdateTimeField
+    state: DatasetState = DatasetStateField
+    deleted: bool
+    purged: bool
+    purgable: bool
+    file_size: int
+    total_size: int
+    uuid: UUID4 = UuidField

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -18,6 +18,7 @@ from galaxy.managers.datasets import DatasetSerializer
 from galaxy.schema.cloud import (
     CloudDatasets,
     CloudObjects,
+    Dataset,
     StatusCode,
     SummarySendDatasets,
 )
@@ -59,7 +60,7 @@ class FastAPICloudController:
         self,
         payload: CloudObjects = Body(default=Required),
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ) -> List[dict]:
+    ) -> List[Dataset]:
         datasets = self.cloud_manager.get(
             trans=trans,
             history_id=payload.history_id,
@@ -70,7 +71,7 @@ class FastAPICloudController:
         )
         rtv = []
         for dataset in datasets:
-            rtv.append(self.datasets_serializer.serialize_to_view(dataset, view="summary"))
+            rtv.append(Dataset(**self.datasets_serializer.serialize_to_view(dataset, view="summary")))
         return rtv
 
     @router.post(

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -3,7 +3,7 @@ API operations on Cloud-based storages, such as Amazon Simple Storage Service (S
 """
 
 import logging
-from typing import Union
+from typing import List
 
 from fastapi import (
     Body,
@@ -18,9 +18,7 @@ from galaxy.managers.datasets import DatasetSerializer
 from galaxy.schema.cloud import (
     CloudDatasets,
     CloudObjects,
-    InputArguments,
     StatusCode,
-    SummaryGetObjects,
     SummarySendDatasets,
 )
 from galaxy.webapps.galaxy.api import (
@@ -61,20 +59,19 @@ class FastAPICloudController:
         self,
         payload: CloudObjects = Body(default=Required),
         trans: ProvidesHistoryContext = DependsOnTrans,
-    ) -> SummaryGetObjects:
-        input_args: Union[InputArguments, dict] = payload.input_args or {}
+    ) -> List[dict]:
         datasets = self.cloud_manager.get(
             trans=trans,
             history_id=payload.history_id,
             bucket_name=payload.bucket,
             objects=payload.objects,
             authz_id=payload.authz_id,
-            input_args=input_args,
+            input_args=payload.input_args,
         )
         rtv = []
         for dataset in datasets:
             rtv.append(self.datasets_serializer.serialize_to_view(dataset, view="summary"))
-        return SummaryGetObjects(datasets=rtv)
+        return rtv
 
     @router.post(
         "/api/cloud/storage/send",

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -3,255 +3,104 @@ API operations on Cloud-based storages, such as Amazon Simple Storage Service (S
 """
 
 import logging
-
-from galaxy import exceptions
-from galaxy.exceptions import ActionInputError
-from galaxy.managers import (
-    cloud,
-    datasets,
+from typing import (
+    Any,
+    Dict,
+    List,
+    Union,
 )
-from galaxy.structured_app import StructuredApp
-from galaxy.web import expose_api
-from . import BaseGalaxyAPIController
+
+from fastapi import (
+    Body,
+    HTTPException,
+)
+from pydantic import Required
+
+from galaxy.managers.cloud import CloudManager
+from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.managers.datasets import DatasetSerializer
+from galaxy.schema.cloud import (
+    CloudDatasets,
+    CloudObjects,
+    InputArguments,
+)
+from galaxy.webapps.galaxy.api import (
+    depends,
+    Router,
+)
+from . import DependsOnTrans
 
 log = logging.getLogger(__name__)
 
+router = Router(tags=["cloud"])
 
-class CloudController(BaseGalaxyAPIController):
-    """
-    RESTfull controller for interaction with Amazon S3.
-    """
 
-    def __init__(
-        self, app: StructuredApp, cloud_manager: cloud.CloudManager, datasets_serializer: datasets.DatasetSerializer
+@router.cbv
+class FastAPICloudController:
+    cloud_manager: CloudManager = depends(CloudManager)
+    datasets_serializer: DatasetSerializer = depends(DatasetSerializer)
+
+    @router.get(
+        "/api/cloud/storage",
+        summary="Lists cloud-based buckets (e.g., S3 bucket, Azure blob) user has defined. Is not yet implemented",
+    )
+    def index(
+        self,
     ):
-        super().__init__(app)
-        self.cloud_manager = cloud_manager
-        self.datasets_serializer = datasets_serializer
-
-    @expose_api
-    def index(self, trans, **kwargs):
-        """
-        GET /api/cloud/storage
-
-        Lists cloud-based buckets (e.g., S3 bucket, Azure blob) user has defined.
-
-        :return: A list of cloud-based buckets user has defined.
-        """
         # TODO: This can be implemented leveraging PluggedMedia objects (part of the user-based object store project)
-        trans.response.status = 501
-        return "Not Implemented"
+        raise HTTPException(status_code=501)
 
-    @expose_api
-    def get(self, trans, payload, **kwargs):
-        """
-        POST /api/cloud/storage/get
-
-        gets given objects from a given cloud-based bucket to a Galaxy history.
-
-        :type  trans: galaxy.webapps.base.webapp.GalaxyWebTransaction
-        :param trans: Galaxy web transaction
-
-        :type  payload: dict
-        :param payload: A dictionary structure containing the following keys:
-
-            *   history_id:    the (encoded) id of history to which the object should be received to.
-            *   bucket:        the name of a bucket from which data should be fetched from (e.g., a bucket name on AWS S3).
-            *   objects:       a list of the names of objects to be fetched.
-            *   authz_id:      the encoded ID of CloudAuthz to be used for authorizing access to the resource
-                               provider. You may get a list of the defined authorizations via
-                               `/api/cloud/authz`. Also, you can use `/api/cloud/authz/create` to define a
-                               new authorization.
-            *   input_args     [Optional; default value is an empty dict] a dictionary containing the following keys:
-
-                                **   `dbkey`:           [Optional; default value: is `?`]
-                                                        Sets the genome (e.g., `hg19`) of the objects being
-                                                        fetched to Galaxy.
-
-                                **   `file_type`:       [Optional; default value is `auto`]
-                                                        Sets the Galaxy datatype (e.g., `bam`) for the
-                                                        objects being fetched to Galaxy. See the following
-                                                        link for a complete list of Galaxy data types:
-                                                        https://galaxyproject.org/learn/datatypes/
-
-                                **   `space_to_tab`:    [Optional; default value is `False`]
-                                                        A boolean value ("true" or "false") that sets if spaces
-                                                        should be converted to tab in the objects being
-                                                        fetched to Galaxy. Applicable only if `to_posix_lines`
-                                                        is True
-
-                                **   `to_posix_lines`:  [Optional; default value is `Yes`]
-                                                        A boolean value ("true" or "false"); if "Yes", converts
-                                                        universal line endings to POSIX line endings. Set to
-                                                        "False" if you upload a gzip, bz2 or zip archive
-                                                        containing a binary file.
-
-        :param kwargs:
-
-        :rtype:  dictionary
-        :return: a dictionary containing a `summary` view of the datasets copied from the given cloud-based storage.
-
-        """
-        if not isinstance(payload, dict):
-            raise ActionInputError(
-                "Invalid payload data type. The payload is expected to be a dictionary, "
-                "but received data of type `{}`.".format(str(type(payload)))
-            )
-
-        missing_arguments = []
-        encoded_history_id = payload.get("history_id", None)
-        if encoded_history_id is None:
-            missing_arguments.append("history_id")
-
-        bucket = payload.get("bucket", None)
-        if bucket is None:
-            missing_arguments.append("bucket")
-
-        objects = payload.get("objects", None)
-        if objects is None:
-            missing_arguments.append("objects")
-
-        encoded_authz_id = payload.get("authz_id", None)
-        if encoded_authz_id is None:
-            missing_arguments.append("authz_id")
-
-        if len(missing_arguments) > 0:
-            raise ActionInputError(f"The following required arguments are missing in the payload: {missing_arguments}")
-
-        try:
-            history_id = self.decode_id(encoded_history_id)
-        except exceptions.MalformedId as e:
-            raise ActionInputError(f"Invalid history ID. {e}")
-
-        try:
-            authz_id = self.decode_id(encoded_authz_id)
-        except exceptions.MalformedId as e:
-            raise ActionInputError(f"Invalid authz ID. {e}")
-
-        if not isinstance(objects, list):
-            raise ActionInputError(
-                f"The `objects` should be a list, but received an object of type {type(objects)} instead."
-            )
-
+    @router.post(
+        "/api/cloud/storage/get",
+        summary="Gets given objects from a given cloud-based bucket to a Galaxy history.",
+    )
+    def get(
+        self,
+        payload: CloudObjects = Body(default=Required),
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> List[Dict[Any, Any]]:
+        input_args: Union[InputArguments, dict] = payload.input_args or {}
         datasets = self.cloud_manager.get(
             trans=trans,
-            history_id=history_id,
-            bucket_name=bucket,
-            objects=objects,
-            authz_id=authz_id,
-            input_args=payload.get("input_args", None),
+            history_id=payload.history_id,
+            bucket_name=payload.bucket,
+            objects=payload.objects,
+            authz_id=payload.authz_id,
+            input_args=input_args,
         )
         rtv = []
         for dataset in datasets:
             rtv.append(self.datasets_serializer.serialize_to_view(dataset, view="summary"))
         return rtv
 
-    @expose_api
-    def send(self, trans, payload, **kwargs):
-        """
-        POST /api/cloud/storage/send
-
-        Sends given dataset(s) in a given history to a given cloud-based bucket. Each dataset is named
-        using the label assigned to the dataset in the given history (see `HistoryDatasetAssociation.name`).
-        If no dataset ID is given, this API sends all the datasets belonging to a given history to a given
-        cloud-based bucket.
-
-        :type  trans: galaxy.webapps.base.webapp.GalaxyWebTransaction
-        :param trans: Galaxy web transaction
-
-        :type  payload: dictionary
-        :param payload: A dictionary structure containing the following keys:
-
-            *   history_id              the (encoded) id of history from which the object should be downloaed.
-            *   bucket:                 the name of a bucket to which data should be sent (e.g., a bucket name on AWS S3).
-            *   authz_id:               the encoded ID of CloudAuthz to be used for authorizing access to the resource
-                                        provider. You may get a list of the defined authorizations via
-                                        `/api/cloud/authz`. Also, you can use `/api/cloud/authz/create` to define a
-                                        new authorization.
-            *   dataset_ids:            [Optional; default: None]
-                                        A list of encoded dataset IDs belonging to the specified history
-                                        that should be sent to the given bucket. If not provided, Galaxy sends
-                                        all the datasets belonging the specified history.
-            *   overwrite_existing:     [Optional; default: False]
-                                        A boolean value. If set to "True", and an object with same name of the dataset
-                                        to be sent already exist in the bucket, Galaxy replaces the existing object
-                                        with the dataset to be sent. If set to "False", Galaxy appends datetime
-                                        to the dataset name to prevent overwriting an existing object.
-
-        :rtype:     dictionary
-        :return:    Information about the (un)successfully submitted dataset send jobs,
-                    containing the following keys:
-
-                        *   `bucket_name`:                  The name of bucket to which the listed datasets are queued
-                                                            to be sent.
-                        *   `sent_dataset_labels`:          A list of JSON objects with the following key-value pair:
-                            **  `object`:                   The name of object is queued to be created.
-                            **  `job_id`:                   The id of the queued send job.
-
-                        *   `failed_dataset_labels`:        A list of JSON objects with the following key-value pair
-                                                            representing the datasets Galaxy failed to create
-                                                            (and queue) send job for:
-
-                            **  `object`:                   The name of object is queued to be created.
-                            **  `error`:                    A descriptive error message.
-
-        """
-        missing_arguments = []
-        encoded_history_id = payload.get("history_id", None)
-        if encoded_history_id is None:
-            missing_arguments.append("history_id")
-
-        bucket = payload.get("bucket", None)
-        if bucket is None:
-            missing_arguments.append("bucket")
-
-        encoded_authz_id = payload.get("authz_id", None)
-        if encoded_authz_id is None:
-            missing_arguments.append("authz_id")
-
-        if len(missing_arguments) > 0:
-            raise ActionInputError(f"The following required arguments are missing in the payload: {missing_arguments}")
-
-        try:
-            history_id = self.decode_id(encoded_history_id)
-        except exceptions.MalformedId as e:
-            raise ActionInputError(f"Invalid history ID. {e}")
-
-        try:
-            authz_id = self.decode_id(encoded_authz_id)
-        except exceptions.MalformedId as e:
-            raise ActionInputError(f"Invalid authz ID. {e}")
-
-        encoded_dataset_ids = payload.get("dataset_ids", None)
-        if encoded_dataset_ids is None:
-            dataset_ids = None
-        else:
-            dataset_ids = set()
-            invalid_dataset_ids = []
-            for encoded_id in encoded_dataset_ids:
-                try:
-                    dataset_ids.add(self.decode_id(encoded_id))
-                except exceptions.MalformedId:
-                    invalid_dataset_ids.append(encoded_id)
-            if len(invalid_dataset_ids) > 0:
-                raise ActionInputError(
-                    "The following provided dataset IDs are invalid, please correct them and retry. "
-                    "{}".format(invalid_dataset_ids)
-                )
-
+    @router.post(
+        "/api/cloud/storage/send",
+        summary="Sends given dataset(s) in a given history to a given cloud-based bucket. Each dataset is named using the label assigned to the dataset in the given history (see `HistoryDatasetAssociation.name`). If no dataset ID is given, this API sends all the datasets belonging to a given history to a given cloud-based bucket.",
+    )
+    def send(
+        self,
+        payload: CloudDatasets,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> Dict[str, Union[List[Any], str]]:
         log.info(
             msg="Received api/send request for `{}` datasets using authnz with id `{}`, and history `{}`."
             "".format(
-                "all the dataset in the given history" if not dataset_ids else len(dataset_ids), authz_id, history_id
+                "all the dataset in the given history" if not payload.dataset_ids else len(payload.dataset_ids),
+                payload.authz_id,
+                payload.history_id,
             )
         )
 
         sent, failed = self.cloud_manager.send(
             trans=trans,
-            history_id=history_id,
-            bucket_name=bucket,
-            authz_id=authz_id,
-            dataset_ids=dataset_ids,
-            overwrite_existing=payload.get("overwrite_existing", False),
+            history_id=payload.history_id,
+            bucket_name=payload.bucket,
+            authz_id=payload.authz_id,
+            dataset_ids=payload.dataset_ids,
+            overwrite_existing=payload.overwrite_existing,
         )
-        return {"sent_dataset_labels": sent, "failed_dataset_labels": failed, "bucket_name": bucket}
+        return {
+            "sent_dataset_labels": sent,
+            "failed_dataset_labels": failed,
+            "bucket_name": payload.bucket,
+        }

--- a/lib/galaxy/webapps/galaxy/api/cloud.py
+++ b/lib/galaxy/webapps/galaxy/api/cloud.py
@@ -42,6 +42,7 @@ class FastAPICloudController:
     @router.get(
         "/api/cloud/storage",
         summary="Lists cloud-based buckets (e.g., S3 bucket, Azure blob) user has defined. Is not yet implemented",
+        deprecated=True,
     )
     def index(
         self,
@@ -54,6 +55,7 @@ class FastAPICloudController:
     @router.post(
         "/api/cloud/storage/get",
         summary="Gets given objects from a given cloud-based bucket to a Galaxy history.",
+        deprecated=True,
     )
     def get(
         self,
@@ -77,6 +79,7 @@ class FastAPICloudController:
     @router.post(
         "/api/cloud/storage/send",
         summary="Sends given dataset(s) in a given history to a given cloud-based bucket.",
+        deprecated=True,
     )
     def send(
         self,

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -310,23 +310,6 @@ def populate_api_routes(webapp, app):
     _add_item_tags_controller(
         webapp, name_prefix="history_content_", path_prefix="/api/histories/{history_id}/contents/{history_content_id}"
     )
-    webapp.mapper.connect(
-        "cloud_storage", "/api/cloud/storage/", controller="cloud", action="index", conditions=dict(method=["GET"])
-    )
-    webapp.mapper.connect(
-        "cloud_storage_get",
-        "/api/cloud/storage/get",
-        controller="cloud",
-        action="get",
-        conditions=dict(method=["POST"]),
-    )
-    webapp.mapper.connect(
-        "cloud_storage_send",
-        "/api/cloud/storage/send",
-        controller="cloud",
-        action="send",
-        conditions=dict(method=["POST"]),
-    )
 
     _add_item_tags_controller(webapp, name_prefix="history_", path_prefix="/api/histories/{history_id}")
     _add_item_tags_controller(webapp, name_prefix="workflow_", path_prefix="/api/workflows/{workflow_id}")


### PR DESCRIPTION
This is a part of #10889.


## Summary
- [x] Add pydantic models
- [x]  Operations now return pydanctic models
- [x] Removed the mapping to the legacy route and add FastAPI routes


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
    You can find the interactive API documentation here: [http://127.0.0.1:8080/api/docs#/cloud](url) 

![cloud](https://github.com/galaxyproject/galaxy/assets/117033448/f34ceda1-cf39-4269-b737-b84da48be16b)




## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).