### PR TITLE
[23.0] Fix upload paramfile handling (for real user setups)

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -190,8 +190,6 @@ class ToolEvaluator:
         param_dict["__datatypes_config__"] = param_dict["GALAXY_DATATYPES_CONF_FILE"] = os.path.join(
             job_working_directory, "registry.xml"
         )
-        if self.job.tool_id == "upload1":
-            param_dict["paramfile"] = os.path.join(job_working_directory, "upload_params.json")
         if self._history:
             param_dict["__history_id__"] = self.app.security.encode_id(self._history.id)
         param_dict["__galaxy_url__"] = self.compute_environment.galaxy_url()
@@ -208,6 +206,11 @@ class ToolEvaluator:
         self.__sanitize_param_dict(param_dict)
         # Parameters added after this line are not sanitized
         self.__populate_non_job_params(param_dict)
+
+        # MinimalJobWrapper.__prepare_upload_paramfile copies the paramfile to the job working directory
+        # so we should use it (otherwise the upload tool does not work in real user setups)
+        if self.job.tool_id == "upload1":
+            param_dict["paramfile"] = os.path.join(job_working_directory, "upload_params.json")
 
         # Return the dictionary of parameters
         return param_dict


### PR DESCRIPTION
the paramfile is created by `galaxy.tools.actions.upload_common.create_paramfile()` and stored in `database/tmp/upload_params_TMPNAME` with mode 600 (it's created with tmpfile, i.e. the mode is independent of the used umask).

`galaxy.jobs.MinimalJobWrapper.__prepare_upload_paramfile()` copies this file to the jow working dir.

Without the change `ToolEvaluator.build_param_dict()` sets the paramfile to the file in the jow working dir, but it is overwritten immediately by the value in `incoming`.

The original implementation should make no difference for non-real user setups, but real user setups break because the users can't read the paramfile in `database/tmp/`.

I noticed this for an upload to a library (which apparently still uses the old upload tool and not data fetch).

Was thinking if its possible to fix the value in incoming, or just use a config file from the start. But I was unsure how and went for the quick and dirty fix. 

I'm targeting 23.0 because it's the release I'm currently using.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
