### PR TITLE
[23.1] Fix tags ownership

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -7957,14 +7957,11 @@ export interface components {
         TaggableItemClass:
             | "History"
             | "HistoryDatasetAssociation"
+            | "HistoryDatasetCollectionAssociation"
             | "LibraryDatasetDatasetAssociation"
             | "Page"
-            | "WorkflowStep"
             | "StoredWorkflow"
-            | "Visualization"
-            | "HistoryDatasetCollection"
-            | "LibraryDatasetCollection"
-            | "Tool";
+            | "Visualization";
         /** ToolDataDetails */
         ToolDataDetails: {
             /**

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -3802,8 +3802,7 @@ export interface components {
              * @description The current state of this dataset.
              */
             state: components["schemas"]["DatasetState"];
-            /** Tags */
-            tags: string;
+            tags: components["schemas"]["TagCollection"];
             /**
              * Type
              * @enum {string}

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -296,6 +296,10 @@ class MockTrans:
         self.request: Any = Bunch(headers={}, body=None)
         self.response: Any = Bunch(headers={}, set_content_type=lambda i: None)
 
+    @property
+    def tag_handler(self):
+        return self.app.tag_handler
+
     def check_csrf_token(self, payload):
         pass
 

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -293,7 +293,7 @@ class MockTrans:
         self.security = self.app.security
         self.history = history
 
-        self.request: Any = Bunch(headers={}, body=None)
+        self.request: Any = Bunch(headers={}, body=None, host="request.host")
         self.response: Any = Bunch(headers={}, set_content_type=lambda i: None)
 
     @property

--- a/lib/galaxy/job_execution/actions/post.py
+++ b/lib/galaxy/job_execution/actions/post.py
@@ -448,13 +448,13 @@ class TagDatasetAction(DefaultJobAction):
     def execute_on_mapped_over(
         cls, trans, sa_session, action, step_inputs, step_outputs, replacement_dict, final_job_state=None
     ):
-        tag_handler = trans.app.tag_handler.create_tag_handler_session()
         if action.action_arguments:
             tags = [
                 t.replace("#", "name:") if t.startswith("#") else t
                 for t in [t.strip() for t in action.action_arguments.get("tags", "").split(",") if t.strip()]
             ]
-            if tags:
+            if tags and step_outputs:
+                tag_handler = trans.tag_handler
                 for name, step_output in step_outputs.items():
                     if action.output_name == "" or name == action.output_name:
                         cls._execute(tag_handler, trans.user, step_output, tags)
@@ -462,12 +462,12 @@ class TagDatasetAction(DefaultJobAction):
     @classmethod
     def execute(cls, app, sa_session, action, job, replacement_dict, final_job_state=None):
         if action.action_arguments:
-            tag_handler = app.tag_handler.create_tag_handler_session()
             tags = [
                 t.replace("#", "name:") if t.startswith("#") else t
                 for t in [t.strip() for t in action.action_arguments.get("tags", "").split(",") if t.strip()]
             ]
             if tags:
+                tag_handler = app.tag_handler.create_tag_handler_session(job.galaxy_session)
                 for dataset_assoc in job.output_datasets:
                     if action.output_name == "" or dataset_assoc.name == action.output_name:
                         cls._execute(tag_handler, job.user, dataset_assoc.dataset, tags)

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -244,14 +244,14 @@ class JobContext(BaseJobContext):
     @property
     def tag_handler(self):
         if self._tag_handler is None:
-            self._tag_handler = self.app.tag_handler.create_tag_handler_session()
+            self._tag_handler = self.app.tag_handler.create_tag_handler_session(self.job.galaxy_session)
         return self._tag_handler
 
     @property
     def work_context(self):
         from galaxy.work.context import WorkRequestContext
 
-        return WorkRequestContext(self.app, user=self.user)
+        return WorkRequestContext(self.app, user=self.user, galaxy_session=self.job.galaxy_session)
 
     @property
     def sa_session(self) -> ScopedSession:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1058,7 +1058,7 @@ class MinimalJobWrapper(HasResourceParameters):
     def job_io(self):
         if self._job_io is None:
             job = self.get_job()
-            work_request = WorkRequestContext(self.app, user=job.user)
+            work_request = WorkRequestContext(self.app, user=job.user, galaxy_session=job.galaxy_session)
             user_context = ProvidesUserFileSourcesUserContext(work_request)
             tool_source = self.tool and self.tool.tool_source.to_string()
             self._job_io = JobIO(
@@ -1913,7 +1913,7 @@ class MinimalJobWrapper(HasResourceParameters):
                     app=self.app,
                     import_options=import_options,
                     user=job.user,
-                    tag_handler=self.app.tag_handler.create_tag_handler_session(),
+                    tag_handler=self.app.tag_handler.create_tag_handler_session(job.galaxy_session),
                 )
                 import_model_store.perform_import(history=job.history, job=job)
                 if job.state == job.states.ERROR:

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -271,9 +271,7 @@ class DatasetCollectionManager:
         # values.
         if isinstance(tags, list):
             assert implicit_inputs is None, implicit_inputs
-            tags = trans.tag_handler.add_tags_from_list(
-                trans.user, dataset_collection_instance, tags, flush=False, galaxy_session=trans.galaxy_session
-            )
+            tags = trans.tag_handler.add_tags_from_list(trans.user, dataset_collection_instance, tags, flush=False)
         else:
             tags = self._append_tags(dataset_collection_instance, implicit_inputs, tags)
         return self.__persist(dataset_collection_instance, flush=flush)
@@ -500,7 +498,6 @@ class DatasetCollectionManager:
                 trans.user,
                 dataset_collection_instance,
                 new_data["tags"],
-                galaxy_session=trans.galaxy_session,
             )
 
         if changed.keys():
@@ -650,18 +647,14 @@ class DatasetCollectionManager:
                 hda.id, user=trans.user, current_history=history or trans.history
             ):
                 hda.visible = False
-            trans.tag_handler.apply_item_tags(
-                user=trans.user, item=element, tags_str=tag_str, flush=False, galaxy_session=trans.galaxy_session
-            )
+            trans.tag_handler.apply_item_tags(user=trans.user, item=element, tags_str=tag_str, flush=False)
             return element
         elif src_type == "ldda":
             element2 = self.ldda_manager.get(trans, element_id, check_accessible=True)
             element3 = element2.to_history_dataset_association(
                 history or trans.history, add_to_history=True, visible=not hide_source_items
             )
-            trans.tag_handler.apply_item_tags(
-                user=trans.user, item=element3, tags_str=tag_str, flush=False, galaxy_session=trans.galaxy_session
-            )
+            trans.tag_handler.apply_item_tags(user=trans.user, item=element3, tags_str=tag_str, flush=False)
             return element3
         elif src_type == "hdca":
             # TODO: Option to copy? Force copy? Copy or allow if not owned?

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -22,6 +22,11 @@ from galaxy.exceptions import (
     RequestParameterInvalidException,
 )
 from galaxy.managers.collections_util import validate_input_element_identifiers
+from galaxy.managers.context import (
+    ProvidesAppContext,
+    ProvidesHistoryContext,
+    ProvidesUserContext,
+)
 from galaxy.managers.hdas import (
     HDAManager,
     HistoryDatasetAssociationNoHistoryException,
@@ -35,7 +40,6 @@ from galaxy.model.dataset_collections.matching import MatchingCollections
 from galaxy.model.dataset_collections.registry import DATASET_COLLECTION_TYPES_REGISTRY
 from galaxy.model.dataset_collections.type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
 from galaxy.model.mapping import GalaxyModelMapping
-from galaxy.model.tags import GalaxyTagHandler
 from galaxy.schema.schema import DatasetCollectionInstanceType
 from galaxy.schema.tasks import PrepareDatasetCollectionDownload
 from galaxy.security.idencoding import IdEncodingHelper
@@ -65,7 +69,6 @@ class DatasetCollectionManager:
         security: IdEncodingHelper,
         hda_manager: HDAManager,
         history_manager: HistoryManager,
-        tag_handler: GalaxyTagHandler,
         ldda_manager: LDDAManager,
         short_term_storage_monitor: ShortTermStorageMonitor,
     ):
@@ -74,15 +77,13 @@ class DatasetCollectionManager:
         self.model = model
         self.security = security
         self.short_term_storage_monitor = short_term_storage_monitor
-
         self.hda_manager = hda_manager
         self.history_manager = history_manager
-        self.tag_handler = tag_handler.create_tag_handler_session()
         self.ldda_manager = ldda_manager
 
     def precreate_dataset_collection_instance(
         self,
-        trans,
+        trans: ProvidesHistoryContext,
         parent,
         name,
         structure,
@@ -158,7 +159,7 @@ class DatasetCollectionManager:
 
     def create(
         self,
-        trans,
+        trans: ProvidesHistoryContext,
         parent,
         name,
         collection_type,
@@ -222,7 +223,7 @@ class DatasetCollectionManager:
 
     def _create_instance_for_collection(
         self,
-        trans,
+        trans: ProvidesHistoryContext,
         parent,
         name,
         dataset_collection,
@@ -270,14 +271,16 @@ class DatasetCollectionManager:
         # values.
         if isinstance(tags, list):
             assert implicit_inputs is None, implicit_inputs
-            tags = self.tag_handler.add_tags_from_list(trans.user, dataset_collection_instance, tags, flush=False)
+            tags = trans.tag_handler.add_tags_from_list(
+                trans.user, dataset_collection_instance, tags, flush=False, galaxy_session=trans.galaxy_session
+            )
         else:
             tags = self._append_tags(dataset_collection_instance, implicit_inputs, tags)
         return self.__persist(dataset_collection_instance, flush=flush)
 
     def create_dataset_collection(
         self,
-        trans,
+        trans: ProvidesHistoryContext,
         collection_type,
         element_identifiers=None,
         elements=None,
@@ -324,7 +327,9 @@ class DatasetCollectionManager:
         dataset_collection.collection_type = collection_type
         return dataset_collection
 
-    def get_converters_for_collection(self, trans, id, datatypes_registry: Registry, instance_type="history"):
+    def get_converters_for_collection(
+        self, trans: ProvidesHistoryContext, id, datatypes_registry: Registry, instance_type="history"
+    ):
         dataset_collection_instance = self.get_dataset_collection_instance(
             trans, id=id, instance_type=instance_type, check_ownership=True
         )
@@ -360,7 +365,7 @@ class DatasetCollectionManager:
 
     def _element_identifiers_to_elements(
         self,
-        trans,
+        trans: ProvidesHistoryContext,
         collection_type_description,
         element_identifiers,
         hide_source_items=False,
@@ -405,7 +410,7 @@ class DatasetCollectionManager:
     def collection_builder_for(self, dataset_collection):
         return builder.BoundCollectionBuilder(dataset_collection)
 
-    def delete(self, trans, instance_type, id, recursive=False, purge=False):
+    def delete(self, trans: ProvidesHistoryContext, instance_type, id, recursive=False, purge=False):
         dataset_collection_instance = self.get_dataset_collection_instance(
             trans, instance_type, id, check_ownership=True
         )
@@ -431,7 +436,7 @@ class DatasetCollectionManager:
             trans.sa_session.commit()
         return async_result
 
-    def update(self, trans, instance_type, id, payload):
+    def update(self, trans: ProvidesHistoryContext, instance_type, id, payload):
         dataset_collection_instance = self.get_dataset_collection_instance(
             trans, instance_type, id, check_ownership=True
         )
@@ -447,7 +452,15 @@ class DatasetCollectionManager:
         changed = self._set_from_dict(trans, dataset_collection_instance, payload)
         return changed
 
-    def copy(self, trans, parent, source, encoded_source_id, copy_elements=False, dataset_instance_attributes=None):
+    def copy(
+        self,
+        trans: ProvidesHistoryContext,
+        parent,
+        source,
+        encoded_source_id,
+        copy_elements=False,
+        dataset_instance_attributes=None,
+    ):
         """
         PRECONDITION: security checks on ability to add to parent occurred
         during load.
@@ -467,7 +480,7 @@ class DatasetCollectionManager:
             trans.sa_session.commit()
         return new_hdca
 
-    def _set_from_dict(self, trans, dataset_collection_instance, new_data):
+    def _set_from_dict(self, trans: ProvidesUserContext, dataset_collection_instance, new_data):
         # send what we can down into the model
         changed = dataset_collection_instance.set_from_dict(new_data)
 
@@ -481,10 +494,13 @@ class DatasetCollectionManager:
         # the api promises a list of changed fields, but tags are not marked as changed to avoid the
         # flush, so we must handle changed tag responses manually
         new_tags = None
-        if "tags" in new_data.keys() and trans.get_user():
+        if "tags" in new_data.keys():
             # set_tags_from_list will flush on its own, no need to add to 'changed' here and incur a second flush.
-            new_tags = self.tag_handler.set_tags_from_list(
-                trans.get_user(), dataset_collection_instance, new_data["tags"]
+            new_tags = trans.tag_handler.set_tags_from_list(
+                trans.user,
+                dataset_collection_instance,
+                new_data["tags"],
+                galaxy_session=trans.galaxy_session,
             )
 
         if changed.keys():
@@ -634,14 +650,18 @@ class DatasetCollectionManager:
                 hda.id, user=trans.user, current_history=history or trans.history
             ):
                 hda.visible = False
-            self.tag_handler.apply_item_tags(user=trans.user, item=element, tags_str=tag_str, flush=False)
+            trans.tag_handler.apply_item_tags(
+                user=trans.user, item=element, tags_str=tag_str, flush=False, galaxy_session=trans.galaxy_session
+            )
             return element
         elif src_type == "ldda":
             element2 = self.ldda_manager.get(trans, element_id, check_accessible=True)
             element3 = element2.to_history_dataset_association(
                 history or trans.history, add_to_history=True, visible=not hide_source_items
             )
-            self.tag_handler.apply_item_tags(user=trans.user, item=element3, tags_str=tag_str, flush=False)
+            trans.tag_handler.apply_item_tags(
+                user=trans.user, item=element3, tags_str=tag_str, flush=False, galaxy_session=trans.galaxy_session
+            )
             return element3
         elif src_type == "hdca":
             # TODO: Option to copy? Force copy? Copy or allow if not owned?
@@ -658,18 +678,18 @@ class DatasetCollectionManager:
 
     @overload
     def get_dataset_collection_instance(
-        self, trans, instance_type: Literal["history"], id, **kwds: Any
+        self, trans: ProvidesHistoryContext, instance_type: Literal["history"], id, **kwds: Any
     ) -> model.HistoryDatasetCollectionAssociation:
         ...
 
     @overload
     def get_dataset_collection_instance(
-        self, trans, instance_type: Literal["library"], id, **kwds: Any
+        self, trans: ProvidesHistoryContext, instance_type: Literal["library"], id, **kwds: Any
     ) -> model.LibraryDatasetCollectionAssociation:
         ...
 
     def get_dataset_collection_instance(
-        self, trans, instance_type: DatasetCollectionInstanceType, id, **kwds: Any
+        self, trans: ProvidesHistoryContext, instance_type: DatasetCollectionInstanceType, id, **kwds: Any
     ) -> Union[model.HistoryDatasetCollectionAssociation, model.LibraryDatasetCollectionAssociation]:
         """ """
         if instance_type == "history":
@@ -784,7 +804,7 @@ class DatasetCollectionManager:
         return data, sources
 
     def __get_history_collection_instance(
-        self, trans, id, check_ownership=False, check_accessible=True
+        self, trans: ProvidesHistoryContext, id, check_ownership=False, check_accessible=True
     ) -> model.HistoryDatasetCollectionAssociation:
         instance_id = trans.app.security.decode_id(id) if isinstance(id, str) else id
         collection_instance = trans.sa_session.query(trans.app.model.HistoryDatasetCollectionAssociation).get(
@@ -792,6 +812,7 @@ class DatasetCollectionManager:
         )
         if not collection_instance:
             raise RequestParameterInvalidException("History dataset collection association not found")
+        # TODO: that sure looks like a bug, we can't check ownership using the history of the object we're checking ownership for ...
         history = getattr(trans, "history", collection_instance.history)
         if check_ownership:
             self.history_manager.error_unless_owner(collection_instance.history, trans.user, current_history=history)
@@ -802,7 +823,7 @@ class DatasetCollectionManager:
         return collection_instance
 
     def __get_library_collection_instance(
-        self, trans, id, check_ownership=False, check_accessible=True
+        self, trans: ProvidesHistoryContext, id, check_ownership=False, check_accessible=True
     ) -> model.LibraryDatasetCollectionAssociation:
         if check_ownership:
             raise NotImplementedError(
@@ -823,7 +844,7 @@ class DatasetCollectionManager:
                 )
         return collection_instance
 
-    def get_collection_contents(self, trans, parent_id, limit=None, offset=None):
+    def get_collection_contents(self, trans: ProvidesAppContext, parent_id, limit=None, offset=None):
         """Find first level of collection contents by containing collection parent_id"""
         contents_qry = self._get_collection_contents_qry(parent_id, limit=limit, offset=offset)
         contents = contents_qry.with_session(trans.sa_session()).all()

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -71,7 +71,6 @@ class HistoryDatasetAssociationNoHistoryException(Exception):
 class HDAManager(
     datasets.DatasetAssociationManager,
     secured.OwnableManagerMixin,
-    taggable.TaggableManagerMixin,
     annotatable.AnnotatableManagerMixin,
 ):
     """

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -42,7 +42,6 @@ from galaxy.managers import (
 )
 from galaxy.model.base import transaction
 from galaxy.model.deferred import materializer_factory
-from galaxy.model.tags import GalaxyTagHandler
 from galaxy.schema.schema import DatasetSourceType
 from galaxy.schema.storage_cleaner import (
     CleanableItemsSummary,
@@ -92,14 +91,12 @@ class HDAManager(
         app: MinimalManagerApp,
         user_manager: users.UserManager,
         ldda_manager: lddas.LDDAManager,
-        tag_handler: GalaxyTagHandler,
     ):
         """
         Set up and initialize other managers needed by hdas.
         """
         super().__init__(app)
         self.user_manager = user_manager
-        self.tag_handler = tag_handler
         self.ldda_manager = ldda_manager
 
     def get_owned_ids(self, object_ids, history=None):
@@ -708,7 +705,6 @@ class HDADeserializer(
     def __init__(self, app: MinimalManagerApp):
         super().__init__(app)
         self.hda_manager = self.manager
-        self.tag_handler = app.tag_handler
 
     def add_deserializers(self):
         super().add_deserializers()

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -59,7 +59,6 @@ class HDCAManager(
     secured.AccessibleManagerMixin,
     secured.OwnableManagerMixin,
     deletable.PurgableManagerMixin,
-    taggable.TaggableManagerMixin,
     annotatable.AnnotatableManagerMixin,
 ):
     """

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -13,7 +13,6 @@ from galaxy.exceptions import (
 )
 from galaxy.managers import datasets
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.model import tags
 from galaxy.model.base import transaction
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.util import validation

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -109,12 +109,10 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
             changed = True
         new_tags = new_data.get("tags", None)
         if new_tags is not None and new_tags != ldda.tags:
-            trans.tag_handler.delete_item_tags(item=ldda, user=trans.user, galaxy_session=trans.galaxy_session)
+            trans.tag_handler.delete_item_tags(item=ldda, user=trans.user)
             tag_list = trans.tag_handler.parse_tags_list(new_tags)
             for tag in tag_list:
-                trans.tag_handler.apply_item_tag(
-                    item=ldda, user=trans.user, name=tag[0], value=tag[1], galaxy_session=trans.galaxy_session
-                )
+                trans.tag_handler.apply_item_tag(item=ldda, user=trans.user, name=tag[0], value=tag[1])
             changed = True
         if changed:
             ldda.update_parent_folder_update_times()

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -250,7 +250,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
             current_user_roles, ld
         )
         rval["is_unrestricted"] = trans.app.security_agent.dataset_is_public(ldda.dataset)
-        rval["tags"] = trans.tag_handler.get_tags_str(ldda.tags)
+        rval["tags"] = trans.tag_handler.get_tags_list(ldda.tags)
 
         #  Manage dataset permission is always attached to the dataset itself, not the the ld or ldda to maintain consistency
         rval["can_user_manage"] = trans.user_is_admin or trans.app.security_agent.can_manage_dataset(

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -58,7 +58,6 @@ class SharableModelManager(
     base.ModelManager,
     secured.OwnableManagerMixin,
     secured.AccessibleManagerMixin,
-    taggable.TaggableManagerMixin,
     annotatable.AnnotatableManagerMixin,
     ratable.RatableManagerMixin,
 ):

--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -6,10 +6,7 @@ Mixins for Taggable model managers and serializers.
 
 import logging
 import re
-from typing import (
-    Optional,
-    Type,
-)
+from typing import Optional
 
 from sqlalchemy import (
     func,
@@ -19,7 +16,6 @@ from sqlalchemy import (
 from galaxy import model
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model.tags import GalaxyTagHandler
-from galaxy.util import unicodify
 from .base import (
     ModelValidator,
     raise_filter_err,

--- a/lib/galaxy/managers/taggable.py
+++ b/lib/galaxy/managers/taggable.py
@@ -42,40 +42,13 @@ def _tags_to_strings(item):
     return sorted(tag_list, key=lambda str: re.sub("^name:", "#", str))
 
 
-def _tags_from_strings(item, tag_handler, new_tags_list, user=None):
-    # TODO: have to assume trans.user here...
-    if not user:
-        # raise galaxy_exceptions.RequestParameterMissingException( 'User required for tags on ' + str( item ) )
-        # TODO: this becomes a 'silent failure' - no tags are set. This is a questionable approach but
-        # I haven't found a better one for anon users copying items with tags
-        return
+def _tags_from_strings(item, tag_handler, new_tags_list, user: Optional[User], galaxy_session: Optional[GalaxySession] = None):
     # TODO: duped from tags manager - de-dupe when moved to taggable mixin
-    tag_handler.delete_item_tags(user, item)
+    tag_handler.delete_item_tags(user, item, galaxy_session=galaxy_session)
     new_tags_str = ",".join(new_tags_list)
-    tag_handler.apply_item_tags(user, item, unicodify(new_tags_str, "utf-8"))
+    tag_handler.apply_item_tags(user, item, unicodify(new_tags_str, "utf-8"), galaxy_session=galaxy_session)
     # TODO:!! does the creation of new_tags_list mean there are now more and more unused tag rows in the db?
 
-
-class TaggableManagerMixin:
-    tag_assoc: Type[model.ItemTagAssociation]
-    tag_handler: GalaxyTagHandler
-
-    # TODO: most of this can be done by delegating to the GalaxyTagHandler?
-    def get_tags(self, item):
-        """
-        Return a list of tag strings.
-        """
-        return _tags_to_strings(item)
-
-    def set_tags(self, item, new_tags, user=None):
-        """
-        Set an `item`'s tags from a list of strings.
-        """
-        return _tags_from_strings(item, self.tag_handler, new_tags, user=user)
-
-    # def tags_by_user( self, user, **kwargs ):
-    # TODO: here or GalaxyTagHandler
-    #    pass
 
 
 class TaggableSerializerMixin:

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -46,17 +46,15 @@ class TagsManager:
 
     def update(self, trans: ProvidesUserContext, payload: ItemTagsPayload) -> None:
         """Apply a new set of tags to an item; previous tags are deleted."""
-        sa_session = trans.sa_session
         user = trans.user
-        tag_handler = GalaxyTagHandlerSession(sa_session, trans.galaxy_session)
         new_tags: Optional[str] = None
         if payload.item_tags and len(payload.item_tags.__root__) > 0:
             new_tags = ",".join(payload.item_tags.__root__)
-        item = self._get_item(tag_handler, payload)
-        tag_handler.delete_item_tags(user, item, galaxy_session=trans.galaxy_session)
-        tag_handler.apply_item_tags(user, item, new_tags, galaxy_session=trans.galaxy_session)
-        with transaction(sa_session):
-            sa_session.commit()
+        item = self._get_item(trans.tag_handler, payload)
+        trans.tag_handler.delete_item_tags(user, item)
+        trans.tag_handler.apply_item_tags(user, item, new_tags)
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
 
     def _get_item(self, tag_handler: GalaxyTagHandlerSession, payload: ItemTagsPayload):
         """

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -48,13 +48,13 @@ class TagsManager:
         """Apply a new set of tags to an item; previous tags are deleted."""
         sa_session = trans.sa_session
         user = trans.user
-        tag_handler = GalaxyTagHandlerSession(sa_session)
+        tag_handler = GalaxyTagHandlerSession(sa_session, trans.galaxy_session)
         new_tags: Optional[str] = None
         if payload.item_tags and len(payload.item_tags.__root__) > 0:
             new_tags = ",".join(payload.item_tags.__root__)
         item = self._get_item(tag_handler, payload)
-        tag_handler.delete_item_tags(user, item)
-        tag_handler.apply_item_tags(user, item, new_tags)
+        tag_handler.delete_item_tags(user, item, galaxy_session=trans.galaxy_session)
+        tag_handler.apply_item_tags(user, item, new_tags, galaxy_session=trans.galaxy_session)
         with transaction(sa_session):
             sa_session.commit()
 

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -4,7 +4,6 @@ from typing import Optional
 from pydantic import Field
 
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.model import ItemTagAssociation
 from galaxy.model.base import transaction
 from galaxy.model.tags import GalaxyTagHandlerSession
 from galaxy.schema.fields import DecodedDatabaseIdField
@@ -13,10 +12,15 @@ from galaxy.schema.schema import (
     TagCollection,
 )
 
-taggable_item_names = {item: item for item in ItemTagAssociation.associated_item_names}
-# This Enum is generated dynamically and mypy can not statically infer its real type,
-# so it should be ignored. See: https://github.com/python/mypy/issues/4865#issuecomment-592560696
-TaggableItemClass = Enum("TaggableItemClass", taggable_item_names)  # type: ignore[misc]
+
+class TaggableItemClass(Enum):
+    History = "History"
+    HistoryDatasetAssociation = "HistoryDatasetAssociation"
+    HistoryDatasetCollectionAssociation = "HistoryDatasetCollectionAssociation"
+    LibraryDatasetDatasetAssociation = "LibraryDatasetDatasetAssociation"
+    Page = "Page"
+    StoredWorkflow = "StoredWorkflow"
+    Visualization = "Visualization"
 
 
 class ItemTagsPayload(Model):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -639,9 +639,7 @@ class WorkflowContentsManager(UsesAnnotations):
             annotation = sanitize_html(data["annotation"])
             self.add_item_annotation(trans.sa_session, stored.user, stored, annotation)
         workflow_tags = data.get("tags", [])
-        trans.app.tag_handler.set_tags_from_list(
-            user=trans.user, item=stored, new_tags_list=workflow_tags, galaxy_session=trans.galaxy_session
-        )
+        trans.tag_handler.set_tags_from_list(user=trans.user, item=stored, new_tags_list=workflow_tags)
 
         # Persist
         trans.sa_session.add(stored)

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -639,7 +639,9 @@ class WorkflowContentsManager(UsesAnnotations):
             annotation = sanitize_html(data["annotation"])
             self.add_item_annotation(trans.sa_session, stored.user, stored, annotation)
         workflow_tags = data.get("tags", [])
-        trans.app.tag_handler.set_tags_from_list(user=trans.user, item=stored, new_tags_list=workflow_tags)
+        trans.app.tag_handler.set_tags_from_list(
+            user=trans.user, item=stored, new_tags_list=workflow_tags, galaxy_session=trans.galaxy_session
+        )
 
         # Persist
         trans.sa_session.add(stored)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9829,13 +9829,11 @@ class Tag(Base, RepresentById):
 class ItemTagAssociation(Dictifiable):
     dict_collection_visible_keys = ["id", "user_tname", "user_value"]
     dict_element_visible_keys = dict_collection_visible_keys
-    associated_item_names: List[str] = []
     user_tname: Column
     user_value = Column(TrimmedString(255), index=True)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        cls.associated_item_names.append(cls.__name__.replace("TagAssociation", ""))
 
     def copy(self, cls=None):
         if cls:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -2936,7 +2936,7 @@ def source_to_import_store(
     else:
         source_uri: str = str(source)
         delete = False
-        tag_handler = app.tag_handler.create_tag_handler_session()
+        tag_handler = app.tag_handler.create_tag_handler_session(galaxy_session=None)
         if source_uri.startswith("file://"):
             source_uri = source_uri[len("file://") :]
         if "://" in source_uri:

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -165,9 +165,7 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
 
         if tag_list:
             job = self.get_job()
-            self.tag_handler.add_tags_from_list(
-                job and job.user, primary_data, tag_list, flush=False,
-            )
+            self.tag_handler.add_tags_from_list(job and job.user, primary_data, tag_list, flush=False)
 
         # If match specified a name use otherwise generate one from
         # designation.

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -166,7 +166,7 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
         if tag_list:
             job = self.get_job()
             self.tag_handler.add_tags_from_list(
-                job and job.user, primary_data, tag_list, flush=False, galaxy_session=job and job.galaxy_session
+                job and job.user, primary_data, tag_list, flush=False,
             )
 
         # If match specified a name use otherwise generate one from

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -395,12 +395,9 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
         self.set_datasets_metadata(datasets=element_datasets["datasets"])
 
     def add_tags_to_datasets(self, datasets, tag_lists):
-        job = self.get_job()
         if any(tag_lists):
             for dataset, tags in zip(datasets, tag_lists):
-                self.tag_handler.add_tags_from_list(
-                    self.user, dataset, tags, flush=False, galaxy_session=job and job.galaxy_session
-                )
+                self.tag_handler.add_tags_from_list(self.user, dataset, tags, flush=False)
 
     def update_object_store_with_datasets(self, datasets, paths, extra_files, output_name):
         for dataset, path, extra_file in zip(datasets, paths, extra_files):

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -381,39 +381,50 @@ class TagHandler:
 
 
 class GalaxyTagHandler(TagHandler):
+    _item_tag_assoc_info: Dict[str, ItemTagAssocInfo] = {}
+
     def __init__(self, sa_session: galaxy_scoped_session):
+        TagHandler.__init__(self, sa_session)
+        if not GalaxyTagHandler._item_tag_assoc_info:
+            GalaxyTagHandler.init_tag_associations()
+        self.item_tag_assoc_info = GalaxyTagHandler._item_tag_assoc_info
+
+    @classmethod
+    def init_tag_associations(cls):
         from galaxy import model
 
-        TagHandler.__init__(self, sa_session)
-        self.item_tag_assoc_info["History"] = ItemTagAssocInfo(
-            model.History, model.HistoryTagAssociation, model.HistoryTagAssociation.history_id
-        )
-        self.item_tag_assoc_info["HistoryDatasetAssociation"] = ItemTagAssocInfo(
-            model.HistoryDatasetAssociation,
-            model.HistoryDatasetAssociationTagAssociation,
-            model.HistoryDatasetAssociationTagAssociation.history_dataset_association_id,
-        )
-        self.item_tag_assoc_info["HistoryDatasetCollectionAssociation"] = ItemTagAssocInfo(
-            model.HistoryDatasetCollectionAssociation,
-            model.HistoryDatasetCollectionTagAssociation,
-            model.HistoryDatasetCollectionTagAssociation.history_dataset_collection_id,
-        )
-        self.item_tag_assoc_info["LibraryDatasetDatasetAssociation"] = ItemTagAssocInfo(
-            model.LibraryDatasetDatasetAssociation,
-            model.LibraryDatasetDatasetAssociationTagAssociation,
-            model.LibraryDatasetDatasetAssociationTagAssociation.library_dataset_dataset_association_id,
-        )
-        self.item_tag_assoc_info["Page"] = ItemTagAssocInfo(
-            model.Page, model.PageTagAssociation, model.PageTagAssociation.page_id
-        )
-        self.item_tag_assoc_info["StoredWorkflow"] = ItemTagAssocInfo(
-            model.StoredWorkflow,
-            model.StoredWorkflowTagAssociation,
-            model.StoredWorkflowTagAssociation.stored_workflow_id,
-        )
-        self.item_tag_assoc_info["Visualization"] = ItemTagAssocInfo(
-            model.Visualization, model.VisualizationTagAssociation, model.VisualizationTagAssociation.visualization_id
-        )
+        cls._item_tag_assoc_info = {
+            "History": ItemTagAssocInfo(
+                model.History, model.HistoryTagAssociation, model.HistoryTagAssociation.history_id
+            ),
+            "HistoryDatasetAssociation": ItemTagAssocInfo(
+                model.HistoryDatasetAssociation,
+                model.HistoryDatasetAssociationTagAssociation,
+                model.HistoryDatasetAssociationTagAssociation.history_dataset_association_id,
+            ),
+            "HistoryDatasetCollectionAssociation": ItemTagAssocInfo(
+                model.HistoryDatasetCollectionAssociation,
+                model.HistoryDatasetCollectionTagAssociation,
+                model.HistoryDatasetCollectionTagAssociation.history_dataset_collection_id,
+            ),
+            "LibraryDatasetDatasetAssociation": ItemTagAssocInfo(
+                model.LibraryDatasetDatasetAssociation,
+                model.LibraryDatasetDatasetAssociationTagAssociation,
+                model.LibraryDatasetDatasetAssociationTagAssociation.library_dataset_dataset_association_id,
+            ),
+            "Page": ItemTagAssocInfo(model.Page, model.PageTagAssociation, model.PageTagAssociation.page_id),
+            "StoredWorkflow": ItemTagAssocInfo(
+                model.StoredWorkflow,
+                model.StoredWorkflowTagAssociation,
+                model.StoredWorkflowTagAssociation.stored_workflow_id,
+            ),
+            "Visualization": ItemTagAssocInfo(
+                model.Visualization,
+                model.VisualizationTagAssociation,
+                model.VisualizationTagAssociation.visualization_id,
+            ),
+        }
+        return cls._item_tag_assoc_info
 
 
 class GalaxyTagHandlerSession(GalaxyTagHandler):

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -90,7 +90,10 @@ class TagHandler:
         item,
         new_tags_list,
         flush=True,
+        galaxy_session: Optional["GalaxySession"] = None,
     ):
+        # Override galaxy_session if passed in
+        self.galaxy_session = self.galaxy_session or galaxy_session
         # precondition: item is already security checked against user
         # precondition: incoming tags is a list of sanitized/formatted strings
         self.delete_item_tags(user, item)

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -276,19 +276,25 @@ class TagHandler:
         for name, value in parsed_tags:
             self.apply_item_tag(user, item, name, value, flush=flush)
 
-    def get_tags_str(self, tags):
-        """Build a string from an item's tags."""
-        # Return empty string if there are no tags.
+    def get_tags_list(self, tags) -> List[str]:
+        """Build a list of tags from an item's tags."""
+        # Return empty list if there are no tags.
         if not tags:
-            return ""
-        # Create string of tags.
-        tags_str_list = list()
+            return []
+        # Create list of tags.
+        tags_list: List[str] = []
         for tag in tags:
             tag_str = tag.user_tname
             if tag.value is not None:
                 tag_str += f":{tag.user_value}"
-            tags_str_list.append(tag_str)
-        return ", ".join(tags_str_list)
+            tags_list.append(tag_str)
+        return tags_list
+
+    def get_tags_str(self, tags):
+        """Build a string from an item's tags."""
+        tags_list = self.get_tags_list(tags)
+        # Return empty string if there are no tags.
+        return ", ".join(tags_list)
 
     def get_tag_by_id(self, tag_id):
         """Get a Tag object from a tag id."""

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -68,21 +68,21 @@ class TagHandler:
         return GalaxyTagHandlerSession(self.sa_session, galaxy_session=galaxy_session)
 
     def add_tags_from_list(
-        self, user, item, new_tags_list, flush=True, galaxy_session: Optional["GalaxySession"] = None
+        self, user, item, new_tags_list, flush=True,
     ):
         new_tags_set = set(new_tags_list)
         if item.tags:
             new_tags_set.update(self.get_tags_str(item.tags).split(","))
-        return self.set_tags_from_list(user, item, new_tags_set, flush=flush, galaxy_session=galaxy_session)
+        return self.set_tags_from_list(user, item, new_tags_set, flush=flush)
 
     def remove_tags_from_list(
-        self, user, item, tag_to_remove_list, flush=True, galaxy_session: Optional["GalaxySession"] = None
+        self, user, item, tag_to_remove_list, flush=True,
     ):
         tag_to_remove_set = set(tag_to_remove_list)
         tags_set = {_.strip() for _ in self.get_tags_str(item.tags).split(",")}
         if item.tags:
             tags_set -= tag_to_remove_set
-        return self.set_tags_from_list(user, item, tags_set, flush=flush, galaxy_session=galaxy_session)
+        return self.set_tags_from_list(user, item, tags_set, flush=flush)
 
     def set_tags_from_list(
         self,
@@ -90,10 +90,7 @@ class TagHandler:
         item,
         new_tags_list,
         flush=True,
-        galaxy_session: Optional["GalaxySession"] = None,
     ):
-        # Override galaxy_session if passed in
-        self.galaxy_session = self.galaxy_session or galaxy_session
         # precondition: item is already security checked against user
         # precondition: incoming tags is a list of sanitized/formatted strings
         self.delete_item_tags(user, item)

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -13,10 +13,7 @@ from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import func
 
 import galaxy.model
-from galaxy.exceptions import (
-    AuthenticationRequired,
-    ItemOwnershipException,
-)
+from galaxy.exceptions import ItemOwnershipException
 from galaxy.model.base import transaction
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.util import (
@@ -166,8 +163,6 @@ class TagHandler:
             # Item is not persisted, likely it is being copied from an existing, so no need
             # to check ownership at this point.
             return
-        if user is None:
-            raise AuthenticationRequired("Must be logged in to manage tags.")
         history = getattr(item, "history", None)
         is_owner = getattr(item, "user", None) == user or getattr(history, "user", None) == user
         if not is_owner:

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -67,17 +67,13 @@ class TagHandler:
         # Creates a transient tag handler that avoids repeated flushes
         return GalaxyTagHandlerSession(self.sa_session, galaxy_session=galaxy_session)
 
-    def add_tags_from_list(
-        self, user, item, new_tags_list, flush=True,
-    ):
+    def add_tags_from_list(self, user, item, new_tags_list, flush=True):
         new_tags_set = set(new_tags_list)
         if item.tags:
             new_tags_set.update(self.get_tags_str(item.tags).split(","))
         return self.set_tags_from_list(user, item, new_tags_set, flush=flush)
 
-    def remove_tags_from_list(
-        self, user, item, tag_to_remove_list, flush=True,
-    ):
+    def remove_tags_from_list(self, user, item, tag_to_remove_list, flush=True):
         tag_to_remove_set = set(tag_to_remove_list)
         tags_set = {_.strip() for _ in self.get_tags_str(item.tags).split(",")}
         if item.tags:

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -162,6 +162,10 @@ class TagHandler:
         Notice that even admin users cannot directly modify tags on items they do not own.
         To modify tags on items they don't own, admin users must impersonate the item's owner.
         """
+        if getattr(item, "id", None) is None:
+            # Item is not persisted, likely it is being copied from an existing, so no need
+            # to check ownership at this point.
+            return
         if user is None:
             raise AuthenticationRequired("Must be logged in to manage tags.")
         history = getattr(item, "history", None)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2912,7 +2912,7 @@ class FileLibraryFolderItem(LibraryFolderItemBase):
     file_size: str
     raw_size: int
     ldda_id: EncodedDatabaseIdField
-    tags: str
+    tags: TagCollection
     message: Optional[str]
 
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3725,7 +3725,10 @@ class ApplyRulesTool(DatabaseOperationTool):
             copied_dataset = dataset.copy(copy_tags=dataset.tags, flush=False)
             if tags is not None:
                 tag_handler.set_tags_from_list(
-                    trans.get_user(), copied_dataset, tags, flush=False, galaxy_session=trans.galaxy_session
+                    trans.get_user(),
+                    copied_dataset,
+                    tags,
+                    flush=False,
                 )
             copied_dataset.history_id = history.id
             copied_datasets.append(copied_dataset)
@@ -3778,7 +3781,6 @@ class TagFromFileTool(DatabaseOperationTool):
                         item=copied_value,
                         new_tags_list=new_tags,
                         flush=False,
-                        galaxy_session=history.galaxy_sessions,
                     )
             else:
                 # We have a collection, and we copy the elements so that we don't manipulate the original tags

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3724,7 +3724,9 @@ class ApplyRulesTool(DatabaseOperationTool):
         def copy_dataset(dataset, tags):
             copied_dataset = dataset.copy(copy_tags=dataset.tags, flush=False)
             if tags is not None:
-                tag_handler.set_tags_from_list(trans.get_user(), copied_dataset, tags, flush=False)
+                tag_handler.set_tags_from_list(
+                    trans.get_user(), copied_dataset, tags, flush=False, galaxy_session=trans.galaxy_session
+                )
             copied_dataset.history_id = history.id
             copied_datasets.append(copied_dataset)
             return copied_dataset
@@ -3772,7 +3774,11 @@ class TagFromFileTool(DatabaseOperationTool):
                             old_tags = old_tags - set(new_tags)
                         new_tags = old_tags
                     tag_handler.add_tags_from_list(
-                        user=history.user, item=copied_value, new_tags_list=new_tags, flush=False
+                        user=history.user,
+                        item=copied_value,
+                        new_tags_list=new_tags,
+                        flush=False,
+                        galaxy_session=history.galaxy_sessions,
                     )
             else:
                 # We have a collection, and we copy the elements so that we don't manipulate the original tags

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -977,7 +977,7 @@ class OutputCollections:
         hdca_tags,
     ):
         self.trans = trans
-        self.tag_handler = trans.app.tag_handler.create_tag_handler_session()
+        self.tag_handler = trans.tag_handler
         self.history = history
         self.tool = tool
         self.tool_action = tool_action

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -1,10 +1,14 @@
 import logging
+from typing import TYPE_CHECKING
 
 from galaxy.tools.actions import (
     DefaultToolAction,
     OutputCollections,
     ToolExecutionCache,
 )
+
+if TYPE_CHECKING:
+    from galaxy.managers.context import ProvidesUserContext
 
 log = logging.getLogger(__name__)
 
@@ -103,8 +107,10 @@ class ModelOperationToolAction(DefaultToolAction):
         log.info(f"Calling produce_outputs, tool is {tool}")
         return job, out_data, history
 
-    def _produce_outputs(self, trans, tool, out_data, output_collections, incoming, history, tags, hdca_tags):
-        tag_handler = trans.app.tag_handler.create_tag_handler_session()
+    def _produce_outputs(
+        self, trans: "ProvidesUserContext", tool, out_data, output_collections, incoming, history, tags, hdca_tags
+    ):
+        tag_handler = trans.tag_handler
         tool.produce_outputs(
             trans,
             out_data,

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -28,7 +28,6 @@ from galaxy.model import (
     LibraryDataset,
     LibraryFolder,
     Role,
-    tags,
 )
 from galaxy.model.base import transaction
 from galaxy.util import is_url

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -22,6 +22,7 @@ from galaxy.files.uris import (
     stream_to_file,
     validate_non_local,
 )
+from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import (
     FormDefinition,
     LibraryDataset,
@@ -261,8 +262,10 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
     return ldda
 
 
-def new_upload(trans, cntrller, uploaded_dataset, library_bunch=None, history=None, state=None, tag_list=None):
-    tag_handler = tags.GalaxyTagHandlerSession(trans.sa_session)
+def new_upload(
+    trans: ProvidesUserContext, cntrller, uploaded_dataset, library_bunch=None, history=None, state=None, tag_list=None
+):
+    tag_handler = trans.tag_handler
     if library_bunch:
         upload_target_dataset_instance = __new_library_upload(
             trans, cntrller, uploaded_dataset, library_bunch, tag_handler, state

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -268,7 +268,9 @@ class ToolEvaluator:
         visit_input_values(self.tool.inputs, incoming, replace_deferred)
 
     def _validate_incoming(self, incoming: dict):
-        request_context = WorkRequestContext(app=self.app, user=self._user, history=self._history)
+        request_context = WorkRequestContext(
+            app=self.app, user=self._user, history=self._history, galaxy_session=self.job.galaxy_session
+        )
 
         def validate_inputs(input, value, context, **kwargs):
             value = input.from_json(value, request_context, context)

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -64,7 +64,10 @@ class JobImportHistoryArchiveWrapper:
                     "history import archive directory",
                 )
             model_store = store.get_import_model_store_for_directory(
-                archive_dir, app=self.app, user=user, tag_handler=self.app.tag_handler.create_tag_handler_session()
+                archive_dir,
+                app=self.app,
+                user=user,
+                tag_handler=self.app.tag_handler.create_tag_handler_session(jiha.job.galaxy_session),
             )
             job = jiha.job
             with model_store.target_history(default_history=job.history) as new_history:

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1389,9 +1389,6 @@ class SharableMixin:
 
 
 class UsesTagsMixin(SharableItemSecurityMixin):
-    def get_tag_handler(self, trans) -> tags.GalaxyTagHandler:
-        return trans.app.tag_handler
-
     def _get_user_tags(self, trans, item_class_name, id):
         user = trans.user
         tagged_item = self._get_tagged_item(trans, item_class_name, id)
@@ -1407,7 +1404,9 @@ class UsesTagsMixin(SharableItemSecurityMixin):
         """Remove a tag from an item."""
         user = trans.user
         tagged_item = self._get_tagged_item(trans, item_class_name, id)
-        deleted = tagged_item and self.get_tag_handler(trans).remove_item_tag(trans, user, tagged_item, tag_name)
+        deleted = tagged_item and trans.tag_handler.remove_item_tag(
+            user, tagged_item, tag_name, galaxy_session=trans.galaxy_session
+        )
         with transaction(trans.sa_session):
             trans.sa_session.commit()
         return deleted
@@ -1415,7 +1414,7 @@ class UsesTagsMixin(SharableItemSecurityMixin):
     def _apply_item_tag(self, trans, item_class_name, id, tag_name, tag_value=None):
         user = trans.user
         tagged_item = self._get_tagged_item(trans, item_class_name, id)
-        tag_assoc = self.get_tag_handler(trans).apply_item_tag(user, tagged_item, tag_name, tag_value)
+        tag_assoc = trans.tag_handler.apply_item_tag(user, tagged_item, tag_name, tag_value)
         with transaction(trans.sa_session):
             trans.sa_session.commit()
         return tag_assoc
@@ -1424,11 +1423,10 @@ class UsesTagsMixin(SharableItemSecurityMixin):
         user = trans.user
         tagged_item = self._get_tagged_item(trans, item_class_name, id)
         log.debug(f"In get_item_tag_assoc with tagged_item {tagged_item}")
-        return self.get_tag_handler(trans)._get_item_tag_assoc(user, tagged_item, tag_name)
+        return trans.tag_handler._get_item_tag_assoc(user, tagged_item, tag_name)
 
     def set_tags_from_list(self, trans, item, new_tags_list, user=None):
-        tag_handler = tags.GalaxyTagHandler(trans.app.model.context)
-        return tag_handler.set_tags_from_list(user, item, new_tags_list)
+        return trans.tag_handler.set_tags_from_list(user, item, new_tags_list, galaxy_session=trans.galaxy_session)
 
     def get_user_tags_used(self, trans, user=None):
         """
@@ -1444,7 +1442,7 @@ class UsesTagsMixin(SharableItemSecurityMixin):
             return []
 
         # get all the taggable model TagAssociations
-        tag_models = [v.tag_assoc_class for v in trans.app.tag_handler.item_tag_assoc_info.values()]
+        tag_models = [v.tag_assoc_class for v in trans.tag_handler.item_tag_assoc_info.values()]
         # create a union of subqueries for each for this user - getting only the tname and user_value
         all_tags_query = None
         for tag_model in tag_models:

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -35,7 +35,6 @@ from galaxy.model import (
     ExtendedMetadataIndex,
     HistoryDatasetAssociation,
     LibraryDatasetDatasetAssociation,
-    tags,
 )
 from galaxy.model.base import transaction
 from galaxy.model.item_attrs import UsesAnnotations

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1404,9 +1404,7 @@ class UsesTagsMixin(SharableItemSecurityMixin):
         """Remove a tag from an item."""
         user = trans.user
         tagged_item = self._get_tagged_item(trans, item_class_name, id)
-        deleted = tagged_item and trans.tag_handler.remove_item_tag(
-            user, tagged_item, tag_name, galaxy_session=trans.galaxy_session
-        )
+        deleted = tagged_item and trans.tag_handler.remove_item_tag(user, tagged_item, tag_name)
         with transaction(trans.sa_session):
             trans.sa_session.commit()
         return deleted

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1423,7 +1423,7 @@ class UsesTagsMixin(SharableItemSecurityMixin):
         return trans.tag_handler._get_item_tag_assoc(user, tagged_item, tag_name)
 
     def set_tags_from_list(self, trans, item, new_tags_list, user=None):
-        return trans.tag_handler.set_tags_from_list(user, item, new_tags_list, galaxy_session=trans.galaxy_session)
+        return trans.tag_handler.set_tags_from_list(user, item, new_tags_list)
 
     def get_user_tags_used(self, trans, user=None):
         """

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -487,9 +487,7 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
         for k, v in payload.items():
             if k.startswith("files_") or k.startswith("__files_"):
                 inputs[k] = v
-        request_context = WorkRequestContext(
-            app=trans.app, user=trans.user, history=trans.history, galaxy_session=trans.galaxy_session
-        )
+        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=trans.history)
         all_params, all_errors, _, _ = tool.expand_incoming(
             trans=trans, incoming=inputs, request_context=request_context
         )

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -487,7 +487,9 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
         for k, v in payload.items():
             if k.startswith("files_") or k.startswith("__files_"):
                 inputs[k] = v
-        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=trans.history)
+        request_context = WorkRequestContext(
+            app=trans.app, user=trans.user, history=trans.history, galaxy_session=trans.galaxy_session
+        )
         all_params, all_errors, _, _ = tool.expand_incoming(
             trans=trans, incoming=inputs, request_context=request_context
         )

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -183,7 +183,7 @@ class LibraryContentsController(
             rval["parent_library_id"] = trans.security.encode_id(rval["parent_library_id"])
 
             tag_manager = tags.GalaxyTagHandler(trans.sa_session)
-            rval["tags"] = tag_manager.get_tags_str(content.library_dataset_dataset_association.tags)
+            rval["tags"] = tag_manager.get_tags_list(content.library_dataset_dataset_association.tags)
         return rval
 
     @expose_api

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -525,7 +525,10 @@ class WorkflowsAPIController(
             # set tags
             if "tags" in workflow_dict:
                 trans.app.tag_handler.set_tags_from_list(
-                    user=trans.user, item=stored_workflow, new_tags_list=workflow_dict["tags"]
+                    user=trans.user,
+                    item=stored_workflow,
+                    new_tags_list=workflow_dict["tags"],
+                    galaxy_session=trans.galaxy_session,
                 )
 
             if require_flush:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -524,11 +524,10 @@ class WorkflowsAPIController(
                         require_flush = True
             # set tags
             if "tags" in workflow_dict:
-                trans.app.tag_handler.set_tags_from_list(
+                trans.tag_handler.set_tags_from_list(
                     user=trans.user,
                     item=stored_workflow,
                     new_tags_list=workflow_dict["tags"],
-                    galaxy_session=trans.galaxy_session,
                 )
 
             if require_flush:

--- a/lib/galaxy/webapps/galaxy/controllers/tag.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tag.py
@@ -30,7 +30,7 @@ class TagsController(BaseUIController, UsesTagsMixin):
         # Apply tag.
         item = self._get_item(trans, item_class, trans.security.decode_id(item_id))
         user = trans.user
-        self.get_tag_handler(trans).apply_item_tags(user, item, new_tag)
+        trans.tag_handler.apply_item_tags(user, item, new_tag)
         with transaction(trans.sa_session):
             trans.sa_session.commit()
         # Log.
@@ -46,7 +46,7 @@ class TagsController(BaseUIController, UsesTagsMixin):
         # Remove tag.
         item = self._get_item(trans, item_class, trans.security.decode_id(item_id))
         user = trans.user
-        self.get_tag_handler(trans).remove_item_tag(user, item, tag_name)
+        trans.tag_handler.remove_item_tag(user, item, tag_name, galaxy_session=trans.galaxy_session)
         with transaction(trans.sa_session):
             trans.sa_session.commit()
         # Log.
@@ -82,7 +82,7 @@ class TagsController(BaseUIController, UsesTagsMixin):
             raise RuntimeError("Both item and item_class cannot be None")
         elif item is not None:
             item_class = item.__class__
-        item_tag_assoc_class = self.get_tag_handler(trans).get_tag_assoc_class(item_class)
+        item_tag_assoc_class = trans.tag_handler.get_tag_assoc_class(item_class)
         # Build select statement.
         cols_to_select = [item_tag_assoc_class.table.c.tag_id, func.count("*")]
         from_obj = item_tag_assoc_class.table.join(item_class.table).join(trans.app.model.Tag.table)
@@ -104,9 +104,9 @@ class TagsController(BaseUIController, UsesTagsMixin):
         # Create and return autocomplete data.
         ac_data = "#Header|Your Tags\n"
         for row in result_set:
-            tag = self.get_tag_handler(trans).get_tag_by_id(row[0])
+            tag = trans.tag_handler.get_tag_by_id(row[0])
             # Exclude tags that are already applied to the item.
-            if (item is not None) and (self.get_tag_handler(trans).item_has_tag(trans.user, item, tag)):
+            if (item is not None) and (trans.tag_handler.item_has_tag(trans.user, item, tag)):
                 continue
             # Add tag to autocomplete data. Use the most frequent name that user
             # has employed for the tag.
@@ -122,7 +122,7 @@ class TagsController(BaseUIController, UsesTagsMixin):
         tag_name_and_value = q.split(":")
         tag_name = tag_name_and_value[0]
         tag_value = tag_name_and_value[1]
-        tag = self.get_tag_handler(trans).get_tag_by_name(tag_name)
+        tag = trans.tag_handler.get_tag_by_name(tag_name)
         # Don't autocomplete if tag doesn't exist.
         if tag is None:
             return ""
@@ -131,7 +131,7 @@ class TagsController(BaseUIController, UsesTagsMixin):
             raise RuntimeError("Both item and item_class cannot be None")
         elif item is not None:
             item_class = item.__class__
-        item_tag_assoc_class = self.get_tag_handler(trans).get_tag_assoc_class(item_class)
+        item_tag_assoc_class = trans.tag_handler.get_tag_assoc_class(item_class)
         # Build select statement.
         cols_to_select = [item_tag_assoc_class.table.c.value, func.count("*")]
         from_obj = item_tag_assoc_class.table.join(item_class.table).join(trans.app.model.Tag.table)
@@ -183,6 +183,6 @@ class TagsController(BaseUIController, UsesTagsMixin):
         """
         Get an item based on type and id.
         """
-        item_class = self.get_tag_handler(trans).item_tag_assoc_info[item_class_name].item_class
+        item_class = trans.tag_handler.item_tag_assoc_info[item_class_name].item_class
         item = trans.sa_session.query(item_class).filter(item_class.id == id)[0]
         return item

--- a/lib/galaxy/webapps/galaxy/controllers/tag.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tag.py
@@ -46,7 +46,7 @@ class TagsController(BaseUIController, UsesTagsMixin):
         # Remove tag.
         item = self._get_item(trans, item_class, trans.security.decode_id(item_id))
         user = trans.user
-        trans.tag_handler.remove_item_tag(user, item, tag_name, galaxy_session=trans.galaxy_session)
+        trans.tag_handler.remove_item_tag(user, item, tag_name)
         with transaction(trans.sa_session):
             trans.sa_session.commit()
         # Log.

--- a/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/library_folder_contents.py
@@ -183,7 +183,7 @@ class LibraryFolderContentsService(ServiceBase, UsesLibraryMixinItems):
             file_size=util.nice_size(raw_size),
             raw_size=raw_size,
             ldda_id=ldda.id,
-            tags=tag_manager.get_tags_str(ldda.tags),
+            tags=tag_manager.get_tags_list(ldda.tags),
             message=ldda.message or ldda.info,
         )
         return dataset_item

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -1,8 +1,15 @@
 import abc
-from typing import Optional
+from typing import (
+    List,
+    Optional,
+)
 
 from galaxy.managers.context import ProvidesHistoryContext
-from galaxy.model import History
+from galaxy.model import (
+    GalaxySession,
+    History,
+    Role,
+)
 from galaxy.model.base import transaction
 
 
@@ -19,13 +26,22 @@ class WorkRequestContext(ProvidesHistoryContext):
     objects.
     """
 
-    def __init__(self, app, user=None, history=None, workflow_building_mode=False, url_builder=None):
+    def __init__(
+        self,
+        app,
+        user=None,
+        history=None,
+        workflow_building_mode=False,
+        url_builder=None,
+        galaxy_session: Optional[GalaxySession] = None,
+    ):
         self._app = app
         self.__user = user
-        self.__user_current_roles = None
+        self.__user_current_roles: Optional[List[Role]] = None
         self.__history = history
         self._url_builder = url_builder
         self.workflow_building_mode = workflow_building_mode
+        self.galaxy_session = galaxy_session
 
     @property
     def app(self):
@@ -88,10 +104,9 @@ class GalaxyAbstractResponse:
 
 
 class SessionRequestContext(WorkRequestContext):
-    """Like WorkRequestContext, but provides access to galaxy session and request."""
+    """Like WorkRequestContext, but provides access to request."""
 
     def __init__(self, **kwargs):
-        self.galaxy_session = kwargs.pop("galaxy_session", None)
         self.__request: GalaxyAbstractRequest = kwargs.pop("request")
         self.__response: GalaxyAbstractResponse = kwargs.pop("response")
         super().__init__(**kwargs)
@@ -112,7 +127,7 @@ class SessionRequestContext(WorkRequestContext):
         return self.galaxy_session
 
     def set_history(self, history):
-        if history and not history.deleted:
+        if history and not history.deleted and self.galaxy_session:
             self.galaxy_session.current_history = history
         self.sa_session.add(self.galaxy_session)
         with transaction(self.sa_session):
@@ -134,4 +149,5 @@ def proxy_work_context_for_history(
         history=history or trans.history,
         url_builder=trans.url_builder,
         workflow_building_mode=workflow_building_mode,
+        galaxy_session=trans.galaxy_session,
     )

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -1,4 +1,5 @@
 import textwrap
+import urllib
 import zipfile
 from io import BytesIO
 from typing import (
@@ -529,6 +530,39 @@ class TestDatasetsApi(ApiTestCase):
         assert "tag_c" in updated_hda["tags"]
         assert "name:tag_d" in updated_hda["tags"]
         assert "name:tag_e" in updated_hda["tags"]
+
+    def test_anon_tag_permissions(self):
+        with self._different_user(anon=True):
+            history_id = self._get(urllib.parse.urljoin(self.url, "history/current_history_json")).json()["id"]
+            hda_id = self.dataset_populator.new_dataset(history_id, content="abc", wait=True)["id"]
+            payload = {
+                "item_id": hda_id,
+                "item_class": "HistoryDatasetAssociation",
+                "item_tags": ["cool:tag_a", "cool:tag_b", "tag_c", "name:tag_d", "#tag_e"],
+            }
+            put_response = self._put("tags", data=payload, json=True)
+            updated_hda = self._get(f"histories/{history_id}/contents/{hda_id}").json()
+            assert len(updated_hda["tags"]) == 5
+            # ensure we can remove these tags again
+            payload = {
+                "item_id": hda_id,
+                "item_class": "HistoryDatasetAssociation",
+                "item_tags": [],
+            }
+            put_response = self._put("tags", data=payload, json=True)
+            put_response.raise_for_status()
+            updated_hda = self._get(f"histories/{history_id}/contents/{hda_id}").json()
+            assert len(updated_hda["tags"]) == 0
+        with self._different_user(anon=True):
+            # another anon user can't modify tags
+            payload = {
+                "item_id": hda_id,
+                "item_class": "HistoryDatasetAssociation",
+                "item_tags": ["cool:tag_a", "cool:tag_b", "tag_c", "name:tag_d", "#tag_e"],
+            }
+            put_response = self._put("tags", data=payload, json=True)
+            updated_hda = self._get(f"histories/{history_id}/contents/{hda_id}").json()
+            assert len(updated_hda["tags"]) == 0
 
     @skip_without_tool("cat_data_and_sleep")
     def test_update_datatype(self, history_id):

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -458,7 +458,7 @@ class TestLibrariesApi(ApiTestCase):
         data = {"tags": ["#Lancelot", "name:Holy Grail", "blue"]}
         ld_updated = self._patch_library_dataset(ld["id"], data)
         self._assert_has_keys(ld_updated, "tags")
-        assert ld_updated["tags"] == "name:Lancelot, name:HolyGrail, blue"
+        assert ld_updated["tags"] == ["name:Lancelot", "name:HolyGrail", "blue"]
 
     @requires_new_library
     def test_invalid_update_dataset_in_folder(self):

--- a/lib/galaxy_test/api/test_tags.py
+++ b/lib/galaxy_test/api/test_tags.py
@@ -78,10 +78,14 @@ class TagsApiTests(ApiTestCase):
         update_history_tags_response = self._put("tags", data=payload, json=True)
         return update_history_tags_response
 
-    def _assert_tags_in_item(self, item_id, expected_tags: List[str]):
+    def _get_item(self, item_id: str):
         item_response = self._get(f"{self.api_name}/{item_id}")
         self._assert_status_code_is(item_response, 200)
         item = item_response.json()
+        return item
+
+    def _assert_tags_in_item(self, item_id, expected_tags: List[str]):
+        item = self._get_item(item_id)
         assert "tags" in item
         assert item["tags"] == expected_tags
 
@@ -131,7 +135,15 @@ class TestLibraryDatasetTags(TagsApiTests):
 
     def create_item(self) -> str:
         ld = self.library_populator.new_library_dataset(name=f"test-library-dataset-{uuid4()}")
+        self.library_id = ld["parent_library_id"]
         return ld["id"]
+
+    def _get_item(self, item_id: str):
+        assert self.library_id is not None, "Library ID not set"
+        item_response = self._get(f"{self.api_name}/{self.library_id}/contents/{item_id}")
+        self._assert_status_code_is(item_response, 200)
+        item = item_response.json()
+        return item
 
 
 class TestPageTags(TagsApiTests):

--- a/lib/galaxy_test/api/test_tags.py
+++ b/lib/galaxy_test/api/test_tags.py
@@ -1,0 +1,191 @@
+import json
+from typing import List
+from unittest import SkipTest
+from uuid import uuid4
+
+from galaxy_test.base.populators import (
+    DatasetCollectionPopulator,
+    DatasetPopulator,
+    LibraryPopulator,
+    WorkflowPopulator,
+)
+from ._framework import ApiTestCase
+
+
+class TagsApiTests(ApiTestCase):
+    api_name: str
+    item_class: str
+    publishable: bool
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def create_item(self) -> str:
+        """Creates a taggable item and returns it's ID."""
+        raise SkipTest("Abstract")
+
+    def test_tags_on_item(self):
+        item_id = self.create_item()
+
+        self._assert_tags_in_item(item_id, [])
+
+        tag_name = "mytagname"
+        tag_value = "mytagvalue"
+        create_tag_response = self._create_named_tag_on_item(item_id, tag_name, tag_value)
+        self._assert_status_code_is(create_tag_response, 200)
+        item_tag_assoc = create_tag_response.json()
+        assert item_tag_assoc["user_tname"] == tag_name
+        assert item_tag_assoc["user_value"] == tag_value
+
+        new_tags = ["UpdatedTag"]
+        self._update_tags_using_item_update(item_id, new_tags)
+        self._assert_tags_in_item(item_id, new_tags)
+
+        new_tags = ["APITag"]
+        update_history_tags_response = self._update_tags_using_tags_api(item_id, new_tags)
+        self._assert_status_code_is(update_history_tags_response, 204)
+        self._assert_tags_in_item(item_id, new_tags)
+
+        # other users can't create or update tags
+        with self._different_user():
+            create_tag_response = self._create_named_tag_on_item(
+                item_id, tag_name="othertagname", tag_value="othertagvalue"
+            )
+            self._assert_status_code_is(create_tag_response, 403)
+
+            new_tags = ["otherAPITag"]
+            update_item_response = self._update_tags_using_item_update(item_id, new_tags)
+            self._assert_status_code_is(update_item_response, 403)
+
+            new_tags = ["otherAPITag"]
+            update_history_tags_response = self._update_tags_using_tags_api(item_id, new_tags)
+            self._assert_status_code_is(update_history_tags_response, 403)
+
+    def _create_named_tag_on_item(self, item_id, tag_name, tag_value):
+        create_tag_response = self._post(
+            f"{self.api_name}/{item_id}/tags/{tag_name}", data={"value": tag_value}, json=True
+        )
+
+        return create_tag_response
+
+    def _update_tags_using_item_update(self, item_id, new_tags):
+        update_item_response = self._put(f"{self.api_name}/{item_id}", data={"tags": new_tags}, json=True)
+        return update_item_response
+
+    def _update_tags_using_tags_api(self, item_id, new_tags):
+        payload = {"item_class": self.item_class, "item_id": item_id, "item_tags": new_tags}
+        update_history_tags_response = self._put("tags", data=payload, json=True)
+        return update_history_tags_response
+
+    def _assert_tags_in_item(self, item_id, expected_tags: List[str]):
+        item_response = self._get(f"{self.api_name}/{item_id}")
+        self._assert_status_code_is(item_response, 200)
+        item = item_response.json()
+        assert "tags" in item
+        assert item["tags"] == expected_tags
+
+
+class TestHistoryTags(TagsApiTests):
+    api_name = "histories"
+    item_class = "History"
+
+    def create_item(self) -> str:
+        item_id = self.dataset_populator.new_history(name=f"history-{uuid4()}")
+        return item_id
+
+
+class TestDatasetTags(TagsApiTests):
+    api_name = "datasets"
+    item_class = "HistoryDatasetAssociation"
+
+    def create_item(self) -> str:
+        history_id = self.dataset_populator.new_history(name=f"history-{uuid4()}")
+        item_id = self.dataset_populator.new_dataset(history_id=history_id)
+        return item_id["id"]
+
+
+class TestDatasetCollectionTags(TagsApiTests):
+    api_name = "dataset_collections"
+    item_class = "HistoryDatasetCollectionAssociation"
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
+
+    def create_item(self) -> str:
+        history_id = self.dataset_populator.new_history(name=f"history-{uuid4()}")
+        response = self.dataset_collection_populator.create_list_in_history(history_id)
+        self._assert_status_code_is(response, 200)
+        hdca = response.json()["outputs"][0]
+        return hdca["id"]
+
+
+class TestLibraryDatasetTags(TagsApiTests):
+    api_name = "libraries"
+    item_class = "LibraryDatasetDatasetAssociation"
+
+    def setUp(self):
+        super().setUp()
+        self.library_populator = LibraryPopulator(self.galaxy_interactor)
+
+    def create_item(self) -> str:
+        ld = self.library_populator.new_library_dataset(name=f"test-library-dataset-{uuid4()}")
+        return ld["id"]
+
+
+class TestPageTags(TagsApiTests):
+    api_name = "pages"
+    item_class = "Page"
+
+    def create_item(self) -> str:
+        page = self.dataset_populator.new_page(slug=f"page-{uuid4()}")
+        return page["id"]
+
+
+class TestWorkflowTags(TagsApiTests):
+    api_name = "workflows"
+    item_class = "StoredWorkflow"
+
+    def setUp(self):
+        super().setUp()
+        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
+
+    def create_item(self) -> str:
+        workflow = self.workflow_populator.load_workflow(name=f"workflow-{uuid4()}")
+        data = dict(
+            workflow=json.dumps(workflow),
+        )
+        upload_response = self._post("workflows", data=data)
+
+        self._assert_status_code_is(upload_response, 200)
+        return upload_response.json()["id"]
+
+
+class TestVisualizationTags(TagsApiTests):
+    api_name = "visualizations"
+    item_class = "Visualization"
+
+    def create_item(self) -> str:
+        uuid_str = str(uuid4())
+
+        title = f"Test Visualization {uuid_str}"
+        slug = f"test-visualization-{uuid_str}"
+        config = json.dumps(
+            {
+                "x": 10,
+                "y": 12,
+            }
+        )
+        create_payload = {
+            "title": title,
+            "slug": slug,
+            "type": "example",
+            "dbkey": "hg17",
+            "annotation": "this is a test visualization for tags",
+            "config": config,
+        }
+        response = self._post("visualizations", data=create_payload)
+        self._assert_status_code_is(response, 200)
+        viz = response.json()
+        return viz["id"]

--- a/lib/galaxy_test/api/test_tags.py
+++ b/lib/galaxy_test/api/test_tags.py
@@ -27,20 +27,7 @@ class TagsApiTests(ApiTestCase):
 
     def test_tags_on_item(self):
         item_id = self.create_item()
-
         self._assert_tags_in_item(item_id, [])
-
-        tag_name = "mytagname"
-        tag_value = "mytagvalue"
-        create_tag_response = self._create_named_tag_on_item(item_id, tag_name, tag_value)
-        self._assert_status_code_is(create_tag_response, 200)
-        item_tag_assoc = create_tag_response.json()
-        assert item_tag_assoc["user_tname"] == tag_name
-        assert item_tag_assoc["user_value"] == tag_value
-
-        new_tags = ["UpdatedTag"]
-        self._update_tags_using_item_update(item_id, new_tags)
-        self._assert_tags_in_item(item_id, new_tags)
 
         new_tags = ["APITag"]
         update_history_tags_response = self._update_tags_using_tags_api(item_id, new_tags)
@@ -49,29 +36,9 @@ class TagsApiTests(ApiTestCase):
 
         # other users can't create or update tags
         with self._different_user():
-            create_tag_response = self._create_named_tag_on_item(
-                item_id, tag_name="othertagname", tag_value="othertagvalue"
-            )
-            self._assert_status_code_is(create_tag_response, 403)
-
-            new_tags = ["otherAPITag"]
-            update_item_response = self._update_tags_using_item_update(item_id, new_tags)
-            self._assert_status_code_is(update_item_response, 403)
-
             new_tags = ["otherAPITag"]
             update_history_tags_response = self._update_tags_using_tags_api(item_id, new_tags)
             self._assert_status_code_is(update_history_tags_response, 403)
-
-    def _create_named_tag_on_item(self, item_id, tag_name, tag_value):
-        create_tag_response = self._post(
-            f"{self.api_name}/{item_id}/tags/{tag_name}", data={"value": tag_value}, json=True
-        )
-
-        return create_tag_response
-
-    def _update_tags_using_item_update(self, item_id, new_tags):
-        update_item_response = self._put(f"{self.api_name}/{item_id}", data={"tags": new_tags}, json=True)
-        return update_item_response
 
     def _update_tags_using_tags_api(self, item_id, new_tags):
         payload = {"item_class": self.item_class, "item_id": item_id, "item_tags": new_tags}

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -894,6 +894,10 @@ class MockTrans(ProvidesAppContext):
         self.workflow_building_mode = workflow_building_modes.ENABLED
 
     @property
+    def galaxy_session(self):
+        return None
+
+    @property
     def app(self):
         return self._app
 

--- a/test/unit/app/managers/base.py
+++ b/test/unit/app/managers/base.py
@@ -2,12 +2,14 @@
 """
 
 import json
+from typing import cast
 
 import sqlalchemy
 
 from galaxy.app_unittest_utils import galaxy_mock
 from galaxy.managers.users import UserManager
 from galaxy.util.unittest import TestCase
+from galaxy.work.context import SessionRequestContext
 
 # =============================================================================
 admin_email = "admin@admin.admin"
@@ -33,7 +35,9 @@ class BaseTestCase(TestCase):
 
     def set_up_mocks(self):
         admin_users_list = [u for u in admin_users.split(",") if u]
-        self.trans = galaxy_mock.MockTrans(admin_users=admin_users, admin_users_list=admin_users_list)
+        self.trans = cast(
+            SessionRequestContext, galaxy_mock.MockTrans(admin_users=admin_users, admin_users_list=admin_users_list)
+        )
         self.app = self.trans.app
 
     def set_up_managers(self):
@@ -99,7 +103,7 @@ class BaseTestCase(TestCase):
 
 
 class CreatesCollectionsMixin:
-    trans: galaxy_mock.MockTrans
+    trans: SessionRequestContext
 
     def build_element_identifiers(self, elements):
         identifier_list = []

--- a/test/unit/app/managers/test_CollectionManager.py
+++ b/test/unit/app/managers/test_CollectionManager.py
@@ -28,6 +28,7 @@ class TestDatasetCollectionManager(BaseTestCase, CreatesCollectionsMixin):
 
     def test_create_simple_list(self):
         owner = self.user_manager.create(**user2_data)
+        self.trans.set_user(owner)
 
         history = self.history_manager.create(name="history1", user=owner)
 
@@ -80,6 +81,7 @@ class TestDatasetCollectionManager(BaseTestCase, CreatesCollectionsMixin):
 
     def test_update_from_dict(self):
         owner = self.user_manager.create(**user2_data)
+        self.trans.set_user(owner)
 
         history = self.history_manager.create(name="history1", user=owner)
 

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -118,7 +118,7 @@ class TestHDAManager(HDATestCase):
         self.log("tags should be copied between HDAs")
         tagged = self.hda_manager.create(history=history1, dataset=self.dataset_manager.create())
         tags_to_set = ["tag-one", "tag-two"]
-        self.hda_manager.tag_handler.add_tags_from_list(owner, tagged, tags_to_set)
+        self.app.tag_handler.add_tags_from_list(owner, tagged, tags_to_set)
         hda2 = self.hda_manager.copy(tagged, history=history1)
         assert tagged.make_tag_string_list() == hda2.make_tag_string_list()
 

--- a/test/unit/app/managers/test_HDAManager.py
+++ b/test/unit/app/managers/test_HDAManager.py
@@ -89,18 +89,6 @@ class TestHDAManager(HDATestCase):
         assert hda3.history is None, "history will be None"
         assert hda3.hid is None, "should allow setting hid to None (or any other value)"
 
-    def test_hda_tags(self):
-        owner = self.user_manager.create(**user2_data)
-        history1 = self.history_manager.create(name="history1", user=owner)
-        dataset1 = self.dataset_manager.create()
-        hda1 = self.hda_manager.create(history=history1, dataset=dataset1)
-
-        self.log("should be able to set tags on an hda")
-        tags_to_set = ["tag-one", "tag-two"]
-        self.hda_manager.set_tags(hda1, tags_to_set, user=owner)
-        tag_str_array = self.hda_manager.get_tags(hda1)
-        assert sorted(tags_to_set) == sorted(tag_str_array)
-
     def test_hda_annotation(self):
         owner = self.user_manager.create(**user2_data)
         history1 = self.history_manager.create(name="history1", user=owner)
@@ -130,11 +118,9 @@ class TestHDAManager(HDATestCase):
         self.log("tags should be copied between HDAs")
         tagged = self.hda_manager.create(history=history1, dataset=self.dataset_manager.create())
         tags_to_set = ["tag-one", "tag-two"]
-        self.hda_manager.set_tags(tagged, tags_to_set, user=owner)
-
+        self.hda_manager.tag_handler.add_tags_from_list(owner, tagged, tags_to_set)
         hda2 = self.hda_manager.copy(tagged, history=history1)
-        tag_str_array = self.hda_manager.get_tags(hda2)
-        assert sorted(tags_to_set) == sorted(tag_str_array)
+        assert tagged.make_tag_string_list() == hda2.make_tag_string_list()
 
         self.log("annotations should be copied between HDAs")
         annotated = self.hda_manager.create(history=history1, dataset=self.dataset_manager.create())

--- a/test/unit/app/managers/test_HDCAManager.py
+++ b/test/unit/app/managers/test_HDCAManager.py
@@ -31,6 +31,7 @@ class HDCATestCase(BaseTestCase, CreatesCollectionsMixin):
     def _create_history(self, user_data=None, **kwargs):
         user_data = user_data or user2_data
         owner = self.user_manager.create(**user_data)
+        self.trans.set_user(owner)
         return self.history_manager.create(user=owner, **kwargs)
 
     def _create_hda(self, history, dataset=None, **kwargs):

--- a/test/unit/app/managers/test_HistoryContentsManager.py
+++ b/test/unit/app/managers/test_HistoryContentsManager.py
@@ -56,6 +56,7 @@ class HistoryAsContainerBaseTestCase(BaseTestCase, CreatesCollectionsMixin):
 class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
     def test_contents(self):
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
 
         self.log("calling contents on an empty history should return an empty list")
@@ -74,6 +75,7 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
 
     def test_contained(self):
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
 
         self.log("calling contained on an empty history should return an empty list")
@@ -86,6 +88,7 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
 
     def test_copy_elements_on_collection_creation(self):
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
         hdas = [self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)]
         hdca = self.add_list_collection_to_history(history, hdas)
@@ -96,6 +99,7 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
 
     def test_subcontainers(self):
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
 
         self.log("calling subcontainers on an empty history should return an empty list")
@@ -109,6 +113,7 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
 
     def test_limit_and_offset(self):
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
         contents = []
         contents.extend([self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)])
@@ -130,6 +135,7 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
     def test_orm_filtering(self):
         parse_filter = self.history_contents_filters.parse_filter
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
         contents = []
         contents.extend([self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)])
@@ -228,6 +234,7 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
 
     def test_order_by(self):
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
         contents = []
         contents.extend([self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)])
@@ -263,6 +270,7 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
 
     def test_update_time_filter(self):
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
         contents = []
         contents.extend([self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)])
@@ -292,6 +300,7 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
     def test_filtered_counting(self):
         parse_filter = self.history_contents_filters.parse_filter
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
         contents = []
         contents.extend([self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)])
@@ -324,6 +333,7 @@ class TestHistoryAsContainer(HistoryAsContainerBaseTestCase):
 
     def test_type_id(self):
         user2 = self.user_manager.create(**user2_data)
+        self.trans.set_user(user2)
         history = self.history_manager.create(name="history", user=user2)
         contents = []
         contents.extend([self.add_hda_to_history(history, name=("hda-" + str(x))) for x in range(3)])

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -86,13 +86,13 @@ class TestHistoryManager(BaseTestCase):
         history1 = self.history_manager.create(name="history1", user=user2)
         tags = ["tag-one"]
         annotation = "history annotation"
-        self.history_manager.set_tags(history1, tags, user=user2)
+        self.history_manager.tag_handler.set_tags_from_list(user=user2, item=history1, new_tags_list=tags)
         self.history_manager.annotate(history1, annotation, user=user2)
 
         hda = self.add_hda_to_history(history1, name="wat")
         hda_tags = ["tag-one", "tag-two"]
         hda_annotation = "annotation"
-        self.hda_manager.set_tags(hda, hda_tags, user=user2)
+        self.hda_manager.tag_handler.set_tags_from_list(user=user2, item=hda, new_tags_list=hda_tags)
         self.hda_manager.annotate(hda, hda_annotation, user=user2)
 
         history2 = self.history_manager.copy(history1, user=user3)
@@ -103,8 +103,7 @@ class TestHistoryManager(BaseTestCase):
         assert history2 != history1
 
         copied_hda = history2.datasets[0]
-        copied_hda_tags = self.hda_manager.get_tags(copied_hda)
-        assert sorted(hda_tags) == sorted(copied_hda_tags)
+        assert hda.make_tag_string_list() == copied_hda.make_tag_string_list()
         copied_hda_annotation = self.hda_manager.annotation(copied_hda)
         assert hda_annotation == copied_hda_annotation
 

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -92,7 +92,7 @@ class TestHistoryManager(BaseTestCase):
         hda = self.add_hda_to_history(history1, name="wat")
         hda_tags = ["tag-one", "tag-two"]
         hda_annotation = "annotation"
-        self.hda_manager.tag_handler.set_tags_from_list(user=user2, item=hda, new_tags_list=hda_tags)
+        self.app.tag_handler.set_tags_from_list(user=user2, item=hda, new_tags_list=hda_tags)
         self.hda_manager.annotate(hda, hda_annotation, user=user2)
 
         history2 = self.history_manager.copy(history1, user=user3)

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -195,7 +195,7 @@ class TestUserManager(BaseTestCase):
     def test_activation_email(self):
         self.log("should produce the activation email")
         self.user_manager.create(email="user@nopassword.com", username="nopassword")
-        self.trans.request.host = "request.host"
+        setattr(self.trans.request, "host", "request.host")
 
         def validate_send_email(frm, to, subject, body, config, html=None):
             assert frm == "email_from"
@@ -219,7 +219,7 @@ class TestUserManager(BaseTestCase):
     def test_reset_email(self):
         self.log("should produce the password reset email")
         self.user_manager.create(email="user@nopassword.com", username="nopassword")
-        self.trans.request.host = "request.host"
+        setattr(self.trans.request, "host", "request.host")
 
         def validate_send_email(frm, to, subject, body, config, html=None):
             assert frm == "email_from"

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -195,7 +195,6 @@ class TestUserManager(BaseTestCase):
     def test_activation_email(self):
         self.log("should produce the activation email")
         self.user_manager.create(email="user@nopassword.com", username="nopassword")
-        self.trans.request.host = "request.host"
 
         def validate_send_email(frm, to, subject, body, config, html=None):
             assert frm == "email_from"
@@ -219,7 +218,6 @@ class TestUserManager(BaseTestCase):
     def test_reset_email(self):
         self.log("should produce the password reset email")
         self.user_manager.create(email="user@nopassword.com", username="nopassword")
-        self.trans.request.host = "request.host"
 
         def validate_send_email(frm, to, subject, body, config, html=None):
             assert frm == "email_from"

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -195,7 +195,7 @@ class TestUserManager(BaseTestCase):
     def test_activation_email(self):
         self.log("should produce the activation email")
         self.user_manager.create(email="user@nopassword.com", username="nopassword")
-        setattr(self.trans.request, "host", "request.host")
+        self.trans.request.host = "request.host"
 
         def validate_send_email(frm, to, subject, body, config, html=None):
             assert frm == "email_from"
@@ -219,7 +219,7 @@ class TestUserManager(BaseTestCase):
     def test_reset_email(self):
         self.log("should produce the password reset email")
         self.user_manager.create(email="user@nopassword.com", username="nopassword")
-        setattr(self.trans.request, "host", "request.host")
+        self.trans.request.host = "request.host"
 
         def validate_send_email(frm, to, subject, body, config, html=None):
             assert frm == "email_from"

--- a/test/unit/app/tools/test_actions.py
+++ b/test/unit/app/tools/test_actions.py
@@ -259,6 +259,10 @@ class MockTrans:
         self._user_is_active = True
         self.user_is_admin = False
 
+    @property
+    def tag_handler(self):
+        return self.app.tag_handler
+
     def get_user_is_active(self):
         # NOTE: the real user_is_active also checks whether activation is enabled in the config
         return self._user_is_active

--- a/test/unit/app/tools/test_execution.py
+++ b/test/unit/app/tools/test_execution.py
@@ -205,6 +205,7 @@ class MockTrans:
         self.webapp = Bunch(name="galaxy")
         self.sa_session = self.app.model.context
         self.url_builder = None
+        self.galaxy_session = None
 
     def get_history(self, **kwargs):
         return self.history

--- a/test/unit/data/model/test_model_discovery.py
+++ b/test/unit/data/model/test_model_discovery.py
@@ -250,7 +250,11 @@ def _import_directory_to_history(app, target, work_directory):
 
     import_options = store.ImportOptions(allow_dataset_object_edit=True)
     import_model_store = store.get_import_model_store_for_directory(
-        target, app=app, user=u, import_options=import_options, tag_handler=app.tag_handler.create_tag_handler_session()
+        target,
+        app=app,
+        user=u,
+        import_options=import_options,
+        tag_handler=app.tag_handler.create_tag_handler_session(None),
     )
     with import_model_store.target_history(default_history=import_history):
         import_model_store.perform_import(import_history)


### PR DESCRIPTION
Fixes #16314

See individual commit messages for details.

For a quick fix on the UI level see #16348 (included in this PR)

I found some inconsistencies in the way we handle tags between different *taggable* items. Details below.

## Summary
- Fixes an issue with the ItemTagAssociation.associated_item_names not being properly converted due to a difference in class naming convention.
   - The TagHandler.item_tag_assoc_info is now initialized just once instead of every time the TagHandler is instantiated.
- Altering tags of a taggable item now requires the item to be owned by the user making the request. Some items, like datasets or collections, will check the owner of the history they are contained in.
- Handles tagging by anonymous users consistently by using the current galaxy_session thanks to @mvdbeek 

## Tags API inconsistencies
I added some API tests for all taggable items with all the ways of modifying tags that I found, in particular:
- POST request to `api/{item_type}/{item_id}/tags/{tag_name}` with a `value` key in the payload
- PUT request to `api/{item_type}/{item_id}` with a `tags` key in the payload
- PUT request to `api/tags` with a payload indicating `item_class`, `item_id`, `item_tags`


<del>The test will fail for now until we decide how to unify the tag handling.</del> Decided to move the unification to a follow-up on dev. The only "breaking change" is unifying the tags serialization for Library Datasets to return a list of tags instead of a string as a comma-separated list.

### Taggable Items

- History
- HistoryDatasetAssociation
- HistoryDatasetCollectionAssociation
- LibraryDatasetDatasetAssociation
- Page
- StoredWorkflow
- Visualization

### Inconsistencies

- [ ] There are more models that inherit from `ItemTagAssociation` but they are not handled by `GalaxyTagHandler`:
  - [ ] WorkflowStepTagAssociation
  - [ ] LibraryDatasetCollectionTagAssociation
  - [x] ToolTagAssociation (only managed by admins)

- [ ] Not all taggable items can update tags through a regular PUT request to `api/{item_type}/{item_id}` with a `tags` key in the payload:

  - [x] History
  - [ ] HistoryDatasetAssociation
  - [ ] HistoryDatasetCollectionAssociation
  - [ ] LibraryDatasetDatasetAssociation
  - [ ] Page
  - [x] StoredWorkflow
  - [ ] Visualization

- [ ] Not all taggable items can create *named tags* through POST request to `api/{item_type}/{item_id}/tags/{tag_name}` with a `value` key in the payload:

  - [x] History
  - [ ] HistoryDatasetAssociation
  - [ ] HistoryDatasetCollectionAssociation
  - [ ] LibraryDatasetDatasetAssociation
  - [ ] Page
  - [x] StoredWorkflow
  - [ ] Visualization

- [x] The `TaggableItemClass` enum incorrectly converts `HistoryDatasetCollectionAssociation` and `LibraryDatasetDatasetAssociation`. Which brakes the `api/tags` endpoint for those 2 item types (I guess nobody used this in 2 years...) Fixed in [9997057](https://github.com/galaxyproject/galaxy/pull/16339/commits/999705704f9472932ab52701bdddcaeeb7b04537).

- [x] `LibraryDatasetDatasetAssociation` <del>items do not serialize a `tags` attribute. Were they really meant to be taggable?</del> My bad, they do serialize a `tags` field but apparently [only as a comma-separated string](https://github.com/galaxyproject/galaxy/blob/a662d8034c89ad0e766b3a62e48d8ac4e74040ad/lib/galaxy/webapps/galaxy/api/library_contents.py#L186) and not a list of tags like other items. **Update**: changed to a list of tags for the sake of consistency.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
