### PR TITLE
[23.0] Fix test discovery in vscode

### DIFF
--- a/test/unit/app/test_remote_shell.py
+++ b/test/unit/app/test_remote_shell.py
@@ -8,7 +8,7 @@ from typing import (
 try:
     import mockssh
 except ImportError:
-    raise unittest.SkipTest("Skipping tests that require mockssh")
+    mockssh = None
 
 from galaxy.jobs.runners.util.cli import CliInterface
 from galaxy.security.ssh_util import (
@@ -42,6 +42,8 @@ class TestCliInterface(TestCase):
         cls.cli_interface = CliInterface()
 
     def test_secure_shell_plugin_without_strict(self):
+        if not mockssh:
+            raise unittest.SkipTest("Skipping tests that require mockssh")
         with mockssh.Server(users={self.username: self.ssh_keys.private_key_file}) as server:
             self.shell_params["port"] = server.port
             self.shell_params["plugin"] = "SecureShell"
@@ -51,6 +53,8 @@ class TestCliInterface(TestCase):
         assert result.stdout.strip() == "hello"
 
     def test_get_shell_plugin(self):
+        if not mockssh:
+            raise unittest.SkipTest("Skipping tests that require mockssh")
         with mockssh.Server(users={self.username: self.ssh_keys.private_key_file}) as server:
             self.shell_params["port"] = server.port
             self.shell_params["plugin"] = "ParamikoShell"
@@ -58,6 +62,8 @@ class TestCliInterface(TestCase):
         assert self.shell.username == self.username
 
     def test_paramiko_shell_plugin(self):
+        if not mockssh:
+            raise unittest.SkipTest("Skipping tests that require mockssh")
         with mockssh.Server(users={self.username: self.ssh_keys.private_key_file}) as server:
             self.shell_params["port"] = server.port
             self.shell_params["plugin"] = "ParamikoShell"


### PR DESCRIPTION
The vscode extension doesn't like the skip being raised during discovery anymore.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
