### PR TITLE
Test that object store cache file gets updated

### DIFF
--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -57,8 +57,14 @@ class BaseObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase, i
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
 
+def get_files(directory):
+    for rel_directory, _, files in os.walk(directory):
+        for _file in files:
+            yield os.path.join(rel_directory, _file)
+
+
 def files_count(directory):
-    return sum(len(files) for _, _, files in os.walk(directory))
+    return sum(1 for _ in get_files(directory))
 
 
 @integration_util.skip_unless_docker()
@@ -85,7 +91,7 @@ class BaseSwiftObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase
         config_path = os.path.join(temp_directory, "object_store_conf.xml")
         config["object_store_store_by"] = "uuid"
         config["metadata_strategy"] = "extended"
-        config["outpus_to_working_dir"] = True
+        config["outputs_to_working_directory"] = True
         config["retry_metadata_internally"] = False
         with open(config_path, "w") as f:
             f.write(

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -59,8 +59,8 @@ class BaseObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase, i
 
 def get_files(directory):
     for rel_directory, _, files in os.walk(directory):
-        for _file in files:
-            yield os.path.join(rel_directory, _file)
+        for file_ in files:
+            yield os.path.join(rel_directory, file_)
 
 
 def files_count(directory):

--- a/test/integration/objectstore/test_objectstore_datatype_upload.py
+++ b/test/integration/objectstore/test_objectstore_datatype_upload.py
@@ -126,7 +126,7 @@ class BaseObjectstoreUploadTest(UploadTestDatatypeDataTestCase):
         cls.object_stores_parent = temp_directory
         cls.object_store_config_path = os.path.join(temp_directory, "object_store_conf.xml")
         config["metadata_strategy"] = "extended"
-        config["outpus_to_working_dir"] = True
+        config["outputs_to_working_directory"] = True
         config["retry_metadata_internally"] = False
         config["object_store_store_by"] = "uuid"
         with open(cls.object_store_config_path, "w") as f:

--- a/test/integration/objectstore/test_remote_objectstore_cache_operations.py
+++ b/test/integration/objectstore/test_remote_objectstore_cache_operations.py
@@ -6,6 +6,7 @@ import pytest
 from ._base import (
     BaseSwiftObjectStoreIntegrationTestCase,
     files_count,
+    get_files,
 )
 
 
@@ -71,3 +72,9 @@ class TestCacheOperation(BaseSwiftObjectStoreIntegrationTestCase):
                 hda["history_id"], content_id=hda["id"], wait=False, assert_ok=False
             )
             assert "File Not Found" in str(excinfo.value)
+
+    def test_upload_updates_cache(self):
+        self.upload_dataset()
+        assert files_count(self.object_store_cache_path) == 1
+        only_file = next(iter(get_files(self.object_store_cache_path)))
+        assert os.path.getsize(only_file) == 4

--- a/test/integration/test_extended_metadata_outputs_to_working_directory.py
+++ b/test/integration/test_extended_metadata_outputs_to_working_directory.py
@@ -14,7 +14,7 @@ class ExtendedMetadataOutputsToWorkingDirIntegrationInstance(ExtendedMetadataInt
     def handle_galaxy_config_kwds(cls, config):
         config["metadata_strategy"] = "extended"
         config["object_store_store_by"] = "uuid"
-        config["outpus_to_working_dir"] = True
+        config["outputs_to_working_directory"] = True
         config["retry_metadata_internally"] = False
 
 

--- a/test/integration/test_extended_metadata_outputs_to_working_directory.py
+++ b/test/integration/test_extended_metadata_outputs_to_working_directory.py
@@ -8,7 +8,7 @@ from .test_extended_metadata import (
 
 
 class ExtendedMetadataOutputsToWorkingDirIntegrationInstance(ExtendedMetadataIntegrationInstance):
-    """Describe a Galaxy test instance with metadata_strategy set to extended and outputs_to_working_dir set."""
+    """Describe a Galaxy test instance with metadata_strategy set to extended and outputs_to_working_directory set."""
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):


### PR DESCRIPTION
A basic test that ensure files get pushed to the object store cache (when object store cache is writable).
Also fixes `outpus_to_working_dir` typo in test setup.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
