### PR TITLE
[22.05] Bump version of chromedriver setup action

### DIFF
--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -21,8 +21,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  setup-selenium:
+    uses: ./.github/workflows/setup_selenium.yaml
   test:
     name: Test
+    needs: setup-selenium
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -66,7 +69,6 @@ jobs:
       - uses: mvdbeek/gha-yarn-cache@master
         with:
           yarn-lock-file: 'galaxy root/client/yarn.lock'
-      - uses: nanasess/setup-chromedriver@v1
       - name: Run tests
         run: ./run_tests.sh --coverage -integration test/integration_selenium
         working-directory: 'galaxy root'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -66,7 +66,7 @@ jobs:
       - uses: mvdbeek/gha-yarn-cache@master
         with:
           yarn-lock-file: 'galaxy root/client/yarn.lock'
-      - uses: nanasess/setup-chromedriver@v1
+      - uses: nanasess/setup-chromedriver@v2
       - name: Run tests
         run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -66,7 +66,8 @@ jobs:
       - uses: mvdbeek/gha-yarn-cache@master
         with:
           yarn-lock-file: 'galaxy root/client/yarn.lock'
-      - uses: nanasess/setup-chromedriver@v2
+      - run: npx @puppeteer/browsers install chrome@stable
+      - run: npx @puppeteer/browsers install chromedriver@stable
       - name: Run tests
         run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -66,8 +66,7 @@ jobs:
       - uses: mvdbeek/gha-yarn-cache@master
         with:
           yarn-lock-file: 'galaxy root/client/yarn.lock'
-      - run: npx @puppeteer/browsers install chrome@stable
-      - run: npx @puppeteer/browsers install chromedriver@stable
+      - uses: mvdbeek/setup-chromedriver@chromedriver_puppeteer
       - name: Run tests
         run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -21,8 +21,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  setup-selenium:
+    uses: ./.github/workflows/setup_selenium.yaml
   test:
     name: Test
+    needs: setup-selenium
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -66,7 +69,6 @@ jobs:
       - uses: mvdbeek/gha-yarn-cache@master
         with:
           yarn-lock-file: 'galaxy root/client/yarn.lock'
-      - uses: mvdbeek/setup-chromedriver@chromedriver_puppeteer
       - name: Run tests
         run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -23,8 +23,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  setup-selenium:
+    uses: ./.github/workflows/setup_selenium.yaml
   test:
     name: Test
+    needs: setup-selenium
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -68,7 +71,6 @@ jobs:
       - uses: mvdbeek/gha-yarn-cache@master
         with:
           yarn-lock-file: 'galaxy root/client/yarn.lock'
-      - uses: nanasess/setup-chromedriver@v2
       - name: Run tests
         run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -68,7 +68,7 @@ jobs:
       - uses: mvdbeek/gha-yarn-cache@master
         with:
           yarn-lock-file: 'galaxy root/client/yarn.lock'
-      - uses: nanasess/setup-chromedriver@v1
+      - uses: nanasess/setup-chromedriver@v2
       - name: Run tests
         run: ./run_tests.sh --coverage -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'

--- a/.github/workflows/setup_selenium.yaml
+++ b/.github/workflows/setup_selenium.yaml
@@ -1,0 +1,8 @@
+on:
+  workflow_call:
+jobs:
+  setup_chromedriver:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install chromedriver
+        uses: mvdbeek/setup-chromedriver@chromedriver_puppeteer


### PR DESCRIPTION
Saw a failure on https://github.com/galaxyproject/galaxy/pull/15933, not sure if related.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
