### PR TITLE
Never consider `_galaxy_` conda env as unused

### DIFF
--- a/lib/galaxy/tool_util/deps/resolvers/conda.py
+++ b/lib/galaxy/tool_util/deps/resolvers/conda.py
@@ -340,6 +340,8 @@ class CondaDependencyResolver(
         dir_contents = set(
             os.listdir(self.conda_context.envs_path) if os.path.exists(self.conda_context.envs_path) else []
         )
+        # never delete Galaxy's conda env
+        used_paths.add("_galaxy_")
         unused_paths = dir_contents.difference(used_paths)  # New set with paths in dir_contents but not in used_paths
         unused_paths = [os.path.join(self.conda_context.envs_path, p) for p in unused_paths]
         return unused_paths


### PR DESCRIPTION
used via `/api/dependency_resolvers/unused_paths`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
