### PR TITLE
[23.1] Make ToolBox v-b-tooltip.hover directives noninteractive

### DIFF
--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -13,7 +13,7 @@
         <b-input-group-append>
             <b-button
                 v-if="enableAdvanced"
-                v-b-tooltip.hover
+                v-b-tooltip.hover.noninteractive
                 aria-haspopup="true"
                 size="sm"
                 :pressed="showAdvanced"
@@ -25,7 +25,7 @@
                 <icon v-else fixed-width icon="angle-double-down" />
             </b-button>
             <b-button
-                v-b-tooltip.hover
+                v-b-tooltip.hover.noninteractive
                 aria-haspopup="true"
                 class="search-clear"
                 size="sm"

--- a/client/src/components/Panels/Buttons/FavoritesButton.vue
+++ b/client/src/components/Panels/Buttons/FavoritesButton.vue
@@ -1,6 +1,6 @@
 <template>
     <b-button
-        v-b-tooltip.hover
+        v-b-tooltip.hover.noninteractive
         class="panel-header-button-toolbox"
         size="sm"
         variant="link"

--- a/client/src/components/Panels/Buttons/PanelViewButton.vue
+++ b/client/src/components/Panels/Buttons/PanelViewButton.vue
@@ -1,6 +1,6 @@
 <template>
     <b-dropdown
-        v-b-tooltip.hover
+        v-b-tooltip.hover.noninteractive
         right
         title="Show panel options"
         variant="link"

--- a/client/src/components/Panels/Common/ToolPanelLabel.vue
+++ b/client/src/components/Panels/Common/ToolPanelLabel.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-b-tooltip.topright.hover class="tool-panel-label" tabindex="0" :title="description">
+    <div v-b-tooltip.topright.hover.noninteractive class="tool-panel-label" tabindex="0" :title="description">
         {{ definition.text }}
         <ToolPanelLinks :links="definition.links" />
     </div>

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="isSection && hasElements" class="tool-panel-section">
         <div
-            v-b-tooltip.topright.hover
+            v-b-tooltip.topright.hover.noninteractive
             :class="['toolSectionTitle', `tool-menu-section-${sectionName}`]"
             :title="title">
             <a class="title-link" href="javascript:void(0)" @click="toggleMenu()">

--- a/client/src/components/Upload/UploadButton.vue
+++ b/client/src/components/Upload/UploadButton.vue
@@ -1,7 +1,7 @@
 <template>
     <b-button
         id="activity-upload"
-        v-b-tooltip.hover.bottom
+        v-b-tooltip.hover.noninteractive.bottom
         :aria-label="title | localize"
         :title="title | localize"
         class="upload-button"


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/16337
As reported here ^, tooltips can get in the way when trying to navigate around the ToolBox (especially when an EDAM view is enabled with the tooltips showing description text for each section)

| Before | After |
| ------- | ----- |
| <video src="https://github.com/galaxyproject/galaxy/assets/78516064/b99fc443-eb38-42e7-81bf-a2f7683f61cd" /> | <video src="https://github.com/galaxyproject/galaxy/assets/78516064/7fea8229-e319-4ce2-87fc-1be184d94723" /> |

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
