### PR TITLE
[23.1] Fix recalculate_quota throug kombu message

### DIFF
--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -216,15 +216,12 @@ def reload_sanitize_allowlist(app):
 
 
 def recalculate_user_disk_usage(app, **kwargs):
-    object_store = kwargs.get("object_store", None)
     user_id = kwargs.get("user_id", None)
     sa_session = app.model.context
-    if object_store is None:
-        log.error("Recalculate user disk usage task received without object_store.")
     if user_id:
         user = sa_session.query(app.model.User).get(user_id)
         if user:
-            user.calculate_and_set_disk_usage(object_store)
+            user.calculate_and_set_disk_usage(app.object_store)
         else:
             log.error(f"Recalculate user disk usage task failed, user {user_id} not found")
     else:

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -41,7 +41,6 @@ class UsersService(ServiceBase):
                 trans.app,
                 "recalculate_user_disk_usage",
                 kwargs={
-                    "object_store": trans.app.object_store,
                     "user_id": trans.user.id,
                 },
             )


### PR DESCRIPTION
No need to serialize the object store, I think. Fixes #16298 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Start a galaxy instance without celery, go to the storage dashboad and refresh usage. No error should be in the logs.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
