### PR TITLE
[23.1] Make tags in public histories read-only

### DIFF
--- a/client/src/components/History/HistoryPublishedList.vue
+++ b/client/src/components/History/HistoryPublishedList.vue
@@ -35,7 +35,7 @@ const fields = [
     { key: "name", sortable: true },
     { key: "annotation", sortable: false },
     { label: "Owner", key: "username", sortable: false },
-    { label: "Community Tags", key: "tags", sortable: false },
+    { label: "Tags", key: "tags", sortable: false },
     { label: "Last Updated", key: "update_time", sortable: true },
 ];
 
@@ -210,7 +210,7 @@ watch([filterText, sortBy, sortDesc], () => {
                     <StatelessTags
                         clickable
                         :value="row.item.tags"
-                        :disabled="row.item.deleted"
+                        :disabled="true"
                         @input="(tags) => onTagsUpdate(tags, row)"
                         @tag-click="onTagClick" />
                 </template>


### PR DESCRIPTION
This is part of #16339 as a quick fix to avoid *free for all tagging* in public histories from the UI. It also makes the tags' functionality consistent with other lists or grids.

The underline issue of checking for item ownership when manipulating tags seems to be more involved and will be resolved or discussed in #16339

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Go to public histories and try to edit tags on public histories that you don't own.
  - It shouldn't be possible.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
