### PR TITLE
[23.1] Disable console instead of dropping

### DIFF
--- a/client/src/onload/console.js
+++ b/client/src/onload/console.js
@@ -1,0 +1,56 @@
+/**
+ * This module disables the console in production,
+ * and adds the ability to toggle console logging
+ * using the global functions
+ * enableDebugging() and disableDebugging()
+ */
+import { useLocalStorage } from "@vueuse/core";
+import { watch } from "vue";
+
+export function overrideProductionConsole() {
+    let defaultEnabled = true;
+
+    if (process.env.NODE_ENV == "production") {
+        defaultEnabled = false;
+    }
+
+    const isEnabled = useLocalStorage("console-debugging-enabled", defaultEnabled);
+
+    let storedConsole = null;
+
+    const disableConsole = () => {
+        storedConsole = console;
+        // eslint-disable-next-line no-global-assign
+        console = {};
+        Object.keys(storedConsole).forEach((key) => {
+            console[key] = () => {};
+        });
+    };
+
+    const enableConsole = () => {
+        if (storedConsole) {
+            // eslint-disable-next-line no-global-assign
+            console = storedConsole;
+        }
+    };
+
+    watch(
+        () => isEnabled.value,
+        (enabled) => {
+            if (enabled) {
+                enableConsole();
+            } else {
+                disableConsole();
+            }
+        },
+        { immediate: true }
+    );
+
+    window.enableDebugging = () => {
+        isEnabled.value = true;
+    };
+
+    window.disableDebugging = () => {
+        isEnabled.value = false;
+    };
+}

--- a/client/src/onload/index.js
+++ b/client/src/onload/index.js
@@ -12,6 +12,8 @@ import "./publicPath";
 // Default Font
 import "@fontsource/atkinson-hyperlegible";
 
+import { overrideProductionConsole } from "./console";
+
 // Module exports appear as objects on window.config in the browser
 export { standardInit } from "./standardInit";
 export { initializations$, addInitialization, prependInitialization, clearInitQueue } from "./initQueue";
@@ -20,6 +22,8 @@ export { getRootFromIndexLink } from "./getRootFromIndexLink";
 
 // Client-side configuration variables (based on environment)
 import config from "config";
+
+overrideProductionConsole();
 
 if (!config.testBuild === true) {
     console.log(`Galaxy Client '${config.name}' build, dated ${config.buildTimestamp}`);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -37,16 +37,7 @@ module.exports = (env = {}, argv = {}) => {
     if (targetEnv == "production") {
         minimizations = {
             minimize: true,
-            minimizer: [
-                new TerserPlugin({
-                    terserOptions: {
-                        compress: {
-                            drop_console: true,
-                        },
-                    },
-                }),
-                new CssMinimizerPlugin(),
-            ],
+            minimizer: [new TerserPlugin(), new CssMinimizerPlugin()],
         };
     } else {
         minimizations = {


### PR DESCRIPTION
We are currently dropping all console commands from production builds.
This is desirable, as console commands can cause performance impacts and memory leaks.

However, it can make looking into issues on production a lot harder. Some useful vue errors, warning logs, or custom logs which could help in quickly pinning down an issue may be hidden.

This PR disables the console instead of dropping it, by overriding each key of the global console object with empty functions. It also adds the global functions `enableDebugging()` and `disableDebugging()`, which can be run from the console.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
