### PR TITLE
Exclude auto-generated schema file from labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -63,8 +63,8 @@ area/toolshed:
   - lib/toolshed/**/*
   - templates/webapps/tool_shed/**/*
 area/UI-UX:
-  - client/src/**/*
-  - templates/**/*
+  - any: ["client/src/**/*", "templates/**/*"]
+    all: ["!client/src/schema/schema.ts"]
 area/util:
   - lib/galaxy/util/**/*
 area/visualizations:


### PR DESCRIPTION
Currently we attach the ui/ux label to any PR that changes client files. With the introduction of end-to-end typing however all api changes result in this label being applied, due to the generated schema.ts

This PR excludes said file.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
