### PR TITLE
[23.1] Fix workflow invocation detail reactivity

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationDetails.vue
@@ -1,8 +1,8 @@
-<script setup>
+<script setup lang="ts">
 import { useWorkflowInstance } from "@/composables/useWorkflowInstance";
-import ParameterStep from "./ParameterStep";
-import GenericHistoryItem from "components/History/Content/GenericItem";
-import WorkflowInvocationStep from "./WorkflowInvocationStep";
+import ParameterStep from "./ParameterStep.vue";
+import GenericHistoryItem from "components/History/Content/GenericItem.vue";
+import WorkflowInvocationStep from "./WorkflowInvocationStep.vue";
 
 const props = defineProps({
     invocation: {
@@ -11,9 +11,13 @@ const props = defineProps({
     },
 });
 
+interface HasSrc {
+    src: string;
+}
+
 const { workflow } = useWorkflowInstance(props.invocation.workflow_id);
 
-function dataInputStepLabel(key, input) {
+function dataInputStepLabel(key: number, input: HasSrc) {
     const invocationStep = props.invocation.steps[key];
     let label = invocationStep && invocationStep.workflow_step_label;
     if (!label) {

--- a/client/src/composables/useWorkflowInstance.ts
+++ b/client/src/composables/useWorkflowInstance.ts
@@ -1,9 +1,9 @@
 import { useWorkflowStore } from "@/stores/workflowStore";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 export function useWorkflowInstance(workflowId: string) {
     const workflowStore = useWorkflowStore();
-    const workflow = ref(workflowStore.getStoredWorkflowByInstanceId(workflowId));
+    const workflow = computed(() => workflowStore.getStoredWorkflowByInstanceId(workflowId));
     const loading = ref(false);
 
     async function getWorkflowInstance() {

--- a/client/src/composables/useWorkflowInstance.ts
+++ b/client/src/composables/useWorkflowInstance.ts
@@ -12,8 +12,9 @@ export function useWorkflowInstance(workflowId: string) {
             try {
                 await workflowStore.fetchWorkflowForInstanceId(workflowId);
             } catch (e) {
-                loading.value = false;
                 console.error("unable to fetch workflow \n", e);
+            } finally {
+                loading.value = false;
             }
         }
     }


### PR DESCRIPTION
If you run a workflow from the submission screen without first populating the store by loading workflow instances through the invocation menu you would notice that the "steps" tabs panel is missing (to  reproduce click "Run" from the workflow editor). I think the computed ensures a that the store return value is tracked as a reactive dependency (as opposed to using the ref alone), but would appreciate confirmation that that is indeed what fixes the bug.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
