### PR TITLE
[23.1] Refactor workflow store to be more reliable

### DIFF
--- a/client/src/components/Workflow/InvocationsList.test.js
+++ b/client/src/components/Workflow/InvocationsList.test.js
@@ -6,13 +6,13 @@ import { getLocalVue } from "tests/jest/helpers";
 import mockInvocationData from "./test/json/invocation.json";
 import { parseISO, formatDistanceToNow } from "date-fns";
 
-import { createPinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
 
 import "jest-location-mock";
 
 const localVue = getLocalVue();
 
-const pinia = createPinia();
+const pinia = createTestingPinia();
 describe("InvocationsList.vue", () => {
     let axiosMock;
     let wrapper;

--- a/client/src/components/Workflow/InvocationsList.test.js
+++ b/client/src/components/Workflow/InvocationsList.test.js
@@ -139,11 +139,11 @@ describe("InvocationsList.vue", () => {
             wrapper = mount(InvocationsList, {
                 propsData,
                 computed: {
-                    getWorkflowNameByInstanceId: (state) => (id) => "workflow name",
+                    getStoredWorkflowNameByInstanceId: (state) => (id) => "workflow name",
                     getStoredWorkflowIdByInstanceId: (state) => (id) => {
                         return "workflowId";
                     },
-                    getWorkflowByInstanceId: (state) => (id) => {
+                    getStoredWorkflowByInstanceId: (state) => (id) => {
                         return { id: "workflowId" };
                     },
                     getHistoryById: (state) => (id) => {
@@ -216,8 +216,8 @@ describe("InvocationsList.vue", () => {
             wrapper = mount(InvocationsList, {
                 propsData,
                 computed: {
-                    getWorkflowNameByInstanceId: (state) => (id) => "workflow name",
-                    getWorkflowByInstanceId: (state) => (id) => {
+                    getStoredWorkflowNameByInstanceId: (state) => (id) => "workflow name",
+                    getStoredWorkflowByInstanceId: (state) => (id) => {
                         return { id: "workflowId" };
                     },
                     getHistoryById: (state) => (id) => {

--- a/client/src/components/Workflow/InvocationsList.vue
+++ b/client/src/components/Workflow/InvocationsList.vue
@@ -45,9 +45,12 @@
                     @click.stop="swapRowDetails(data)" />
             </template>
             <template v-slot:cell(workflow_id)="data">
-                <div v-b-tooltip.hover.top :title="getWorkflowNameByInstanceId(data.item.workflow_id)" class="truncate">
+                <div
+                    v-b-tooltip.hover.top
+                    :title="getStoredWorkflowNameByInstanceId(data.item.workflow_id)"
+                    class="truncate">
                     <b-link href="#" @click.stop="swapRowDetails(data)">
-                        <b>{{ getWorkflowNameByInstanceId(data.item.workflow_id) }}</b>
+                        <b>{{ getStoredWorkflowNameByInstanceId(data.item.workflow_id) }}</b>
                     </b-link>
                 </div>
             </template>
@@ -91,7 +94,7 @@ import { invocationsProvider } from "components/providers/InvocationsProvider";
 import WorkflowInvocationState from "components/WorkflowInvocationState/WorkflowInvocationState";
 import WorkflowRunButton from "./WorkflowRunButton.vue";
 import UtcDate from "components/UtcDate";
-import { useWorkflowStore } from "stores/workflowStore";
+import { useWorkflowStore } from "@/stores/workflowStore";
 import paginationMixin from "./paginationMixin";
 
 export default {
@@ -134,9 +137,9 @@ export default {
     },
     computed: {
         ...mapState(useWorkflowStore, [
-            "getWorkflowNameByInstanceId",
-            "getWorkflowByInstanceId",
+            "getStoredWorkflowByInstanceId",
             "getStoredWorkflowIdByInstanceId",
+            "getStoredWorkflowNameByInstanceId",
         ]),
         ...mapState(useHistoryStore, ["getHistoryById", "getHistoryNameById"]),
         title() {
@@ -178,21 +181,18 @@ export default {
             if (invocations) {
                 const historyIds = new Set();
                 const workflowIds = new Set();
-                invocations.map((invocation) => {
+                invocations.forEach((invocation) => {
                     historyIds.add(invocation.history_id);
                     workflowIds.add(invocation.workflow_id);
                 });
                 historyIds.forEach((history_id) => this.getHistoryById(history_id) || this.loadHistoryById(history_id));
-                workflowIds.forEach(
-                    (workflow_id) =>
-                        this.getWorkflowByInstanceId(workflow_id) || this.fetchWorkflowForInstanceId(workflow_id)
-                );
+                workflowIds.forEach((workflow_id) => this.fetchWorkflowForInstanceIdCached(workflow_id));
             }
         },
     },
     methods: {
         ...mapActions(useHistoryStore, ["loadHistoryById"]),
-        ...mapActions(useWorkflowStore, ["fetchWorkflowForInstanceId"]),
+        ...mapActions(useWorkflowStore, ["fetchWorkflowForInstanceIdCached"]),
         async provider(ctx) {
             ctx.root = this.root;
             const extraParams = this.ownerGrid ? {} : { include_terminal: false };

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -116,7 +116,7 @@ export default {
         };
     },
     computed: {
-        ...mapState(useWorkflowStore, ["getWorkflowByInstanceId"]),
+        ...mapState(useWorkflowStore, ["getStoredWorkflowByInstanceId"]),
         ...mapGetters(["getToolForId", "getToolNameById", "getInvocationStepById"]),
         isReady() {
             return this.invocation.steps.length > 0;
@@ -173,7 +173,7 @@ export default {
                 case "tool":
                     return `Step ${oneBasedStepIndex}: ${this.getToolNameById(workflowStep.tool_id)}`;
                 case "subworkflow": {
-                    const subworkflow = this.getWorkflowByInstanceId(workflowStep.workflow_id);
+                    const subworkflow = this.getStoredWorkflowByInstanceId(workflowStep.workflow_id);
                     const label = subworkflow ? subworkflow.name : "Subworkflow";
                     return `Step ${oneBasedStepIndex}: ${label}`;
                 }

--- a/client/src/composables/useWorkflowInstance.ts
+++ b/client/src/composables/useWorkflowInstance.ts
@@ -3,7 +3,7 @@ import { ref } from "vue";
 
 export function useWorkflowInstance(workflowId: string) {
     const workflowStore = useWorkflowStore();
-    const workflow = ref(workflowStore.getWorkflowByInstanceId(workflowId));
+    const workflow = ref(workflowStore.getStoredWorkflowByInstanceId(workflowId));
     const loading = ref(false);
 
     async function getWorkflowInstance() {

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -34,6 +34,10 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
     // stores in progress promises to avoid overlapping requests
     const workflowDetailPromises = new Map<string, Promise<unknown>>();
 
+    /**
+     * Fetches workflow details, avoiding multiple fetches occurring simultaneously
+     * @param workflowId instance id of workflow to fetch
+     */
     async function fetchWorkflowForInstanceId(workflowId: string) {
         const promise = workflowDetailPromises.get(workflowId);
 
@@ -56,6 +60,10 @@ export const useWorkflowStore = defineStore("workflowStore", () => {
         workflowDetailPromises.delete(workflowId);
     }
 
+    /**
+     * Fetches workflow details only if they are not already in the store
+     * @param workflowId instance id of workflow to maybe fetch
+     */
     async function fetchWorkflowForInstanceIdCached(workflowId: string) {
         if (!Object.keys(workflowsByInstanceId.value).includes(workflowId)) {
             await fetchWorkflowForInstanceId(workflowId);

--- a/client/src/stores/workflowStore.ts
+++ b/client/src/stores/workflowStore.ts
@@ -2,47 +2,72 @@ import { defineStore } from "pinia";
 import axios from "axios";
 import type { Steps } from "@/stores/workflowStepStore";
 import { getAppRoot } from "@/onload/loadConfig";
+import { computed, ref, set } from "vue";
 
 interface Workflow {
     [index: string]: any;
     steps: Steps;
 }
 
-export const useWorkflowStore = defineStore("workflowStore", {
-    state: () => ({
-        workflowsByInstanceId: {} as { [index: string]: Workflow },
-    }),
-    getters: {
-        getWorkflowByInstanceId: (state) => {
-            return (workflowId: string) => {
-                return state.workflowsByInstanceId[workflowId];
-            };
-        },
-        getWorkflowNameByInstanceId: (state) => {
-            return (workflowId: string) => {
-                const details = state.workflowsByInstanceId[workflowId];
-                if (details && details.name) {
-                    return details.name;
-                } else {
-                    return "...";
-                }
-            };
-        },
-        getStoredWorkflowIdByInstanceId: (state) => {
-            return (workflowId: string) => {
-                const storedWorkflow = state.workflowsByInstanceId[workflowId];
-                return storedWorkflow?.id;
-            };
-        },
-    },
-    actions: {
-        async fetchWorkflowForInstanceId(workflowId: string) {
+export const useWorkflowStore = defineStore("workflowStore", () => {
+    const workflowsByInstanceId = ref<{ [index: string]: Workflow }>({});
+
+    const getStoredWorkflowByInstanceId = computed(() => (workflowId: string) => {
+        return workflowsByInstanceId.value[workflowId];
+    });
+
+    const getStoredWorkflowIdByInstanceId = computed(() => (workflowId: string) => {
+        const storedWorkflow = workflowsByInstanceId.value[workflowId];
+        return storedWorkflow?.id;
+    });
+
+    const getStoredWorkflowNameByInstanceId = computed(() => (workflowId: string, defaultName = "...") => {
+        const details = workflowsByInstanceId.value[workflowId];
+
+        if (details && details.name) {
+            return details.name;
+        } else {
+            return defaultName;
+        }
+    });
+
+    // stores in progress promises to avoid overlapping requests
+    const workflowDetailPromises = new Map<string, Promise<unknown>>();
+
+    async function fetchWorkflowForInstanceId(workflowId: string) {
+        const promise = workflowDetailPromises.get(workflowId);
+
+        if (promise) {
+            console.debug("Workflow details fetching already requested for", workflowId);
+            await promise;
+        } else {
             console.debug("Fetching workflow details for", workflowId);
+
             const params = { instance: "true" };
-            const { data } = await axios.get(`${getAppRoot()}api/workflows/${workflowId}`, { params });
-            this.$patch((state) => {
-                state.workflowsByInstanceId[workflowId] = data as Workflow;
-            });
-        },
-    },
+            const promise = axios.get(`${getAppRoot()}api/workflows/${workflowId}`, { params });
+
+            workflowDetailPromises.set(workflowId, promise);
+
+            const { data } = await promise;
+
+            set(workflowsByInstanceId.value, workflowId, data as Workflow);
+        }
+
+        workflowDetailPromises.delete(workflowId);
+    }
+
+    async function fetchWorkflowForInstanceIdCached(workflowId: string) {
+        if (!Object.keys(workflowsByInstanceId.value).includes(workflowId)) {
+            await fetchWorkflowForInstanceId(workflowId);
+        }
+    }
+
+    return {
+        workflowsByInstanceId,
+        getStoredWorkflowByInstanceId,
+        getStoredWorkflowIdByInstanceId,
+        getStoredWorkflowNameByInstanceId,
+        fetchWorkflowForInstanceId,
+        fetchWorkflowForInstanceIdCached,
+    };
 });


### PR DESCRIPTION
fixes  #16315

The refactors are:
* move cached fetching to store action, avoiding use of getter function to check store cache
* composition api allows for use of promise map, which avoids overlapping promises in edge-cases
* use of vue set within `fetchWorkflowForInstanceId` ensures reactivity of getter functions

unified naming within the store in the process

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
