### PR TITLE
[23.0] [cherry-pick] tool_util: switch to mambaforge on non-32bit; add arm64 support

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import logging
 import os
+import platform
 import re
 import shutil
 import sys
@@ -53,10 +54,16 @@ USE_LOCAL_DEFAULT = False
 
 def conda_link() -> str:
     if IS_OS_X:
-        url = "https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+        if "arm64" in platform.platform():
+            url = "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-arm64.sh"
+        else:
+            url = "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-MacOSX-x86_64.sh"
     else:
         if sys.maxsize > 2**32:
-            url = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+            if "arm64" in platform.platform():
+                url = "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-aarch64.sh"
+            else:
+                url = "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh"
         else:
             url = "https://repo.anaconda.com/miniconda/Miniconda3-4.5.12-Linux-x86.sh"
     return url


### PR DESCRIPTION
cherry-pick https://github.com/galaxyproject/galaxy/commit/ac67e23a830c7118e35412f0e9ba4e122026f4e4 for 23.0.5

## How to test the changes?
(Select all options that apply)
- ~~I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).~~
- [x] This is a refactoring of components with existing test coverage.
- ~~Instructions for manual testing are as follows:~~


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
