### PR TITLE
[23.1] Filter deleted keys from api_keys relationship

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -729,7 +729,15 @@ class User(Base, Dictifiable, RepresentById):
     )
     # Add type hint (will this work w/SA?)
     api_keys: "List[APIKeys]" = relationship(
-        "APIKeys", back_populates="user", order_by=lambda: desc(APIKeys.create_time)
+        "APIKeys",
+        back_populates="user",
+        order_by=lambda: desc(APIKeys.create_time),
+        primaryjoin=(
+            lambda: and_(
+                User.id == APIKeys.user_id,  # type: ignore[attr-defined]
+                not_(APIKeys.deleted == true()),  # type: ignore[has-type]
+            )
+        ),
     )
     data_manager_histories = relationship("DataManagerHistoryAssociation", back_populates="user")
     roles = relationship("UserRoleAssociation", back_populates="user")


### PR DESCRIPTION
Update user model, do not include deleted API keys in api_keys relationship.  Discussed in wg-backend, deleted api keys don't need to be accessible to the application.  They cannot be undeleted, and are only available for auditing purposes, which an admin would perform externally.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
