### PR TITLE
[23.1] Fix histories count

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -403,6 +403,15 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
 
         return history
 
+    def get_active_count(self, user: model.User) -> int:
+        """Return the number of active histories for the given user."""
+        user_active_histories_filter = [
+            model.History.user_id == user.id,
+            model.History.deleted == false(),
+            model.History.archived == false(),
+        ]
+        return self.count(filters=user_active_histories_filter)
+
 
 class HistoryStorageCleanerManager(StorageCleanerManager):
     def __init__(self, history_manager: HistoryManager):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -702,7 +702,7 @@ class User(Base, Dictifiable, RepresentById):
     )
     active_histories = relationship(
         "History",
-        primaryjoin=(lambda: (History.user_id == User.id) & (not_(History.deleted))),  # type: ignore[has-type]
+        primaryjoin=(lambda: (History.user_id == User.id) & (not_(History.deleted)) & (not_(History.archived))),  # type: ignore[has-type]
         viewonly=True,
         order_by=lambda: desc(History.update_time),  # type: ignore[has-type]
     )

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -476,10 +476,8 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         current_user = self.user_manager.current_user(trans)
         if self.user_manager.is_anonymous(current_user):
             current_history = self.manager.get_current(trans)
-            if not current_history:
-                return 0
-            return 1
-        return len(current_user.active_histories)
+            return 1 if current_history else 0
+        return self.manager.get_active_count(current_user)
 
     def published(
         self,


### PR DESCRIPTION
Fixes #16397

The counting is now made at the database level to make it a little bit more optimal.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
