### PR TITLE
[23.0] Fix folder access for anonymous user

### DIFF
--- a/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
@@ -169,7 +169,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
             type=FILE_TYPE_NAME,
             create_time=library_dataset.create_time.isoformat(),
             update_time=ldda.update_time.isoformat(),
-            can_manage=is_admin or (trans.user and security_agent.can_manage_dataset(current_user_roles, dataset)),
+            can_manage=is_admin or bool(trans.user and security_agent.can_manage_dataset(current_user_roles, dataset)),
             deleted=library_dataset.deleted,
             file_ext=library_dataset_dict["file_ext"],
             date_uploaded=library_dataset_dict["date_uploaded"],


### PR DESCRIPTION
if trans.user is None the value passed on to the model is None, and that leads to
```
WouldBlock: null
  File "anyio/streams/memory.py", line 98, in receive
    return self.receive_nowait()
  File "anyio/streams/memory.py", line 93, in receive_nowait
    raise WouldBlock
EndOfStream: null
  File "starlette/middleware/base.py", line 78, in call_next
    message = await recv_stream.receive()
  File "anyio/streams/memory.py", line 118, in receive
    raise EndOfStream
ValidationError: 1 validation error for FileLibraryFolderItem
can_manage
  none is not an allowed value (type=type_error.none.not_allowed)
  File "starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "starlette_context/middleware/raw_middleware.py", line 93, in __call__
    await self.app(scope, receive, send_wrapper)
  File "starlette/middleware/base.py", line 108, in __call__
    response = await self.dispatch_func(request, call_next)
  File "galaxy/webapps/galaxy/fast_app.py", line 103, in add_x_frame_options
    response = await call_next(request)
  File "starlette/middleware/base.py", line 84, in call_next
    raise app_exc
  File "starlette/middleware/base.py", line 70, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "fastapi/middleware/asyncexitstack.py", line 20, in __call__
    raise e
  File "fastapi/middleware/asyncexitstack.py", line 17, in __call__
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "starlette/routing.py", line 66, in app
    response = await func(request)
  File "fastapi/routing.py", line 241, in app
    raw_response = await run_endpoint_function(
  File "fastapi/routing.py", line 169, in run_endpoint_function
    return await run_in_threadpool(dependant.call, **values)
  File "starlette/concurrency.py", line 41, in run_in_threadpool
    return await anyio.to_thread.run_sync(func, *args)
  File "anyio/to_thread.py", line 33, in run_sync
    return await get_asynclib().run_sync_in_worker_thread(
  File "anyio/_backends/_asyncio.py", line 877, in run_sync_in_worker_thread
    return await future
  File "anyio/_backends/_asyncio.py", line 807, in run
    result = context.run(func, *args)
  File "galaxy/webapps/galaxy/api/folder_contents.py", line 114, in index
    return self.service.index(trans, folder_id, payload)
  File "galaxy/webapps/galaxy/services/library_folder_contents.py", line 83, in index
    self._serialize_library_dataset(trans, current_user_roles, tag_manager, content_item)
  File "galaxy/webapps/galaxy/services/library_folder_contents.py", line 168, in _serialize_library_dataset
    dataset_item = FileLibraryFolderItem(
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
    raise validation_error
```
as seen in https://sentry.galaxyproject.org/share/issue/3eec9cfa26744415b0c8d9885de9d273/

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
