### PR TITLE
Fix SA2.0 syntax in scripts/helper.py, fix ancient bug

### DIFF
--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -43,7 +43,7 @@ if args.hda_id:
         hda_id = int(args.hda_id)
     except Exception:
         hda_id = int(helper.decode_id(args.hda_id))
-    hda = model.context.current.query(model.HistoryDatasetAssociation).get(hda_id)
+    hda = model.session.get(model.HistoryDatasetAssociation, hda_id)
     print(f'HDA "{hda.id}" is Dataset "{hda.dataset.id}" at: {hda.file_name}')
 
 if args.ldda_id:
@@ -51,5 +51,5 @@ if args.ldda_id:
         ldda_id = int(args.ldda_id)
     except Exception:
         ldda_id = int(helper.decode_id(args.ldda_id))
-    ldda = model.context.current.query(model.HistoryDatasetAssociation).get(ldda_id)
+    ldda = model.session.get(model.LibraryDatasetDatasetAssociation, ldda_id)
     print(f'LDDA "{ldda.id}" is Dataset "{ldda.dataset.id}" at: {ldda.file_name}')


### PR DESCRIPTION
1. Replace legacy `session.query().get`  with SA2.0 `session.get()`. ([ref](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#orm-query-get-method-moves-to-session))
2. Fix 12 year old bug: use `LibraryDatasetDatasetAssociation`, not `HistoryDatasetAssociation`

Ref: #12541

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
