### PR TITLE
[23.0] Don't always install node in the virtualenv

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -199,7 +199,7 @@ fi
 
 # Install node if not installed
 if [ -n "$VIRTUAL_ENV" ]; then
-    if ! in_venv "$(command -v node)" || [ "$(node --version)" != "v${NODE_VERSION}" ]; then
+    if ! command -v node >/dev/null || [ "$(node --version)" != "v${NODE_VERSION}" ]; then
         echo "Installing node into $VIRTUAL_ENV with nodeenv."
         if [ -d "${VIRTUAL_ENV}/lib/node_modules" ]; then
             echo "Removing old ${VIRTUAL_ENV}/lib/node_modules directory."


### PR DESCRIPTION
if it's already installed system-wide at the correct version.

Prevent node installation issues during CI builds where we install node with the setup-node action but it was ignored because it was not inside the virtualenv, e.g.:

https://github.com/galaxyproject/galaxy/actions/runs/5530959878/jobs/10091018774

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
