### PR TITLE
[23.1] Makefile-based setting of NODE_OPTIONS for client build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ OPEN_RESOURCE=bash -c 'open $$0 || xdg-open $$0'
 SLIDESHOW_TO_PDF?=bash -c 'docker run --rm -v `pwd`:/cwd astefanutti/decktape /cwd/$$0 /cwd/`dirname $$0`/`basename -s .html $$0`.pdf'
 YARN := $(shell command -v yarn 2> /dev/null)
 YARN_INSTALL_OPTS=--network-timeout 300000 --check-files
+NODE_OPTIONS ?= --max-old-space-size=3072
+NODE_ENV = env NODE_OPTIONS=$(NODE_OPTIONS)
 CWL_TARGETS := test/functional/tools/cwl_tools/v1.0/conformance_tests.yaml \
 	test/functional/tools/cwl_tools/v1.1/conformance_tests.yaml \
 	test/functional/tools/cwl_tools/v1.2/conformance_tests.yaml \
@@ -197,19 +199,19 @@ install-client: node-deps ## Install prebuilt client as defined in root package.
 	yarn install && yarn run stage
 
 client: client-node-deps ## Rebuild client-side artifacts for local development.
-	cd client && yarn run build
+	cd client && $(NODE_ENV) yarn run build
 
 client-production: client-node-deps ## Rebuild client-side artifacts for a production deployment without sourcemaps.
-	cd client && yarn run build-production
+	cd client && $(NODE_ENV) yarn run build-production
 
 client-production-maps: client-node-deps ## Rebuild client-side artifacts for a production deployment with sourcemaps.
-	cd client && yarn run build-production-maps
+	cd client && $(NODE_ENV) yarn run build-production-maps
 
 client-format: client-node-deps ## Reformat client code
 	cd client && yarn run format
 
 client-dev-server: client-node-deps ## Starts a webpack dev server for client development (HMR enabled)
-	cd client && yarn run develop
+	cd client && $(NODE_ENV) yarn run develop
 
 client-test: client-node-deps  ## Run JS unit tests
 	cd client && yarn run test

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ OPEN_RESOURCE=bash -c 'open $$0 || xdg-open $$0'
 SLIDESHOW_TO_PDF?=bash -c 'docker run --rm -v `pwd`:/cwd astefanutti/decktape /cwd/$$0 /cwd/`dirname $$0`/`basename -s .html $$0`.pdf'
 YARN := $(shell command -v yarn 2> /dev/null)
 YARN_INSTALL_OPTS=--network-timeout 300000 --check-files
+# Respect predefined NODE_OPTIONS, otherwise set maximum heap size low for
+# compatibility with smaller machines.
 NODE_OPTIONS ?= --max-old-space-size=3072
 NODE_ENV = env NODE_OPTIONS=$(NODE_OPTIONS)
 CWL_TARGETS := test/functional/tools/cwl_tools/v1.0/conformance_tests.yaml \

--- a/client/package.json
+++ b/client/package.json
@@ -112,7 +112,7 @@
     "xml-beautifier": "^0.5.0"
   },
   "scripts": {
-    "develop": "NODE_OPTIONS=--max-old-space-size=4096 NODE_ENV=development gulp && webpack-dev-server",
+    "develop": "NODE_ENV=development gulp && webpack-dev-server",
     "build": "NODE_ENV=development gulp && webpack && yarn run stage-build",
     "build-production": "NODE_ENV=production gulp && yarn run webpack-production && yarn run stage-build",
     "build-production-maps": "NODE_ENV=production gulp && yarn run webpack-production-maps && yarn run stage-build",


### PR DESCRIPTION
Instead of tinkering with NODE_OPTIONS in package.json, this shifts the responsibility to the Makefile, and sets (if unset) low limits for max-old-space-size.  This works to build the production client with maps (most expensive build) for me on a 1cpu4gb VM.  Before this change I was indeed getting a 137 oom.

prompted by the issue in https://help.galaxyproject.org/t/caniuse-lite-is-outdated-error-during-run-sh-build/10345/4.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
