### PR TITLE
[23.1] Restore resolution of Conda environments generated from non-lowercase package names

### DIFF
--- a/lib/galaxy/tool_util/deps/__init__.py
+++ b/lib/galaxy/tool_util/deps/__init__.py
@@ -325,7 +325,7 @@ class DependencyManager:
     def uses_tool_shed_dependencies(self):
         return any(map(lambda r: isinstance(r, ToolShedPackageDependencyResolver), self.dependency_resolvers))
 
-    def find_dep(self, name, version=None, type="package", **kwds):
+    def find_dep(self, name: str, version: Optional[str] = None, type: str = "package", **kwds):
         log.debug(f"Find dependency {name} version {version}")
         requirements = ToolRequirements([ToolRequirement(name=name, version=version, type=type)])
         dep_dict = self._requirements_to_dependencies_dict(requirements, **kwds)

--- a/lib/galaxy/tool_util/deps/dependencies.py
+++ b/lib/galaxy/tool_util/deps/dependencies.py
@@ -122,13 +122,12 @@ class DependenciesDescription:
         return dict(
             requirements=[r.to_dict() for r in self.requirements],
             installed_tool_dependencies=[
-                DependenciesDescription._toolshed_install_dependency_to_dict(d)
-                for d in self.installed_tool_dependencies
+                self._toolshed_install_dependency_to_dict(d) for d in self.installed_tool_dependencies
             ],
         )
 
-    @staticmethod
-    def from_dict(as_dict):
+    @classmethod
+    def from_dict(cls, as_dict):
         if as_dict is None:
             return None
 
@@ -136,11 +135,9 @@ class DependenciesDescription:
         requirements = ToolRequirements.from_list(requirements_dicts)
         installed_tool_dependencies_dicts = as_dict.get("installed_tool_dependencies", [])
         installed_tool_dependencies = list(
-            map(DependenciesDescription._toolshed_install_dependency_from_dict, installed_tool_dependencies_dicts)
+            map(cls._toolshed_install_dependency_from_dict, installed_tool_dependencies_dicts)
         )
-        return DependenciesDescription(
-            requirements=requirements, installed_tool_dependencies=installed_tool_dependencies
-        )
+        return cls(requirements=requirements, installed_tool_dependencies=installed_tool_dependencies)
 
     @staticmethod
     def _toolshed_install_dependency_from_dict(as_dict):

--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -37,7 +37,7 @@ class ToolRequirement:
 
     def __init__(
         self,
-        name: Optional[str] = None,
+        name: str,
         type: Optional[str] = None,
         version: Optional[str] = None,
         specs: Optional[Iterable["RequirementSpecification"]] = None,
@@ -56,13 +56,13 @@ class ToolRequirement:
     def copy(self) -> "ToolRequirement":
         return copy.deepcopy(self)
 
-    @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "ToolRequirement":
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "ToolRequirement":
         version = d.get("version")
-        name = d.get("name")
+        name = d["name"]
         type = d.get("type")
         specs = [RequirementSpecification.from_dict(s) for s in d.get("specs", [])]
-        return ToolRequirement(name=name, type=type, version=version, specs=specs)
+        return cls(name=name, type=type, version=version, specs=specs)
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -99,11 +99,11 @@ class RequirementSpecification:
     def to_dict(self) -> Dict[str, Any]:
         return dict(uri=self.uri, version=self.version)
 
-    @staticmethod
-    def from_dict(dict) -> "RequirementSpecification":
-        uri = dict.get("uri")
+    @classmethod
+    def from_dict(cls, dict: Dict) -> "RequirementSpecification":
+        uri = dict["uri"]
         version = dict.get("version", None)
-        return RequirementSpecification(uri=uri, version=version)
+        return cls(uri=uri, version=version)
 
     def __eq__(self, other: Any) -> bool:
         return self.uri == other.uri and self.version == other.version
@@ -127,9 +127,9 @@ class ToolRequirements:
         else:
             self.tool_requirements = OrderedSet()
 
-    @staticmethod
-    def from_list(requirements: List[Union[ToolRequirement, Dict[str, Any]]]) -> "ToolRequirements":
-        return ToolRequirements(requirements)
+    @classmethod
+    def from_list(cls, requirements: List[Union[ToolRequirement, Dict[str, Any]]]) -> "ToolRequirements":
+        return cls(requirements)
 
     @property
     def resolvable(self) -> "ToolRequirements":
@@ -208,13 +208,13 @@ class ContainerDescription:
             shell=self.shell,
         )
 
-    @staticmethod
-    def from_dict(dict: Dict[str, Any]) -> "ContainerDescription":
+    @classmethod
+    def from_dict(cls, dict: Dict[str, Any]) -> "ContainerDescription":
         identifier = dict["identifier"]
         type = dict.get("type", DEFAULT_CONTAINER_TYPE)
         resolve_dependencies = dict.get("resolve_dependencies", DEFAULT_CONTAINER_RESOLVE_DEPENDENCIES)
         shell = dict.get("shell", DEFAULT_CONTAINER_SHELL)
-        return ContainerDescription(
+        return cls(
             identifier=identifier,
             type=type,
             resolve_dependencies=resolve_dependencies,

--- a/lib/galaxy/tool_util/deps/resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/resolvers/__init__.py
@@ -9,13 +9,17 @@ from abc import (
 from typing import (
     Any,
     Dict,
+    List,
 )
 
 import yaml
 
 from galaxy.util import listify
 from galaxy.util.dictifiable import Dictifiable
-from ..requirements import ToolRequirement
+from ..requirements import (
+    ToolRequirement,
+    ToolRequirements,
+)
 
 
 class DependencyResolver(Dictifiable, metaclass=ABCMeta):
@@ -39,7 +43,7 @@ class DependencyResolver(Dictifiable, metaclass=ABCMeta):
     read_only = True
 
     @abstractmethod
-    def resolve(self, requirement, **kwds):
+    def resolve(self, requirement: ToolRequirement, **kwds) -> "Dependency":
         """Given inputs describing dependency in the abstract yield a Dependency object.
 
         The Dependency object describes various attributes (script, bin,
@@ -72,7 +76,7 @@ class MultipleDependencyResolver:
     """Variant of DependencyResolver that can optionally resolve multiple dependencies together."""
 
     @abstractmethod
-    def resolve_all(self, requirements, **kwds):
+    def resolve_all(self, requirements: ToolRequirements, **kwds) -> List["Dependency"]:
         """
         Given multiple requirements yields a list of Dependency objects if and only if they may all be resolved together.
 

--- a/test/unit/tool_util/test_conda_resolution.py
+++ b/test/unit/tool_util/test_conda_resolution.py
@@ -1,6 +1,8 @@
 import os.path
 import tempfile
 
+import pytest
+
 from galaxy.tool_util.deps import DependencyManager
 from galaxy.tool_util.deps.conda_util import (
     best_search_result,
@@ -9,10 +11,16 @@ from galaxy.tool_util.deps.conda_util import (
     install_conda,
     installed_conda_targets,
 )
-from galaxy.tool_util.deps.requirements import ToolRequirement
+from galaxy.tool_util.deps.requirements import (
+    ToolRequirement,
+    ToolRequirements,
+)
+from galaxy.tool_util.deps.resolvers import NullDependency
 from galaxy.tool_util.deps.resolvers.conda import (
+    CondaDependency,
     CondaDependencyResolver,
     DEFAULT_ENSURE_CHANNELS,
+    MergedCondaDependency,
 )
 from .util import external_dependency_management
 
@@ -27,25 +35,92 @@ def test_install_conda_build(tmp_path) -> None:
     assert cc.conda_build_available
 
 
-@external_dependency_management
-def test_conda_resolution(tmp_path) -> None:
-    job_dir = os.path.join(tmp_path, "000")
-    dependency_manager = DependencyManager(tmp_path)
-    resolver = CondaDependencyResolver(
+@pytest.fixture(scope="module")
+def resolver(tmp_path_factory):
+    dependency_manager = DependencyManager(tmp_path_factory.mktemp("dependencies"))
+    return CondaDependencyResolver(
         dependency_manager,
         auto_init=True,
         auto_install=True,
         use_path_exec=False,  # For the test ensure this is always a clean install
     )
+
+
+@external_dependency_management
+def test_single_package_resolution(resolver: CondaDependencyResolver) -> None:
+    # Test that a read-only resolver returns a NullDependency
     resolver.read_only = True
-    req = ToolRequirement(name="samtools", version=None, type="package")
-    dependency = resolver.resolve(req, job_directory=job_dir)
+    package_name = "eXpress"
+    req = ToolRequirement(name=package_name, version=None, type="package")
+    dependency = resolver.resolve(req)
+    assert isinstance(dependency, NullDependency)
     assert dependency.shell_commands() is None
 
+    # Test that a (fake) environment generated from a non-lowercase package name
+    # is still accepted by the resolver
+    env_path = resolver.conda_context.env_path(f"__{package_name}@_uv_")
+    os.mkdir(env_path)
+    dependency = resolver.resolve(req)
+    assert isinstance(dependency, CondaDependency)
+    assert dependency.name == package_name
+    assert dependency.version is None
+    assert dependency.exact
+    assert dependency.environment_path == env_path
+    os.rmdir(env_path)
+
+    # Test that a non-read-only resolver creates a conda environment (with a
+    # lowercase package name) and returns a CondaDependency
     resolver.read_only = False
-    req = ToolRequirement(name="samtools", version=None, type="package")
-    dependency = resolver.resolve(req, job_directory=job_dir)
+    dependency = resolver.resolve(req)
+    assert isinstance(dependency, CondaDependency)
+    assert dependency.name == package_name
+    assert dependency.version is None
+    assert dependency.exact
+    assert dependency.environment_path == resolver.conda_context.env_path(f"__{package_name.lower()}@_uv_")
     assert dependency.shell_commands() is not None
+
+
+@external_dependency_management
+def test_multi_package_resolution(resolver: CondaDependencyResolver) -> None:
+    # Test that a read-only resolver returns an empty list
+    resolver.read_only = True
+    reqs = ToolRequirements(
+        [
+            ToolRequirement(name="samtools", version=None, type="package"),
+            ToolRequirement(name="eXpress", version=None, type="package"),
+        ]
+    )
+    dependency_list = resolver.resolve_all(reqs)
+    assert dependency_list == []
+
+    # Test that a (fake) mulled environment generated from non-lowercase package
+    # names is still accepted by the resolver
+    env_path = resolver.conda_context.env_path(
+        "mulled-v1-37955d8b3667efa38f1fe42bc37b4c9a03e67a90f0055d1db9d388b2f98fe3a1"
+    )
+    os.mkdir(env_path)
+    dependency_list = resolver.resolve_all(reqs)
+    assert len(dependency_list) == 2
+    for dependency in dependency_list:
+        assert isinstance(dependency, MergedCondaDependency)
+        assert dependency.version is None
+        assert dependency.exact
+        assert dependency.environment_path == env_path
+    os.rmdir(env_path)
+
+    # Test that a non-read-only resolver creates a mulled conda environment
+    # (with a hash from lowercase package names) and returns a list of
+    # MergedCondaDependency
+    resolver.read_only = False
+    dependency_list = resolver.resolve_all(reqs)
+    assert len(dependency_list) == 2
+    for dependency in dependency_list:
+        assert isinstance(dependency, MergedCondaDependency)
+        assert dependency.version is None
+        assert dependency.exact
+        assert dependency.environment_path == resolver.conda_context.env_path(
+            "mulled-v1-f36491d362c22cdb24f7de3e1ff978a5ee02cadc8c12a12ae06bce57bbf0765c"
+        )
 
 
 @external_dependency_management


### PR DESCRIPTION
Fix https://github.com/galaxyproject/galaxy/issues/16435 .

Also:
- More type annotations for tool dependency resolution
- Turn some `from_dict()`/`from_list()` static methods to class methods.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
