### PR TITLE
Update interactivetool_mgnify_notebook to v1.2.2

### DIFF
--- a/tools/interactive/interactivetool_mgnify_notebook.xml
+++ b/tools/interactive/interactivetool_mgnify_notebook.xml
@@ -1,6 +1,6 @@
-<tool id="interactive_tool_mgnify_notebook" tool_type="interactive" name="Interactive MGnify Notebook" version="1.1.0" profile="22.01">
+<tool id="interactive_tool_mgnify_notebook" tool_type="interactive" name="Interactive MGnify Notebook" version="1.2.2" profile="22.01">
     <requirements>
-        <container type="docker">quay.io/microbiome-informatics/emg-notebooks.dev:v1.1.0</container>
+        <container type="docker">quay.io/microbiome-informatics/emg-notebooks.dev:v1.2.2</container>
     </requirements>
     <entry_points>
         <entry_point name="MGnify Interactive Tool" requires_domain="True">


### PR DESCRIPTION
This PR updates the "MGnify Notebooks" interactive tool to the latest docker built image, v1.2.2. This new image includes new notebooks covering more of MGnify, and some improvements to the way libraries are packaged in the docker image.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
