### PR TITLE
Add Invenio RDM repository integration

### DIFF
--- a/client/src/components/Common/ExportDOIForm.vue
+++ b/client/src/components/Common/ExportDOIForm.vue
@@ -2,7 +2,7 @@
 import { BButton, BCard, BFormGroup, BFormInput, BFormRadio, BFormRadioGroup } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
-import { CreatedEntry, createRemoteEntry } from "@/components/FilesDialog/services";
+import { CreatedEntry, createRemoteEntry, FilterFileSourcesOptions } from "@/components/FilesDialog/services";
 import localize from "@/utils/localization";
 
 import ExternalLink from "@/components/ExternalLink.vue";
@@ -27,6 +27,8 @@ const emit = defineEmits<{
 }>();
 
 type ExportChoice = "existing" | "new";
+
+const includeOnlyDOICompatible: FilterFileSourcesOptions = { include: ["rdm"] };
 
 const recordUri = ref<string>("");
 const sourceUri = ref<string>("");
@@ -115,7 +117,7 @@ function clearInputs() {
                         v-model="sourceUri"
                         mode="source"
                         :require-writable="true"
-                        :rdm-only="true" />
+                        :filter-options="includeOnlyDOICompatible" />
                 </BFormGroup>
                 <BFormGroup
                     id="fieldset-record-name"
@@ -148,7 +150,7 @@ function clearInputs() {
                     v-model="recordUri"
                     mode="directory"
                     :require-writable="true"
-                    :rdm-only="true" />
+                    :filter-options="includeOnlyDOICompatible" />
             </BFormGroup>
             <BButton
                 v-localize

--- a/client/src/components/Common/ExportDOIForm.vue
+++ b/client/src/components/Common/ExportDOIForm.vue
@@ -90,7 +90,8 @@ function clearInputs() {
                         <span v-localize> draft record has been created in the repository.</span>
                     </p>
                     <p v-if="newEntry.external_link">
-                        You can preview the record in the repository and further edit its metadata at
+                        You can preview the record in the repository, further edit its metadata and decide when to
+                        publish it at
                         <ExternalLink :href="newEntry.external_link">
                             <b>{{ newEntry.external_link }}</b>
                         </ExternalLink>

--- a/client/src/components/Common/ExportDOIForm.vue
+++ b/client/src/components/Common/ExportDOIForm.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import { BButton, BCard, BFormGroup, BFormInput, BFormRadio, BFormRadioGroup } from "bootstrap-vue";
+import { computed, ref } from "vue";
+
+import { CreatedEntry, createRemoteEntry } from "@/components/FilesDialog/services";
+import localize from "@/utils/localization";
+
+import ExternalLink from "@/components/ExternalLink.vue";
+import FilesInput from "@/components/FilesDialog/FilesInput.vue";
+
+interface Props {
+    what?: string;
+    clearInputAfterExport?: boolean;
+    defaultRecordName?: string;
+    defaultFilename?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    what: "archive",
+    clearInputAfterExport: false,
+    defaultRecordName: "",
+    defaultFilename: "",
+});
+
+const emit = defineEmits<{
+    (e: "export", recordUri: string, fileName: string, newRecordName?: string): void;
+}>();
+
+type ExportChoice = "existing" | "new";
+
+const recordUri = ref<string>("");
+const sourceUri = ref<string>("");
+const fileName = ref<string>(props.defaultFilename);
+const exportChoice = ref<ExportChoice>("new");
+const recordName = ref<string>(props.defaultRecordName);
+const newEntry = ref<CreatedEntry>();
+
+const canCreateRecord = computed(() => Boolean(sourceUri.value) && Boolean(recordName.value));
+
+const canExport = computed(() => Boolean(recordUri.value) && Boolean(fileName.value));
+
+const repositoryRecordDescription = computed(() => localize(`Select a repository to export ${props.what} to.`));
+
+const nameDescription = computed(() => localize("Give the exported file a name."));
+const recordNameDescription = computed(() => localize("Give the new record a name or title."));
+
+const namePlaceholder = computed(() => localize("File name"));
+const recordNamePlaceholder = computed(() => localize("Record name"));
+
+function doExport() {
+    emit("export", recordUri.value, fileName.value);
+
+    if (props.clearInputAfterExport) {
+        clearInputs();
+    }
+}
+
+async function doCreateRecord() {
+    //TODO: handle errors
+    newEntry.value = await createRemoteEntry(sourceUri.value, recordName.value);
+    recordUri.value = newEntry.value.uri;
+}
+
+function clearInputs() {
+    recordUri.value = "";
+    sourceUri.value = "";
+    fileName.value = "";
+    newEntry.value = undefined;
+}
+</script>
+
+<template>
+    <div class="export-to-doi-repository">
+        <BFormGroup id="fieldset-name" label-for="name" :description="nameDescription" class="mt-3">
+            <BFormInput id="name" v-model="fileName" :placeholder="namePlaceholder" required />
+        </BFormGroup>
+
+        <BFormRadioGroup v-model="exportChoice" class="export-radio-group">
+            <BFormRadio v-localize name="exportChoice" value="new"> Export to new record </BFormRadio>
+            <BFormRadio v-localize name="exportChoice" value="existing"> Export to existing draft record </BFormRadio>
+        </BFormRadioGroup>
+
+        <div v-if="exportChoice === 'new'">
+            <div v-if="newEntry">
+                <BCard>
+                    <p v-localize>
+                        A new draft record with name <b>{{ newEntry.name }}</b> has been created in the repository.
+                    </p>
+                    <p v-if="newEntry.external_link">
+                        You can preview the record in the repository and further edit its metadata at
+                        <ExternalLink :href="newEntry.external_link">
+                            <b>{{ newEntry.external_link }}</b>
+                        </ExternalLink>
+                    </p>
+                    <p v-localize>Please use the button below to upload the exported {{ props.what }} to the record.</p>
+                    <BButton
+                        v-localize
+                        class="export-button"
+                        variant="primary"
+                        :disabled="!canExport"
+                        @click.prevent="doExport">
+                        Export to this record
+                    </BButton>
+                </BCard>
+            </div>
+            <div v-else>
+                <BFormGroup
+                    id="fieldset-record"
+                    label-for="source-selector"
+                    :description="repositoryRecordDescription"
+                    class="mt-3">
+                    <FilesInput
+                        id="repository-selector"
+                        v-model="sourceUri"
+                        mode="source"
+                        :require-writable="true"
+                        :rdm-only="true" />
+                </BFormGroup>
+                <BFormGroup
+                    id="fieldset-record-name"
+                    label-for="record-name"
+                    :description="recordNameDescription"
+                    class="mt-3">
+                    <BFormInput id="record-name" v-model="recordName" :placeholder="recordNamePlaceholder" required />
+                </BFormGroup>
+                <p v-localize>
+                    You need to create the new record in a repository before exporting the {{ props.what }} to it.
+                </p>
+                <BButton
+                    v-localize
+                    class="export-button"
+                    variant="primary"
+                    :disabled="!canCreateRecord"
+                    @click.prevent="doCreateRecord">
+                    Create new record
+                </BButton>
+            </div>
+        </div>
+        <div v-else>
+            <BFormGroup
+                id="fieldset-record"
+                label-for="existing-record-selector"
+                :description="repositoryRecordDescription"
+                class="mt-3">
+                <FilesInput
+                    id="existing-record-selector"
+                    v-model="recordUri"
+                    mode="directory"
+                    :require-writable="true"
+                    :rdm-only="true" />
+            </BFormGroup>
+            <BButton
+                v-localize
+                class="export-button"
+                variant="primary"
+                :disabled="!canExport"
+                @click.prevent="doExport">
+                Export to existing record
+            </BButton>
+        </div>
+    </div>
+</template>

--- a/client/src/components/Common/ExportDOIForm.vue
+++ b/client/src/components/Common/ExportDOIForm.vue
@@ -83,8 +83,9 @@ function clearInputs() {
         <div v-if="exportChoice === 'new'">
             <div v-if="newEntry">
                 <BCard>
-                    <p v-localize>
-                        A new draft record with name <b>{{ newEntry.name }}</b> has been created in the repository.
+                    <p>
+                        <b>{{ newEntry.name }}</b>
+                        <span v-localize> draft record has been created in the repository.</span>
                     </p>
                     <p v-if="newEntry.external_link">
                         You can preview the record in the repository and further edit its metadata at

--- a/client/src/components/Common/ExportForm.vue
+++ b/client/src/components/Common/ExportForm.vue
@@ -2,6 +2,7 @@
 import { BButton, BCol, BFormGroup, BFormInput, BRow } from "bootstrap-vue";
 import { computed, ref } from "vue";
 
+import { FilterFileSourcesOptions } from "@/components/FilesDialog/services";
 import localize from "@/utils/localization";
 
 import FilesInput from "@/components/FilesDialog/FilesInput.vue";
@@ -19,6 +20,8 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
     (e: "export", directory: string, name: string): void;
 }>();
+
+const defaultExportFilterOptions: FilterFileSourcesOptions = { exclude: ["rdm"] };
 
 const directory = ref<string>("");
 const name = ref<string>("");
@@ -43,7 +46,12 @@ const doExport = () => {
 <template>
     <div class="export-to-remote-file">
         <BFormGroup id="fieldset-directory" label-for="directory" :description="directoryDescription" class="mt-3">
-            <FilesInput id="directory" v-model="directory" mode="directory" :require-writable="true" />
+            <FilesInput
+                id="directory"
+                v-model="directory"
+                mode="directory"
+                :require-writable="true"
+                :filter-options="defaultExportFilterOptions" />
         </BFormGroup>
         <BFormGroup id="fieldset-name" label-for="name" :description="nameDescription" class="mt-3">
             <BFormInput id="name" v-model="name" :placeholder="namePlaceholder" required />

--- a/client/src/components/Common/ExportRDMForm.test.ts
+++ b/client/src/components/Common/ExportRDMForm.test.ts
@@ -1,0 +1,139 @@
+import { getLocalVue } from "@tests/jest/helpers";
+import { mount, Wrapper } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+
+import { mockFetcher } from "@/schema/__mocks__";
+
+import { CreatedEntry } from "../FilesDialog/services";
+
+import ExportRDMForm from "./ExportRDMForm.vue";
+import FilesInput from "@/components/FilesDialog/FilesInput.vue";
+
+jest.mock("@/schema");
+
+const localVue = getLocalVue(true);
+
+const CREATE_RECORD_BTN = "#create-record-button";
+const EXPORT_TO_NEW_RECORD_BTN = "#export-button-new-record";
+const EXPORT_TO_EXISTING_RECORD_BTN = "#export-button-existing-record";
+
+const FAKE_RDM_SOURCE_URI = "gxfiles://test-uri";
+const FAKE_RDM_EXISTING_RECORD_URI = "gxfiles://test-uri/test-record";
+const FAKE_RECORD_NAME = "test record name";
+const FAKE_ENTRY: CreatedEntry = {
+    uri: FAKE_RDM_SOURCE_URI,
+    name: FAKE_RECORD_NAME,
+    external_link: "http://example.com",
+};
+
+async function initWrapper() {
+    mockFetcher.path("/api/remote_files").method("post").mock({ data: FAKE_ENTRY });
+
+    const wrapper = mount(ExportRDMForm, {
+        propsData: {},
+        localVue,
+    });
+    await flushPromises();
+    return wrapper;
+}
+
+describe("ExportRDMForm", () => {
+    let wrapper: Wrapper<Vue>;
+
+    beforeEach(async () => {
+        wrapper = await initWrapper();
+    });
+
+    describe("Export to new record", () => {
+        beforeEach(async () => {
+            await selectExportChoice("new");
+        });
+
+        it("enables the create new record button when the required fields are filled in", async () => {
+            expect(wrapper.find(CREATE_RECORD_BTN).attributes("disabled")).toBeTruthy();
+
+            await setRecordNameInput(FAKE_RECORD_NAME);
+            await setRDMSourceInput(FAKE_RDM_SOURCE_URI);
+
+            expect(wrapper.find(CREATE_RECORD_BTN).attributes("disabled")).toBeFalsy();
+        });
+
+        it("displays the export to this record button when the create new record button is clicked", async () => {
+            expect(wrapper.find(EXPORT_TO_NEW_RECORD_BTN).exists()).toBeFalsy();
+
+            await setRecordNameInput(FAKE_RECORD_NAME);
+            await setRDMSourceInput(FAKE_RDM_SOURCE_URI);
+            await clickCreateNewRecordButton();
+
+            expect(wrapper.find(EXPORT_TO_NEW_RECORD_BTN).exists()).toBeTruthy();
+        });
+
+        it("emits an export event when the export to new record button is clicked", async () => {
+            await setFileNameInput("test file name");
+            await setRecordNameInput(FAKE_RECORD_NAME);
+            await setRDMSourceInput(FAKE_RDM_SOURCE_URI);
+            await clickCreateNewRecordButton();
+
+            await wrapper.find(EXPORT_TO_NEW_RECORD_BTN).trigger("click");
+            expect(wrapper.emitted("export")).toBeTruthy();
+        });
+    });
+
+    describe("Export to existing record", () => {
+        beforeEach(async () => {
+            await selectExportChoice("existing");
+        });
+
+        it("enables the export to existing record button when the required fields are filled in", async () => {
+            expect(wrapper.find(EXPORT_TO_EXISTING_RECORD_BTN).attributes("disabled")).toBeTruthy();
+
+            await setFileNameInput("test file name");
+            await setRDMDirectoryInput(FAKE_RDM_EXISTING_RECORD_URI);
+
+            expect(wrapper.find(EXPORT_TO_EXISTING_RECORD_BTN).attributes("disabled")).toBeFalsy();
+        });
+
+        it("emits an export event when the export to existing record button is clicked", async () => {
+            await setFileNameInput("test file name");
+            await setRDMDirectoryInput(FAKE_RDM_EXISTING_RECORD_URI);
+            await wrapper.find(EXPORT_TO_EXISTING_RECORD_BTN).trigger("click");
+            expect(wrapper.emitted("export")).toBeTruthy();
+        });
+    });
+
+    async function selectExportChoice(choice: string) {
+        const exportChoice = wrapper.find(`#radio-${choice}`);
+        await exportChoice.setChecked(true);
+    }
+
+    async function setRDMSourceInput(newValue: string) {
+        const component = wrapper.findComponent(FilesInput);
+        expect(component.attributes("placeholder")).toContain("source");
+        component.vm.$emit("input", newValue);
+        await flushPromises();
+    }
+
+    async function setRDMDirectoryInput(newValue: string) {
+        const component = wrapper.findComponent(FilesInput);
+        expect(component.attributes("placeholder")).toContain("directory");
+        component.vm.$emit("input", newValue);
+        await flushPromises();
+    }
+
+    async function setRecordNameInput(newValue: string) {
+        const recordNameInput = wrapper.find("#record-name-input");
+        await recordNameInput.setValue(newValue);
+    }
+
+    async function setFileNameInput(newValue: string) {
+        const recordNameInput = wrapper.find("#file-name-input");
+        await recordNameInput.setValue(newValue);
+    }
+
+    async function clickCreateNewRecordButton() {
+        const createRecordButton = wrapper.find(CREATE_RECORD_BTN);
+        expect(createRecordButton.attributes("disabled")).toBeFalsy();
+        await createRecordButton.trigger("click");
+        await flushPromises();
+    }
+});

--- a/client/src/components/Common/ExportRDMForm.vue
+++ b/client/src/components/Common/ExportRDMForm.vue
@@ -28,7 +28,7 @@ const emit = defineEmits<{
 
 type ExportChoice = "existing" | "new";
 
-const includeOnlyDOICompatible: FilterFileSourcesOptions = { include: ["rdm"] };
+const includeOnlyRDMCompatible: FilterFileSourcesOptions = { include: ["rdm"] };
 
 const recordUri = ref<string>("");
 const sourceUri = ref<string>("");
@@ -72,7 +72,7 @@ function clearInputs() {
 </script>
 
 <template>
-    <div class="export-to-doi-repository">
+    <div class="export-to-rdm-repository">
         <BFormGroup id="fieldset-name" label-for="name" :description="nameDescription" class="mt-3">
             <BFormInput id="name" v-model="fileName" :placeholder="namePlaceholder" required />
         </BFormGroup>
@@ -118,7 +118,7 @@ function clearInputs() {
                         v-model="sourceUri"
                         mode="source"
                         :require-writable="true"
-                        :filter-options="includeOnlyDOICompatible" />
+                        :filter-options="includeOnlyRDMCompatible" />
                 </BFormGroup>
                 <BFormGroup
                     id="fieldset-record-name"
@@ -151,7 +151,7 @@ function clearInputs() {
                     v-model="recordUri"
                     mode="directory"
                     :require-writable="true"
-                    :filter-options="includeOnlyDOICompatible" />
+                    :filter-options="includeOnlyRDMCompatible" />
             </BFormGroup>
             <BButton
                 v-localize

--- a/client/src/components/Common/ExportRDMForm.vue
+++ b/client/src/components/Common/ExportRDMForm.vue
@@ -81,12 +81,14 @@ function clearInputs() {
 <template>
     <div class="export-to-rdm-repository">
         <BFormGroup id="fieldset-name" label-for="name" :description="nameDescription" class="mt-3">
-            <BFormInput id="name" v-model="fileName" :placeholder="namePlaceholder" required />
+            <BFormInput id="file-name-input" v-model="fileName" :placeholder="namePlaceholder" required />
         </BFormGroup>
 
         <BFormRadioGroup v-model="exportChoice" class="export-radio-group">
-            <BFormRadio v-localize name="exportChoice" value="new"> Export to new record </BFormRadio>
-            <BFormRadio v-localize name="exportChoice" value="existing"> Export to existing draft record </BFormRadio>
+            <BFormRadio id="radio-new" v-localize name="exportChoice" value="new"> Export to new record </BFormRadio>
+            <BFormRadio id="radio-existing" v-localize name="exportChoice" value="existing">
+                Export to existing draft record
+            </BFormRadio>
         </BFormRadioGroup>
 
         <div v-if="exportChoice === 'new'">
@@ -105,6 +107,7 @@ function clearInputs() {
                     </p>
                     <p v-localize>Please use the button below to upload the exported {{ props.what }} to the record.</p>
                     <BButton
+                        id="export-button-new-record"
                         v-localize
                         class="export-button"
                         variant="primary"
@@ -116,12 +119,12 @@ function clearInputs() {
             </div>
             <div v-else>
                 <BFormGroup
-                    id="fieldset-record"
+                    id="fieldset-record-new"
                     label-for="source-selector"
                     :description="repositoryRecordDescription"
                     class="mt-3">
                     <FilesInput
-                        id="repository-selector"
+                        id="source-selector"
                         v-model="sourceUri"
                         mode="source"
                         :require-writable="true"
@@ -132,14 +135,18 @@ function clearInputs() {
                     label-for="record-name"
                     :description="recordNameDescription"
                     class="mt-3">
-                    <BFormInput id="record-name" v-model="recordName" :placeholder="recordNamePlaceholder" required />
+                    <BFormInput
+                        id="record-name-input"
+                        v-model="recordName"
+                        :placeholder="recordNamePlaceholder"
+                        required />
                 </BFormGroup>
                 <p v-localize>
                     You need to create the new record in a repository before exporting the {{ props.what }} to it.
                 </p>
                 <BButton
+                    id="create-record-button"
                     v-localize
-                    class="export-button"
                     variant="primary"
                     :disabled="!canCreateRecord"
                     @click.prevent="doCreateRecord">
@@ -149,7 +156,7 @@ function clearInputs() {
         </div>
         <div v-else>
             <BFormGroup
-                id="fieldset-record"
+                id="fieldset-record-existing"
                 label-for="existing-record-selector"
                 :description="repositoryRecordDescription"
                 class="mt-3">
@@ -161,6 +168,7 @@ function clearInputs() {
                     :filter-options="includeOnlyRDMCompatible" />
             </BFormGroup>
             <BButton
+                id="export-button-existing-record"
                 v-localize
                 class="export-button"
                 variant="primary"

--- a/client/src/components/Common/ExportRDMForm.vue
+++ b/client/src/components/Common/ExportRDMForm.vue
@@ -3,10 +3,14 @@ import { BButton, BCard, BFormGroup, BFormInput, BFormRadio, BFormRadioGroup } f
 import { computed, ref } from "vue";
 
 import { CreatedEntry, createRemoteEntry, FilterFileSourcesOptions } from "@/components/FilesDialog/services";
+import { useToast } from "@/composables/toast";
 import localize from "@/utils/localization";
+import { errorMessageAsString } from "@/utils/simple-error";
 
 import ExternalLink from "@/components/ExternalLink.vue";
 import FilesInput from "@/components/FilesDialog/FilesInput.vue";
+
+const toast = useToast();
 
 interface Props {
     what?: string;
@@ -58,9 +62,12 @@ function doExport() {
 }
 
 async function doCreateRecord() {
-    //TODO: handle errors
-    newEntry.value = await createRemoteEntry(sourceUri.value, recordName.value);
-    recordUri.value = newEntry.value.uri;
+    try {
+        newEntry.value = await createRemoteEntry(sourceUri.value, recordName.value);
+        recordUri.value = newEntry.value.uri;
+    } catch (e) {
+        toast.error(errorMessageAsString(e));
+    }
 }
 
 function clearInputs() {

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -70,6 +70,9 @@ const selectAllIcon = ref(selectionStates.unselected);
 const urlTracker = ref(new UrlTracker(""));
 
 const fileMode = computed(() => props.mode == "file");
+const okButtonDisabled = computed(
+    () => (fileMode.value && !hasValue.value) || isBusy.value || (!fileMode.value && urlTracker.value.atRoot())
+);
 
 /** Collects selected datasets in value array **/
 function clicked(record: RecordItem) {
@@ -392,7 +395,7 @@ onMounted(() => {
                 size="sm"
                 class="float-right ml-1 file-dialog-modal-ok"
                 variant="primary"
-                :disabled="(fileMode && !hasValue) || isBusy || (!fileMode && urlTracker.atRoot())"
+                :disabled="okButtonDisabled"
                 @click="onOk">
                 {{ fileMode ? "Ok" : "Select this folder" }}
             </BButton>

--- a/client/src/components/FilesDialog/FilesInput.vue
+++ b/client/src/components/FilesDialog/FilesInput.vue
@@ -4,11 +4,13 @@ import { computed } from "vue";
 
 import { filesDialog } from "@/utils/data";
 
+import { FileSourceBrowsingMode, FilterFileSourcesOptions } from "./services";
+
 interface Props {
     value: string;
-    mode?: "file" | "directory";
+    mode?: FileSourceBrowsingMode;
     requireWritable?: boolean;
-    rdmOnly?: boolean;
+    filterOptions?: FilterFileSourcesOptions;
 }
 
 interface SelectableFile {
@@ -18,6 +20,7 @@ interface SelectableFile {
 const props = withDefaults(defineProps<Props>(), {
     mode: "file",
     requireWritable: false,
+    filterOptions: undefined,
 });
 
 const emit = defineEmits<{
@@ -37,7 +40,7 @@ const selectFile = () => {
     const dialogProps = {
         mode: props.mode,
         requireWritable: props.requireWritable,
-        rdmOnly: props.rdmOnly,
+        filterOptions: props.filterOptions,
     };
     filesDialog((selected: SelectableFile) => {
         currentValue.value = selected?.url;

--- a/client/src/components/FilesDialog/FilesInput.vue
+++ b/client/src/components/FilesDialog/FilesInput.vue
@@ -8,6 +8,7 @@ interface Props {
     value: string;
     mode?: "file" | "directory";
     requireWritable?: boolean;
+    rdmOnly?: boolean;
 }
 
 interface SelectableFile {
@@ -36,6 +37,7 @@ const selectFile = () => {
     const dialogProps = {
         mode: props.mode,
         requireWritable: props.requireWritable,
+        rdmOnly: props.rdmOnly,
     };
     filesDialog((selected: SelectableFile) => {
         currentValue.value = selected?.url;

--- a/client/src/components/FilesDialog/services.ts
+++ b/client/src/components/FilesDialog/services.ts
@@ -25,11 +25,11 @@ const getRemoteFiles = fetcher.path("/api/remote_files").method("get").create();
  * Get the list of files and directories from the server for the given file source URI.
  * @param uri The file source URI to browse.
  * @param isRecursive Whether to recursively retrieve all files inside subdirectories.
- * @param writeIntent Whether to include only entries that can be written to.
+ * @param writeable Whether to return only entries that can be written to.
  * @returns The list of files and directories from the server for the given URI.
  */
-export async function browseRemoteFiles(uri: string, isRecursive = false, writeIntent = false): Promise<RemoteEntry[]> {
-    const { data } = await getRemoteFiles({ target: uri, recursive: isRecursive, write_intent: writeIntent });
+export async function browseRemoteFiles(uri: string, isRecursive = false, writeable = false): Promise<RemoteEntry[]> {
+    const { data } = await getRemoteFiles({ target: uri, recursive: isRecursive, writeable });
     return data as RemoteEntry[];
 }
 

--- a/client/src/components/FilesDialog/services.ts
+++ b/client/src/components/FilesDialog/services.ts
@@ -5,17 +5,43 @@ export type FilesSourcePlugin = components["schemas"]["FilesSourcePlugin"];
 export type RemoteFile = components["schemas"]["RemoteFile"];
 export type RemoteDirectory = components["schemas"]["RemoteDirectory"];
 export type RemoteEntry = RemoteFile | RemoteDirectory;
+export type CreatedEntry = components["schemas"]["CreatedEntryResponse"];
 
 const getRemoteFilesPlugins = fetcher.path("/api/remote_files/plugins").method("get").create();
 
-export async function getFileSources(): Promise<FilesSourcePlugin[]> {
-    const { data } = await getRemoteFilesPlugins({ browsable_only: true });
+/**
+ * Get the list of available file sources from the server that can be browsed.
+ * @param rdm_only Whether to only include Research Data Management (RDM) specific file sources.
+ * @returns The list of available file sources from the server.
+ */
+export async function getFileSources(rdm_only = false): Promise<FilesSourcePlugin[]> {
+    const { data } = await getRemoteFilesPlugins({ browsable_only: true, rdm_only: rdm_only });
     return data;
 }
 
 const getRemoteFiles = fetcher.path("/api/remote_files").method("get").create();
 
-export async function browseRemoteFiles(uri: string, isRecursive = false): Promise<RemoteEntry[]> {
-    const { data } = await getRemoteFiles({ target: uri, recursive: isRecursive });
+/**
+ * Get the list of files and directories from the server for the given file source URI.
+ * @param uri The file source URI to browse.
+ * @param isRecursive Whether to recursively retrieve all files inside subdirectories.
+ * @param writeIntent Whether to include only entries that can be written to.
+ * @returns The list of files and directories from the server for the given URI.
+ */
+export async function browseRemoteFiles(uri: string, isRecursive = false, writeIntent = false): Promise<RemoteEntry[]> {
+    const { data } = await getRemoteFiles({ target: uri, recursive: isRecursive, write_intent: writeIntent });
     return data as RemoteEntry[];
+}
+
+const createEntry = fetcher.path("/api/remote_files").method("post").create();
+
+/**
+ * Create a new entry (directory/record) on the given file source URI.
+ * @param uri The file source URI to create the entry in.
+ * @param name The name of the entry to create.
+ * @returns The created entry details.
+ */
+export async function createRemoteEntry(uri: string, name: string): Promise<CreatedEntry> {
+    const { data } = await createEntry({ target: uri, name: name });
+    return data;
 }

--- a/client/src/components/FilesDialog/testingData.ts
+++ b/client/src/components/FilesDialog/testingData.ts
@@ -1,4 +1,4 @@
-import { FilesSourcePlugin } from "./services";
+import { BrowsableFilesSourcePlugin } from "./services";
 
 export const ftpId = "_ftp";
 export const rootId = "pdb-gzip";
@@ -26,7 +26,7 @@ export interface RemoteFile extends RemoteEntry {
 
 export type RemoteFilesList = (RemoteDirectory | RemoteFile)[];
 
-export const rootResponse: FilesSourcePlugin[] = [
+export const rootResponse: BrowsableFilesSourcePlugin[] = [
     {
         id: "_ftp",
         type: "gxftp",
@@ -34,6 +34,7 @@ export const rootResponse: FilesSourcePlugin[] = [
         label: "FTP Directory",
         doc: "Galaxy User's FTP Directory",
         writable: true,
+        browsable: true,
     },
     {
         id: "pdb-gzip",
@@ -42,6 +43,7 @@ export const rootResponse: FilesSourcePlugin[] = [
         label: "PDB",
         doc: "Protein Data Bank (PDB)",
         writable: true,
+        browsable: true,
     },
     {
         id: "empty-dir",
@@ -50,6 +52,7 @@ export const rootResponse: FilesSourcePlugin[] = [
         label: "Empty Directory",
         doc: "Empty Directory",
         writable: true,
+        browsable: true,
     },
 ];
 

--- a/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
+++ b/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
@@ -12,6 +12,7 @@ import type { HistorySummary } from "@/stores/historyStore";
 import ExportRecordCard from "./ExportRecordCard.vue";
 import ExportToFileSourceForm from "@/components/Common/ExportForm.vue";
 import ExportToRDMRepositoryForm from "@/components/Common/ExportRDMForm.vue";
+import ExternalLink from "@/components/ExternalLink.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const {
@@ -217,10 +218,12 @@ function onArchiveHistoryWithExport() {
                 </BTab>
                 <BTab id="to-rdm-repository-tab" title="To RDM Repository">
                     <p>
-                        <b>Exporting to a RDM repository</b> (e.g. Invenio RDM or Zenodo RDM) will require to create or
-                        select an existing record in the repository where the history archive will be uploaded. The
-                        export record will be associated with the archived history and you will be able to recreate the
-                        history later by importing it from the export record.
+                        <b>Exporting to a RDM repository</b> (e.g. any
+                        <ExternalLink href="https://inveniosoftware.org/products/rdm/"> Invenio RDM </ExternalLink>
+                        compatible repository) will require to create or select an existing record in the repository
+                        where the history archive will be uploaded. The export record will be associated with the
+                        archived history and you will be able to recreate the history later by importing it from the
+                        export record.
                     </p>
                     <p>
                         You may need to setup your credentials for the selected repository in your

--- a/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
+++ b/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
@@ -99,16 +99,19 @@ async function onCreateExportRecord() {
     isExportDialogOpen.value = true;
 }
 
+async function doExportToFileSourceWithPrefix(exportDirectory: string, fileName: string) {
+    // Avoid name collisions if multiple different histories are exported to the
+    // same destination with the same name
+    const fileNameCompatibleUpdateTime = props.history.update_time.replace(/:/g, "-");
+    const prefixedFileName = `${fileNameCompatibleUpdateTime}_${fileName}`;
+    doExportToFileSource(exportDirectory, prefixedFileName);
+}
+
 async function doExportToFileSource(exportDirectory: string, fileName: string) {
     isExportingRecord.value = true;
     isExportDialogOpen.value = false;
-
-    // Avoid name collisions if multiple different histories are exported to the
-    // same destination with the same name
-    const prefixedFileName = `${props.history.id}_${fileName}`;
-
     try {
-        await exportToFileSource(props.history.id, exportDirectory, prefixedFileName, DEFAULT_EXPORT_PARAMS);
+        await exportToFileSource(props.history.id, exportDirectory, fileName, DEFAULT_EXPORT_PARAMS);
     } catch (error) {
         exportErrorMessage.value = "The history export request failed. Please try again later.";
     }
@@ -196,7 +199,7 @@ function onArchiveHistoryWithExport() {
         </BButton>
 
         <BModal v-model="isExportDialogOpen" title="Export history to permanent storage" size="lg" hide-footer>
-            <ExportToFileSourceForm what="history" @export="doExportToFileSource" />
+            <ExportToFileSourceForm what="history" @export="doExportToFileSourceWithPrefix" />
         </BModal>
     </div>
 </template>

--- a/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
+++ b/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
@@ -10,8 +10,8 @@ import { useTaskMonitor } from "@/composables/taskMonitor";
 import type { HistorySummary } from "@/stores/historyStore";
 
 import ExportRecordCard from "./ExportRecordCard.vue";
-import ExportToDOIRepositoryForm from "@/components/Common/ExportDOIForm.vue";
 import ExportToFileSourceForm from "@/components/Common/ExportForm.vue";
+import ExportToRDMRepositoryForm from "@/components/Common/ExportRDMForm.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
 const {
@@ -227,7 +227,7 @@ function onArchiveHistoryWithExport() {
                         <RouterLink to="/user/information" target="_blank">settings page</RouterLink> to be able to
                         export.
                     </p>
-                    <ExportToDOIRepositoryForm
+                    <ExportToRDMRepositoryForm
                         what="history"
                         :default-filename="historyName + ' (Galaxy History)'"
                         :default-record-name="historyName"

--- a/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
+++ b/client/src/components/History/Archiving/HistoryArchiveExportSelector.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { BAlert, BButton, BFormCheckbox, BModal } from "bootstrap-vue";
 import { computed, onMounted, ref, watch } from "vue";
+import { RouterLink } from "vue-router";
 
 import type { ExportRecord } from "@/components/Common/models/exportRecordModel";
 import { exportToFileSource, getExportRecords } from "@/components/History/Export/services";
@@ -9,6 +10,7 @@ import { useTaskMonitor } from "@/composables/taskMonitor";
 import type { HistorySummary } from "@/stores/historyStore";
 
 import ExportRecordCard from "./ExportRecordCard.vue";
+import ExportToDOIRepositoryForm from "@/components/Common/ExportDOIForm.vue";
 import ExportToFileSourceForm from "@/components/Common/ExportForm.vue";
 import LoadingSpan from "@/components/LoadingSpan.vue";
 
@@ -35,6 +37,10 @@ const isExportingRecord = ref(false);
 const isExportDialogOpen = ref(false);
 const isDeleteContentsConfirmed = ref(false);
 const exportErrorMessage = ref<string | null>(null);
+
+const historyName = computed(() => {
+    return props.history.name;
+});
 
 const mostUpToDateExport = computed(() => {
     return existingExports.value.find(
@@ -199,7 +205,35 @@ function onArchiveHistoryWithExport() {
         </BButton>
 
         <BModal v-model="isExportDialogOpen" title="Export history to permanent storage" size="lg" hide-footer>
-            <ExportToFileSourceForm what="history" @export="doExportToFileSourceWithPrefix" />
+            <BTabs card vertical lazy class="export-option-tabs">
+                <BTab id="to-remote-file-tab" title="To Remote File Source" active>
+                    <p>
+                        <b>Exporting to a remote file source</b> will create a compressed archive of the history
+                        contents, copy it to a remote location (e.g. an FTP server) and create an export record with
+                        this information that will be associated with the archived history. You will be able to recreate
+                        the history later by importing it from the export record.
+                    </p>
+                    <ExportToFileSourceForm what="history" @export="doExportToFileSourceWithPrefix" />
+                </BTab>
+                <BTab id="to-rdm-repository-tab" title="To RDM Repository">
+                    <p>
+                        <b>Exporting to a RDM repository</b> (e.g. Invenio RDM or Zenodo RDM) will require to create or
+                        select an existing record in the repository where the history archive will be uploaded. The
+                        export record will be associated with the archived history and you will be able to recreate the
+                        history later by importing it from the export record.
+                    </p>
+                    <p>
+                        You may need to setup your credentials for the selected repository in your
+                        <RouterLink to="/user/information" target="_blank">settings page</RouterLink> to be able to
+                        export.
+                    </p>
+                    <ExportToDOIRepositoryForm
+                        what="history"
+                        :default-filename="historyName + ' (Galaxy History)'"
+                        :default-record-name="historyName"
+                        @export="doExportToFileSource" />
+                </BTab>
+            </BTabs>
         </BModal>
     </div>
 </template>

--- a/client/src/components/History/Export/HistoryExport.test.ts
+++ b/client/src/components/History/Export/HistoryExport.test.ts
@@ -37,10 +37,10 @@ const REMOTE_FILES_API_RESPONSE: FilesSourcePluginList = [
     {
         id: "test-posix-source",
         type: "posix",
-        uri_root: "gxfiles://test-posix-source",
         label: "TestSource",
         doc: "For testing",
         writable: true,
+        browsable: true,
         requires_roles: undefined,
         requires_groups: undefined,
     },

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -18,10 +18,10 @@ import { absPath } from "@/utils/redirect";
 import { exportToFileSource, getExportRecords, reimportHistoryFromRecord } from "./services";
 
 import ExportOptions from "./ExportOptions.vue";
-import ExportDOIForm from "components/Common/ExportDOIForm.vue";
-import ExportForm from "components/Common/ExportForm.vue";
-import ExportRecordDetails from "components/Common/ExportRecordDetails.vue";
-import ExportRecordTable from "components/Common/ExportRecordTable.vue";
+import ExportToFileSourceForm from "@/components/Common/ExportForm.vue";
+import ExportToRDMRepositoryForm from "@/components/Common/ExportRDMForm.vue";
+import ExportRecordDetails from "@/components/Common/ExportRecordDetails.vue";
+import ExportRecordTable from "@/components/Common/ExportRecordTable.vue";
 
 const {
     isRunning: isExportTaskRunning,
@@ -229,14 +229,17 @@ function updateExportParams(newParams) {
                         one of the available remote file sources here. You will be able to re-import it later as long as
                         it remains available on the remote server.
                     </p>
-                    <ExportForm what="history" :clear-input-after-export="true" @export="doExportToFileSource" />
+                    <ExportToFileSourceForm
+                        what="history"
+                        :clear-input-after-export="true"
+                        @export="doExportToFileSource" />
                 </BTab>
                 <BTab
                     v-if="hasWritableRDMFileSources"
                     id="rdm-file-source-tab"
-                    title="to DOI repository"
-                    title-link-class="tab-export-to-doi-repo">
-                    <p>You can <b>upload your history</b> to one of the available DOI repositories here.</p>
+                    title="to RDM repository"
+                    title-link-class="tab-export-to-rdm-repo">
+                    <p>You can <b>upload your history</b> to one of the available RDM repositories here.</p>
                     <p>
                         Your history export archive needs to be uploaded to an existing <i>draft</i> record. You will
                         need to create a <b>new record</b> on the repository or select an existing
@@ -249,7 +252,7 @@ function updateExportParams(newParams) {
                         public name you want to associate with your records or whether you want to publish them
                         immediately or keep them as drafts after export.
                     </BAlert>
-                    <ExportDOIForm
+                    <ExportToRDMRepositoryForm
                         what="history"
                         :default-filename="historyName + ' (Galaxy History)'"
                         :default-record-name="historyName"

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -10,6 +10,7 @@ import { DEFAULT_EXPORT_PARAMS, useShortTermStorage } from "composables/shortTer
 import { useTaskMonitor } from "composables/taskMonitor";
 import { copy as sendToClipboard } from "utils/clipboard";
 import { computed, onMounted, reactive, ref, watch } from "vue";
+import { RouterLink } from "vue-router";
 
 import { useHistoryStore } from "@/stores/historyStore";
 import { absPath } from "@/utils/redirect";
@@ -17,6 +18,7 @@ import { absPath } from "@/utils/redirect";
 import { exportToFileSource, getExportRecords, reimportHistoryFromRecord } from "./services";
 
 import ExportOptions from "./ExportOptions.vue";
+import ExportDOIForm from "components/Common/ExportDOIForm.vue";
 import ExportForm from "components/Common/ExportForm.vue";
 import ExportRecordDetails from "components/Common/ExportRecordDetails.vue";
 import ExportRecordTable from "components/Common/ExportRecordTable.vue";
@@ -29,6 +31,7 @@ const {
 } = useTaskMonitor();
 
 const { hasWritable: hasWritableFileSources } = useFileSources();
+const { hasWritable: hasWritableRDMFileSources } = useFileSources(true);
 
 const {
     isPreparing: isPreparingDownload,
@@ -227,6 +230,31 @@ function updateExportParams(newParams) {
                         it remains available on the remote server.
                     </p>
                     <ExportForm what="history" :clear-input-after-export="true" @export="doExportToFileSource" />
+                </BTab>
+                <BTab
+                    v-if="hasWritableRDMFileSources"
+                    id="rdm-file-source-tab"
+                    title="to DOI repository"
+                    title-link-class="tab-export-to-doi-repo">
+                    <p>You can <b>publish your history</b> to one of the available DOI repositories here.</p>
+                    <p>
+                        Your history export archive needs to be uploaded to an existing record. You will need to create
+                        a <b>new record</b> on the repository or select an existing <b>draft record</b> and then export
+                        your history to it.
+                    </p>
+                    <BAlert show variant="info">
+                        You may need to setup your credentials for the selected repository in your
+                        <RouterLink to="/user/information" target="_blank">settings page</RouterLink> to be able to
+                        export. You can also define some default options for the export in those settings, like the
+                        public name you want to associate with your records or whether you want to publish them
+                        immediately or keep them as drafts after export.
+                    </BAlert>
+                    <ExportDOIForm
+                        what="history"
+                        :default-filename="historyName + ' (Galaxy History)'"
+                        :default-record-name="historyName"
+                        :clear-input-after-export="true"
+                        @export="doExportToFileSource" />
                 </BTab>
             </BTabs>
         </BCard>

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -236,11 +236,11 @@ function updateExportParams(newParams) {
                     id="rdm-file-source-tab"
                     title="to DOI repository"
                     title-link-class="tab-export-to-doi-repo">
-                    <p>You can <b>publish your history</b> to one of the available DOI repositories here.</p>
+                    <p>You can <b>upload your history</b> to one of the available DOI repositories here.</p>
                     <p>
-                        Your history export archive needs to be uploaded to an existing record. You will need to create
-                        a <b>new record</b> on the repository or select an existing <b>draft record</b> and then export
-                        your history to it.
+                        Your history export archive needs to be uploaded to an existing <i>draft</i> record. You will
+                        need to create a <b>new record</b> on the repository or select an existing
+                        <b>draft record</b> and then export your history to it.
                     </p>
                     <BAlert show variant="info">
                         You may need to setup your credentials for the selected repository in your

--- a/client/src/components/History/Export/HistoryExport.vue
+++ b/client/src/components/History/Export/HistoryExport.vue
@@ -30,8 +30,8 @@ const {
     hasFailed: taskHasFailed,
 } = useTaskMonitor();
 
-const { hasWritable: hasWritableFileSources } = useFileSources();
-const { hasWritable: hasWritableRDMFileSources } = useFileSources(true);
+const { hasWritable: hasWritableFileSources } = useFileSources({ exclude: ["rdm"] });
+const { hasWritable: hasWritableRDMFileSources } = useFileSources({ include: ["rdm"] });
 
 const {
     isPreparing: isPreparingDownload,

--- a/client/src/composables/fileSources.ts
+++ b/client/src/composables/fileSources.ts
@@ -4,14 +4,16 @@ import { FilesSourcePlugin, getFileSources } from "@/components/FilesDialog/serv
 
 /**
  * Composable for accessing and working with file sources.
+ *
+ * @param rdmOnly Whether to only include Research Data Management (RDM) specific file sources.
  */
-export function useFileSources() {
+export function useFileSources(rdmOnly = false) {
     const isLoading = ref(true);
     const hasWritable = ref(false);
     const fileSources = ref<FilesSourcePlugin[]>([]);
 
     onMounted(async () => {
-        fileSources.value = await getFileSources();
+        fileSources.value = await getFileSources(rdmOnly);
         hasWritable.value = fileSources.value.some((fs) => fs.writable);
         isLoading.value = false;
     });

--- a/client/src/composables/fileSources.ts
+++ b/client/src/composables/fileSources.ts
@@ -1,19 +1,23 @@
 import { onMounted, readonly, ref } from "vue";
 
-import { FilesSourcePlugin, getFileSources } from "@/components/FilesDialog/services";
+import {
+    BrowsableFilesSourcePlugin,
+    FilterFileSourcesOptions,
+    getFileSources,
+} from "@/components/FilesDialog/services";
 
 /**
  * Composable for accessing and working with file sources.
  *
- * @param rdmOnly Whether to only include Research Data Management (RDM) specific file sources.
+ * @param options - The options to filter the file sources.
  */
-export function useFileSources(rdmOnly = false) {
+export function useFileSources(options: FilterFileSourcesOptions = {}) {
     const isLoading = ref(true);
     const hasWritable = ref(false);
-    const fileSources = ref<FilesSourcePlugin[]>([]);
+    const fileSources = ref<BrowsableFilesSourcePlugin[]>([]);
 
     onMounted(async () => {
-        fileSources.value = await getFileSources(rdmOnly);
+        fileSources.value = await getFileSources(options);
         hasWritable.value = fileSources.value.some((fs) => fs.writable);
         isLoading.value = false;
     });

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -16196,10 +16196,8 @@ export interface operations {
          */
         parameters?: {
             /** @description Whether to return browsable filesources only. The default is `True`, which will omit filesourceslike `http` and `base64` that do not implement a list method. */
-            /** @description Whether to return only RDM compatible plugins. The default is `False`, which will return all plugins. */
             query?: {
                 browsable_only?: boolean;
-                rdm_only?: boolean;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -2213,6 +2213,63 @@ export interface components {
             variant: components["schemas"]["NotificationVariant"];
         };
         /**
+         * BrowsableFilesSourcePlugin
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        BrowsableFilesSourcePlugin: {
+            /**
+             * Browsable
+             * @enum {boolean}
+             */
+            browsable: true;
+            /**
+             * Documentation
+             * @description Documentation or extended description for this plugin.
+             * @example Galaxy's library import directory
+             */
+            doc: string;
+            /**
+             * ID
+             * @description The `FilesSource` plugin identifier
+             * @example _import
+             */
+            id: string;
+            /**
+             * Label
+             * @description The display label for this plugin.
+             * @example Library Import Directory
+             */
+            label: string;
+            /**
+             * Requires groups
+             * @description Only users belonging to the groups specified here can access this files source.
+             */
+            requires_groups?: string;
+            /**
+             * Requires roles
+             * @description Only users with the roles specified here can access this files source.
+             */
+            requires_roles?: string;
+            /**
+             * Type
+             * @description The type of the plugin.
+             * @example gximport
+             */
+            type: string;
+            /**
+             * URI root
+             * @description The URI root used by this type of plugin.
+             * @example gximport://
+             */
+            uri_root: string;
+            /**
+             * Writeable
+             * @description Whether this files source plugin allows write access.
+             * @example false
+             */
+            writable: boolean;
+        };
+        /**
          * BulkOperationItemError
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -4346,6 +4403,11 @@ export interface components {
          */
         FilesSourcePlugin: {
             /**
+             * Browsable
+             * @description Whether this file source plugin can list items.
+             */
+            browsable: boolean;
+            /**
              * Documentation
              * @description Documentation or extended description for this plugin.
              * @example Galaxy's library import directory
@@ -4380,12 +4442,6 @@ export interface components {
              */
             type: string;
             /**
-             * URI root
-             * @description The URI root used by this type of plugin.
-             * @example gximport://
-             */
-            uri_root: string;
-            /**
              * Writeable
              * @description Whether this files source plugin allows write access.
              * @example false
@@ -4408,7 +4464,10 @@ export interface components {
          *   }
          * ]
          */
-        FilesSourcePluginList: components["schemas"]["FilesSourcePlugin"][];
+        FilesSourcePluginList: (
+            | components["schemas"]["BrowsableFilesSourcePlugin"]
+            | components["schemas"]["FilesSourcePlugin"]
+        )[];
         /**
          * FolderLibraryFolderItem
          * @description Base model definition with common configuration used by all derived models.

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -7820,6 +7820,12 @@ export interface components {
          */
         PersonalNotificationCategory: "message" | "new_shared_item";
         /**
+         * PluginKind
+         * @description Enum to distinguish between different kinds or categories of plugins.
+         * @enum {string}
+         */
+        PluginKind: "rfs" | "drs" | "rdm" | "stock";
+        /**
          * PrepareStoreDownloadPayload
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -16255,8 +16261,12 @@ export interface operations {
          */
         parameters?: {
             /** @description Whether to return browsable filesources only. The default is `True`, which will omit filesourceslike `http` and `base64` that do not implement a list method. */
+            /** @description Whether to return **only** filesources of the specified kind. The default is `None`, which will return all filesources. Multiple values can be specified by repeating the parameter. */
+            /** @description Whether to exclude filesources of the specified kind from the list. The default is `None`, which will return all filesources. Multiple values can be specified by repeating the parameter. */
             query?: {
                 browsable_only?: boolean;
+                include_kind?: components["schemas"]["PluginKind"][];
+                exclude_kind?: components["schemas"]["PluginKind"][];
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -11167,13 +11167,13 @@ export interface operations {
             /** @description The requested format of returned data. Either `flat` to simply list all the files, `jstree` to get a tree representation of the files, or the default `uri` to list files and directories by their URI. */
             /** @description Wether to recursively lists all sub-directories. This will be `True` by default depending on the `target`. */
             /** @description (This only applies when `format` is `jstree`) The value can be either `folders` or `files` and it will disable the corresponding nodes of the tree. */
-            /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be accessible. */
+            /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be returned. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"];
                 recursive?: boolean;
                 disable?: components["schemas"]["RemoteFilesDisableMode"];
-                write_intent?: boolean;
+                writeable?: boolean;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -16128,13 +16128,13 @@ export interface operations {
             /** @description The requested format of returned data. Either `flat` to simply list all the files, `jstree` to get a tree representation of the files, or the default `uri` to list files and directories by their URI. */
             /** @description Wether to recursively lists all sub-directories. This will be `True` by default depending on the `target`. */
             /** @description (This only applies when `format` is `jstree`) The value can be either `folders` or `files` and it will disable the corresponding nodes of the tree. */
-            /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be accessible. */
+            /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be returned. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"];
                 recursive?: boolean;
                 disable?: components["schemas"]["RemoteFilesDisableMode"];
-                write_intent?: boolean;
+                writeable?: boolean;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1232,6 +1232,11 @@ export interface paths {
          * @description Lists all remote files available to the user from different sources.
          */
         get: operations["index_api_remote_files_get"];
+        /**
+         * Creates a new entry (directory/record) on the remote files source.
+         * @description Creates a new entry on the remote files source.
+         */
+        post: operations["create_entry_api_remote_files_post"];
     };
     "/api/remote_files/plugins": {
         /**
@@ -2598,6 +2603,23 @@ export interface components {
             [key: string]: string | undefined;
         };
         /**
+         * CreateEntryPayload
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CreateEntryPayload: {
+            /**
+             * Name
+             * @description The name of the entry to create.
+             * @example my_new_entry
+             */
+            name: string;
+            /**
+             * Target
+             * @description The target file source to create the entry in.
+             */
+            target: string;
+        };
+        /**
          * CreateHistoryContentFromStore
          * @description Base model definition with common configuration used by all derived models.
          */
@@ -2967,6 +2989,29 @@ export interface components {
              * @description The relative URL to get this particular Quota details from the rest API.
              */
             url: string;
+        };
+        /**
+         * CreatedEntryResponse
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        CreatedEntryResponse: {
+            /**
+             * External link
+             * @description An optional external link to the created entry if available.
+             */
+            external_link?: string;
+            /**
+             * Name
+             * @description The name of the created entry.
+             * @example my_new_entry
+             */
+            name: string;
+            /**
+             * URI
+             * @description The URI of the created entry.
+             * @example gxfiles://my_new_entry
+             */
+            uri: string;
         };
         /**
          * CreatedUserModel
@@ -11122,11 +11167,13 @@ export interface operations {
             /** @description The requested format of returned data. Either `flat` to simply list all the files, `jstree` to get a tree representation of the files, or the default `uri` to list files and directories by their URI. */
             /** @description Wether to recursively lists all sub-directories. This will be `True` by default depending on the `target`. */
             /** @description (This only applies when `format` is `jstree`) The value can be either `folders` or `files` and it will disable the corresponding nodes of the tree. */
+            /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be accessible. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"];
                 recursive?: boolean;
                 disable?: components["schemas"]["RemoteFilesDisableMode"];
+                write_intent?: boolean;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -16081,11 +16128,13 @@ export interface operations {
             /** @description The requested format of returned data. Either `flat` to simply list all the files, `jstree` to get a tree representation of the files, or the default `uri` to list files and directories by their URI. */
             /** @description Wether to recursively lists all sub-directories. This will be `True` by default depending on the `target`. */
             /** @description (This only applies when `format` is `jstree`) The value can be either `folders` or `files` and it will disable the corresponding nodes of the tree. */
+            /** @description Whether the query is made with the intention of writing to the source. If set to True, only entries that can be written to will be accessible. */
             query?: {
                 target?: string;
                 format?: components["schemas"]["RemoteFilesFormat"];
                 recursive?: boolean;
                 disable?: components["schemas"]["RemoteFilesDisableMode"];
+                write_intent?: boolean;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {
@@ -16109,6 +16158,37 @@ export interface operations {
             };
         };
     };
+    create_entry_api_remote_files_post: {
+        /**
+         * Creates a new entry (directory/record) on the remote files source.
+         * @description Creates a new entry on the remote files source.
+         */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateEntryPayload"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["CreatedEntryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     plugins_api_remote_files_plugins_get: {
         /**
          * Display plugin information for each of the gxfiles:// URI targets available.
@@ -16116,8 +16196,10 @@ export interface operations {
          */
         parameters?: {
             /** @description Whether to return browsable filesources only. The default is `True`, which will omit filesourceslike `http` and `base64` that do not implement a list method. */
+            /** @description Whether to return only RDM compatible plugins. The default is `False`, which will return all plugins. */
             query?: {
                 browsable_only?: boolean;
+                rdm_only?: boolean;
             };
             /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
             header?: {

--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -191,3 +191,9 @@
   label: Stock DRS filesource
   id: drsstock
   doc: Make sure to define this generic drs file source if you have defined any other drs file sources, or stock drs download capability will be disabled.
+
+- type: inveniordm
+  id: invenio
+  doc: Invenio RDM turn-key research data management repository
+  label: Invenio RDM Demo Repository
+  url: https://inveniordm.web.cern.ch/

--- a/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
+++ b/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
@@ -94,3 +94,20 @@ preferences:
               label: Password
               type:  password
               required: False
+
+    invenio:
+        description: Your Invenio RDM Account
+        inputs:
+            - name: token
+              label: Personal Token to publish records to Invenio RDM
+              type: secret
+              store: vault # Requires setting up vault_config_file in your galaxy.yml
+              required: False
+            - name: public_name
+              label: Public name to publish records (formatted as "Lastname, Firstname")
+              type: text
+              required: False
+            - name: public_records
+              label: Whether to publish records (file exports) or make them restricted. Only public records can be imported back.
+              type: boolean
+              required: False

--- a/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
+++ b/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
@@ -96,18 +96,18 @@ preferences:
               required: False
 
     invenio:
-        description: Your Invenio RDM Account
+        description: Your Invenio RDM Integration Settings
         inputs:
             - name: token
-              label: Personal Token to publish records to Invenio RDM
+              label: Personal Token to upload files to Invenio RDM
               type: secret
               store: vault # Requires setting up vault_config_file in your galaxy.yml
               required: False
             - name: public_name
-              label: Public name to publish records (formatted as "Lastname, Firstname")
+              label: Creator name to associate with new records (formatted as "Last name, First name"). If left blank "Anonymous Galaxy User" will be used.
               type: text
               required: False
             - name: public_records
-              label: Whether to publish records (file exports) or make them restricted. Only public records can be imported back.
+              label: Whether to make draft records publicly available or restricted.
               type: boolean
               required: False

--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -165,10 +165,13 @@ class ConfiguredFileSources:
         for_serialization: bool = False,
         user_context: Optional["FileSourceDictifiable"] = None,
         browsable_only: Optional[bool] = False,
+        rdm_only: Optional[bool] = False,
     ) -> List[Dict[str, Any]]:
         rval = []
         for file_source in self._file_sources:
             if not file_source.user_has_access(user_context):
+                continue
+            if rdm_only and not getattr(file_source, "supports_rdm", False):
                 continue
             if browsable_only and not file_source.get_browsable():
                 continue

--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -165,13 +165,10 @@ class ConfiguredFileSources:
         for_serialization: bool = False,
         user_context: Optional["FileSourceDictifiable"] = None,
         browsable_only: Optional[bool] = False,
-        rdm_only: Optional[bool] = False,
     ) -> List[Dict[str, Any]]:
         rval = []
         for file_source in self._file_sources:
             if not file_source.user_has_access(user_context):
-                continue
-            if rdm_only and not getattr(file_source, "supports_rdm", False):
                 continue
             if browsable_only and not file_source.get_browsable():
                 continue

--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -11,7 +11,10 @@ from typing import (
 )
 
 from galaxy import exceptions
-from galaxy.files.sources import BaseFilesSource
+from galaxy.files.sources import (
+    BaseFilesSource,
+    PluginKind,
+)
 from galaxy.util import plugin_config
 from galaxy.util.dictifiable import Dictifiable
 
@@ -165,10 +168,16 @@ class ConfiguredFileSources:
         for_serialization: bool = False,
         user_context: Optional["FileSourceDictifiable"] = None,
         browsable_only: Optional[bool] = False,
+        include_kind: Optional[Set[PluginKind]] = None,
+        exclude_kind: Optional[Set[PluginKind]] = None,
     ) -> List[Dict[str, Any]]:
         rval = []
         for file_source in self._file_sources:
             if not file_source.user_has_access(user_context):
+                continue
+            if include_kind and file_source.plugin_kind not in include_kind:
+                continue
+            if exclude_kind and file_source.plugin_kind in exclude_kind:
                 continue
             if browsable_only and not file_source.get_browsable():
                 continue

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -53,7 +53,12 @@ class FilesSourceProperties(TypedDict):
 
 
 class FilesSourceOptions:
-    """Options to control behaviour of filesource operations, such as realize_to and write_from"""
+    """Options to control behavior of file source operations, such as realize_to, write_from and list."""
+
+    # Indicates access to the FS operation with intent to write.
+    # A file source can be "writeable" but, for example, some directories (or elements) may be restricted or read-only
+    # so those should be skipped while browsing with write_intent=True.
+    write_intent: Optional[bool]
 
     # Property overrides for values initially configured through the constructor. For example
     # the HTTPFilesSource passes in additional http_headers through these properties, which

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -1,6 +1,7 @@
 import abc
 import os
 import time
+from enum import Enum
 from typing import (
     Any,
     ClassVar,
@@ -30,6 +31,40 @@ DEFAULT_WRITABLE = False
 
 if TYPE_CHECKING:
     from galaxy.files import ConfiguredFileSourcesConfig
+
+
+class PluginKind(str, Enum):
+    """Enum to distinguish between different kinds or categories of plugins."""
+
+    rfs = "rfs"
+    """Remote File System
+
+    A remote file system is a file source that is backed by a remote file system
+    that is accessible via a URI. Examples include FTP, SFTP, S3, etc.
+    """
+
+    drs = "drs"
+    """Data Repository Service
+
+    A data repository service is a file source that is backed by a remote data
+    repository service implementing the (DRS) API which provides a generic interface
+    to data repositories so data consumers, including workflow systems,
+    can access data in a single, standard way regardless of where it's stored and how it's managed.
+    """
+
+    rdm = "rdm"
+    """Research Data Management
+
+    A research data management file source is a file source that is backed by a remote
+    research data management system that can provide DOIs. Examples include InvenioRDM, Zenodo, etc.
+    """
+
+    stock = "stock"
+    """Stock Plugin
+
+    A stock plugin is a file source that is shipped with Galaxy and covers common
+    use cases. Examples include the UserFTP, LibraryImport, UserLibraryImport, etc.
+    """
 
 
 class FilesSourceProperties(TypedDict):
@@ -234,6 +269,7 @@ class FilesSource(SingleFileSource, SupportsBrowsing):
 
 class BaseFilesSource(FilesSource):
     plugin_type: ClassVar[str]
+    plugin_kind: ClassVar[PluginKind] = PluginKind.rfs  # Remote File Source by default, override in subclasses
 
     def get_browsable(self) -> bool:
         # Check whether the list method has been overridden

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -10,6 +10,7 @@ from typing import (
 )
 
 from typing_extensions import (
+    Literal,
     NotRequired,
     TypedDict,
 )
@@ -68,15 +69,38 @@ class FilesSourceOptions:
 
 
 class EntryData(TypedDict):
+    """Provides data to create a new entry in a file source."""
+
     name: str
     # May contain additional properties depending on the file source
 
 
 class Entry(TypedDict):
+    """Represents the result of creating a new entry in a file source."""
+
     name: str
     uri: str
     # May contain additional properties depending on the file source
     external_link: NotRequired[str]
+
+
+class RemoteEntry(TypedDict):
+    name: str
+    uri: str
+    path: str
+
+
+TDirectoryClass = TypedDict("TDirectoryClass", {"class": Literal["Directory"]})
+TFileClass = TypedDict("TFileClass", {"class": Literal["File"]})
+
+
+class RemoteDirectory(RemoteEntry, TDirectoryClass):
+    pass
+
+
+class RemoteFile(RemoteEntry, TFileClass):
+    size: int
+    ctime: str
 
 
 class SingleFileSource(metaclass=abc.ABCMeta):
@@ -320,6 +344,11 @@ class BaseFilesSource(FilesSource):
     def _create_entry(
         self, entry_data: EntryData, user_context=None, opts: Optional[FilesSourceOptions] = None
     ) -> Entry:
+        """Create a new entry (directory) in the file source.
+
+        The file source must be writeable.
+        This function can be overridden by subclasses to provide a way of creating entries in the file source.
+        """
         raise NotImplementedError()
 
     def write_from(self, target_path, native_path, user_context=None, opts: Optional[FilesSourceOptions] = None):

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -57,9 +57,9 @@ class FilesSourceOptions:
     """Options to control behavior of file source operations, such as realize_to, write_from and list."""
 
     # Indicates access to the FS operation with intent to write.
-    # A file source can be "writeable" but, for example, some directories (or elements) may be restricted or read-only
-    # so those should be skipped while browsing with write_intent=True.
-    write_intent: Optional[bool]
+    # Even if a file source is "writeable" some directories (or elements) may be restricted or read-only
+    # so those should be skipped while browsing with writeable=True.
+    writeable: Optional[bool]
 
     # Property overrides for values initially configured through the constructor. For example
     # the HTTPFilesSource passes in additional http_headers through these properties, which

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -1,6 +1,8 @@
 import logging
 from typing import (
     cast,
+    List,
+    NamedTuple,
     Optional,
 )
 
@@ -10,13 +12,108 @@ from galaxy.files import ProvidesUserFileSourcesUserContext
 from galaxy.files.sources import (
     BaseFilesSource,
     FilesSourceProperties,
+    RemoteDirectory,
+    RemoteFile,
 )
 
 log = logging.getLogger(__name__)
 
+OptionalUserContext = Optional[ProvidesUserFileSourcesUserContext]
+
 
 class RDMFilesSourceProperties(FilesSourceProperties):
     url: str
+
+
+class RecordFilename(NamedTuple):
+    record_id: str
+    filename: str
+
+
+class RDMRepositoryInteractor:
+    """Base class for interacting with an external RDM repository.
+
+    This class is not intended to be used directly, but rather to be subclassed
+    by file sources that interact with RDM repositories.
+    """
+
+    def __init__(self, repository_url: str, plugin: BaseFilesSource):
+        self._repository_url = repository_url
+        self._plugin = plugin
+
+    @property
+    def plugin(self) -> BaseFilesSource:
+        """Returns the plugin associated with this repository interactor."""
+        return self._plugin
+
+    @property
+    def repository_url(self) -> str:
+        """Returns the base URL of the repository.
+
+        Example: https://zenodo.org
+        """
+        return self._repository_url
+
+    def to_plugin_uri(self, record_id: str, filename: Optional[str] = None) -> str:
+        """Creates a valid plugin URI to reference the given record_id.
+
+        If a filename is provided, the URI will reference the specific file in the record."""
+        raise NotImplementedError()
+
+    def get_records(self, write_intent: bool, user_context: OptionalUserContext = None) -> List[RemoteDirectory]:
+        """Returns the list of records in the repository."""
+        raise NotImplementedError()
+
+    def get_files_in_record(
+        self, record_id: str, write_intent: bool, user_context: OptionalUserContext = None
+    ) -> List[RemoteFile]:
+        """Returns the list of files contained in the given record."""
+        raise NotImplementedError()
+
+    def create_draft_record(self, title: str, user_context: OptionalUserContext = None):
+        """Creates a draft record (directory) in the repository with basic metadata.
+
+        The metadata is usually just the title of the record and the user that created it.
+        Some plugins might also provide additional metadata defaults in the user settings."""
+        raise NotImplementedError()
+
+    def upload_file_to_draft_record(
+        self,
+        record_id: str,
+        filename: str,
+        file_path: str,
+        user_context: OptionalUserContext = None,
+    ) -> None:
+        """Uploads a file with the provided filename (from file_path) to a draft record with the given record_id.
+
+        The draft record must have been created in advance with the `create_draft_record` method.
+        The file must exist in the file system at the given file_path.
+        The user_context might be required to authenticate the user in the repository.
+        """
+        raise NotImplementedError()
+
+    def download_file_from_record(
+        self,
+        record_id: str,
+        filename: str,
+        file_path: str,
+        user_context: OptionalUserContext = None,
+    ) -> None:
+        """Downloads a file with the provided filename from the record with the given record_id.
+
+        The file will be downloaded to the file system at the given file_path.
+        The user_context might be required to authenticate the user in the repository if the
+        file is not publicly available.
+        """
+        raise NotImplementedError()
+
+    def publish_draft_record(self, record_id: str, user_context: OptionalUserContext = None) -> None:
+        """Publishes the draft record with the given record_id.
+
+        The draft record must have been created in advance with the `create_draft_record` method.
+        The user_context might be required to authenticate the user in the repository.
+        """
+        raise NotImplementedError()
 
 
 class RDMFilesSource(BaseFilesSource):
@@ -46,16 +143,27 @@ class RDMFilesSource(BaseFilesSource):
             raise Exception("URL for RDM repository must be provided in configuration")
         self._repository_url = base_url
         self._props = props
+        self._repository_interactor = self.get_repository_interactor(base_url)
 
     @property
-    def repository_url(self) -> str:
-        return self._repository_url
+    def repository(self) -> RDMRepositoryInteractor:
+        return self._repository_interactor
 
-    def _serialization_props(
-        self, user_context: Optional[ProvidesUserFileSourcesUserContext] = None
-    ) -> RDMFilesSourceProperties:
+    def get_repository_interactor(self, repository_url: str) -> RDMRepositoryInteractor:
+        """Returns an interactor compatible with the given repository URL.
+
+        This must be implemented by subclasses."""
+        raise NotImplementedError()
+
+    def parse_path(self, source_path: str) -> RecordFilename:
+        # source_path has always the format: '/{record_id}/{file_name}'
+        record_id = source_path.split("/")[1]
+        filename = source_path.split("/")[-1]
+        return RecordFilename(record_id=record_id, filename=filename)
+
+    def _serialization_props(self, user_context: OptionalUserContext = None) -> RDMFilesSourceProperties:
         effective_props = {}
         for key, val in self._props.items():
             effective_props[key] = self._evaluate_prop(val, user_context=user_context)
-        effective_props["url"] = self.repository_url
+        effective_props["url"] = self._repository_url
         return cast(RDMFilesSourceProperties, effective_props)

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -115,14 +115,6 @@ class RDMRepositoryInteractor:
         """
         raise NotImplementedError()
 
-    def publish_draft_record(self, record_id: str, user_context: OptionalUserContext = None) -> None:
-        """Publishes the draft record with the given record_id.
-
-        The draft record must have been created in advance with the `create_draft_record` method.
-        The user_context might be required to authenticate the user in the repository.
-        """
-        raise NotImplementedError()
-
 
 class RDMFilesSource(BaseFilesSource):
     """Base class for Research Data Management (RDM) file sources.

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -1,0 +1,61 @@
+import logging
+from typing import (
+    cast,
+    Optional,
+)
+
+from typing_extensions import Unpack
+
+from galaxy.files import ProvidesUserFileSourcesUserContext
+from galaxy.files.sources import (
+    BaseFilesSource,
+    FilesSourceProperties,
+)
+
+log = logging.getLogger(__name__)
+
+
+class RDMFilesSourceProperties(FilesSourceProperties):
+    url: str
+
+
+class RDMFilesSource(BaseFilesSource):
+    """Base class for Research Data Management (RDM) file sources.
+
+    This class is not intended to be used directly, but rather to be subclassed
+    by file sources that interact with RDM repositories.
+
+    A RDM file source is similar to a regular file source, but instead of tree of
+    files and directories, it provides a (one level) list of records (representing directories)
+    that can contain only files (no subdirectories).
+
+    In addition, RDM file sources might need to create a new record (directory) in advance in the
+    repository, and then upload a file to it. This is done by calling the `create_entry`
+    method.
+
+    """
+
+    # This allows to filter out the RDM file sources from the list of available
+    # file sources.
+    supports_rdm = True
+
+    def __init__(self, **kwd: Unpack[FilesSourceProperties]):
+        props = self._parse_common_config_opts(kwd)
+        base_url = props.get("url", None)
+        if not base_url:
+            raise Exception("URL for RDM repository must be provided in configuration")
+        self._repository_url = base_url
+        self._props = props
+
+    @property
+    def repository_url(self) -> str:
+        return self._repository_url
+
+    def _serialization_props(
+        self, user_context: Optional[ProvidesUserFileSourcesUserContext] = None
+    ) -> RDMFilesSourceProperties:
+        effective_props = {}
+        for key, val in self._props.items():
+            effective_props[key] = self._evaluate_prop(val, user_context=user_context)
+        effective_props["url"] = self.repository_url
+        return cast(RDMFilesSourceProperties, effective_props)

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -161,15 +161,29 @@ class RDMFilesSource(BaseFilesSource):
         raise NotImplementedError()
 
     def parse_path(self, source_path: str, record_id_only: bool = False) -> RecordFilename:
+        """Parses the given source path and returns the record_id and filename.
+
+        The source path must have the format '/<record_id>/<file_name>'.
+        If record_id_only is True, the source path must have the format '/<record_id>' and an
+        empty filename will be returned.
+        """
+
+        def get_error_msg(details: str) -> str:
+            return f"Invalid source path: '{source_path}'. Expected format: '{expected_format}'. {details}"
+
+        expected_format = "/<record_id>"
         if not source_path.startswith("/"):
-            raise ValueError(f"Invalid source path: '{source_path}'. Must start with '/'")
+            raise ValueError(get_error_msg("Must start with '/'."))
         parts = source_path[1:].split("/", 2)
         if record_id_only:
             if len(parts) != 1:
-                raise ValueError(f"Invalid source path: '{source_path}'. Must have the format '/<record_id>'.")
+                raise ValueError(get_error_msg("Please provide the record_id only."))
             return RecordFilename(record_id=parts[0], filename="")
-        if len(parts) != 2:
-            raise ValueError(f"Invalid source path: '{source_path}'. Must have the format '/<record_id>/<file_name>'.")
+        expected_format = "/<record_id>/<file_name>"
+        if len(parts) < 2:
+            raise ValueError(get_error_msg("Please provide both the record_id and file_name."))
+        if len(parts) > 2:
+            raise ValueError(get_error_msg("Too many parts. Please provide the record_id and file_name only."))
         record_id, file_name = parts
         return RecordFilename(record_id=record_id, filename=file_name)
 

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -60,14 +60,21 @@ class RDMRepositoryInteractor:
         If a filename is provided, the URI will reference the specific file in the record."""
         raise NotImplementedError()
 
-    def get_records(self, write_intent: bool, user_context: OptionalUserContext = None) -> List[RemoteDirectory]:
-        """Returns the list of records in the repository."""
+    def get_records(self, writeable: bool, user_context: OptionalUserContext = None) -> List[RemoteDirectory]:
+        """Returns the list of records in the repository.
+
+        If writeable is True, only records that the user can write to will be returned.
+        The user_context might be required to authenticate the user in the repository.
+        """
         raise NotImplementedError()
 
     def get_files_in_record(
-        self, record_id: str, write_intent: bool, user_context: OptionalUserContext = None
+        self, record_id: str, writeable: bool, user_context: OptionalUserContext = None
     ) -> List[RemoteFile]:
-        """Returns the list of files contained in the given record."""
+        """Returns the list of files contained in the given record.
+
+        If writeable is True, we are signaling that the user intends to write to the record.
+        """
         raise NotImplementedError()
 
     def create_draft_record(self, title: str, user_context: OptionalUserContext = None):

--- a/lib/galaxy/files/sources/_rdm.py
+++ b/lib/galaxy/files/sources/_rdm.py
@@ -12,6 +12,7 @@ from galaxy.files import ProvidesUserFileSourcesUserContext
 from galaxy.files.sources import (
     BaseFilesSource,
     FilesSourceProperties,
+    PluginKind,
     RemoteDirectory,
     RemoteFile,
 )
@@ -139,9 +140,7 @@ class RDMFilesSource(BaseFilesSource):
 
     """
 
-    # This allows to filter out the RDM file sources from the list of available
-    # file sources.
-    supports_rdm = True
+    plugin_kind = PluginKind.rdm
 
     def __init__(self, **kwd: Unpack[FilesSourceProperties]):
         props = self._parse_common_config_opts(kwd)

--- a/lib/galaxy/files/sources/base64.py
+++ b/lib/galaxy/files/sources/base64.py
@@ -8,6 +8,7 @@ from . import (
     BaseFilesSource,
     FilesSourceOptions,
     FilesSourceProperties,
+    PluginKind,
 )
 
 log = logging.getLogger(__name__)
@@ -15,6 +16,7 @@ log = logging.getLogger(__name__)
 
 class Base64FilesSource(BaseFilesSource):
     plugin_type = "base64"
+    plugin_kind = PluginKind.stock
 
     def __init__(self, **kwd: Unpack[FilesSourceProperties]):
         kwds: FilesSourceProperties = dict(

--- a/lib/galaxy/files/sources/drs.py
+++ b/lib/galaxy/files/sources/drs.py
@@ -13,6 +13,7 @@ from . import (
     BaseFilesSource,
     FilesSourceOptions,
     FilesSourceProperties,
+    PluginKind,
 )
 
 log = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ class DRSFilesSourceProperties(FilesSourceProperties, total=False):
 
 class DRSFilesSource(BaseFilesSource):
     plugin_type = "drs"
+    plugin_kind = PluginKind.drs
 
     def __init__(self, **kwd: Unpack[FilesSourceProperties]):
         kwds: FilesSourceProperties = dict(

--- a/lib/galaxy/files/sources/galaxy.py
+++ b/lib/galaxy/files/sources/galaxy.py
@@ -7,6 +7,7 @@ from typing import (
 
 from typing_extensions import Unpack
 
+from galaxy.files.sources import PluginKind
 from .posix import (
     PosixFilesSource,
     PosixFilesSourceProperties,
@@ -15,6 +16,7 @@ from .posix import (
 
 class UserFtpFilesSource(PosixFilesSource):
     plugin_type = "gxftp"
+    plugin_kind = PluginKind.stock
 
     def __init__(self, **kwd: Unpack[PosixFilesSourceProperties]):
         posix_kwds: PosixFilesSourceProperties = dict(
@@ -39,6 +41,7 @@ class UserFtpFilesSource(PosixFilesSource):
 
 class LibraryImportFilesSource(PosixFilesSource):
     plugin_type = "gximport"
+    plugin_kind = PluginKind.stock
 
     def __init__(self, **kwd: Unpack[PosixFilesSourceProperties]):
         posix_kwds: PosixFilesSourceProperties = dict(
@@ -59,6 +62,7 @@ class LibraryImportFilesSource(PosixFilesSource):
 
 class UserLibraryImportFilesSource(PosixFilesSource):
     plugin_type = "gxuserimport"
+    plugin_kind = PluginKind.stock
 
     def __init__(self, **kwd: Unpack[PosixFilesSourceProperties]):
         posix_kwds: PosixFilesSourceProperties = dict(

--- a/lib/galaxy/files/sources/http.py
+++ b/lib/galaxy/files/sources/http.py
@@ -18,6 +18,7 @@ from . import (
     BaseFilesSource,
     FilesSourceOptions,
     FilesSourceProperties,
+    PluginKind,
 )
 
 log = logging.getLogger(__name__)
@@ -30,6 +31,7 @@ class HTTPFilesSourceProperties(FilesSourceProperties, total=False):
 
 class HTTPFilesSource(BaseFilesSource):
     plugin_type = "http"
+    plugin_kind = PluginKind.stock
 
     def __init__(self, **kwd: Unpack[FilesSourceProperties]):
         kwds: FilesSourceProperties = dict(

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -1,13 +1,21 @@
+import datetime
+import json
+import os
 import ssl
 import urllib.request
 from typing import (
     cast,
+    List,
     Optional,
 )
 from urllib.parse import urljoin
 
 import requests
-from typing_extensions import Unpack
+from typing_extensions import (
+    Literal,
+    TypedDict,
+    Unpack,
+)
 
 from galaxy.files.sources import (
     BaseFilesSource,
@@ -27,8 +35,80 @@ SSL_CONTEXT.check_hostname = False
 SSL_CONTEXT.verify_mode = ssl.CERT_NONE
 
 
+AccessStatus = Literal["public", "restricted"]
+
+
 class InvenioFilesSourceProperties(FilesSourceProperties):
     url: str
+
+
+class ResourceType(TypedDict):
+    id: str
+
+
+class RecordAccess(TypedDict):
+    record: AccessStatus
+    files: AccessStatus
+
+
+class RecordFiles(TypedDict):
+    enabled: bool
+
+
+class IdentifierEntry(TypedDict):
+    scheme: str
+    identifier: str
+
+
+class AffiliationEntry(TypedDict):
+    id: str
+    name: str
+
+
+class RecordPersonOrOrg(TypedDict):
+    family_name: str
+    given_name: str
+    type: Literal["personal", "organizational"]
+    name: str
+    identifiers: List[IdentifierEntry]
+
+
+class Creator(TypedDict):
+    person_or_org: RecordPersonOrOrg
+    affiliations: Optional[List[AffiliationEntry]]
+
+
+class RecordMetadata(TypedDict):
+    title: str
+    resource_type: ResourceType
+    publication_date: str
+    creators: List[Creator]
+
+
+class RecordLinks(TypedDict):
+    self: str
+    self_html: str
+    self_iiif_manifest: str
+    self_iiif_sequence: str
+    files: str
+    record: str
+    record_html: str
+    publish: str
+    review: str
+    versions: str
+    access_links: str
+    reserve_doi: str
+
+
+class InvenioRecord(TypedDict):
+    id: str
+    title: str
+    resource_type: ResourceType
+    publication_date: str
+    access: RecordAccess
+    files: RecordFiles
+    metadata: RecordMetadata
+    links: RecordLinks
 
 
 class InvenioFilesSource(BaseFilesSource):
@@ -45,26 +125,56 @@ class InvenioFilesSource(BaseFilesSource):
         self._props = props
 
     def _list(self, path="/", recursive=True, user_context=None, opts: Optional[FilesSourceOptions] = None):
-        is_listing_records = path == "/"
-        if is_listing_records:
-            # TODO: This is limited to 25 records by default. We should add pagination support.
-            request_url = urljoin(self._invenio_url, "api/records")
-        else:
-            # listing a record's files
-            request_url = urljoin(self._invenio_url, f"{path}/files")
+        is_root_path = path == "/"
+        if is_root_path:
+            return self._list_records(user_context)
+        return self._list_record_files(path, user_context)
 
-        rval = []
+    def _realize_to(
+        self, source_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+    ):
+        # TODO: source_path will be wrong when constructed from the UI as it assumes the target_uri is `get_root_uri() + filename`
+
+        remote_path = urljoin(self._invenio_url, source_path)
+        # TODO: user_context is always None here when called from a data fetch.
+        # This prevents downloading files that require authentication even if the user provided a token.
+        headers = self._get_request_headers(user_context)
+        req = urllib.request.Request(remote_path, headers=headers)
+        with urllib.request.urlopen(req, timeout=DEFAULT_SOCKET_TIMEOUT, context=SSL_CONTEXT) as page:
+            f = open(native_path, "wb")
+            return stream_to_open_named_file(
+                page, f.fileno(), native_path, source_encoding=get_charset_from_http_headers(page.headers)
+            )
+
+    def _write_from(
+        self, target_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+    ):
+        filename = os.path.basename(target_path)
+        record_title = f"{filename} (exported by Galaxy)"
+        draft_record = self._create_draft_record(title=record_title, user_context=user_context)
+        try:
+            self._upload_file_to_draft_record(draft_record, filename, native_path, user_context=user_context)
+            self._publish_draft_record(draft_record, user_context=user_context)
+        except Exception:
+            self._delete_draft_record(draft_record, user_context)
+            raise
+
+    def _list_records(self, user_context=None):
+        # TODO: This is limited to 25 records by default. Add pagination support?
+        request_url = urljoin(self._invenio_url, "api/records")
+        response_data = self._get_response(user_context, request_url)
+        return self._get_records_from_response(response_data)
+
+    def _list_record_files(self, path, user_context=None):
+        request_url = urljoin(self._invenio_url, f"{path}/files")
+        response_data = self._get_response(user_context, request_url)
+        return self._get_record_files_from_response(path, response_data)
+
+    def _get_response(self, user_context, request_url: str) -> dict:
         headers = self._get_request_headers(user_context)
         response = requests.get(request_url, headers=headers, verify=VERIFY)
-        if response.status_code == 200:
-            response_json = response.json()
-            if is_listing_records:
-                rval = self._get_records_from_response(path, response_json)
-            else:
-                rval = self._get_record_files_from_response(path, response_json)
-        else:
-            raise Exception(f"Request to {request_url} failed with status code {response.status_code}")
-        return rval
+        self._ensure_response_has_expected_status_code(response, 200)
+        return response.json()
 
     def _get_request_headers(self, user_context):
         preferences = user_context.preferences if user_context else None
@@ -72,7 +182,7 @@ class InvenioFilesSource(BaseFilesSource):
         headers = {"Authorization": f"Bearer {token}"} if token else {}
         return headers
 
-    def _get_records_from_response(self, path: str, response: dict):
+    def _get_records_from_response(self, response: dict):
         records = response["hits"]["hits"]
         rval = []
         for record in records:
@@ -83,7 +193,7 @@ class InvenioFilesSource(BaseFilesSource):
                     "name": record["metadata"]["title"],
                     "ctime": record["created"],
                     "uri": uri,
-                    "path": path,
+                    "path": f"/{record['id']}",
                 }
             )
 
@@ -98,6 +208,7 @@ class InvenioFilesSource(BaseFilesSource):
         for entry in entries:
             if entry.get("status") == "completed":
                 uri = self._to_plugin_uri(entry["links"]["content"])
+                path = self._to_plugin_uri(entry["links"]["self"])
                 rval.append(
                     {
                         "class": "File",
@@ -113,31 +224,110 @@ class InvenioFilesSource(BaseFilesSource):
     def _to_plugin_uri(self, uri: str) -> str:
         return uri.replace(self._invenio_url, self.get_uri_root())
 
-    def _realize_to(
-        self, source_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
-    ):
-        remote_path = urljoin(self._invenio_url, source_path)
-        # TODO: user_context is always None here when called from a data fetch.
-        # This prevents downloading files that require authentication even if the user provided a token.
-        headers = self._get_request_headers(user_context)
-        req = urllib.request.Request(remote_path, headers=headers)
-        with urllib.request.urlopen(req, timeout=DEFAULT_SOCKET_TIMEOUT, context=SSL_CONTEXT) as page:
-            f = open(native_path, "wb")
-            return stream_to_open_named_file(
-                page, f.fileno(), native_path, source_encoding=get_charset_from_http_headers(page.headers)
-            )
-
-    def _write_from(
-        self, target_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
-    ):
-        raise NotImplementedError()
-
     def _serialization_props(self, user_context=None) -> InvenioFilesSourceProperties:
         effective_props = {}
         for key, val in self._props.items():
             effective_props[key] = self._evaluate_prop(val, user_context=user_context)
         effective_props["url"] = self._invenio_url
         return cast(InvenioFilesSourceProperties, effective_props)
+
+    def _create_draft_record(self, title: str, user_context=None) -> InvenioRecord:
+        today = datetime.date.today().isoformat()
+        creator = self._get_creator_from_user_context(user_context)
+        should_publish = self._get_public_records_user_setting_enabled_status(user_context)
+        access = "public" if should_publish else "restricted"
+        create_record_request = {
+            "access": {"record": access, "files": access},
+            "files": {"enabled": True},
+            "metadata": {
+                "title": title,
+                "publication_date": today,
+                "resource_type": {"id": "dataset"},
+                "creators": [
+                    creator,
+                ],
+            },
+        }
+
+        headers = self._get_request_headers(user_context)
+        if "Authorization" not in headers:
+            raise Exception(
+                "Cannot create record without authentication token. Please set your personal access token in your Galaxy preferences."
+            )
+
+        create_record_url = urljoin(self._invenio_url, "api/records")
+        response = requests.post(create_record_url, json=create_record_request, headers=headers, verify=VERIFY)
+        self._ensure_response_has_expected_status_code(response, 201)
+        record = response.json()
+        return record
+
+    def _delete_draft_record(self, record: InvenioRecord, user_context=None):
+        delete_record_url = record["links"]["self"]
+        headers = self._get_request_headers(user_context)
+        response = requests.delete(delete_record_url, headers=headers, verify=VERIFY)
+        self._ensure_response_has_expected_status_code(response, 204)
+
+    def _upload_file_to_draft_record(self, record: InvenioRecord, filename: str, native_path: str, user_context=None):
+        upload_file_url = urljoin(self._invenio_url, f"api/records/{record['id']}/draft/files")
+        headers = self._get_request_headers(user_context)
+
+        # Add file metadata
+        response = requests.post(upload_file_url, json=[{"key": filename}], headers=headers, verify=VERIFY)
+        self._ensure_response_has_expected_status_code(response, 201)
+
+        # Upload file content
+        file_entry = response.json()["entries"][0]
+        upload_file_content_url = file_entry["links"]["content"]
+        commit_file_upload_url = file_entry["links"]["commit"]
+        with open(native_path, "rb") as file:
+            response = requests.put(upload_file_content_url, data=file, headers=headers, verify=VERIFY)
+            self._ensure_response_has_expected_status_code(response, 200)
+
+        # Commit file upload
+        response = requests.post(commit_file_upload_url, headers=headers, verify=VERIFY)
+        self._ensure_response_has_expected_status_code(response, 200)
+
+    def _publish_draft_record(self, record: InvenioRecord, user_context=None):
+        publish_record_url = urljoin(self._invenio_url, f"api/records/{record['id']}/draft/actions/publish")
+        headers = self._get_request_headers(user_context)
+        response = requests.post(publish_record_url, headers=headers, verify=VERIFY)
+        self._ensure_response_has_expected_status_code(response, 202)
+
+    def _get_creator_from_user_context(self, user_context):
+        preferences = user_context.preferences if user_context else None
+        public_name = preferences.get(f"{self.id}|public_name", None) if preferences else None
+        family_name = "Galaxy User"
+        given_name = "Anonymous"
+        if public_name:
+            tokens = public_name.split(", ")
+            if len(tokens) == 2:
+                family_name = tokens[0]
+                given_name = tokens[1]
+            else:
+                given_name = public_name
+        return {"person_or_org": {"family_name": family_name, "given_name": given_name, "type": "personal"}}
+
+    def _get_public_records_user_setting_enabled_status(self, user_context) -> bool:
+        preferences = user_context.preferences if user_context else None
+        public_records = preferences.get(f"{self.id}|public_records", None) if preferences else None
+        if public_records:
+            return True
+        return False
+
+    def _ensure_response_has_expected_status_code(self, response, expected_status_code: int):
+        if response.status_code != expected_status_code:
+            error_message = self._get_response_error_message(response)
+            raise Exception(
+                f"Request to {response.url} failed with status code {response.status_code}: {error_message}"
+            )
+
+    def _get_response_error_message(self, response):
+        response_json = response.json()
+        error_message = response_json.get("message") if response.status_code == 400 else response.text
+        errors = response_json.get("errors", [])
+        for error in errors:
+            error_message += f"\n{json.dumps(error)}"
+        return error_message
 
 
 __all__ = ("InvenioFilesSource",)

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -337,14 +337,9 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         return response.json()
 
     def _get_request_headers(self, user_context: OptionalUserContext):
-        token = self.get_authorization_token(user_context)
+        token = self.plugin.get_authorization_token(user_context)
         headers = {"Authorization": f"Bearer {token}"} if token else {}
         return headers
-
-    def get_authorization_token(self, user_context) -> str:
-        vault = user_context.user_vault if user_context else None
-        token = vault.read_secret(f"preferences/{self.plugin.id}/token") if vault else None
-        return token
 
     def _ensure_response_has_expected_status_code(self, response, expected_status_code: int):
         if response.status_code != expected_status_code:

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -1,0 +1,143 @@
+import ssl
+import urllib.request
+from typing import (
+    cast,
+    Optional,
+)
+from urllib.parse import urljoin
+
+import requests
+from typing_extensions import Unpack
+
+from galaxy.files.sources import (
+    BaseFilesSource,
+    FilesSourceOptions,
+    FilesSourceProperties,
+)
+from galaxy.util import (
+    DEFAULT_SOCKET_TIMEOUT,
+    get_charset_from_http_headers,
+    stream_to_open_named_file,
+)
+
+# TODO: Remove this block. Ignoring SSL errors for testing purposes.
+VERIFY = False
+SSL_CONTEXT = ssl.create_default_context()
+SSL_CONTEXT.check_hostname = False
+SSL_CONTEXT.verify_mode = ssl.CERT_NONE
+
+
+class InvenioFilesSourceProperties(FilesSourceProperties):
+    url: str
+
+
+class InvenioFilesSource(BaseFilesSource):
+    """A files source for Invenio turn-key research data management repository."""
+
+    plugin_type = "inveniordm"
+
+    def __init__(self, **kwd: Unpack[InvenioFilesSourceProperties]):
+        props = self._parse_common_config_opts(kwd)
+        base_url = props.get("url", None)
+        if not base_url:
+            raise Exception("InvenioFilesSource requires a url")
+        self._invenio_url = base_url
+        self._props = props
+
+    def _list(self, path="/", recursive=True, user_context=None, opts: Optional[FilesSourceOptions] = None):
+        is_listing_records = path == "/"
+        if is_listing_records:
+            # TODO: This is limited to 25 records by default. We should add pagination support.
+            request_url = urljoin(self._invenio_url, "api/records")
+        else:
+            # listing a record's files
+            request_url = urljoin(self._invenio_url, f"{path}/files")
+
+        rval = []
+        headers = self._get_request_headers(user_context)
+        response = requests.get(request_url, headers=headers, verify=VERIFY)
+        if response.status_code == 200:
+            response_json = response.json()
+            if is_listing_records:
+                rval = self._get_records_from_response(path, response_json)
+            else:
+                rval = self._get_record_files_from_response(path, response_json)
+        else:
+            raise Exception(f"Request to {request_url} failed with status code {response.status_code}")
+        return rval
+
+    def _get_request_headers(self, user_context):
+        preferences = user_context.preferences if user_context else None
+        token = preferences.get(f"{self.id}|token", None) if preferences else None
+        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        return headers
+
+    def _get_records_from_response(self, path: str, response: dict):
+        records = response["hits"]["hits"]
+        rval = []
+        for record in records:
+            uri = self._to_plugin_uri(record["links"]["self"])
+            rval.append(
+                {
+                    "class": "Directory",
+                    "name": record["metadata"]["title"],
+                    "ctime": record["created"],
+                    "uri": uri,
+                    "path": path,
+                }
+            )
+
+        return rval
+
+    def _get_record_files_from_response(self, path: str, response: dict):
+        files_enabled = response.get("enabled", False)
+        if not files_enabled:
+            return []
+        entries = response["entries"]
+        rval = []
+        for entry in entries:
+            if entry.get("status") == "completed":
+                uri = self._to_plugin_uri(entry["links"]["content"])
+                rval.append(
+                    {
+                        "class": "File",
+                        "name": entry["key"],
+                        "size": entry["size"],
+                        "ctime": entry["created"],
+                        "uri": uri,
+                        "path": path,
+                    }
+                )
+        return rval
+
+    def _to_plugin_uri(self, uri: str) -> str:
+        return uri.replace(self._invenio_url, self.get_uri_root())
+
+    def _realize_to(
+        self, source_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+    ):
+        remote_path = urljoin(self._invenio_url, source_path)
+        # TODO: user_context is always None here when called from a data fetch.
+        # This prevents downloading files that require authentication even if the user provided a token.
+        headers = self._get_request_headers(user_context)
+        req = urllib.request.Request(remote_path, headers=headers)
+        with urllib.request.urlopen(req, timeout=DEFAULT_SOCKET_TIMEOUT, context=SSL_CONTEXT) as page:
+            f = open(native_path, "wb")
+            return stream_to_open_named_file(
+                page, f.fileno(), native_path, source_encoding=get_charset_from_http_headers(page.headers)
+            )
+
+    def _write_from(
+        self, target_path: str, native_path: str, user_context=None, opts: Optional[FilesSourceOptions] = None
+    ):
+        raise NotImplementedError()
+
+    def _serialization_props(self, user_context=None) -> InvenioFilesSourceProperties:
+        effective_props = {}
+        for key, val in self._props.items():
+            effective_props[key] = self._evaluate_prop(val, user_context=user_context)
+        effective_props["url"] = self._invenio_url
+        return cast(InvenioFilesSourceProperties, effective_props)
+
+
+__all__ = ("InvenioFilesSource",)

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -132,7 +132,7 @@ class InvenioRDMFilesSource(RDMFilesSource):
         is_root_path = path == "/"
         if is_root_path:
             return self.repository.get_records(writeable, user_context)
-        record_id, _ = self.parse_path(path)
+        record_id = self.get_record_id_from_path(path)
         return self.repository.get_files_in_record(record_id, writeable, user_context)
 
     def _create_entry(

--- a/lib/galaxy/files/sources/invenio.py
+++ b/lib/galaxy/files/sources/invenio.py
@@ -283,16 +283,16 @@ class InvenioRepositoryInteractor(RDMRepositoryInteractor):
         return download_file_content_url
 
     def _is_draft_record(self, record_id: str, user_context: OptionalUserContext = None):
-        try:
-            self._get_draft_record(record_id, user_context)
-            return True
-        except Exception as e:
-            if "404" in str(e):
-                return False
-            raise e
+        request_url = self._get_draft_record_url(record_id)
+        headers = self._get_request_headers(user_context)
+        response = requests.get(request_url, headers=headers)
+        return response.status_code == 200
+
+    def _get_draft_record_url(self, record_id: str):
+        return f"{self.records_url}/{record_id}/draft"
 
     def _get_draft_record(self, record_id: str, user_context: OptionalUserContext = None):
-        request_url = f"{self.records_url}/{record_id}/draft"
+        request_url = self._get_draft_record_url(record_id)
         draft_record = self._get_response(user_context, request_url)
         return draft_record
 

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -44,7 +44,7 @@ class RemoteFilesManager:
         format: Optional[RemoteFilesFormat],
         recursive: Optional[bool],
         disable: Optional[RemoteFilesDisableMode],
-        write_intent: Optional[bool] = False,
+        writeable: Optional[bool] = False,
     ) -> AnyRemoteFilesListResponse:
         """Returns a list of remote files available to the user."""
 
@@ -81,7 +81,7 @@ class RemoteFilesManager:
         file_source = file_source_path.file_source
 
         opts = FilesSourceOptions()
-        opts.write_intent = write_intent or False
+        opts.writeable = writeable or False
         try:
             index = file_source.list(
                 file_source_path.path,

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -8,6 +8,7 @@ from galaxy.files import (
     ConfiguredFileSources,
     ProvidesUserFileSourcesUserContext,
 )
+from galaxy.files.sources import FilesSourceOptions
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.schema.remote_files import (
     AnyRemoteFilesListResponse,
@@ -41,6 +42,7 @@ class RemoteFilesManager:
         format: Optional[RemoteFilesFormat],
         recursive: Optional[bool],
         disable: Optional[RemoteFilesDisableMode],
+        write_intent: Optional[bool] = False,
     ) -> AnyRemoteFilesListResponse:
         """Returns a list of remote files available to the user."""
 
@@ -75,8 +77,16 @@ class RemoteFilesManager:
 
         file_source_path = self._file_sources.get_file_source_path(uri)
         file_source = file_source_path.file_source
+
+        opts = FilesSourceOptions()
+        opts.write_intent = write_intent or False
         try:
-            index = file_source.list(file_source_path.path, recursive=recursive, user_context=user_file_source_context)
+            index = file_source.list(
+                file_source_path.path,
+                recursive=recursive,
+                user_context=user_file_source_context,
+                opts=opts,
+            )
         except exceptions.MessageException:
             log.warning(f"Problem listing file source path {file_source_path}", exc_info=True)
             raise

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -128,12 +128,16 @@ class RemoteFilesManager:
         return index
 
     def get_files_source_plugins(
-        self, user_context: ProvidesUserContext, browsable_only: Optional[bool] = True
+        self, user_context: ProvidesUserContext, browsable_only: Optional[bool] = True, rdm_only: Optional[bool] = False
     ) -> FilesSourcePluginList:
         """Display plugin information for each of the gxfiles:// URI targets available."""
         user_file_source_context = ProvidesUserFileSourcesUserContext(user_context)
+        browsable_only = True if browsable_only is None else browsable_only
+        rdm_only = rdm_only or False
         plugins_dict = self._file_sources.plugins_to_dict(
-            user_context=user_file_source_context, browsable_only=True if browsable_only is None else browsable_only
+            user_context=user_file_source_context,
+            browsable_only=browsable_only,
+            rdm_only=rdm_only,
         )
         plugins = [FilesSourcePlugin(**plugin_dict) for plugin_dict in plugins_dict]
         return FilesSourcePluginList.construct(__root__=plugins)

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -128,16 +128,14 @@ class RemoteFilesManager:
         return index
 
     def get_files_source_plugins(
-        self, user_context: ProvidesUserContext, browsable_only: Optional[bool] = True, rdm_only: Optional[bool] = False
+        self, user_context: ProvidesUserContext, browsable_only: Optional[bool] = True
     ) -> FilesSourcePluginList:
         """Display plugin information for each of the gxfiles:// URI targets available."""
         user_file_source_context = ProvidesUserFileSourcesUserContext(user_context)
         browsable_only = True if browsable_only is None else browsable_only
-        rdm_only = rdm_only or False
         plugins_dict = self._file_sources.plugins_to_dict(
             user_context=user_file_source_context,
             browsable_only=browsable_only,
-            rdm_only=rdm_only,
         )
         plugins = [FilesSourcePlugin(**plugin_dict) for plugin_dict in plugins_dict]
         return FilesSourcePluginList.construct(__root__=plugins)

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -2,10 +2,8 @@ import hashlib
 import logging
 from operator import itemgetter
 from typing import (
-    Any,
-    Dict,
-    List,
     Optional,
+    Set,
 )
 
 from galaxy import exceptions
@@ -13,7 +11,10 @@ from galaxy.files import (
     ConfiguredFileSources,
     ProvidesUserFileSourcesUserContext,
 )
-from galaxy.files.sources import FilesSourceOptions
+from galaxy.files.sources import (
+    FilesSourceOptions,
+    PluginKind,
+)
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.schema.remote_files import (
     AnyRemoteFilesListResponse,
@@ -130,13 +131,21 @@ class RemoteFilesManager:
 
         return index
 
-    def get_files_source_plugins(self, user_context: ProvidesUserContext, browsable_only: Optional[bool] = True):
+    def get_files_source_plugins(
+        self,
+        user_context: ProvidesUserContext,
+        browsable_only: Optional[bool] = True,
+        include_kind: Optional[Set[PluginKind]] = None,
+        exclude_kind: Optional[Set[PluginKind]] = None,
+    ):
         """Display plugin information for each of the gxfiles:// URI targets available."""
         user_file_source_context = ProvidesUserFileSourcesUserContext(user_context)
         browsable_only = True if browsable_only is None else browsable_only
         plugins_dict = self._file_sources.plugins_to_dict(
             user_context=user_file_source_context,
             browsable_only=browsable_only,
+            include_kind=include_kind,
+            exclude_kind=exclude_kind,
         )
         return plugins_dict
 

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -1,7 +1,12 @@
 import hashlib
 import logging
 from operator import itemgetter
-from typing import Optional
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
 
 from galaxy import exceptions
 from galaxy.files import (
@@ -14,8 +19,6 @@ from galaxy.schema.remote_files import (
     AnyRemoteFilesListResponse,
     CreatedEntryResponse,
     CreateEntryPayload,
-    FilesSourcePlugin,
-    FilesSourcePluginList,
     RemoteFilesDisableMode,
     RemoteFilesFormat,
     RemoteFilesTarget,
@@ -127,9 +130,7 @@ class RemoteFilesManager:
 
         return index
 
-    def get_files_source_plugins(
-        self, user_context: ProvidesUserContext, browsable_only: Optional[bool] = True
-    ) -> FilesSourcePluginList:
+    def get_files_source_plugins(self, user_context: ProvidesUserContext, browsable_only: Optional[bool] = True):
         """Display plugin information for each of the gxfiles:// URI targets available."""
         user_file_source_context = ProvidesUserFileSourcesUserContext(user_context)
         browsable_only = True if browsable_only is None else browsable_only
@@ -137,8 +138,7 @@ class RemoteFilesManager:
             user_context=user_file_source_context,
             browsable_only=browsable_only,
         )
-        plugins = [FilesSourcePlugin(**plugin_dict) for plugin_dict in plugins_dict]
-        return FilesSourcePluginList.construct(__root__=plugins)
+        return plugins_dict
 
     @property
     def _file_sources(self) -> ConfiguredFileSources:

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -7,7 +7,6 @@ from typing import (
 )
 
 from pydantic import (
-    Extra,
     Field,
     Required,
 )
@@ -49,12 +48,6 @@ class FilesSourcePlugin(Model):
         description="The type of the plugin.",
         example="gximport",
     )
-    uri_root: str = Field(
-        Required,
-        title="URI root",
-        description="The URI root used by this type of plugin.",
-        example="gximport://",
-    )
     label: str = Field(
         Required,
         title="Label",
@@ -66,6 +59,11 @@ class FilesSourcePlugin(Model):
         title="Documentation",
         description="Documentation or extended description for this plugin.",
         example="Galaxy's library import directory",
+    )
+    browsable: bool = Field(
+        Required,
+        title="Browsable",
+        description="Whether this file source plugin can list items.",
     )
     writable: bool = Field(
         Required,
@@ -84,15 +82,19 @@ class FilesSourcePlugin(Model):
         description="Only users belonging to the groups specified here can access this files source.",
     )
 
-    class Config:
-        # This allows additional fields (that are not validated)
-        # to be serialized/deserealized. This allows to have
-        # different fields depending on the plugin type
-        extra = Extra.allow
+
+class BrowsableFilesSourcePlugin(FilesSourcePlugin):
+    browsable: Literal[True]
+    uri_root: str = Field(
+        Required,
+        title="URI root",
+        description="The URI root used by this type of plugin.",
+        example="gximport://",
+    )
 
 
 class FilesSourcePluginList(Model):
-    __root__: List[FilesSourcePlugin] = Field(
+    __root__: List[Union[BrowsableFilesSourcePlugin, FilesSourcePlugin]] = Field(
         default=[],
         title="List of files source plugins",
         example=[

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -149,3 +149,37 @@ class ListUriResponse(Model):
 
 
 AnyRemoteFilesListResponse = Union[ListUriResponse, ListJstreeResponse]
+
+
+class CreateEntryPayload(Model):
+    target: str = Field(
+        Required,
+        title="Target",
+        description="The target file source to create the entry in.",
+    )
+    name: str = Field(
+        Required,
+        title="Name",
+        description="The name of the entry to create.",
+        example="my_new_entry",
+    )
+
+
+class CreatedEntryResponse(Model):
+    name: str = Field(
+        Required,
+        title="Name",
+        description="The name of the created entry.",
+        example="my_new_entry",
+    )
+    uri: str = Field(
+        Required,
+        title="URI",
+        description="The URI of the created entry.",
+        example="gxfiles://my_new_entry",
+    )
+    external_link: Optional[str] = Field(
+        default=None,
+        title="External link",
+        description="An optional external link to the created entry if available.",
+    )

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -4,12 +4,15 @@ API operations on remote files.
 import logging
 from typing import Optional
 
+from fastapi import Body
 from fastapi.param_functions import Query
 
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.remote_files import RemoteFilesManager
 from galaxy.schema.remote_files import (
     AnyRemoteFilesListResponse,
+    CreatedEntryResponse,
+    CreateEntryPayload,
     FilesSourcePluginList,
     RemoteFilesDisableMode,
     RemoteFilesFormat,
@@ -115,4 +118,19 @@ class FastAPIRemoteFiles:
         browsable_only: Optional[bool] = BrowsableQueryParam,
     ) -> FilesSourcePluginList:
         """Display plugin information for each of the gxfiles:// URI targets available."""
-        return self.manager.get_files_source_plugins(user_ctx, browsable_only)
+
+    @router.post(
+        "/api/remote_files",
+        summary="Creates a new entry (directory/record) on the remote files source.",
+    )
+    async def create_entry(
+        self,
+        user_ctx: ProvidesUserContext = DependsOnTrans,
+        payload: CreateEntryPayload = Body(
+            ...,
+            title="Entry Data",
+            description="Information about the entry to create. Depends on the target file source.",
+        ),
+    ) -> CreatedEntryResponse:
+        """Creates a new entry on the remote files source."""
+        return self.manager.create_entry(user_ctx, payload)

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -62,9 +62,9 @@ DisableModeQueryParam: Optional[RemoteFilesDisableMode] = Query(
     ),
 )
 
-WriteIntentQueryParam: Optional[bool] = Query(
+WriteableQueryParam: Optional[bool] = Query(
     default=None,
-    title="Write Intent",
+    title="Writeable",
     description=(
         "Whether the query is made with the intention of writing to the source."
         " If set to True, only entries that can be written to will be returned."
@@ -110,10 +110,10 @@ class FastAPIRemoteFiles:
         format: Optional[RemoteFilesFormat] = FormatQueryParam,
         recursive: Optional[bool] = RecursiveQueryParam,
         disable: Optional[RemoteFilesDisableMode] = DisableModeQueryParam,
-        write_intent: Optional[bool] = WriteIntentQueryParam,
+        writeable: Optional[bool] = WriteableQueryParam,
     ) -> AnyRemoteFilesListResponse:
         """Lists all remote files available to the user from different sources."""
-        return self.manager.index(user_ctx, target, format, recursive, disable, write_intent=write_intent)
+        return self.manager.index(user_ctx, target, format, recursive, disable, writeable)
 
     @router.get(
         "/api/remote_files/plugins",

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -80,6 +80,14 @@ BrowsableQueryParam: Optional[bool] = Query(
     ),
 )
 
+RDMOnlyQueryParam: Optional[bool] = Query(
+    default=False,
+    title="RDM only",
+    description=(
+        "Whether to return only RDM compatible plugins. The default is `False`, which will return all plugins."
+    ),
+)
+
 
 @router.cbv
 class FastAPIRemoteFiles:
@@ -116,8 +124,10 @@ class FastAPIRemoteFiles:
         self,
         user_ctx: ProvidesUserContext = DependsOnTrans,
         browsable_only: Optional[bool] = BrowsableQueryParam,
+        rdm_only: Optional[bool] = RDMOnlyQueryParam,
     ) -> FilesSourcePluginList:
         """Display plugin information for each of the gxfiles:// URI targets available."""
+        return self.manager.get_files_source_plugins(user_ctx, browsable_only, rdm_only)
 
     @router.post(
         "/api/remote_files",

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -67,7 +67,7 @@ WriteIntentQueryParam: Optional[bool] = Query(
     title="Write Intent",
     description=(
         "Whether the query is made with the intention of writing to the source."
-        " If set to True, only entries that can be written to will be accessible."
+        " If set to True, only entries that can be written to will be returned."
     ),
 )
 

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -59,6 +59,15 @@ DisableModeQueryParam: Optional[RemoteFilesDisableMode] = Query(
     ),
 )
 
+WriteIntentQueryParam: Optional[bool] = Query(
+    default=None,
+    title="Write Intent",
+    description=(
+        "Whether the query is made with the intention of writing to the source."
+        " If set to True, only entries that can be written to will be accessible."
+    ),
+)
+
 BrowsableQueryParam: Optional[bool] = Query(
     default=True,
     title="Browsable filesources only",
@@ -90,9 +99,10 @@ class FastAPIRemoteFiles:
         format: Optional[RemoteFilesFormat] = FormatQueryParam,
         recursive: Optional[bool] = RecursiveQueryParam,
         disable: Optional[RemoteFilesDisableMode] = DisableModeQueryParam,
+        write_intent: Optional[bool] = WriteIntentQueryParam,
     ) -> AnyRemoteFilesListResponse:
         """Lists all remote files available to the user from different sources."""
-        return self.manager.index(user_ctx, target, format, recursive, disable)
+        return self.manager.index(user_ctx, target, format, recursive, disable, write_intent=write_intent)
 
     @router.get(
         "/api/remote_files/plugins",

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -80,14 +80,6 @@ BrowsableQueryParam: Optional[bool] = Query(
     ),
 )
 
-RDMOnlyQueryParam: Optional[bool] = Query(
-    default=False,
-    title="RDM only",
-    description=(
-        "Whether to return only RDM compatible plugins. The default is `False`, which will return all plugins."
-    ),
-)
-
 
 @router.cbv
 class FastAPIRemoteFiles:
@@ -124,10 +116,9 @@ class FastAPIRemoteFiles:
         self,
         user_ctx: ProvidesUserContext = DependsOnTrans,
         browsable_only: Optional[bool] = BrowsableQueryParam,
-        rdm_only: Optional[bool] = RDMOnlyQueryParam,
     ) -> FilesSourcePluginList:
         """Display plugin information for each of the gxfiles:// URI targets available."""
-        return self.manager.get_files_source_plugins(user_ctx, browsable_only, rdm_only)
+        return self.manager.get_files_source_plugins(user_ctx, browsable_only)
 
     @router.post(
         "/api/remote_files",


### PR DESCRIPTION
First attempt at integrating [InvenioRDM](https://inveniosoftware.org/products/rdm/) into Galaxy.

The idea is to be able to import files directly from InvenioRDM repositories into Galaxy as well as publish records containing artifacts (Histories, datasets, etc.) from Galaxy to InvenioRDM.

Please note that [Zenodo is also transitioning to ZenodoRDM](https://blog.zenodo.org/2022/12/07/2022-12-07-zenodo-on-inveniordm/) therefore this integration will be useful for both once they have migrated their systems.

## Invenio RDM as a Remote File Source Plugin

The first low-hanging fruit is to integrate it as a file source plugin. This will list every record as a directory and every file inside a record as a remote file available for import.

## API changes

Since the _Remote File Source Plugin_ API is not a perfect fit for these kinds o repositories, especially the publication part, it requires some changes to the current API. I tried to keep the changes to a minimum and as generic as possible so other plugins in the future can reuse them:

- `writeable` optional flag parameter in the `GET /api/remote_files` endpoint to express the intent of writing to the remote file source when listing the files. This is required to be able to list only those records that can still upload files (are not yet published). I think this could be useful for other plugins as well, maybe to differentiate between read-only directories and writable ones.

- New endpoint `POST /api/remote_files` to create a new record (or directory) in the remote file source. This is required to be able to create a _draft record_ from Galaxy before trying to upload files to it. Other plugins can implement it as a way of creating new directories in the remote file source, by default it will raise a `NotImplementedError`.

- `include_kind` and `exclude_kind` optional parameters in the `GET /api/remote_files/plugins` endpoint to filter out plugins based on their "kind". The new `PluginKind` class variable defines the "kind" (or category) that groups similar plugins.

### Current known limitations:

- The amount of metadata entered when creating a new record is very limited, mostly the `title` and the `username` (or _Anonymous Galaxy User_ if no name is specified in the user's settings). This is to keep the Remote File Sources API as generic as possible. However, the metadata can always be edited directly in the InvenioRDM UI if required.
- There is no support for paginating the listing of records from the file source while the Invenio API forces pagination and limits the number of items returned. This might be supported in the future, for now limiting the max number of records to 100.
- Only public records can be imported for now. To be able to import private or protected records we need to pass the `user_context` when fetching the files and there is no user context available AFAIK at that point, but maybe that can be fixed.
- The `export_remote` tool is supported, but there are some limitations on the valid paths that can be selected:
  - Only records that are in draft mode are valid, so selecting the root of the repository or creating additional "directories" in the record will make the tool fail. Fortunately, the error message in the logs should be informative enough.

## For Users <a href="#for-users" id="for-users"/>

As a user, you can now import files from Invenio RDM repositories into Galaxy as well as publish records containing artifacts (Histories, datasets, etc.) from Galaxy to Invenio RDM.

### Importing files from Invenio RDM

If you just want to import from published records in Invenio RDM, you can do so by selecting the Invenio RDM repository as a remote file source in the _Upload_ tool and then selecting the records or individual files you want to import to your history. Just like you would do with any other remote file source in Galaxy.

https://github.com/galaxyproject/galaxy/assets/46503462/2a49403f-8c9e-47a7-b083-c38e31339604

By default, only published records will be listed. If you want to import from your own protected records, you will need to set your Invenio RDM API personal token in your Galaxy account settings. See the next section for more details.

### Exporting to Invenio RDM

#### Setting your Invenio RDM API personal token

First, you will need to set some preferences in your Galaxy account. Go to `User > Preferences > Manage Information` and set your Invenio RDM API personal token. You can also set some other options there, like your `Public Name` or whether you want to keep your records only accessible to you.

Galaxy will **never publish your records** (i.e. take them out of draft) as this must be done consciously from the Invenio RDM UI.

![InvenioUserSettings](https://github.com/galaxyproject/galaxy/assets/46503462/ba49924f-7c16-458d-9934-33f2dd5e2bf0)


You can create a new personal token in your Invenio RDM account settings if you don't have one.

![InvenioPersonalToken](https://github.com/galaxyproject/galaxy/assets/46503462/73c1ad11-af0e-43d3-8c2a-37a3f01eb8f0)


#### Exporting your Histories

Once you have set your personal token, you can publish your histories by selecting the Invenio RDM repository as a remote file source in the _Export History to File_ menu option. You will be able to select an existing draft record or create a new one and the files will be uploaded to it.

Once exported, you will be able to import back the history snapshot from the published record at any time.


https://github.com/galaxyproject/galaxy/assets/46503462/8d9cf938-fdd2-48e9-8e34-ed2f910598d7



#### Archiving your Histories

When you are completely done and happy with your history, you can archive it to take it out of your active histories and even free up some disk quota. You can do so by selecting the _Archive History_ menu option. The process will be similar to exporting the history, but your history will be purged from Galaxy once the process is completed.

You will be able to import back the history as a copy from the published record at any time.

In the video below, we will first create the draft record directly from Invenio so we can provide as much metadata as we want.

https://github.com/galaxyproject/galaxy/assets/46503462/26e641c2-1c70-430a-85bb-e017b0464670



#### Exporting your Datasets

You can also publish individual datasets to Invenio RDM by selecting the Invenio RDM repository as a remote file source using the _Export Datasets_ tool. Since the tool interface is a bit limited, you will need to create your draft record manually in advance, and then you can select it when exporting the datasets.

In the video below, we will first create the draft record directly from Invenio as we must select an existing record from the tool.

https://github.com/galaxyproject/galaxy/assets/46503462/b3df659b-57c4-4103-bd3f-4e9ade9bb829



## For Reviewers

This PR includes a bunch of UI modernizations (Composition API + Typescript) for the components that have been modified. To simplify the review, those standalone changes have been extracted to individual PRs:

- [x] #16414
- [x] #16391
- [x] #16420

### Manual Testing Requirements <a href="#requirements" id="requirements"/>

To test the integration you need an **Invenio RDM backend**, ideally, a sandbox environment where you are not really publishing stuff to the world.

- **Create your local instance** by following the [Quick Start documentation](https://inveniordm.docs.cern.ch/install/) (using the `Containerized application` is recommended). 
- You would need to create a user and activate it in your Invenio instance, the [documentation also covers this](https://inveniordm.docs.cern.ch/customize/vocabularies/users/#users).
- Then add to your Galaxy `file_sources_conf.yml` a new entry with something like this:
  ```yaml
  - type: inveniordm
    id: invenio
    doc: Invenio RDM The turn-key research data management repository
    label: Invenio RDM (Local Test)
    url: https://127.0.0.1
    token: ${user.preferences['invenio|token']}
    public_name: ${user.preferences['invenio|public_name']}
    writable: true
  ```
- Also add a new entry in your `user_preferences_extra_conf.yml` with the following:
  ```yaml
  invenio:
      description: Your Invenio RDM Account
      inputs:
          - name: token
            label: Personal Token to publish records to Invenio RDM
            type: secret
            store: vault # Requires setting up vault_config_file in your galaxy.yml
            required: False
          - name: public_name
            label: Public name to publish records (formatted as "Lastname, Firstname")
            type: text
            required: False
          - name: public_records
            label: Whether to make new draft records publicly accessible (Yes) or restricted (No).
            type: boolean
            required: False
  ```
- If you don't have a **Vault** configured in your local instance you should set it up to store the personal token as a secret. Check the [documentation](https://github.com/galaxyproject/galaxy/blob/dev/doc/source/admin/special_topics/vault.md).
- The [new task-based export UI that tracks export records](https://github.com/galaxyproject/galaxy/pull/14839) requires having Celery Task (with Redis backend) setup in your instance. So you will need something like this in your `galaxy.yml`:
  ```yml
     # For details, see Celery documentation at
      # https://docs.celeryq.dev/en/stable/userguide/configuration.html.
      celery_conf:
          result_backend: redis://127.0.0.1:6379/0
      #  task_routes:
      #    galaxy.fetch_data: galaxy.external
      #    galaxy.set_job_metadata: galaxy.external
  
      # Offload long-running tasks to a Celery task queue. Activate this
      # only if you have setup a Celery worker for Galaxy. For details, see
      # https://docs.galaxyproject.org/en/master/admin/production.html
      enable_celery_tasks: true
  ```
- Make sure you have also `pip install redis` in your galaxy Python virtual environment.
---

## TODO

- [x] <del>Handle pagination of records.</del> To properly handle this we need to support pagination at the plugin framework level. This is a bigger project that I would try in a separate PR. Limited to 100 records max for now.
- [x] Handle private/protected records
- [x] Make it work with the `export_remote` tool
  - [x] Provide detailed error messages when export fails due to invalid paths
- [x] Integrate with History export component
- [x] Integrate with History archival component
- [x] Write some tests
- [x] Refactor and clean up code
- [x] Remove temporal SSL verification ignore (for testing)
- [ ] [Optional] Import from non-public records. Requires user_context in fetch for authentication... possible?

---

## How to test the changes?

- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Make sure you have all the requirements under [Manual Testing Requirements](#requirements)
  - See the [For Users](#for-users) section above for usage examples.

## License

- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
