### PR TITLE
pin fs.dropboxfs to >=1

### DIFF
--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -2,7 +2,7 @@
   id: dropbox1
   label: Dropbox files (configure access in user preferences)
   doc: Your Dropbox files - configure an access token via the user preferences
-  accessToken: ${user.preferences['dropbox|access_token']}
+  access_token: ${user.preferences['dropbox|access_token']}
 
 - type: webdav
   id: owncloud1

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -17,7 +17,7 @@ total-perspective-vortex>=2.2.4,<3
 
 # For file sources plugins
 fs.webdavfs>=0.4.2  # type: webdav
-fs.dropboxfs  # type: dropbox
+fs.dropboxfs>=1.0  # type: dropbox
 fs.sshfs  # type: ssh
 fs.anvilfs # type: anvil
 fs.googledrivefs # type: googledrive

--- a/lib/galaxy/files/sources/dropbox.py
+++ b/lib/galaxy/files/sources/dropbox.py
@@ -1,11 +1,7 @@
 try:
     from fs.dropboxfs import DropboxFS
 except ImportError:
-    # fs.dropboxfs < 0.3
-    try:
-        from dropboxfs.dropboxfs import DropboxFS
-    except ImportError:
-        DropboxFS = None
+    DropboxFS = None
 
 from typing import (
     Optional,

--- a/lib/galaxy/files/sources/dropbox.py
+++ b/lib/galaxy/files/sources/dropbox.py
@@ -23,6 +23,10 @@ class DropboxFilesSource(PyFilesystem2FilesSource):
     def _open_fs(self, user_context=None, opts: Optional[FilesSourceOptions] = None):
         props = self._serialization_props(user_context)
         extra_props: Union[FilesSourceProperties, dict] = opts.extra_props or {} if opts else {}
+        # accessToken has been renamed to access_token in fs.dropboxfs 1.0
+        if "accessToken" in props:
+            props["access_token"] = props.pop("accessToken")
+
         handle = DropboxFS(**{**props, **extra_props})
         return handle
 


### PR DESCRIPTION
with 1.0 some breaking changes were implemented e.g. `accessToken` was renamed to `access_token` in the constructor of `DropboxFS`

Noticed this during my upgrade to 23.0. But I still can't get it running

```
galaxy.managers.remote_files WARNING 2023-07-24 20:23:00,388 [pN:main.3,p:23686,tN:MainThread] Problem listing file source path FileSourcePath(file_source=<galaxy.files.sources.dropbox.DropboxFilesSource object at 0x7f300fe94f50>, path='
/')
Traceback (most recent call last):
  File "/gpfs1/data/galaxy_server/galaxy/lib/galaxy/managers/remote_files.py", line 82, in index
    index = file_source.list(file_source_path.path, recursive=recursive, user_context=user_file_source_context)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs1/data/galaxy_server/galaxy/lib/galaxy/files/sources/__init__.py", line 148, in list
    return self._list(path, recursive, user_context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs1/data/galaxy_server/galaxy/lib/galaxy/files/sources/_pyfilesystem2.py", line 50, in _list
    res = h.scandir(path, namespaces=["details"])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs1/data/galaxy_server/galaxy/.venv/lib/python3.11/site-packages/fs/dropboxfs/dropboxfs.py", line 297, in scandir
    result = self.dropbox.files_list_folder(path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs1/data/galaxy_server/galaxy/.venv/lib/python3.11/site-packages/dropbox/base.py", line 2145, in files_list_folder
    r = self.request(
        ^^^^^^^^^^^^^
  File "/gpfs1/data/galaxy_server/galaxy/.venv/lib/python3.11/site-packages/dropbox/dropbox_client.py", line 326, in request
    res = self.request_json_string_with_retry(host,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs1/data/galaxy_server/galaxy/.venv/lib/python3.11/site-packages/dropbox/dropbox_client.py", line 476, in request_json_string_with_retry
    return self.request_json_string(host,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gpfs1/data/galaxy_server/galaxy/.venv/lib/python3.11/site-packages/dropbox/dropbox_client.py", line 596, in request_json_string
    self.raise_dropbox_error_for_resp(r)
  File "/gpfs1/data/galaxy_server/galaxy/.venv/lib/python3.11/site-packages/dropbox/dropbox_client.py", line 639, in raise_dropbox_error_for_resp
    raise AuthError(request_id, err)
dropbox.exceptions.AuthError: AuthError('da1281c09c6442a4b16d12b4c8c398d3', AuthError('invalid_access_token', None))
```

Apparently, I fail at generating a proper access token. Does anyone has a working doc / howto? Or the code is still wrong somewhere.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
