### PR TITLE
SQLAlchemy 2.0 upgrades to ORM usage in /lib

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -16,7 +16,10 @@ from galaxy.exceptions import (
     ObjectNotFound,
     RequestParameterInvalidException,
 )
-from galaxy.model import LibraryDataset
+from galaxy.model import (
+    LibraryDataset,
+    LibraryFolder,
+)
 from galaxy.model.base import transaction
 from galaxy.tools.actions import upload_common
 from galaxy.tools.parameters import populate_state
@@ -307,12 +310,12 @@ class LibraryActions:
     def _create_folder(self, trans, parent_id: int, **kwd):
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
-        parent_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(parent_id)
+        parent_folder = trans.sa_session.get(LibraryFolder, parent_id)
         # Check the library which actually contains the user-supplied parent folder, not the user-supplied
         # library, which could be anything.
         self._check_access(trans, is_admin, parent_folder, current_user_roles)
         self._check_add(trans, is_admin, parent_folder, current_user_roles)
-        new_folder = trans.app.model.LibraryFolder(name=kwd.get("name", ""), description=kwd.get("description", ""))
+        new_folder = LibraryFolder(name=kwd.get("name", ""), description=kwd.get("description", ""))
         # We are associating the last used genome build with folders, so we will always
         # initialize a new folder with the first dbkey in genome builds list which is currently
         # ?    unspecified (?)
@@ -347,7 +350,7 @@ class LibraryActions:
             ):
                 if isinstance(item, trans.model.Library):
                     item_type = "data library"
-                elif isinstance(item, trans.model.LibraryFolder):
+                elif isinstance(item, LibraryFolder):
                     item_type = "folder"
                 else:
                     item_type = "(unknown item type)"

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -15,6 +15,7 @@ from queue import (
     Queue,
 )
 
+from sqlalchemy import select
 from sqlalchemy.orm import object_session
 
 import galaxy.jobs
@@ -397,11 +398,12 @@ class BaseJobRunner:
                 dataset_assoc.dataset.dataset.history_associations + dataset_assoc.dataset.dataset.library_associations
             ):
                 if isinstance(dataset, self.app.model.HistoryDatasetAssociation):
-                    joda = (
-                        self.sa_session.query(self.app.model.JobToOutputDatasetAssociation)
+                    stmt = (
+                        select(self.app.model.JobToOutputDatasetAssociation)
                         .filter_by(job=job, dataset=dataset)
-                        .first()
+                        .limit(1)
                     )
+                    joda = self.sa_session.scalars(stmt).first()
                     yield (joda, dataset)
         # TODO: why is this not just something easy like:
         # for dataset_assoc in job.output_datasets + job.output_library_datasets:

--- a/lib/galaxy/jobs/runners/godocker.py
+++ b/lib/galaxy/jobs/runners/godocker.py
@@ -235,8 +235,7 @@ class GodockerJobRunner(AsynchronousJobRunner):
 
     def stop_job(self, job_wrapper):
         """Attempts to delete a dispatched executing Job in GoDocker"""
-        # This function is called by fail_job() where
-        # param job = self.sa_session.query(self.app.model.Job).get(job_state.job_wrapper.job_id)
+        # This function is called by fail_job()
         # No Return data expected
         job_id = job_wrapper.job_id
         log.debug(f"STOP JOB EXECUTION OF JOB ID: {str(job_id)}")

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -36,6 +36,7 @@ from pulsar.client import (
 
 # TODO: Perform pulsar release with this included in the client package
 from pulsar.client.staging import DEFAULT_DYNAMIC_COLLECTION_PATTERN
+from sqlalchemy import select
 
 from galaxy import model
 from galaxy.job_execution.compute_environment import (
@@ -974,10 +975,8 @@ class PulsarJobRunner(AsynchronousJobRunner):
             remote_job_id = full_status["job_id"]
             if len(remote_job_id) == 32:
                 # It is a UUID - assign_ids = uuid in destination params...
-                sa_session = self.app.model.session
-                galaxy_job_id = (
-                    sa_session.query(model.Job).filter(model.Job.job_runner_external_id == remote_job_id).one().id
-                )
+                stmt = select(model.Job).filter(model.Job.job_runner_external_id == remote_job_id)
+                galaxy_job_id = self.app.model.session.execute(stmt).scalar_one().id
             else:
                 galaxy_job_id = remote_job_id
             job, job_wrapper = self.app.job_manager.job_handler.job_queue.job_pair_for_id(galaxy_job_id)

--- a/lib/galaxy/managers/cloud.py
+++ b/lib/galaxy/managers/cloud.py
@@ -291,7 +291,7 @@ class CloudManager(sharable.SharableModelManager):
 
             params = Params(self._get_inputs(obj, key, input_args), sanitize=False)
             incoming = params.__dict__
-            history = trans.sa_session.query(trans.app.model.History).get(history_id)
+            history = trans.sa_session.get(model.History, history_id)
             if not history:
                 raise ObjectNotFound("History with the ID provided was not found.")
             output = trans.app.toolbox.get_tool("upload1").handle_input(trans, incoming, history=history)
@@ -358,7 +358,7 @@ class CloudManager(sharable.SharableModelManager):
 
         cloudauthz = trans.app.authnz_manager.try_get_authz_config(trans.sa_session, trans.user.id, authz_id)
 
-        history = trans.sa_session.query(trans.app.model.History).get(history_id)
+        history = trans.sa_session.get(model.History, history_id)
         if not history:
             raise ObjectNotFound("History with the provided ID not found.")
 

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -4,9 +4,13 @@ from typing import (
     Optional,
 )
 
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
 from galaxy import model
 from galaxy.exceptions import ObjectNotFound
 from galaxy.managers.context import ProvidesAppContext
+from galaxy.model import GroupRoleAssociation
 from galaxy.model.base import transaction
 from galaxy.structured_app import MinimalManagerApp
 
@@ -61,13 +65,13 @@ class GroupRolesManager:
         return role
 
     def _get_group(self, trans: ProvidesAppContext, group_id: int) -> model.Group:
-        group = trans.sa_session.query(model.Group).get(group_id)
+        group = trans.sa_session.get(model.Group, group_id)
         if not group:
             raise ObjectNotFound("Group with the id provided was not found.")
         return group
 
     def _get_role(self, trans: ProvidesAppContext, role_id: int) -> model.Role:
-        role = trans.sa_session.query(model.Role).get(role_id)
+        role = trans.sa_session.get(model.Role, role_id)
         if not role:
             raise ObjectNotFound("Role with the id provided was not found.")
         return role
@@ -75,11 +79,7 @@ class GroupRolesManager:
     def _get_group_role(
         self, trans: ProvidesAppContext, group: model.Group, role: model.Role
     ) -> Optional[model.GroupRoleAssociation]:
-        return (
-            trans.sa_session.query(model.GroupRoleAssociation)
-            .filter(model.GroupRoleAssociation.group == group, model.GroupRoleAssociation.role == role)
-            .one_or_none()
-        )
+        return get_group_role(trans.sa_session, group, role)
 
     def _add_role_to_group(self, trans: ProvidesAppContext, group: model.Group, role: model.Role):
         gra = model.GroupRoleAssociation(group, role)
@@ -91,3 +91,10 @@ class GroupRolesManager:
         trans.sa_session.delete(group_role)
         with transaction(trans.sa_session):
             trans.sa_session.commit()
+
+
+def get_group_role(session: Session, group, role) -> Optional[GroupRoleAssociation]:
+    stmt = (
+        select(GroupRoleAssociation).where(GroupRoleAssociation.group == group).where(GroupRoleAssociation.role == role)
+    )
+    return session.execute(stmt).scalar_one_or_none()

--- a/lib/galaxy/managers/group_users.py
+++ b/lib/galaxy/managers/group_users.py
@@ -4,9 +4,16 @@ from typing import (
     Optional,
 )
 
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
 from galaxy import model
 from galaxy.exceptions import ObjectNotFound
 from galaxy.managers.context import ProvidesAppContext
+from galaxy.model import (
+    User,
+    UserGroupAssociation,
+)
 from galaxy.model.base import transaction
 from galaxy.structured_app import MinimalManagerApp
 
@@ -61,13 +68,13 @@ class GroupUsersManager:
         return user
 
     def _get_group(self, trans: ProvidesAppContext, group_id: int) -> model.Group:
-        group = trans.sa_session.query(model.Group).get(group_id)
+        group = trans.sa_session.get(model.Group, group_id)
         if group is None:
             raise ObjectNotFound("Group with the id provided was not found.")
         return group
 
     def _get_user(self, trans: ProvidesAppContext, user_id: int) -> model.User:
-        user = trans.sa_session.query(model.User).get(user_id)
+        user = trans.sa_session.get(User, user_id)
         if user is None:
             raise ObjectNotFound("User with the id provided was not found.")
         return user
@@ -75,11 +82,7 @@ class GroupUsersManager:
     def _get_group_user(
         self, trans: ProvidesAppContext, group: model.Group, user: model.User
     ) -> Optional[model.UserGroupAssociation]:
-        return (
-            trans.sa_session.query(model.UserGroupAssociation)
-            .filter(model.UserGroupAssociation.user == user, model.UserGroupAssociation.group == group)
-            .one_or_none()
-        )
+        return get_group_user(trans.sa_session, user, group)
 
     def _add_user_to_group(self, trans: ProvidesAppContext, group: model.Group, user: model.User):
         gra = model.UserGroupAssociation(user, group)
@@ -91,3 +94,10 @@ class GroupUsersManager:
         trans.sa_session.delete(group_user)
         with transaction(trans.sa_session):
             trans.sa_session.commit()
+
+
+def get_group_user(session: Session, user, group) -> Optional[UserGroupAssociation]:
+    stmt = (
+        select(UserGroupAssociation).where(UserGroupAssociation.user == user).where(UserGroupAssociation.group == group)
+    )
+    return session.execute(stmt).scalar_one_or_none()

--- a/lib/galaxy/managers/groups.py
+++ b/lib/galaxy/managers/groups.py
@@ -4,7 +4,11 @@ from typing import (
     List,
 )
 
-from sqlalchemy import false
+from sqlalchemy import (
+    false,
+    select,
+)
+from sqlalchemy.orm import Session
 
 from galaxy import model
 from galaxy.exceptions import (
@@ -14,6 +18,11 @@ from galaxy.exceptions import (
 )
 from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesAppContext
+from galaxy.managers.users import get_users_by_ids
+from galaxy.model import (
+    Group,
+    Role,
+)
 from galaxy.model.base import transaction
 from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.schema.fields import (
@@ -35,7 +44,7 @@ class GroupsManager:
         Displays a collection (list) of groups.
         """
         rval = []
-        for group in trans.sa_session.query(model.Group).filter(model.Group.deleted == false()):
+        for group in get_not_deleted_groups(trans.sa_session):
             item = group.to_dict(value_mapper={"id": DecodedDatabaseIdField.encode})
             encoded_id = DecodedDatabaseIdField.encode(group.id)
             item["url"] = url_for("group", id=encoded_id)
@@ -101,11 +110,11 @@ class GroupsManager:
             sa_session.commit()
 
     def _check_duplicated_group_name(self, sa_session: galaxy_scoped_session, group_name: str) -> None:
-        if sa_session.query(model.Group).filter(model.Group.name == group_name).first():
+        if get_group_by_name(sa_session, group_name):
             raise Conflict(f"A group with name '{group_name}' already exists")
 
     def _get_group(self, sa_session: galaxy_scoped_session, group_id: int) -> model.Group:
-        group = sa_session.query(model.Group).get(group_id)
+        group = sa_session.get(model.Group, group_id)
         if group is None:
             raise ObjectNotFound("Group with the provided id was not found.")
         return group
@@ -114,18 +123,27 @@ class GroupsManager:
         self, sa_session: galaxy_scoped_session, encoded_user_ids: List[EncodedDatabaseIdField]
     ) -> List[model.User]:
         user_ids = self._decode_ids(encoded_user_ids)
-        users = sa_session.query(model.User).filter(model.User.table.c.id.in_(user_ids)).all()
-        return users
+        return get_users_by_ids(sa_session, user_ids)
 
     def _get_roles_by_encoded_ids(
         self, sa_session: galaxy_scoped_session, encoded_role_ids: List[EncodedDatabaseIdField]
     ) -> List[model.Role]:
         role_ids = self._decode_ids(encoded_role_ids)
-        roles = sa_session.query(model.Role).filter(model.Role.id.in_(role_ids)).all()
-        return roles
+        stmt = select(Role).where(Role.id.in_(role_ids))
+        return sa_session.scalars(stmt).all()
 
     def _decode_id(self, encoded_id: EncodedDatabaseIdField) -> int:
         return decode_id(self._app, encoded_id)
 
     def _decode_ids(self, encoded_ids: List[EncodedDatabaseIdField]) -> List[int]:
         return [self._decode_id(encoded_id) for encoded_id in encoded_ids]
+
+
+def get_group_by_name(session: Session, name: str):
+    stmt = select(Group).filter(Group.name == name).limit(1)
+    return session.scalars(stmt).first()
+
+
+def get_not_deleted_groups(session: Session):
+    stmt = select(Group).where(Group.deleted == false())
+    return session.scalars(stmt)

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -24,7 +24,6 @@ from sqlalchemy import (
     select,
     true,
 )
-from sqlalchemy.orm import Session
 from typing_extensions import Literal
 
 from galaxy import (
@@ -44,7 +43,6 @@ from galaxy.managers.base import (
     StorageCleanerManager,
 )
 from galaxy.managers.export_tracker import StoreExportTracker
-from galaxy.model import HistoryDatasetAssociation
 from galaxy.model.base import transaction
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -902,12 +900,3 @@ class HistoryFilters(sharable.SharableModelFilters, deletable.PurgableFiltersMix
 
     def username_contains(self, item, val: str) -> bool:
         return val.lower() in str(item.user.username).lower()
-
-
-def get_fasta_hdas_by_history(session: Session, history_id: int):
-    stmt = (
-        select(HistoryDatasetAssociation)
-        .filter_by(history_id=history_id, extension="fasta", deleted=False)
-        .order_by(HistoryDatasetAssociation.hid.desc())
-    )
-    return session.scalars(stmt).all()

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -24,6 +24,7 @@ from sqlalchemy import (
     select,
     true,
 )
+from sqlalchemy.orm import Session
 from typing_extensions import Literal
 
 from galaxy import (
@@ -43,6 +44,7 @@ from galaxy.managers.base import (
     StorageCleanerManager,
 )
 from galaxy.managers.export_tracker import StoreExportTracker
+from galaxy.model import HistoryDatasetAssociation
 from galaxy.model.base import transaction
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
@@ -900,3 +902,12 @@ class HistoryFilters(sharable.SharableModelFilters, deletable.PurgableFiltersMix
 
     def username_contains(self, item, val: str) -> bool:
         return val.lower() in str(item.user.username).lower()
+
+
+def get_fasta_hdas_by_history(session: Session, history_id: int):
+    stmt = (
+        select(HistoryDatasetAssociation)
+        .filter_by(history_id=history_id, extension="fasta", deleted=False)
+        .order_by(HistoryDatasetAssociation.hid.desc())
+    )
+    return session.scalars(stmt).all()

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -15,9 +15,14 @@ from sqlalchemy import (
     and_,
     false,
     func,
+    null,
     or_,
+    true,
 )
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import (
+    aliased,
+    Session,
+)
 from sqlalchemy.sql import select
 
 from galaxy import model
@@ -38,6 +43,8 @@ from galaxy.managers.lddas import LDDAManager
 from galaxy.model import (
     Job,
     JobParameter,
+    User,
+    YIELD_PER_ROWS,
 )
 from galaxy.model.base import transaction
 from galaxy.model.index_filter_util import (
@@ -1040,3 +1047,21 @@ def summarize_job_outputs(job: model.Job, tool, params, security):
                 }
             )
     return outputs
+
+
+def get_jobs_to_check_at_startup(session: Session, track_jobs_in_database: bool, config):
+    if track_jobs_in_database:
+        in_list = (Job.states.QUEUED, Job.states.RUNNING, Job.states.STOPPED)
+    else:
+        in_list = (Job.states.NEW, Job.states.QUEUED, Job.states.RUNNING)
+
+    stmt = (
+        select(Job)
+        .execution_options(yield_per=YIELD_PER_ROWS)
+        .filter(Job.state.in_(in_list) & (Job.handler == config.server_name))
+    )
+    if config.user_activation_on:
+        # Filter out the jobs of inactive users.
+        stmt = stmt.outerjoin(User).filter(or_((Job.user_id == null()), (User.active == true())))
+
+    return session.scalars(stmt)

--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -18,9 +18,13 @@ from typing import (
 from sqlalchemy import (
     false,
     or_,
+    select,
     true,
 )
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import (
+    aliased,
+    Session,
+)
 
 from galaxy import (
     exceptions,
@@ -38,6 +42,7 @@ from galaxy.managers.markdown_util import (
     ready_galaxy_markdown_for_export,
     ready_galaxy_markdown_for_import,
 )
+from galaxy.model import PageRevision
 from galaxy.model.base import transaction
 from galaxy.model.index_filter_util import (
     append_user_filter,
@@ -621,3 +626,8 @@ def placeholderRenderForSave(trans: ProvidesHistoryContext, item_class, item_id,
         item_id=item_id,
         item_name=item_name,
     )
+
+
+def get_page_revision(session: Session, page_id: int):
+    stmt = select(PageRevision).filter_by(page_id=page_id)
+    return session.scalars(stmt)

--- a/lib/galaxy/managers/quotas.py
+++ b/lib/galaxy/managers/quotas.py
@@ -11,20 +11,12 @@ from typing import (
     Union,
 )
 
-from sqlalchemy import (
-    false,
-    select,
-    true,
-)
-from sqlalchemy.orm import Session
-
 from galaxy import (
     model,
     util,
 )
 from galaxy.exceptions import ActionInputError
 from galaxy.managers import base
-from galaxy.model import Quota
 from galaxy.model.base import transaction
 from galaxy.quota import DatabaseQuotaAgent
 from galaxy.quota._schema import (
@@ -281,11 +273,3 @@ class QuotaManager:
 
     def get_quota(self, trans, id: int, deleted: Optional[bool] = None) -> model.Quota:
         return base.get_object(trans, id, "Quota", check_ownership=False, check_accessible=False, deleted=deleted)
-
-
-def get_quotas(session: Session, deleted: bool = False):
-    is_deleted = true()
-    if not deleted:
-        is_deleted = false()
-    stmt = select(Quota).where(Quota.deleted == is_deleted)
-    return session.scalars(stmt)

--- a/lib/galaxy/managers/quotas.py
+++ b/lib/galaxy/managers/quotas.py
@@ -11,12 +11,20 @@ from typing import (
     Union,
 )
 
+from sqlalchemy import (
+    false,
+    select,
+    true,
+)
+from sqlalchemy.orm import Session
+
 from galaxy import (
     model,
     util,
 )
 from galaxy.exceptions import ActionInputError
 from galaxy.managers import base
+from galaxy.model import Quota
 from galaxy.model.base import transaction
 from galaxy.quota import DatabaseQuotaAgent
 from galaxy.quota._schema import (
@@ -273,3 +281,11 @@ class QuotaManager:
 
     def get_quota(self, trans, id: int, deleted: Optional[bool] = None) -> model.Quota:
         return base.get_object(trans, id, "Quota", check_ownership=False, check_accessible=False, deleted=deleted)
+
+
+def get_quotas(session: Session, deleted: bool = False):
+    is_deleted = true()
+    if not deleted:
+        is_deleted = false()
+    stmt = select(Quota).where(Quota.deleted == is_deleted)
+    return session.scalars(stmt)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -359,7 +359,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         user = None
         if VALID_EMAIL_RE.match(identity):
             # VALID_PUBLICNAME and VALID_EMAIL do not overlap, so 'identity' here is an email address
-            user = self.session().query(self.model_class).filter(self.model_class.table.c.email == identity).first()
+            user = get_user_by_email(self.session(), identity, self.model_class)
             if not user:
                 # Try a case-insensitive match on the email
                 user = (
@@ -369,7 +369,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                     .first()
                 )
         else:
-            user = self.session().query(self.model_class).filter(self.model_class.table.c.username == identity).first()
+            user = get_user_by_username(self.session(), identity, self.model_class)
         return user
 
     # ---- current
@@ -532,7 +532,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         """
         Check for the activation token. Create new activation token and store it in the database if no token found.
         """
-        user = trans.sa_session.query(self.app.model.User).filter(self.app.model.User.table.c.email == email).first()
+        user = get_user_by_email(trans.sa_session, email, self.app.model.User)
         activation_token = user.activation_token
         if activation_token is None:
             activation_token = util.hash_util.new_secure_hash_v2(str(random.getrandbits(256)))
@@ -576,9 +576,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                 return "Failed to produce password reset token. User not found."
 
     def get_reset_token(self, trans, email):
-        reset_user = (
-            trans.sa_session.query(self.app.model.User).filter(self.app.model.User.table.c.email == email).first()
-        )
+        reset_user = get_user_by_email(trans.sa_session, email, self.app.model.User)
         if not reset_user and email != email.lower():
             reset_user = (
                 trans.sa_session.query(self.app.model.User)
@@ -622,12 +620,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             return None
         if getattr(self.app.config, "normalize_remote_user_email", False):
             remote_user_email = remote_user_email.lower()
-        user = (
-            self.session()
-            .query(self.app.model.User)
-            .filter(self.app.model.User.table.c.email == remote_user_email)
-            .first()
-        )
+        user = get_user_by_email(self.session(), remote_user_email, self.app.model.User)
         if user:
             # GVK: June 29, 2009 - This is to correct the behavior of a previous bug where a private
             # role and default user / history permissions were not set for remote users.  When a
@@ -844,18 +837,20 @@ class AdminUserFilterParser(base.ModelFilterParser, deletable.PurgableFiltersMix
         self.fn_filter_parsers.update({})
 
 
-def get_user_by_username(session, user_class, username):
-    """
-    Get a user from the database by username.
-    (We pass the session and the user_class to accommodate usage from the tool_shed app.)
-    """
-    try:
-        stmt = select(user_class).filter(user_class.username == username)
-        return session.execute(stmt).scalar_one()
-    except Exception:
-        return None
-
-
 def get_users_by_ids(session: Session, user_ids):
     stmt = select(User).where(User.id.in_(user_ids))
     return session.scalars(stmt).all()
+
+
+# The get_user_by_email and get_user_by_username functions may be called from
+# the tool_shed app, which has its own User model, which is different from
+# galaxy.model.User. In that case, the tool_shed user model should be passed as
+# the model_class argument.
+def get_user_by_email(session, email: str, model_class=User):
+    stmt = select(model_class).filter(model_class.email == email).limit(1)
+    return session.scalars(stmt).first()
+
+
+def get_user_by_username(session, username: str, model_class=User):
+    stmt = select(model_class).filter(model_class.username == username).limit(1)
+    return session.scalars(stmt).first()

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
     select,
     true,
 )
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
 
 from galaxy import (
@@ -36,7 +37,10 @@ from galaxy.managers import (
     base,
     deletable,
 )
-from galaxy.model import UserQuotaUsage
+from galaxy.model import (
+    User,
+    UserQuotaUsage,
+)
 from galaxy.model.base import transaction
 from galaxy.security.validate_user_input import (
     VALID_EMAIL_RE,
@@ -850,3 +854,8 @@ def get_user_by_username(session, user_class, username):
         return session.execute(stmt).scalar_one()
     except Exception:
         return None
+
+
+def get_users_by_ids(session: Session, user_ids):
+    stmt = select(User).where(User.id.in_(user_ids))
+    return session.scalars(stmt).all()

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -27,16 +27,13 @@ from sqlalchemy import (
     and_,
     desc,
     false,
-    func,
     or_,
-    select,
     true,
 )
 from sqlalchemy.orm import (
     aliased,
     joinedload,
     Query,
-    Session,
     subqueryload,
 )
 
@@ -53,10 +50,7 @@ from galaxy.managers import (
 from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.executables import artifact_class
-from galaxy.model import (
-    StoredWorkflow,
-    StoredWorkflowUserShareAssociation,
-)
+from galaxy.model import StoredWorkflow
 from galaxy.model.base import transaction
 from galaxy.model.index_filter_util import (
     append_user_filter,
@@ -1978,9 +1972,3 @@ class Format2ConverterGalaxyInterface(ImporterGalaxyInterface):
         raise NotImplementedError(
             "Direct format 2 import of nested workflows is not yet implemented, use bioblend client."
         )
-
-
-def count_stored_workflow_user_assocs(session: Session, user, stored_workflow) -> int:
-    stmt = select(StoredWorkflowUserShareAssociation).filter_by(user=user, stored_workflow=stored_workflow)
-    stmt = select(func.count()).select_from(stmt)
-    return session.scalar(stmt)

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -27,13 +27,16 @@ from sqlalchemy import (
     and_,
     desc,
     false,
+    func,
     or_,
+    select,
     true,
 )
 from sqlalchemy.orm import (
     aliased,
     joinedload,
     Query,
+    Session,
     subqueryload,
 )
 
@@ -50,7 +53,10 @@ from galaxy.managers import (
 from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.executables import artifact_class
-from galaxy.model import StoredWorkflow
+from galaxy.model import (
+    StoredWorkflow,
+    StoredWorkflowUserShareAssociation,
+)
 from galaxy.model.base import transaction
 from galaxy.model.index_filter_util import (
     append_user_filter,
@@ -1972,3 +1978,9 @@ class Format2ConverterGalaxyInterface(ImporterGalaxyInterface):
         raise NotImplementedError(
             "Direct format 2 import of nested workflows is not yet implemented, use bioblend client."
         )
+
+
+def count_stored_workflow_user_assocs(session: Session, user, stored_workflow) -> int:
+    stmt = select(StoredWorkflowUserShareAssociation).filter_by(user=user, stored_workflow=stored_workflow)
+    stmt = select(func.count()).select_from(stmt)
+    return session.scalar(stmt)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1169,6 +1169,12 @@ ON CONFLICT
                 return quota_source_usage
         return None
 
+    def count_stored_workflow_user_assocs(self, stored_workflow) -> int:
+        stmt = select(StoredWorkflowUserShareAssociation).filter_by(user=self, stored_workflow=stored_workflow)
+        stmt = select(func.count()).select_from(stmt)
+        session = object_session(self)
+        return session.scalar(stmt)
+
 
 class PasswordResetToken(Base):
     __tablename__ = "password_reset_token"

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -23,6 +23,7 @@ from kombu.pools import producers
 import galaxy.queues
 from galaxy import util
 from galaxy.config import reload_config_options
+from galaxy.model import User
 from galaxy.tools import ToolBox
 from galaxy.tools.data_manager.manager import DataManagers
 from galaxy.tools.special_tools import load_lib_tools
@@ -219,7 +220,7 @@ def recalculate_user_disk_usage(app, **kwargs):
     user_id = kwargs.get("user_id", None)
     sa_session = app.model.context
     if user_id:
-        user = sa_session.query(app.model.User).get(user_id)
+        user = sa_session.get(User, user_id)
         if user:
             user.calculate_and_set_disk_usage(app.object_store)
         else:

--- a/lib/galaxy/quota/__init__.py
+++ b/lib/galaxy/quota/__init__.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Optional
 
+from sqlalchemy import select
 from sqlalchemy.sql import text
 
 import galaxy.util
@@ -209,11 +210,10 @@ WHERE default_quota_association.type = :default_type
             self.sa_session.delete(gqa)
         # Find the old default, assign the new quota if it exists
         label = quota.quota_source_label
-        dqas = (
-            self.sa_session.query(self.model.DefaultQuotaAssociation)
-            .filter(self.model.DefaultQuotaAssociation.table.c.type == default_type)
-            .all()
+        stmt = select(self.model.DefaultQuotaAssociation).filter(
+            self.model.DefaultQuotaAssociation.type == default_type
         )
+        dqas = self.sa_session.scalars(stmt).all()
         target_default = None
         for dqa in dqas:
             if dqa.quota.quota_source_label == label and not dqa.quota.deleted:

--- a/lib/galaxy/tool_shed/util/repository_util.py
+++ b/lib/galaxy/tool_shed/util/repository_util.py
@@ -69,7 +69,7 @@ def check_for_updates(
             message += "Unable to retrieve status from the tool shed for the following repositories:\n"
             message += ", ".join(repository_names_not_updated)
     else:
-        repository = get_tool_shed_repository_by_decoded_id(install_model_context, repository_id)
+        repository = install_model_context.get(ToolShedRepository, repository_id)
         ok, updated = _check_or_update_tool_shed_status_for_installed_repository(
             tool_shed_registry, install_model_context, repository
         )
@@ -632,15 +632,7 @@ def get_tool_shed_from_clone_url(repository_clone_url):
 def get_tool_shed_repository_by_id(app, repository_id) -> ToolShedRepository:
     """Return a tool shed repository database record defined by the id."""
     # This method is used only in Galaxy, not the tool shed.
-    return get_tool_shed_repository_by_decoded_id(app.install_model.context, app.security.decode_id(repository_id))
-
-
-def get_tool_shed_repository_by_decoded_id(
-    install_model_context: install_model_scoped_session, repository_id: int
-) -> ToolShedRepository:
-    return (
-        install_model_context.query(ToolShedRepository).filter(ToolShedRepository.table.c.id == repository_id).first()
-    )
+    return app.install_model.context.get(ToolShedRepository, app.security.decode_id(repository_id))
 
 
 def get_tool_shed_status_for(tool_shed_registry: Registry, repository: ToolShedRepository):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -18,6 +18,8 @@ from galaxy import model
 from galaxy.exceptions import ItemAccessibilityException
 from galaxy.job_execution.actions.post import ActionBox
 from galaxy.model import (
+    HistoryDatasetAssociation,
+    Job,
     LibraryDatasetDatasetAssociation,
     WorkflowRequestInputParameter,
 )
@@ -482,7 +484,7 @@ class DefaultToolAction(ToolAction):
             if async_tool and name in incoming:
                 # HACK: output data has already been created as a result of the async controller
                 dataid = incoming[name]
-                data = trans.sa_session.query(app.model.HistoryDatasetAssociation).get(dataid)
+                data = trans.sa_session.get(HistoryDatasetAssociation, dataid)
                 assert data is not None
                 out_data[name] = data
             else:
@@ -746,7 +748,7 @@ class DefaultToolAction(ToolAction):
         input datasets to be those of the job that is being rerun.
         """
         try:
-            old_job = trans.sa_session.query(trans.app.model.Job).get(rerun_remap_job_id)
+            old_job = trans.sa_session.get(Job, rerun_remap_job_id)
             assert old_job is not None, f"({rerun_remap_job_id}/{current_job.id}): Old job id is invalid"
             assert (
                 old_job.tool_id == current_job.tool_id

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -137,10 +137,10 @@ class ErrorReporter:
         if not isinstance(hda, model.HistoryDatasetAssociation):
             hda_id = hda
             try:
-                hda = sa_session.query(model.HistoryDatasetAssociation).get(hda_id)
+                hda = sa_session.get(model.HistoryDatasetAssociation, hda_id)
                 assert hda is not None, ValueError("No HDA yet")
             except Exception:
-                hda = sa_session.query(model.HistoryDatasetAssociation).get(app.security.decode_id(hda_id))
+                hda = sa_session.get(model.HistoryDatasetAssociation, app.security.decode_id(hda_id))
         assert isinstance(hda, model.HistoryDatasetAssociation), ValueError(f"Bad value provided for HDA ({hda}).")
         self.hda = hda
         # Get the associated job

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -4,6 +4,8 @@ import os
 import shutil
 from typing import Optional
 
+from sqlalchemy import select
+
 from galaxy import model
 from galaxy.model import store
 from galaxy.model.base import transaction
@@ -49,7 +51,8 @@ class JobImportHistoryArchiveWrapper:
         # Import history.
         #
 
-        jiha = self.sa_session.query(model.JobImportHistoryArchive).filter_by(job_id=self.job_id).first()
+        stmt = select(model.JobImportHistoryArchive).filter_by(job_id=self.job_id).limit(1)
+        jiha = self.sa_session.scalars(stmt).first()
         if not jiha:
             return None
         user = jiha.job.user

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2189,7 +2189,7 @@ class DataToolParameter(BaseDataToolParameter):
             if len(rval) > 1:
                 raise ParameterValueError("more than one dataset supplied to single input dataset parameter", self.name)
             if len(rval) > 0:
-                rval = rval[0]  # type:ignore[assignment]
+                return rval[0]
             else:
                 raise ParameterValueError("invalid dataset supplied to single input dataset parameter", self.name)
         return rval

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1943,13 +1943,15 @@ class BaseDataToolParameter(ToolParameter):
             if isinstance(value, dict) and "src" in value:
                 id = value["id"] if isinstance(value["id"], int) else app.security.decode_id(value["id"])
                 if value["src"] == "dce":
-                    return app.model.context.query(DatasetCollectionElement).get(id)
+                    return session.get(DatasetCollectionElement, id)
                 elif value["src"] == "hdca":
-                    return app.model.context.query(HistoryDatasetCollectionAssociation).get(id)
+                    return session.get(HistoryDatasetCollectionAssociation, id)
                 elif value["src"] == "ldda":
-                    return app.model.context.query(LibraryDatasetDatasetAssociation).get(id)
+                    return session.get(LibraryDatasetDatasetAssociation, id)
                 else:
-                    return app.model.context.query(HistoryDatasetAssociation).get(id)
+                    return session.get(HistoryDatasetAssociation, id)
+
+        session = app.model.context
 
         if isinstance(value, dict) and "values" in value:
             if hasattr(self, "multiple") and self.multiple is True:
@@ -1962,22 +1964,18 @@ class BaseDataToolParameter(ToolParameter):
         if value in none_values:
             return None
         if isinstance(value, str) and value.find(",") > -1:
-            return [
-                app.model.context.query(HistoryDatasetAssociation).get(int(v))
-                for v in value.split(",")
-                if v not in none_values
-            ]
+            return [session.get(HistoryDatasetAssociation, int(v)) for v in value.split(",") if v not in none_values]
         elif str(value).startswith("__collection_reduce__|"):
             decoded_id = str(value)[len("__collection_reduce__|") :]
             if not decoded_id.isdigit():
                 decoded_id = app.security.decode_id(decoded_id)
-            return app.model.context.query(HistoryDatasetCollectionAssociation).get(int(decoded_id))
+            return session.get(HistoryDatasetCollectionAssociation, int(decoded_id))
         elif str(value).startswith("dce:"):
-            return app.model.context.query(DatasetCollectionElement).get(int(value[len("dce:") :]))
+            return session.get(DatasetCollectionElement, int(value[len("dce:") :]))
         elif str(value).startswith("hdca:"):
-            return app.model.context.query(HistoryDatasetCollectionAssociation).get(int(value[len("hdca:") :]))
+            return session.get(HistoryDatasetCollectionAssociation, int(value[len("hdca:") :]))
         else:
-            return app.model.context.query(HistoryDatasetAssociation).get(int(value))
+            return session.get(HistoryDatasetAssociation, int(value))
 
     def validate(self, value, trans=None):
         def do_validate(v):
@@ -2079,6 +2077,8 @@ class DataToolParameter(BaseDataToolParameter):
                 self.conversions.append((name, conv_extension, [conv_type]))
 
     def from_json(self, value, trans, other_values=None):
+        session = trans.sa_session
+
         other_values = other_values or {}
         if trans.workflow_building_mode is workflow_building_modes.ENABLED or is_runtime_value(value):
             return None
@@ -2090,24 +2090,31 @@ class DataToolParameter(BaseDataToolParameter):
             value = self.to_python(value, trans.app)
         if isinstance(value, str) and value.find(",") > 0:
             value = [int(value_part) for value_part in value.split(",")]
-        rval = []
+        rval: List[
+            Union[
+                DatasetCollectionElement,
+                HistoryDatasetAssociation,
+                HistoryDatasetCollectionAssociation,
+                LibraryDatasetDatasetAssociation,
+            ]
+        ] = []
         if isinstance(value, list):
             found_hdca = False
             for single_value in value:
                 if isinstance(single_value, dict) and "src" in single_value and "id" in single_value:
                     if single_value["src"] == "hda":
                         decoded_id = trans.security.decode_id(single_value["id"])
-                        rval.append(trans.sa_session.query(HistoryDatasetAssociation).get(decoded_id))
+                        rval.append(session.get(HistoryDatasetAssociation, decoded_id))
                     elif single_value["src"] == "hdca":
                         found_hdca = True
                         decoded_id = trans.security.decode_id(single_value["id"])
-                        rval.append(trans.sa_session.query(HistoryDatasetCollectionAssociation).get(decoded_id))
+                        rval.append(session.get(HistoryDatasetCollectionAssociation, decoded_id))
                     elif single_value["src"] == "ldda":
                         decoded_id = trans.security.decode_id(single_value["id"])
-                        rval.append(trans.sa_session.query(LibraryDatasetDatasetAssociation).get(decoded_id))
+                        rval.append(session.get(LibraryDatasetDatasetAssociation, decoded_id))
                     elif single_value["src"] == "dce":
                         decoded_id = trans.security.decode_id(single_value["id"])
-                        rval.append(trans.sa_session.query(DatasetCollectionElement).get(decoded_id))
+                        rval.append(session.get(DatasetCollectionElement, decoded_id))
                     else:
                         raise ValueError(f"Unknown input source {single_value['src']} passed to job submission API.")
                 elif isinstance(
@@ -2126,7 +2133,7 @@ class DataToolParameter(BaseDataToolParameter):
                         # support that for integer column types.
                         log.warning("Encoded ID where unencoded ID expected.")
                         single_value = trans.security.decode_id(single_value)
-                    rval.append(trans.sa_session.query(HistoryDatasetAssociation).get(single_value))
+                    rval.append(session.get(HistoryDatasetAssociation, single_value))
             if found_hdca:
                 for val in rval:
                     if not isinstance(val, HistoryDatasetCollectionAssociation):
@@ -2142,13 +2149,13 @@ class DataToolParameter(BaseDataToolParameter):
                 rval.append(trans.sa_session.query(LibraryDatasetDatasetAssociation).get(decoded_id))
             if value["src"] == "hda":
                 decoded_id = trans.security.decode_id(value["id"])
-                rval.append(trans.sa_session.query(HistoryDatasetAssociation).get(decoded_id))
+                rval.append(session.get(HistoryDatasetAssociation, decoded_id))
             elif value["src"] == "hdca":
                 decoded_id = trans.security.decode_id(value["id"])
-                rval.append(trans.sa_session.query(HistoryDatasetCollectionAssociation).get(decoded_id))
+                rval.append(session.get(HistoryDatasetCollectionAssociation, decoded_id))
             elif value["src"] == "dce":
                 decoded_id = trans.security.decode_id(value["id"])
-                rval.append(trans.sa_session.query(DatasetCollectionElement).get(decoded_id))
+                rval.append(session.get(DatasetCollectionElement, decoded_id))
             else:
                 raise ValueError(f"Unknown input source {value['src']} passed to job submission API.")
         elif str(value).startswith("__collection_reduce__|"):
@@ -2156,12 +2163,12 @@ class DataToolParameter(BaseDataToolParameter):
             decoded_ids = map(trans.security.decode_id, encoded_ids)
             rval = []
             for decoded_id in decoded_ids:
-                hdca = trans.sa_session.query(HistoryDatasetCollectionAssociation).get(decoded_id)
+                hdca = session.get(HistoryDatasetCollectionAssociation, decoded_id)
                 rval.append(hdca)
         elif isinstance(value, HistoryDatasetCollectionAssociation) or isinstance(value, DatasetCollectionElement):
             rval.append(value)
         else:
-            rval.append(trans.sa_session.query(HistoryDatasetAssociation).get(value))
+            rval.append(session.get(HistoryDatasetAssociation, int(value)))  # type:ignore[arg-type]
         dataset_matcher_factory = get_dataset_matcher_factory(trans)
         dataset_matcher = dataset_matcher_factory.dataset_matcher(self, other_values)
         for v in rval:
@@ -2177,12 +2184,12 @@ class DataToolParameter(BaseDataToolParameter):
                         v = v.hda
                     match = dataset_matcher.hda_match(v)
                     if match and match.implicit_conversion:
-                        v.implicit_conversion = True
+                        v.implicit_conversion = True  # type:ignore[union-attr]
         if not self.multiple:
             if len(rval) > 1:
                 raise ParameterValueError("more than one dataset supplied to single input dataset parameter", self.name)
             if len(rval) > 0:
-                rval = rval[0]
+                rval = rval[0]  # type:ignore[assignment]
             else:
                 raise ParameterValueError("invalid dataset supplied to single input dataset parameter", self.name)
         return rval
@@ -2428,6 +2435,8 @@ class DataCollectionToolParameter(BaseDataToolParameter):
                 yield history_dataset_collection, match.implicit_conversion
 
     def from_json(self, value, trans, other_values=None):
+        session = trans.sa_session
+
         other_values = other_values or {}
         rval: Optional[Union[DatasetCollectionElement, HistoryDatasetCollectionAssociation]] = None
         if trans.workflow_building_mode is workflow_building_modes.ENABLED:
@@ -2449,28 +2458,22 @@ class DataCollectionToolParameter(BaseDataToolParameter):
             rval = value
         elif isinstance(value, dict) and "src" in value and "id" in value:
             if value["src"] == "hdca":
-                rval = trans.sa_session.query(HistoryDatasetCollectionAssociation).get(
-                    trans.security.decode_id(value["id"])
-                )
+                rval = session.get(HistoryDatasetCollectionAssociation, trans.security.decode_id(value["id"]))
         elif isinstance(value, list):
             if len(value) > 0:
                 value = value[0]
                 if isinstance(value, dict) and "src" in value and "id" in value:
                     if value["src"] == "hdca":
-                        rval = trans.sa_session.query(HistoryDatasetCollectionAssociation).get(
-                            trans.security.decode_id(value["id"])
-                        )
+                        rval = session.get(HistoryDatasetCollectionAssociation, trans.security.decode_id(value["id"]))
                     elif value["src"] == "dce":
-                        rval = trans.sa_session.query(DatasetCollectionElement).get(
-                            trans.security.decode_id(value["id"])
-                        )
+                        rval = session.get(DatasetCollectionElement, trans.security.decode_id(value["id"]))
         elif isinstance(value, str):
             if value.startswith("dce:"):
-                rval = trans.sa_session.query(DatasetCollectionElement).get(value[len("dce:") :])
+                rval = session.get(DatasetCollectionElement, int(value[len("dce:") :]))
             elif value.startswith("hdca:"):
-                rval = trans.sa_session.query(HistoryDatasetCollectionAssociation).get(value[len("hdca:") :])
+                rval = session.get(HistoryDatasetCollectionAssociation, int(value[len("hdca:") :]))
             else:
-                rval = trans.sa_session.query(HistoryDatasetCollectionAssociation).get(value)
+                rval = session.get(HistoryDatasetCollectionAssociation, int(value))
         if rval and isinstance(rval, HistoryDatasetCollectionAssociation):
             if rval.deleted:
                 raise ParameterValueError("the previously selected dataset collection has been deleted", self.name)
@@ -2628,6 +2631,7 @@ class LibraryDatasetToolParameter(ToolParameter):
         if not isinstance(value, list):
             value = [value]
         lst = []
+        session = app.model.context
         for item in value:
             if isinstance(item, LibraryDatasetDatasetAssociation):
                 lst.append(item)
@@ -2640,9 +2644,8 @@ class LibraryDatasetToolParameter(ToolParameter):
                 else:
                     lst = []
                     break
-                lda = app.model.context.query(LibraryDatasetDatasetAssociation).get(
-                    lda_id if isinstance(lda_id, int) else app.security.decode_id(lda_id)
-                )
+                id = lda_id if isinstance(lda_id, int) else app.security.decode_id(lda_id)
+                lda = session.get(LibraryDatasetDatasetAssociation, id)
                 if lda is not None:
                     lst.append(lda)
                 elif validate:

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -12,9 +12,9 @@ from typing import (
 
 from galaxy import (
     exceptions,
-    model,
     util,
 )
+from galaxy.model import HistoryDatasetCollectionAssociation
 from galaxy.model.dataset_collections import (
     matching,
     subcollections,
@@ -265,7 +265,7 @@ def __expand_collection_parameter(trans, input_key, incoming_val, collections_to
             encoded_hdc_id = incoming_val
             subcollection_type = None
     hdc_id = trans.app.security.decode_id(encoded_hdc_id)
-    hdc = trans.sa_session.query(model.HistoryDatasetCollectionAssociation).get(hdc_id)
+    hdc = trans.sa_session.get(HistoryDatasetCollectionAssociation, hdc_id)
     collections_to_match.add(input_key, hdc, subcollection_type=subcollection_type, linked=linked)
     if subcollection_type is not None:
         subcollection_elements = subcollections.split_dataset_collection_instance(hdc, subcollection_type)

--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -11,6 +11,8 @@ from galaxy.exceptions import (
     ObjectNotFound,
     ReferenceDataError,
 )
+from galaxy.managers.users import get_user_by_username
+from galaxy.model import HistoryDatasetAssociation
 from galaxy.structured_app import StructuredApp
 from galaxy.util.bunch import Bunch
 

--- a/lib/galaxy/webapps/galaxy/api/forms.py
+++ b/lib/galaxy/webapps/galaxy/api/forms.py
@@ -3,8 +3,11 @@ API operations on FormDefinition objects.
 """
 import logging
 
+from sqlalchemy import select
+
 from galaxy import web
 from galaxy.forms.forms import form_factory
+from galaxy.model import FormDefinition
 from galaxy.model.base import transaction
 from galaxy.util import XML
 from galaxy.webapps.base.controller import url_for
@@ -23,9 +26,10 @@ class FormDefinitionAPIController(BaseGalaxyAPIController):
         if not trans.user_is_admin:
             trans.response.status = 403
             return "You are not authorized to view the list of forms."
-        query = trans.sa_session.query(trans.app.model.FormDefinition)
+
         rval = []
-        for form_definition in query:
+        form_defs = trans.sa_session.scalars(select(FormDefinition))
+        for form_definition in form_defs:
             item = form_definition.to_dict(
                 value_mapper={"id": trans.security.encode_id, "form_definition_current_id": trans.security.encode_id}
             )
@@ -46,7 +50,7 @@ class FormDefinitionAPIController(BaseGalaxyAPIController):
             trans.response.status = 400
             return f"Malformed form definition id ( {str(form_definition_id)} ) specified, unable to decode."
         try:
-            form_definition = trans.sa_session.query(trans.app.model.FormDefinition).get(decoded_form_definition_id)
+            form_definition = trans.sa_session.get(FormDefinition, decoded_form_definition_id)
         except Exception:
             form_definition = None
         if not form_definition or not trans.user_is_admin:

--- a/lib/galaxy/webapps/galaxy/api/job_files.py
+++ b/lib/galaxy/webapps/galaxy/api/job_files.py
@@ -7,9 +7,9 @@ import shutil
 
 from galaxy import (
     exceptions,
-    model,
     util,
 )
+from galaxy.model import Job
 from galaxy.web import (
     expose_api_anonymous_and_sessionless,
     expose_api_raw_anonymous_and_sessionless,
@@ -126,7 +126,7 @@ class JobFilesAPIController(BaseGalaxyAPIController):
             raise exceptions.ItemAccessibilityException("Invalid job_key supplied.")
 
         # Verify job is active. Don't update the contents of complete jobs.
-        job = trans.sa_session.query(model.Job).get(job_id)
+        job = trans.sa_session.get(Job, job_id)
         if job.finished:
             error_message = "Attempting to read or modify the files of a job that has already completed."
             raise exceptions.ItemAccessibilityException(error_message)

--- a/lib/galaxy/webapps/galaxy/api/job_tokens.py
+++ b/lib/galaxy/webapps/galaxy/api/job_tokens.py
@@ -7,11 +7,11 @@ from fastapi.responses import PlainTextResponse
 
 from galaxy import (
     exceptions,
-    model,
     util,
 )
 from galaxy.authnz.util import provider_name_to_backend
 from galaxy.managers.context import ProvidesAppContext
+from galaxy.model import Job
 from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.webapps.galaxy.api import (
     DependsOnTrans,
@@ -52,8 +52,9 @@ class FastAPIJobTokens:
         return tokens["id"]
 
     def __authorize_job_access(self, trans, encoded_job_id, job_key):
+        session = trans.sa_session
         job_id = trans.security.decode_id(encoded_job_id)
-        job = trans.sa_session.query(model.Job).get(job_id)
+        job = session.get(Job, job_id)
         secret = job.destination_params.get("job_secret_base", "jobs_token")
 
         job_key_internal = trans.security.encode_id(job_id, kind=secret)
@@ -61,7 +62,7 @@ class FastAPIJobTokens:
             raise exceptions.AuthenticationFailed("Invalid job_key supplied.")
 
         # Verify job is active
-        job = trans.sa_session.query(model.Job).get(job_id)
+        job = session.get(Job, job_id)
         if job.finished:
             error_message = "Attempting to get oidc token for a job that has already completed."
             raise exceptions.ItemAccessibilityException(error_message)

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -99,6 +99,8 @@ class LibraryContentsController(
             return rval
 
         library = trans.sa_session.get(Library, self.decode_id(library_id))
+        if not library:
+            raise exceptions.RequestParameterInvalidException("No library found with the id provided.")
         if not (trans.user_is_admin or trans.app.security_agent.can_access_library(current_user_roles, library)):
             raise exceptions.RequestParameterInvalidException("No library found with the id provided.")
         encoded_id = f"F{trans.security.encode_id(library.root_folder.id)}"

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -4,11 +4,6 @@ API operations on the contents of a data library.
 import logging
 from typing import Optional
 
-from sqlalchemy.orm.exc import (
-    MultipleResultsFound,
-    NoResultFound,
-)
-
 from galaxy import (
     exceptions,
     managers,
@@ -25,7 +20,9 @@ from galaxy.managers.collections_util import (
 from galaxy.model import (
     ExtendedMetadata,
     ExtendedMetadataIndex,
+    Library,
     LibraryDataset,
+    LibraryFolder,
     tags,
 )
 from galaxy.model.base import transaction
@@ -101,19 +98,7 @@ class LibraryContentsController(
                     rval.append(ld)
             return rval
 
-        decoded_library_id = self.decode_id(library_id)
-        try:
-            library = (
-                trans.sa_session.query(trans.app.model.Library)
-                .filter(trans.app.model.Library.table.c.id == decoded_library_id)
-                .one()
-            )
-        except MultipleResultsFound:
-            raise exceptions.InconsistentDatabase("Multiple libraries found with the same id.")
-        except NoResultFound:
-            raise exceptions.RequestParameterInvalidException("No library found with the id provided.")
-        except Exception as e:
-            raise exceptions.InternalServerError(f"Error loading from the database.{util.unicodify(e)}")
+        library = trans.sa_session.get(Library, self.decode_id(library_id))
         if not (trans.user_is_admin or trans.app.security_agent.can_access_library(current_user_roles, library)):
             raise exceptions.RequestParameterInvalidException("No library found with the id provided.")
         encoded_id = f"F{trans.security.encode_id(library.root_folder.id)}"
@@ -348,7 +333,7 @@ class LibraryContentsController(
         roles = kwd.get("roles", "")
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
-        folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(folder_id)
+        folder = trans.sa_session.get(LibraryFolder, folder_id)
         self._check_access(trans, is_admin, folder, current_user_roles)
         self._check_add(trans, is_admin, folder, current_user_roles)
         library = folder.parent_library

--- a/lib/galaxy/webapps/galaxy/api/page_revisions.py
+++ b/lib/galaxy/webapps/galaxy/api/page_revisions.py
@@ -4,7 +4,10 @@ API for updating Galaxy Pages
 import logging
 
 from galaxy.managers.base import get_object
-from galaxy.managers.pages import PageManager
+from galaxy.managers.pages import (
+    get_page_revision,
+    PageManager,
+)
 from galaxy.web import expose_api
 from . import (
     BaseGalaxyAPIController,
@@ -30,7 +33,7 @@ class PageRevisionsController(BaseGalaxyAPIController):
         :returns:   dictionaries containing different revisions of the page
         """
         page = get_object(trans, page_id, "Page", check_ownership=False, check_accessible=True)
-        r = trans.sa_session.query(trans.app.model.PageRevision).filter_by(page_id=page.id)
+        r = get_page_revision(trans.sa_session, page.id)
         out = []
         for page in r:
             as_dict = self.encode_all_ids(trans, page.to_dict(), True)

--- a/lib/galaxy/webapps/galaxy/api/tool_entry_points.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_entry_points.py
@@ -51,7 +51,7 @@ class ToolEntryPointsAPIController(BaseGalaxyAPIController):
             )
 
         if job_id is not None:
-            job = trans.sa_session.query(Job).get(self.decode_id(job_id))
+            job = trans.sa_session.get(Job, self.decode_id(job_id))
             if not self.interactivetool_manager.can_access_job(trans, job):
                 raise exceptions.ItemAccessibilityException()
             entry_points = job.interactivetool_entry_points
@@ -94,7 +94,7 @@ class ToolEntryPointsAPIController(BaseGalaxyAPIController):
             raise exceptions.RequestParameterMissingException("Must supply entry point id")
         try:
             entry_point_id = self.decode_id(id)
-            entry_point = trans.sa_session.query(InteractiveToolEntryPoint).get(entry_point_id)
+            entry_point = trans.sa_session.get(InteractiveToolEntryPoint, entry_point_id)
         except Exception:
             raise exceptions.RequestParameterInvalidException("entry point invalid")
         if self.app.interactivetool_manager.can_access_entry_point(trans, entry_point):

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -34,6 +34,9 @@ from galaxy.managers.context import (
     ProvidesUserContext,
 )
 from galaxy.model import (
+    FormDefinition,
+    HistoryDatasetAssociation,
+    Role,
     UserAddress,
     UserQuotaUsage,
 )
@@ -491,7 +494,7 @@ class FastAPIUsers:
                 build_dict["count"] = str(counter)
             else:
                 build_dict["fasta"] = trans.security.decode_id(len_value)
-                dataset = trans.sa_session.query(trans.app.model.HistoryDatasetAssociation).get(build_dict["fasta"])
+                dataset = trans.sa_session.get(HistoryDatasetAssociation, int(build_dict["fasta"]))
                 try:
                     new_len = dataset.get_converted_dataset(trans, "len")
                     new_linecount = new_len.get_converted_dataset(trans, "linecount")
@@ -519,9 +522,7 @@ class FastAPIUsers:
         update = False
         for key, dbkey in dbkeys.items():
             if "count" not in dbkey and "linecount" in dbkey:
-                chrom_count_dataset = trans.sa_session.query(trans.app.model.HistoryDatasetAssociation).get(
-                    dbkey["linecount"]
-                )
+                chrom_count_dataset = trans.sa_session.get(HistoryDatasetAssociation, dbkey["linecount"])
                 if (
                     chrom_count_dataset
                     and not chrom_count_dataset.deleted
@@ -779,7 +780,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                     }
                 )
             info_form_models = self.get_all_forms(
-                trans, filter=dict(deleted=False), form_type=trans.app.model.FormDefinition.types.USER_INFO
+                trans, filter=dict(deleted=False), form_type=FormDefinition.types.USER_INFO
             )
             if info_form_models:
                 info_form_id = trans.security.encode_id(user.values.form_definition.id) if user.values else None
@@ -909,9 +910,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         user_info_form_id = payload.get("info|form_id")
         if user_info_form_id:
             prefix = "info|"
-            user_info_form = trans.sa_session.query(trans.app.model.FormDefinition).get(
-                trans.security.decode_id(user_info_form_id)
-            )
+            user_info_form = trans.sa_session.get(FormDefinition, trans.security.decode_id(user_info_form_id))
             user_info_values = {}
             for item in payload:
                 if item.startswith(prefix):
@@ -962,7 +961,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
             d = address_dicts[index]
             if d.get("id"):
                 try:
-                    user_address = trans.sa_session.query(UserAddress).get(trans.security.decode_id(d["id"]))
+                    user_address = trans.sa_session.get(UserAddress, trans.security.decode_id(d["id"]))
                 except Exception as e:
                     raise exceptions.ObjectNotFound(f"Failed to access user address ({d['id']}). {e}")
             else:
@@ -1042,9 +1041,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         permissions = {}
         for index, action in trans.app.model.Dataset.permitted_actions.items():
             action_id = trans.app.security_agent.get_action(action.action).action
-            permissions[action_id] = [
-                trans.sa_session.query(trans.app.model.Role).get(x) for x in (payload.get(index) or [])
-            ]
+            permissions[action_id] = [trans.sa_session.get(Role, x) for x in (payload.get(index) or [])]
         trans.app.security_agent.user_set_default_permissions(user, permissions)
         return {"message": "Permissions have been saved."}
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -192,7 +192,7 @@ class WorkflowsAPIController(
         """
         stored_workflow = self.__get_stored_workflow(trans, id, **kwd)
         if stored_workflow.importable is False and stored_workflow.user != trans.user and not trans.user_is_admin:
-            wf_count = trans.user.count_stored_workflow_user_assocs(stored_workflow)
+            wf_count = 0 if not trans.user else trans.user.count_stored_workflow_user_assocs(stored_workflow)
             if wf_count == 0:
                 message = "Workflow is neither importable, nor owned by or shared with current user"
                 raise exceptions.ItemAccessibilityException(message)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -40,7 +40,6 @@ from galaxy.managers.jobs import (
     invocation_job_source_iter,
 )
 from galaxy.managers.workflows import (
-    count_stored_workflow_user_assocs,
     MissingToolsException,
     RefactorRequest,
     WorkflowCreateOptions,
@@ -193,7 +192,7 @@ class WorkflowsAPIController(
         """
         stored_workflow = self.__get_stored_workflow(trans, id, **kwd)
         if stored_workflow.importable is False and stored_workflow.user != trans.user and not trans.user_is_admin:
-            wf_count = count_stored_workflow_user_assocs(trans.sa_session, trans.user, stored_workflow)
+            wf_count = trans.user.count_stored_workflow_user_assocs(stored_workflow)
             if wf_count == 0:
                 message = "Workflow is neither importable, nor owned by or shared with current user"
                 raise exceptions.ItemAccessibilityException(message)

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -516,11 +516,8 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         # Get history.
         session = trans.sa_session
 
-        stmt = select(model.User).filter_by(username=username).limit(1)
-        user = session.scalars(stmt).first()
-
-        stmt = select(model.History).filter_by(user=user, slug=slug, deleted=False).limit(1)
-        history = session.scalars(stmt).first()
+        user = session.scalars(select(model.User).filter_by(username=username).limit(1)).first()
+        history = session.scalars(select(model.History).filter_by(user=user, slug=slug, deleted=False).limit(1)).first()
 
         if history is None:
             raise web.httpexceptions.HTTPNotFound()

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -18,6 +18,7 @@ from galaxy import (
 )
 from galaxy.exceptions import Conflict
 from galaxy.managers import users
+from galaxy.managers.users import get_user_by_email
 from galaxy.security.validate_user_input import (
     validate_email,
     validate_publicname,
@@ -293,9 +294,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin):
             )
         else:
             # Find the user
-            user = (
-                trans.sa_session.query(trans.app.model.User).filter(trans.app.model.User.table.c.email == email).first()
-            )
+            user = get_user_by_email(trans.sa_session, email)
             if not user:
                 # Probably wrong email address
                 return trans.show_error_message(

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -210,7 +210,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         return rval
 
     def dce_content(self, trans: ProvidesHistoryContext, dce_id: DecodedDatabaseIdField) -> DCESummary:
-        dce: Optional[DatasetCollectionElement] = trans.model.session.query(DatasetCollectionElement).get(dce_id)
+        dce: Optional[DatasetCollectionElement] = trans.model.session.get(DatasetCollectionElement, dce_id)
         if not dce:
             raise exceptions.ObjectNotFound("No DatasetCollectionElement found")
         if not trans.user_is_admin:

--- a/lib/galaxy/webapps/galaxy/services/histories.py
+++ b/lib/galaxy/webapps/galaxy/services/histories.py
@@ -32,6 +32,7 @@ from galaxy.files.uris import validate_uri_access
 from galaxy.managers.citations import CitationsManager
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.managers.histories import (
+    get_fasta_hdas_by_history,
     HistoryDeserializer,
     HistoryExportManager,
     HistoryFilters,
@@ -640,11 +641,7 @@ class HistoriesService(ServiceBase, ConsumesModelStores, ServesExportStores):
         installed_builds = []
         for build in glob.glob(os.path.join(trans.app.config.len_file_path, "*.len")):
             installed_builds.append(os.path.basename(build).split(".len")[0])
-        fasta_hdas = (
-            trans.sa_session.query(model.HistoryDatasetAssociation)
-            .filter_by(history=history, extension="fasta", deleted=False)
-            .order_by(model.HistoryDatasetAssociation.hid.desc())
-        )
+        fasta_hdas = get_fasta_hdas_by_history(trans.sa_session, history.id)
         return CustomBuildsMetadataResponse(
             installed_builds=[LabelValuePair(label=ins, value=ins) for ins in installed_builds],
             fasta_hdas=[

--- a/lib/galaxy/webapps/galaxy/services/libraries.py
+++ b/lib/galaxy/webapps/galaxy/services/libraries.py
@@ -15,6 +15,7 @@ from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.folders import FolderManager
 from galaxy.managers.libraries import LibraryManager
 from galaxy.managers.roles import RoleManager
+from galaxy.model import Role
 from galaxy.schema.fields import DecodedDatabaseIdField
 from galaxy.schema.schema import (
     BasicRoleModel,
@@ -321,7 +322,7 @@ class LibrariesService(ServiceBase, ConsumesModelStores):
         permissions = {}
         for k, v in trans.app.model.Library.permitted_actions.items():
             role_params = payload.get(f"{k}_in", [])
-            in_roles = [trans.sa_session.query(trans.app.model.Role).get(x) for x in util.listify(role_params)]
+            in_roles = [trans.sa_session.get(Role, x) for x in util.listify(role_params)]
             permissions[trans.app.security_agent.get_action(v.action)] = in_roles
         trans.app.security_agent.set_all_library_permissions(trans, library, permissions)
         trans.sa_session.refresh(library)

--- a/lib/galaxy/webapps/galaxy/services/quotas.py
+++ b/lib/galaxy/webapps/galaxy/services/quotas.py
@@ -1,14 +1,19 @@
 import logging
 from typing import Optional
 
+from sqlalchemy import (
+    false,
+    select,
+    true,
+)
+from sqlalchemy.orm import Session
+
 from galaxy import util
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.groups import get_group_by_name
-from galaxy.managers.quotas import (
-    get_quotas,
-    QuotaManager,
-)
+from galaxy.managers.quotas import QuotaManager
 from galaxy.managers.users import get_user_by_email
+from galaxy.model import Quota
 from galaxy.quota._schema import (
     CreateQuotaParams,
     CreateQuotaResult,
@@ -148,3 +153,11 @@ class QuotasService(ServiceBase):
             raise Exception(msg)
         payload["in_users"] = list(map(str, new_in_users))
         payload["in_groups"] = list(map(str, new_in_groups))
+
+
+def get_quotas(session: Session, deleted: bool = False):
+    is_deleted = true()
+    if not deleted:
+        is_deleted = false()
+    stmt = select(Quota).where(Quota.deleted == is_deleted)
+    return session.scalars(stmt)

--- a/lib/galaxy/webapps/galaxy/services/quotas.py
+++ b/lib/galaxy/webapps/galaxy/services/quotas.py
@@ -8,7 +8,7 @@ from galaxy.managers.quotas import (
     get_quotas,
     QuotaManager,
 )
-from galaxy.model.repositories import get_user_by_email
+from galaxy.managers.users import get_user_by_email
 from galaxy.quota._schema import (
     CreateQuotaParams,
     CreateQuotaResult,
@@ -119,7 +119,7 @@ class QuotasService(ServiceBase):
             try:
                 return trans.security.decode_id(item)
             except Exception:
-                return user_repo.get_by_email(item).id
+                return get_user_by_email(trans.sa_session, item).id
 
         def get_group_id(item):
             try:

--- a/lib/galaxy/webapps/galaxy/services/quotas.py
+++ b/lib/galaxy/webapps/galaxy/services/quotas.py
@@ -1,17 +1,14 @@
 import logging
 from typing import Optional
 
-from sqlalchemy import (
-    false,
-    true,
-)
-
-from galaxy import (
-    model,
-    util,
-)
+from galaxy import util
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.managers.quotas import QuotaManager
+from galaxy.managers.groups import get_group_by_name
+from galaxy.managers.quotas import (
+    get_quotas,
+    QuotaManager,
+)
+from galaxy.model.repositories import get_user_by_email
 from galaxy.quota._schema import (
     CreateQuotaParams,
     CreateQuotaResult,
@@ -39,14 +36,13 @@ class QuotasService(ServiceBase):
     def index(self, trans: ProvidesUserContext, deleted: bool = False) -> QuotaSummaryList:
         """Displays a list of quotas."""
         rval = []
-        query = trans.sa_session.query(model.Quota)
         if deleted:
             route = "deleted_quota"
-            query = query.filter(model.Quota.deleted == true())
+            quotas = get_quotas(trans.sa_session, deleted=True)
         else:
             route = "quota"
-            query = query.filter(model.Quota.deleted == false())
-        for quota in query:
+            quotas = get_quotas(trans.sa_session, deleted=False)
+        for quota in quotas:
             item = quota.to_dict(value_mapper={"id": DecodedDatabaseIdField.encode})
             encoded_id = DecodedDatabaseIdField.encode(quota.id)
             item["url"] = url_for(route, id=encoded_id)
@@ -119,25 +115,29 @@ class QuotasService(ServiceBase):
         For convenience, in_users and in_groups can be encoded IDs or emails/group names in the API.
         """
 
-        def get_id(item, model_class, column):
+        def get_user_id(item):
             try:
                 return trans.security.decode_id(item)
             except Exception:
-                pass  # maybe an email/group name
-            # this will raise if the item is invalid
-            return trans.sa_session.query(model_class).filter(column == item).first().id
+                return user_repo.get_by_email(item).id
+
+        def get_group_id(item):
+            try:
+                return trans.security.decode_id(item)
+            except Exception:
+                return get_group_by_name(trans.sa_session, item).id
 
         new_in_users = []
         new_in_groups = []
         invalid = []
         for item in util.listify(payload.get("in_users", [])):
             try:
-                new_in_users.append(get_id(item, model.User, model.User.email))
+                new_in_users.append(get_user_id(item))
             except Exception:
                 invalid.append(item)
         for item in util.listify(payload.get("in_groups", [])):
             try:
-                new_in_groups.append(get_id(item, model.Group, model.Group.name))
+                new_in_groups.append(get_group_id(item))
             except Exception:
                 invalid.append(item)
         if invalid:

--- a/lib/galaxy/webapps/galaxy/services/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/services/tool_shed_repositories.py
@@ -5,9 +5,9 @@ from typing import (
 
 from pydantic import BaseModel
 from sqlalchemy import (
-    and_,
     cast,
     Integer,
+    select,
 )
 
 from galaxy.model.scoped_session import install_model_scoped_session
@@ -17,10 +17,7 @@ from galaxy.schema.schema import (
     CheckForUpdatesResponse,
     InstalledToolShedRepository,
 )
-from galaxy.tool_shed.util.repository_util import (
-    check_for_updates,
-    get_tool_shed_repository_by_decoded_id,
-)
+from galaxy.tool_shed.util.repository_util import check_for_updates
 from galaxy.util.tool_shed.tool_shed_registry import Registry
 from galaxy.web import url_for
 
@@ -43,31 +40,20 @@ class ToolShedRepositoriesService:
         self._tool_shed_registry = tool_shed_registry
 
     def index(self, request: InstalledToolShedRepositoryIndexRequest) -> List[InstalledToolShedRepository]:
-        clause_list = []
-        if request.name is not None:
-            clause_list.append(ToolShedRepository.table.c.name == request.name)
-        if request.owner is not None:
-            clause_list.append(ToolShedRepository.table.c.owner == request.owner)
-        if request.changeset is not None:
-            clause_list.append(ToolShedRepository.table.c.changeset_revision == request.changeset)
-        if request.deleted is not None:
-            clause_list.append(ToolShedRepository.table.c.deleted == request.deleted)
-        if request.uninstalled is not None:
-            clause_list.append(ToolShedRepository.table.c.uninstalled == request.uninstalled)
-        query = (
-            self._install_model_context.query(ToolShedRepository)
-            .order_by(ToolShedRepository.table.c.name)
-            .order_by(cast(ToolShedRepository.ctx_rev, Integer).desc())
+        repositories = self._get_tool_shed_repositories(
+            name=request.name,
+            owner=request.owner,
+            changeset_revision=request.changeset,
+            deleted=request.deleted,
+            uninstalled=request.uninstalled,
         )
-        if len(clause_list) > 0:
-            query = query.filter(and_(*clause_list))
         index = []
-        for repository in query.all():
+        for repository in repositories:
             index.append(self._show(repository))
         return index
 
     def show(self, repository_id: DecodedDatabaseIdField) -> InstalledToolShedRepository:
-        tool_shed_repository = get_tool_shed_repository_by_decoded_id(self._install_model_context, int(repository_id))
+        tool_shed_repository = self._install_model_context.get(ToolShedRepository, repository_id)
         return self._show(tool_shed_repository)
 
     def check_for_updates(self, repository_id: Optional[int]) -> CheckForUpdatesResponse:
@@ -81,3 +67,13 @@ class ToolShedRepositoriesService:
         tool_shed_repository_dict["error_message"] = tool_shed_repository.error_message or ""
         tool_shed_repository_dict["url"] = url_for("tool_shed_repositories", id=encoded_id)
         return InstalledToolShedRepository(**tool_shed_repository_dict)
+
+    def _get_tool_shed_repositories(self, **kwd):
+        stmt = select(ToolShedRepository)
+        for key, value in kwd.items():
+            if value is not None:
+                column = ToolShedRepository.table.c[key]
+                stmt = stmt.filter(column == value)
+        stmt = stmt.order_by(ToolShedRepository.name).order_by(cast(ToolShedRepository.ctx_rev, Integer).desc())
+        session = self._install_model_context
+        return session.scalars(stmt).all()

--- a/lib/galaxy/webapps/galaxy/services/tools.py
+++ b/lib/galaxy/webapps/galaxy/services/tools.py
@@ -23,7 +23,10 @@ from galaxy.managers.context import (
     ProvidesUserContext,
 )
 from galaxy.managers.histories import HistoryManager
-from galaxy.model import PostJobAction
+from galaxy.model import (
+    LibraryDatasetDatasetAssociation,
+    PostJobAction,
+)
 from galaxy.model.base import transaction
 from galaxy.schema.fetch_data import (
     FetchDataFormPayload,
@@ -277,7 +280,7 @@ class ToolsService(ServiceBase):
 
     def _patch_library_dataset(self, trans: ProvidesHistoryContext, v, target_history):
         if isinstance(v, dict) and "id" in v and v.get("src") == "ldda":
-            ldda = trans.sa_session.query(trans.app.model.LibraryDatasetDatasetAssociation).get(self.decode_id(v["id"]))
+            ldda = trans.sa_session.get(LibraryDatasetDatasetAssociation, self.decode_id(v["id"]))
             if trans.user_is_admin or trans.app.security_agent.can_access_dataset(
                 trans.get_current_user_roles(), ldda.dataset
             ):

--- a/lib/galaxy/webapps/reports/controllers/jobs.py
+++ b/lib/galaxy/webapps/reports/controllers/jobs.py
@@ -18,15 +18,14 @@ from sqlalchemy import (
     and_,
     not_,
     or_,
-    select,
 )
 
 from galaxy import (
     model,
     util,
 )
+from galaxy.managers.users import get_user_by_email
 from galaxy.model import Job
-from galaxy.model.repositories import get_user_by_email
 from galaxy.web.legacy_framework import grids
 from galaxy.webapps.base.controller import (
     BaseUIController,
@@ -1307,8 +1306,7 @@ def get_monitor_id(trans, monitor_email):
     A convenience method to obtain the monitor job id.
     """
     monitor_user_id = None
-    stmt = select(trans.model.User.id).filter(trans.model.User.email == monitor_email).limit(1)
-    monitor_row = trans.sa_session.scalars(stmt).first()
+    monitor_row = get_user_by_email(trans.sa_session, monitor_email)
     if monitor_row is not None:
         monitor_user_id = monitor_row[0]
     return monitor_user_id

--- a/lib/galaxy/webapps/reports/controllers/jobs.py
+++ b/lib/galaxy/webapps/reports/controllers/jobs.py
@@ -18,12 +18,15 @@ from sqlalchemy import (
     and_,
     not_,
     or_,
+    select,
 )
 
 from galaxy import (
     model,
     util,
 )
+from galaxy.model import Job
+from galaxy.model.repositories import get_user_by_email
 from galaxy.web.legacy_framework import grids
 from galaxy.webapps.base.controller import (
     BaseUIController,
@@ -1288,7 +1291,7 @@ class Jobs(BaseUIController, ReportQueryBuilder):
     @web.expose
     def job_info(self, trans, **kwd):
         message = ""
-        job = trans.sa_session.query(model.Job).get(trans.security.decode_id(kwd.get("id", "")))
+        job = trans.sa_session.get(Job, trans.security.decode_id(kwd.get("id", "")))
         return trans.fill_template("/webapps/reports/job_info.mako", job=job, message=message)
 
 
@@ -1296,7 +1299,7 @@ class Jobs(BaseUIController, ReportQueryBuilder):
 
 
 def get_job(trans, id):
-    return trans.sa_session.query(trans.model.Job).get(trans.security.decode_id(id))
+    return trans.sa_session.get(Job, trans.security.decode_id(id))
 
 
 def get_monitor_id(trans, monitor_email):
@@ -1304,9 +1307,8 @@ def get_monitor_id(trans, monitor_email):
     A convenience method to obtain the monitor job id.
     """
     monitor_user_id = None
-    monitor_row = (
-        trans.sa_session.query(trans.model.User.id).filter(trans.model.User.table.c.email == monitor_email).first()
-    )
+    stmt = select(trans.model.User.id).filter(trans.model.User.email == monitor_email).limit(1)
+    monitor_row = trans.sa_session.scalars(stmt).first()
     if monitor_row is not None:
         monitor_user_id = monitor_row[0]
     return monitor_user_id

--- a/lib/galaxy/webapps/reports/controllers/system.py
+++ b/lib/galaxy/webapps/reports/controllers/system.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     desc,
     false,
     null,
+    select,
     true,
 )
 from sqlalchemy.orm import joinedload
@@ -74,13 +75,14 @@ class System(BaseUIController):
             cutoff_time = datetime.utcnow() - timedelta(days=userless_histories_days)
             history_count = 0
             dataset_count = 0
-            for history in trans.sa_session.query(model.History).filter(
+            stmt = select(model.History).filter(
                 and_(
-                    model.History.table.c.user_id == null(),
-                    model.History.table.c.deleted == true(),
+                    model.History.user_id == null(),
+                    model.History.deleted == true(),
                     model.History.update_time < cutoff_time,
                 )
-            ):
+            )
+            for history in trans.sa_session.scalars(stmt).all():
                 for dataset in history.datasets:
                     if not dataset.deleted:
                         dataset_count += 1
@@ -106,18 +108,21 @@ class System(BaseUIController):
             history_count = 0
             dataset_count = 0
             disk_space = 0
-            histories = (
-                trans.sa_session.query(model.History)
+
+            stmt = (
+                select(model.History)
                 .filter(
                     and_(
-                        model.History.table.c.deleted == true(),
-                        model.History.table.c.purged == false(),
+                        model.History.deleted == true(),
+                        model.History.purged == false(),
                         model.History.update_time < cutoff_time,
                     )
                 )
                 .options(joinedload(model.History.datasets))
+                .unique()
             )
 
+            histories = trans.sa_session.scalars(stmt).all()
             for history in histories:
                 for hda in history.datasets:
                     if not hda.dataset.purged:
@@ -144,13 +149,14 @@ class System(BaseUIController):
             cutoff_time = datetime.utcnow() - timedelta(days=deleted_datasets_days)
             dataset_count = 0
             disk_space = 0
-            for dataset in trans.sa_session.query(model.Dataset).filter(
+            stmt = select(model.Dataset).filter(
                 and_(
-                    model.Dataset.table.c.deleted == true(),
-                    model.Dataset.table.c.purged == false(),
-                    model.Dataset.table.c.update_time < cutoff_time,
+                    model.Dataset.deleted == true(),
+                    model.Dataset.purged == false(),
+                    model.Dataset.update_time < cutoff_time,
                 )
-            ):
+            )
+            for dataset in trans.sa_session.scalars(stmt).all():
                 dataset_count += 1
                 try:
                     disk_space += dataset.file_size
@@ -167,28 +173,22 @@ class System(BaseUIController):
     @web.expose
     def dataset_info(self, trans, **kwd):
         message = ""
-        dataset = trans.sa_session.query(model.Dataset).get(trans.security.decode_id(kwd.get("id", "")))
+        dataset = trans.sa_session.get(model.Dataset, trans.security.decode_id(kwd.get("id", "")))
         # Get all associated hdas and lddas that use the same disk file.
-        associated_hdas = (
-            trans.sa_session.query(trans.model.HistoryDatasetAssociation)
-            .filter(
-                and_(
-                    trans.model.HistoryDatasetAssociation.deleted == false(),
-                    trans.model.HistoryDatasetAssociation.dataset_id == dataset.id,
-                )
+        stmt = select(trans.model.HistoryDatasetAssociation).filter(
+            and_(
+                trans.model.HistoryDatasetAssociation.deleted == false(),
+                trans.model.HistoryDatasetAssociation.dataset_id == dataset.id,
             )
-            .all()
         )
-        associated_lddas = (
-            trans.sa_session.query(trans.model.LibraryDatasetDatasetAssociation)
-            .filter(
-                and_(
-                    trans.model.LibraryDatasetDatasetAssociation.deleted == false(),
-                    trans.model.LibraryDatasetDatasetAssociation.dataset_id == dataset.id,
-                )
+        associated_hdas = trans.sa_session.scalars(stmt).all()
+        stmt = select(trans.model.LibraryDatasetDatasetAssociation).filter(
+            and_(
+                trans.model.LibraryDatasetDatasetAssociation.deleted == false(),
+                trans.model.LibraryDatasetDatasetAssociation.dataset_id == dataset.id,
             )
-            .all()
         )
+        associated_lddas = trans.sa_session.scalars(stmt).all()
         return trans.fill_template(
             "/webapps/reports/dataset_info.mako",
             dataset=dataset,
@@ -208,11 +208,12 @@ class System(BaseUIController):
         disk_usage = self.get_disk_usage(file_path)
         min_file_size = 2**32  # 4 Gb
         file_size_str = nice_size(min_file_size)
-        datasets = (
-            trans.sa_session.query(model.Dataset)
-            .filter(and_(model.Dataset.table.c.purged == false(), model.Dataset.table.c.file_size > min_file_size))
-            .order_by(desc(model.Dataset.table.c.file_size))
+        stmt = (
+            select(model.Dataset)
+            .filter(and_(model.Dataset.purged == false(), model.Dataset.file_size > min_file_size))
+            .order_by(desc(model.Dataset.file_size))
         )
+        datasets = trans.sa_session.scalars(stmt).all()
         return file_path, disk_usage, datasets, file_size_str
 
 

--- a/lib/galaxy/webapps/reports/controllers/workflows.py
+++ b/lib/galaxy/webapps/reports/controllers/workflows.py
@@ -491,4 +491,4 @@ class Workflows(BaseUIController, ReportQueryBuilder):
 
 
 def get_workflow(trans, id):
-    return trans.sa_session.query(trans.model.Workflow).get(trans.security.decode_id(id))
+    return trans.sa_session.get(model.Workflow, trans.security.decode_id(id))

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -370,26 +370,22 @@ def build_workflow_run_configs(
             input_id = input_dict["id"]
             try:
                 if input_source == "ldda":
-                    ldda = trans.sa_session.query(LibraryDatasetDatasetAssociation).get(
-                        trans.security.decode_id(input_id)
-                    )
+                    ldda = trans.sa_session.get(LibraryDatasetDatasetAssociation, trans.security.decode_id(input_id))
                     assert trans.user_is_admin or trans.app.security_agent.can_access_dataset(
                         trans.get_current_user_roles(), ldda.dataset
                     )
                     content = ldda.to_history_dataset_association(history, add_to_history=add_to_history)
                 elif input_source == "ld":
-                    ldda = (
-                        trans.sa_session.query(LibraryDataset)
-                        .get(trans.security.decode_id(input_id))
-                        .library_dataset_dataset_association
-                    )
+                    ldda = trans.sa_session.get(
+                        LibraryDataset, trans.security.decode_id(input_id)
+                    ).library_dataset_dataset_association
                     assert trans.user_is_admin or trans.app.security_agent.can_access_dataset(
                         trans.get_current_user_roles(), ldda.dataset
                     )
                     content = ldda.to_history_dataset_association(history, add_to_history=add_to_history)
                 elif input_source == "hda":
                     # Get dataset handle, add to dict and history if necessary
-                    content = trans.sa_session.query(HistoryDatasetAssociation).get(trans.security.decode_id(input_id))
+                    content = trans.sa_session.get(HistoryDatasetAssociation, trans.security.decode_id(input_id))
                     assert trans.user_is_admin or trans.app.security_agent.can_access_dataset(
                         trans.get_current_user_roles(), content.dataset
                     )

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -79,12 +79,12 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
             log.info(
                 "(%s) Handler unassigned at startup, resubmitting workflow invocation for assignment", invocation_id
             )
-            workflow_invocation = sa_session.query(model.WorkflowInvocation).get(invocation_id)
+            workflow_invocation = sa_session.get(model.WorkflowInvocation, invocation_id)
             self._assign_handler(workflow_invocation)
 
     def _handle_setup_msg(self, workflow_invocation_id=None):
         sa_session = self.app.model.context
-        workflow_invocation = sa_session.query(model.WorkflowInvocation).get(workflow_invocation_id)
+        workflow_invocation = sa_session.get(model.WorkflowInvocation, workflow_invocation_id)
         if workflow_invocation.handler is None:
             workflow_invocation.handler = self.app.config.server_name
             sa_session.add(workflow_invocation)

--- a/lib/tool_shed/test/base/test_db_util.py
+++ b/lib/tool_shed/test/base/test_db_util.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
 import galaxy.model
 import galaxy.model.tool_shed_install
 import tool_shed.webapp.model as model
+from galaxy.managers.users import get_user_by_username
 
 log = logging.getLogger("test.tool_shed.test_db_util")
 
@@ -171,10 +172,6 @@ def get_user(email):
     return sa_session().query(model.User).filter(model.User.table.c.email == email).first()
 
 
-def get_user_by_name(username):
-    return sa_session().query(model.User).filter(model.User.table.c.username == username).first()
-
-
 def mark_obj_deleted(obj):
     obj.deleted = True
     sa_session().add(obj)
@@ -190,7 +187,7 @@ def ga_refresh(obj):
 
 
 def get_repository_by_name_and_owner(name, owner_username, return_multiple=False):
-    owner = get_user_by_name(owner_username)
+    owner = get_user_by_username(sa_session(), owner_username, model.User)
     repository = (
         sa_session()
         .query(model.Repository)

--- a/lib/tool_shed/webapp/controllers/repository.py
+++ b/lib/tool_shed/webapp/controllers/repository.py
@@ -2293,7 +2293,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
     def sharable_owner(self, trans, owner):
         """Support for sharable URL for each repository owner's tools, e.g. http://example.org/view/owner."""
         try:
-            user = get_user_by_username(trans.model.session, trans.model.User, owner)
+            user = get_user_by_username(trans.model.session, owner, trans.model.User)
         except Exception:
             user = None
         if user:
@@ -2321,7 +2321,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         else:
             # If the owner is valid, then show all of their repositories.
             try:
-                user = get_user_by_username(trans.model.session, trans.model.User, owner)
+                user = get_user_by_username(trans.model.session, owner, trans.model.User)
             except Exception:
                 user = None
             if user:

--- a/test/integration/test_user_preferences.py
+++ b/test/integration/test_user_preferences.py
@@ -7,8 +7,8 @@ from requests import (
     get,
     put,
 )
-from sqlalchemy import select
 
+from galaxy.managers.users import get_user_by_email
 from galaxy_test.driver import integration_util
 
 TEST_USER_EMAIL = "test_user_preferences@bx.psu.edu"
@@ -19,8 +19,8 @@ class TestUserPreferences(integration_util.IntegrationTestCase):
         user = self._setup_user(TEST_USER_EMAIL)
         url = self._api_url(f"users/{user['id']}/theme/test_theme", params=dict(key=self.master_api_key))
         app = cast(Any, self._test_driver.app if self._test_driver else None)
-        stmt = select(app.model.User).filter(app.model.User.email == user["email"]).limit(1)
-        db_user = app.model.session.scalars(stmt).first()
+
+        db_user = get_user_by_email(app.model.session, user["email"])
 
         # create some initial data
         put(url)

--- a/test/integration/test_vault_extra_prefs.py
+++ b/test/integration/test_vault_extra_prefs.py
@@ -9,8 +9,8 @@ from requests import (
     get,
     put,
 )
-from sqlalchemy import select
 
+from galaxy.managers.users import get_user_by_email
 from galaxy_test.driver import integration_util
 
 TEST_USER_EMAIL = "vault_test_user@bx.psu.edu"
@@ -133,5 +133,4 @@ class TestExtraUserPreferences(integration_util.IntegrationTestCase, integration
         return self._api_url(f"users/{user['id']}/{action}", params=dict(key=self.master_api_key))
 
     def _get_dbuser(self, app, user):
-        stmt = select(app.model.User).filter(app.model.User.email == user["email"]).limit(1)
-        return app.model.session.scalars(stmt).first()
+        return get_user_by_email(app.model.session, user["email"])

--- a/test/integration/test_vault_file_source.py
+++ b/test/integration/test_vault_file_source.py
@@ -1,8 +1,7 @@
 import os
 import tempfile
 
-from sqlalchemy import select
-
+from galaxy.managers.users import get_user_by_email
 from galaxy.security.vault import UserVaultWrapper
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import DatasetPopulator
@@ -36,7 +35,7 @@ class TestVaultFileSourceIntegration(integration_util.IntegrationTestCase, integ
         app = self._app
 
         with self._different_user(email=self.USER_1_APP_VAULT_ENTRY):
-            user = self._get_user_by_email(self.USER_1_APP_VAULT_ENTRY)
+            user = get_user_by_email(self._app.model.session, self.USER_1_APP_VAULT_ENTRY)
             user_vault = UserVaultWrapper(app.vault, user)
             # use a valid symlink path so the posix list succeeds
             user_vault.write_secret("posix/root_path", app.config.user_library_import_symlink_allowlist[0])
@@ -48,7 +47,7 @@ class TestVaultFileSourceIntegration(integration_util.IntegrationTestCase, integ
             print(remote_files)
 
         with self._different_user(email=self.USER_2_APP_VAULT_ENTRY):
-            user = self._get_user_by_email(self.USER_2_APP_VAULT_ENTRY)
+            user = get_user_by_email(self._app.model.session, self.USER_2_APP_VAULT_ENTRY)
             user_vault = UserVaultWrapper(app.vault, user)
             # use an invalid symlink path so the posix list fails
             user_vault.write_secret("posix/root_path", "/invalid/root")
@@ -69,7 +68,7 @@ class TestVaultFileSourceIntegration(integration_util.IntegrationTestCase, integ
         app.vault.write_secret("posix/root_path", app.config.user_library_import_symlink_allowlist[0])
 
         with self._different_user(email=self.USER_1_APP_VAULT_ENTRY):
-            user = self._get_user_by_email(self.USER_1_APP_VAULT_ENTRY)
+            user = get_user_by_email(self._app.model.session, self.USER_1_APP_VAULT_ENTRY)
             user_vault = UserVaultWrapper(app.vault, user)
             # use a valid symlink path so the posix list succeeds
             user_vault.write_secret("posix/root_path", app.config.user_library_import_symlink_allowlist[0])
@@ -81,7 +80,7 @@ class TestVaultFileSourceIntegration(integration_util.IntegrationTestCase, integ
             print(remote_files)
 
         with self._different_user(email=self.USER_2_APP_VAULT_ENTRY):
-            user = self._get_user_by_email(self.USER_2_APP_VAULT_ENTRY)
+            user = get_user_by_email(self._app.model.session, self.USER_2_APP_VAULT_ENTRY)
             user_vault = UserVaultWrapper(app.vault, user)
             # use an invalid symlink path so the posix list would fail if used
             user_vault.write_secret("posix/root_path", "/invalid/root")
@@ -95,7 +94,7 @@ class TestVaultFileSourceIntegration(integration_util.IntegrationTestCase, integ
     def test_upload_file_from_remote_source(self):
         with self._different_user(email=self.USER_1_APP_VAULT_ENTRY):
             app = self._app
-            user = self._get_user_by_email(self.USER_1_APP_VAULT_ENTRY)
+            user = get_user_by_email(self._app.model.session, self.USER_1_APP_VAULT_ENTRY)
             user_vault = UserVaultWrapper(app.vault, user)
             # use a valid symlink path so the posix list succeeds
             user_vault.write_secret("posix/root_path", app.config.user_library_import_symlink_allowlist[0])
@@ -120,7 +119,3 @@ class TestVaultFileSourceIntegration(integration_util.IntegrationTestCase, integ
                 new_dataset = self.dataset_populator.fetch(payload, assert_ok=True).json()["outputs"][0]
                 content = self.dataset_populator.get_history_dataset_content(history_id, dataset=new_dataset)
                 assert content == "I require access to the vault", content
-
-    def _get_user_by_email(self, email):
-        stmt = select(self._app.model.User).filter(self._app.model.User.email == email).limit(1)
-        return self._app.model.session.scalars(stmt).first()


### PR DESCRIPTION
## SA 2.0 ORM usage to-do:
- [x] lib/galaxy/actions
- [x] lib/galaxy/celery
- [ ] lib/galaxy/datatypes
- [ ] lib/galaxy/jobs
- [ ] lib/galaxy/managers
- [ ] lib/galaxy/metadata
- [ ] lib/galaxy/model
- [x] lib/galaxy/queue_worker
- [x] lib/galaxy/quota
- [x] lib/galaxy/security
- [ ] lib/galaxy/tool_shed
- [x] lib/galaxy/util
- [x] lib/galaxy/visualization
- [ ] lib/galaxy/web
- [x] lib/galaxy/webapps/base
- [x] lib/galaxy/webapps/galaxy/api
- [ ] lib/galaxy/webapps/galaxy/controllers
- [x] lib/galaxy/webapps/galaxy/services
- [x] lib/galaxy/webapps/reports (except enable_eagerloads)
- [x] lib/galaxy/workflow
- [ ] lib/galaxy_test
- [ ] lib/tool_shed


## Requires more work:
- [ ] lib/galaxy/job_execution (requires addressing SessionlessContext, which implements a small subset of SQLAlchemy session's API)
- [x] lib/galaxy/tools (same as above: SessionlessContext)
- [ ] lib/galaxy/authnz (requires rewriting all the authnz unit tests, because they are all based on a mocked subset of SQLAlchemy)
- [ ] lib/galaxy/webapps/reports: handle `.query.enable_eagerloads()`
- [x] Fix the `FormDefinition.to_dict` bug ([ref](https://app.element.io/#/room/#galaxyproject_backend:gitter.im/$TJCv12X_UdHUSYQXTvERHD1R7dTIZFQPPWbePf2MkpQ)) 

Ref: #12541

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
