### PR TITLE
Migrate a part of the users API to Fast API

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1390,13 +1390,10 @@ export interface paths {
     "/api/users": {
         /**
          * Get Users
-         * @description Return a collection of users
+         * @description Return a collection of users. Filters will only work if enabled in config or user is admin.
          */
         get: operations["get_users_api_users_get"];
-        /**
-         * Create a new Galaxy user
-         * @description Rework CreateUserPayload payload and add pydantic model for return
-         */
+        /** Create a new Galaxy user. Only admins can create users for now. */
         post: operations["create_user_api_users_post"];
     };
     "/api/users/current": {
@@ -1418,16 +1415,16 @@ export interface paths {
     "/api/users/deleted": {
         /**
          * Get Deleted Users
-         * @description Return a collection of deleted users
+         * @description Return a collection of deleted users. Only admins can see deleted users.
          */
         get: operations["get_deleted_users_api_users_deleted_get"];
     };
     "/api/users/deleted/{user_id}": {
-        /** Return information about a deleted user */
+        /** Return information about a deleted user. Only admins can see deleted users. */
         get: operations["get_deleted_user_api_users_deleted__user_id__get"];
     };
     "/api/users/deleted/{user_id}/undelete": {
-        /** Restore a deleted user */
+        /** Restore a deleted user. Only admins can restore users. */
         post: operations["undelete_user_api_users_deleted__user_id__undelete_post"];
     };
     "/api/users/recalculate_disk_usage": {
@@ -1441,11 +1438,11 @@ export interface paths {
         put: operations["recalculate_disk_usage_api_users_recalculate_disk_usage_put"];
     };
     "/api/users/{user_id}": {
-        /** Return information about a specified user */
+        /** Return information about a specified user. Only admin can see deleted or other users */
         get: operations["get_user_api_users__user_id__get"];
-        /** Update the values of a user */
+        /** Update the values of a user. Only admin can update others. */
         put: operations["update_user_api_users__user_id__put"];
-        /** Delete a user */
+        /** Delete a user. Only admins can delete others or purge users. */
         delete: operations["delete_user_api_users__user_id__delete"];
     };
     "/api/users/{user_id}/api_key": {
@@ -16728,9 +16725,13 @@ export interface operations {
     get_users_api_users_get: {
         /**
          * Get Users
-         * @description Return a collection of users
+         * @description Return a collection of users. Filters will only work if enabled in config or user is admin.
          */
         parameters?: {
+            /** @description Indicates if the collection will be about deleted users */
+            /** @description An email address to filter on */
+            /** @description An username address to filter on */
+            /** @description Filter on username OR email */
             query?: {
                 deleted?: boolean;
                 f_email?: string;
@@ -16758,10 +16759,7 @@ export interface operations {
         };
     };
     create_user_api_users_post: {
-        /**
-         * Create a new Galaxy user
-         * @description Rework CreateUserPayload payload and add pydantic model for return
-         */
+        /** Create a new Galaxy user. Only admins can create users for now. */
         parameters?: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -16857,9 +16855,12 @@ export interface operations {
     get_deleted_users_api_users_deleted_get: {
         /**
          * Get Deleted Users
-         * @description Return a collection of deleted users
+         * @description Return a collection of deleted users. Only admins can see deleted users.
          */
         parameters?: {
+            /** @description An email address to filter on */
+            /** @description An username address to filter on */
+            /** @description Filter on username OR email */
             query?: {
                 f_email?: string;
                 f_name?: string;
@@ -16886,7 +16887,7 @@ export interface operations {
         };
     };
     get_deleted_user_api_users_deleted__user_id__get: {
-        /** Return information about a deleted user */
+        /** Return information about a deleted user. Only admins can see deleted users. */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -16915,7 +16916,7 @@ export interface operations {
         };
     };
     undelete_user_api_users_deleted__user_id__undelete_post: {
-        /** Restore a deleted user */
+        /** Restore a deleted user. Only admins can restore users. */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -16973,7 +16974,7 @@ export interface operations {
         };
     };
     get_user_api_users__user_id__get: {
-        /** Return information about a specified user */
+        /** Return information about a specified user. Only admin can see deleted or other users */
         parameters: {
             /** @description Indicates if the user is deleted */
             query?: {
@@ -17006,7 +17007,7 @@ export interface operations {
         };
     };
     update_user_api_users__user_id__put: {
-        /** Update the values of a user */
+        /** Update the values of a user. Only admin can update others. */
         parameters: {
             /** @description Indicates if the user is deleted */
             query?: {
@@ -17042,7 +17043,7 @@ export interface operations {
         };
     };
     delete_user_api_users__user_id__delete: {
-        /** Delete a user */
+        /** Delete a user. Only admins can delete others or purge users. */
         parameters: {
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1393,6 +1393,8 @@ export interface paths {
          * @description Return a collection of users. Filters will only work if enabled in config or user is admin.
          */
         get: operations["get_users_api_users_get"];
+        /** Create a new Galaxy user. Only admins can create users for now. */
+        post: operations["create_user_api_users_post"];
     };
     "/api/users/current/recalculate_disk_usage": {
         /**
@@ -2996,6 +2998,65 @@ export interface components {
              * @description The name of the custom build.
              */
             name: string;
+        };
+        /**
+         * CreatedUserModel
+         * @description User in a transaction context.
+         */
+        CreatedUserModel: {
+            /**
+             * Active
+             * @description User is active
+             */
+            active: boolean;
+            /**
+             * Deleted
+             * @description  User is deleted
+             */
+            deleted: boolean;
+            /**
+             * Email
+             * @description Email of the user
+             */
+            email: string;
+            /**
+             * ID
+             * @description Encoded ID of the user
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /**
+             * Last password change
+             * Format: date-time
+             */
+            last_password_change?: string;
+            /**
+             * Model class
+             * @description The name of the database model class.
+             * @default User
+             * @enum {string}
+             */
+            model_class: "User";
+            /**
+             * Nice total disc usage
+             * @description Size of all non-purged, unique datasets of the user in a nice format.
+             */
+            nice_total_disk_usage: string;
+            /**
+             * Preferred Object Store ID
+             * @description The ID of the object store that should be used to store new datasets in this history.
+             */
+            preferred_object_store_id?: string;
+            /**
+             * Total disk usage
+             * @description Size of all non-purged, unique datasets of the user in bytes.
+             */
+            total_disk_usage: number;
+            /**
+             * user_name
+             * @description The name of the user.
+             */
+            username: string;
         };
         /**
          * CustomBuildCreationPayload
@@ -8920,6 +8981,32 @@ export interface components {
              * @description True if beacon sharing is enabled
              */
             enabled: boolean;
+        };
+        /**
+         * UserCreationPayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        UserCreationPayload: {
+            /**
+             * Email
+             * @description Email of the user
+             */
+            email: string;
+            /**
+             * user_password
+             * @description The password of the user.
+             */
+            password: string;
+            /**
+             * user_email
+             * @description The email of the remote user.
+             */
+            remote_user_email?: string;
+            /**
+             * user_name
+             * @description The name of the user.
+             */
+            username: string;
         };
         /**
          * UserDeletionPayload
@@ -16823,6 +16910,34 @@ export interface operations {
                         | components["schemas"]["UserModel"]
                         | components["schemas"]["LimitedUserModel"]
                     )[];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_user_api_users_post: {
+        /** Create a new Galaxy user. Only admins can create users for now. */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UserCreationPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["CreatedUserModel"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -16889,9 +16889,9 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
-            /** @description The ID of the user to get. */
+            /** @description The ID of the user to get or 'current'. */
             path: {
-                user_id: string;
+                user_id: string | "current";
             };
         };
         requestBody: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1393,8 +1393,6 @@ export interface paths {
          * @description Return a collection of users. Filters will only work if enabled in config or user is admin.
          */
         get: operations["get_users_api_users_get"];
-        /** Create a new Galaxy user. Only admins can create users for now. */
-        post: operations["create_user_api_users_post"];
     };
     "/api/users/current": {
         /**
@@ -1468,6 +1466,14 @@ export interface paths {
          * @description **Warning**: This endpoint is experimental and might change or disappear in future versions.
          */
         post: operations["set_beacon_settings_api_users__user_id__beacon_post"];
+    };
+    "/api/users/{user_id}/favorites/{object_type}": {
+        /** Add the object to user's favorites */
+        put: operations["set_favorite_api_users__user_id__favorites__object_type__put"];
+    };
+    "/api/users/{user_id}/favorites/{object_type}/{object_id}": {
+        /** Remove the object from user's favorites */
+        delete: operations["remove_favorite_api_users__user_id__favorites__object_type___object_id__delete"];
     };
     "/api/users/{user_id}/theme/{theme}": {
         /** Set the user's theme choice */
@@ -2958,91 +2964,6 @@ export interface components {
             url: string;
         };
         /**
-         * CreateUserPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        CreateUserPayload: {
-            /**
-             * Email
-             * @description Email of the user
-             */
-            email: string;
-            /**
-             * user_password
-             * @description The password of the user.
-             */
-            password: string;
-            /**
-             * user_email
-             * @description The email of the remote user.
-             */
-            remote_user_email?: string;
-            /**
-             * user_name
-             * @description The name of the user.
-             */
-            username: string;
-        };
-        /**
-         * CreatedUserModel
-         * @description User in a transaction context.
-         */
-        CreatedUserModel: {
-            /**
-             * Active
-             * @description User is active
-             */
-            active: boolean;
-            /**
-             * Deleted
-             * @description  User is deleted
-             */
-            deleted: boolean;
-            /**
-             * Email
-             * @description Email of the user
-             */
-            email: string;
-            /**
-             * ID
-             * @description Encoded ID of the user
-             * @example 0123456789ABCDEF
-             */
-            id: string;
-            /**
-             * Last password change
-             * Format: date-time
-             */
-            last_password_change?: string;
-            /**
-             * Model class
-             * @description The name of the database model class.
-             * @default User
-             * @enum {string}
-             */
-            model_class: "User";
-            /**
-             * Nice total disc usage
-             * @description Size of all non-purged, unique datasets of the user in a nice format.
-             */
-            nice_total_disk_usage: string;
-            /**
-             * Preferred Object Store ID
-             * @description The ID of the object store that should be used to store new datasets in this history.
-             */
-            preferred_object_store_id?: string;
-            /**
-             * Total disk usage
-             * @description Size of all non-purged, unique datasets of the user in bytes.
-             */
-            total_disk_usage: number;
-            /**
-             * user_name
-             * @description The name of the user.
-             */
-            username: string;
-        };
-        /**
          * CustomBuildsMetadataResponse
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -4061,6 +3982,17 @@ export interface components {
             /** Items From */
             items_from?: string;
             src: components["schemas"]["Src"];
+        };
+        /**
+         * FavoriteModel
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        FavoriteModel: {
+            /**
+             * Favorite tools
+             * @description The name of the tools the user favored.
+             */
+            tools: string[];
         };
         /**
          * FetchDataPayload
@@ -8045,6 +7977,17 @@ export interface components {
              * @example 1.0.0
              */
             version: string;
+        };
+        /**
+         * SetFavoritePayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        SetFavoritePayload: {
+            /**
+             * Object ID
+             * @description The id of an object the user wants to favorite.
+             */
+            object_id: string;
         };
         /**
          * SetSlugPayload
@@ -16758,34 +16701,6 @@ export interface operations {
             };
         };
     };
-    create_user_api_users_post: {
-        /** Create a new Galaxy user. Only admins can create users for now. */
-        parameters?: {
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateUserPayload"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json": components["schemas"]["CreatedUserModel"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     get_current_user_api_users_current_get: {
         /**
          * Get Current User
@@ -17235,6 +17150,71 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["UserBeaconSetting"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_favorite_api_users__user_id__favorites__object_type__put: {
+        /** Add the object to user's favorites */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The object type the user wants to favorite */
+            /** @description The ID of the user to get. */
+            path: {
+                object_type: string;
+                user_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetFavoritePayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["FavoriteModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_favorite_api_users__user_id__favorites__object_type___object_id__delete: {
+        /** Remove the object from user's favorites */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The object type the user wants to favorite */
+            /** @description The ID of an object the user wants to remove from favorites */
+            /** @description The ID of the user to get. */
+            path: {
+                object_type: string;
+                object_id: string;
+                user_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["FavoriteModel"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1387,6 +1387,13 @@ export interface paths {
          */
         post: operations["update_tour_api_tours__tour_id__post"];
     };
+    "/api/users/current": {
+        /**
+         * Get Current User
+         * @description Display information about current user
+         */
+        get: operations["get_current_user_api_users_current_get"];
+    };
     "/api/users/current/recalculate_disk_usage": {
         /**
          * Triggers a recalculation of the current user disk usage.
@@ -1395,6 +1402,10 @@ export interface paths {
          * Please use `/api/users/current/recalculate_disk_usage` instead.
          */
         put: operations["recalculate_disk_usage_api_users_current_recalculate_disk_usage_put"];
+    };
+    "/api/users/deleted/{user_id}": {
+        /** Display information about a deleted user */
+        get: operations["get_deleted_user_api_users_deleted__user_id__get"];
     };
     "/api/users/recalculate_disk_usage": {
         /**
@@ -1405,6 +1416,10 @@ export interface paths {
          * Please use `/api/users/current/recalculate_disk_usage` instead.
          */
         put: operations["recalculate_disk_usage_api_users_recalculate_disk_usage_put"];
+    };
+    "/api/users/{user_id}": {
+        /** Display information about a specified user */
+        get: operations["get_user_api_users__user_id__get"];
     };
     "/api/users/{user_id}/api_key": {
         /** Return the user's API key */
@@ -1669,6 +1684,27 @@ export interface components {
              * @description The link to be opened when the button is clicked.
              */
             link: string;
+        };
+        /**
+         * AnonUserModel
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        AnonUserModel: {
+            /**
+             * Nice total disc usage
+             * @description Size of all non-purged, unique datasets of the user in a nice format.
+             */
+            nice_total_disk_usage: string;
+            /**
+             * Storage quota
+             * @description Percentage of the storage quota applicable to the user.
+             */
+            quota_percent: number;
+            /**
+             * Total disk usage
+             * @description Size of all non-purged, unique datasets of the user in bytes.
+             */
+            total_disk_usage: number;
         };
         /**
          * ArchiveHistoryRequestPayload
@@ -3637,6 +3673,40 @@ export interface components {
              * @default false
              */
             purge?: boolean;
+        };
+        /**
+         * DetailedUserModel
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        DetailedUserModel: {
+            /** Deleted */
+            deleted: boolean;
+            /** Email */
+            email: string;
+            /** Id */
+            id: string;
+            /** Is Admin */
+            is_admin: boolean;
+            /** Nice Total Disk Usage */
+            nice_total_disk_usage: string;
+            /** Preferences */
+            preferences: Record<string, never>;
+            /** Preferred Object Store Id */
+            preferred_object_store_id: Record<string, never>;
+            /** Purged */
+            purged: boolean;
+            /** Quota */
+            quota: string;
+            /** Quota Bytes */
+            quota_bytes: Record<string, never>;
+            /** Quota Percent */
+            quota_percent: Record<string, never>;
+            /** Tags Used */
+            tags_used: string[];
+            /** Total Disk Usage */
+            total_disk_usage: number;
+            /** Username */
+            username: string;
         };
         /**
          * DisplayApp
@@ -16500,6 +16570,42 @@ export interface operations {
             };
         };
     };
+    get_current_user_api_users_current_get: {
+        /**
+         * Get Current User
+         * @description Display information about current user
+         */
+        parameters: {
+            /** @description Indicates if the user is deleted */
+            query?: {
+                deleted?: boolean;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the user to get or 'current'. */
+            path: {
+                user_id: string | "current";
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json":
+                        | components["schemas"]["AnonUserModel"]
+                        | components["schemas"]["DetailedUserModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     recalculate_disk_usage_api_users_current_recalculate_disk_usage_put: {
         /**
          * Triggers a recalculation of the current user disk usage.
@@ -16522,6 +16628,35 @@ export interface operations {
             };
             /** @description The background task was submitted but there is no status tracking ID available. */
             204: never;
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_deleted_user_api_users_deleted__user_id__get: {
+        /** Display information about a deleted user */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the user to get. */
+            path: {
+                user_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json":
+                        | components["schemas"]["AnonUserModel"]
+                        | components["schemas"]["DetailedUserModel"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 content: {
@@ -16553,6 +16688,39 @@ export interface operations {
             };
             /** @description The background task was submitted but there is no status tracking ID available. */
             204: never;
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_user_api_users__user_id__get: {
+        /** Display information about a specified user */
+        parameters: {
+            /** @description Indicates if the user is deleted */
+            query?: {
+                deleted?: boolean;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the user to get or 'current'. */
+            path: {
+                user_id: string | "current";
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json":
+                        | components["schemas"]["AnonUserModel"]
+                        | components["schemas"]["DetailedUserModel"];
+                };
+            };
             /** @description Validation Error */
             422: {
                 content: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -2967,19 +2967,32 @@ export interface components {
             url: string;
         };
         /**
+         * CreatedCustomBuild
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CreatedCustomBuild: {
+            /** Count */
+            count?: string;
+            /** Fasta */
+            fasta?: number;
+            /** Length */
+            len: number;
+            /** Line count */
+            linecount?: number;
+            /**
+             * Name
+             * @description The name of the custom build.
+             */
+            name: string;
+        };
+        /**
          * CustomBuildCreationPayload
          * @description Base model definition with common configuration used by all derived models.
          */
         CustomBuildCreationPayload: {
-            /**
-             * ?
-             * @description ?
-             */
+            /** Length type */
             "len|type": string;
-            /**
-             * ?
-             * @description ?
-             */
+            /** Length value */
             "len|value": string;
             /**
              * Name
@@ -2987,6 +3000,35 @@ export interface components {
              */
             name: string;
         };
+        /**
+         * CustomBuildModel
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CustomBuildModel: {
+            /** Count */
+            count?: string;
+            /** Fasta */
+            fasta?: number;
+            /**
+             * ID
+             * @description The ID of the custom build.
+             */
+            id: string;
+            /** Length */
+            len: number;
+            /** Line count */
+            linecount?: number;
+            /**
+             * Name
+             * @description The name of the custom build.
+             */
+            name: string;
+        };
+        /**
+         * CustomBuildsCollection
+         * @description The custom builds associated with the user.
+         */
+        CustomBuildsCollection: components["schemas"]["CustomBuildModel"][];
         /**
          * CustomBuildsMetadataResponse
          * @description Base model definition with common configuration used by all derived models.
@@ -17181,7 +17223,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["CustomBuildsCollection"];
                 };
             };
             /** @description Validation Error */
@@ -17215,7 +17257,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>;
+                    "application/json": components["schemas"]["CreatedCustomBuild"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -2971,13 +2971,25 @@ export interface components {
          * @description Base model definition with common configuration used by all derived models.
          */
         CreatedCustomBuild: {
-            /** Count */
+            /**
+             * Count
+             * @description TODO
+             */
             count?: string;
-            /** Fasta */
+            /**
+             * Fasta
+             * @description TODO
+             */
             fasta?: number;
-            /** Length */
+            /**
+             * Length
+             * @description TODO
+             */
             len: number;
-            /** Line count */
+            /**
+             * Line count
+             * @description TODO
+             */
             linecount?: number;
             /**
              * Name
@@ -2990,9 +3002,15 @@ export interface components {
          * @description Base model definition with common configuration used by all derived models.
          */
         CustomBuildCreationPayload: {
-            /** Length type */
+            /**
+             * Length type
+             * @description TODO
+             */
             "len|type": string;
-            /** Length value */
+            /**
+             * Length value
+             * @description TODO
+             */
             "len|value": string;
             /**
              * Name
@@ -3005,18 +3023,30 @@ export interface components {
          * @description Base model definition with common configuration used by all derived models.
          */
         CustomBuildModel: {
-            /** Count */
+            /**
+             * Count
+             * @description TODO
+             */
             count?: string;
-            /** Fasta */
+            /**
+             * Fasta
+             * @description TODO
+             */
             fasta?: number;
             /**
              * ID
              * @description The ID of the custom build.
              */
             id: string;
-            /** Length */
+            /**
+             * Length
+             * @description TODO
+             */
             len: number;
-            /** Line count */
+            /**
+             * Line count
+             * @description TODO
+             */
             linecount?: number;
             /**
              * Name
@@ -6681,6 +6711,22 @@ export interface components {
              * @example http://www.apache.org/licenses/LICENSE-2.0
              */
             url: string;
+        };
+        /**
+         * LimitedUserModel
+         * @description This is used when config options (expose_user_name and expose_user_email) are in place.
+         */
+        LimitedUserModel: {
+            /** Email */
+            email?: string;
+            /**
+             * ID
+             * @description Encoded ID of the user
+             * @example 0123456789ABCDEF
+             */
+            id: string;
+            /** Username */
+            username?: string;
         };
         /** Link */
         Link: {
@@ -16773,7 +16819,10 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["UserModel"][];
+                    "application/json": (
+                        | components["schemas"]["UserModel"]
+                        | components["schemas"]["LimitedUserModel"]
+                    )[];
                 };
             };
             /** @description Validation Error */
@@ -16837,7 +16886,10 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["UserModel"][];
+                    "application/json": (
+                        | components["schemas"]["UserModel"]
+                        | components["schemas"]["LimitedUserModel"]
+                    )[];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -2969,40 +2969,6 @@ export interface components {
             url: string;
         };
         /**
-         * CreatedCustomBuild
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        CreatedCustomBuild: {
-            /**
-             * Count
-             * @description The number of chromosomes/contigs.
-             */
-            count?: string;
-            /**
-             * Fasta
-             * @description The primary id of the fasta file from a history.
-             * @example 0123456789ABCDEF
-             */
-            fasta?: string;
-            /**
-             * Length
-             * @description The primary id of the len file.
-             * @example 0123456789ABCDEF
-             */
-            len: string;
-            /**
-             * Line count
-             * @description The primary id of a linecount dataset.
-             * @example 0123456789ABCDEF
-             */
-            linecount?: string;
-            /**
-             * Name
-             * @description The name of the custom build.
-             */
-            name: string;
-        };
-        /**
          * CreatedUserModel
          * @description User in a transaction context.
          */
@@ -17444,7 +17410,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["CreatedCustomBuild"];
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -7930,6 +7930,17 @@ export interface components {
          */
         RemoteFilesFormat: "flat" | "jstree" | "uri";
         /**
+         * RemoteUserCreationPayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        RemoteUserCreationPayload: {
+            /**
+             * Email
+             * @description Email of the user
+             */
+            remote_user_email: string;
+        };
+        /**
          * RequestDataType
          * @description Particular pieces of information that can be requested for a dataset.
          * @enum {string}
@@ -8997,11 +9008,6 @@ export interface components {
              * @description The password of the user.
              */
             password: string;
-            /**
-             * user_email
-             * @description The email of the remote user.
-             */
-            remote_user_email?: string;
             /**
              * user_name
              * @description The name of the user.
@@ -16930,7 +16936,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["UserCreationPayload"];
+                "application/json":
+                    | components["schemas"]["UserCreationPayload"]
+                    | components["schemas"]["RemoteUserCreationPayload"];
             };
         };
         responses: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1420,6 +1420,8 @@ export interface paths {
     "/api/users/{user_id}": {
         /** Display information about a specified user */
         get: operations["get_user_api_users__user_id__get"];
+        /** Delete the user with the given `id`, only admins can delete other users. */
+        delete: operations["delete_user_api_users__user_id__delete"];
     };
     "/api/users/{user_id}/api_key": {
         /** Return the user's API key */
@@ -3679,33 +3681,75 @@ export interface components {
          * @description Base model definition with common configuration used by all derived models.
          */
         DetailedUserModel: {
-            /** Deleted */
+            /**
+             * Deleted
+             * @description  User is deleted
+             */
             deleted: boolean;
-            /** Email */
+            /**
+             * Email
+             * @description User email
+             */
             email: string;
-            /** Id */
+            /**
+             * ID
+             * @description User ID
+             */
             id: string;
-            /** Is Admin */
+            /**
+             * Is admin
+             * @description User is admin
+             */
             is_admin: boolean;
-            /** Nice Total Disk Usage */
+            /**
+             * Nice total disc usage
+             * @description Size of all non-purged, unique datasets of the user in a nice format.
+             */
             nice_total_disk_usage: string;
-            /** Preferences */
+            /**
+             * Preferences
+             * @description Preferences of the user
+             */
             preferences: Record<string, never>;
-            /** Preferred Object Store Id */
+            /**
+             * Preferred object store id
+             * @description Preferred id of the object store
+             */
             preferred_object_store_id: Record<string, never>;
-            /** Purged */
+            /**
+             * Purged
+             * @description User is purged
+             */
             purged: boolean;
-            /** Quota */
+            /**
+             * Quota
+             * @description Quota applicable to the user
+             */
             quota: string;
-            /** Quota Bytes */
+            /**
+             * Quota in bytes
+             * @description Quota applicable to the user in bytes.
+             */
             quota_bytes: Record<string, never>;
-            /** Quota Percent */
+            /**
+             * Quota percent
+             * @description Percentage of the storage quota applicable to the user.
+             */
             quota_percent: Record<string, never>;
-            /** Tags Used */
+            /**
+             * Tags used
+             * @description Tags used by the user
+             */
             tags_used: string[];
-            /** Total Disk Usage */
+            /**
+             * Total disk usage
+             * @description Size of all non-purged, unique datasets of the user in bytes.
+             */
             total_disk_usage: number;
-            /** Username */
+            /**
+             * Username
+             * @description User username
+             */
             username: string;
         };
         /**
@@ -7500,6 +7544,17 @@ export interface components {
              * @default tar.gz
              */
             model_store_format?: components["schemas"]["ModelStoreFormat"];
+        };
+        /**
+         * PurgeUserPayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        PurgeUserPayload: {
+            /**
+             * Purge user
+             * @description Purge the user
+             */
+            purge: boolean;
         };
         /**
          * QuotaDetails
@@ -16708,6 +16763,38 @@ export interface operations {
                     "application/json":
                         | components["schemas"]["AnonUserModel"]
                         | components["schemas"]["DetailedUserModel"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_user_api_users__user_id__delete: {
+        /** Delete the user with the given `id`, only admins can delete other users. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the user to get. */
+            path: {
+                user_id: string;
+            };
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["PurgeUserPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["DetailedUserModel"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1460,6 +1460,16 @@ export interface paths {
          */
         post: operations["set_beacon_settings_api_users__user_id__beacon_post"];
     };
+    "/api/users/{user_id}/custom_builds": {
+        /** Returns collection of custom builds. */
+        get: operations["get_custom_builds_api_users__user_id__custom_builds_get"];
+    };
+    "/api/users/{user_id}/custom_builds/{key}": {
+        /** Add new custom build. */
+        put: operations["add_custom_builds_api_users__user_id__custom_builds__key__put"];
+        /** Delete a custom build */
+        delete: operations["delete_custom_build_api_users__user_id__custom_builds__key__delete"];
+    };
     "/api/users/{user_id}/favorites/{object_type}": {
         /** Add the object to user's favorites */
         put: operations["set_favorite_api_users__user_id__favorites__object_type__put"];
@@ -2957,6 +2967,27 @@ export interface components {
             url: string;
         };
         /**
+         * CustomBuildCreationPayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CustomBuildCreationPayload: {
+            /**
+             * ?
+             * @description ?
+             */
+            "len|type": string;
+            /**
+             * ?
+             * @description ?
+             */
+            "len|value": string;
+            /**
+             * Name
+             * @description The name of the custom build.
+             */
+            name: string;
+        };
+        /**
          * CustomBuildsMetadataResponse
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -3698,6 +3729,17 @@ export interface components {
             purge?: boolean;
         };
         /**
+         * DeletedCustomBuild
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        DeletedCustomBuild: {
+            /**
+             * Deletion message
+             * @description Confirmation of the custom build deletion.
+             */
+            message: string;
+        };
+        /**
          * DetailedUserModel
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -3977,10 +4019,27 @@ export interface components {
             src: components["schemas"]["Src"];
         };
         /**
-         * FavoriteModel
+         * FavoriteObject
          * @description Base model definition with common configuration used by all derived models.
          */
-        FavoriteModel: {
+        FavoriteObject: {
+            /**
+             * Object ID
+             * @description The id of an object the user wants to favorite.
+             */
+            object_id: string;
+        };
+        /**
+         * FavoriteObjectType
+         * @description An enumeration.
+         * @enum {string}
+         */
+        FavoriteObjectType: "tools";
+        /**
+         * FavoriteObjectsSummary
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        FavoriteObjectsSummary: {
             /**
              * Favorite tools
              * @description The name of the tools the user favored.
@@ -7579,17 +7638,6 @@ export interface components {
             model_store_format?: components["schemas"]["ModelStoreFormat"];
         };
         /**
-         * PurgeUserPayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        PurgeUserPayload: {
-            /**
-             * Purge user
-             * @description Purge the user
-             */
-            purge: boolean;
-        };
-        /**
          * QuotaDetails
          * @description Base model containing common fields for Quotas.
          */
@@ -7970,17 +8018,6 @@ export interface components {
              * @example 1.0.0
              */
             version: string;
-        };
-        /**
-         * SetFavoritePayload
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        SetFavoritePayload: {
-            /**
-             * Object ID
-             * @description The id of an object the user wants to favorite.
-             */
-            object_id: string;
         };
         /**
          * SetSlugPayload
@@ -8795,6 +8832,17 @@ export interface components {
              * @description True if beacon sharing is enabled
              */
             enabled: boolean;
+        };
+        /**
+         * UserDeletionPayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        UserDeletionPayload: {
+            /**
+             * Purge user
+             * @description Purge the user
+             */
+            purge: boolean;
         };
         /**
          * UserEmail
@@ -16928,7 +16976,7 @@ export interface operations {
         };
         requestBody?: {
             content: {
-                "application/json": components["schemas"]["PurgeUserPayload"];
+                "application/json": components["schemas"]["UserDeletionPayload"];
             };
         };
         responses: {
@@ -17117,6 +17165,96 @@ export interface operations {
             };
         };
     };
+    get_custom_builds_api_users__user_id__custom_builds_get: {
+        /** Returns collection of custom builds. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the user to get. */
+            path: {
+                user_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    add_custom_builds_api_users__user_id__custom_builds__key__put: {
+        /** Add new custom build. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The key of the custom build to be deleted. */
+            /** @description The ID of the user to get. */
+            path: {
+                key: string;
+                user_id: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CustomBuildCreationPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_custom_build_api_users__user_id__custom_builds__key__delete: {
+        /** Delete a custom build */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The key of the custom build to be deleted. */
+            /** @description The ID of the user to get. */
+            path: {
+                key: string;
+                user_id: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["DeletedCustomBuild"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     set_favorite_api_users__user_id__favorites__object_type__put: {
         /** Add the object to user's favorites */
         parameters: {
@@ -17128,19 +17266,19 @@ export interface operations {
             /** @description The object type the user wants to favorite */
             path: {
                 user_id: string;
-                object_type: string;
+                object_type: components["schemas"]["FavoriteObjectType"];
             };
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SetFavoritePayload"];
+                "application/json": components["schemas"]["FavoriteObject"];
             };
         };
         responses: {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["FavoriteModel"];
+                    "application/json": components["schemas"]["FavoriteObjectsSummary"];
                 };
             };
             /** @description Validation Error */
@@ -17163,7 +17301,7 @@ export interface operations {
             /** @description The ID of an object the user wants to remove from favorites */
             path: {
                 user_id: string;
-                object_type: string;
+                object_type: components["schemas"]["FavoriteObjectType"];
                 object_id: string;
             };
         };
@@ -17171,7 +17309,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["FavoriteModel"];
+                    "application/json": components["schemas"]["FavoriteObjectsSummary"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -2975,24 +2975,27 @@ export interface components {
         CreatedCustomBuild: {
             /**
              * Count
-             * @description TODO
+             * @description The number of chromosomes/contigs.
              */
             count?: string;
             /**
              * Fasta
-             * @description TODO
+             * @description The primary id of the fasta file from a history.
+             * @example 0123456789ABCDEF
              */
-            fasta?: number;
+            fasta?: string;
             /**
              * Length
-             * @description TODO
+             * @description The primary id of the len file.
+             * @example 0123456789ABCDEF
              */
-            len: number;
+            len: string;
             /**
              * Line count
-             * @description TODO
+             * @description The primary id of a linecount dataset.
+             * @example 0123456789ABCDEF
              */
-            linecount?: number;
+            linecount?: string;
             /**
              * Name
              * @description The name of the custom build.
@@ -3065,12 +3068,12 @@ export interface components {
         CustomBuildCreationPayload: {
             /**
              * Length type
-             * @description TODO
+             * @description The type of the len file.
              */
-            "len|type": string;
+            "len|type": components["schemas"]["CustomBuildLenType"];
             /**
              * Length value
-             * @description TODO
+             * @description The content of the length file.
              */
             "len|value": string;
             /**
@@ -3080,20 +3083,27 @@ export interface components {
             name: string;
         };
         /**
+         * CustomBuildLenType
+         * @description An enumeration.
+         * @enum {string}
+         */
+        CustomBuildLenType: "file" | "fasta" | "text";
+        /**
          * CustomBuildModel
          * @description Base model definition with common configuration used by all derived models.
          */
         CustomBuildModel: {
             /**
              * Count
-             * @description TODO
+             * @description The number of chromosomes/contigs.
              */
             count?: string;
             /**
              * Fasta
-             * @description TODO
+             * @description The primary id of the fasta file from a history.
+             * @example 0123456789ABCDEF
              */
-            fasta?: number;
+            fasta?: string;
             /**
              * ID
              * @description The ID of the custom build.
@@ -3101,14 +3111,16 @@ export interface components {
             id: string;
             /**
              * Length
-             * @description TODO
+             * @description The primary id of the len file.
+             * @example 0123456789ABCDEF
              */
-            len: number;
+            len: string;
             /**
              * Line count
-             * @description TODO
+             * @description The primary id of a linecount dataset.
+             * @example 0123456789ABCDEF
              */
-            linecount?: number;
+            linecount?: string;
             /**
              * Name
              * @description The name of the custom build.

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -8925,17 +8925,6 @@ export interface components {
             /** Total Disk Usage */
             total_disk_usage: number;
         };
-        /**
-         * UserTheme
-         * @description Base model definition with common configuration used by all derived models.
-         */
-        UserTheme: {
-            /**
-             * user_theme
-             * @description The theme of the users GUI
-             */
-            theme: string;
-        };
         /** ValidationError */
         ValidationError: {
             /** Location */
@@ -16918,7 +16907,7 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": components["schemas"]["UserTheme"];
+                    "application/json": string;
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1394,13 +1394,6 @@ export interface paths {
          */
         get: operations["get_users_api_users_get"];
     };
-    "/api/users/current": {
-        /**
-         * Get Current User
-         * @description Return information about the current user
-         */
-        get: operations["get_current_user_api_users_current_get"];
-    };
     "/api/users/current/recalculate_disk_usage": {
         /**
          * Triggers a recalculation of the current user disk usage.
@@ -1436,7 +1429,7 @@ export interface paths {
         put: operations["recalculate_disk_usage_api_users_recalculate_disk_usage_put"];
     };
     "/api/users/{user_id}": {
-        /** Return information about a specified user. Only admin can see deleted or other users */
+        /** Return information about a specified or the current user. Only admin can see deleted or other users */
         get: operations["get_user_api_users__user_id__get"];
         /** Update the values of a user. Only admin can update others. */
         put: operations["update_user_api_users__user_id__put"];
@@ -16701,42 +16694,6 @@ export interface operations {
             };
         };
     };
-    get_current_user_api_users_current_get: {
-        /**
-         * Get Current User
-         * @description Return information about the current user
-         */
-        parameters: {
-            /** @description Indicates if the user is deleted */
-            query?: {
-                deleted?: boolean;
-            };
-            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
-            header?: {
-                "run-as"?: string;
-            };
-            /** @description The ID of the user to get or 'current'. */
-            path: {
-                user_id: string | "current";
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                content: {
-                    "application/json":
-                        | components["schemas"]["DetailedUserModel"]
-                        | components["schemas"]["AnonUserModel"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     recalculate_disk_usage_api_users_current_recalculate_disk_usage_put: {
         /**
          * Triggers a recalculation of the current user disk usage.
@@ -16889,7 +16846,7 @@ export interface operations {
         };
     };
     get_user_api_users__user_id__get: {
-        /** Return information about a specified user. Only admin can see deleted or other users */
+        /** Return information about a specified or the current user. Only admin can see deleted or other users */
         parameters: {
             /** @description Indicates if the user is deleted */
             query?: {
@@ -17167,11 +17124,11 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
-            /** @description The object type the user wants to favorite */
             /** @description The ID of the user to get. */
+            /** @description The object type the user wants to favorite */
             path: {
-                object_type: string;
                 user_id: string;
+                object_type: string;
             };
         };
         requestBody: {
@@ -17201,13 +17158,13 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
+            /** @description The ID of the user to get. */
             /** @description The object type the user wants to favorite */
             /** @description The ID of an object the user wants to remove from favorites */
-            /** @description The ID of the user to get. */
             path: {
+                user_id: string;
                 object_type: string;
                 object_id: string;
-                user_id: string;
             };
         };
         responses: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1430,6 +1430,10 @@ export interface paths {
          */
         post: operations["set_beacon_api_users__user_id__beacon_post"];
     };
+    "/api/users/{user_id}/theme/{theme}": {
+        /** Sets the user's theme choice. */
+        put: operations["set_theme_api_users__user_id__theme__theme__put"];
+    };
     "/api/users/{user_id}/usage": {
         /** Return the user's quota usage summary broken down by quota source */
         get: operations["get_user_usage_api_users__user_id__usage_get"];
@@ -8850,6 +8854,17 @@ export interface components {
             quota_source_label?: string;
             /** Total Disk Usage */
             total_disk_usage: number;
+        };
+        /**
+         * UserTheme
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        UserTheme: {
+            /**
+             * user_theme
+             * @description The theme of the users GUI
+             */
+            theme: string;
         };
         /** ValidationError */
         ValidationError: {
@@ -16707,6 +16722,35 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["UserBeaconSetting"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_theme_api_users__user_id__theme__theme__put: {
+        /** Sets the user's theme choice. */
+        parameters: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+            /** @description The ID of the user to get. */
+            /** @description The theme of the GUI */
+            path: {
+                user_id: string;
+                theme: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["UserTheme"];
                 };
             };
             /** @description Validation Error */

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1387,6 +1387,13 @@ export interface paths {
          */
         post: operations["update_tour_api_tours__tour_id__post"];
     };
+    "/api/users": {
+        /**
+         * Get Users
+         * @description Display a collection of users
+         */
+        get: operations["Get_users_api_users_get"];
+    };
     "/api/users/current": {
         /**
          * Get Current User
@@ -1402,6 +1409,13 @@ export interface paths {
          * Please use `/api/users/current/recalculate_disk_usage` instead.
          */
         put: operations["recalculate_disk_usage_api_users_current_recalculate_disk_usage_put"];
+    };
+    "/api/users/deleted": {
+        /**
+         * Get Deleted Users
+         * @description Display a collection of deleted users
+         */
+        get: operations["Get_deleted_users_api_users_deleted_get"];
     };
     "/api/users/deleted/{user_id}": {
         /** Display information about a deleted user */
@@ -16614,6 +16628,38 @@ export interface operations {
             };
         };
     };
+    Get_users_api_users_get: {
+        /**
+         * Get Users
+         * @description Display a collection of users
+         */
+        parameters?: {
+            query?: {
+                deleted?: boolean;
+                f_email?: string;
+                f_name?: string;
+                f_any?: string;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["UserModel"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_current_user_api_users_current_get: {
         /**
          * Get Current User
@@ -16672,6 +16718,37 @@ export interface operations {
             };
             /** @description The background task was submitted but there is no status tracking ID available. */
             204: never;
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    Get_deleted_users_api_users_deleted_get: {
+        /**
+         * Get Deleted Users
+         * @description Display a collection of deleted users
+         */
+        parameters?: {
+            query?: {
+                f_email?: string;
+                f_name?: string;
+                f_any?: string;
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["UserModel"][];
+                };
+            };
             /** @description Validation Error */
             422: {
                 content: {

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -607,20 +607,6 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         with transaction(session):
             session.commit()
 
-    # TODO: move to more basal, common resource than this
-    def anon_user_api_value(self, trans):
-        """Return data for an anonymous user, truncated to only usage and quota_percent"""
-        if not trans.user and not trans.history:
-            # Can't return info about this user, may not have a history yet.
-            return {}
-        usage = trans.app.quota_agent.get_usage(trans, history=trans.history)
-        percent = trans.app.quota_agent.get_percent(trans=trans, usage=usage)
-        return {
-            "total_disk_usage": int(usage),
-            "nice_total_disk_usage": util.nice_size(usage),
-            "quota_percent": percent,
-        }
-
 
 class UserSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):
     model_manager_class = UserManager

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -329,34 +329,29 @@ class DetailedUserModel(BaseUserModel, AnonUserModel):
     )
     tags_used: List[str] = Field(default=Required, title="Tags used", description="Tags used by the user")
 
-# TODO rename without verbs
+
 class CreatedUserModel(UserModel, DiskUsageUserModel):
     preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField
 
 
-class PurgeUserPayload(Model):
+class UserDeletionPayload(Model):
     purge: bool = Field(default=Required, title="Purge user", description="Purge the user")
 
 
-class CreateUserPayload(Model):
-    password: str = Field(default=Required, title="user_password", description="The password of the user.")
-    remote_user_email: Optional[str] = Field(
-        default=None, title="user_email", description="The email of the remote user."
-    )
-    email: str = UserEmailField
-    username: str = UserNameField
-
-
-class SetFavoritePayload(Model):
+class FavoriteObject(Model):
     object_id: str = Field(
         default=Required, title="Object ID", description="The id of an object the user wants to favorite."
     )
 
 
-class FavoriteModel(Model):
+class FavoriteObjectsSummary(Model):
     tools: List[str] = Field(
         default=Required, title="Favorite tools", description="The name of the tools the user favored."
     )
+
+
+class FavoriteObjectType(str, Enum):
+    tools = "tools"
 
 
 class AddCustomBuildPayload(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -347,6 +347,18 @@ class CreateUserPayload(Model):
     username: str = UserNameField
 
 
+class SetFavoritePayload(Model):
+    object_id: str = Field(
+        default=Required, title="Object ID", description="The id of an object the user wants to favorite."
+    )
+
+
+class FavoriteModel(Model):
+    tools: List[str] = Field(
+        default=Required, title="Favorite tools", description="The name of the tools the user favored."
+    )
+
+
 class GroupModel(Model):
     """User group model"""
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -286,20 +286,34 @@ class AnonUserModel(Model):
 
 
 class DetailedUserModel(Model):
-    preferences: Dict[Any, Any] = Field(default=Required)
-    is_admin: bool = Field(default=Required)
-    quota_percent: Any = Field(default=Required)
-    total_disk_usage: float = Field(default=Required)
-    nice_total_disk_usage: str = Field(default=Required)
-    tags_used: List[str] = Field(default=Required)
-    deleted: bool = Field(default=Required)
-    id: str = Field(default=Required)
-    email: str = Field(default=Required)
-    preferred_object_store_id: Any = Field(default=Required)
-    username: str = Field(default=Required)
-    quota_bytes: Any = Field(default=Required)
-    quota: str = Field(default=Required)
-    purged: bool = Field(default=Required)
+    preferences: Dict[Any, Any] = Field(default=Required, title="Preferences", description="Preferences of the user")
+    is_admin: bool = Field(default=Required, title="Is admin", description="User is admin")
+    quota_percent: Any = Field(
+        default=Required, title="Quota percent", description="Percentage of the storage quota applicable to the user."
+    )
+    total_disk_usage: float = Field(
+        default=Required,
+        title="Total disk usage",
+        description="Size of all non-purged, unique datasets of the user in bytes.",
+    )
+    nice_total_disk_usage: str = Field(
+        default=Required,
+        title="Nice total disc usage",
+        description="Size of all non-purged, unique datasets of the user in a nice format.",
+    )
+    tags_used: List[str] = Field(default=Required, title="Tags used", description="Tags used by the user")
+    deleted: bool = Field(default=Required, title="Deleted", description=" User is deleted")
+    id: str = Field(default=Required, title="ID", description="User ID")
+    email: str = Field(default=Required, title="Email", description="User email")
+    preferred_object_store_id: Any = Field(
+        default=Required, title="Preferred object store id", description="Preferred id of the object store"
+    )
+    username: str = Field(default=Required, title="Username", description="User username")
+    quota_bytes: Any = Field(
+        default=Required, title="Quota in bytes", description="Quota applicable to the user in bytes."
+    )
+    quota: str = Field(default=Required, title="Quota", description="Quota applicable to the user")
+    purged: bool = Field(default=Required, title="Purged", description="User is purged")
 
 
 FlexibleUserIdType = Union[DecodedDatabaseIdField, Literal["current"]]

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -359,6 +359,12 @@ class FavoriteModel(Model):
     )
 
 
+class AddCustomBuildPayload(Model):
+    name: str = Field(default=Required, title="Name", description="The name of the custom build.")
+    lentype: str = Field(default=Required, title="?", description="?")
+    lenvalue: str = Field(default=Required, title="?", description="?")
+
+
 class GroupModel(Model):
     """User group model"""
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -322,6 +322,10 @@ class DiskUsageUserModel(Model):
     nice_total_disk_usage: str = NiceTotalDiskUsageField
 
 
+class CreatedUserModel(UserModel, DiskUsageUserModel):
+    preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField
+
+
 class AnonUserModel(DiskUsageUserModel):
     quota_percent: Any = QuotaPercentField
 
@@ -336,6 +340,15 @@ class DetailedUserModel(BaseUserModel, AnonUserModel):
         default=Required, title="Quota in bytes", description="Quota applicable to the user in bytes."
     )
     tags_used: List[str] = Field(default=Required, title="Tags used", description="Tags used by the user")
+
+
+class UserCreationPayload(Model):
+    password: str = Field(default=Required, title="user_password", description="The password of the user.")
+    remote_user_email: Optional[str] = Field(
+        default=None, title="user_email", description="The email of the remote user."
+    )
+    email: str = UserEmailField
+    username: str = UserNameField
 
 
 class UserDeletionPayload(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -354,6 +354,12 @@ class FavoriteObjectType(str, Enum):
     tools = "tools"
 
 
+class DeletedCustomBuild(Model):
+    message: str = Field(
+        default=Required, title="Deletion message", description="Confirmation of the custom build deletion."
+    )
+
+
 class AddCustomBuildPayload(Model):
     name: str = Field(default=Required, title="Name", description="The name of the custom build.")
     lentype: str = Field(default=Required, title="?", description="?")

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -382,28 +382,37 @@ class CustomBuildBaseModel(Model):
     name: str = Field(default=Required, title="Name", description="The name of the custom build.")
 
 
-# TODO Add descriptions
+class CustomBuildLenType(str, Enum):
+    file = "file"
+    fasta = "fasta"
+    text = "text"
+
+
+# TODO Evaluate if the titles and descriptions are fitting
 class CustomBuildCreationPayload(CustomBuildBaseModel):
-    len_type: str = Field(
+    len_type: CustomBuildLenType = Field(
         default=Required,
         alias="len|type",
         title="Length type",
-        description="TODO",
+        description="The type of the len file.",
     )
     len_value: str = Field(
         default=Required,
         alias="len|value",
         title="Length value",
-        description="TODO",
+        description="The content of the length file.",
     )
 
 
-# TODO Add descriptions
 class CreatedCustomBuild(CustomBuildBaseModel):
-    len: int = Field(default=Required, title="Length", description="TODO")
-    count: Optional[str] = Field(default=None, title="Count", description="TODO")
-    fasta: Optional[int] = Field(default=None, title="Fasta", description="TODO")
-    linecount: Optional[int] = Field(default=None, title="Line count", description="TODO")
+    len: EncodedDatabaseIdField = Field(default=Required, title="Length", description="The primary id of the len file.")
+    count: Optional[str] = Field(default=None, title="Count", description="The number of chromosomes/contigs.")
+    fasta: Optional[EncodedDatabaseIdField] = Field(
+        default=None, title="Fasta", description="The primary id of the fasta file from a history."
+    )
+    linecount: Optional[EncodedDatabaseIdField] = Field(
+        default=None, title="Line count", description="The primary id of a linecount dataset."
+    )
 
 
 class CustomBuildModel(CreatedCustomBuild):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -319,6 +319,10 @@ class DetailedUserModel(Model):
 FlexibleUserIdType = Union[DecodedDatabaseIdField, Literal["current"]]
 
 
+class PurgeUserPayload(Model):
+    purge: bool = Field(default=Required, title="Purge user", description="Purge the user")
+
+
 class UserModel(Model):
     """User in a transaction context."""
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -302,6 +302,9 @@ class DetailedUserModel(Model):
     purged: bool = Field(default=Required)
 
 
+FlexibleUserIdType = Union[DecodedDatabaseIdField, Literal["current"]]
+
+
 class UserModel(Model):
     """User in a transaction context."""
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -333,14 +333,6 @@ class GroupModel(Model):
     )
 
 
-class UserTheme(Model):
-    theme: str = Field(
-        default=Required,
-        title="user_theme",
-        description="The theme of the users GUI",
-    )
-
-
 class JobSourceType(str, Enum):
     """Available types of job sources (model classes) that produce dataset collections."""
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -309,6 +309,14 @@ class UserModel(BaseUserModel):
     last_password_change: Optional[datetime] = Field(title="Last password change", description="")
 
 
+class LimitedUserModel(Model):
+    """This is used when config options (expose_user_name and expose_user_email) are in place."""
+
+    id: EncodedDatabaseIdField = UserIdField
+    username: Optional[str]
+    email: Optional[str]
+
+
 class DiskUsageUserModel(Model):
     total_disk_usage: float = TotalDiskUsageField
     nice_total_disk_usage: str = NiceTotalDiskUsageField
@@ -366,22 +374,22 @@ class CustomBuildCreationPayload(CustomBuildBaseModel):
         default=Required,
         alias="len|type",
         title="Length type",
-        description="",
+        description="TODO",
     )
     len_value: str = Field(
         default=Required,
         alias="len|value",
         title="Length value",
-        description="",
+        description="TODO",
     )
 
 
 # TODO Add descriptions
 class CreatedCustomBuild(CustomBuildBaseModel):
-    len: int = Field(default=Required, title="Length", description="")
-    count: Optional[str] = Field(default=None, title="Count", description="")
-    fasta: Optional[int] = Field(default=None, title="Fasta", description="")
-    linecount: Optional[int] = Field(default=None, title="Line count", description="")
+    len: int = Field(default=Required, title="Length", description="TODO")
+    count: Optional[str] = Field(default=None, title="Count", description="TODO")
+    fasta: Optional[int] = Field(default=None, title="Fasta", description="TODO")
+    linecount: Optional[int] = Field(default=None, title="Line count", description="TODO")
 
 
 class CustomBuildModel(CreatedCustomBuild):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -330,10 +330,6 @@ class DetailedUserModel(BaseUserModel, AnonUserModel):
     tags_used: List[str] = Field(default=Required, title="Tags used", description="Tags used by the user")
 
 
-class CreatedUserModel(UserModel, DiskUsageUserModel):
-    preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField
-
-
 class UserDeletionPayload(Model):
     purge: bool = Field(default=Required, title="Purge user", description="Purge the user")
 
@@ -360,10 +356,11 @@ class DeletedCustomBuild(Model):
     )
 
 
-class AddCustomBuildPayload(Model):
+# TODO Does name fit to add_custom_build operation?
+class CustomBuildCreationPayload(Model):
     name: str = Field(default=Required, title="Name", description="The name of the custom build.")
-    lentype: str = Field(default=Required, title="?", description="?")
-    lenvalue: str = Field(default=Required, title="?", description="?")
+    len_type: str = Field(default=Required, alias="len|type", title="?", description="?")
+    len_value: str = Field(default=Required, alias="len|value", title="?", description="?")
 
 
 class GroupModel(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -329,7 +329,7 @@ class DetailedUserModel(BaseUserModel, AnonUserModel):
     )
     tags_used: List[str] = Field(default=Required, title="Tags used", description="Tags used by the user")
 
-
+# TODO rename without verbs
 class CreatedUserModel(UserModel, DiskUsageUserModel):
     preferred_object_store_id: Optional[str] = PreferredObjectStoreIdField
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -344,11 +344,12 @@ class DetailedUserModel(BaseUserModel, AnonUserModel):
 
 class UserCreationPayload(Model):
     password: str = Field(default=Required, title="user_password", description="The password of the user.")
-    remote_user_email: Optional[str] = Field(
-        default=None, title="user_email", description="The email of the remote user."
-    )
     email: str = UserEmailField
     username: str = UserNameField
+
+
+class RemoteUserCreationPayload(Model):
+    remote_user_email: str = UserEmailField
 
 
 class UserDeletionPayload(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -25,6 +25,7 @@ from pydantic import (
     Extra,
     Field,
     Json,
+    Required,
     UUID4,
 )
 from typing_extensions import (
@@ -291,6 +292,14 @@ class GroupModel(Model):
         ...,  # Required
         title="Name",
         description="The name of the group.",
+    )
+
+
+class UserTheme(Model):
+    theme: str = Field(
+        default=Required,
+        title="user_theme",
+        description="The theme of the users GUI",
     )
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -267,6 +267,41 @@ class Model(BaseModel):
                 del properties[prop_key_to_remove]
 
 
+class AnonUserModel(Model):
+    total_disk_usage: int = Field(
+        default=Required,
+        title="Total disk usage",
+        description="Size of all non-purged, unique datasets of the user in bytes.",
+    )
+    nice_total_disk_usage: str = Field(
+        default=Required,
+        title="Nice total disc usage",
+        description="Size of all non-purged, unique datasets of the user in a nice format.",
+    )
+    quota_percent: int = Field(
+        default=Required,
+        title="Storage quota",
+        description="Percentage of the storage quota applicable to the user.",
+    )
+
+
+class DetailedUserModel(Model):
+    preferences: Dict[Any, Any] = Field(default=Required)
+    is_admin: bool = Field(default=Required)
+    quota_percent: Any = Field(default=Required)
+    total_disk_usage: float = Field(default=Required)
+    nice_total_disk_usage: str = Field(default=Required)
+    tags_used: List[str] = Field(default=Required)
+    deleted: bool = Field(default=Required)
+    id: str = Field(default=Required)
+    email: str = Field(default=Required)
+    preferred_object_store_id: Any = Field(default=Required)
+    username: str = Field(default=Required)
+    quota_bytes: Any = Field(default=Required)
+    quota: str = Field(default=Required)
+    purged: bool = Field(default=Required)
+
+
 class UserModel(Model):
     """User in a transaction context."""
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -356,11 +356,42 @@ class DeletedCustomBuild(Model):
     )
 
 
-# TODO Does name fit to add_custom_build operation?
-class CustomBuildCreationPayload(Model):
+class CustomBuildBaseModel(Model):
     name: str = Field(default=Required, title="Name", description="The name of the custom build.")
-    len_type: str = Field(default=Required, alias="len|type", title="?", description="?")
-    len_value: str = Field(default=Required, alias="len|value", title="?", description="?")
+
+
+# TODO Add descriptions
+class CustomBuildCreationPayload(CustomBuildBaseModel):
+    len_type: str = Field(
+        default=Required,
+        alias="len|type",
+        title="Length type",
+        description="",
+    )
+    len_value: str = Field(
+        default=Required,
+        alias="len|value",
+        title="Length value",
+        description="",
+    )
+
+
+# TODO Add descriptions
+class CreatedCustomBuild(CustomBuildBaseModel):
+    len: int = Field(default=Required, title="Length", description="")
+    count: Optional[str] = Field(default=None, title="Count", description="")
+    fasta: Optional[int] = Field(default=None, title="Fasta", description="")
+    linecount: Optional[int] = Field(default=None, title="Line count", description="")
+
+
+class CustomBuildModel(CreatedCustomBuild):
+    id: str = Field(default=Required, title="ID", description="The ID of the custom build.")
+
+
+class CustomBuildsCollection(Model):
+    __root__: List[CustomBuildModel] = Field(
+        default=Required, title="Custom builds collection", description="The custom builds associated with the user."
+    )
 
 
 class GroupModel(Model):

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -845,7 +845,7 @@ class GalaxyInteractorApi:
                 password=password,
                 username=username,
             )
-            test_user = self._post("users", data, key=admin_key).json()
+            test_user = self._post("users", data, key=admin_key, json=True).json()
         return test_user
 
     def __test_data_downloader(self, tool_id, tool_version=None, attributes: Optional[dict] = None):

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -203,8 +203,7 @@ class FastAPIUsers:
                 self.service.user_manager.delete(user_to_update)
             else:
                 raise exceptions.InsufficientPermissionsException("You may only delete your own account.")
-        user_response = self.user_serializer.serialize_to_view(user_to_update, view="detailed")
-        return DetailedUserModel(**user_response)
+        return self.service.user_to_detailed_model(user_to_update)
 
     @router.delete(
         "/api/users/{user_id}/api_key",

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -272,12 +272,29 @@ class FastAPIUsers:
         trans: ProvidesUserContext = DependsOnTrans,
         user_id: DecodedDatabaseIdField = UserIdPathParam,
         theme: str = ThemePathParam,
-    ) -> UserTheme:
+    ) -> str:
         user = self.service._get_user(trans, user_id)
         user.preferences["theme"] = theme
         with transaction(trans.sa_session):
             trans.sa_session.commit()
-        return UserTheme(theme=theme)
+        return theme
+
+    @expose_api
+    def set_theme(self, trans, id: str, theme: str, payload=None, **kwd) -> str:
+        """Sets the user's theme choice.
+        PUT /api/users/{id}/theme/{theme}
+
+        :param id: the encoded id of the user
+        :type  id: str
+        :param theme: the theme identifier/name that the user has selected as preference
+        :type  theme: str
+        """
+        payload = payload or {}
+        user = self._get_user(trans, id)
+        user.preferences["theme"] = theme
+        with transaction(trans.sa_session):
+            trans.sa_session.commit()
+        return theme
 
     @router.get(
         "/api/users/deleted/{user_id}",

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -112,6 +112,7 @@ RecalculateDiskUsageResponseDescriptions = {
 CreateUserBody = Body(default=Required, title="Create user", description="The values to create a user.")
 PurgeUserBody = Body(default=None, title="Purge user", description="Purge the user.")
 UpdateUserBody = Body(default=Required, title="Update user", description="The user values to update.")
+AnyUserModel = Union[DetailedUserModel, AnonUserModel]
 
 
 @router.cbv
@@ -173,7 +174,7 @@ class FastAPIUsers:
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         user_id: DecodedDatabaseIdField = UserIdPathParam,
-    ) -> Union[AnonUserModel, DetailedUserModel]:
+    ) -> AnyUserModel:
         return self.service.show_user(trans=trans, user_id=user_id, deleted=True)
 
     @router.get(
@@ -383,7 +384,7 @@ class FastAPIUsers:
         trans: ProvidesHistoryContext = DependsOnTrans,
         user_id: FlexibleUserIdType = FlexibleUserIdPathParam,
         deleted: Optional[bool] = UserDeleted,
-    ) -> Union[AnonUserModel, DetailedUserModel]:
+    ) -> AnyUserModel:
         user_deleted = deleted or False
         return self.service.show_user(trans=trans, user_id=user_id, deleted=user_deleted)
 

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -268,7 +268,7 @@ class FastAPIUsers:
         """
         **Warning**: This endpoint is experimental and might change or disappear in future versions.
         """
-        user = self.service._get_user(trans, user_id)
+        user = self.service.get_user(trans, user_id)
 
         enabled = user.preferences["beacon_enabled"] if "beacon_enabled" in user.preferences else False
 
@@ -287,7 +287,7 @@ class FastAPIUsers:
         """
         **Warning**: This endpoint is experimental and might change or disappear in future versions.
         """
-        user = self.service._get_user(trans, user_id)
+        user = self.service.get_user(trans, user_id)
 
         user.preferences["beacon_enabled"] = payload.enabled
         with transaction(trans.sa_session):
@@ -305,7 +305,7 @@ class FastAPIUsers:
         user_id: DecodedDatabaseIdField = UserIdPathParam,
         theme: str = ThemePathParam,
     ) -> str:
-        user = self.service._get_user(trans, user_id)
+        user = self.service.get_user(trans, user_id)
         user.preferences["theme"] = theme
         with transaction(trans.sa_session):
             trans.sa_session.commit()

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -142,7 +142,7 @@ class FastAPIUsers:
         result = self.service.recalculate_disk_usage(trans)
         return Response(status_code=status.HTTP_204_NO_CONTENT) if result is None else result
 
-    @router.get("/api/users/deleted", name="Get deleted users", description="Display a collection of deleted users")
+    @router.get("/api/users/deleted", name="get_deleted_users", description="Return a collection of deleted users")
     def index_deleted(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
@@ -155,7 +155,7 @@ class FastAPIUsers:
     @router.post(
         "/api/users/deleted/{user_id}/undelete",
         name="undelete_user",
-        summary="Restore the deleted user with the given `id`",
+        summary="Restore a deleted user",
         require_admin=True,
     )
     def undelete(
@@ -168,7 +168,7 @@ class FastAPIUsers:
     @router.get(
         "/api/users/deleted/{user_id}",
         name="get_deleted_user",
-        summary="Display information about a deleted user",
+        summary="Return information about a deleted user",
     )
     def show_deleted(
         self,
@@ -207,7 +207,7 @@ class FastAPIUsers:
         api_key = self.service.get_api_key(trans, user_id)
         return api_key if api_key else Response(status_code=status.HTTP_204_NO_CONTENT)
 
-    @router.post("/api/users/{user_id}/api_key", summary="Creates a new API key for the user")
+    @router.post("/api/users/{user_id}/api_key", name="create_api_key", summary="Create a new API key for the user")
     def create_api_key(
         self, trans: ProvidesUserContext = DependsOnTrans, user_id: DecodedDatabaseIdField = UserIdPathParam
     ) -> str:
@@ -215,6 +215,7 @@ class FastAPIUsers:
 
     @router.delete(
         "/api/users/{user_id}/api_key",
+        name="delete_api_key",
         summary="Delete the current API key of the user",
         status_code=status.HTTP_204_NO_CONTENT,
     )
@@ -266,7 +267,8 @@ class FastAPIUsers:
 
     @router.get(
         "/api/users/{user_id}/beacon",
-        summary="Returns information about beacon share settings",
+        name="get_beacon_settings",
+        summary="Return information about beacon share settings",
     )
     def get_beacon(
         self,
@@ -284,7 +286,8 @@ class FastAPIUsers:
 
     @router.post(
         "/api/users/{user_id}/beacon",
-        summary="Changes beacon setting",
+        name="set_beacon_settings",
+        summary="Change beacon setting",
     )
     def set_beacon(
         self,
@@ -305,7 +308,8 @@ class FastAPIUsers:
 
     @router.put(
         "/api/users/{user_id}/theme/{theme}",
-        summary="Sets the user's theme choice.",
+        name="set_theme",
+        summary="Set the user's theme choice",
     )
     def set_theme(
         self,
@@ -319,7 +323,7 @@ class FastAPIUsers:
             trans.sa_session.commit()
         return theme
 
-    @router.get("/api/users", name="Get users", description="Display a collection of users")
+    @router.get("/api/users", name="get_users", description="Return a collection of users")
     def index(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
@@ -332,8 +336,8 @@ class FastAPIUsers:
 
     @router.post(
         "/api/users",
-        name="Create user",
-        summary="Creates a new Galaxy user.",
+        name="create_user",
+        summary="Create a new Galaxy user",
     )
     def create(
         self,
@@ -372,12 +376,12 @@ class FastAPIUsers:
     @router.get(
         "/api/users/current",
         name="get_current_user",
-        description="Display information about current user",
+        description="Return information about the current user",
     )
     @router.get(
         "/api/users/{user_id}",
         name="get_user",
-        summary="Display information about a specified user",
+        summary="Return information about a specified user",
     )
     def show(
         self,
@@ -388,7 +392,7 @@ class FastAPIUsers:
         user_deleted = deleted or False
         return self.service.show_user(trans=trans, user_id=user_id, deleted=user_deleted)
 
-    @router.put("/api/users/{user_id}", name="update_user", summary="Updates the values of the user")
+    @router.put("/api/users/{user_id}", name="update_user", summary="Update the values of a user")
     def update(
         self,
         payload: Dict[Any, Any] = UpdateUserBody,
@@ -405,7 +409,7 @@ class FastAPIUsers:
     @router.delete(
         "/api/users/{user_id}",
         name="delete_user",
-        summary="Delete the user with the given `id`, only admins can delete other users.",
+        summary="Delete a user",
     )
     def delete(
         self,

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -175,34 +175,6 @@ class FastAPIUsers:
     ) -> str:
         return self.service.create_api_key(trans, user_id).key
 
-    # @expose_api
-    # def delete(self, trans, id, **kwd):
-    #     """
-    #     DELETE /api/users/{id}
-    #     delete the user with the given ``id``
-    #     Functionality restricted based on admin status
-
-    #     :param id: the encoded id of the user to delete
-    #     :type  id: str
-
-    #     :param purge: (optional) if True, purge the user
-    #     :type  purge: bool
-    #     """
-    #     user_to_update = self.user_manager.by_id(self.decode_id(id))
-    #     if trans.user_is_admin:
-    #         purge = util.string_as_bool(kwd.get("purge", False))
-    #         if purge:
-    #             log.debug("Purging user %s", user_to_update)
-    #             self.user_manager.purge(user_to_update)
-    #         else:
-    #             self.user_manager.delete(user_to_update)
-    #     else:
-    #         if trans.user == user_to_update:
-    #             self.user_manager.delete(user_to_update)
-    #         else:
-    #             raise exceptions.InsufficientPermissionsException("You may only delete your own account.")
-    #     return self.user_serializer.serialize_to_view(user_to_update, view="detailed")
-
     @router.delete(
         "/api/users/{user_id}",
         name="delete_user",

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -125,10 +125,11 @@ RecalculateDiskUsageResponseDescriptions = {
     },
 }
 
+# TODO rename without verbs
 CreateUserBody = Body(default=Required, title="Create user", description="The values to create a user.")
 PurgeUserBody = Body(default=None, title="Purge user", description="Purge the user.")
 UpdateUserBody = Body(default=Required, title="Update user", description="The user values to update.")
-# TODO ask if it is ok to set this to required
+# TODO make enum
 SetFavoriteBody = Body(
     default=Required, title="Set favorite", description="The id of an object the user wants to favorite."
 )
@@ -447,7 +448,7 @@ class FastAPIUsers:
     def update(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        user_id: DecodedDatabaseIdField = UserIdPathParamQueryParam,
+        user_id: FlexibleUserIdType = FlexibleUserIdPathParam,
         payload: Dict[Any, Any] = UpdateUserBody,
         deleted: Optional[bool] = UserDeletedQueryParam,
     ) -> DetailedUserModel:

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -43,7 +43,6 @@ from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     AnonUserModel,
     AsyncTaskResultSummary,
-    CreatedCustomBuild,
     CreatedUserModel,
     CustomBuildCreationPayload,
     CustomBuildsCollection,
@@ -431,7 +430,7 @@ class FastAPIUsers:
         trans: ProvidesUserContext = DependsOnTrans,
         user_id: DecodedDatabaseIdField = UserIdPathParamQueryParam,
         payload: CustomBuildCreationPayload = CustomBuildCreationBody,
-    ) -> CreatedCustomBuild:
+    ) -> Any:
         user = self.service.get_user(trans, user_id)
         dbkeys = json.loads(user.preferences["dbkeys"]) if "dbkeys" in user.preferences else {}
         name = payload.name

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -429,14 +429,9 @@ class FastAPIUsers:
         return self.service.get_index(trans=trans, deleted=deleted, f_email=f_email, f_name=f_name, f_any=f_any)
 
     @router.get(
-        "/api/users/current",
-        name="get_current_user",
-        description="Return information about the current user",
-    )
-    @router.get(
         "/api/users/{user_id}",
         name="get_user",
-        summary="Return information about a specified user. Only admin can see deleted or other users",
+        summary="Return information about a specified or the current user. Only admin can see deleted or other users",
     )
     def show(
         self,

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -278,23 +278,6 @@ class FastAPIUsers:
             trans.sa_session.commit()
         return theme
 
-    @expose_api
-    def set_theme(self, trans, id: str, theme: str, payload=None, **kwd) -> str:
-        """Sets the user's theme choice.
-        PUT /api/users/{id}/theme/{theme}
-
-        :param id: the encoded id of the user
-        :type  id: str
-        :param theme: the theme identifier/name that the user has selected as preference
-        :type  theme: str
-        """
-        payload = payload or {}
-        user = self._get_user(trans, id)
-        user.preferences["theme"] = theme
-        with transaction(trans.sa_session):
-            trans.sa_session.commit()
-        return theme
-
     @router.get(
         "/api/users/deleted/{user_id}",
         name="get_deleted_user",

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -504,7 +504,7 @@ class FastAPIUsers:
             user.preferences["dbkeys"] = json.dumps(dbkeys)
             with transaction(trans.sa_session):
                 trans.sa_session.commit()
-            return CreatedCustomBuild(**build_dict)
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @router.get(
         "/api/users/{user_id}/custom_builds", name="get_custom_builds", summary=" Returns collection of custom builds."

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -64,7 +64,6 @@ from galaxy.util import (
 )
 from galaxy.web import (
     expose_api,
-    expose_api_anonymous,
 )
 from galaxy.web.form_builder import AddressField
 from galaxy.webapps.base.controller import (
@@ -509,20 +508,6 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         user = self.get_user(trans, id)
         self.user_manager.undelete(user)
         return self.user_serializer.serialize_to_view(user, view="detailed")
-
-    # TODO: move to more basal, common resource than this
-    def anon_user_api_value(self, trans):
-        """Return data for an anonymous user, truncated to only usage and quota_percent"""
-        if not trans.user and not trans.history:
-            # Can't return info about this user, may not have a history yet.
-            return {}
-        usage = trans.app.quota_agent.get_usage(trans, history=trans.history)
-        percent = trans.app.quota_agent.get_percent(trans=trans, usage=usage)
-        return {
-            "total_disk_usage": int(usage),
-            "nice_total_disk_usage": util.nice_size(usage),
-            "quota_percent": percent,
-        }
 
     def _get_extra_user_preferences(self, trans):
         """

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -50,7 +50,6 @@ from galaxy.schema.schema import (
     DetailedUserModel,
     FlexibleUserIdType,
     UserBeaconSetting,
-    UserTheme,
 )
 from galaxy.security.validate_user_input import (
     validate_email,

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -398,7 +398,7 @@ class FastAPIUsers:
     ) -> DetailedUserModel:
         deleted = deleted or False
         current_user = trans.user
-        user_to_update = self.service.get_user_full(trans, user_id, deleted=deleted)
+        user_to_update = self.service.get_non_anonymous_user_full(trans, user_id, deleted=deleted)
         self.service.user_deserializer.deserialize(user_to_update, payload, user=current_user, trans=trans)
         return self.service.user_to_detailed_model(user_to_update)
 

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -83,7 +83,9 @@ router = Router(tags=["users"])
 
 ThemePathParam: str = Path(default=Required, title="Theme", description="The theme of the GUI")
 UserDeleted: bool = Query(default=None, title="Deleted user", description="Indicates if the user is deleted")
-UsersDeleted: bool = Query(default=False, title="Deleted users", description="Indicates if the collection will be about deleted users")
+UsersDeleted: bool = Query(
+    default=False, title="Deleted users", description="Indicates if the collection will be about deleted users"
+)
 FilterEmail: str = Query(default=None, title="Email filter", description="An email address to filter on")
 FilterName: str = Query(default=None, title="Name filter", description="An username address to filter on")
 FilterAny: str = Query(default=None, title="Any filter", description="Filter on username OR email")
@@ -150,9 +152,9 @@ class FastAPIUsers:
     def index_deleted(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
-        f_email: str = FilterEmail,
-        f_name: str = FilterName,
-        f_any: str = FilterAny,
+        f_email: Optional[str] = FilterEmail,
+        f_name: Optional[str] = FilterName,
+        f_any: Optional[str] = FilterAny,
     ) -> List[UserModel]:
         return self.service.get_index(trans=trans, deleted=True, f_email=f_email, f_name=f_name, f_any=f_any)
 
@@ -327,14 +329,18 @@ class FastAPIUsers:
             trans.sa_session.commit()
         return theme
 
-    @router.get("/api/users", name="get_users", description="Return a collection of users. Filters will only work if enabled in config or user is admin.")
+    @router.get(
+        "/api/users",
+        name="get_users",
+        description="Return a collection of users. Filters will only work if enabled in config or user is admin.",
+    )
     def index(
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         deleted: bool = UsersDeleted,
-        f_email: str = FilterEmail,
-        f_name: str = FilterName,
-        f_any: str = FilterAny,
+        f_email: Optional[str] = FilterEmail,
+        f_name: Optional[str] = FilterName,
+        f_any: Optional[str] = FilterAny,
     ) -> List[UserModel]:
         return self.service.get_index(trans=trans, deleted=deleted, f_email=f_email, f_name=f_name, f_any=f_any)
 
@@ -393,7 +399,9 @@ class FastAPIUsers:
         user_deleted = deleted or False
         return self.service.show_user(trans=trans, user_id=user_id, deleted=user_deleted)
 
-    @router.put("/api/users/{user_id}", name="update_user", summary="Update the values of a user. Only admin can update others.")
+    @router.put(
+        "/api/users/{user_id}", name="update_user", summary="Update the values of a user. Only admin can update others."
+    )
     def update(
         self,
         payload: Dict[Any, Any] = UpdateUserBody,

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -821,14 +821,6 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["PUT"]),
     )
 
-    webapp.mapper.connect(
-        "create_user",
-        "/api/users",
-        controller="users",
-        action="create",
-        conditions=dict(method=["POST"]),
-    )
-
     # ========================
     # ===== WEBHOOKS API =====
     # ========================

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -845,14 +845,6 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["DELETE"]),
     )
 
-    webapp.mapper.connect(
-        "remove_favorite_tool",
-        "/api/users/{id}/favorites/{object_type}/{object_id:.*?}",
-        controller="users",
-        action="remove_favorite",
-        conditions=dict(method=["DELETE"]),
-    )
-
     # ========================
     # ===== WEBHOOKS API =====
     # ========================

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -845,14 +845,6 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["PUT"]),
     )
 
-    webapp.mapper.connect(
-        "delete_custom_builds",
-        "/api/users/{id}/custom_builds/{key}",
-        controller="users",
-        action="delete_custom_builds",
-        conditions=dict(method=["DELETE"]),
-    )
-
     # ========================
     # ===== WEBHOOKS API =====
     # ========================

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -829,14 +829,6 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["POST"]),
     )
 
-    webapp.mapper.connect(
-        "add_custom_builds",
-        "/api/users/{id}/custom_builds/{key}",
-        controller="users",
-        action="add_custom_builds",
-        conditions=dict(method=["PUT"]),
-    )
-
     # ========================
     # ===== WEBHOOKS API =====
     # ========================

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -822,6 +822,14 @@ def populate_api_routes(webapp, app):
     )
 
     webapp.mapper.connect(
+        "create_user",
+        "/api/users",
+        controller="users",
+        action="create",
+        conditions=dict(method=["POST"]),
+    )
+
+    webapp.mapper.connect(
         "get_custom_builds",
         "/api/users/{id}/custom_builds",
         controller="users",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -830,14 +830,6 @@ def populate_api_routes(webapp, app):
     )
 
     webapp.mapper.connect(
-        "get_custom_builds",
-        "/api/users/{id}/custom_builds",
-        controller="users",
-        action="get_custom_builds",
-        conditions=dict(method=["GET"]),
-    )
-
-    webapp.mapper.connect(
         "add_custom_builds",
         "/api/users/{id}/custom_builds/{key}",
         controller="users",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -846,14 +846,6 @@ def populate_api_routes(webapp, app):
     )
 
     webapp.mapper.connect(
-        "set_favorite_tool",
-        "/api/users/{id}/favorites/{object_type}",
-        controller="users",
-        action="set_favorite",
-        conditions=dict(method=["PUT"]),
-    )
-
-    webapp.mapper.connect(
         "remove_favorite_tool",
         "/api/users/{id}/favorites/{object_type}/{object_id:.*?}",
         controller="users",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -571,7 +571,6 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["POST"]),
     )
 
-    webapp.mapper.resource_with_deleted("user", "users", path_prefix="/api")
     webapp.mapper.resource("visualization", "visualizations", path_prefix="/api")
     webapp.mapper.resource("plugins", "plugins", path_prefix="/api")
     webapp.mapper.connect("/api/workflows/build_module", action="build_module", controller="workflows")

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -862,14 +862,6 @@ def populate_api_routes(webapp, app):
         conditions=dict(method=["DELETE"]),
     )
 
-    webapp.mapper.connect(
-        "set_theme",
-        "/api/users/{id}/theme/{theme}",
-        controller="users",
-        action="set_theme",
-        conditions=dict(method=["PUT"]),
-    )
-
     # ========================
     # ===== WEBHOOKS API =====
     # ========================

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -255,11 +255,3 @@ class UsersService(ServiceBase):
             # TODO: move into api_values
             rval.append(item)
         return rval
-
-    def validate_favorite_object_type(self, object_type):
-        if object_type in ["tools"]:
-            pass
-        else:
-            raise glx_exceptions.ObjectAttributeInvalidException(
-                f"This type is not supported. Given object_type: {object_type}"
-            )

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -32,6 +32,7 @@ from galaxy.schema.schema import (
     AnonUserModel,
     DetailedUserModel,
     FlexibleUserIdType,
+    LimitedUserModel,
     UserModel,
 )
 from galaxy.security.idencoding import IdEncodingHelper
@@ -198,7 +199,7 @@ class UsersService(ServiceBase):
         f_email: Optional[str],
         f_name: Optional[str],
         f_any: Optional[str],
-    ) -> List[UserModel]:
+    ) -> List[Union[UserModel, LimitedUserModel]]:
         rval = []
         query = trans.sa_session.query(User)
 

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -128,6 +128,17 @@ class UsersService(ServiceBase):
             "quota_percent": percent,
         }
 
+    def get_non_anonymous_user_full(
+        self,
+        trans: ProvidesUserContext,
+        user_id: FlexibleUserIdType,
+        deleted: bool,
+    ) -> User:
+        user = self.get_user_full(trans, user_id, deleted)
+        if user is None:
+            raise glx_exceptions.AuthenticationRequired(err_msg="You need to be logged in.")
+        return user
+
     def get_user_full(
         self,
         trans: ProvidesUserContext,

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -195,9 +195,9 @@ class UsersService(ServiceBase):
         self,
         trans: ProvidesUserContext,
         deleted: bool,
-        f_email: str,
-        f_name: str,
-        f_any: str,
+        f_email: Optional[str],
+        f_name: Optional[str],
+        f_any: Optional[str],
     ) -> List[UserModel]:
         rval = []
         query = trans.sa_session.query(User)

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -62,28 +62,28 @@ class UsersService(ServiceBase):
 
     def get_api_key(self, trans: ProvidesUserContext, user_id: int) -> Optional[APIKeyModel]:
         """Returns the current API key or None if the user doesn't have any valid API key."""
-        user = self._get_user(trans, user_id)
+        user = self.get_user(trans, user_id)
         api_key = self.api_key_manager.get_api_key(user)
         return APIKeyModel.construct(key=api_key.key, create_time=api_key.create_time) if api_key else None
 
     def get_or_create_api_key(self, trans: ProvidesUserContext, user_id: int) -> str:
         """Returns the current API key (as plain string) or creates a new one."""
-        user = self._get_user(trans, user_id)
+        user = self.get_user(trans, user_id)
         return self.api_key_manager.get_or_create_api_key(user)
 
     def create_api_key(self, trans: ProvidesUserContext, user_id: int) -> APIKeyModel:
         """Creates a new API key for the given user"""
-        user = self._get_user(trans, user_id)
+        user = self.get_user(trans, user_id)
         api_key = self.api_key_manager.create_api_key(user)
         result = APIKeyModel.construct(key=api_key.key, create_time=api_key.create_time)
         return result
 
     def delete_api_key(self, trans: ProvidesUserContext, user_id: int) -> None:
         """Deletes a particular API key"""
-        user = self._get_user(trans, user_id)
+        user = self.get_user(trans, user_id)
         self.api_key_manager.delete_api_key(user)
 
-    def _get_user(self, trans: ProvidesUserContext, user_id):
+    def get_user(self, trans: ProvidesUserContext, user_id):
         user = trans.user
         if trans.anonymous or (user and user.id != user_id and not trans.user_is_admin):
             raise glx_exceptions.InsufficientPermissionsException("Access denied.")

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -1,20 +1,39 @@
-from typing import List, Optional, Union
+from typing import (
+    List,
+    Optional,
+    Union,
+)
 
-from sqlalchemy import false, true, or_
+from sqlalchemy import (
+    false,
+    or_,
+    true,
+)
 
-from galaxy import exceptions as glx_exceptions, util
+import galaxy.managers.base as managers_base
+from galaxy import (
+    exceptions as glx_exceptions,
+    util,
+)
 from galaxy.managers import api_keys
-from galaxy.managers.context import ProvidesHistoryContext, ProvidesUserContext
+from galaxy.managers.context import (
+    ProvidesHistoryContext,
+    ProvidesUserContext,
+)
 from galaxy.managers.users import (
+    UserDeserializer,
     UserManager,
     UserSerializer,
 )
-import galaxy.managers.base as managers_base
 from galaxy.model import User
 from galaxy.queue_worker import send_local_control_task
 from galaxy.schema import APIKeyModel
-
-from galaxy.schema.schema import AnonUserModel, DetailedUserModel, FlexibleUserIdType, UserModel
+from galaxy.schema.schema import (
+    AnonUserModel,
+    DetailedUserModel,
+    FlexibleUserIdType,
+    UserModel,
+)
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.webapps.galaxy.services.base import (
     async_task_summary,
@@ -35,11 +54,13 @@ class UsersService(ServiceBase):
         user_manager: UserManager,
         api_key_manager: api_keys.ApiKeyManager,
         user_serializer: UserSerializer,
+        user_deserializer: UserDeserializer,
     ):
         super().__init__(security)
         self.user_manager = user_manager
         self.api_key_manager = api_key_manager
         self.user_serializer = user_serializer
+        self.user_deserializer = user_deserializer
 
     def recalculate_disk_usage(
         self,

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -255,3 +255,11 @@ class UsersService(ServiceBase):
             # TODO: move into api_values
             rval.append(item)
         return rval
+
+    def validate_favorite_object_type(self, object_type):
+        if object_type in ["tools"]:
+            pass
+        else:
+            raise glx_exceptions.ObjectAttributeInvalidException(
+                f"This type is not supported. Given object_type: {object_type}"
+            )

--- a/lib/galaxy/webapps/galaxy/services/users.py
+++ b/lib/galaxy/webapps/galaxy/services/users.py
@@ -146,7 +146,13 @@ class UsersService(ServiceBase):
     ) -> Union[DetailedUserModel, AnonUserModel]:
         user = self.get_user_full(trans=trans, deleted=deleted, user_id=user_id)
         if user is not None:
-            user_response = self.user_serializer.serialize_to_view(user, view="detailed")
-            return DetailedUserModel(**user_response)
+            return self.user_to_detailed_model(user)
         anon_response = self._anon_user_api_value(trans)
         return AnonUserModel(**anon_response)
+
+    def user_to_detailed_model(
+        self,
+        user: User,
+    ) -> DetailedUserModel:
+        user_response = self.user_serializer.serialize_to_view(user, view="detailed")
+        return DetailedUserModel(**user_response)

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -237,6 +237,17 @@ class TestUsersApi(ApiTestCase):
         search_response = get(url).json()
         assert "cat1" in search_response
 
+    @requires_new_user
+    def test_set_theme(self):
+        user = self._setup_user(TEST_USER_EMAIL)
+        with self._different_user(email=TEST_USER_EMAIL):
+            url = self._api_url(f"users/{user['id']}/theme/test_theme")
+            theme_response = self._put(url)
+            self._assert_status_code_is_ok(theme_response)
+            url = self._api_url("users/current")
+            updated_theme = self._get(url).json()["preferences"]["theme"]
+            assert updated_theme == "test_theme"
+
     def __url(self, action, user):
         return self._api_url(f"users/{user['id']}/{action}", params=dict(key=self.master_api_key))
 

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -141,7 +141,7 @@ class TestUsersApi(ApiTestCase):
         response = self._get(url).json()
         assert response["username"] == "newname"
         assert response["email"] == "new@email.email"
-        payload = {"username": str(user["username"]), "email": TEST_USER_EMAIL}
+        payload = {"username": user["username"], "email": TEST_USER_EMAIL}
         self._put(url, data=payload, json=True)
         response = self._get(url).json()
         assert response["username"] == user["username"]

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -104,7 +104,7 @@ class TestUsersApi(ApiTestCase):
         response = self._delete(f"users/{user['id']}", admin=True)
         self._assert_status_code_is_ok(response)
         data = dict(purge="True")
-        response = self._delete(f"users/{user['id']}", data=data, admin=True)
+        response = self._delete(f"users/{user['id']}", data=data, admin=True, json=True)
         self._assert_status_code_is_ok(response)
         payload = {"deleted": "True"}
         purged_user = self._get(f"users/{user['id']}", payload, admin=True).json()

--- a/lib/tool_shed/webapp/app.py
+++ b/lib/tool_shed/webapp/app.py
@@ -80,7 +80,7 @@ class UniverseApplication(ToolShedApp, SentryClientMixin, HaltableContainer):
         self._register_singleton(SharedModelMapping, model)
         self._register_singleton(mapping.ToolShedModelMapping, model)
         self._register_singleton(scoped_session, self.model.context)
-        self.user_manager = self._register_singleton(UserManager, UserManager)
+        self.user_manager = self._register_singleton(UserManager, UserManager(self, app_type="tool_shed"))
         self.api_keys_manager = self._register_singleton(ApiKeyManager)
         # initialize the Tool Shed tag handler.
         self.tag_handler = CommunityTagHandler(self)


### PR DESCRIPTION
This is a part of #10889.

## Routes
- [x] Get
    - [x] `/api/users/{id}/custom_builds` --> `/api/users/{user_id}/custom_builds`
    - [x]  `/api/users/deleted` --> `/api/users/deleted`
    - [x] `/api/users/deleted/{id}` --> `/api/users/deleted/{user_id}` 
    - [x] `/api/users` --> `/api/users` 
    - [x] `/api/users/{id}` --> `/api/users/{user_id}` 
- [x] Put
    - [x] `/api/users/{id}/custom_builds/{key}` --> `/api/users/{user_id}/custom_builds/{key}`
    - [x] `/api/users/{id}/favorites/{object_type}` --> `/api/users/{user_id}/favorites/{object_type}`
    - [x] `/api/users/{id}/theme/{theme}` --> `/api/users/{user_id}/theme/{theme}` 
    - [x] `/api/users/{id}` --> `/api/users/{user_id}` 
- [x] Post
    - [x] `/api/users/deleted/{id}/undelete` -->  `/api/users/deleted/{user_id}/undelete`
    - [x] `/api/users`
- [x] Delete
    - [x]  `/api/users/{id}/custom_builds/{key}` --> `/api/users/{user_id}/custom_builds/{key}`
    - [x] `/api/users/{id}/favorites/{object_type}/{object_id}` --> `/api/users/{user_id}/favorites/{object_type}/{object_id}` 
    - [x]  `/api/users/{id}` --> `/api/users/{user_id}` 




## Summary
- [x] Add pydantic models
- [x]  Operations now return pydanctic models
- [x] Removed the mapping to the legacy route and add FastAPI routes


## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
    You can find the interactive API documentation here: [http://127.0.0.1:8080/api/docs#/users](url)

![Screenshot from 2023-06-29 17-28-51](https://github.com/galaxyproject/galaxy/assets/117033448/063b1607-2d52-4089-b868-467a2fd9997a)




## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).