### PR TITLE
[23.0] Fix active step display in workflow editor side panel

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -643,27 +643,25 @@ export default {
                 this.isCanvas = true;
                 return;
             }
-            const stepData = {
-                name: name,
-                content_id: contentId,
-                input_connections: {},
-                type: type,
-                outputs: [],
-                position: defaultPosition(this.graphOffset, this.transform),
-                post_job_actions: {},
-            };
-            const { id } = this.stepStore.addStep(stepData);
-            getModule(stepData, id, this.stateStore.setLoadingState).then((response) => {
-                this.stepStore.updateStep({
-                    ...stepData,
-                    id: id,
-                    tool_state: response.tool_state,
-                    inputs: response.inputs,
-                    outputs: response.outputs,
-                    config_form: response.config_form,
-                });
-                this.stateStore.setActiveNode(id);
-            });
+            const stepData = this.stepStore.insertNewStep(
+                contentId,
+                name,
+                type,
+                defaultPosition(this.graphOffset, this.transform)
+            );
+
+            getModule({ name, type, content_id: contentId }, stepData.id, this.stateStore.setLoadingState).then(
+                (response) => {
+                    this.stepStore.updateStep({
+                        ...stepData,
+                        tool_state: response.tool_state,
+                        inputs: response.inputs,
+                        outputs: response.outputs,
+                        config_form: response.config_form,
+                    });
+                    this.stateStore.setActiveNode(stepData.id);
+                }
+            );
         },
         async _loadEditorData(data) {
             if (data.name !== undefined) {

--- a/client/src/components/Workflow/Editor/composables/useStepProps.ts
+++ b/client/src/components/Workflow/Editor/composables/useStepProps.ts
@@ -11,12 +11,12 @@ export function useStepProps(step: Ref<Step>) {
         type,
         inputs: stepInputs,
         outputs: stepOutputs,
-        config_form: configForm,
         post_job_actions: postJobActions,
     } = toRefs(step);
 
     const label = computed(() => step.value.label ?? undefined);
     const annotation = computed(() => step.value.annotation ?? null);
+    const configForm = computed(() => step.value.config_form);
 
     return {
         stepId,

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -190,6 +190,25 @@ export const useWorkflowStepStore = defineStore("workflowStepStore", {
             this.stepExtraInputs[step.id] = getStepExtraInputs(step);
             return step;
         },
+        insertNewStep(
+            contentId: NewStep["content_id"],
+            name: NewStep["name"],
+            type: NewStep["type"],
+            position: NewStep["position"]
+        ) {
+            const stepData: NewStep = {
+                name: name,
+                content_id: contentId,
+                input_connections: {},
+                type: type,
+                inputs: [],
+                outputs: [],
+                position: position,
+                post_job_actions: {},
+                tool_state: {},
+            };
+            return this.addStep(stepData);
+        },
         updateStep(this: State, step: Step) {
             const workflow_outputs = step.workflow_outputs?.filter((workflowOutput) =>
                 step.outputs.find((output) => workflowOutput.output_name == output.name)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -574,6 +574,7 @@ class WorkflowsAPIController(
         POST /api/workflows/build_module
         Builds module models for the workflow editor.
         """
+        # payload is tool state
         if payload is None:
             payload = {}
         inputs = payload.get("inputs", {})
@@ -584,8 +585,6 @@ class WorkflowsAPIController(
             populate_state(trans, module.get_inputs(), inputs, module_state, check=False)
             module.recover_state(module_state, from_tool_form=True)
         return {
-            "label": inputs.get("__label", ""),
-            "annotation": inputs.get("__annotation", ""),
             "name": module.get_name(),
             "tool_state": module.get_state(),
             "content_id": module.get_content_id(),


### PR DESCRIPTION
The minimal fix is the switch from `toRefs` to the computed property for
configForm. I think that is because when we inserted a minimal new step
we didn't include the `config_form` key, and so the later addition
wasn't reactive ? Not exactly sure that is the right explanation.

In any case the extended fix creates valid object that satisfies the
`NewStep` interface, and drop the label and annotation handling, which
does not happen in the tool state inputs.

Fixes this:

![insert new step bug](https://github.com/galaxyproject/galaxy/assets/6804901/50e5be2c-5501-4f23-b86c-4aa168d5de21)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
