### PR TITLE
Add script for importing data bundles on the command line

### DIFF
--- a/scripts/import_data_bundle.py
+++ b/scripts/import_data_bundle.py
@@ -1,0 +1,39 @@
+from tempfile import NamedTemporaryFile
+from typing import Optional
+
+import click
+import yaml
+
+from galaxy.app import GalaxyManagerApplication
+from galaxy.managers.tool_data import ToolDataImportManager
+
+
+@click.command(help="Import tool data bundle. URI can be a path to a zipped file or directory.")
+@click.option("-c", "--galaxy-config-file", type=click.Path(exists=True, resolve_path=True))
+@click.option(
+    "-t",
+    "--tool-data-file-path",
+    type=click.Path(exists=True, resolve_path=True),
+    help="loc file to append data to. Must be be loaded in general data tables",
+)
+@click.argument("uri")
+def run_import_data_bundle(uri: str, galaxy_config_file: str, tool_data_file_path: Optional[str] = None):
+
+    with open(galaxy_config_file) as fh:
+        galaxy_config = yaml.safe_load(fh)
+        galaxy_config["file_sources"] = []
+        galaxy_config["file_source_config_file"] = None
+        galaxy_config["vault_config_file"] = NamedTemporaryFile().name
+    app = GalaxyManagerApplication(
+        use_converters=False,
+        use_display_applications=False,
+        configure_logging=False,
+        check_migrate_databases=False,
+        **galaxy_config,
+    )
+    import_manager = ToolDataImportManager(app)
+    import_manager.import_data_bundle_by_uri(app.config, uri=uri, tool_data_file_path=tool_data_file_path)
+
+
+if __name__ == "__main__":
+    run_import_data_bundle()


### PR DESCRIPTION
Doesn't necessarily need to live with galaxy, we could also keep that an external script and depend on galaxy-app

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
