### PR TITLE
[23.1] Fix Nested Tool Panel Labels

### DIFF
--- a/client/src/components/Panels/Common/ToolPanelLabel.vue
+++ b/client/src/components/Panels/Common/ToolPanelLabel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-b-tooltip.topright.hover class="tool-panel-label" :title="description">
+    <div v-b-tooltip.topright.hover class="tool-panel-label" tabindex="0" :title="description">
         {{ definition.text }}
         <ToolPanelLinks :links="definition.links" />
     </div>
@@ -30,8 +30,12 @@ export default {
         display: none;
     }
 
-    &:hover:deep(.tool-panel-links) {
-        display: inline;
+    &:hover,
+    &:focus,
+    &:focus-within {
+        &:deep(.tool-panel-links) {
+            display: inline;
+        }
     }
 }
 </style>

--- a/client/src/components/Panels/Common/ToolPanelLabel.vue
+++ b/client/src/components/Panels/Common/ToolPanelLabel.vue
@@ -1,12 +1,7 @@
 <template>
-    <div
-        v-b-tooltip.topright.hover
-        class="tool-panel-label"
-        :title="description"
-        @mouseover="hover = true"
-        @mouseleave="hover = false">
+    <div v-b-tooltip.topright.hover class="tool-panel-label" :title="description">
         {{ definition.text }}
-        <ToolPanelLinks :show="hover" :links="definition.links" />
+        <ToolPanelLinks :links="definition.links" />
     </div>
 </template>
 
@@ -21,11 +16,6 @@ export default {
             required: true,
         },
     },
-    data() {
-        return {
-            hover: false,
-        };
-    },
     computed: {
         description() {
             return this.definition.description;
@@ -33,3 +23,15 @@ export default {
     },
 };
 </script>
+
+<style scoped lang="scss">
+.tool-panel-label {
+    &:deep(.tool-panel-links) {
+        display: none;
+    }
+
+    &:hover:deep(.tool-panel-links) {
+        display: inline;
+    }
+}
+</style>

--- a/client/src/components/Panels/Common/ToolPanelLinks.vue
+++ b/client/src/components/Panels/Common/ToolPanelLinks.vue
@@ -1,7 +1,8 @@
 <template>
-    <span v-if="link">
+    <span v-if="link" class="tool-panel-links">
         <a :href="link" target="_blank" style="display: inline">
-            <font-awesome-icon v-show="show" v-b-tooltip.hover title="Link" icon="external-link-alt" />
+            <font-awesome-icon v-b-tooltip.hover title="Link" icon="external-link-alt" />
+            <span class="sr-only">Link</span>
         </a>
     </span>
 </template>
@@ -18,9 +19,7 @@ export default {
     props: {
         links: {
             type: Object,
-        },
-        show: {
-            type: Boolean,
+            default: () => ({}),
         },
     },
     computed: {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -18,7 +18,10 @@
         <transition name="slide">
             <div v-if="opened">
                 <template v-for="[key, el] in sortedElements">
-                    <ToolPanelLabel v-if="category.text" :key="key" :definition="el" />
+                    <ToolPanelLabel
+                        v-if="category.text || el.model_class === 'ToolSectionLabel'"
+                        :key="key"
+                        :definition="el" />
                     <tool
                         v-else
                         :key="key"
@@ -252,5 +255,15 @@ export default {
 .slide-leave-to {
     overflow: hidden;
     max-height: 0;
+}
+
+.title-link {
+    &:deep(.tool-panel-links) {
+        display: none;
+    }
+
+    &:hover:deep(.tool-panel-links) {
+        display: inline;
+    }
 }
 </style>

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -3,16 +3,12 @@
         <div
             v-b-tooltip.topright.hover
             :class="['toolSectionTitle', `tool-menu-section-${sectionName}`]"
-            :title="title"
-            @mouseover="hover = true"
-            @mouseleave="hover = false"
-            @focus="hover = true"
-            @blur="hover = false">
+            :title="title">
             <a class="title-link" href="javascript:void(0)" @click="toggleMenu()">
                 <span class="name">
                     {{ name }}
                 </span>
-                <ToolPanelLinks :links="links" :show="hover" />
+                <ToolPanelLinks :links="links" />
             </a>
         </div>
         <transition name="slide">
@@ -262,8 +258,12 @@ export default {
         display: none;
     }
 
-    &:hover:deep(.tool-panel-links) {
-        display: inline;
+    &:hover,
+    &:focus,
+    &:focus-within {
+        &:deep(.tool-panel-links) {
+            display: inline;
+        }
     }
 }
 </style>

--- a/test/integration_selenium/test_edam_tool_panel_views.py
+++ b/test/integration_selenium/test_edam_tool_panel_views.py
@@ -38,4 +38,4 @@ class TestEdamToolPanelViewsSeleniumIntegration(SeleniumIntegrationTestCase):
         labels = tool_panel.panel_labels.all()
         assert len(labels) > 0
         label0 = labels[0]
-        assert label0.text.strip() == "ANALYSIS"
+        assert label0.text.strip().startswith("ANALYSIS")


### PR DESCRIPTION
Fixes the rendering of sub-labels.

| ![image](https://github.com/galaxyproject/galaxy/assets/44241786/c866935f-6b42-4669-92a0-d7a75fccdac3) | ![image](https://github.com/galaxyproject/galaxy/assets/44241786/5858a51b-17d7-4e60-9078-e92daa3ba468) |
| ---- | ---- |
| before | after |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
