### PR TITLE
[23.0] Fix static file serving for ``robots.txt`` and ``favicon.ico`` when using per_host settings

### DIFF
--- a/lib/galaxy/web/framework/middleware/static.py
+++ b/lib/galaxy/web/framework/middleware/static.py
@@ -18,7 +18,10 @@ class CacheableStaticURLParser(StaticURLParser):
 
     def __call__(self, environ, start_response):
         path_info = environ.get("PATH_INFO", "")
-        if not path_info:
+        script_name = environ.get("SCRIPT_NAME", "")
+        if script_name == "/robots.txt" or script_name == "/favicon.ico":
+            filename = script_name.replace("/", "")
+        elif not path_info:
             # See if this is a static file hackishly mapped.
             if os.path.exists(self.directory) and os.path.isfile(self.directory):
                 app = FileApp(self.directory)
@@ -26,7 +29,7 @@ class CacheableStaticURLParser(StaticURLParser):
                     app.cache_control(max_age=int(self.cache_seconds))
                 return app(environ, start_response)
             return self.add_slash(environ, start_response)
-        if path_info == "/":
+        elif path_info == "/":
             # @@: This should obviously be configurable
             filename = "index.html"
         else:

--- a/lib/galaxy/web/framework/middleware/static.py
+++ b/lib/galaxy/web/framework/middleware/static.py
@@ -39,7 +39,7 @@ class CacheableStaticURLParser(StaticURLParser):
         host = environ.get("HTTP_HOST")
         if self.directory_per_host and host:
             for host_key, host_val in self.directory_per_host.items():
-                if host_key in host:
+                if host_key == host:
                     directory = host_val
                     break
 


### PR DESCRIPTION
Fixes for static files `robots.txt` and `favicon.ico` and for the host matching (domain shouldn't match all subdomains).
Closes:
 - https://github.com/galaxyproject/galaxy/issues/16429

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows: See the issue above

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
