### PR TITLE
[23.1] Fix disk usage recalculation for distributed object stores

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -622,7 +622,7 @@ FROM new
         else:
             statement = """
 INSERT INTO user_quota_source_usage(user_id, quota_source_label, disk_usage)
-VALUES(:user_id, :label, ({label_usage}))
+VALUES(:id, :label, ({label_usage}))
 ON CONFLICT
 ON constraint uqsu_unique_label_per_user
 DO UPDATE SET disk_usage = excluded.disk_usage

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -566,9 +566,7 @@ FROM dataset
 LEFT OUTER JOIN library_dataset_dataset_association ON dataset.id = library_dataset_dataset_association.dataset_id
 WHERE dataset.id IN (SELECT dataset_id FROM per_hist_hdas)
     AND library_dataset_dataset_association.id IS NULL
-    AND (
-        {dataset_condition}
-    )
+    {and_dataset_condition}
 """
 
 
@@ -577,7 +575,7 @@ def calculate_user_disk_usage_statements(user_id, quota_source_map, for_sqlite=F
     statements = []
     default_quota_enabled = quota_source_map.default_quota_enabled
     default_exclude_ids = quota_source_map.default_usage_excluded_ids()
-    default_cond = "dataset.object_store_id IS NULL" if default_quota_enabled else ""
+    default_cond = "dataset.object_store_id IS NULL" if default_quota_enabled and default_exclude_ids else ""
     exclude_cond = "dataset.object_store_id NOT IN :exclude_object_store_ids" if default_exclude_ids else ""
     use_or = " OR " if (default_cond != "" and exclude_cond != "") else ""
     default_usage_dataset_condition = "{default_cond} {use_or} {exclude_cond}".format(
@@ -585,7 +583,9 @@ def calculate_user_disk_usage_statements(user_id, quota_source_map, for_sqlite=F
         exclude_cond=exclude_cond,
         use_or=use_or,
     )
-    default_usage = UNIQUE_DATASET_USER_USAGE.format(dataset_condition=default_usage_dataset_condition)
+    if default_usage_dataset_condition.strip():
+        default_usage_dataset_condition = f"AND ( {default_usage_dataset_condition} )"
+    default_usage = UNIQUE_DATASET_USER_USAGE.format(and_dataset_condition=default_usage_dataset_condition)
     default_usage = (
         """
 UPDATE galaxy_user SET disk_usage = (%s)
@@ -602,7 +602,7 @@ WHERE id = :id
     # the object_store_id to quota_source_label into a temp table of values
     for quota_source_label, object_store_ids in source.items():
         label_usage = UNIQUE_DATASET_USER_USAGE.format(
-            dataset_condition="dataset.object_store_id IN :include_object_store_ids"
+            and_dataset_condition="AND ( dataset.object_store_id IN :include_object_store_ids )"
         )
         if for_sqlite:
             # hacky alternative for older sqlite
@@ -997,16 +997,25 @@ ON CONFLICT
         assert object_store is not None
         quota_source_map = object_store.get_quota_source_map()
         default_quota_enabled = quota_source_map.default_quota_enabled
-        default_cond = "dataset.object_store_id IS NULL OR" if default_quota_enabled else ""
+        exclude_objectstore_ids = quota_source_map.default_usage_excluded_ids()
+        default_cond = "dataset.object_store_id IS NULL OR" if default_quota_enabled and exclude_objectstore_ids else ""
         default_usage_dataset_condition = (
-            "{default_cond} dataset.object_store_id NOT IN :exclude_object_store_ids".format(
-                default_cond=default_cond,
+            (
+                "AND ( {default_cond} dataset.object_store_id NOT IN :exclude_object_store_ids )".format(
+                    default_cond=default_cond,
+                )
             )
+            if exclude_objectstore_ids
+            else ""
         )
-        default_usage = UNIQUE_DATASET_USER_USAGE.format(dataset_condition=default_usage_dataset_condition)
+        default_usage = UNIQUE_DATASET_USER_USAGE.format(and_dataset_condition=default_usage_dataset_condition)
         sql_calc = text(default_usage)
-        sql_calc = sql_calc.bindparams(bindparam("id"), bindparam("exclude_object_store_ids", expanding=True))
-        params = {"id": self.id, "exclude_object_store_ids": quota_source_map.default_usage_excluded_ids()}
+        params = {"id": self.id}
+        bindparams = [bindparam("id")]
+        if exclude_objectstore_ids:
+            params["exclude_object_store_ids"] = exclude_objectstore_ids
+            bindparams.append(bindparam("exclude_object_store_ids", expanding=True))
+        sql_calc = sql_calc.bindparams(*bindparams)
         sa_session = object_session(self)
         usage = sa_session.scalar(sql_calc, params)
         return usage


### PR DESCRIPTION
~~Found this while adding the additional test cases in the first commit. I don't know yet why this wasn't failing on usegalaxy.org (maybe an empty iterable in `quota_source_map.ids_per_quota_source()` ?), and I suppose it won't fix the issue that @natefoo found in the backend channel.~~

[fd15b82](https://github.com/galaxyproject/galaxy/pull/16380/commits/fd15b824815a67ebea1ed1a1832f5703aace7caf) fixes a bind param mismatch. I'll say the unpopular thing here: we should've used sqlalchemy core for this, since that'd have done the parameter binding for us. Found this while adding the additional test cases in the first commit

[53dc916f0d722a350c53dba70e4fabda42d2d7ff](https://github.com/galaxyproject/galaxy/pull/16380/commits/53dc916f0d722a350c53dba70e4fabda42d2d7ff) fixes the case Nate reported in the backend channel, which is because main uses a hierarchical object store where no backend defines a `quota_source` attribute.

> Disk usage calculation seems to be broken on .org, does anyone know of recent changes that might be suspect?
e.g.:

```
galaxy_main=> select sum(d.total_size) from history_dataset_association hda join history h on hda.history_id = h.id join galaxy_user u on h.user_id = u.id join dataset d on hda.dataset_id = d.id where u.username = '84756234z' and not hda.purged and not d.purged;
     sum
--------------
 320534890258
(1 row)

galaxy_main=> select disk_usage from galaxy_user where username = '84756234z';
 disk_usage
------------
          0
```
> And recalculating just remains 0.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
