### PR TITLE
[23.0] Adjust test_data_download method in GalaxyInteractorApi so an admin user is not required

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -453,9 +453,7 @@ class GalaxyInteractorApi:
 
         if self.supports_test_data_download:
             version_fragment = f"&tool_version={tool_version}" if tool_version else ""
-            response = self._get(
-                f"tools/{tool_id}/test_data_download?filename={filename}{version_fragment}", admin=True
-            )
+            response = self._get(f"tools/{tool_id}/test_data_download?filename={filename}{version_fragment}")
             if response.status_code == 200:
                 if mode == "file":
                     result = response.content


### PR DESCRIPTION
If I'm not mistaken `admin=True` shouldn't be necessary here, but if I'm wrong, feel free to close. 

## How to test the changes?
The context is trying to run a tool test with Planemo on an external Galaxy server with:

```
planemo t tool.xml --galaxy_url ... --galaxy_user_key ... --no_cleanup
```

which fails, whereas using `--galaxy_admin_key` succeeds. Using `--galaxy_user_key` is preferable, especially since it makes accessing the tool test history via the UI more straightforward.

To test, compare running the above command with and without this change.

(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
