### PR TITLE
[23.1] Swap datatype&convert tab to a static 'datatypes' tab. 

### DIFF
--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -31,31 +31,8 @@
                             !result['metadata_disable']
                         ">
                         <template v-slot:title>
-                            <span v-if="!result['conversion_disable']">
-                                <font-awesome-icon icon="cog" class="mr-1" />{{ "Convert" | l }}
-                            </span>
-                            <span v-else>
-                                <font-awesome-icon icon="database" class="mr-1" />{{ "Datatypes" | l }}
-                            </span>
+                            <font-awesome-icon icon="database" class="mr-1" />{{ "Datatypes" | l }}
                         </template>
-                        <div v-if="!result['conversion_disable']" class="ui-portlet-section">
-                            <div class="portlet-header">
-                                <div class="portlet-title">
-                                    <font-awesome-icon icon="cog" class="portlet-title-icon fa-fw mr-1" />
-                                    <span class="portlet-title-text">
-                                        <b itemprop="name">{{ "Convert" | l }}</b>
-                                    </span>
-                                </div>
-                            </div>
-                            <div class="portlet-content">
-                                <FormDisplay :inputs="result['conversion_inputs']" @onChange="onConversion" />
-                                <div class="mt-2">
-                                    <b-button variant="primary" @click="submit('conversion', 'conversion')">
-                                        <font-awesome-icon icon="exchange-alt" class="mr-1" />{{ "Create Dataset" | l }}
-                                    </b-button>
-                                </div>
-                            </div>
-                        </div>
                         <div v-if="!result['datatype_disable']" class="ui-portlet-section">
                             <div class="portlet-header">
                                 <div class="portlet-title">
@@ -73,6 +50,24 @@
                                     </b-button>
                                     <b-button @click="submit('datatype', 'datatype_detect')">
                                         <font-awesome-icon icon="redo" class="mr-1" />{{ "Auto-detect" | l }}
+                                    </b-button>
+                                </div>
+                            </div>
+                        </div>
+                        <div v-if="!result['conversion_disable']" class="ui-portlet-section">
+                            <div class="portlet-header">
+                                <div class="portlet-title">
+                                    <font-awesome-icon icon="cog" class="portlet-title-icon fa-fw mr-1" />
+                                    <span class="portlet-title-text">
+                                        <b itemprop="name">{{ "Convert" | l }}</b>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="portlet-content">
+                                <FormDisplay :inputs="result['conversion_inputs']" @onChange="onConversion" />
+                                <div class="mt-2">
+                                    <b-button variant="primary" @click="submit('conversion', 'conversion')">
+                                        <font-awesome-icon icon="exchange-alt" class="mr-1" />{{ "Create Dataset" | l }}
                                     </b-button>
                                 </div>
                             </div>

--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -38,7 +38,7 @@
                                 <div class="portlet-title">
                                     <font-awesome-icon icon="database" class="portlet-title-icon fa-fw mr-1" />
                                     <span class="portlet-title-text">
-                                        <b itemprop="name">{{ "Datatypes" | l }}</b>
+                                        <b itemprop="name">{{ "Assign Datatype" | l }}</b>
                                     </span>
                                 </div>
                             </div>
@@ -59,7 +59,7 @@
                                 <div class="portlet-title">
                                     <font-awesome-icon icon="cog" class="portlet-title-icon fa-fw mr-1" />
                                     <span class="portlet-title-text">
-                                        <b itemprop="name">{{ "Convert" | l }}</b>
+                                        <b itemprop="name">{{ "Convert to Datatype" | l }}</b>
                                     </span>
                                 </div>
                             </div>


### PR DESCRIPTION
This reduces user confusion -- all datatype related stuff is now in this one tab that is consistently named.  Fixes https://github.com/galaxyproject/galaxy/issues/16151

I also reordered the form so that 'datatype' is first, followed by 'convert', since the latter is not always an option -- so stuff stays in a consistent order.

This could use some modernization, but let's target dev for that.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
