### PR TITLE
[23.0] Don't attempt to call a bool when using mem-self handler assignment.

### DIFF
--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -335,7 +335,7 @@ class ConfiguresHandlers:
                 HANDLER_ASSIGNMENT_METHODS.MEM_SELF,
                 configured,
             )
-        if flush():
+        if flush:
             _timed_flush_obj(obj)
         queue_callback()
         return self.app.config.server_name


### PR DESCRIPTION
## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Set `assign: ['mem-self']` in job conf.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
