### PR TITLE
[23.0] Fix default when statement evaluation

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormConditional.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormConditional.vue
@@ -18,7 +18,7 @@ function onSkipBoolean(value: boolean) {
     if (props.step.when && value === false) {
         emit("onUpdateStep", { ...props.step, when: undefined });
     } else if (value === true && !props.step.when) {
-        const when = "${inputs.when}";
+        const when = "$(inputs.when)";
         const newStep = {
             ...props.step,
             when,

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -204,6 +204,9 @@ def evaluate_value_from_expressions(progress, step, execution_state, extra_step_
             step_state[key] = to_cwl(value)
 
     if when_expression is not None:
+        if when_expression == "${inputs.when}":
+            # Fallback for workflows defined on 23.0
+            when_expression = "$(inputs.when)"
         try:
             as_cwl_value = do_eval(
                 when_expression,


### PR DESCRIPTION
~~It's unclear why this is needed, I think this worked before and the tests that I added worked fine before.~~

Fixes https://github.com/galaxyproject/galaxy/issues/16331

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
