### PR TITLE
[23.1] Fix Storage Dashboard missing archived histories

### DIFF
--- a/client/src/components/User/DiskUsage/Management/Cleanup/categories.ts
+++ b/client/src/components/User/DiskUsage/Management/Cleanup/categories.ts
@@ -7,6 +7,8 @@ import {
     cleanupDiscardedHistories,
     fetchDiscardedHistories,
     fetchDiscardedHistoriesSummary,
+    fetchArchivedHistoriesSummary,
+    fetchArchivedHistories,
 } from "../services";
 import type { CleanupCategory } from "./model";
 
@@ -38,6 +40,24 @@ export function useCleanupCategories() {
                     ),
                     fetchSummary: fetchDiscardedHistoriesSummary,
                     fetchItems: fetchDiscardedHistories,
+                    cleanupItems: cleanupDiscardedHistories,
+                },
+            ],
+        },
+        {
+            id: "archived_items",
+            name: localize("Archived Items"),
+            operations: [
+                {
+                    id: "archived_histories",
+                    name: localize("Archived histories"),
+                    description: localize(
+                        "Archived histories are a good way to keep some of your important but not frequently used histories out of the way." +
+                            " But they can still take up space on the disk." +
+                            " Here you can quickly find and permanently remove those histories to free up some space"
+                    ),
+                    fetchSummary: fetchArchivedHistoriesSummary,
+                    fetchItems: fetchArchivedHistories,
                     cleanupItems: cleanupDiscardedHistories,
                 },
             ],

--- a/client/src/components/User/DiskUsage/Management/services.ts
+++ b/client/src/components/User/DiskUsage/Management/services.ts
@@ -71,7 +71,7 @@ export async function fetchDiscardedHistories(options?: PaginationOptions): Prom
 }
 
 const _cleanupDiscardedHistories = fetcher.path("/api/storage/histories").method("delete").create();
-
+// TODO rename, this removes histories in general, not just discarded ones
 export async function cleanupDiscardedHistories(items: CleanableItem[]) {
     try {
         const item_ids = items.map((item) => item.id);
@@ -82,4 +82,26 @@ export async function cleanupDiscardedHistories(items: CleanableItem[]) {
     } catch (error) {
         return new CleanupResult(undefined, items, error as string);
     }
+}
+
+const fetchArchivedHistoriesSummaryData = fetcher
+    .path("/api/storage/histories/archived/summary")
+    .method("get")
+    .create();
+
+export async function fetchArchivedHistoriesSummary(): Promise<CleanableSummary> {
+    const { data } = await fetchArchivedHistoriesSummaryData({});
+    return new CleanableSummary(data);
+}
+
+const fetchArchivedHistoriesData = fetcher.path("/api/storage/histories/archived").method("get").create();
+
+export async function fetchArchivedHistories(options?: PaginationOptions): Promise<CleanableItem[]> {
+    options = options ?? new PaginationOptions();
+    const { data } = await fetchArchivedHistoriesData({
+        offset: options.offset,
+        limit: options.limit,
+        order: options.order,
+    });
+    return data;
 }

--- a/client/src/components/User/DiskUsage/Visualizations/HistoriesStorageOverview.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/HistoriesStorageOverview.vue
@@ -87,6 +87,14 @@ function isRecoverableDataPoint(dataPoint?: DataValuePoint): boolean {
     return false;
 }
 
+function isArchivedDataPoint(dataPoint: DataValuePoint): boolean {
+    if (dataPoint) {
+        const historiesSizeSummary = historiesSizeSummaryMap.get(dataPoint.id);
+        return historiesSizeSummary?.archived || false;
+    }
+    return false;
+}
+
 function onViewHistory(historyId: string) {
     router.push({ name: "HistoryOverview", params: { historyId } });
 }
@@ -175,13 +183,17 @@ async function onPermanentlyDeleteHistory(historyId: string) {
                     </b-form-select>
                 </template>
                 <template v-slot:tooltip="{ data }">
-                    <RecoverableItemSizeTooltip :data="data" :is-recoverable="isRecoverableDataPoint(data)" />
+                    <RecoverableItemSizeTooltip
+                        :data="data"
+                        :is-recoverable="isRecoverableDataPoint(data)"
+                        :is-archived="isArchivedDataPoint(data)" />
                 </template>
                 <template v-slot:selection="{ data }">
                     <SelectedItemActions
                         :data="data"
                         item-type="history"
                         :is-recoverable="isRecoverableDataPoint(data)"
+                        :is-archived="isArchivedDataPoint(data)"
                         @view-item="onViewHistory"
                         @undelete-item="onUndeleteHistory"
                         @permanently-delete-item="onPermanentlyDeleteHistory" />

--- a/client/src/components/User/DiskUsage/Visualizations/RecoverableItemSizeTooltip.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/RecoverableItemSizeTooltip.vue
@@ -2,13 +2,21 @@
 import { bytesToString } from "@/utils/utils";
 import type { DataValuePoint } from "./Charts";
 import { computed } from "vue";
+import { faArchive } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+
+library.add(faArchive);
 
 interface RecoverableItemSizeTooltipProps {
     data: DataValuePoint;
     isRecoverable: boolean;
+    isArchived?: boolean;
 }
 
-const props = defineProps<RecoverableItemSizeTooltipProps>();
+const props = withDefaults(defineProps<RecoverableItemSizeTooltipProps>(), {
+    isArchived: false,
+});
 
 const label = computed(() => props.data?.label ?? "No data");
 const prettySize = computed(() => bytesToString(props.data?.value ?? 0));
@@ -17,6 +25,7 @@ const prettySize = computed(() => bytesToString(props.data?.value ?? 0));
     <div>
         <div class="h-md mx-2">{{ label }}</div>
         <b class="h-md m-2">{{ prettySize }}</b>
+        <div v-if="isArchived" class="text-muted mx-2"><FontAwesomeIcon icon="archive" /> This item is archived</div>
         <div v-if="isRecoverable" class="text-muted mx-2">Recoverable storage space</div>
     </div>
 </template>

--- a/client/src/components/User/DiskUsage/Visualizations/SelectedItemActions.vue
+++ b/client/src/components/User/DiskUsage/Visualizations/SelectedItemActions.vue
@@ -4,7 +4,7 @@ import { bytesToString } from "@/utils/utils";
 import localize from "@/utils/localization";
 import type { DataValuePoint } from "./Charts";
 import { computed } from "vue";
-import { faChartBar, faUndo, faTrash, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
+import { faChartBar, faUndo, faTrash, faInfoCircle, faArchive } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 
@@ -14,12 +14,14 @@ interface SelectedItemActionsProps {
     data: DataValuePoint;
     isRecoverable: boolean;
     itemType: ItemTypes;
+    isArchived?: boolean;
 }
 
-const props = defineProps<SelectedItemActionsProps>();
+const props = withDefaults(defineProps<SelectedItemActionsProps>(), {
+    isArchived: false,
+});
 
-//@ts-ignore bad library types
-library.add(faChartBar, faUndo, faTrash, faInfoCircle);
+library.add(faChartBar, faUndo, faTrash, faInfoCircle, faArchive);
 
 const label = computed(() => props.data?.label ?? "No data");
 const prettySize = computed(() => bytesToString(props.data?.value ?? 0));
@@ -49,6 +51,7 @@ function onPermanentlyDeleteItem() {
             <b>{{ label }}</b>
         </div>
         <div class="text-muted mx-2">
+            <span v-if="isArchived"><FontAwesomeIcon icon="archive" /> This {{ itemType }} is archived.</span><br />
             Total storage space taken: <b>{{ prettySize }}</b
             >.
             <span v-if="isRecoverable">

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -1259,6 +1259,14 @@ export interface paths {
          */
         delete: operations["cleanup_histories_api_storage_histories_delete"];
     };
+    "/api/storage/histories/archived": {
+        /** Returns archived histories owned by the given user that are not purged. The results can be paginated. */
+        get: operations["archived_histories_api_storage_histories_archived_get"];
+    };
+    "/api/storage/histories/archived/summary": {
+        /** Returns information with the total storage space taken by non-purged archived histories associated with the given user. */
+        get: operations["archived_histories_summary_api_storage_histories_archived_summary_get"];
+    };
     "/api/storage/histories/discarded": {
         /** Returns all discarded histories associated with the given user. */
         get: operations["discarded_histories_api_storage_histories_discarded_get"];
@@ -15636,6 +15644,60 @@ export interface operations {
             200: {
                 content: {
                     "application/json": components["schemas"]["StorageItemsCleanupResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archived_histories_api_storage_histories_archived_get: {
+        /** Returns archived histories owned by the given user that are not purged. The results can be paginated. */
+        parameters?: {
+            /** @description Starts at the beginning skip the first ( offset - 1 ) items and begin returning at the Nth item */
+            /** @description The maximum number of items to return. */
+            /** @description String containing one of the valid ordering attributes followed by '-asc' or '-dsc' for ascending and descending order respectively. */
+            query?: {
+                offset?: number;
+                limit?: number;
+                order?: components["schemas"]["StoredItemOrderBy"];
+            };
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["StoredItem"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archived_histories_summary_api_storage_histories_archived_summary_get: {
+        /** Returns information with the total storage space taken by non-purged archived histories associated with the given user. */
+        parameters?: {
+            /** @description The user ID that will be used to effectively make this API call. Only admins and designated users can make API calls on behalf of other users. */
+            header?: {
+                "run-as"?: string;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                content: {
+                    "application/json": components["schemas"]["CleanableItemsSummary"];
                 };
             };
             /** @description Validation Error */

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -1347,6 +1347,8 @@ class StorageCleanerManager(Protocol):
     Interface for monitoring storage usage and managing deletion/purging of objects that consume user's storage space.
     """
 
+    # TODO: refactor this interface to be more generic and allow for more types of cleanable items
+
     sort_map: Dict[StoredItemOrderBy, Any]
 
     def get_discarded_summary(self, user: model.User) -> CleanableItemsSummary:
@@ -1364,6 +1366,24 @@ class StorageCleanerManager(Protocol):
         order: Optional[StoredItemOrderBy],
     ) -> List[StoredItem]:
         """Returns a paginated list of items deleted by the given user that are not yet purged."""
+        raise NotImplementedError
+
+    def get_archived_summary(self, user: model.User) -> CleanableItemsSummary:
+        """Returns information with the total storage space taken by archived items for the given user.
+
+        Archived items are those that are not currently active. Some archived items may be purged already, but
+        this method does not return information about those.
+        """
+        raise NotImplementedError
+
+    def get_archived(
+        self,
+        user: model.User,
+        offset: Optional[int],
+        limit: Optional[int],
+        order: Optional[StoredItemOrderBy],
+    ) -> List[StoredItem]:
+        """Returns a paginated list of items archived by the given user that are not yet purged."""
         raise NotImplementedError
 
     def cleanup_items(self, user: model.User, item_ids: Set[int]) -> StorageItemsCleanupResult:

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -457,6 +457,40 @@ class HistoryStorageCleanerManager(StorageCleanerManager):
         discarded = [self._history_to_stored_item(item) for item in result]
         return discarded
 
+    # TODO reduce duplication
+
+    def get_archived_summary(self, user: model.User) -> CleanableItemsSummary:
+        stmt = select(func.sum(model.History.disk_size), func.count(model.History.id)).where(
+            model.History.user_id == user.id,
+            model.History.archived == true(),
+            model.History.purged == false(),
+        )
+        result = self.history_manager.session().execute(stmt).fetchone()
+        total_size = 0 if result[0] is None else result[0]
+        return CleanableItemsSummary(total_size=total_size, total_items=result[1])
+
+    def get_archived(
+        self,
+        user: model.User,
+        offset: Optional[int],
+        limit: Optional[int],
+        order: Optional[StoredItemOrderBy],
+    ) -> List[StoredItem]:
+        stmt = select(model.History).where(
+            model.History.user_id == user.id,
+            model.History.archived == true(),
+            model.History.purged == false(),
+        )
+        if offset:
+            stmt = stmt.offset(offset)
+        if limit:
+            stmt = stmt.limit(limit)
+        if order:
+            stmt = stmt.order_by(self.sort_map[order])
+        result = self.history_manager.session().execute(stmt).scalars()
+        archived = [self._history_to_stored_item(item) for item in result]
+        return archived
+
     def cleanup_items(self, user: model.User, item_ids: Set[int]) -> StorageItemsCleanupResult:
         success_item_count = 0
         total_free_bytes = 0
@@ -465,6 +499,7 @@ class HistoryStorageCleanerManager(StorageCleanerManager):
         for history_id in item_ids:
             try:
                 history = self.history_manager.get_owned(history_id, user)
+                self._unarchive_if_needed(history)
                 self.history_manager.purge(history, flush=False)
                 success_item_count += 1
                 total_free_bytes += int(history.disk_size)
@@ -482,6 +517,10 @@ class HistoryStorageCleanerManager(StorageCleanerManager):
             total_free_bytes=total_free_bytes,
             errors=errors,
         )
+
+    def _unarchive_if_needed(self, history: model.History):
+        if history.archived:
+            self.history_manager.restore_archived_history(history, force=True)
 
     def _history_to_stored_item(self, history: model.History) -> StoredItem:
         return StoredItem(

--- a/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/api/storage_cleaner.py
@@ -119,3 +119,26 @@ class FastAPIStorageCleaner:
         **Warning**: This operation cannot be undone. All objects will be deleted permanently from the disk.
         """
         return self.service.cleanup_items(trans, stored_item_type="dataset", item_ids=set(payload.item_ids))
+
+    @router.get(
+        "/api/storage/histories/archived/summary",
+        summary="Returns information with the total storage space taken by non-purged archived histories associated with the given user.",
+    )
+    def archived_histories_summary(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+    ) -> CleanableItemsSummary:
+        return self.service.get_archived_summary(trans, stored_item_type="history")
+
+    @router.get(
+        "/api/storage/histories/archived",
+        summary="Returns archived histories owned by the given user that are not purged. The results can be paginated.",
+    )
+    def archived_histories(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        offset: Optional[int] = OffsetQueryParam,
+        limit: Optional[int] = LimitQueryParam,
+        order: Optional[StoredItemOrderBy] = OrderQueryParam,
+    ) -> List[StoredItem]:
+        return self.service.get_archived(trans, "history", offset, limit, order)

--- a/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
+++ b/lib/galaxy/webapps/galaxy/services/storage_cleaner.py
@@ -51,6 +51,21 @@ class StorageCleanerService(ServiceBase):
         user = self.get_authenticated_user(trans)
         return self.storage_cleaner_map[stored_item_type].get_discarded(user, offset, limit, order)
 
+    def get_archived_summary(self, trans: ProvidesHistoryContext, stored_item_type: StoredItemType):
+        user = self.get_authenticated_user(trans)
+        return self.storage_cleaner_map[stored_item_type].get_archived_summary(user)
+
+    def get_archived(
+        self,
+        trans: ProvidesHistoryContext,
+        stored_item_type: StoredItemType,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+        order: Optional[StoredItemOrderBy] = None,
+    ):
+        user = self.get_authenticated_user(trans)
+        return self.storage_cleaner_map[stored_item_type].get_archived(user, offset, limit, order)
+
     def cleanup_items(self, trans: ProvidesHistoryContext, stored_item_type: StoredItemType, item_ids: Set[int]):
         user = self.get_authenticated_user(trans)
         return self.storage_cleaner_map[stored_item_type].cleanup_items(user, item_ids)


### PR DESCRIPTION
Fixes #16467

This adds the missing cleanup action for `Archived histories` in the Storage Dashboard and includes archived histories in the visualization charts. Without these changes, the users can get really confused with the storage quota if they happen to have archived histories. Sorry about that :pray: 

![image](https://github.com/galaxyproject/galaxy/assets/46503462/c94d2ec8-f4cf-44a4-8dd2-5439b0a15482)

![image](https://github.com/galaxyproject/galaxy/assets/46503462/e5d9a23d-e7fb-4d54-8a08-b7b9ef02df26)

![image](https://github.com/galaxyproject/galaxy/assets/46503462/de42d62b-0d76-461a-9807-15405653523e)


I've also identified some potential refactorings to reduce duplication now that there is a new "archived" flavor of the storage cleanup. I will follow up on `dev` with those when this is merged.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
