### PR TITLE
Migrate some Remote Files Export components to composition API + TS

### DIFF
--- a/client/src/components/Common/ExportForm.test.ts
+++ b/client/src/components/Common/ExportForm.test.ts
@@ -1,14 +1,12 @@
+import { getLocalVue } from "@tests/jest/helpers";
 import { shallowMount } from "@vue/test-utils";
-import { getLocalVue } from "tests/jest/helpers";
 
 import ExportForm from "./ExportForm.vue";
 
 const localVue = getLocalVue(true);
 
-jest.mock("components/JobStates/wait");
-
 describe("ExportForm.vue", () => {
-    let wrapper;
+    let wrapper: any;
 
     beforeEach(async () => {
         wrapper = shallowMount(ExportForm, {
@@ -17,24 +15,41 @@ describe("ExportForm.vue", () => {
         });
     });
 
-    it("should render a form with export disable because inputs empty", async () => {
-        expect(wrapper.find(".export-button").exists()).toBeTruthy();
-        expect(wrapper.find(".export-button").attributes("disabled")).toBeTruthy();
-        expect(wrapper.vm.canExport).toBeFalsy();
+    it("should render a form with export button disabled because inputs are empty", async () => {
+        expect(wrapper.vm.directory).toEqual("");
+        expect(wrapper.vm.name).toEqual("");
+
+        expectExportButtonDisabled();
     });
 
-    it("should allow export when name and directory available", async () => {
+    it("should render a form with export button disabled because directory is empty", async () => {
+        await wrapper.setData({
+            name: "export.tar.gz",
+        });
+
+        expectExportButtonDisabled();
+    });
+
+    it("should render a form with export button disabled because name is empty", async () => {
+        await wrapper.setData({
+            directory: "gxfiles://",
+        });
+
+        expectExportButtonDisabled();
+    });
+
+    it("should allow export when all inputs are defined", async () => {
         await wrapper.setData({
             name: "export.tar.gz",
             directory: "gxfiles://",
         });
-        expect(wrapper.vm.directory).toEqual("gxfiles://");
-        expect(wrapper.vm.name).toEqual("export.tar.gz");
-        expect(wrapper.vm.canExport).toBeTruthy();
+
+        expectExportButtonEnabled();
     });
 
     it("should localize button text", async () => {
-        expect(wrapper.find(".export-button").text()).toBeLocalizationOf("Export");
+        const newLocal = wrapper.find(".export-button").text();
+        expect(newLocal).toBeLocalizationOf("Export");
     });
 
     it("should emit 'export' event with correct inputs on export button click", async () => {
@@ -64,7 +79,17 @@ describe("ExportForm.vue", () => {
 
         await wrapper.find(".export-button").trigger("click");
 
-        expect(wrapper.vm.directory).toBe(null);
-        expect(wrapper.vm.name).toBe(null);
+        expect(wrapper.vm.directory).toBe("");
+        expect(wrapper.vm.name).toBe("");
     });
+
+    function expectExportButtonDisabled() {
+        expect(wrapper.find(".export-button").exists()).toBeTruthy();
+        expect(wrapper.find(".export-button").attributes("disabled")).toBeTruthy();
+    }
+
+    function expectExportButtonEnabled() {
+        expect(wrapper.find(".export-button").exists()).toBeTruthy();
+        expect(wrapper.find(".export-button").attributes("disabled")).toBeFalsy();
+    }
 });

--- a/client/src/components/Common/ExportForm.vue
+++ b/client/src/components/Common/ExportForm.vue
@@ -1,73 +1,73 @@
+<script setup lang="ts">
+import { BButton, BCol, BFormGroup, BFormInput, BRow } from "bootstrap-vue";
+import { computed, ref } from "vue";
+
+import localize from "@/utils/localization";
+
+import FilesInput from "@/components/FilesDialog/FilesInput.vue";
+
+interface Props {
+    what?: string;
+    clearInputAfterExport?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    what: "archive",
+    clearInputAfterExport: false,
+});
+
+const emit = defineEmits<{
+    (e: "export", directory: string, name: string): void;
+}>();
+
+const directory = ref<string>("");
+const name = ref<string>("");
+
+const canExport = computed(() => name.value.length > 0 && directory.value.length > 0);
+
+const directoryDescription = computed(() => localize(`Select a 'remote files' directory to export ${props.what} to.`));
+
+const nameDescription = computed(() => localize("Give the exported file a name."));
+
+const namePlaceholder = computed(() => localize("Name"));
+
+const doExport = () => {
+    emit("export", directory.value, name.value);
+    if (props.clearInputAfterExport) {
+        directory.value = "";
+        name.value = "";
+    }
+};
+
+// This is required to make the component testable with script setup,
+// otherwise we cannot access the component's data.
+// We probably can remove this once we switch to Vue 3 or other testing framework.
+defineExpose({
+    directory,
+    name,
+    canExport,
+});
+</script>
+
 <template>
     <div class="export-to-remote-file">
-        <b-form-group
-            id="fieldset-directory"
-            label-for="directory"
-            :description="directoryDescription | localize"
-            class="mt-3">
+        <BFormGroup id="fieldset-directory" label-for="directory" :description="directoryDescription" class="mt-3">
             <FilesInput id="directory" v-model="directory" mode="directory" :require-writable="true" />
-        </b-form-group>
-        <b-form-group id="fieldset-name" label-for="name" :description="nameDescription | localize" class="mt-3">
-            <b-form-input id="name" v-model="name" :placeholder="namePlaceholder | localize" required></b-form-input>
-        </b-form-group>
-        <b-row align-h="end">
-            <b-col
-                ><b-button class="export-button" variant="primary" :disabled="!canExport" @click.prevent="doExport">{{
-                    exportButtonText | localize
-                }}</b-button></b-col
-            >
-        </b-row>
+        </BFormGroup>
+        <BFormGroup id="fieldset-name" label-for="name" :description="nameDescription" class="mt-3">
+            <BFormInput id="name" v-model="name" :placeholder="namePlaceholder" required />
+        </BFormGroup>
+        <BRow align-h="end">
+            <BCol>
+                <BButton
+                    v-localize
+                    class="export-button"
+                    variant="primary"
+                    :disabled="!canExport"
+                    @click.prevent="doExport">
+                    Export
+                </BButton>
+            </BCol>
+        </BRow>
     </div>
 </template>
-
-<script>
-import FilesInput from "components/FilesDialog/FilesInput.vue";
-
-export default {
-    components: {
-        FilesInput,
-    },
-    props: {
-        what: {
-            type: String,
-            default: "archive",
-        },
-        clearInputAfterExport: {
-            type: Boolean,
-            default: false,
-        },
-    },
-    data() {
-        return {
-            directory: null,
-            name: null,
-        };
-    },
-    computed: {
-        directoryDescription() {
-            return `Select a 'remote files' directory to export ${this.what} to.`;
-        },
-        nameDescription() {
-            return "Give the exported file a name.";
-        },
-        namePlaceholder() {
-            return "Name";
-        },
-        exportButtonText() {
-            return "Export";
-        },
-        canExport() {
-            return !!this.name && !!this.directory;
-        },
-    },
-    methods: {
-        doExport() {
-            this.$emit("export", this.directory, this.name);
-            if (this.clearInputAfterExport) {
-                this.directory = null;
-                this.name = null;
-            }
-        },
-    },
-};
-</script>

--- a/client/src/components/Common/ExportForm.vue
+++ b/client/src/components/Common/ExportForm.vue
@@ -38,15 +38,6 @@ const doExport = () => {
         name.value = "";
     }
 };
-
-// This is required to make the component testable with script setup,
-// otherwise we cannot access the component's data.
-// We probably can remove this once we switch to Vue 3 or other testing framework.
-defineExpose({
-    directory,
-    name,
-    canExport,
-});
 </script>
 
 <template>

--- a/client/src/components/FilesDialog/FilesInput.vue
+++ b/client/src/components/FilesDialog/FilesInput.vue
@@ -1,55 +1,50 @@
-<template>
-    <BFormInput v-model="localValue" class="directory-form-input" :placeholder="placeholder" @click="selectFile">
-    </BFormInput>
-</template>
-
-<script>
+<script setup lang="ts">
 import { BFormInput } from "bootstrap-vue";
-import { filesDialog } from "utils/data";
+import { computed } from "vue";
 
-export default {
-    components: { BFormInput },
-    props: {
-        value: {
-            type: String,
-        },
-        mode: {
-            type: String,
-            default: "file",
-        },
-        requireWritable: {
-            type: Boolean,
-            default: false,
-        },
+import { filesDialog } from "@/utils/data";
+
+interface Props {
+    value: string;
+    mode?: string;
+    requireWritable?: boolean;
+}
+
+interface SelectableFile {
+    url: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+    mode: "file",
+    requireWritable: false,
+});
+
+const emit = defineEmits<{
+    (e: "input", value: string): void;
+}>();
+
+const currentValue = computed({
+    get() {
+        return props.value;
     },
-    data() {
-        return {
-            localValue: this.value,
-        };
+    set(newValue) {
+        emit("input", newValue);
     },
-    computed: {
-        placeholder() {
-            return `Click to select ${this.mode}`;
-        },
-    },
-    watch: {
-        localValue(newValue) {
-            this.$emit("input", newValue);
-        },
-        value(newValue) {
-            this.localValue = newValue;
-        },
-    },
-    methods: {
-        selectFile() {
-            const props = {
-                mode: this.mode,
-                requireWritable: this.requireWritable,
-            };
-            filesDialog((selected) => {
-                this.localValue = selected?.url;
-            }, props);
-        },
-    },
+});
+
+const selectFile = () => {
+    const dialogProps = {
+        mode: props.mode,
+        requireWritable: props.requireWritable,
+    };
+    filesDialog((selected: SelectableFile) => {
+        currentValue.value = selected?.url;
+    }, dialogProps);
 };
+
+const placeholder = `Click to select ${props.mode}`;
 </script>
+
+<template>
+    <BFormInput v-model="currentValue" class="directory-form-input" :placeholder="placeholder" @click="selectFile" />
+</template>

--- a/client/src/components/FilesDialog/FilesInput.vue
+++ b/client/src/components/FilesDialog/FilesInput.vue
@@ -6,7 +6,7 @@ import { filesDialog } from "@/utils/data";
 
 interface Props {
     value: string;
-    mode?: string;
+    mode?: "file" | "directory";
     requireWritable?: boolean;
 }
 

--- a/client/src/components/HistoryImport.vue
+++ b/client/src/components/HistoryImport.vue
@@ -125,7 +125,7 @@ export default {
             initializing: true,
             importType: "externalUrl",
             sourceFile: null,
-            sourceRemoteFilesUri: null,
+            sourceRemoteFilesUri: "",
             errorMessage: null,
             waitingOnJob: false,
             complete: false,

--- a/client/src/utils/navigation/navigation.yml
+++ b/client/src/utils/navigation/navigation.yml
@@ -493,6 +493,7 @@ last_export_record:
 history_import:
   selectors:
     radio_button_remote_files: '.history-import-component .fa-folder-open'
+    open_files_dialog: '.history-import-component .directory-form-input'
     import_button: '.import-button'
     running: '.history-import-component .loading-icon'
     success_message: '.history-import-component .alert-success'

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -71,6 +71,7 @@ class TestHistoryImportExportFtpSeleniumIntegration(TestHistoryImportExportFtpSe
         gx_selenium_context.components.histories.import_button.wait_for_and_click()
         history_import = gx_selenium_context.components.history_import
         history_import.radio_button_remote_files.wait_for_and_click()
+        history_import.open_files_dialog.wait_for_and_click()
         files_dialog.ftp_label.wait_for_and_click()
         files_dialog.row(uri="gxftp://my_export.tar.gz").wait_for_and_click()
 


### PR DESCRIPTION
This is part of #16381 in preparation for some adaptations.

Just converts `components/Common/ExportForm.vue` and `components/FilesDialog/FilesInput.vue` to script setup composition API and Typescript.

Bonus: Units tests migrated to TS too and slightly increased coverage.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
