### PR TITLE
[23.1] Fix multi-broadcast overlap

### DIFF
--- a/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.test.ts
+++ b/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.test.ts
@@ -1,0 +1,81 @@
+import { setActivePinia } from "pinia";
+import flushPromises from "flush-promises";
+import { getLocalVue } from "@tests/jest/helpers";
+import { createTestingPinia } from "@pinia/testing";
+import BroadcastsOverlay from "./BroadcastsOverlay.vue";
+import { shallowMount } from "@vue/test-utils";
+import { type BroadcastNotification, useBroadcastsStore } from "@/stores/broadcastsStore";
+
+const localVue = getLocalVue(true);
+
+const now = new Date();
+const inTwoMonths = new Date(now.setMonth(now.getMonth() + 2));
+
+function generateBroadcastNotification(id: string): BroadcastNotification {
+    return {
+        id: id,
+        create_time: now.toISOString(),
+        update_time: now.toISOString(),
+        publication_time: now.toISOString(),
+        expiration_time: inTwoMonths.toISOString(),
+        source: "testing",
+        variant: "info",
+        content: {
+            subject: `Test subject ${id}`,
+            message: `Test message ${id}`,
+        },
+    };
+}
+
+const FAKE_BROADCASTS: BroadcastNotification[] = [
+    generateBroadcastNotification("1"),
+    generateBroadcastNotification("2"),
+];
+
+async function mountBroadcastsOverlayWith(broadcasts: BroadcastNotification[] = []) {
+    const pinia = createTestingPinia();
+    setActivePinia(pinia);
+
+    const broadcastsStore = useBroadcastsStore();
+    broadcastsStore.broadcasts = broadcasts;
+
+    const spyOnDismissBroadcast = jest.spyOn(broadcastsStore, "dismissBroadcast");
+    spyOnDismissBroadcast.mockImplementation(async (broadcast) => {
+        broadcastsStore.broadcasts = broadcastsStore.broadcasts.filter((b) => b.id !== broadcast.id);
+    });
+
+    const wrapper = shallowMount(BroadcastsOverlay, {
+        localVue,
+        pinia,
+    });
+
+    await flushPromises();
+    return wrapper;
+}
+
+describe("BroadcastsOverlay.vue", () => {
+    it("should not render anything when there is no broadcast", async () => {
+        const wrapper = await mountBroadcastsOverlayWith();
+
+        expect(wrapper.exists()).toBe(true);
+        expect(wrapper.html()).toBe("");
+    });
+
+    it("should render only one broadcast at a time", async () => {
+        const wrapper = await mountBroadcastsOverlayWith(FAKE_BROADCASTS);
+        expect(wrapper.findAll(".broadcast-message")).toHaveLength(1);
+        expect(wrapper.find(".broadcast-message").text()).toContain("Test message 1");
+    });
+
+    it("should render the next broadcast when the current one is dismissed", async () => {
+        const wrapper = await mountBroadcastsOverlayWith(FAKE_BROADCASTS);
+        expect(wrapper.findAll(".broadcast-message")).toHaveLength(1);
+        expect(wrapper.find(".broadcast-message").text()).toContain("Test message 1");
+
+        const dismissButton = wrapper.find("#dismiss-button");
+        await dismissButton.trigger("click");
+
+        expect(wrapper.findAll(".broadcast-message")).toHaveLength(1);
+        expect(wrapper.find(".broadcast-message").text()).toContain("Test message 2");
+    });
+});

--- a/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.vue
+++ b/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.vue
@@ -95,7 +95,11 @@ function onDismiss(item: BroadcastNotification) {
                 </BRow>
             </BCol>
             <BCol cols="auto" align-self="center" class="p-0">
-                <BButton variant="light" class="align-items-center d-flex" @click="onDismiss(currentBroadcast)">
+                <BButton
+                    id="dismiss-button"
+                    variant="light"
+                    class="align-items-center d-flex"
+                    @click="onDismiss(currentBroadcast)">
                     <FontAwesomeIcon class="mx-1" icon="times" />
                     Dismiss
                 </BButton>

--- a/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.vue
+++ b/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
-import { storeToRefs } from "pinia";
-import { BButton } from "bootstrap-vue";
-import { useRouter } from "vue-router/composables";
-import { useMarkdown } from "@/composables/markdown";
-import Heading from "@/components/Common/Heading.vue";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faInfoCircle, faTimes } from "@fortawesome/free-solid-svg-icons";
-import { useBroadcastsStore, type BroadcastNotification } from "@/stores/broadcastsStore";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { BButton } from "bootstrap-vue";
+import { storeToRefs } from "pinia";
+import { computed } from "vue";
+import { useRouter } from "vue-router/composables";
+
+import { useMarkdown } from "@/composables/markdown";
+import { type BroadcastNotification, useBroadcastsStore } from "@/stores/broadcastsStore";
+
+import Heading from "@/components/Common/Heading.vue";
 
 library.add(faInfoCircle, faTimes);
 
@@ -16,6 +19,16 @@ const router = useRouter();
 const broadcastsStore = useBroadcastsStore();
 const { activeBroadcasts } = storeToRefs(useBroadcastsStore());
 const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
+
+const currentBroadcast = computed(() => getNextActiveBroadcast());
+
+function getNextActiveBroadcast(): BroadcastNotification | undefined {
+    return activeBroadcasts.value.sort(sortByPublicationTime).at(0);
+}
+
+function sortByPublicationTime(a: BroadcastNotification, b: BroadcastNotification) {
+    return new Date(a.publication_time).getTime() - new Date(b.publication_time).getTime();
+}
 
 function getBroadcastVariant(item: BroadcastNotification) {
     switch (item.variant) {
@@ -32,58 +45,57 @@ function onActionClick(item: BroadcastNotification, link: string) {
     } else {
         window.open(link, "_blank");
     }
+    onDismiss(item);
+}
+
+function onDismiss(item: BroadcastNotification) {
     broadcastsStore.dismissBroadcast(item);
 }
 </script>
 
 <template>
-    <div v-if="activeBroadcasts.length > 0">
-        <div v-for="broadcast in activeBroadcasts" :key="broadcast.id">
-            <BRow
-                align-v="center"
-                class="broadcast-banner m-0"
-                :class="{ 'non-urgent': broadcast.variant !== 'urgent' }">
-                <BCol cols="auto">
-                    <FontAwesomeIcon
-                        class="mx-2"
-                        fade
-                        size="2xl"
-                        :class="`text-${getBroadcastVariant(broadcast)}`"
-                        :icon="faInfoCircle" />
-                </BCol>
-                <BCol>
-                    <BRow align-v="center">
-                        <Heading size="md" bold>
-                            {{ broadcast.content.subject }}
-                        </Heading>
-                    </BRow>
-                    <BRow align-v="center">
-                        <span class="broadcast-message" v-html="renderMarkdown(broadcast.content.message)" />
-                    </BRow>
-                    <BRow>
-                        <div v-if="broadcast.content.action_links">
-                            <BButton
-                                v-for="actionLink in broadcast.content.action_links"
-                                :key="actionLink.action_name"
-                                :title="actionLink.action_name"
-                                variant="primary"
-                                @click="onActionClick(broadcast, actionLink.link)">
-                                {{ actionLink.action_name }}
-                            </BButton>
-                        </div>
-                    </BRow>
-                </BCol>
-                <BCol cols="auto" align-self="center" class="p-0">
-                    <BButton
-                        variant="light"
-                        class="align-items-center d-flex"
-                        @click="broadcastsStore.dismissBroadcast(broadcast)">
-                        <FontAwesomeIcon class="mx-1" icon="times" />
-                        Dismiss
-                    </BButton>
-                </BCol>
-            </BRow>
-        </div>
+    <div v-if="currentBroadcast">
+        <BRow
+            align-v="center"
+            class="broadcast-banner m-0"
+            :class="{ 'non-urgent': currentBroadcast.variant !== 'urgent' }">
+            <BCol cols="auto">
+                <FontAwesomeIcon
+                    class="mx-2"
+                    fade
+                    size="2xl"
+                    :class="`text-${getBroadcastVariant(currentBroadcast)}`"
+                    :icon="faInfoCircle" />
+            </BCol>
+            <BCol>
+                <BRow align-v="center">
+                    <Heading size="md" bold>
+                        {{ currentBroadcast.content.subject }}
+                    </Heading>
+                </BRow>
+                <BRow align-v="center">
+                    <span class="broadcast-message" v-html="renderMarkdown(currentBroadcast.content.message)" />
+                </BRow>
+                <BRow>
+                    <div v-if="currentBroadcast.content.action_links">
+                        <BButton
+                            v-for="actionLink in currentBroadcast.content.action_links"
+                            :key="actionLink.action_name"
+                            :title="actionLink.action_name"
+                            variant="primary"
+                            @click="onActionClick(currentBroadcast, actionLink.link)">
+                            {{ actionLink.action_name }}
+                        </BButton>
+                    </div>
+                </BRow>
+            </BCol>
+            <BCol cols="auto" align-self="center" class="p-0">
+                <BButton variant="light" class="align-items-center d-flex" @click="onDismiss(currentBroadcast)">
+                    <FontAwesomeIcon class="mx-1" icon="times" />
+                    Dismiss
+                </BButton>
+            </BCol>
+        </BRow>
     </div>
 </template>
 

--- a/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.vue
+++ b/client/src/components/Notifications/Broadcasts/BroadcastsOverlay.vue
@@ -22,6 +22,11 @@ const { renderMarkdown } = useMarkdown({ openLinksInNewPage: true });
 
 const currentBroadcast = computed(() => getNextActiveBroadcast());
 
+const remainingBroadcastsCountText = computed(() => {
+    const count = activeBroadcasts.value.length - 1;
+    return count > 0 ? `${count} more` : "";
+});
+
 function getNextActiveBroadcast(): BroadcastNotification | undefined {
     return activeBroadcasts.value.sort(sortByPublicationTime).at(0);
 }
@@ -94,6 +99,9 @@ function onDismiss(item: BroadcastNotification) {
                     <FontAwesomeIcon class="mx-1" icon="times" />
                     Dismiss
                 </BButton>
+                <div v-if="remainingBroadcastsCountText" class="text-center mt-2">
+                    {{ remainingBroadcastsCountText }}...
+                </div>
             </BCol>
         </BRow>
     </div>


### PR DESCRIPTION
Fixes #16363

When there are multiple un-dismissed broadcasts they now show one after the other.


https://github.com/galaxyproject/galaxy/assets/46503462/3f71f5d1-28d9-4fb6-bfb2-e0a7258f4c63



**Bonus**: display an indicator with the remaining messages to appear to help manage the expectations when dismissing.

![Screenshot from 2023-07-24 14-16-36](https://github.com/galaxyproject/galaxy/assets/46503462/f9c9a90f-63ab-4833-99fe-f449e6463ae4)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Create a couple of broadcast notifications as admin.
     Here is a simple [Rest-client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) script as an example:
     ```
      @host = 127.0.0.1:8080
      @admin_key = <your admin key>
      
      ### Create a new BROADCAST notification
      POST http://{{host}}/api/notifications/broadcast HTTP/1.1
      x-api-key: {{admin_key}}
      content-type: application/json
      
      {
        "source": "admin",
        "variant": "info",
        "content": {
          "subject": "Galaxy Server Upgrade",
          "message": "Dear users,\n\nWe're excited to announce a major upgrade to the Galaxy server!\n\nThe new version includes several performance enhancements and new tools to boost your data analysis experience. The upgrade is scheduled for next week, and during this time, the server will be temporarily unavailable. We apologize for any inconvenience and thank you for your understanding.\n\nHappy analyzing!\nThe Galaxy Team!\n\n![Galaxy Logo](http://127.0.0.1:8081/static/favicon.svg)\n\n"
        }
      }
      
      # {
      #   "source": "admin",
      #   "variant": "warning",
      #   "content": {
      #     "subject": "Important: Data Cleanup",
      #     "message": "Attention all users,\n\nWe've noticed that the server's storage space is reaching its limit. To ensure smooth operations and accommodate new data, we will be performing a data cleanup process. Any data older than six months that hasn't been accessed will be permanently deleted.\n\nPlease make sure to download and back up any critical data you wish to retain before the cleanup, which is scheduled for the end of this month.\n\nThank you for your cooperation,\nThe Galaxy Team\n\n![Galaxy Logo](http://127.0.0.1:8081/static/favicon.svg)"
      #   }
      # }
     ```
  - Ensure only one is shown at a time and the next one is shown after dismissing the previous.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
