### PR TITLE
Refactor FilesDialog + Remote Files API schema improvements

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -5,6 +5,7 @@ import flushPromises from "flush-promises";
 import { selectionStates } from "@/components/SelectionDialog/selectionStates";
 import { mockFetcher } from "@/schema/__mocks__";
 
+import { RecordItem } from "./model";
 import {
     directory1RecursiveResponse,
     directory1Response,
@@ -12,8 +13,6 @@ import {
     directoryId,
     ftpId,
     pdbResponse,
-    RemoteDirectory,
-    RemoteFile,
     RemoteFilesList,
     rootId,
     rootResponse,
@@ -39,13 +38,7 @@ interface RemoteFilesResponse {
     data?: RemoteFilesList;
 }
 
-interface RowElement extends Element {
-    id: string;
-    label: string;
-    details: string;
-    isLeaf: boolean;
-    url: string;
-    labelTitle: string;
+interface RowElement extends RecordItem, Element {
     _rowVariant: string;
 }
 
@@ -120,159 +113,120 @@ describe("FilesDialog, file mode", () => {
         utils = new Utils(wrapper);
     });
 
-    it("should show the same number of items", async () => {
-        await utils.open_root_folder();
-        utils.assertShownItems(pdbResponse.length);
+    it("should show the number of items expected", async () => {
+        await utils.openRootDirectory();
+
+        expect(utils.getRenderedRows().length).toBe(pdbResponse.length);
     });
 
-    it("select files", async () => {
-        const applyForEachFile = (func: { (item: RowElement): void }) => {
-            utils.getRenderedFiles().forEach((item: RowElement) => {
-                func(item);
-            });
-        };
+    it("should allow selecting files and update OK button accordingly", async () => {
+        await utils.openRootDirectory();
+        const filesInResponse = pdbResponse.filter((item) => item.class === "File");
 
-        await utils.open_root_folder();
-        const files = pdbResponse.filter((item) => item.class === "File");
+        utils.expectOkButtonDisabled();
 
-        // assert that OK button is disabled
-        expect(wrapper.vm.hasValue).toBe(false);
+        expect(utils.getRenderedFiles().length).toBe(filesInResponse.length);
 
-        // assert number of rendered files
-        utils.assertShownItems(files.length, true);
+        // select each file
+        await utils.applyToEachFile((item) => utils.clickOn(item));
 
-        // select each rendered file
-        applyForEachFile((item: RowElement) => utils.clickOn(item));
+        utils.expectNumberOfSelectedItemsToBe(filesInResponse.length);
 
-        await flushPromises();
-        // assert the number of selected files
-        expect(wrapper.vm.model.count()).toBe(files.length);
-
-        // assert that re-rendered files are selected
-        applyForEachFile((item) => {
+        await utils.applyToEachFile((item) => {
             expect(item._rowVariant).toBe(selectionStates.selected);
-            wrapper.vm.model.exists(item.id);
         });
-        // assert that OK button is active
-        expect(wrapper.vm.hasValue).toBe(true);
+
+        utils.expectOkButtonEnabled();
 
         // unselect each file
-        applyForEachFile((item: RowElement) => utils.clickOn(item));
+        await utils.applyToEachFile((item) => utils.clickOn(item));
 
-        // assert that OK button is disabled
-        expect(wrapper.vm.hasValue).toBe(false);
+        utils.expectOkButtonDisabled();
     });
 
-    it("select directory", async () => {
-        await utils.open_root_folder();
+    it("should select all files contained in a directory when selecting the directory and update selection status accordingly", async () => {
+        const targetDirectoryId = directoryId;
+        await utils.openRootDirectory();
 
         // select directory
-        await utils.clickOn(utils.getRenderedDirectory(directoryId));
-
-        const response_files: RemoteFile[] = [];
-        const response_directories: RemoteDirectory[] = [];
-        // separate files and directories from response
-        directory1RecursiveResponse.forEach((item) => {
-            item.class === "File"
-                ? response_files.push(item as RemoteFile)
-                : response_directories.push(item as RemoteDirectory);
-        });
-
-        expect(wrapper.vm.model.count()).toBe(response_files.length);
-
-        // +1 because we additionally selected the "directory1" dir
-        expect(wrapper.vm.selectedDirectories.length).toBe(response_directories.length + 1);
+        await utils.clickOn(utils.findRenderedDirectory(targetDirectoryId));
 
         // go inside directory1
-        await utils.openDirectory(directoryId);
+        await utils.openDirectoryById(targetDirectoryId);
 
-        // select icon button should be active
-        expect(wrapper.vm.selectAllIcon).toBe(selectionStates.selected);
+        utils.expectSelectAllIconStatusToBe(selectionStates.selected);
 
         //every item should be selected
-        utils.assertAllRenderedItemsSelected();
+        utils.expectAllRenderedItemsSelected();
 
-        const file = wrapper.vm.items.find((item: RowElement) => item.isLeaf);
-
-        // unlesect random file
-        await utils.clickOn(file);
+        // unselect first file
+        const firstFile = utils.findFirstFile();
+        await utils.clickOn(firstFile);
 
         await utils.navigateBack();
-        // ensure that it has "mixed" icon
-        expect(utils.getRenderedDirectory(directoryId)._rowVariant).toBe(selectionStates.mixed);
+
+        // ensure that it has "mixed" status icon
+        const directory = utils.findRenderedDirectory(targetDirectoryId);
+        expect(directory._rowVariant).toBe(selectionStates.mixed);
     });
 
-    // Unselect subdirectory1
-    it("unselect sub-directory", async () => {
-        await utils.open_root_folder();
+    it("should be able to unselect a sub-directory keeping the rest selected", async () => {
+        await utils.openRootDirectory();
         // select directory1
-        await utils.clickOn(utils.getRenderedDirectory(directoryId));
+        await utils.clickOn(utils.findRenderedDirectory(directoryId));
         //go inside subDirectoryId
-        await utils.openDirectory(directoryId);
-        await utils.openDirectory(subDirectoryId);
+        await utils.openDirectoryById(directoryId);
+        await utils.openDirectoryById(subDirectoryId);
         // unselect subfolder
-        await utils.clickOn(utils.getRenderedDirectory(subSubDirectoryId));
+        await utils.clickOn(utils.findRenderedDirectory(subSubDirectoryId));
         // directory should be unselected
-        expect(utils.getRenderedDirectory(subSubDirectoryId)._rowVariant).toBe(selectionStates.unselected);
+        expect(utils.findRenderedDirectory(subSubDirectoryId)._rowVariant).toBe(selectionStates.unselected);
         // selectAllIcon should be unselected
-        expect(wrapper.vm.selectAllIcon).toBe(selectionStates.unselected);
+        utils.expectSelectAllIconStatusToBe(selectionStates.unselected);
         await utils.navigateBack();
         await utils.navigateBack();
-        await flushPromises();
-        expect(utils.getRenderedDirectory(directoryId)._rowVariant).toBe(selectionStates.mixed);
+        expect(utils.findRenderedDirectory(directoryId)._rowVariant).toBe(selectionStates.mixed);
     });
 
     it("should select all on 'toggleSelectAll' event", async () => {
-        await utils.open_root_folder();
-        // selectAll button was pressed
-        utils.getTable().$emit("toggleSelectAll");
-        await flushPromises();
-        utils.assertAllRenderedItemsSelected();
+        await utils.openRootDirectory();
+        utils.selectAll();
+        utils.expectAllRenderedItemsSelected();
         // open directory1
-        await utils.openDirectory(directoryId);
-        utils.assertAllRenderedItemsSelected();
+        await utils.openDirectoryById(directoryId);
+        utils.expectAllRenderedItemsSelected();
         await utils.navigateBack();
-        utils.assertAllRenderedItemsSelected();
+        utils.expectAllRenderedItemsSelected();
         await utils.navigateBack();
-        const rootNode = utils.getRenderedDirectory(rootId);
+        const rootNode = utils.findRenderedDirectory(rootId);
         expect(rootNode._rowVariant).toBe(selectionStates.selected);
     });
 
     it("should show ftp helper only in ftp directory", async () => {
         // open some other directory than ftp
-        await utils.open_root_folder();
+        await utils.openRootDirectory();
         // check that ftp helper is not visible
-        expect(wrapper.vm.showFTPHelper).toBe(false);
         expect(wrapper.find("#helper").exists()).toBe(false);
+
         // back to root folder
         await utils.navigateBack();
 
         // open ftp directory
-        await utils.openDirectory(ftpId);
+        await utils.openDirectoryById(ftpId);
         // check that ftp helper is visible
-        expect(wrapper.vm.showFTPHelper).toBe(true);
         expect(wrapper.find("#helper").exists()).toBe(true);
     });
 
-    it("should show loading error and can return back", async () => {
-        expect(wrapper.vm.errorMessage).toBeNull();
+    it("should show loading error and can return back when there is an error", async () => {
+        utils.expectNoErrorMessage();
 
         // open directory with error
-        await utils.openDirectory("empty-dir");
-        // assert that error message is set and showed
-        expect(wrapper.vm.errorMessage).toBe(someErrorText);
-        expect(wrapper.html()).toContain(someErrorText);
-
-        // assert that OK button is disabled
-        expect(wrapper.vm.hasValue).toBe(false);
+        await utils.openDirectoryById("empty-dir");
+        utils.expectErrorMessage();
 
         // back to the root folder
-        await wrapper.find("#back-btn").trigger("click");
-        await flushPromises();
-        expect(wrapper.vm.items.length).toBe(rootResponse.length);
-
-        // assert that OK button is disabled
-        expect(wrapper.vm.hasValue).toBe(false);
+        await utils.navigateBack();
+        expect(utils.getRenderedRows().length).toBe(rootResponse.length);
     });
 });
 
@@ -285,62 +239,40 @@ describe("FilesDialog, directory mode", () => {
         utils = new Utils(wrapper);
     });
 
-    it("should render directories", async () => {
-        const assertOnlyDirectoriesRendered = () =>
-            wrapper.vm.items.forEach((item: RowElement) => expect(item.isLeaf).toBe(false));
+    it("should render directories only", async () => {
+        const expectOnlyDirectoriesRendered = () =>
+            utils.getRenderedRows().forEach((item) => expect(item.isLeaf).toBe(false));
 
-        await utils.open_root_folder(false);
+        await utils.openRootDirectory();
         // rendered files should be directories
-        assertOnlyDirectoriesRendered();
+        expectOnlyDirectoriesRendered();
         // check subdirectories
-        await utils.openDirectory(directoryId);
-        assertOnlyDirectoriesRendered();
+        await utils.openDirectoryById(directoryId);
+        expectOnlyDirectoriesRendered();
     });
 
-    it("should select folders", async () => {
-        const btn = wrapper.find("#ok-btn");
+    it("should allow to select folders by navigating to them", async () => {
+        utils.expectOkButtonDisabled();
 
-        expect(btn.attributes().disabled).toBe("disabled");
-        await utils.open_root_folder(false);
-        const folder = utils.getRenderedDirectory(directoryId);
-        await utils.getTable().$emit("open", folder);
-        await flushPromises();
+        await utils.openRootDirectory();
+        utils.openDirectoryById(directoryId);
 
-        const currentDirectory = wrapper.vm.currentDirectory;
-        expect(currentDirectory.id).toBe(folder.id);
-
-        // make sure that disabled attribute is absent
-        expect(btn.attributes().disabled).toBe(undefined);
-        wrapper.vm.selectLeaf(currentDirectory);
-        await flushPromises();
-
-        //should close modal
-        expect(wrapper.vm.modalShow).toBe(false);
+        utils.expectOkButtonEnabled();
     });
 
-    it("should show loading error and can return back", async () => {
-        expect(wrapper.vm.errorMessage).toBeNull();
+    it("should show loading error and can return back when there is an error", async () => {
+        utils.expectNoErrorMessage();
 
         // open directory with error
-        await utils.openDirectory("empty-dir");
-        // assert that error message is set and showed
-        expect(wrapper.vm.errorMessage).toBe(someErrorText);
-        expect(wrapper.html()).toContain(someErrorText);
-
-        // assert that OK button is disabled
-        expect(wrapper.vm.hasValue).toBe(false);
+        await utils.openDirectoryById("empty-dir");
+        utils.expectErrorMessage();
 
         // back to the root folder
-        await wrapper.find("#back-btn").trigger("click");
-        await flushPromises();
-        expect(wrapper.vm.items.length).toBe(rootResponse.length);
-
-        // assert that OK button is disabled
-        expect(wrapper.vm.hasValue).toBe(false);
+        await utils.navigateBack();
+        expect(utils.getRenderedRows().length).toBe(rootResponse.length);
     });
 });
 
-/** Util methods **/
 class Utils {
     wrapper: Wrapper<any>;
 
@@ -348,61 +280,115 @@ class Utils {
         this.wrapper = wrapper;
     }
 
-    async open_root_folder(isFileMode = true) {
+    async openRootDirectory() {
         expect(this.wrapper.findComponent(SelectionDialog).exists()).toBe(true);
-        this.assertShownItems(rootResponse.length);
-        if (isFileMode) {
-            // find desired rootElement
-            const rootElement = this.wrapper.vm.items.find((item: RowElement) => rootId === item.id);
-            // open root folder with rootId (since root folder cannot be selected "click" should open it)
-            await this.clickOn(rootElement);
-        } else {
-            await this.openDirectory(rootId);
-        }
+        expect(this.getRenderedRows().length).toBe(rootResponse.length);
+        await this.openDirectoryById(rootId);
     }
 
     async navigateBack() {
-        this.wrapper.vm.load();
+        const backBtn = this.getBackButton();
+        await backBtn.trigger("click");
         await flushPromises();
     }
 
-    assertAllRenderedItemsSelected() {
-        this.wrapper.vm.items.forEach((item: RowElement) => {
-            // assert style/icon of selected field
-            expect(item._rowVariant).toBe(selectionStates.selected);
-            // selected items are selected
-            expect(
-                item.isLeaf
-                    ? this.wrapper.vm.model.exists(item.id)
-                    : this.wrapper.vm.selectedDirectories.some(({ id }: RowElement) => id === item.id)
-            ).toBe(true);
-        });
+    async openDirectoryById(directoryId: string) {
+        const directory = this.findRenderedDirectory(directoryId);
+        return this.openDirectory(directory);
     }
 
-    async openDirectory(directoryId: string) {
-        this.getTable().$emit("open", this.getRenderedDirectory(directoryId));
+    async openDirectory(directory: RowElement) {
+        this.getTable().vm.$emit("open", directory);
         await flushPromises();
     }
 
     async clickOn(element: Element) {
-        this.getTable().$emit("clicked", element);
+        this.getTable().vm.$emit("clicked", element);
         await flushPromises();
     }
 
-    getRenderedDirectory(directoryId: string): RowElement {
-        return this.wrapper.vm.items.find(({ id }: RowElement) => directoryId === id);
+    async selectAll() {
+        this.getTable().vm.$emit("toggleSelectAll");
+        await flushPromises();
+    }
+
+    findRenderedDirectory(directoryId: string): RowElement {
+        const directory = this.getRenderedRows().find(({ id }: RowElement) => directoryId === id);
+        if (!directory) {
+            throw new Error(`Directory with id ${directoryId} not found`);
+        }
+        return directory;
     }
 
     getRenderedFiles(): RowElement[] {
-        return this.wrapper.vm.items.filter((item: RowElement) => item.isLeaf);
+        return this.getRenderedRows().filter((item: RowElement) => item.isLeaf);
     }
 
-    getTable() {
-        return this.wrapper.findComponent(DataDialogTable).vm;
+    findFirstFile(): RowElement {
+        const file = this.getRenderedFiles().at(0);
+        if (!file) {
+            throw new Error("File not found");
+        }
+        return file;
     }
 
-    assertShownItems(length: number, filesOnly = false) {
-        const shownItems = filesOnly ? this.getRenderedFiles() : this.wrapper.vm.items;
-        expect(shownItems.length).toBe(length);
+    async applyToEachFile(func: (item: RowElement) => void) {
+        this.getRenderedFiles().forEach((item) => {
+            func(item);
+        });
+        await flushPromises();
+    }
+
+    getTable(): any {
+        return this.wrapper.findComponent(DataDialogTable);
+    }
+
+    getButtonById(id: string): any {
+        const button = this.wrapper.find(id);
+        expect(button.exists()).toBe(true);
+        return button;
+    }
+
+    getOkButton(): any {
+        return this.getButtonById("#ok-btn");
+    }
+
+    getBackButton(): any {
+        return this.getButtonById("#back-btn");
+    }
+
+    getRenderedRows(): RowElement[] {
+        return this.getTable().vm.items as RowElement[];
+    }
+
+    expectAllRenderedItemsSelected() {
+        this.getRenderedRows().forEach((item) => {
+            expect(item._rowVariant).toBe(selectionStates.selected);
+        });
+    }
+
+    expectNumberOfSelectedItemsToBe(number: number) {
+        const selectedItems = this.getRenderedRows().filter((item) => item._rowVariant === selectionStates.selected);
+        expect(selectedItems.length).toBe(number);
+    }
+
+    expectOkButtonDisabled() {
+        expect(this.getOkButton().attributes("disabled")).toBeTruthy();
+    }
+
+    expectOkButtonEnabled() {
+        expect(this.getOkButton().attributes("disabled")).toBeFalsy();
+    }
+
+    expectSelectAllIconStatusToBe(status: string) {
+        expect(this.getTable().attributes("selectallicon")).toBe(status);
+    }
+
+    expectNoErrorMessage() {
+        expect(this.wrapper.html()).not.toContain(someErrorText);
+    }
+
+    expectErrorMessage() {
+        expect(this.wrapper.html()).toContain(someErrorText);
     }
 }

--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -29,6 +29,13 @@ import SelectionDialog from "@/components/SelectionDialog/SelectionDialog.vue";
 jest.mock("app");
 jest.mock("@/schema");
 
+jest.mock("@/composables/config", () => ({
+    useConfig: jest.fn(() => ({
+        config: { ftp_upload_site: "Test ftp upload site" },
+        isLoaded: true,
+    })),
+}));
+
 interface RemoteFilesParams {
     target: string;
     recursive: boolean;

--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -32,7 +32,7 @@ jest.mock("@/schema");
 jest.mock("@/composables/config", () => ({
     useConfig: jest.fn(() => ({
         config: { ftp_upload_site: "Test ftp upload site" },
-        isLoaded: true,
+        isConfigLoaded: true,
     })),
 }));
 
@@ -332,7 +332,7 @@ class Utils {
     }
 
     findFirstFile(): RowElement {
-        const file = this.getRenderedFiles().at(0);
+        const file = this.getRenderedFiles()[0];
         if (!file) {
             throw new Error("File not found");
         }

--- a/client/src/components/FilesDialog/FilesDialog.test.ts
+++ b/client/src/components/FilesDialog/FilesDialog.test.ts
@@ -5,7 +5,7 @@ import flushPromises from "flush-promises";
 import { selectionStates } from "@/components/SelectionDialog/selectionStates";
 import { mockFetcher } from "@/schema/__mocks__";
 
-import { RecordItem } from "./model";
+import { BaseRecordItem } from "./model";
 import {
     directory1RecursiveResponse,
     directory1Response,
@@ -45,7 +45,7 @@ interface RemoteFilesResponse {
     data?: RemoteFilesList;
 }
 
-interface RowElement extends RecordItem, Element {
+interface RowElement extends BaseRecordItem, Element {
     _rowVariant: string;
 }
 

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -65,12 +65,10 @@ function clicked(record: RecordItem) {
     }
     if (record.isLeaf) {
         // record is file
-        selectLeaf(record as FileRecord);
+        selectLeaf(record);
     } else {
-        // record is directory
-        const directory = record as DirectoryRecord;
         // you cannot select entire root directory
-        urlTracker.value.atRoot() ? open(directory) : selectDirectory(directory);
+        urlTracker.value.atRoot() ? open(record) : selectDirectory(record);
     }
     formatRows();
 }
@@ -133,13 +131,13 @@ function selectDirectory(record: DirectoryRecord) {
         browseRemoteFiles(record.url, recursive).then((items) => {
             items.forEach((item) => {
                 // construct record
-                const sub_record = entryToRecord(item);
-                if (sub_record.isLeaf) {
+                const subRecord = entryToRecord(item);
+                if (subRecord.isLeaf) {
                     // select file under this path
-                    selectLeaf(sub_record as FileRecord, true);
+                    selectLeaf(subRecord, true);
                 } else {
                     // select subdirectory
-                    selectedDirectories.value.push(sub_record as DirectoryRecord);
+                    selectedDirectories.value.push(subRecord);
                 }
             });
             isBusy.value = false;
@@ -281,10 +279,10 @@ function toggleSelectAll() {
     for (const item of items.value) {
         if (isUnselectAll) {
             if (model.value.exists(item.id) || model.value.pathExists(item.id)) {
-                item.isLeaf ? model.value.add(item) : selectDirectory(item as DirectoryRecord);
+                item.isLeaf ? model.value.add(item) : selectDirectory(item);
             }
         } else {
-            item.isLeaf ? model.value.add(item) : selectDirectory(item as DirectoryRecord);
+            item.isLeaf ? model.value.add(item) : selectDirectory(item);
         }
     }
 

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -1,5 +1,340 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faCaretLeft } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BAlert, BButton } from "bootstrap-vue";
+import Vue, { computed, onMounted, ref } from "vue";
+
+import { UrlTracker } from "@/components/DataDialog/utilities";
+import { isSubPath } from "@/components/FilesDialog/utilities";
+import { selectionStates } from "@/components/SelectionDialog/selectionStates";
+import { errorMessageAsString } from "@/utils/simple-error";
+
+import { getGalaxyInstance } from "../../app";
+import { Model } from "./model";
+import { browseRemoteFiles, FilesSourcePlugin, getFileSources, RemoteEntry } from "./services";
+
+import DataDialogSearch from "@/components/SelectionDialog/DataDialogSearch.vue";
+import DataDialogTable from "@/components/SelectionDialog/DataDialogTable.vue";
+import SelectionDialog from "@/components/SelectionDialog/SelectionDialog.vue";
+
+library.add(faCaretLeft);
+
+interface FilesDialogProps {
+    multiple?: boolean;
+    mode?: "file" | "directory";
+    requireWritable?: boolean;
+    callback?: (files: any) => void;
+}
+
+interface Record {
+    id: string;
+    label: string;
+    details: string;
+    isLeaf: boolean;
+    url: string;
+    labelTitle: string | undefined;
+}
+
+interface FileRecord extends Record {
+    isLeaf: true;
+}
+
+interface DirectoryRecord extends Record {
+    isLeaf: false;
+}
+
+const props = withDefaults(defineProps<FilesDialogProps>(), {
+    multiple: false,
+    mode: "file",
+    requireWritable: false,
+    callback: () => {},
+});
+
+const model = ref<Model>(new Model({ multiple: props.multiple }));
+
+const allSelected = ref(false);
+const selectedDirectories = ref<DirectoryRecord[]>([]);
+const errorMessage = ref<string>();
+const filter = ref();
+const items = ref<Record[]>([]);
+const modalShow = ref(true);
+const optionsShow = ref(false);
+const undoShow = ref(false);
+const hasValue = ref(false);
+const showTime = ref(true);
+const showDetails = ref(true);
+const isBusy = ref(false);
+const currentDirectory = ref<DirectoryRecord>();
+const showFTPHelper = ref(false);
+const selectAllIcon = ref(selectionStates.unselected);
+const ftpUploadSite = ref(getGalaxyInstance()?.config?.ftp_upload_site);
+const oidcEnabled = ref(getGalaxyInstance()?.config?.enable_oidc);
+
+const urlTracker = ref(new UrlTracker(""));
+
+const fileMode = computed(() => props.mode == "file");
+
+/** Collects selected datasets in value array **/
+function clicked(record: Record) {
+    // ignore the click during directory mode
+    if (!fileMode.value) {
+        return;
+    }
+    if (record.isLeaf) {
+        // record is file
+        selectLeaf(record as FileRecord);
+    } else {
+        // record is directory
+        const directory = record as DirectoryRecord;
+        // you cannot select entire root directory
+        urlTracker.value.atRoot() ? open(directory) : selectDirectory(directory);
+    }
+    formatRows();
+}
+
+function selectLeaf(file: FileRecord, selectOnly = false) {
+    const selected = model.value.exists(file.id);
+    if (selected) {
+        unselectPath(file.url, true);
+    }
+    if (selectOnly) {
+        if (!selected) {
+            model.value.add(file);
+        }
+    } else {
+        model.value.add(file);
+    }
+
+    hasValue.value = model.value.count() > 0;
+    if (props.multiple) {
+        formatRows();
+    } else {
+        finalize();
+    }
+}
+
+function unselectPath(path: string, unselectOnlyAboveDirectories = false, unselectId?: string) {
+    // unselect directories
+    selectedDirectories.value = selectedDirectories.value.filter((directory) => {
+        if (unselectId === directory.id) {
+            return false;
+        }
+
+        let matched;
+        if (unselectOnlyAboveDirectories) {
+            matched = isSubPath(directory.url, path);
+        } else {
+            // unselect all folders under or above the current path
+            matched = isSubPath(directory.url, path) || isSubPath(path, directory.url);
+        }
+        // filter out those that matched
+        return !matched;
+    });
+
+    // unselect files
+    if (!unselectOnlyAboveDirectories) {
+        // unselect all files under this path
+        model.value.unselectUnderPath(path);
+    }
+}
+
+function selectDirectory(record: DirectoryRecord) {
+    // if directory is `selected` or `mixed` unselect everything
+    if (isDirectorySelected(record.id) || model.value.pathExists(record.url)) {
+        unselectPath(record.url, false, record.id);
+    } else {
+        selectedDirectories.value.push(record);
+        // look for subdirectories
+        const recursive = true;
+        isBusy.value = true;
+        browseRemoteFiles(record.url, recursive).then((items) => {
+            items.forEach((item) => {
+                // construct record
+                const sub_record = entryToRecord(item);
+                if (sub_record.isLeaf) {
+                    // select file under this path
+                    selectLeaf(sub_record as FileRecord, true);
+                } else {
+                    // select subdirectory
+                    selectedDirectories.value.push(sub_record as DirectoryRecord);
+                }
+            });
+            isBusy.value = false;
+        });
+    }
+}
+
+/** Add highlighting for record variations, i.e. datasets vs. libraries/collections **/
+function formatRows() {
+    const getIcon = (isSelected: boolean, path: string) => {
+        if (isSelected) {
+            return selectionStates.selected;
+        } else {
+            return model.value.pathExists(path) ? selectionStates.mixed : selectionStates.unselected;
+        }
+    };
+
+    hasValue.value = model.value.count() > 0 || selectedDirectories.value.length > 0;
+    for (const item of items.value) {
+        let _rowVariant = "active";
+        if (item.isLeaf || !fileMode.value) {
+            _rowVariant = model.value.exists(item.id) ? "success" : "default";
+        }
+        // if directory
+        else if (!item.isLeaf) {
+            _rowVariant = getIcon(isDirectorySelected(item.id), item.url);
+        }
+        Vue.set(item, "_rowVariant", _rowVariant);
+    }
+    allSelected.value = checkIfAllSelected();
+    if (currentDirectory.value?.url) {
+        selectAllIcon.value = getIcon(allSelected.value, currentDirectory.value.url);
+    }
+}
+
+function isDirectorySelected(directoryId: string): boolean {
+    return selectedDirectories.value.some(({ id }) => id === directoryId);
+}
+
+/** check if all objects in this folders are selected **/
+function checkIfAllSelected(): boolean {
+    const isAllSelected =
+        Boolean(items.value.length) && items.value.every(({ id }) => model.value.exists(id) || isDirectorySelected(id));
+
+    if (isAllSelected && currentDirectory.value && !isDirectorySelected(currentDirectory.value.id)) {
+        // if all selected, select current folder
+        selectedDirectories.value.push(currentDirectory.value);
+    }
+
+    return isAllSelected;
+}
+
+function open(record: DirectoryRecord) {
+    load(record);
+}
+
+/** Performs server request to retrieve data records **/
+function load(record?: DirectoryRecord) {
+    currentDirectory.value = urlTracker.value.getUrl(record);
+    showFTPHelper.value = record?.url === "gxftp://";
+    filter.value = undefined;
+    optionsShow.value = false;
+    undoShow.value = !urlTracker.value.atRoot();
+    if (urlTracker.value.atRoot() || errorMessage.value) {
+        errorMessage.value = undefined;
+        getFileSources()
+            .then((results) => {
+                const convertedItems = results
+                    .filter((item) => !props.requireWritable || item.writable)
+                    .map(fileSourcePluginToRecord);
+                items.value = convertedItems;
+                formatRows();
+                optionsShow.value = true;
+                showTime.value = false;
+                showDetails.value = true;
+            })
+            .catch((error) => {
+                errorMessage.value = errorMessageAsString(error);
+            });
+    } else {
+        if (!currentDirectory.value) {
+            return;
+        }
+        browseRemoteFiles(currentDirectory.value?.url)
+            .then((results) => {
+                items.value = filterByMode(results).map(entryToRecord);
+                formatRows();
+                optionsShow.value = true;
+                showTime.value = true;
+                showDetails.value = false;
+            })
+            .catch((error) => {
+                errorMessage.value = errorMessageAsString(error);
+            });
+    }
+}
+
+function filterByMode(results: RemoteEntry[]): RemoteEntry[] {
+    if (!fileMode.value) {
+        // In directory mode, only show directories
+        return results.filter((item) => item.class === "Directory");
+    }
+    return results;
+}
+
+function entryToRecord(entry: RemoteEntry): Record {
+    const result = {
+        id: entry.uri,
+        label: entry.name,
+        time: entry.class === "File" ? entry.ctime : "",
+        details: entry.class === "File" ? entry.ctime : "",
+        isLeaf: entry.class === "File",
+        url: entry.uri,
+        labelTitle: entry.uri,
+        size: entry.class === "File" ? entry.size : 0,
+    };
+    return result;
+}
+
+function fileSourcePluginToRecord(plugin: FilesSourcePlugin): Record {
+    const result = {
+        id: plugin.id,
+        label: plugin.label,
+        details: plugin.doc,
+        isLeaf: false,
+        url: plugin.uri_root,
+        labelTitle: plugin.uri_root,
+    };
+    return result;
+}
+
+/** select all files in current folder**/
+function toggleSelectAll() {
+    if (!currentDirectory.value) {
+        return;
+    }
+    const isUnselectAll = model.value.pathExists(currentDirectory.value.url);
+
+    for (const item of items.value) {
+        if (isUnselectAll) {
+            if (model.value.exists(item.id) || model.value.pathExists(item.id)) {
+                item.isLeaf ? model.value.add(item) : selectDirectory(item as DirectoryRecord);
+            }
+        } else {
+            item.isLeaf ? model.value.add(item) : selectDirectory(item as DirectoryRecord);
+        }
+    }
+
+    if (!isUnselectAll && items.value.length !== 0) {
+        selectedDirectories.value.push(currentDirectory.value);
+    } else if (isDirectorySelected(currentDirectory.value.id)) {
+        selectDirectory(currentDirectory.value);
+    }
+
+    hasValue.value = model.value.count() > 0;
+    formatRows();
+}
+
+/** Called when selection is complete, values are formatted and parsed to external callback **/
+function finalize() {
+    const results = model.value.finalize();
+    modalShow.value = false;
+    props.callback(results);
+}
+
+function goBack() {
+    // Loading without a record navigates back one level
+    load();
+}
+
+onMounted(() => {
+    load();
+});
+</script>
+
 <template>
-    <selection-dialog
+    <SelectionDialog
         :error-message="errorMessage"
         :options-show="optionsShow"
         :modal-show="modalShow"
@@ -7,10 +342,10 @@
         :back-func="goBack"
         :undo-show="undoShow">
         <template v-slot:search>
-            <data-dialog-search v-model="filter" />
+            <DataDialogSearch v-model="filter" />
         </template>
         <template v-slot:helper>
-            <b-alert v-if="showFTPHelper" id="helper" variant="info" show>
+            <BAlert v-if="showFTPHelper" id="helper" variant="info" show>
                 This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at
                 <strong>{{ ftpUploadSite }}</strong> using your Galaxy credentials. For help visit the
                 <a href="https://galaxyproject.org/ftp-upload/" target="_blank">tutorial</a>.
@@ -19,10 +354,10 @@
                     <strong>do not have a Galaxy password</strong> please use the reset password option in the login
                     form with your email to create a password for your account.</span
                 >
-            </b-alert>
+            </BAlert>
         </template>
         <template v-slot:options>
-            <data-dialog-table
+            <DataDialogTable
                 v-if="optionsShow"
                 :items="items"
                 :multiple="multiple"
@@ -37,11 +372,11 @@
                 @toggleSelectAll="toggleSelectAll" />
         </template>
         <template v-slot:buttons>
-            <b-btn v-if="undoShow" id="back-btn" size="sm" class="float-left" @click="load()">
+            <BButton v-if="undoShow" id="back-btn" size="sm" class="float-left" @click="load()">
                 <FontAwesomeIcon :icon="['fas', 'caret-left']" />
                 Back
-            </b-btn>
-            <b-btn
+            </BButton>
+            <BButton
                 v-if="multiple || !fileMode"
                 id="ok-btn"
                 size="sm"
@@ -50,324 +385,7 @@
                 :disabled="(fileMode && !hasValue) || isBusy || (!fileMode && urlTracker.atRoot())"
                 @click="fileMode ? finalize() : selectLeaf(currentDirectory)">
                 {{ fileMode ? "Ok" : "Select this folder" }}
-            </b-btn>
+            </BButton>
         </template>
-    </selection-dialog>
+    </SelectionDialog>
 </template>
-
-<script>
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faCaretLeft } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { UrlTracker } from "components/DataDialog/utilities";
-import { isSubPath } from "components/FilesDialog/utilities";
-import SelectionDialogMixin from "components/SelectionDialog/SelectionDialogMixin";
-import { selectionStates } from "components/SelectionDialog/selectionStates";
-import Vue from "vue";
-
-import { errorMessageAsString } from "@/utils/simple-error";
-
-import { getGalaxyInstance } from "../../app";
-import { Model } from "./model";
-import { browseRemoteFiles, getFileSources } from "./services";
-
-library.add(faCaretLeft);
-export default {
-    components: {
-        FontAwesomeIcon,
-    },
-    mixins: [SelectionDialogMixin],
-    props: {
-        multiple: {
-            type: Boolean,
-            default: false,
-        },
-        mode: {
-            type: String,
-            default: "file",
-            validator: (prop) => ["file", "directory"].includes(prop),
-        },
-        requireWritable: {
-            type: Boolean,
-            default: false,
-        },
-    },
-    data() {
-        return {
-            allSelected: false,
-            selectedDirectories: [],
-            errorMessage: null,
-            filter: null,
-            items: [],
-            modalShow: true,
-            optionsShow: false,
-            undoShow: false,
-            hasValue: false,
-            showTime: true,
-            showDetails: true,
-            isBusy: false,
-            currentDirectory: undefined,
-            showFTPHelper: false,
-            selectAllIcon: selectionStates.unselected,
-            ftpUploadSite: getGalaxyInstance()?.config?.ftp_upload_site,
-            oidcEnabled: getGalaxyInstance()?.config?.enable_oidc,
-        };
-    },
-    computed: {
-        fileMode() {
-            return this.mode == "file";
-        },
-    },
-    created: function () {
-        this.urlTracker = new UrlTracker("");
-        this.model = new Model({ multiple: this.multiple });
-        this.load();
-    },
-    methods: {
-        /** Add highlighting for record variations, i.e. datasets vs. libraries/collections **/
-        formatRows() {
-            const getIcon = (isSelected, path) => {
-                if (isSelected) {
-                    return selectionStates.selected;
-                } else {
-                    return this.model.pathExists(path) ? selectionStates.mixed : selectionStates.unselected;
-                }
-            };
-
-            this.hasValue = this.model.count() > 0 || this.selectedDirectories.length > 0;
-            for (const item of this.items) {
-                let _rowVariant = "active";
-                if (item.isLeaf || !this.fileMode) {
-                    _rowVariant = this.model.exists(item.id) ? "success" : "default";
-                }
-                // if directory
-                else if (!item.isLeaf) {
-                    _rowVariant = getIcon(this.isDirectorySelected(item.id), item.url);
-                }
-                Vue.set(item, "_rowVariant", _rowVariant);
-            }
-            this.allSelected = this.checkIfAllSelected();
-            if (this.currentDirectory.url) {
-                this.selectAllIcon = getIcon(this.allSelected, this.currentDirectory.url);
-            }
-        },
-        /** Collects selected datasets in value array **/
-        clicked: function (record) {
-            // ignore the click during directory mode
-            if (!this.fileMode) {
-                return;
-            }
-            if (record.isLeaf) {
-                // record is file
-                this.selectLeaf(record);
-            } else {
-                // record is directory
-                // you cannot select entire root directory
-                this.urlTracker.atRoot() ? this.open(record) : this.selectDirectory(record);
-            }
-            this.formatRows();
-        },
-        unselectPath(path, unselectOnlyAboveDirectories = false, unselectId) {
-            // unselect directories
-            this.selectedDirectories = this.selectedDirectories.filter((directory) => {
-                if (unselectId === directory.id) {
-                    return false;
-                }
-
-                let matched;
-                if (unselectOnlyAboveDirectories) {
-                    matched = isSubPath(directory.url, path);
-                } else {
-                    // unselect all folders under or above the current path
-                    matched = isSubPath(directory.url, path) || isSubPath(path, directory.url);
-                }
-                // filter out those that matched
-                return !matched;
-            });
-
-            // unselect files
-            if (!unselectOnlyAboveDirectories) {
-                // unselect all files under this path
-                this.model.unselectUnderPath(path);
-            }
-        },
-        selectLeaf(file, selectOnly = false) {
-            const selected = this.model.exists(file.id);
-            if (selected) {
-                this.unselectPath(file.url, true);
-            }
-            if (selectOnly) {
-                if (!selected) {
-                    this.model.add(file);
-                }
-            } else {
-                this.model.add(file);
-            }
-
-            this.hasValue = this.model.count() > 0;
-            if (this.multiple) {
-                this.formatRows();
-            } else {
-                this.finalize();
-            }
-        },
-        selectDirectory(record) {
-            // if directory is `selected` or `mixed` unselect everything
-            if (this.isDirectorySelected(record.id) || this.model.pathExists(record.url)) {
-                this.unselectPath(record.url, false, record.id);
-            } else {
-                this.selectedDirectories.push(record);
-                // look for subdirectories
-                const recursive = true;
-                this.isBusy = true;
-                browseRemoteFiles(record.url, recursive).then((items) => {
-                    items.forEach((item) => {
-                        // construct record
-                        const sub_record = this.parseItemFileMode(item);
-                        if (sub_record.isLeaf) {
-                            // select file under this path
-                            this.selectLeaf(sub_record, true);
-                        } else {
-                            // select subdirectory
-                            this.selectedDirectories.push(sub_record);
-                        }
-                    });
-                    this.isBusy = false;
-                });
-            }
-        },
-        isDirectorySelected(directoryId) {
-            return this.selectedDirectories.some(({ id }) => id === directoryId);
-        },
-        open: function (record) {
-            this.load(record);
-        },
-        /** Called when selection is complete, values are formatted and parsed to external callback **/
-        finalize: function () {
-            const results = this.model.finalize();
-            this.modalShow = false;
-            this.callback(results);
-        },
-        /** check if all objects in this folders are selected **/
-        checkIfAllSelected() {
-            const isAllSelected =
-                this.items.length &&
-                this.items.every(({ id }) => this.model.exists(id) || this.isDirectorySelected(id));
-
-            if (isAllSelected && !this.isDirectorySelected(this.currentDirectory.id)) {
-                // if all selected, select current folder
-                this.selectedDirectories.push(this.currentDirectory);
-            }
-
-            return isAllSelected;
-        },
-        /** select all files in current folder**/
-        toggleSelectAll: function () {
-            const isUnselectAll = this.model.pathExists(this.currentDirectory.url);
-
-            for (const item of this.items) {
-                if (isUnselectAll) {
-                    if (this.model.exists(item.id) || this.model.pathExists(item.id)) {
-                        item.isLeaf ? this.model.add(item) : this.selectDirectory(item);
-                    }
-                } else {
-                    item.isLeaf ? this.model.add(item) : this.selectDirectory(item);
-                }
-            }
-
-            if (!isUnselectAll && this.items.length !== 0) {
-                this.selectedDirectories.push(this.currentDirectory);
-            } else if (this.isDirectorySelected(this.currentDirectory.id)) {
-                this.selectDirectory(this.currentDirectory);
-            }
-
-            this.hasValue = this.model.count() > 0;
-            this.formatRows();
-        },
-        /** Performs server request to retrieve data records **/
-        load: function (record) {
-            this.currentDirectory = this.urlTracker.getUrl(record);
-            this.showFTPHelper = record?.url === "gxftp://";
-            this.filter = null;
-            this.optionsShow = false;
-            this.undoShow = !this.urlTracker.atRoot();
-            if (this.urlTracker.atRoot() || this.errorMessage) {
-                this.errorMessage = null;
-                getFileSources()
-                    .then((items) => {
-                        items = items
-                            .filter((item) => !this.requireWritable || item.writable)
-                            .map((item) => {
-                                return {
-                                    id: item.id,
-                                    label: item.label,
-                                    details: item.doc,
-                                    isLeaf: false,
-                                    url: item.uri_root,
-                                    labelTitle: item.uri_root,
-                                };
-                            });
-                        this.items = items;
-                        this.formatRows();
-                        this.optionsShow = true;
-                        this.showTime = false;
-                        this.showDetails = true;
-                    })
-                    .catch((error) => {
-                        this.errorMessage = errorMessageAsString(error);
-                    });
-            } else {
-                browseRemoteFiles(this.currentDirectory.url)
-                    .then((items) => {
-                        this.items = this.parseItems(items);
-                        this.formatRows();
-                        this.optionsShow = true;
-                        this.showTime = true;
-                        this.showDetails = false;
-                    })
-                    .catch((error) => {
-                        this.errorMessage = errorMessageAsString(error);
-                    });
-            }
-        },
-        goBack() {
-            // Loading without a record navigates back one level
-            this.load();
-        },
-        parseItemFileMode(item) {
-            const result = {
-                id: item.uri,
-                label: item.name,
-                time: item.ctime,
-                isLeaf: item.class === "File",
-                size: item.size,
-                url: item.uri,
-                labelTitle: item.uri,
-            };
-            return result;
-        },
-        parseItems(items) {
-            if (this.fileMode) {
-                items = items.map((item) => {
-                    return this.parseItemFileMode(item);
-                });
-            } else {
-                items = items
-                    .filter((item) => item.class == "Directory")
-                    .map((item) => {
-                        return {
-                            id: item.uri,
-                            label: item.name,
-                            time: item.ctime,
-                            isLeaf: false,
-                            size: item.size,
-                            url: item.uri,
-                            labelTitle: item.uri,
-                        };
-                    });
-            }
-            return items;
-        },
-    },
-};
-</script>

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -34,9 +34,7 @@ const props = withDefaults(defineProps<FilesDialogProps>(), {
     callback: () => {},
 });
 
-// TODO: this is not working currently because this component
-// has it's own Vue instance and therefore doesn't inject the store.
-const { config, isLoaded: configIsLoaded } = useConfig();
+const { config, isConfigLoaded } = useConfig();
 
 const model = ref<Model>(new Model({ multiple: props.multiple }));
 
@@ -329,7 +327,7 @@ onMounted(() => {
             <DataDialogSearch v-model="filter" />
         </template>
         <template v-slot:helper>
-            <BAlert v-if="showFTPHelper && configIsLoaded" id="helper" variant="info" show>
+            <BAlert v-if="showFTPHelper && isConfigLoaded" id="helper" variant="info" show>
                 This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at
                 <strong>{{ config.ftp_upload_site }}</strong> using your Galaxy credentials. For help visit the
                 <a href="https://galaxyproject.org/ftp-upload/" target="_blank">tutorial</a>.

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -11,7 +11,7 @@ import { selectionStates } from "@/components/SelectionDialog/selectionStates";
 import { errorMessageAsString } from "@/utils/simple-error";
 
 import { getGalaxyInstance } from "../../app";
-import { Model } from "./model";
+import { DirectoryRecord, FileRecord, Model, RecordItem } from "./model";
 import { browseRemoteFiles, FilesSourcePlugin, getFileSources, RemoteEntry } from "./services";
 
 import DataDialogSearch from "@/components/SelectionDialog/DataDialogSearch.vue";
@@ -27,23 +27,6 @@ interface FilesDialogProps {
     callback?: (files: any) => void;
 }
 
-interface Record {
-    id: string;
-    label: string;
-    details: string;
-    isLeaf: boolean;
-    url: string;
-    labelTitle: string | undefined;
-}
-
-interface FileRecord extends Record {
-    isLeaf: true;
-}
-
-interface DirectoryRecord extends Record {
-    isLeaf: false;
-}
-
 const props = withDefaults(defineProps<FilesDialogProps>(), {
     multiple: false,
     mode: "file",
@@ -57,7 +40,7 @@ const allSelected = ref(false);
 const selectedDirectories = ref<DirectoryRecord[]>([]);
 const errorMessage = ref<string>();
 const filter = ref();
-const items = ref<Record[]>([]);
+const items = ref<RecordItem[]>([]);
 const modalShow = ref(true);
 const optionsShow = ref(false);
 const undoShow = ref(false);
@@ -76,7 +59,7 @@ const urlTracker = ref(new UrlTracker(""));
 const fileMode = computed(() => props.mode == "file");
 
 /** Collects selected datasets in value array **/
-function clicked(record: Record) {
+function clicked(record: RecordItem) {
     // ignore the click during directory mode
     if (!fileMode.value) {
         return;
@@ -263,7 +246,7 @@ function filterByMode(results: RemoteEntry[]): RemoteEntry[] {
     return results;
 }
 
-function entryToRecord(entry: RemoteEntry): Record {
+function entryToRecord(entry: RemoteEntry): RecordItem {
     const result = {
         id: entry.uri,
         label: entry.name,
@@ -277,7 +260,7 @@ function entryToRecord(entry: RemoteEntry): Record {
     return result;
 }
 
-function fileSourcePluginToRecord(plugin: FilesSourcePlugin): Record {
+function fileSourcePluginToRecord(plugin: FilesSourcePlugin): RecordItem {
     const result = {
         id: plugin.id,
         label: plugin.label,

--- a/client/src/components/FilesDialog/model.ts
+++ b/client/src/components/FilesDialog/model.ts
@@ -3,7 +3,7 @@
  */
 import { isSubPath } from "@/components/FilesDialog/utilities";
 
-export interface RecordItem {
+export interface BaseRecordItem {
     id: string;
     label: string;
     details: string;
@@ -12,11 +12,11 @@ export interface RecordItem {
     labelTitle: string | undefined;
 }
 
-export interface FileRecord extends RecordItem {
+export interface FileRecord extends BaseRecordItem {
     isLeaf: true;
 }
 
-export interface DirectoryRecord extends RecordItem {
+export interface DirectoryRecord extends BaseRecordItem {
     isLeaf: false;
 }
 
@@ -24,8 +24,10 @@ interface ModelOptions {
     multiple?: boolean;
 }
 
+export type RecordItem = FileRecord | DirectoryRecord;
+
 export class Model {
-    private values: Record<string, RecordItem>;
+    private values: Record<string, BaseRecordItem>;
     private multiple: boolean;
 
     constructor(options: ModelOptions = {}) {
@@ -34,7 +36,7 @@ export class Model {
     }
 
     /** Adds a new record to the value stack **/
-    add(record: RecordItem) {
+    add(record: BaseRecordItem) {
         if (!this.multiple) {
             this.values = {};
         }
@@ -78,13 +80,13 @@ export class Model {
     }
 
     /** Finalizes the results from added records **/
-    finalize(): RecordItem | RecordItem[] {
-        const results: RecordItem[] = [];
+    finalize(): BaseRecordItem | BaseRecordItem[] {
+        const results: BaseRecordItem[] = [];
         Object.values(this.values).forEach((v) => {
             results.push(v);
         });
         if (results.length > 0 && !this.multiple) {
-            return results.at(0) as RecordItem;
+            return results.at(0) as BaseRecordItem;
         }
         return results;
     }

--- a/client/src/components/FilesDialog/model.ts
+++ b/client/src/components/FilesDialog/model.ts
@@ -1,16 +1,40 @@
 /**
  * Model to track selected URI for FilesDialog - mirroring DataDialog's model.
  */
-import { isSubPath } from "components/FilesDialog/utilities";
+import { isSubPath } from "@/components/FilesDialog/utilities";
+
+export interface RecordItem {
+    id: string;
+    label: string;
+    details: string;
+    isLeaf: boolean;
+    url: string;
+    labelTitle: string | undefined;
+}
+
+export interface FileRecord extends RecordItem {
+    isLeaf: true;
+}
+
+export interface DirectoryRecord extends RecordItem {
+    isLeaf: false;
+}
+
+interface ModelOptions {
+    multiple?: boolean;
+}
 
 export class Model {
-    constructor(options = {}) {
+    private values: Record<string, RecordItem>;
+    private multiple: boolean;
+
+    constructor(options: ModelOptions = {}) {
         this.values = {};
         this.multiple = options.multiple || false;
     }
 
     /** Adds a new record to the value stack **/
-    add(record) {
+    add(record: RecordItem) {
         if (!this.multiple) {
             this.values = {};
         }
@@ -32,34 +56,35 @@ export class Model {
     }
 
     /** Returns true if a record is available for a given key **/
-    exists(key) {
+    exists(key: string) {
         return !!this.values[key];
     }
 
     /** Returns true if a record under given path exists **/
-    pathExists(path) {
+    pathExists(path: string) {
         return Object.values(this.values).some((value) => {
             return isSubPath(path, value.url);
         });
     }
 
     /** unselect all files under this path **/
-    unselectUnderPath(path) {
+    unselectUnderPath(path: string) {
         Object.keys(this.values).forEach((key) => {
-            if (isSubPath(path, this.values[key].url)) {
+            const value = this.values[key];
+            if (value && isSubPath(path, value.url)) {
                 delete this.values[key];
             }
         });
     }
 
     /** Finalizes the results from added records **/
-    finalize() {
-        let results = [];
+    finalize(): RecordItem | RecordItem[] {
+        const results: RecordItem[] = [];
         Object.values(this.values).forEach((v) => {
             results.push(v);
         });
         if (results.length > 0 && !this.multiple) {
-            results = results[0];
+            return results.at(0) as RecordItem;
         }
         return results;
     }

--- a/client/src/components/FilesDialog/model.ts
+++ b/client/src/components/FilesDialog/model.ts
@@ -40,7 +40,7 @@ export class Model {
         if (!this.multiple) {
             this.values = {};
         }
-        const key = record && record.id;
+        const key = record.id;
         if (key) {
             if (!this.values[key]) {
                 this.values[key] = record;

--- a/client/src/components/FilesDialog/services.ts
+++ b/client/src/components/FilesDialog/services.ts
@@ -2,6 +2,9 @@ import type { components } from "@/schema";
 import { fetcher } from "@/schema/fetcher";
 
 export type FilesSourcePlugin = components["schemas"]["FilesSourcePlugin"];
+export type RemoteFile = components["schemas"]["RemoteFile"];
+export type RemoteDirectory = components["schemas"]["RemoteDirectory"];
+export type RemoteEntry = RemoteFile | RemoteDirectory;
 
 const getRemoteFilesPlugins = fetcher.path("/api/remote_files/plugins").method("get").create();
 
@@ -12,7 +15,7 @@ export async function getFileSources(): Promise<FilesSourcePlugin[]> {
 
 const getRemoteFiles = fetcher.path("/api/remote_files").method("get").create();
 
-export async function browseRemoteFiles(uri: string, isRecursive = false) {
+export async function browseRemoteFiles(uri: string, isRecursive = false): Promise<RemoteEntry[]> {
     const { data } = await getRemoteFiles({ target: uri, recursive: isRecursive });
-    return data;
+    return data as RemoteEntry[];
 }

--- a/client/src/components/FilesDialog/utilities.ts
+++ b/client/src/components/FilesDialog/utilities.ts
@@ -1,11 +1,11 @@
-export const isSubPath = (originPath, destinationPath) => {
+export const isSubPath = (originPath: string, destinationPath: string) => {
     return subPathCondition(ensureTrailingSlash(originPath), ensureTrailingSlash(destinationPath));
 };
-// we need "/" at the end to avoid a usecase, when we have 2 folders with similar name
+// we need "/" at the end to avoid a use case, when we have 2 folders with similar name
 // namely, "folder_example" starts with "folder"
-function ensureTrailingSlash(path) {
+function ensureTrailingSlash(path: string) {
     return path.endsWith("/") ? path : path + "/";
 }
-function subPathCondition(originPath, destinationPath) {
+function subPathCondition(originPath: string, destinationPath: string) {
     return originPath !== destinationPath && destinationPath.startsWith(originPath);
 }

--- a/client/src/components/Form/Elements/FormDirectory.test.js
+++ b/client/src/components/Form/Elements/FormDirectory.test.js
@@ -2,6 +2,7 @@ import { mount } from "@vue/test-utils";
 import FilesDialog from "components/FilesDialog/FilesDialog";
 import { rootResponse } from "components/FilesDialog/testingData";
 import flushPromises from "flush-promises";
+import { createPinia } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
 
 import { mockFetcher } from "@/schema/__mocks__";
@@ -52,12 +53,16 @@ describe("DirectoryPathEditableBreadcrumb", () => {
         spyOnUpdateURL = jest.spyOn(FormDirectory.methods, "updateURL");
 
         mockFetcher.path("/api/remote_files/plugins").method("get").mock({ data: rootResponse });
+        mockFetcher.path("/api/configuration").method("get").mock({ data: {} });
+
+        const pinia = createPinia();
 
         wrapper = mount(FormDirectory, {
             propsData: {
                 callback: () => {},
             },
             localVue: localVue,
+            pinia,
         });
         await flushPromises();
         await init();

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -4340,7 +4340,7 @@ export interface components {
              * @description The URI root used by this type of plugin.
              * @example gximport://
              */
-            uri_root?: string;
+            uri_root: string;
             /**
              * Writeable
              * @description Whether this files source plugin allows write access.

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -6773,6 +6773,19 @@ export interface components {
             name: string;
         };
         /**
+         * ListJstreeResponse
+         * @deprecated
+         * @description List of files in Jstree format.
+         * @default []
+         */
+        ListJstreeResponse: Record<string, never>[];
+        /**
+         * ListUriResponse
+         * @description List of directories and files.
+         * @default []
+         */
+        ListUriResponse: (components["schemas"]["RemoteFile"] | components["schemas"]["RemoteDirectory"])[];
+        /**
          * MandatoryNotificationCategory
          * @description These notification categories cannot be opt-out by the user.
          *
@@ -7894,6 +7907,68 @@ export interface components {
             message: string;
             /** Reloaded */
             reloaded: string[];
+        };
+        /**
+         * RemoteDirectory
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        RemoteDirectory: {
+            /**
+             * Class
+             * @enum {string}
+             */
+            class: "Directory";
+            /**
+             * Name
+             * @description The name of the entry.
+             */
+            name: string;
+            /**
+             * Path
+             * @description The path of the entry.
+             */
+            path: string;
+            /**
+             * URI
+             * @description The URI of the entry.
+             */
+            uri: string;
+        };
+        /**
+         * RemoteFile
+         * @description Base model definition with common configuration used by all derived models.
+         */
+        RemoteFile: {
+            /**
+             * Class
+             * @enum {string}
+             */
+            class: "File";
+            /**
+             * Creation time
+             * @description The creation time of the file.
+             */
+            ctime: string;
+            /**
+             * Name
+             * @description The name of the entry.
+             */
+            name: string;
+            /**
+             * Path
+             * @description The path of the entry.
+             */
+            path: string;
+            /**
+             * Size
+             * @description The size of the file in bytes.
+             */
+            size: number;
+            /**
+             * URI
+             * @description The URI of the entry.
+             */
+            uri: string;
         };
         /**
          * RemoteFilesDisableMode
@@ -11066,7 +11141,9 @@ export interface operations {
             /** @description Successful Response */
             200: {
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json":
+                        | components["schemas"]["ListUriResponse"]
+                        | components["schemas"]["ListJstreeResponse"];
                 };
             };
             /** @description Validation Error */
@@ -16023,7 +16100,9 @@ export interface operations {
             /** @description A list with details about the remote files available to the user. */
             200: {
                 content: {
-                    "application/json": Record<string, never>[];
+                    "application/json":
+                        | components["schemas"]["ListUriResponse"]
+                        | components["schemas"]["ListJstreeResponse"];
                 };
             };
             /** @description Validation Error */

--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -1,25 +1,31 @@
 import logging
 import os
-from collections import (
-    defaultdict,
-    namedtuple,
-)
+from collections import defaultdict
 from typing import (
     Any,
     Dict,
     List,
+    NamedTuple,
     Optional,
     Set,
 )
 
 from galaxy import exceptions
+from galaxy.files.sources import BaseFilesSource
 from galaxy.util import plugin_config
 from galaxy.util.dictifiable import Dictifiable
 
 log = logging.getLogger(__name__)
 
-FileSourcePath = namedtuple("FileSourcePath", ["file_source", "path"])
-FileSourceScore = namedtuple("FileSourceScore", ["file_source", "score"])
+
+class FileSourcePath(NamedTuple):
+    file_source: BaseFilesSource
+    path: str
+
+
+class FileSourceScore(NamedTuple):
+    file_source: BaseFilesSource
+    score: int
 
 
 class NoMatchingFileSource(Exception):

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -1,12 +1,7 @@
 import hashlib
 import logging
 from operator import itemgetter
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-)
+from typing import Optional
 
 from galaxy import exceptions
 from galaxy.files import (
@@ -15,6 +10,7 @@ from galaxy.files import (
 )
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.schema.remote_files import (
+    AnyRemoteFilesListResponse,
     FilesSourcePlugin,
     FilesSourcePluginList,
     RemoteFilesDisableMode,
@@ -45,7 +41,7 @@ class RemoteFilesManager:
         format: Optional[RemoteFilesFormat],
         recursive: Optional[bool],
         disable: Optional[RemoteFilesDisableMode],
-    ) -> List[Dict[str, Any]]:
+    ) -> AnyRemoteFilesListResponse:
         """Returns a list of remote files available to the user."""
 
         user_file_source_context = ProvidesUserFileSourcesUserContext(user_ctx)

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -1,12 +1,19 @@
 from enum import Enum
 from typing import (
+    Any,
     List,
     Optional,
+    Union,
 )
 
 from pydantic import (
     Extra,
     Field,
+    Required,
+)
+from typing_extensions import (
+    Annotated,
+    Literal,
 )
 
 from galaxy.schema.schema import Model
@@ -31,13 +38,13 @@ class RemoteFilesDisableMode(str, Enum):
 
 class FilesSourcePlugin(Model):
     id: str = Field(
-        ...,  # This field is required
+        Required,
         title="ID",
         description="The `FilesSource` plugin identifier",
         example="_import",
     )
     type: str = Field(
-        ...,  # This field is required
+        Required,
         title="Type",
         description="The type of the plugin.",
         example="gximport",
@@ -49,19 +56,19 @@ class FilesSourcePlugin(Model):
         example="gximport://",
     )
     label: str = Field(
-        ...,  # This field is required
+        Required,
         title="Label",
         description="The display label for this plugin.",
         example="Library Import Directory",
     )
     doc: str = Field(
-        ...,  # This field is required
+        Required,
         title="Documentation",
         description="Documentation or extended description for this plugin.",
         example="Galaxy's library import directory",
     )
     writable: bool = Field(
-        ...,  # This field is required
+        Required,
         title="Writeable",
         description="Whether this files source plugin allows write access.",
         example=False,
@@ -100,3 +107,45 @@ class FilesSourcePluginList(Model):
             }
         ],
     )
+
+
+class RemoteEntry(Model):
+    name: str = Field(Required, title="Name", description="The name of the entry.")
+    uri: str = Field(Required, title="URI", description="The URI of the entry.")
+    path: str = Field(Required, title="Path", description="The path of the entry.")
+
+
+class RemoteDirectory(RemoteEntry):
+    class_: Literal["Directory"] = Field(Required, alias="class", const=True)
+
+
+class RemoteFile(RemoteEntry):
+    class_: Literal["File"] = Field(Required, alias="class", const=True)
+    size: int = Field(Required, title="Size", description="The size of the file in bytes.")
+    ctime: str = Field(Required, title="Creation time", description="The creation time of the file.")
+
+
+class ListJstreeResponse(Model):
+    __root__: List[Any] = Field(
+        default=[],
+        title="List of files",
+        description="List of files in Jstree format.",
+        deprecated=True,
+    )
+
+
+AnyRemoteEntry = Annotated[
+    Union[RemoteFile, RemoteDirectory],
+    Field(discriminator="class_"),
+]
+
+
+class ListUriResponse(Model):
+    __root__: List[AnyRemoteEntry] = Field(
+        default=[],
+        title="List of remote entries",
+        description="List of directories and files.",
+    )
+
+
+AnyRemoteFilesListResponse = Union[ListUriResponse, ListJstreeResponse]

--- a/lib/galaxy/schema/remote_files.py
+++ b/lib/galaxy/schema/remote_files.py
@@ -49,8 +49,8 @@ class FilesSourcePlugin(Model):
         description="The type of the plugin.",
         example="gximport",
     )
-    uri_root: Optional[str] = Field(
-        None,
+    uri_root: str = Field(
+        Required,
         title="URI root",
         description="The URI root used by this type of plugin.",
         example="gximport://",

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -2,18 +2,14 @@
 API operations on remote files.
 """
 import logging
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-)
+from typing import Optional
 
 from fastapi.param_functions import Query
 
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.remote_files import RemoteFilesManager
 from galaxy.schema.remote_files import (
+    AnyRemoteFilesListResponse,
     FilesSourcePluginList,
     RemoteFilesDisableMode,
     RemoteFilesFormat,
@@ -94,7 +90,7 @@ class FastAPIRemoteFiles:
         format: Optional[RemoteFilesFormat] = FormatQueryParam,
         recursive: Optional[bool] = RecursiveQueryParam,
         disable: Optional[RemoteFilesDisableMode] = DisableModeQueryParam,
-    ) -> List[Dict[str, Any]]:
+    ) -> AnyRemoteFilesListResponse:
         """Lists all remote files available to the user from different sources."""
         return self.manager.index(user_ctx, target, format, recursive, disable)
 


### PR DESCRIPTION
More refactorings in preparation for #16381
Requires https://github.com/galaxyproject/galaxy/pull/16514

This batch is mainly focused on migrating the `FilesDialog` component to script setup and Typescript but includes some improvements around typing and schema documentation for the `remote_files` API.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
