### PR TITLE
Don't re-import TRS workflow if it already exists

### DIFF
--- a/test/unit/workflows/test_workflows_manager.py
+++ b/test/unit/workflows/test_workflows_manager.py
@@ -1,0 +1,22 @@
+from galaxy import model
+
+from .workflow_support import MockApp
+
+TRS_TOOL_ID = "#the_id"
+TRS_TOOL_VERSION = "v1"
+
+
+def test_find_workflow_by_trs_id():
+    app = MockApp()
+    with app.model.session.begin():
+        w = model.Workflow()
+
+        w.stored_workflow = model.StoredWorkflow()
+        w.stored_workflow.latest_workflow = w
+        u = model.User("test@test.com", "test", "test")
+        w.stored_workflow.user = u
+        w.source_metadata = {"trs_server": "dockstore", "trs_tool_id": TRS_TOOL_ID, "trs_version_id": TRS_TOOL_VERSION}
+        app.model.session.add(w)
+        app.model.session.commit()
+        app.model.session.flush()
+    assert app.workflow_manager.get_workflow_by_trs_id_and_version(app.model.session, TRS_TOOL_ID, TRS_TOOL_VERSION, u.id) == w


### PR DESCRIPTION
Works for postgres and sqlite. I think this might be the first time we query on JSON attributes ... let's try to never do that again.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
