### PR TITLE
[23.1] Remove pin on ``packaging`` in packages

### DIFF
--- a/packages/app/setup.cfg
+++ b/packages/app/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     Mako
     Markdown
     MarkupSafe
-    packaging<22
+    packaging
     paramiko!=2.9.0,!=2.9.1
     pebble
     pulsar-galaxy-lib>=0.15.0.dev0

--- a/packages/tool_util/setup.cfg
+++ b/packages/tool_util/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     conda-package-streaming
     lxml
     MarkupSafe
-    packaging<22
+    packaging
     pydantic
     PyYAML
     requests

--- a/packages/util/setup.cfg
+++ b/packages/util/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     boltons
     docutils
     importlib_resources
-    packaging<22  # packaging 22.0 dropped LegacyVersion
+    packaging
     pyparsing
     PyYAML
     requests


### PR DESCRIPTION
Follow-up on https://github.com/galaxyproject/galaxy/pull/16058 where the pin was removed from ``pyproject.toml`` .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
