### PR TITLE
Scope Workflow Stores to Workflow ID

### DIFF
--- a/client/src/components/Workflow/Editor/ConnectionMenu.vue
+++ b/client/src/components/Workflow/Editor/ConnectionMenu.vue
@@ -25,7 +25,7 @@
 import { computed, type ComputedRef, onMounted, ref, watch } from "vue";
 
 import { useFocusWithin } from "@/composables/useActiveElement";
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { useWorkflowStores } from "@/composables/workflowStores";
 import { assertDefined } from "@/utils/assertions";
 
 import {
@@ -62,7 +62,7 @@ watch(focused, (focused) => {
     }
 });
 
-const stepStore = useWorkflowStepStore();
+const { connectionStore, stepStore } = useWorkflowStores();
 
 interface InputObject {
     stepId: number;
@@ -97,7 +97,7 @@ function inputObjectToTerminal(inputObject: InputObject): InputTerminals {
     const step = stepStore.getStep(inputObject.stepId);
     assertDefined(step);
     const inputSource = step.inputs.find((input) => input.name == inputObject.inputName)!;
-    return terminalFactory(inputObject.stepId, inputSource, props.terminal.datatypesMapper);
+    return terminalFactory(inputObject.stepId, inputSource, props.terminal.datatypesMapper, connectionStore, stepStore);
 }
 
 const validInputs: ComputedRef<InputObject[]> = computed(() => {

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
@@ -34,6 +34,9 @@ describe("FormDefault", () => {
             },
             localVue,
             pinia: createTestingPinia(),
+            provide: {
+                workflowId: "mock-workflow",
+            },
         });
     });
 

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -62,7 +62,8 @@ import { computed, toRef } from "vue";
 
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 import WorkflowIcons from "@/components/Workflow/icons";
-import { type Step, useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { useWorkflowStores } from "@/composables/workflowStores";
+import type { Step } from "@/stores/workflowStepStore";
 
 import { useStepProps } from "../composables/useStepProps";
 import { useUniqueLabelError } from "../composables/useUniqueLabelError";
@@ -80,7 +81,7 @@ const props = defineProps<{
 const emit = defineEmits(["onAnnotation", "onLabel", "onAttemptRefactor", "onEditSubworkflow", "onSetData"]);
 const stepRef = toRef(props, "step");
 const { stepId, contentId, annotation, label, name, type, configForm } = useStepProps(stepRef);
-const stepStore = useWorkflowStepStore();
+const { stepStore } = useWorkflowStores();
 const uniqueErrorLabel = useUniqueLabelError(stepStore, label.value);
 const stepTitle = computed(() => {
     if (label.value) {

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.test.js
@@ -39,7 +39,7 @@ describe("FormOutputLabel", () => {
             localVue,
             pinia,
         });
-        stepStore = useWorkflowStepStore();
+        stepStore = useWorkflowStepStore("mock-workflow");
         stepStore.addStep(stepOne);
         stepStore.addStep(stepTwo);
     });

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.test.js
@@ -29,7 +29,9 @@ describe("FormOutputLabel", () => {
             },
             localVue,
             pinia,
+            provide: { workflowId: "mock-workflow" },
         });
+
         const stepTwo = { id: 1, outputs: [{ name: "other-name" }], workflow_outputs: outputs };
         wrapperOther = mount(FormOutputLabel, {
             propsData: {
@@ -38,6 +40,7 @@ describe("FormOutputLabel", () => {
             },
             localVue,
             pinia,
+            provide: { workflowId: "mock-workflow" },
         });
         stepStore = useWorkflowStepStore("mock-workflow");
         stepStore.addStep(stepOne);

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
@@ -13,8 +13,8 @@
 import type { Ref } from "vue";
 import { computed, ref } from "vue";
 
+import { useWorkflowStores } from "@/composables/workflowStores";
 import type { Step } from "@/stores/workflowStepStore";
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 
 import FormElement from "@/components/Form/FormElement.vue";
 
@@ -29,7 +29,7 @@ const props = withDefaults(
     }
 );
 
-const stepStore = useWorkflowStepStore();
+const { stepStore } = useWorkflowStores();
 
 const error: Ref<string | undefined> = ref(undefined);
 const id = computed(() => `__label__${props.name}`);

--- a/client/src/components/Workflow/Editor/Forms/FormTool.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.test.js
@@ -48,6 +48,7 @@ describe("FormTool", () => {
                 ToolFooter: { template: "<div>tool-footer</div>" },
             },
             pinia: createTestingPinia(),
+            provide: { workflowId: "mock-workflow" },
         });
     }
 

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -56,7 +56,7 @@
 import Utils from "utils/utils";
 import { toRef } from "vue";
 
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { useWorkflowStores } from "@/composables/workflowStores";
 
 import { useStepProps } from "../composables/useStepProps";
 import { useUniqueLabelError } from "../composables/useUniqueLabelError";
@@ -93,7 +93,7 @@ export default {
         const { stepId, annotation, label, stepInputs, stepOutputs, configForm, postJobActions } = useStepProps(
             toRef(props, "step")
         );
-        const stepStore = useWorkflowStepStore();
+        const { stepStore } = useWorkflowStores();
         const uniqueErrorLabel = useUniqueLabelError(stepStore, label);
 
         return {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -469,7 +469,7 @@ export default {
             // Load workflow definition
             this.onWorkflowMessage("Importing workflow", "progress");
             loadWorkflow({ id }).then((data) => {
-                fromSimple(id, data, true, defaultPosition(this.graphOffset, this.transform));
+                fromSimple(this.id, data, true, defaultPosition(this.graphOffset, this.transform));
                 // Determine if any parameters were 'upgraded' and provide message
                 const insertedStateMessages = getStateUpgradeMessages(data);
                 this.onInsertedStateMessages(insertedStateMessages);

--- a/client/src/components/Workflow/Editor/Lint.test.js
+++ b/client/src/components/Workflow/Editor/Lint.test.js
@@ -1,6 +1,6 @@
 import { createTestingPinia } from "@pinia/testing";
 import { mount } from "@vue/test-utils";
-import { PiniaVuePlugin } from "pinia";
+import { PiniaVuePlugin, setActivePinia } from "pinia";
 import { getLocalVue } from "tests/jest/helpers";
 
 import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
@@ -88,6 +88,9 @@ describe("Lint", () => {
     let stepStore;
 
     beforeEach(() => {
+        const pinia = createTestingPinia({ stubActions: false });
+        setActivePinia(pinia);
+
         wrapper = mount(Lint, {
             propsData: {
                 untypedParameters: getUntypedWorkflowParameters(steps),
@@ -98,9 +101,11 @@ describe("Lint", () => {
                 datatypesMapper: testDatatypesMapper,
             },
             localVue,
-            pinia: createTestingPinia({ stubActions: false }),
+            pinia,
+            provide: { workflowId: "mock-workflow" },
         });
-        stepStore = useWorkflowStepStore("mock-store");
+
+        stepStore = useWorkflowStepStore("mock-workflow");
         Object.values(steps).map((step) => stepStore.addStep(step));
     });
 
@@ -131,7 +136,7 @@ describe("Lint", () => {
     });
 
     it("should fire refactor event to extract untyped parameter and remove unlabeled workflows", async () => {
-        wrapper.vm.onRefactor();
+        await wrapper.find(".refactor-button").trigger("click");
         expect(wrapper.emitted().onRefactor.length).toBe(1);
         const actions = wrapper.emitted().onRefactor[0][0];
         expect(actions.length).toBe(2);
@@ -139,9 +144,10 @@ describe("Lint", () => {
         expect(actions[0].name).toBe("untyped_parameter");
         expect(actions[1].action_type).toBe("remove_unlabeled_workflow_outputs");
     });
+
     it("should include connect input action when input disconnected", async () => {
         stepStore.removeStep(0);
-        wrapper.vm.onRefactor();
+        await wrapper.find(".refactor-button").trigger("click");
         expect(wrapper.emitted().onRefactor.length).toBe(1);
         const actions = wrapper.emitted().onRefactor[0][0];
         expect(actions.length).toBe(3);

--- a/client/src/components/Workflow/Editor/Lint.test.js
+++ b/client/src/components/Workflow/Editor/Lint.test.js
@@ -100,7 +100,7 @@ describe("Lint", () => {
             localVue,
             pinia: createTestingPinia({ stubActions: false }),
         });
-        stepStore = useWorkflowStepStore();
+        stepStore = useWorkflowStepStore("mock-store");
         Object.values(steps).map((step) => stepStore.addStep(step));
     });
 

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -85,7 +85,7 @@ import { storeToRefs } from "pinia";
 import Vue from "vue";
 
 import { DatatypesMapperModel } from "@/components/Datatypes/model";
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { useWorkflowStores } from "@/composables/workflowStores";
 
 import {
     fixAllIssues,
@@ -135,8 +135,9 @@ export default {
         },
     },
     setup() {
-        const { hasActiveOutputs } = storeToRefs(useWorkflowStepStore());
-        return { hasActiveOutputs };
+        const { connectionStore, stepStore } = useWorkflowStores();
+        const { hasActiveOutputs } = storeToRefs(stepStore);
+        return { connectionStore, stepStore, hasActiveOutputs };
     },
     computed: {
         showRefactor() {
@@ -170,7 +171,7 @@ export default {
             return getUntypedParameters(this.untypedParameters);
         },
         warningDisconnectedInputs() {
-            return getDisconnectedInputs(this.steps, this.datatypesMapper);
+            return getDisconnectedInputs(this.steps, this.datatypesMapper, this.connectionStore, this.stepStore);
         },
         warningMissingMetadata() {
             return getMissingMetadata(this.steps);
@@ -226,7 +227,7 @@ export default {
             this.$emit("onUnhighlight", item.stepId);
         },
         onRefactor() {
-            const actions = fixAllIssues(this.steps, this.untypedParameters);
+            const actions = fixAllIssues(this.steps, this.untypedParameters, this.connectionStore, this.stepStore);
             this.$emit("onRefactor", actions);
         },
     },

--- a/client/src/components/Workflow/Editor/Lint.vue
+++ b/client/src/components/Workflow/Editor/Lint.vue
@@ -6,7 +6,7 @@
                 Best Practices Review
             </div>
             <div v-if="showRefactor">
-                <a href="#" @click="onRefactor"> Try to automatically fix issues. </a>
+                <a class="refactor-button" href="#" @click="onRefactor"> Try to automatically fix issues. </a>
             </div>
         </template>
         <b-card-body>
@@ -227,7 +227,13 @@ export default {
             this.$emit("onUnhighlight", item.stepId);
         },
         onRefactor() {
-            const actions = fixAllIssues(this.steps, this.untypedParameters, this.connectionStore, this.stepStore);
+            const actions = fixAllIssues(
+                this.steps,
+                this.untypedParameters,
+                this.datatypesMapper,
+                this.connectionStore,
+                this.stepStore
+            );
             this.$emit("onRefactor", actions);
         },
     },

--- a/client/src/components/Workflow/Editor/Node.test.ts
+++ b/client/src/components/Workflow/Editor/Node.test.ts
@@ -18,7 +18,7 @@ describe("Node", () => {
     it("test attributes", async () => {
         const testingPinia = createTestingPinia();
         setActivePinia(testingPinia);
-        const wrapper = shallowMount(Node, {
+        const wrapper = shallowMount(Node as any, {
             propsData: {
                 id: 0,
                 contentId: "tool name",
@@ -30,6 +30,9 @@ describe("Node", () => {
             },
             localVue,
             pinia: testingPinia,
+            provide: {
+                workflowId: "mock-workflow",
+            },
         });
         await flushPromises();
         // fa-wrench is the tool icon ...

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -120,10 +120,9 @@ import { getGalaxyInstance } from "@/app";
 import { DatatypesMapperModel } from "@/components/Datatypes/model";
 import { useNodePosition } from "@/components/Workflow/Editor/composables/useNodePosition";
 import WorkflowIcons from "@/components/Workflow/icons";
-import { useConnectionStore } from "@/stores/workflowConnectionStore";
-import { type TerminalPosition, useWorkflowStateStore, type XYPosition } from "@/stores/workflowEditorStateStore";
+import { useWorkflowStores } from "@/composables/workflowStores";
+import type { TerminalPosition, XYPosition } from "@/stores/workflowEditorStateStore";
 import type { Step } from "@/stores/workflowStepStore";
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 
 import type { OutputTerminals } from "./modules/terminals";
 
@@ -180,9 +179,7 @@ const elHtml: Ref<HTMLElement | null> = computed(() => (el.value?.$el as HTMLEle
 
 const postJobActions = computed(() => props.step.post_job_actions || {});
 const workflowOutputs = computed(() => props.step.workflow_outputs || []);
-const connectionStore = useConnectionStore();
-const stateStore = useWorkflowStateStore();
-const stepStore = useWorkflowStepStore();
+const { connectionStore, stateStore, stepStore } = useWorkflowStores();
 const isLoading = computed(() => Boolean(stateStore.getStepLoadingState(props.id)?.loading));
 useNodePosition(
     elHtml,

--- a/client/src/components/Workflow/Editor/NodeOutput.test.ts
+++ b/client/src/components/Workflow/Editor/NodeOutput.test.ts
@@ -4,6 +4,7 @@ import { getLocalVue } from "tests/jest/helpers";
 import { nextTick, ref } from "vue";
 
 import { testDatatypesMapper } from "@/components/Datatypes/test_fixtures";
+import { useConnectionStore } from "@/stores/workflowConnectionStore";
 import { type Step, type Steps, useWorkflowStepStore } from "@/stores/workflowStepStore";
 
 import { terminalFactory } from "./modules/terminals";
@@ -51,11 +52,13 @@ const transform = ref({ x: 0, y: 0, k: 1 });
 describe("NodeOutput", () => {
     let pinia: ReturnType<typeof createPinia>;
     let stepStore: ReturnType<typeof useWorkflowStepStore>;
+    let connectionStore: ReturnType<typeof useConnectionStore>;
 
     beforeEach(() => {
         pinia = createPinia();
         setActivePinia(pinia);
-        stepStore = useWorkflowStepStore();
+        stepStore = useWorkflowStepStore("mock-workflow");
+        connectionStore = useConnectionStore("mock-workflow");
         Object.values(advancedSteps).map((step) => stepStore.addStep(step));
     });
 
@@ -73,8 +76,20 @@ describe("NodeOutput", () => {
     it("displays multiple icon if not mapped over", async () => {
         const simpleDataStep = stepForLabel("simple data", stepStore.steps);
         const listInputStep = stepForLabel("list input", stepStore.steps);
-        const inputTerminal = terminalFactory(simpleDataStep.id, simpleDataStep.inputs[0]!, testDatatypesMapper);
-        const outputTerminal = terminalFactory(listInputStep.id, listInputStep.outputs[0]!, testDatatypesMapper);
+        const inputTerminal = terminalFactory(
+            simpleDataStep.id,
+            simpleDataStep.inputs[0]!,
+            testDatatypesMapper,
+            connectionStore,
+            stepStore
+        );
+        const outputTerminal = terminalFactory(
+            listInputStep.id,
+            listInputStep.outputs[0]!,
+            testDatatypesMapper,
+            connectionStore,
+            stepStore
+        );
         const propsData = propsForStep(simpleDataStep);
         const wrapper = shallowMount(NodeOutput, {
             propsData: propsData,

--- a/client/src/components/Workflow/Editor/NodeOutput.test.ts
+++ b/client/src/components/Workflow/Editor/NodeOutput.test.ts
@@ -65,14 +65,15 @@ describe("NodeOutput", () => {
     it("does not display multiple icon if not mapped over", async () => {
         const simpleDataStep = stepForLabel("simple data", stepStore.steps);
         const propsData = propsForStep(simpleDataStep);
-        const wrapper = shallowMount(NodeOutput, {
+        const wrapper = shallowMount(NodeOutput as any, {
             propsData: propsData,
             localVue,
             pinia,
-            provide: { transform },
+            provide: { transform, workflowId: "mock-workflow" },
         });
         expect(wrapper.find(".multiple").exists()).toBe(false);
     });
+
     it("displays multiple icon if not mapped over", async () => {
         const simpleDataStep = stepForLabel("simple data", stepStore.steps);
         const listInputStep = stepForLabel("list input", stepStore.steps);
@@ -91,11 +92,11 @@ describe("NodeOutput", () => {
             stepStore
         );
         const propsData = propsForStep(simpleDataStep);
-        const wrapper = shallowMount(NodeOutput, {
+        const wrapper = shallowMount(NodeOutput as any, {
             propsData: propsData,
             localVue,
             pinia,
-            provide: { transform },
+            provide: { transform, workflowId: "mock-workflow" },
         });
         expect(wrapper.find(".multiple").exists()).toBe(false);
         inputTerminal.connect(outputTerminal);

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -6,13 +6,13 @@ import type { UseElementBoundingReturn, UseScrollReturn } from "@vueuse/core";
 import { computed, nextTick, onBeforeUnmount, type Ref, ref, toRefs, type UnwrapRef, watch } from "vue";
 
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
-import { useWorkflowStateStore, type XYPosition } from "@/stores/workflowEditorStateStore";
+import { useWorkflowStores } from "@/composables/workflowStores";
+import type { XYPosition } from "@/stores/workflowEditorStateStore";
 import {
     type OutputTerminalSource,
     type PostJobAction,
     type PostJobActions,
     type Step,
-    useWorkflowStepStore,
 } from "@/stores/workflowStepStore";
 import { assertDefined, ensureDefined } from "@/utils/assertions";
 
@@ -43,8 +43,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits(["pan-by", "stopDragging", "onDragConnector"]);
-const stateStore = useWorkflowStateStore();
-const stepStore = useWorkflowStepStore();
+const { stateStore, stepStore } = useWorkflowStores();
 const icon: Ref<HTMLElement | null> = ref(null);
 const { rootOffset, output, stepId, datatypesMapper } = toRefs(props);
 

--- a/client/src/components/Workflow/Editor/Recommendations.vue
+++ b/client/src/components/Workflow/Editor/Recommendations.vue
@@ -21,7 +21,7 @@
 import LoadingSpan from "components/LoadingSpan";
 import _l from "utils/localization";
 
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import { useWorkflowStores } from "@/composables/workflowStores";
 
 import { getToolPredictions } from "./modules/services";
 import { getCompatibleRecommendations } from "./modules/utilities";
@@ -41,7 +41,7 @@ export default {
         },
     },
     setup() {
-        const stepStore = useWorkflowStepStore();
+        const { stepStore } = useWorkflowStores();
         return { stepStore };
     },
     data() {

--- a/client/src/components/Workflow/Editor/SVGConnection.vue
+++ b/client/src/components/Workflow/Editor/SVGConnection.vue
@@ -2,10 +2,9 @@
 import { curveBasis, line } from "d3";
 import { computed, type PropType } from "vue";
 
+import { useWorkflowStores } from "@/composables/workflowStores";
 import { type Connection, getConnectionId } from "@/stores/workflowConnectionStore";
-import { useConnectionStore } from "@/stores/workflowConnectionStore";
-import { type TerminalPosition, useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+import type { TerminalPosition } from "@/stores/workflowEditorStateStore";
 
 const props = defineProps({
     id: String,
@@ -23,9 +22,7 @@ const ribbonMargin = 4;
 
 const curve = line().curve(curveBasis);
 
-const stateStore = useWorkflowStateStore();
-const connectionStore = useConnectionStore();
-const stepStore = useWorkflowStepStore();
+const { connectionStore, stateStore, stepStore } = useWorkflowStores();
 
 const outputPos = computed(() => {
     if (props.terminalPosition) {

--- a/client/src/components/Workflow/Editor/WorkflowEdges.vue
+++ b/client/src/components/Workflow/Editor/WorkflowEdges.vue
@@ -2,7 +2,8 @@
 import { storeToRefs } from "pinia";
 import { computed, type Ref } from "vue";
 
-import { type Connection, type OutputTerminal, useConnectionStore } from "@/stores/workflowConnectionStore";
+import { useWorkflowStores } from "@/composables/workflowStores";
+import type { Connection, OutputTerminal } from "@/stores/workflowConnectionStore";
 import type { TerminalPosition } from "@/stores/workflowEditorStateStore";
 
 import type { OutputTerminals } from "./modules/terminals";
@@ -15,7 +16,7 @@ const props = defineProps<{
     transform: { x: number; y: number; k: number };
 }>();
 
-const connectionStore = useConnectionStore();
+const { connectionStore } = useWorkflowStores();
 const { connections } = storeToRefs(connectionStore);
 
 const draggingConnection: Ref<[Connection, TerminalPosition] | null> = computed(() => {

--- a/client/src/components/Workflow/Editor/WorkflowGraph.vue
+++ b/client/src/components/Workflow/Editor/WorkflowGraph.vue
@@ -51,9 +51,9 @@ import { storeToRefs } from "pinia";
 import { computed, type PropType, provide, reactive, type Ref, ref, watch, watchEffect } from "vue";
 
 import { DatatypesMapperModel } from "@/components/Datatypes/model";
+import { useWorkflowStores } from "@/composables/workflowStores";
 import type { TerminalPosition, XYPosition } from "@/stores/workflowEditorStateStore";
-import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
-import { type Step, useWorkflowStepStore } from "@/stores/workflowStepStore";
+import type { Step } from "@/stores/workflowStepStore";
 import { assertDefined } from "@/utils/assertions";
 
 import { useD3Zoom } from "./composables/d3Zoom";
@@ -75,8 +75,7 @@ const props = defineProps({
     scrollToId: { type: null as unknown as PropType<number | null>, default: null },
 });
 
-const stateStore = useWorkflowStateStore();
-const stepStore = useWorkflowStepStore();
+const { stateStore, stepStore } = useWorkflowStores();
 const { scale, activeNodeId, draggingPosition, draggingTerminal } = storeToRefs(stateStore);
 const canvas: Ref<HTMLElement | null> = ref(null);
 

--- a/client/src/components/Workflow/Editor/WorkflowMinimap.vue
+++ b/client/src/components/Workflow/Editor/WorkflowMinimap.vue
@@ -5,7 +5,7 @@ import { computed, onMounted, ref, unref, watch } from "vue";
 
 import { useAnimationFrame } from "@/composables/sensors/animationFrame";
 import { useAnimationFrameThrottle } from "@/composables/throttle";
-import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
+import { useWorkflowStores } from "@/composables/workflowStores";
 import type { Step, Steps } from "@/stores/workflowStepStore";
 
 import { AxisAlignedBoundingBox, Transform } from "./modules/geometry";
@@ -21,7 +21,7 @@ const emit = defineEmits<{
     (e: "moveTo", position: { x: number; y: number }): void;
 }>();
 
-const stateStore = useWorkflowStateStore();
+const { stateStore } = useWorkflowStores();
 
 /** reference to the main canvas element */
 const canvas: Ref<HTMLCanvasElement | null> = ref(null);

--- a/client/src/components/Workflow/Editor/composables/useTerminal.ts
+++ b/client/src/components/Workflow/Editor/composables/useTerminal.ts
@@ -2,8 +2,8 @@ import { computed, type Ref, ref, watch } from "vue";
 
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 import { terminalFactory } from "@/components/Workflow/Editor/modules/terminals";
+import { useWorkflowStores } from "@/composables/workflowStores";
 import type { Step, TerminalSource } from "@/stores/workflowStepStore";
-import { useWorkflowStepStore } from "@/stores/workflowStepStore";
 
 export function useTerminal(
     stepId: Ref<Step["id"]>,
@@ -11,7 +11,7 @@ export function useTerminal(
     datatypesMapper: Ref<DatatypesMapperModel>
 ) {
     const terminal: Ref<ReturnType<typeof terminalFactory> | null> = ref(null);
-    const stepStore = useWorkflowStepStore();
+    const { connectionStore, stepStore } = useWorkflowStores();
     const step = computed(() => stepStore.getStep(stepId.value));
     const isMappedOver = computed(() => stepStore.stepMapOver[stepId.value]?.isCollection ?? false);
 
@@ -19,7 +19,13 @@ export function useTerminal(
         [step, terminalSource, datatypesMapper],
         () => {
             // rebuild terminal if any of the tracked dependencies change
-            const newTerminal = terminalFactory(stepId.value, terminalSource.value, datatypesMapper.value);
+            const newTerminal = terminalFactory(
+                stepId.value,
+                terminalSource.value,
+                datatypesMapper.value,
+                connectionStore,
+                stepStore
+            );
             newTerminal.getInvalidConnectedTerminals();
             terminal.value = newTerminal;
         },

--- a/client/src/components/Workflow/Editor/modules/layout.ts
+++ b/client/src/components/Workflow/Editor/modules/layout.ts
@@ -33,9 +33,9 @@ interface NewGraph {
     edges: GraphEdge[];
 }
 
-export async function autoLayout(steps: { [index: string]: Step }) {
-    const stateStore = useWorkflowStateStore();
-    const connectionStore = useConnectionStore();
+export async function autoLayout(id: string, steps: { [index: string]: Step }) {
+    const connectionStore = useConnectionStore(id);
+    const stateStore = useWorkflowStateStore(id);
 
     // Convert this to ELK compat.
     const newGraph: NewGraph = {

--- a/client/src/components/Workflow/Editor/modules/linting.ts
+++ b/client/src/components/Workflow/Editor/modules/linting.ts
@@ -1,6 +1,7 @@
 import type { DatatypesMapperModel } from "@/components/Datatypes/model";
 import type { UntypedParameters } from "@/components/Workflow/Editor/modules/parameters";
-import type { Step, Steps } from "@/stores/workflowStepStore";
+import type { useConnectionStore } from "@/stores/workflowConnectionStore";
+import type { Step, Steps, useWorkflowStepStore } from "@/stores/workflowStepStore";
 import { assertDefined } from "@/utils/assertions";
 
 import { terminalFactory } from "./terminals";
@@ -14,11 +15,16 @@ interface LintState {
     autofix?: boolean;
 }
 
-export function getDisconnectedInputs(steps: Steps = {}, datatypesMapper: DatatypesMapperModel) {
+export function getDisconnectedInputs(
+    steps: Steps = {},
+    datatypesMapper: DatatypesMapperModel,
+    connectionStore: ReturnType<typeof useConnectionStore>,
+    stepStore: ReturnType<typeof useWorkflowStepStore>
+) {
     const inputs: LintState[] = [];
     Object.values(steps).forEach((step) => {
         step.inputs.map((inputSource) => {
-            const inputTerminal = terminalFactory(step.id, inputSource, datatypesMapper);
+            const inputTerminal = terminalFactory(step.id, inputSource, datatypesMapper, connectionStore, stepStore);
             if (!inputTerminal.optional && inputTerminal.connections.length === 0) {
                 const inputLabel = inputSource.label || inputSource.name;
                 inputs.push({
@@ -114,7 +120,13 @@ export function getUntypedParameters(untypedParameters: UntypedParameters) {
     return items;
 }
 
-export function fixAllIssues(steps: Steps, parameters: UntypedParameters, datatypesMapper: DatatypesMapperModel) {
+export function fixAllIssues(
+    steps: Steps,
+    parameters: UntypedParameters,
+    datatypesMapper: DatatypesMapperModel,
+    connectionStore: ReturnType<typeof useConnectionStore>,
+    stepStore: ReturnType<typeof useWorkflowStepStore>
+) {
     const actions = [];
     const untypedParameters = getUntypedParameters(parameters);
     for (const untypedParameter of untypedParameters) {
@@ -122,7 +134,7 @@ export function fixAllIssues(steps: Steps, parameters: UntypedParameters, dataty
             actions.push(fixUntypedParameter(untypedParameter));
         }
     }
-    const disconnectedInputs = getDisconnectedInputs(steps, datatypesMapper);
+    const disconnectedInputs = getDisconnectedInputs(steps, datatypesMapper, connectionStore, stepStore);
     for (const disconnectedInput of disconnectedInputs) {
         if (disconnectedInput.autofix) {
             actions.push(fixDisconnectedInput(disconnectedInput));

--- a/client/src/components/Workflow/Editor/modules/model.ts
+++ b/client/src/components/Workflow/Editor/modules/model.ts
@@ -10,8 +10,13 @@ interface Workflow {
     steps: Steps;
 }
 
-export async function fromSimple(data: Workflow, appendData = false, defaultPosition = { top: 0, left: 0 }) {
-    const stepStore = useWorkflowStepStore();
+export async function fromSimple(
+    id: string,
+    data: Workflow,
+    appendData = false,
+    defaultPosition = { top: 0, left: 0 }
+) {
+    const stepStore = useWorkflowStepStore(id);
     const stepIdOffset = stepStore.getStepIndex + 1;
     Object.values(data.steps).forEach((step) => {
         // If workflow being copied into another, wipe UUID and let

--- a/client/src/components/Workflow/Editor/modules/model.ts
+++ b/client/src/components/Workflow/Editor/modules/model.ts
@@ -10,6 +10,14 @@ interface Workflow {
     steps: Steps;
 }
 
+/**
+ * Loads a workflow into the editor
+ *
+ * @param id ID of workflow to load data *into*
+ * @param data Workflow data to load from
+ * @param appendData if true appends data to current workflow, making sure to create new uuids
+ * @param defaultPosition where to position workflow in the editor
+ */
 export async function fromSimple(
     id: string,
     data: Workflow,

--- a/client/src/composables/workflowStores.ts
+++ b/client/src/composables/workflowStores.ts
@@ -1,0 +1,63 @@
+import { inject, onScopeDispose, provide } from "vue";
+
+import { useConnectionStore } from "@/stores/workflowConnectionStore";
+import { useWorkflowStateStore } from "@/stores/workflowEditorStateStore";
+import { useWorkflowStepStore } from "@/stores/workflowStepStore";
+
+/**
+ * Creates stores scoped to a specific workflowId, and manages their lifetime.
+ * In child components, use `useWorkflowStores` instead.
+ *
+ * Provides `workflowId` to all child components.
+ *
+ * @param workflowId the workflow to scope to
+ * @returns workflow Stores
+ */
+export function provideScopedWorkflowStores(workflowId: string) {
+    provide("workflowId", workflowId);
+
+    const connectionStore = useConnectionStore(workflowId);
+    const stateStore = useWorkflowStateStore(workflowId);
+    const stepStore = useWorkflowStepStore(workflowId);
+
+    onScopeDispose(() => {
+        connectionStore.$dispose();
+        stateStore.$dispose();
+        stepStore.$dispose();
+    });
+
+    return {
+        connectionStore,
+        stateStore,
+        stepStore,
+    };
+}
+
+/**
+ * Uses all workflow related stores scoped to the workflow defined by a parent component.
+ * Does not manage lifetime.
+ *
+ * `provideScopedWorkflowStores` needs to be called by a parent component,
+ * or this composable will throw an error.
+ *
+ * @returns workflow stores
+ */
+export function useWorkflowStores() {
+    const workflowId = inject("workflowId");
+
+    if (typeof workflowId !== "string") {
+        throw new Error(
+            "Workflow ID not provided by parent component. Use `setupWorkflowStores` on a parent component."
+        );
+    }
+
+    const connectionStore = useConnectionStore(workflowId);
+    const stateStore = useWorkflowStateStore(workflowId);
+    const stepStore = useWorkflowStepStore(workflowId);
+
+    return {
+        connectionStore,
+        stateStore,
+        stepStore,
+    };
+}

--- a/client/src/stores/workflowConnectionStore.test.ts
+++ b/client/src/stores/workflowConnectionStore.test.ts
@@ -38,25 +38,25 @@ const connection: Connection = {
 describe("Connection Store", () => {
     beforeEach(() => {
         setActivePinia(createPinia());
-        const workflowStepStore = useWorkflowStepStore();
+        const workflowStepStore = useWorkflowStepStore("mock-workflow");
         workflowStepStore.addStep(workflowStepZero);
         workflowStepStore.addStep(workflowStepOne);
     });
 
     it("adds connection", () => {
-        const connectionStore = useConnectionStore();
+        const connectionStore = useConnectionStore("mock-workflow");
         expect(connectionStore.connections.length).toBe(0);
         connectionStore.addConnection(connection);
         expect(connectionStore.connections.length).toBe(1);
     });
     it("removes connection", () => {
-        const connectionStore = useConnectionStore();
+        const connectionStore = useConnectionStore("mock-workflow");
         connectionStore.addConnection(connection);
         connectionStore.removeConnection(inputTerminal);
         expect(connectionStore.connections.length).toBe(0);
     });
     it("finds connections for steps", () => {
-        const connectionStore = useConnectionStore();
+        const connectionStore = useConnectionStore("mock-workflow");
         expect(connectionStore.getConnectionsForStep(0)).toStrictEqual([]);
         expect(connectionStore.getConnectionsForStep(1)).toStrictEqual([]);
         connectionStore.addConnection(connection);
@@ -67,7 +67,7 @@ describe("Connection Store", () => {
         expect(connectionStore.getConnectionsForStep(1)).toStrictEqual([]);
     });
     it("finds output terminals for input terminal", () => {
-        const connectionStore = useConnectionStore();
+        const connectionStore = useConnectionStore("mock-workflow");
         expect(connectionStore.getOutputTerminalsForInputTerminal(getTerminalId(connection.input))).toStrictEqual([]);
         connectionStore.addConnection(connection);
         expect(connectionStore.getOutputTerminalsForInputTerminal(getTerminalId(connection.input))).toStrictEqual([

--- a/client/src/stores/workflowEditorStateStore.ts
+++ b/client/src/stores/workflowEditorStateStore.ts
@@ -33,67 +33,69 @@ interface State {
     stepLoadingState: { [index: number]: { loading?: boolean; error?: string } };
 }
 
-export const useWorkflowStateStore = defineStore("workflowStateStore", {
-    state: (): State => ({
-        inputTerminals: {},
-        outputTerminals: {},
-        draggingPosition: null,
-        draggingTerminal: null,
-        activeNodeId: null,
-        scale: 1,
-        stepPosition: {},
-        stepLoadingState: {},
-    }),
-    getters: {
-        getInputTerminalPosition(state: State) {
-            return (stepId: number, inputName: string) => {
-                return state.inputTerminals[stepId]?.[inputName] as InputTerminalPosition | undefined;
-            };
+export const useWorkflowStateStore = (workflowId: string) => {
+    return defineStore(`workflowStateStore${workflowId}`, {
+        state: (): State => ({
+            inputTerminals: {},
+            outputTerminals: {},
+            draggingPosition: null,
+            draggingTerminal: null,
+            activeNodeId: null,
+            scale: 1,
+            stepPosition: {},
+            stepLoadingState: {},
+        }),
+        getters: {
+            getInputTerminalPosition(state: State) {
+                return (stepId: number, inputName: string) => {
+                    return state.inputTerminals[stepId]?.[inputName] as InputTerminalPosition | undefined;
+                };
+            },
+            getOutputTerminalPosition(state: State) {
+                return (stepId: number, outputName: string) => {
+                    return state.outputTerminals[stepId]?.[outputName] as OutputTerminalPosition | undefined;
+                };
+            },
+            getStepLoadingState(state: State) {
+                return (stepId: number) => state.stepLoadingState[stepId];
+            },
         },
-        getOutputTerminalPosition(state: State) {
-            return (stepId: number, outputName: string) => {
-                return state.outputTerminals[stepId]?.[outputName] as OutputTerminalPosition | undefined;
-            };
-        },
-        getStepLoadingState(state: State) {
-            return (stepId: number) => state.stepLoadingState[stepId];
-        },
-    },
-    actions: {
-        setInputTerminalPosition(stepId: number, inputName: string, position: InputTerminalPosition) {
-            if (!this.inputTerminals[stepId]) {
-                Vue.set(this.inputTerminals, stepId, {});
-            }
+        actions: {
+            setInputTerminalPosition(stepId: number, inputName: string, position: InputTerminalPosition) {
+                if (!this.inputTerminals[stepId]) {
+                    Vue.set(this.inputTerminals, stepId, {});
+                }
 
-            Vue.set(this.inputTerminals[stepId]!, inputName, position);
-        },
-        setOutputTerminalPosition(stepId: number, outputName: string, position: OutputTerminalPosition) {
-            if (!this.outputTerminals[stepId]) {
-                Vue.set(this.outputTerminals, stepId, reactive({}));
-            }
+                Vue.set(this.inputTerminals[stepId]!, inputName, position);
+            },
+            setOutputTerminalPosition(stepId: number, outputName: string, position: OutputTerminalPosition) {
+                if (!this.outputTerminals[stepId]) {
+                    Vue.set(this.outputTerminals, stepId, reactive({}));
+                }
 
-            Vue.set(this.outputTerminals[stepId]!, outputName, position);
+                Vue.set(this.outputTerminals[stepId]!, outputName, position);
+            },
+            deleteInputTerminalPosition(stepId: number, inputName: string) {
+                delete this.inputTerminals[stepId]?.[inputName];
+            },
+            deleteOutputTerminalPosition(stepId: number, outputName: string) {
+                delete this.outputTerminals[stepId]?.[outputName];
+            },
+            setActiveNode(nodeId: number | null) {
+                this.activeNodeId = nodeId;
+            },
+            setScale(scale: number) {
+                this.scale = scale;
+            },
+            setStepPosition(stepId: number, position: UnwrapRef<UseElementBoundingReturn>) {
+                Vue.set(this.stepPosition, stepId, position);
+            },
+            deleteStepPosition(stepId: number) {
+                delete this.stepPosition[stepId];
+            },
+            setLoadingState(stepId: number, loading: boolean, error: string | undefined) {
+                Vue.set(this.stepLoadingState, stepId, { loading, error });
+            },
         },
-        deleteInputTerminalPosition(stepId: number, inputName: string) {
-            delete this.inputTerminals[stepId]?.[inputName];
-        },
-        deleteOutputTerminalPosition(stepId: number, outputName: string) {
-            delete this.outputTerminals[stepId]?.[outputName];
-        },
-        setActiveNode(nodeId: number | null) {
-            this.activeNodeId = nodeId;
-        },
-        setScale(scale: number) {
-            this.scale = scale;
-        },
-        setStepPosition(stepId: number, position: UnwrapRef<UseElementBoundingReturn>) {
-            Vue.set(this.stepPosition, stepId, position);
-        },
-        deleteStepPosition(stepId: number) {
-            delete this.stepPosition[stepId];
-        },
-        setLoadingState(stepId: number, loading: boolean, error: string | undefined) {
-            Vue.set(this.stepLoadingState, stepId, { loading, error });
-        },
-    },
-});
+    })();
+};

--- a/client/src/stores/workflowStepStore.test.ts
+++ b/client/src/stores/workflowStepStore.test.ts
@@ -32,29 +32,29 @@ describe("Connection Store", () => {
     });
 
     it("adds step", () => {
-        const stepStore = useWorkflowStepStore();
+        const stepStore = useWorkflowStepStore("mock-workflow");
         expect(stepStore.steps).toStrictEqual({});
         stepStore.addStep(workflowStepZero);
         expect(stepStore.getStep(0)).toStrictEqual(workflowStepZero);
         expect(workflowStepZero.id).toBe(0);
     });
     it("removes step", () => {
-        const stepStore = useWorkflowStepStore();
+        const stepStore = useWorkflowStepStore("mock-workflow");
         const addedStep = stepStore.addStep(workflowStepZero);
         expect(addedStep.id).toBe(0);
         stepStore.removeStep(addedStep.id);
         expect(stepStore.getStep(0)).toBe(undefined);
     });
     it("creates connection if step has connection", () => {
-        const stepStore = useWorkflowStepStore();
-        const connectionStore = useConnectionStore();
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        const connectionStore = useConnectionStore("mock-workflow");
         stepStore.addStep(workflowStepZero);
         stepStore.addStep(workflowStepOne);
         expect(connectionStore.connections.length).toBe(1);
     });
     it("removes connection if step has connection", () => {
-        const stepStore = useWorkflowStepStore();
-        const connectionStore = useConnectionStore();
+        const stepStore = useWorkflowStepStore("mock-workflow");
+        const connectionStore = useConnectionStore("mock-workflow");
         stepStore.addStep(workflowStepZero);
         const stepOne = stepStore.addStep(workflowStepOne);
         expect(connectionStore.connections.length).toBe(1);

--- a/client/src/stores/workflowStepStore.ts
+++ b/client/src/stores/workflowStepStore.ts
@@ -142,165 +142,170 @@ interface StepInputMapOver {
     [index: number]: { [index: string]: CollectionTypeDescriptor };
 }
 
-export const useWorkflowStepStore = defineStore("workflowStepStore", {
-    state: (): State => ({
-        steps: {} as Steps,
-        stepMapOver: {} as { [index: number]: CollectionTypeDescriptor },
-        stepInputMapOver: {} as StepInputMapOver,
-        stepIndex: -1,
-        stepExtraInputs: {} as { [index: number]: InputTerminalSource[] },
-    }),
-    getters: {
-        getStep(state: State) {
-            return (stepId: number): Step | undefined => {
-                return state.steps[stepId.toString()];
-            };
+export const useWorkflowStepStore = (workflowId: string) => {
+    return defineStore(`workflowStepStore${workflowId}`, {
+        state: (): State => ({
+            steps: {} as Steps,
+            stepMapOver: {} as { [index: number]: CollectionTypeDescriptor },
+            stepInputMapOver: {} as StepInputMapOver,
+            stepIndex: -1,
+            stepExtraInputs: {} as { [index: number]: InputTerminalSource[] },
+        }),
+        getters: {
+            getStep(state: State) {
+                return (stepId: number): Step | undefined => {
+                    return state.steps[stepId.toString()];
+                };
+            },
+            getStepExtraInputs(state: State) {
+                return (stepId: number) => this.stepExtraInputs[stepId] || [];
+            },
+            getStepIndex(state: State) {
+                return Math.max(...Object.values(state.steps).map((step) => step.id), state.stepIndex);
+            },
+            hasActiveOutputs(state: State) {
+                return Boolean(Object.values(state.steps).find((step) => step.workflow_outputs?.length));
+            },
+            workflowOutputs(state: State) {
+                const workflowOutputs: WorkflowOutputs = {};
+                Object.values(state.steps).forEach((step) => {
+                    if (step.workflow_outputs?.length) {
+                        step.workflow_outputs.forEach((workflowOutput) => {
+                            if (workflowOutput.label) {
+                                workflowOutputs[workflowOutput.label] = {
+                                    outputName: workflowOutput.output_name,
+                                    stepId: step.id,
+                                };
+                            }
+                        });
+                    }
+                });
+                return workflowOutputs;
+            },
         },
-        getStepExtraInputs(state: State) {
-            return (stepId: number) => this.stepExtraInputs[stepId] || [];
-        },
-        getStepIndex(state: State) {
-            return Math.max(...Object.values(state.steps).map((step) => step.id), state.stepIndex);
-        },
-        hasActiveOutputs(state: State) {
-            return Boolean(Object.values(state.steps).find((step) => step.workflow_outputs?.length));
-        },
-        workflowOutputs(state: State) {
-            const workflowOutputs: WorkflowOutputs = {};
-            Object.values(state.steps).forEach((step) => {
-                if (step.workflow_outputs?.length) {
-                    step.workflow_outputs.forEach((workflowOutput) => {
-                        if (workflowOutput.label) {
-                            workflowOutputs[workflowOutput.label] = {
-                                outputName: workflowOutput.output_name,
-                                stepId: step.id,
-                            };
-                        }
-                    });
-                }
-            });
-            return workflowOutputs;
-        },
-    },
-    actions: {
-        addStep(newStep: NewStep): Step {
-            const stepId = newStep.id ? newStep.id : this.getStepIndex + 1;
-            const step = Object.freeze({ ...newStep, id: stepId } as Step);
-            Vue.set(this.steps, stepId.toString(), step);
-            const connectionStore = useConnectionStore();
-            stepToConnections(step).map((connection) => connectionStore.addConnection(connection));
-            this.stepExtraInputs[step.id] = getStepExtraInputs(step);
-            return step;
-        },
-        insertNewStep(
-            contentId: NewStep["content_id"],
-            name: NewStep["name"],
-            type: NewStep["type"],
-            position: NewStep["position"]
-        ) {
-            const stepData: NewStep = {
-                name: name,
-                content_id: contentId,
-                input_connections: {},
-                type: type,
-                inputs: [],
-                outputs: [],
-                position: position,
-                post_job_actions: {},
-                tool_state: {},
-            };
-            return this.addStep(stepData);
-        },
-        updateStep(this: State, step: Step) {
-            const workflow_outputs = step.workflow_outputs?.filter((workflowOutput) =>
-                step.outputs.find((output) => workflowOutput.output_name == output.name)
-            );
-            this.steps[step.id.toString()] = Object.freeze({ ...step, workflow_outputs });
-            this.stepExtraInputs[step.id] = getStepExtraInputs(step);
-        },
-        changeStepMapOver(stepId: number, mapOver: CollectionTypeDescriptor) {
-            Vue.set(this.stepMapOver, stepId, mapOver);
-        },
-        resetStepInputMapOver(stepId: number) {
-            Vue.set(this.stepInputMapOver, stepId, {});
-        },
-        changeStepInputMapOver(stepId: number, inputName: string, mapOver: CollectionTypeDescriptor) {
-            if (this.stepInputMapOver[stepId]) {
-                Vue.set(this.stepInputMapOver[stepId]!, inputName, mapOver);
-            } else {
-                Vue.set(this.stepInputMapOver, stepId, { [inputName]: mapOver });
-            }
-        },
-        addConnection(connection: Connection) {
-            const inputStep = this.getStep(connection.input.stepId);
-            assertDefined(
-                inputStep,
-                `Failed to add connection, because step with id ${connection.input.stepId} is undefined`
-            );
-            const input = inputStep.inputs.find((input) => input.name === connection.input.name);
-            const connectionLink: ConnectionOutputLink = {
-                output_name: connection.output.name,
-                id: connection.output.stepId,
-            };
-            if (input && "input_subworkflow_step_id" in input && input.input_subworkflow_step_id !== undefined) {
-                connectionLink["input_subworkflow_step_id"] = input.input_subworkflow_step_id;
-            }
-            let connectionLinks: ConnectionOutputLink[] = [connectionLink];
-            let inputConnection = inputStep.input_connections[connection.input.name];
-            if (inputConnection) {
-                if (!Array.isArray(inputConnection)) {
-                    inputConnection = [inputConnection];
-                }
-                inputConnection = inputConnection.filter(
-                    (connection) =>
-                        !(connection.id === connectionLink.id && connection.output_name === connectionLink.output_name)
+        actions: {
+            addStep(newStep: NewStep): Step {
+                const stepId = newStep.id ? newStep.id : this.getStepIndex + 1;
+                const step = Object.freeze({ ...newStep, id: stepId } as Step);
+                Vue.set(this.steps, stepId.toString(), step);
+                const connectionStore = useConnectionStore(workflowId);
+                stepToConnections(step).map((connection) => connectionStore.addConnection(connection));
+                this.stepExtraInputs[step.id] = getStepExtraInputs(step);
+                return step;
+            },
+            insertNewStep(
+                contentId: NewStep["content_id"],
+                name: NewStep["name"],
+                type: NewStep["type"],
+                position: NewStep["position"]
+            ) {
+                const stepData: NewStep = {
+                    name: name,
+                    content_id: contentId,
+                    input_connections: {},
+                    type: type,
+                    inputs: [],
+                    outputs: [],
+                    position: position,
+                    post_job_actions: {},
+                    tool_state: {},
+                };
+                return this.addStep(stepData);
+            },
+            updateStep(this: State, step: Step) {
+                const workflow_outputs = step.workflow_outputs?.filter((workflowOutput) =>
+                    step.outputs.find((output) => workflowOutput.output_name == output.name)
                 );
-                connectionLinks = [...connectionLinks, ...inputConnection];
-            }
-            const updatedStep = {
-                ...inputStep,
-                input_connections: {
-                    ...inputStep.input_connections,
-                    [connection.input.name]: connectionLinks.sort((a, b) =>
-                        a.id === b.id ? a.output_name.localeCompare(b.output_name) : a.id - b.id
-                    ),
-                },
-            };
-            this.updateStep(updatedStep);
-        },
-        removeConnection(connection: Connection) {
-            const inputStep = this.getStep(connection.input.stepId);
-            assertDefined(
-                inputStep,
-                `Failed to remove connection, because step with id ${connection.input.stepId} is undefined`
-            );
-
-            const inputConnections = inputStep.input_connections[connection.input.name];
-            if (this.getStepExtraInputs(inputStep.id).find((input) => connection.input.name === input.name)) {
-                inputStep.input_connections[connection.input.name] = undefined;
-            } else {
-                if (Array.isArray(inputConnections)) {
-                    inputStep.input_connections[connection.input.name] = inputConnections.filter(
-                        (outputLink) =>
-                            !(outputLink.id === connection.output.stepId,
-                            outputLink.output_name === connection.output.name)
-                    );
+                this.steps[step.id.toString()] = Object.freeze({ ...step, workflow_outputs });
+                this.stepExtraInputs[step.id] = getStepExtraInputs(step);
+            },
+            changeStepMapOver(stepId: number, mapOver: CollectionTypeDescriptor) {
+                Vue.set(this.stepMapOver, stepId, mapOver);
+            },
+            resetStepInputMapOver(stepId: number) {
+                Vue.set(this.stepInputMapOver, stepId, {});
+            },
+            changeStepInputMapOver(stepId: number, inputName: string, mapOver: CollectionTypeDescriptor) {
+                if (this.stepInputMapOver[stepId]) {
+                    Vue.set(this.stepInputMapOver[stepId]!, inputName, mapOver);
                 } else {
-                    Vue.delete(inputStep.input_connections, connection.input.name);
+                    Vue.set(this.stepInputMapOver, stepId, { [inputName]: mapOver });
                 }
-            }
-            this.updateStep(inputStep);
+            },
+            addConnection(connection: Connection) {
+                const inputStep = this.getStep(connection.input.stepId);
+                assertDefined(
+                    inputStep,
+                    `Failed to add connection, because step with id ${connection.input.stepId} is undefined`
+                );
+                const input = inputStep.inputs.find((input) => input.name === connection.input.name);
+                const connectionLink: ConnectionOutputLink = {
+                    output_name: connection.output.name,
+                    id: connection.output.stepId,
+                };
+                if (input && "input_subworkflow_step_id" in input && input.input_subworkflow_step_id !== undefined) {
+                    connectionLink["input_subworkflow_step_id"] = input.input_subworkflow_step_id;
+                }
+                let connectionLinks: ConnectionOutputLink[] = [connectionLink];
+                let inputConnection = inputStep.input_connections[connection.input.name];
+                if (inputConnection) {
+                    if (!Array.isArray(inputConnection)) {
+                        inputConnection = [inputConnection];
+                    }
+                    inputConnection = inputConnection.filter(
+                        (connection) =>
+                            !(
+                                connection.id === connectionLink.id &&
+                                connection.output_name === connectionLink.output_name
+                            )
+                    );
+                    connectionLinks = [...connectionLinks, ...inputConnection];
+                }
+                const updatedStep = {
+                    ...inputStep,
+                    input_connections: {
+                        ...inputStep.input_connections,
+                        [connection.input.name]: connectionLinks.sort((a, b) =>
+                            a.id === b.id ? a.output_name.localeCompare(b.output_name) : a.id - b.id
+                        ),
+                    },
+                };
+                this.updateStep(updatedStep);
+            },
+            removeConnection(connection: Connection) {
+                const inputStep = this.getStep(connection.input.stepId);
+                assertDefined(
+                    inputStep,
+                    `Failed to remove connection, because step with id ${connection.input.stepId} is undefined`
+                );
+
+                const inputConnections = inputStep.input_connections[connection.input.name];
+                if (this.getStepExtraInputs(inputStep.id).find((input) => connection.input.name === input.name)) {
+                    inputStep.input_connections[connection.input.name] = undefined;
+                } else {
+                    if (Array.isArray(inputConnections)) {
+                        inputStep.input_connections[connection.input.name] = inputConnections.filter(
+                            (outputLink) =>
+                                !(outputLink.id === connection.output.stepId,
+                                outputLink.output_name === connection.output.name)
+                        );
+                    } else {
+                        Vue.delete(inputStep.input_connections, connection.input.name);
+                    }
+                }
+                this.updateStep(inputStep);
+            },
+            removeStep(this: State, stepId: number) {
+                const connectionStore = useConnectionStore(workflowId);
+                connectionStore
+                    .getConnectionsForStep(stepId)
+                    .forEach((connection) => connectionStore.removeConnection(getConnectionId(connection)));
+                Vue.delete(this.steps, stepId.toString());
+                Vue.delete(this.stepExtraInputs, stepId);
+            },
         },
-        removeStep(this: State, stepId: number) {
-            const connectionStore = useConnectionStore();
-            connectionStore
-                .getConnectionsForStep(stepId)
-                .forEach((connection) => connectionStore.removeConnection(getConnectionId(connection)));
-            Vue.delete(this.steps, stepId.toString());
-            Vue.delete(this.stepExtraInputs, stepId);
-        },
-    },
-});
+    })();
+};
 
 export function stepToConnections(step: Step): Connection[] {
     const connections: Connection[] = [];


### PR DESCRIPTION
Changes the workflow stores to be scoped, in preparation for enabling to use multiple instances of the workflow editor simultaneously.

Relevant comment: https://github.com/galaxyproject/galaxy/pull/16510#discussion_r1282988670

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
