### PR TITLE
[23.1] Fix for Accessibility, on Workflows List page Tooltip

### DIFF
--- a/client/src/components/Workflow/WorkflowDropdown.vue
+++ b/client/src/components/Workflow/WorkflowDropdown.vue
@@ -10,21 +10,21 @@
             @dragend="onDragEnd">
             <Icon icon="caret-down" class="fa-lg" />
             <span class="workflow-dropdown-name">{{ workflow.name }}</span>
+            <span
+                v-if="sourceType.includes('trs')"
+                v-b-tooltip.hover
+                aria-haspopup="true"
+                :title="getWorkflowTooltip(sourceType, workflow)">
+                <Icon fixed-width icon="check" class="mr-1 workflow-trs-icon" />
+            </span>
+            <span
+                v-if="sourceType == 'url'"
+                v-b-tooltip.hover
+                aria-haspopup="true"
+                :title="getWorkflowTooltip(sourceType, workflow)">
+                <Icon fixed-width icon="link" class="mr-1 workflow-external-link" />
+            </span>
         </b-link>
-        <span
-            v-if="sourceType.includes('trs')"
-            v-b-tooltip.hover
-            aria-haspopup="true"
-            :title="getWorkflowTooltip(sourceType, workflow)">
-            <Icon fixed-width icon="check" class="mr-1 workflow-trs-icon" />
-        </span>
-        <span
-            v-if="sourceType == 'url'"
-            v-b-tooltip.hover
-            aria-haspopup="true"
-            :title="getWorkflowTooltip(sourceType, workflow)">
-            <Icon fixed-width icon="link" class="mr-1 workflow-external-link" />
-        </span>
         <p v-if="workflow.description" class="workflow-dropdown-description">
             <TextSummary :description="workflow.description" :show-details.sync="showDetails" />
         </p>


### PR DESCRIPTION
Fix for Accessibility, on Workflows List page Tooltip when hover over Workflow Title; Fix previously in place but likely remoed from bad merge. New fix related to this Issue: #16327 

- To get an idea of the fix, see video link in this prior PR: #15517 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
