### PR TITLE
Implement simple datatype converters listing

### DIFF
--- a/client/src/components/DatatypeConverters/DatatypeConverters.vue
+++ b/client/src/components/DatatypeConverters/DatatypeConverters.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import type { FetchReturnType } from "openapi-typescript-fetch";
+import { onMounted, ref } from "vue";
+
+import { useFilterObjectArray } from "@/composables/filter";
+import { fetcher } from "@/schema";
+
+import DelayedInput from "@/components/Common/DelayedInput.vue";
+import Heading from "@/components/Common/Heading.vue";
+
+const fetchConverters = fetcher.path("/api/datatypes/converters").method("get").create();
+const data = ref<FetchReturnType<typeof fetchConverters>>([]);
+const filterText = ref("");
+const filterFields: Array<keyof (typeof data.value)[0]> = ["source", "target", "tool_id"];
+
+onMounted(async () => {
+    const response = await fetchConverters({});
+    data.value = response.data;
+});
+
+const displayedData = useFilterObjectArray(data, filterText, filterFields);
+
+const fields = [
+    {
+        key: "source",
+        sortable: true,
+    },
+    {
+        key: "target",
+        sortable: true,
+    },
+    {
+        key: "tool_id",
+        label: "Tool ID",
+        sortable: true,
+    },
+];
+</script>
+
+<template>
+    <div class="genome-list">
+        <Heading h1 separator>Datatype Converter Listing</Heading>
+
+        <DelayedInput placeholder="filter converters" class="mb-3" :delay="200" @change="(val) => (filterText = val)" />
+
+        <b-table striped small sort-icon-left sort-by="tool_id" :items="displayedData" :fields="fields">
+            <template v-slot:cell(source)="row">
+                {{ row.item.source }}
+            </template>
+
+            <template v-slot:cell(target)="row">
+                {{ row.item.target }}
+            </template>
+
+            <template v-slot:cell(tool_id)="row">
+                {{ row.item.tool_id }}
+            </template>
+        </b-table>
+    </div>
+</template>

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -65,6 +65,7 @@ import AvailableDatatypes from "@/components/AvailableDatatypes/AvailableDatatyp
 import { patchRouterPush } from "./router-push";
 
 import AboutGalaxy from "@/components/AboutGalaxy.vue";
+import DatatypeConverters from "@/components/DatatypeConverters/DatatypeConverters.vue";
 import HistoryArchive from "@/components/History/Archiving/HistoryArchive.vue";
 import HistoryArchiveWizard from "@/components/History/Archiving/HistoryArchiveWizard.vue";
 import NotificationsList from "@/components/Notifications/NotificationsList.vue";
@@ -537,6 +538,10 @@ export function getRouter(Galaxy) {
                         path: "workflows/:storedWorkflowId/invocations",
                         component: StoredWorkflowInvocations,
                         props: true,
+                    },
+                    {
+                        path: "datatype_converters",
+                        component: DatatypeConverters,
                     },
                 ],
             },

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -277,6 +277,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     webapp.add_client_route("/interactivetool_entry_points/list")
     webapp.add_client_route("/libraries{path:.*?}")
     webapp.add_client_route("/storage{path:.*?}")
+    webapp.add_client_route("/datatype_converters")
 
     # ==== Done
     # Indicate that all configuration settings have been provided


### PR DESCRIPTION
As part of @ElectronicBlueberry's Vue crash course, here is the requested (very simple) datatype converters listing.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Testing would require mocking the entire endpoint, so, we've skipped testing. The datatypes endpoint is tested elsewhere

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
