### PR TITLE
[23.1] Fix tool remote test data

### DIFF
--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -51,23 +51,19 @@ def verify(
 
     Throw an informative assertion error if any of these tests fail.
     """
-    use_default_test_data_resolver = get_filecontent is None
     if get_filename is None:
+        get_filecontent_: Callable[[str], bytes]
+        if get_filecontent is None:
+            get_filecontent_ = DEFAULT_TEST_DATA_RESOLVER.get_filecontent
+        else:
+            get_filecontent_ = get_filecontent
 
         def get_filename(filename: str) -> str:
-            file_content = _retrieve_file_content(filename)
+            file_content = get_filecontent_(filename)
             local_name = make_temp_fname(fname=filename)
             with open(local_name, "wb") as f:
                 f.write(file_content)
             return local_name
-
-        def _retrieve_file_content(filename: str) -> bytes:
-            if use_default_test_data_resolver:
-                file_content = DEFAULT_TEST_DATA_RESOLVER.get_filecontent(filename, context=attributes)
-            else:
-                assert get_filecontent is not None
-                file_content = get_filecontent(filename)
-            return file_content
 
     # Check assertions...
     assertions = attributes.get("assert_list", None)

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -478,10 +478,7 @@ class GalaxyInteractorApi:
             local_path = self.test_data_path(tool_id, filename, tool_version=tool_version)
 
         if result is None and (local_path is None or not os.path.exists(local_path)):
-            for test_data_directory in self.test_data_directories:
-                local_path = os.path.join(test_data_directory, filename)
-                if os.path.exists(local_path):
-                    break
+            local_path = self._find_in_test_data_directories(filename)
 
         if result is None and local_path is not None and os.path.exists(local_path):
             if mode == "file":
@@ -502,6 +499,14 @@ class GalaxyInteractorApi:
                 raise AssertionError(f"Test input file ({filename}) cannot be found.")
 
         return result
+
+    def _find_in_test_data_directories(self, filename: str) -> Optional[str]:
+        local_path = None
+        for test_data_directory in self.test_data_directories:
+            local_path = os.path.join(test_data_directory, filename)
+            if os.path.exists(local_path):
+                break
+        return local_path
 
     def __output_id(self, output_data):
         # Allow data structure coming out of tools API - {id: <id>, output_name: <name>, etc...}

--- a/lib/galaxy/tool_util/verify/test_data.py
+++ b/lib/galaxy/tool_util/verify/test_data.py
@@ -3,24 +3,11 @@ import os
 import re
 import subprocess
 from string import Template
-from typing import (
-    Any,
-    Dict,
-    Optional,
-)
-
-from typing_extensions import Protocol
 
 from galaxy.util import (
     asbool,
-    download_to_file,
     in_directory,
-    is_url,
     smart_str,
-)
-from galaxy.util.hash_util import (
-    memory_bound_hexdigest,
-    parse_checksum_hash,
 )
 
 UPDATE_TEMPLATE = Template(
@@ -34,8 +21,6 @@ UPDATE_FAILED_TEMPLATE = Template(
 
 LIST_SEP = re.compile(r"\s*,\s*")
 
-TestDataContext = Dict[str, Any]
-
 
 class TestDataResolver:
     __test__ = False  # Prevent pytest from discovering this class (issue #12071)
@@ -44,23 +29,23 @@ class TestDataResolver:
         if file_dirs is None:
             file_dirs = environ.get(env_var, None)
         if file_dirs is None:
-            file_dirs = "test-data,url-location,https://github.com/galaxyproject/galaxy-test-data.git"
+            file_dirs = "test-data,https://github.com/galaxyproject/galaxy-test-data.git"
         if file_dirs:
             self.resolvers = [build_resolver(u, environ) for u in LIST_SEP.split(file_dirs)]
         else:
             self.resolvers = []
 
-    def get_filename(self, name: str, context: Optional[TestDataContext] = None) -> str:
+    def get_filename(self, name: str) -> str:
         for resolver in self.resolvers or []:
-            if not resolver.exists(name, context):
+            if not resolver.exists(name):
                 continue
             filename = resolver.path(name)
             if filename:
                 return os.path.abspath(filename)
         raise TestDataNotFoundError(f"Failed to find test file {name} against any test data resolvers")
 
-    def get_filecontent(self, name: str, context: Optional[TestDataContext] = None) -> bytes:
-        filename = self.get_filename(name=name, context=context)
+    def get_filecontent(self, name: str) -> bytes:
+        filename = self.get_filename(name=name)
         with open(filename, mode="rb") as f:
             return f.read()
 
@@ -72,32 +57,18 @@ class TestDataNotFoundError(ValueError):
     pass
 
 
-class TestDataChecksumError(ValueError):
-    pass
-
-
 def build_resolver(uri: str, environ):
     if uri.startswith("http") and uri.endswith(".git"):
         return GitDataResolver(uri, environ)
-    elif uri == "url-location":
-        return RemoteLocationDataResolver(environ)
     else:
         return FileDataResolver(uri)
 
 
-class DataResolver(Protocol):
-    def exists(self, filename: str, context: Optional[TestDataContext] = None):
-        raise NotImplementedError
-
-    def path(self, filename: str):
-        raise NotImplementedError
-
-
-class FileDataResolver(DataResolver):
+class FileDataResolver:
     def __init__(self, file_dir: str):
         self.file_dir = file_dir
 
-    def exists(self, filename: str, context: Optional[TestDataContext] = None):
+    def exists(self, filename: str):
         path = os.path.abspath(self.path(filename))
         return os.path.exists(path) and in_directory(path, self.file_dir)
 
@@ -118,12 +89,12 @@ class GitDataResolver(FileDataResolver):
         # will leave it as true for now.
         self.fetch_data = asbool(environ.get("GALAXY_TEST_FETCH_DATA", "true"))
 
-    def exists(self, filename: str, context: Optional[TestDataContext] = None):
-        exists_now = super().exists(filename, context)
+    def exists(self, filename: str):
+        exists_now = super().exists(filename)
         if exists_now or not self.fetch_data or self.updated:
             return exists_now
         self.update_repository()
-        return super().exists(filename, context)
+        return super().exists(filename)
 
     def update_repository(self):
         self.updated = True
@@ -151,59 +122,3 @@ class GitDataResolver(FileDataResolver):
                 "stderr": stderr,
             }
             print(UPDATE_FAILED_TEMPLATE.substitute(**kwds))
-
-
-class RemoteLocationDataResolver(FileDataResolver):
-    def __init__(self, environ):
-        self.fetch_data = asbool(environ.get("GALAXY_TEST_FETCH_DATA", True))
-        repo_cache = environ.get("GALAXY_TEST_DATA_REPO_CACHE", "test-data-cache")
-        repo_path = os.path.join(repo_cache, "from-location")
-        super().__init__(repo_path)
-
-    def exists(self, filename: str, context: Optional[TestDataContext] = None):
-        exists_now = super().exists(filename, context)
-        if exists_now or not self.fetch_data or context is None:
-            return exists_now
-        self._try_download_from_location(filename, context)
-        exists_now = super().exists(filename, context)
-        if exists_now:
-            self._verify_checksum(filename, context)
-        return exists_now
-
-    def _try_download_from_location(self, filename: str, context: TestDataContext):
-        location = context.get("location")
-        if location is None:
-            return
-        if not is_url(location):
-            raise ValueError(f"Invalid 'location' URL for remote test data provided: {location}")
-        if not self._is_valid_filename(filename):
-            raise ValueError(f"Invalid 'filename' provided: '{filename}'")
-        self._ensure_base_dir_exists()
-        dest_file_path = self.path(filename)
-        download_to_file(location, dest_file_path)
-
-    def _ensure_base_dir_exists(self):
-        if not os.path.exists(self.file_dir):
-            os.makedirs(self.file_dir)
-
-    def _verify_checksum(self, filename: str, context: Optional[TestDataContext] = None):
-        if context is None or is_url(filename):
-            return
-        checksum = context.get("checksum")
-        if checksum is None:
-            return
-        hash_function, expected_hash_value = parse_checksum_hash(checksum)
-        file_path = self.path(filename)
-        calculated_hash_value = memory_bound_hexdigest(hash_func_name=hash_function, path=file_path)
-        if calculated_hash_value != expected_hash_value:
-            raise TestDataChecksumError(
-                f"Failed to validate test data '{filename}' with [{hash_function}] - expected [{expected_hash_value}] got [{calculated_hash_value}]"
-            )
-
-    def _is_valid_filename(self, filename: str):
-        """
-        Checks that the filename does not contain the following
-        characters: <, >, :, ", /, \\, |, ?, *, or any control characters.
-        """
-        pattern = r"^[^<>:\"/\\|?*\x00-\x1F]+$"
-        return bool(re.match(pattern, filename))

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1544,9 +1544,8 @@ of ``type`` ``data``.</xs:documentation>
 Please use this option only when is not possible to include the files in the `test-data` folder, since
 this is more error prone due to external factors like remote availability.
 You can use it in two ways:
-- Specifiying the `location` without a `value`, it will directly upload the input file to Galaxy from the location URL (same as regular pasted URL upload).
-- In combination with `value` it will look for the input file specified in `value` in the test data directory, if it's not available on disk it will
-use the `location` to upload the input as the previous case.
+- If only ``location`` is given (and `value` is absent), the input file will be uploaded directly to Galaxy from the URL specified by the ``location``  (same as regular pasted URL upload).
+- If ``location`` as well as ``value`` are given, the input file specified in ``value`` will be used from the tes data directory, if it's not available on disk it will use the ``location`` to upload the input as the previous case.
 </xs:documentation>
       </xs:annotation>
     </xs:attribute>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1544,17 +1544,10 @@ of ``type`` ``data``.</xs:documentation>
 Please use this option only when is not possible to include the files in the `test-data` folder, since
 this is more error prone due to external factors like remote availability.
 You can use it in two ways:
-- In combination with `value` it will look for the input file specified in `value`, if it's not available on disk it will
-download the file pointed by `location` using the same name as in `value` and then use it as input.
-- Specifiying the `location` without a `value`, it will download the file and use it as an alias of `value`. The name of the file
-will be infered from the last component of the location URL. For example, `location="https://my_url/my_file.txt"` will be equivalent to `value="my_file.txt"`.
-If you specify a `checksum`, it will be also used to check the integrity of the download.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="checksum" type="xs:string" gxdocs:added="23.1">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">If specified in combination with `location`, after downloading the test input file, the checksum should match the value specified
-here. This value should have the form ``hash_type$hash_value`` (e.g. ``sha1$8156d7ca0f46ed7abac98f82e36cfaddb2aca041``).</xs:documentation>
+- Specifiying the `location` without a `value`, it will directly upload the input file to Galaxy from the location URL (same as regular pasted URL upload).
+- In combination with `value` it will look for the input file specified in `value` in the test data directory, if it's not available on disk it will
+use the `location` to upload the input as the previous case.
+</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1355,30 +1355,12 @@ class Tool(Dictifiable):
         if not test_data:
             # Fallback to Galaxy test data directory for builtin tools, tools
             # under development, and some older ToolShed published tools that
-            # used stock test data. Also possible remote test data using `location`.
+            # used stock test data.
             try:
-                test_data_context = self._find_test_data_context(filename)
-                test_data = self.app.test_data_resolver.get_filename(filename, test_data_context)
+                test_data = self.app.test_data_resolver.get_filename(filename)
             except TestDataNotFoundError:
                 test_data = None
         return test_data
-
-    def _find_test_data_context(self, filename: str):
-        """Returns the attributes (context) associated with a required file for test inputs or outputs."""
-        # We are returning the attributes of the first test input or output that matches the filename
-        # Could there be multiple different test data files with the same filename and different attributes?
-        # I hope not... otherwise we need a way to match a test file with its test definition.
-        for test in self.tests:
-            # Check for input context attributes
-            for required_file in test.required_files:
-                if len(required_file) > 1 and required_file[0] == filename:
-                    return required_file[1]
-            # Check for outputs context attributes too
-            for output in test.outputs:
-                value = output.get("value", None)
-                if value and value == filename:
-                    return output.get("attributes")
-        return None
 
     def __walk_test_data(self, dir, filename):
         for root, dirs, _ in os.walk(dir):

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -56,7 +56,7 @@ from .test_logging import logging_config_file
 galaxy_root = galaxy_directory()
 DEFAULT_CONFIG_PREFIX = "GALAXY"
 GALAXY_TEST_DIRECTORY = os.path.join(galaxy_root, "test")
-GALAXY_TEST_FILE_DIR = "test-data,url-location,https://github.com/galaxyproject/galaxy-test-data.git"
+GALAXY_TEST_FILE_DIR = "test-data,https://github.com/galaxyproject/galaxy-test-data.git"
 TOOL_SHED_TEST_DATA = os.path.join(galaxy_root, "lib", "tool_shed", "test", "test_data")
 TEST_WEBHOOKS_DIR = os.path.join(galaxy_root, "test", "functional", "webhooks")
 FRAMEWORK_TOOLS_DIR = os.path.join(GALAXY_TEST_DIRECTORY, "functional", "tools")

--- a/test/functional/tools/remote_test_data_location.xml
+++ b/test/functional/tools/remote_test_data_location.xml
@@ -21,18 +21,8 @@
         </test>
         <test>
             <!-- When the `value` and the `location` are defined, if the local file is missing, the remote file pointed by location will be pre-downloaded
-                to the test data cache directory (GALAXY_TEST_DATA_REPO_CACHE) and then uploaded to Galaxy as usual.
-                Additional download integrity checks can be done by specifying a `checksum`. -->
+                to the test data cache directory (GALAXY_TEST_DATA_REPO_CACHE) and then uploaded to Galaxy as usual. -->
             <param name="input" value="missing_file_1.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
-            <output name="output">
-                <assert_contents>
-                    <has_line line="Hello World!"/>
-                </assert_contents>
-            </output>
-        </test>
-        <test>
-            <!-- Additional download integrity checks can be done by specifying a `checksum`. -->
-            <param name="input" value="missing_file_2.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt" checksum="sha1$2ef7bde608ce5404e97d5f042f95f89f1c232871"/>
             <output name="output">
                 <assert_contents>
                     <has_line line="Hello World!"/>
@@ -51,13 +41,13 @@
         <test>
             <!-- Outputs can also be backed up by a remote `location` and will be resolved to a local file.
                 The `checksum` will be also used to check the integrity of the download. -->
-            <param name="input" value="not_local_input.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/master/tests/data/not_hello.txt" checksum="sha1$3436387a8a45b00ef11e621e501ba23b52f06101"/>
+            <param name="input" value="not_local_input.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/master/tests/data/not_hello.txt"/>
             <output name="output" file="not_local_output.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/master/tests/data/not_hello.txt" checksum="sha1$3436387a8a45b00ef11e621e501ba23b52f06101"/>
         </test>
         <test>
             <!-- If the output `file` or `value` is not specified, the last component of the location URL will be used
                 as filename. In this example, this will be equivalent to `file="not_hello.txt"`. -->
-            <param name="input" value="not_local_input.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/master/tests/data/not_hello.txt" checksum="sha1$3436387a8a45b00ef11e621e501ba23b52f06101"/>
+            <param name="input" value="not_local_input.txt" location="https://raw.githubusercontent.com/galaxyproject/planemo/master/tests/data/not_hello.txt"/>
             <output name="output" location="https://raw.githubusercontent.com/galaxyproject/planemo/master/tests/data/not_hello.txt" checksum="sha1$3436387a8a45b00ef11e621e501ba23b52f06101"/>
         </test>
     </tests>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -87,7 +87,6 @@
   <tool file="is_valid_xml.xml" />
   <tool file="expression_tools/parse_values_from_file.xml"/>
   <tool file="expression_tools/pick_value.xml" />
-  <tool file="remote_test_data_location.xml" />
   <!--
   TODO: Figure out why this transiently fails on Jenkins.
   <tool file="maxseconds.xml" />


### PR DESCRIPTION
Follow up on #15510 and #16291

This PR reverts most of the changes in #15510 as that approach was moving too much unnecessary data back and forth to Galaxy.

The new implementation is simpler and makes use of the pasted URL upload for inputs. The only difference in functionality with the previous implementation is that there is no checksum verification for remote inputs for now as we are still using the `upload1` tool to upload test datasets (we can use the `__DATA_FETCH__` that supports checksums to upload test data in future improvements).

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Make sure you have a tool with inputs and outputs defined in `location` attributes (like [test/functional/tools/remote_test_data_location.xml](https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/remote_test_data_location.xml) and there is no local test data already present.
  2. Make sure galaxy is running with this branch
  3. Call `galaxy-tool-test` with the appropriate parameters to test your tool

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
