### PR TITLE
[23.0] Fix display of named tags in mako

### DIFF
--- a/templates/tagging_common.mako
+++ b/templates/tagging_common.mako
@@ -33,13 +33,7 @@ from markupsafe import escape
         tagged_item_id = str( trans.security.encode_id ( tagged_item.id ) )
         controller_name = get_controller_name(tagged_item)
         click_url = h.url_for( controller='/' + modern_route_for_controller(controller_name) , action='list_published')
-        community_tags = trans.app.tag_handler.get_community_tags( item=tagged_item, limit=5 )
-
-        ## Having trouble converting list of tags into a plain array, this just
-        ## just plucks out the name
-        community_tag_names = []
-        for tag in community_tags:
-            community_tag_names.append(escape(tag.name))
+        community_tag_names = community_tags = tagged_item.make_tag_string_list()
     %>
     
     <div id="tags-community-${controller_name}-${tagged_item_id}"></div>


### PR DESCRIPTION
Fixes #16343

This seems to be apparently broken for a long time. In 23.1 we are replacing most of the published item listings with Vue components that are already fixed, but I think is worth fixing at least in 23.0 while we migrate the rest of them. I can backport the fix to older versions if necessary.

## Before
![image](https://github.com/galaxyproject/galaxy/assets/46503462/39595c0f-e032-4eda-80cc-c9c1b07c4784)


## After

![image](https://github.com/galaxyproject/galaxy/assets/46503462/17b49669-6e88-4ac3-b575-3a305ff1bc39)


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Add some named tags (#hash tags) to a workflow and publish it
  - Go to Shared Data -> Workflows
  - Observe that instead of `name` the correct `#whatever` tag is displayed in your workflow

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
