### PR TITLE
[23.1] Fix error_reports linting

### DIFF
--- a/lib/galaxy/tools/error_reports/plugins/github.py
+++ b/lib/galaxy/tools/error_reports/plugins/github.py
@@ -99,8 +99,7 @@ class GithubPlugin(BaseGitPlugin):
             else:
                 self._append_issue(issue_cache_key, error_title, error_message)
             return (
-                "Submitted error report to GitHub. Your issue number is [#%s](%s/%s/issues/%s)"
-                % (
+                "Submitted error report to GitHub. Your issue number is [#{}]({}/{}/issues/{})".format(
                     self.issue_cache[issue_cache_key][error_title].number,
                     self.github_base_url,
                     github_projecturl,

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -185,8 +185,7 @@ class GitLabPlugin(BaseGitPlugin):
                         )
 
                 return (
-                    "Submitted error report to GitLab. Your Issue number is [#%s](%s/%s/issues/%s)"
-                    % (
+                    "Submitted error report to GitLab. Your Issue number is [#{}]({}/{}/issues/{})".format(
                         self.issue_cache[issue_cache_key][error_title],
                         self.gitlab_base_url,
                         gitlab_projecturl,


### PR DESCRIPTION
Introduced while merging the 23.0 branch forward.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
