### PR TITLE
[23.0] Linter: fix regex for profile version

### DIFF
--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -13,7 +13,7 @@ VALID_NAME_MSG = "Tool defines a name [%s]."
 ERROR_ID_MSG = "Tool does not define an id attribute."
 VALID_ID_MSG = "Tool defines an id [%s]."
 
-PROFILE_PATTERN = re.compile(r"^[12]\d\.(01|05|09|\d)$")
+PROFILE_PATTERN = re.compile(r"^[12]\d\.\d{1,2}$")
 PROFILE_INFO_DEFAULT_MSG = "Tool targets 16.01 Galaxy profile."
 PROFILE_INFO_SPECIFIED_MSG = "Tool specifies profile version [%s]."
 PROFILE_INVALID_MSG = "Tool specifies an invalid profile version [%s]."

--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -13,7 +13,7 @@ VALID_NAME_MSG = "Tool defines a name [%s]."
 ERROR_ID_MSG = "Tool does not define an id attribute."
 VALID_ID_MSG = "Tool defines an id [%s]."
 
-PROFILE_PATTERN = re.compile(r"^[1,2]\d\.[0,1]\d$")
+PROFILE_PATTERN = re.compile(r"^[12]\d\.(01|05|09|\d)$")
 PROFILE_INFO_DEFAULT_MSG = "Tool targets 16.01 Galaxy profile."
 PROFILE_INFO_SPECIFIED_MSG = "Tool specifies profile version [%s]."
 PROFILE_INVALID_MSG = "Tool specifies an invalid profile version [%s]."

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -109,6 +109,11 @@ GENERAL_VALID = """
 </tool>
 """
 
+GENERAL_VALID_NEW_PROFILE_FMT = """
+<tool name="valid name" id="valid_id" version="1.0+galaxy1" profile="23.0">
+</tool>
+"""
+
 # test tool xml for help linter
 HELP_MULTIPLE = """
 <tool>
@@ -1008,6 +1013,19 @@ def test_general_valid(lint_ctx):
     run_lint(lint_ctx, general.lint_general, XmlToolSource(tool_source))
     assert "Tool defines a version [1.0+galaxy1]." in lint_ctx.valid_messages
     assert "Tool specifies profile version [21.09]." in lint_ctx.valid_messages
+    assert "Tool defines an id [valid_id]." in lint_ctx.valid_messages
+    assert "Tool defines a name [valid name]." in lint_ctx.valid_messages
+    assert not lint_ctx.info_messages
+    assert len(lint_ctx.valid_messages) == 4
+    assert not lint_ctx.warn_messages
+    assert not lint_ctx.error_messages
+
+
+def test_general_valid_new_profile_fmt(lint_ctx):
+    tool_source = get_xml_tool_source(GENERAL_VALID_NEW_PROFILE_FMT)
+    run_lint(lint_ctx, general.lint_general, XmlToolSource(tool_source))
+    assert "Tool defines a version [1.0+galaxy1]." in lint_ctx.valid_messages
+    assert "Tool specifies profile version [23.0]." in lint_ctx.valid_messages
     assert "Tool defines an id [valid_id]." in lint_ctx.valid_messages
     assert "Tool defines a name [valid name]." in lint_ctx.valid_messages
     assert not lint_ctx.info_messages


### PR DESCRIPTION
- did not allow for new style profile versions (that may have only a single digit after the dot)
- fix: do not allow `,` in profile version

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
