### PR TITLE
[23.1] Fix 'news' webhook to account for the RC one more time. 

### DIFF
--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -51,12 +51,12 @@
 
         let currentGalaxyVersion = Galaxy.config.version_major;
 
-        // TODO/@hexylena: By 21.01 we will have a proper solution for this. For
-        // now we'll hardcode the version users 'see'. @hexylena will remove this
-        // code when she writes the user-facing release notes, and then will file
-        // an issue for how we'll fix this properly.
-        if (currentGalaxyVersion == "22.01") {
-            currentGalaxyVersion = "21.09";
+        // If we're at the 23.1 release candidate, we want to show the 23.0 release notes still.
+        // This should be the last release using this hack -- new notification
+        // system will provide notes moving forward
+
+        if (currentGalaxyVersion == "23.1" && Galaxy.config.version_minor.startsWith("rc")) {
+            currentGalaxyVersion = "23.0";
         }
 
         const releaseNotes = `https://docs.galaxyproject.org/en/latest/releases/${currentGalaxyVersion}_announce_user.html`;


### PR DESCRIPTION
The 23.1 release notes won't be published for a while now and shouldn't be flagged yet.  Moving forward we will use the notification framework for these kinds of update announcements.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
