### PR TITLE
Replace Persistedstate Pinia Plugin with User-Scoped Composable

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -76,7 +76,6 @@
     "openapi-typescript": "^6.1.0",
     "openapi-typescript-fetch": "^1.1.3",
     "pinia": "^2.0.36",
-    "pinia-plugin-persistedstate": "^2.4.0",
     "popper.js": "^1.16.1",
     "pretty-bytes": "^6.0.0",
     "pyre-to-regexp": "^0.0.5",

--- a/client/src/composables/__mocks__/userLocalStorage.ts
+++ b/client/src/composables/__mocks__/userLocalStorage.ts
@@ -1,0 +1,6 @@
+import { ref } from "vue";
+
+// set to always mock in jest.setup.js
+export function useUserLocalStorage<T>(_key: string, initialValue: T) {
+    return ref(initialValue);
+}

--- a/client/src/entry/analysis/index.ts
+++ b/client/src/entry/analysis/index.ts
@@ -1,5 +1,4 @@
 import { createPinia, PiniaVuePlugin } from "pinia";
-import piniaPluginPersistedstate from "pinia-plugin-persistedstate";
 import Vue, { provide } from "vue";
 
 import { addInitialization, standardInit } from "@/onload";
@@ -11,7 +10,6 @@ import App from "./App.vue";
 
 Vue.use(PiniaVuePlugin);
 const pinia = createPinia();
-pinia.use(piniaPluginPersistedstate);
 
 addInitialization((Galaxy: any) => {
     console.log("App setup");

--- a/client/src/stores/activityStore.ts
+++ b/client/src/stores/activityStore.ts
@@ -3,7 +3,9 @@
  */
 
 import { defineStore } from "pinia";
-import { type Ref, ref } from "vue";
+import { type Ref } from "vue";
+
+import { useUserLocalStorage } from "@/composables/userLocalStorage";
 
 import { Activities } from "./activitySetup";
 
@@ -19,80 +21,72 @@ export interface Activity {
     visible: boolean;
 }
 
-export const useActivityStore = defineStore(
-    "activityStore",
-    () => {
-        const activities: Ref<Array<Activity>> = ref([]);
+export const useActivityStore = defineStore("activityStore", () => {
+    const activities: Ref<Array<Activity>> = useUserLocalStorage("activity-store-activities", []);
 
-        /**
-         * The set of built-in activities is defined in activitySetup.js.
-         * This helper function applies changes of the built-in activities,
-         * to the user stored activities which are persisted in local cache.
-         */
-        function sync() {
-            // create a map of built-in activities
-            const activitiesMap: Record<string, Activity> = {};
-            Activities.forEach((a) => {
-                activitiesMap[a.id] = a;
-            });
-            // create an updated array of activities
-            const newActivities: Array<Activity> = [];
-            const foundActivity = new Set();
-            activities.value.forEach((a: Activity) => {
-                if (a.mutable) {
-                    // existing custom activity
-                    newActivities.push({ ...a });
-                } else {
-                    // update existing built-in activity attributes
-                    // skip legacy built-in activities
-                    const sourceActivity = activitiesMap[a.id];
-                    if (sourceActivity) {
-                        foundActivity.add(a.id);
-                        newActivities.push({
-                            ...sourceActivity,
-                            visible: a.visible,
-                        });
-                    }
+    /**
+     * The set of built-in activities is defined in activitySetup.js.
+     * This helper function applies changes of the built-in activities,
+     * to the user stored activities which are persisted in local cache.
+     */
+    function sync() {
+        // create a map of built-in activities
+        const activitiesMap: Record<string, Activity> = {};
+        Activities.forEach((a) => {
+            activitiesMap[a.id] = a;
+        });
+        // create an updated array of activities
+        const newActivities: Array<Activity> = [];
+        const foundActivity = new Set();
+        activities.value.forEach((a: Activity) => {
+            if (a.mutable) {
+                // existing custom activity
+                newActivities.push({ ...a });
+            } else {
+                // update existing built-in activity attributes
+                // skip legacy built-in activities
+                const sourceActivity = activitiesMap[a.id];
+                if (sourceActivity) {
+                    foundActivity.add(a.id);
+                    newActivities.push({
+                        ...sourceActivity,
+                        visible: a.visible,
+                    });
                 }
-            });
-            // add new built-in activities
-            Activities.forEach((a) => {
-                if (!foundActivity.has(a.id)) {
-                    newActivities.push({ ...a });
-                }
-            });
-            // update activities stored in local cache only if changes were applied
-            if (JSON.stringify(activities.value) !== JSON.stringify(newActivities)) {
-                activities.value = newActivities;
             }
-        }
-
-        function getAll() {
-            return activities.value;
-        }
-
-        function setAll(newActivities: Array<Activity>) {
+        });
+        // add new built-in activities
+        Activities.forEach((a) => {
+            if (!foundActivity.has(a.id)) {
+                newActivities.push({ ...a });
+            }
+        });
+        // update activities stored in local cache only if changes were applied
+        if (JSON.stringify(activities.value) !== JSON.stringify(newActivities)) {
             activities.value = newActivities;
         }
-
-        function remove(activityId: string) {
-            const findIndex = activities.value.findIndex((a: Activity) => a.id === activityId);
-            if (findIndex !== -1) {
-                activities.value.splice(findIndex, 1);
-            }
-        }
-
-        return {
-            activities,
-            getAll,
-            remove,
-            setAll,
-            sync,
-        };
-    },
-    {
-        persist: {
-            paths: ["activities"],
-        },
     }
-);
+
+    function getAll() {
+        return activities.value;
+    }
+
+    function setAll(newActivities: Array<Activity>) {
+        activities.value = newActivities;
+    }
+
+    function remove(activityId: string) {
+        const findIndex = activities.value.findIndex((a: Activity) => a.id === activityId);
+        if (findIndex !== -1) {
+            activities.value.splice(findIndex, 1);
+        }
+    }
+
+    return {
+        activities,
+        getAll,
+        remove,
+        setAll,
+        sync,
+    };
+});

--- a/client/src/stores/broadcastsStore.ts
+++ b/client/src/stores/broadcastsStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import Vue, { computed, ref } from "vue";
 
+import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import type { components } from "@/schema";
 import { loadBroadcastsFromServer } from "@/stores/services/broadcasts.service";
 import { mergeObjectListsById } from "@/utils/utils";
@@ -8,71 +9,63 @@ import { mergeObjectListsById } from "@/utils/utils";
 export type BroadcastNotification = components["schemas"]["BroadcastNotificationResponse"];
 type Expirable = Pick<BroadcastNotification, "expiration_time">;
 
-export const useBroadcastsStore = defineStore(
-    "broadcastsStore",
-    () => {
-        const broadcasts = ref<BroadcastNotification[]>([]);
+export const useBroadcastsStore = defineStore("broadcastsStore", () => {
+    const broadcasts = ref<BroadcastNotification[]>([]);
 
-        const loadingBroadcasts = ref<boolean>(false);
-        const dismissedBroadcasts = ref<{ [key: string]: Expirable }>({});
+    const loadingBroadcasts = ref<boolean>(false);
+    const dismissedBroadcasts = useUserLocalStorage<{ [key: string]: Expirable }>("dismissed-broadcasts", {});
 
-        const activeBroadcasts = computed(() => {
-            return broadcasts.value.filter((b) => !dismissedBroadcasts.value[b.id]);
-        });
+    const activeBroadcasts = computed(() => {
+        return broadcasts.value.filter((b) => !dismissedBroadcasts.value[b.id]);
+    });
 
-        async function loadBroadcasts() {
-            loadingBroadcasts.value = true;
-            await loadBroadcastsFromServer()
-                .then((data) => {
-                    broadcasts.value = mergeObjectListsById(data, [], "create_time", "desc");
-                })
-                .finally(() => {
-                    loadingBroadcasts.value = false;
-                });
-        }
-
-        function updateBroadcasts(broadcastList: BroadcastNotification[]) {
-            broadcasts.value = mergeObjectListsById(broadcasts.value, broadcastList, "create_time", "desc").filter(
-                (b) => !hasExpired(b.expiration_time)
-            );
-        }
-
-        function dismissBroadcast(broadcast: BroadcastNotification) {
-            Vue.set(dismissedBroadcasts.value, broadcast.id, { expiration_time: broadcast.expiration_time });
-        }
-
-        function hasExpired(expirationTimeStr?: string) {
-            if (!expirationTimeStr) {
-                return false;
-            }
-            const expirationTime = new Date(`${expirationTimeStr}Z`);
-            const now = new Date();
-            return now > expirationTime;
-        }
-
-        function clearExpiredDismissedBroadcasts() {
-            for (const key in dismissedBroadcasts.value) {
-                if (hasExpired(dismissedBroadcasts.value[key]?.expiration_time)) {
-                    delete dismissedBroadcasts.value[key];
-                }
-            }
-        }
-
-        clearExpiredDismissedBroadcasts();
-
-        return {
-            broadcasts,
-            dismissedBroadcasts,
-            loadingBroadcasts,
-            activeBroadcasts,
-            dismissBroadcast,
-            loadBroadcasts,
-            updateBroadcasts,
-        };
-    },
-    {
-        persist: {
-            paths: ["dismissedBroadcasts"],
-        },
+    async function loadBroadcasts() {
+        loadingBroadcasts.value = true;
+        await loadBroadcastsFromServer()
+            .then((data) => {
+                broadcasts.value = mergeObjectListsById(data, [], "create_time", "desc");
+            })
+            .finally(() => {
+                loadingBroadcasts.value = false;
+            });
     }
-);
+
+    function updateBroadcasts(broadcastList: BroadcastNotification[]) {
+        broadcasts.value = mergeObjectListsById(broadcasts.value, broadcastList, "create_time", "desc").filter(
+            (b) => !hasExpired(b.expiration_time)
+        );
+    }
+
+    function dismissBroadcast(broadcast: BroadcastNotification) {
+        Vue.set(dismissedBroadcasts.value, broadcast.id, { expiration_time: broadcast.expiration_time });
+    }
+
+    function hasExpired(expirationTimeStr?: string) {
+        if (!expirationTimeStr) {
+            return false;
+        }
+        const expirationTime = new Date(`${expirationTimeStr}Z`);
+        const now = new Date();
+        return now > expirationTime;
+    }
+
+    function clearExpiredDismissedBroadcasts() {
+        for (const key in dismissedBroadcasts.value) {
+            if (hasExpired(dismissedBroadcasts.value[key]?.expiration_time)) {
+                delete dismissedBroadcasts.value[key];
+            }
+        }
+    }
+
+    clearExpiredDismissedBroadcasts();
+
+    return {
+        broadcasts,
+        dismissedBroadcasts,
+        loadingBroadcasts,
+        activeBroadcasts,
+        dismissBroadcast,
+        loadBroadcasts,
+        updateBroadcasts,
+    };
+});

--- a/client/src/stores/userFlagsStore.ts
+++ b/client/src/stores/userFlagsStore.ts
@@ -1,21 +1,16 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
 
-export const useUserFlagsStore = defineStore(
-    "userFlagsStore",
-    () => {
-        const showSelectionQueryBreakWarning = ref(true);
+import { useUserLocalStorage } from "@/composables/userLocalStorage";
 
-        function ignoreSelectionQueryBreakWarning() {
-            showSelectionQueryBreakWarning.value = false;
-        }
+export const useUserFlagsStore = defineStore("userFlagsStore", () => {
+    const showSelectionQueryBreakWarning = useUserLocalStorage("user-flags-store-show-break-warning", true);
 
-        return {
-            showSelectionQueryBreakWarning,
-            ignoreSelectionQueryBreakWarning,
-        };
-    },
-    {
-        persist: true,
+    function ignoreSelectionQueryBreakWarning() {
+        showSelectionQueryBreakWarning.value = false;
     }
-);
+
+    return {
+        showSelectionQueryBreakWarning,
+        ignoreSelectionQueryBreakWarning,
+    };
+});

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
+import { useUserLocalStorage } from "@/composables/userLocalStorage";
 import { useHistoryStore } from "@/stores/historyStore";
 import {
     addFavoriteToolQuery,
@@ -20,120 +21,110 @@ interface Preferences {
     favorites: { tools: string[] };
 }
 
-export const useUserStore = defineStore(
-    "userStore",
-    () => {
-        const toggledSideBar = ref("tools");
-        const showActivityBar = ref(false);
-        const currentUser = ref<User | null>(null);
-        const currentPreferences = ref<Preferences | null>(null);
+export const useUserStore = defineStore("userStore", () => {
+    const toggledSideBar = useUserLocalStorage("user-store-toggled-side-bar", "tools");
+    const showActivityBar = useUserLocalStorage("user-store-show-activity-bar", false);
+    const currentUser = ref<User | null>(null);
+    const currentPreferences = ref<Preferences | null>(null);
 
-        let loadPromise: Promise<void> | null = null;
+    let loadPromise: Promise<void> | null = null;
 
-        const isAnonymous = computed(() => {
-            return !currentUser.value?.email;
-        });
+    const isAnonymous = computed(() => {
+        return !currentUser.value?.email;
+    });
 
-        const currentTheme = computed(() => {
-            return currentPreferences.value?.theme ?? null;
-        });
+    const currentTheme = computed(() => {
+        return currentPreferences.value?.theme ?? null;
+    });
 
-        const currentFavorites = computed(() => {
-            if (currentPreferences.value?.favorites) {
-                return currentPreferences.value.favorites;
-            } else {
-                return { tools: [] };
-            }
-        });
-
-        function setCurrentUser(user: User) {
-            currentUser.value = user;
+    const currentFavorites = computed(() => {
+        if (currentPreferences.value?.favorites) {
+            return currentPreferences.value.favorites;
+        } else {
+            return { tools: [] };
         }
+    });
 
-        function loadUser() {
-            if (!loadPromise) {
-                loadPromise = getCurrentUser()
-                    .then(async (user) => {
-                        const historyStore = useHistoryStore();
-                        currentUser.value = { ...user, isAnonymous: !user.email };
-                        currentPreferences.value = user?.preferences ?? null;
-                        // TODO: This is a hack to get around the fact that the API returns a string
-                        if (currentPreferences.value?.favorites) {
-                            currentPreferences.value.favorites = JSON.parse(
-                                user?.preferences?.favorites ?? { tools: [] }
-                            );
-                        }
-                        await historyStore.loadCurrentHistory();
-                        // load first few histories for user to start pagination
-                        await historyStore.loadHistories();
-                    })
-                    .catch((e) => {
-                        console.error("Failed to load user", e);
-                    })
-                    .finally(() => {
-                        loadPromise = null;
-                    });
-            }
-        }
-
-        async function setCurrentTheme(theme: string) {
-            if (!currentUser.value) {
-                return;
-            }
-            const currentTheme = await setCurrentThemeQuery(currentUser.value.id, theme);
-            if (currentPreferences.value) {
-                currentPreferences.value.theme = currentTheme;
-            }
-        }
-        async function addFavoriteTool(toolId: string) {
-            if (!currentUser.value) {
-                return;
-            }
-            const tools = await addFavoriteToolQuery(currentUser.value.id, toolId);
-            setFavoriteTools(tools);
-        }
-
-        async function removeFavoriteTool(toolId: string) {
-            if (!currentUser.value) {
-                return;
-            }
-            const tools = await removeFavoriteToolQuery(currentUser.value.id, toolId);
-            setFavoriteTools(tools);
-        }
-
-        function setFavoriteTools(tools: string[]) {
-            if (currentPreferences.value) {
-                currentPreferences.value.favorites.tools = tools ?? { tools: [] };
-            }
-        }
-
-        function toggleActivityBar() {
-            showActivityBar.value = !showActivityBar.value;
-        }
-        function toggleSideBar(currentOpen = "") {
-            toggledSideBar.value = toggledSideBar.value === currentOpen ? "" : currentOpen;
-        }
-
-        return {
-            currentUser,
-            currentPreferences,
-            isAnonymous,
-            currentTheme,
-            currentFavorites,
-            showActivityBar,
-            toggledSideBar,
-            loadUser,
-            setCurrentUser,
-            setCurrentTheme,
-            addFavoriteTool,
-            removeFavoriteTool,
-            toggleActivityBar,
-            toggleSideBar,
-        };
-    },
-    {
-        persist: {
-            paths: ["showActivityBar", "toggledSideBar"],
-        },
+    function setCurrentUser(user: User) {
+        currentUser.value = user;
     }
-);
+
+    function loadUser() {
+        if (!loadPromise) {
+            loadPromise = getCurrentUser()
+                .then(async (user) => {
+                    const historyStore = useHistoryStore();
+                    currentUser.value = { ...user, isAnonymous: !user.email };
+                    currentPreferences.value = user?.preferences ?? null;
+                    // TODO: This is a hack to get around the fact that the API returns a string
+                    if (currentPreferences.value?.favorites) {
+                        currentPreferences.value.favorites = JSON.parse(user?.preferences?.favorites ?? { tools: [] });
+                    }
+                    await historyStore.loadCurrentHistory();
+                    // load first few histories for user to start pagination
+                    await historyStore.loadHistories();
+                })
+                .catch((e) => {
+                    console.error("Failed to load user", e);
+                })
+                .finally(() => {
+                    loadPromise = null;
+                });
+        }
+    }
+
+    async function setCurrentTheme(theme: string) {
+        if (!currentUser.value) {
+            return;
+        }
+        const currentTheme = await setCurrentThemeQuery(currentUser.value.id, theme);
+        if (currentPreferences.value) {
+            currentPreferences.value.theme = currentTheme;
+        }
+    }
+    async function addFavoriteTool(toolId: string) {
+        if (!currentUser.value) {
+            return;
+        }
+        const tools = await addFavoriteToolQuery(currentUser.value.id, toolId);
+        setFavoriteTools(tools);
+    }
+
+    async function removeFavoriteTool(toolId: string) {
+        if (!currentUser.value) {
+            return;
+        }
+        const tools = await removeFavoriteToolQuery(currentUser.value.id, toolId);
+        setFavoriteTools(tools);
+    }
+
+    function setFavoriteTools(tools: string[]) {
+        if (currentPreferences.value) {
+            currentPreferences.value.favorites.tools = tools ?? { tools: [] };
+        }
+    }
+
+    function toggleActivityBar() {
+        showActivityBar.value = !showActivityBar.value;
+    }
+    function toggleSideBar(currentOpen = "") {
+        toggledSideBar.value = toggledSideBar.value === currentOpen ? "" : currentOpen;
+    }
+
+    return {
+        currentUser,
+        currentPreferences,
+        isAnonymous,
+        currentTheme,
+        currentFavorites,
+        showActivityBar,
+        toggledSideBar,
+        loadUser,
+        setCurrentUser,
+        setCurrentTheme,
+        addFavoriteTool,
+        removeFavoriteTool,
+        toggleActivityBar,
+        toggleSideBar,
+    };
+});

--- a/client/tests/jest/jest.setup.js
+++ b/client/tests/jest/jest.setup.js
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom";
+
 import Vue from "vue";
 
 // Set Vue to suppress production / devtools / etc. warnings
@@ -12,3 +13,4 @@ global.setImmediate = global.setTimeout;
 
 // Always mock the following imports
 jest.mock("@/composables/hashedUserId");
+jest.mock("@/composables/userLocalStorage");

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9092,11 +9092,6 @@ pikaday@1.5.1:
   optionalDependencies:
     moment "2.x"
 
-pinia-plugin-persistedstate@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/pinia-plugin-persistedstate/-/pinia-plugin-persistedstate-2.4.0.tgz#fda569b3c397517a0cf8aba83a628283767da620"
-  integrity sha512-bQcpv47jk3ISl+InuJWsFaS/K7pRZ97kfoD2WCf/suhnlLy48k3BnFM2tI6YZ1xMsDaPv4yOsaPuPAUuSmEO2Q==
-
 pinia@^2.0.36:
   version "2.0.36"
   resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.0.36.tgz#65130f3b94cc7fe25156308634010fab893dff24"


### PR DESCRIPTION
The persisted state pinia plugin makes it easy to save store values in the browsers local storage. Unfortunately for our use-case it comes with the edge-case that all values stored in this manner are the same for all users of a given browser.

e.g in #16357

This PR replaces the pinia plugin with the composable introduced in #16142

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
