### PR TITLE
[23.1] Fix history item states help display to apply same styling attributes

### DIFF
--- a/client/src/components/History/Content/model/StatesInfo.vue
+++ b/client/src/components/History/Content/model/StatesInfo.vue
@@ -45,7 +45,7 @@ function onFilter(value: string) {
         <p>Here are all available item states in Galaxy:</p>
         <p><i>(Note that the colors for each state correspond to content item state colors in the history)</i></p>
         <dl v-for="(state, key, index) in states" :key="index">
-            <b-alert :variant="state.status || 'success'" show>
+            <div :class="['alert', 'content-item', 'alert-' + state.status]" :data-state="key">
                 <dt>
                     <a class="text-decoration-none" href="javascript:void(0)" @click="onFilter(key)"
                         ><code>{{ key }}</code></a
@@ -53,7 +53,7 @@ function onFilter(value: string) {
                     <icon v-if="state.icon" :icon="state.icon" />
                 </dt>
                 <dd>{{ helpText[key] || state.text }}</dd>
-            </b-alert>
+            </div>
         </dl>
     </b-modal>
 </template>


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/16323.  Now accurately reflects the colors used by the history, instead of aligning to potentially incorrect (for new and queued) alert variants.

![image](https://github.com/galaxyproject/galaxy/assets/155398/b61041d9-fde4-4b4b-ae3f-5299133b198f)

This also points out to me that I didn't realize the default (non-selected, non-highlighted) running #ffe6cd looks way too similar to #c2ebc2.  We should look to adjust these for better discernment.

An alternative is something like https://github.com/galaxyproject/galaxy/commit/9b4ff2315a8968aa760e7b0e79747e9de914c92c, where we fully define these other states and only rely on that, instead of a mix of alert variants and data attribute specific rules.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
