### PR TITLE
[23.0] Fixes for (gitlab) error reporting

### DIFF
--- a/client/src/components/DatasetInformation/DatasetError.vue
+++ b/client/src/components/DatasetInformation/DatasetError.vue
@@ -58,9 +58,9 @@
                         v-for="(resultMessage, index) in resultMessages"
                         :key="index"
                         :variant="resultMessage[1]"
-                        show
-                        >{{ resultMessage[0] }}</b-alert
-                    >
+                        show>
+                        <span v-html="renderMarkdown(resultMessage[0])"></span>
+                    </b-alert>
                     <CurrentUser v-slot="{ user }">
                         <div v-if="showForm" id="fieldsAndButton">
                             <span class="mr-2 font-weight-bold">{{ emailTitle }}</span>
@@ -94,6 +94,7 @@ import { JobDetailsProvider, JobProblemProvider } from "components/providers/Job
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faBug } from "@fortawesome/free-solid-svg-icons";
+import { useMarkdown } from "@/composables/markdown";
 import { sendErrorReport } from "./services";
 import CurrentUser from "components/providers/CurrentUser";
 
@@ -114,6 +115,10 @@ export default {
             type: String,
             required: true,
         },
+    },
+    setup() {
+        const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
+        return { renderMarkdown };
     },
     data() {
         return {

--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -99,12 +99,11 @@ class GithubPlugin(BaseGitPlugin):
             else:
                 self._append_issue(issue_cache_key, error_title, error_message)
             return (
-                'Submitted error report to Github. Your issue number is <a href="%s/%s/issues/%s" '
-                'target="_blank">#%s</a>.'
+                "Submitted error report to Github. Your issue number is [#%s](%s/%s/issues/%s)"
                 % (
+                    self.issue_cache[issue_cache_key][error_title].number,
                     self.github_base_url,
                     github_projecturl,
-                    self.issue_cache[issue_cache_key][error_title].number,
                     self.issue_cache[issue_cache_key][error_title].number,
                 ),
                 "success",

--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -99,7 +99,7 @@ class GithubPlugin(BaseGitPlugin):
             else:
                 self._append_issue(issue_cache_key, error_title, error_message)
             return (
-                "Submitted error report to Github. Your issue number is [#%s](%s/%s/issues/%s)"
+                "Submitted error report to GitHub. Your issue number is [#%s](%s/%s/issues/%s)"
                 % (
                     self.issue_cache[issue_cache_key][error_title].number,
                     self.github_base_url,

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -185,7 +185,7 @@ class GitLabPlugin(BaseGitPlugin):
                         )
 
                 return (
-                    'Submitted error report to GitLab. Your Issue number is [#%s](%s/%s/issues/%s)'
+                    "Submitted error report to GitLab. Your Issue number is [#%s](%s/%s/issues/%s)"
                     % (
                         self.issue_cache[issue_cache_key][error_title],
                         self.gitlab_base_url,

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -276,7 +276,7 @@ class GitLabPlugin(BaseGitPlugin):
                 "api",
                 "v4",
                 "projects",
-                kwargs.get("gitlab_projecturl"),
+                urllib.parse.quote(kwargs.get("gitlab_projecturl"), safe=""),
                 "issues",
                 str(self.issue_cache[issue_cache_key][error_title]),
                 "notes",
@@ -288,7 +288,7 @@ class GitLabPlugin(BaseGitPlugin):
         self.issue_cache[issue_cache_key] = {}
         # Loop over all open issues and add the issue iid to the cache
         for issue in git_project.issues.list():
-            if issue.state != "closed":
+            if issue.state != "closed" or not self.gitlab_new_issue_on_closed:
                 log.info("GitLab error reporting - Repo issue: %s", str(issue.iid))
                 self.issue_cache[issue_cache_key][issue.title] = issue.iid
 

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -185,12 +185,11 @@ class GitLabPlugin(BaseGitPlugin):
                         )
 
                 return (
-                    'Submitted error report to GitLab. Your issue number is <a href="%s/%s/issues/%s" '
-                    'target="_blank">#%s</a>.'
+                    'Submitted error report to GitLab. Your Issue number is [#%s](%s/%s/issues/%s)'
                     % (
+                        self.issue_cache[issue_cache_key][error_title],
                         self.gitlab_base_url,
                         gitlab_projecturl,
-                        self.issue_cache[issue_cache_key][error_title],
                         self.issue_cache[issue_cache_key][error_title],
                     ),
                     "success",


### PR DESCRIPTION
Fixes the gitlab error reporting plugin (for the case that comments should be added to existing issues if possible) and also fixes the display of the message of the error reporters to the users (which should not be quoted).

@davelopez I could not get your suggested markdown solution running.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
