### PR TITLE
Disable verbose parso logging in db_shell.py

### DIFF
--- a/scripts/db_shell.py
+++ b/scripts/db_shell.py
@@ -15,6 +15,7 @@
 
 import datetime
 import decimal
+import logging
 import os.path
 import sys
 
@@ -31,6 +32,11 @@ from galaxy.model import *  # noqa
 from galaxy.model import set_datatypes_registry  # More explicit than `*` import
 from galaxy.model.mapping import init
 from galaxy.model.orm.scripts import get_config
+
+WARNING_MODULES = ["parso", "asyncio", "galaxy.datatypes"]
+for mod in WARNING_MODULES:
+    logger = logging.getLogger(mod)
+    logger.setLevel("WARNING")
 
 registry = Registry()
 registry.load_datatypes()


### PR DESCRIPTION
This makes the tab-automplete usable again in db_shell.py

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
