### PR TITLE
Make it obvious that `WorkflowInvocationStep` is clickable/expandable

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationStep.vue
@@ -1,11 +1,12 @@
 <template>
     <div class="d-flex" :data-step="workflowStep.id">
         <div class="ui-portlet-section" style="width: 100%">
-            <div class="portlet-header portlet-title portlet-operations" @click="toggleStep">
+            <div class="portlet-header portlet-title portlet-operations cursor-pointer" @click="toggleStep">
                 <i :class="'portlet-title-icon fa mr-1 ' + stepIcon"></i>
                 <span class="portlet-title-text">
                     <u class="step-title">{{ stepLabel }}</u>
                 </span>
+                <FontAwesomeIcon class="float-right" :icon="expanded ? 'fa-chevron-up' : 'fa-chevron-down'" />
             </div>
             <div v-if="expanded" class="portlet-content">
                 <InvocationStepProvider
@@ -84,6 +85,9 @@
     </div>
 </template>
 <script>
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import GenericHistoryItem from "components/History/Content/GenericItem";
 import LoadingSpan from "components/LoadingSpan";
 import { InvocationStepProvider } from "components/providers";
@@ -96,9 +100,12 @@ import { mapCacheActions } from "vuex-cache";
 import JobStep from "./JobStep";
 import ParameterStep from "./ParameterStep";
 
+library.add(faChevronUp, faChevronDown);
+
 export default {
     components: {
         LoadingSpan,
+        FontAwesomeIcon,
         JobStep,
         ParameterStep,
         InvocationStepProvider,


### PR DESCRIPTION
Added `cursor-pointer` class as well as `fa-chevron-up/down` icons. Fixes #16502 

## Before
https://github.com/galaxyproject/galaxy/assets/78516064/f534ac74-5bc1-438a-b0bd-eacab64d9d81

## After
https://github.com/galaxyproject/galaxy/assets/78516064/85a8e594-5d39-46f9-bf7e-7beabacacffc

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
