### PR TITLE
[23.1] Fix invocation progress bar for skipped and deleted jobs

### DIFF
--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -5,7 +5,7 @@
         <table id="job-information" class="tabletip info_data_table">
             <tbody>
                 <tr v-if="job && job.tool_id">
-                    <td>Galaxy Tool ID:</td>
+                    <td>Galaxy Tool ID</td>
                     <td id="galaxy-tool-id">
                         {{ job.tool_id }}
                         <copy-to-clipboard
@@ -14,8 +14,12 @@
                             title="Copy Tool ID" />
                     </td>
                 </tr>
+                <tr v-if="job && job.state">
+                    <td>Job State</td>
+                    <td data-description="galaxy-job-state">{{ job.state }}</td>
+                </tr>
                 <tr v-if="job && job.tool_version">
-                    <td>Galaxy Tool Version:</td>
+                    <td>Galaxy Tool Version</td>
                     <td id="galaxy-tool-version">{{ job.tool_version }}</td>
                 </tr>
                 <tr v-if="job && includeTimes">
@@ -45,7 +49,7 @@
                     :code-label="'Unexpected Job Errors'"
                     :code-item="job.traceback" />
                 <tr v-if="job">
-                    <td>Tool Exit Code:</td>
+                    <td>Tool Exit Code</td>
                     <td id="exit-code">{{ job.exit_code }}</td>
                 </tr>
                 <tr v-if="job && job.job_messages && job.job_messages.length > 0" id="job-messages">
@@ -58,11 +62,11 @@
                 </tr>
                 <slot></slot>
                 <tr v-if="job && job.id">
-                    <td>Job API ID:</td>
+                    <td>Job API ID</td>
                     <td id="encoded-job-id">{{ job.id }} <decoded-id :id="job.id" /></td>
                 </tr>
                 <tr v-if="job && job.copied_from_job_id">
-                    <td>Copied from Job API ID:</td>
+                    <td>Copied from Job API ID</td>
                     <td id="encoded-copied-from-job-id">
                         {{ job.copied_from_job_id }} <decoded-id :id="job.copied_from_job_id" />
                     </td>

--- a/client/src/components/JobStates/mixin.js
+++ b/client/src/components/JobStates/mixin.js
@@ -24,10 +24,10 @@ export default {
             return this.countStates(["running"]);
         },
         okCount() {
-            return this.countStates(["ok"]);
+            return this.countStates(["ok", "skipped"]);
         },
         errorCount() {
-            return this.countStates(["error"]);
+            return this.countStates(["error", "deleted"]);
         },
         newCount() {
             return this.jobCount - this.okCount - this.runningCount - this.errorCount;

--- a/client/src/utils/job-states-model.js
+++ b/client/src/utils/job-states-model.js
@@ -6,7 +6,7 @@ import AJAX_QUEUE from "utils/ajax-queue";
 var UPDATE_DELAY = 2000;
 var NON_TERMINAL_STATES = ["new", "queued", "running", "waiting"];
 var ERROR_STATES = ["error", "deleted"];
-var TERMINAL_STATES = ["ok"].concat(ERROR_STATES);
+var TERMINAL_STATES = ["ok", "skipped"].concat(ERROR_STATES);
 const POPULATED_STATE_FAILED = "failed";
 /** Fetch state on add or just wait for polling to start. */
 var FETCH_STATE_ON_ADD = false;


### PR DESCRIPTION
Skipped and deleted jobs would previously appear as running. It sure would be a good idea to
sync the item states and their categorization with the backend schema,
which would have caught these issues. We also seem to have at least two
independent job state classes / mixins / objects, there's surely room
for improvement.

Bonus commit drops inconsistent colons from the job info page and include the job state.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
