### PR TITLE
Fix labeler for UI UX labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -63,8 +63,8 @@ area/toolshed:
   - lib/toolshed/**/*
   - templates/webapps/tool_shed/**/*
 area/UI-UX:
-  - any: ["client/src/**/*", "templates/**/*"]
-    all: ["!client/src/schema/schema.ts"]
+  - all: ["client/src/**/*", "!client/src/schema/schema.ts"]
+    any: ["templates/**/*"]
 area/util:
   - lib/galaxy/util/**/*
 area/visualizations:


### PR DESCRIPTION
The previous changes of excluding schema seem to have broken labeler for the ui/ux label. Reading through the labeler PR which added this feature, I think I have identified the issue.

## How to test the changes?
I don't know. Open to suggestions!

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
