### PR TITLE
[23.0] Redact private role name and description when purging user

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -211,6 +211,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                 role.description = role.description.replace(user.email, email_hash)
             user.email = email_hash
             user.username = uname_hash
+            private_role.name = email_hash
+            private_role.description = f"Private Role for {email_hash}"
+            self.session().add(private_role)
         # Redact user addresses as well
         if self.app.config.redact_user_address_during_deletion:
             user_addresses = (


### PR DESCRIPTION
Fixes
```
UniqueViolation: duplicate key value violates unique constraint "ix_role_name"
DETAIL:  Key (name)=(email@example.com) already exists.

  File "sqlalchemy/engine/base.py", line 1905, in _execute_context
    self.dialect.do_execute(
  File "sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "ix_role_name"
DETAIL:  Key (name)=(email@example.com) already exists.

[SQL: INSERT INTO role (create_time, update_time, name, description, type, deleted) VALUES (%(create_time)s, %(update_time)s, %(name)s, %(description)s, %(type)s, %(deleted)s) RETURNING role.id]
[parameters: {'create_time': datetime.datetime(2023, 6, 28, 22, 15, 51,
947910), 'update_time': datetime.datetime(2023, 6, 28, 22, 15, 51,
947918), 'name': 'email@example.com', 'description': 'Private Role for
email@example.com', 'type': <types.PRIVATE: 'private'>, 'deleted': False}]
(Background on this error at: https://sqlalche.me/e/14/gkpj)
  File "galaxy/web/framework/decorators.py", line 337, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/controllers/user.py", line 142, in login
    return self.__validate_login(trans, payload, **kwd)
  File "galaxy/webapps/galaxy/controllers/user.py", line 199, in __validate_login
    trans.handle_user_login(user)
  File "galaxy/webapps/base/webapp.py", line 891, in handle_user_login
    self.app.security_agent.create_user_role(user, self.app)
  File "galaxy/model/security.py", line 738, in create_user_role
    self.get_private_user_role(user, auto_create=True)
  File "galaxy/model/security.py", line 765, in get_private_user_role
    return self.create_private_user_role(user)
  File "galaxy/model/security.py", line 748, in create_private_user_role
    user.attempt_create_private_role()
  File "galaxy/model/__init__.py", line 1105, in attempt_create_private_role
    with transaction(session):
  File "contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "galaxy/model/base.py", line 52, in transaction
    with session.begin():
  File "<string>", line 2, in begin
  File "sqlalchemy/util/deprecations.py", line 375, in warned
    return fn(*args, **kwargs)
  File "sqlalchemy/orm/session.py", line 1347, in begin
    trans = SessionTransaction(self, nested=nested)
  File "sqlalchemy/orm/session.py", line 545, in __init__
    self._take_snapshot(autobegin=autobegin)
  File "sqlalchemy/orm/session.py", line 662, in _take_snapshot
    self.session.flush()
  File "sqlalchemy/orm/session.py", line 3449, in flush
    self._flush(objects)
  File "sqlalchemy/orm/session.py", line 3589, in _flush
    transaction.rollback(_capture_exception=True)
  File "sqlalchemy/util/langhelpers.py", line 70, in __exit__
    compat.raise_(
  File "sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "sqlalchemy/orm/session.py", line 3549, in _flush
    flush_context.execute()
  File "sqlalchemy/orm/unitofwork.py", line 456, in execute
    rec.execute(self)
  File "sqlalchemy/orm/unitofwork.py", line 630, in execute
    util.preloaded.orm_persistence.save_obj(
  File "sqlalchemy/orm/persistence.py", line 245, in save_obj
    _emit_insert_statements(
  File "sqlalchemy/orm/persistence.py", line 1238, in _emit_insert_statements
    result = connection._execute_20(
  File "sqlalchemy/engine/base.py", line 1710, in _execute_20
    return meth(self, args_10style, kwargs_10style, execution_options)
  File "sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
    return connection._execute_clauseelement(
  File "sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
    ret = self._execute_context(
  File "sqlalchemy/engine/base.py", line 1948, in _execute_context
    self._handle_dbapi_exception(
  File "sqlalchemy/engine/base.py", line 2129, in _handle_dbapi_exception
    util.raise_(
  File "sqlalchemy/util/compat.py", line 211, in raise_
    raise exception
  File "sqlalchemy/engine/base.py", line 1905, in _execute_context
    self.dialect.do_execute(
  File "sqlalchemy/engine/default.py", line 736, in do_execute
    cursor.execute(statement, parameters)
```

when a user attempts to login after they previously purged their account.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Set allow_user_deletion to true.
Purge a user from the admin panel. check that the users' role doesn't contain the email address:
`select name from role where role.name = 'email@example.com';`. Create a new user and be able to log in.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
