### PR TITLE
[23.1] Run through tmp_dir_creation_statement only once

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -4,9 +4,13 @@ $headers
 
 _galaxy_setup_environment() {
     local _use_framework_galaxy="$1"
-    _GALAXY_JOB_DIR="$working_directory"
-    _GALAXY_JOB_HOME_DIR="$home_directory"
-    _GALAXY_JOB_TMP_DIR=$tmp_dir_creation_statement
+
+    if [ -z "$_GALAXY_JOB_TMP_DIR" ]; then
+        _GALAXY_JOB_DIR="$working_directory"
+        _GALAXY_JOB_HOME_DIR="$home_directory"
+        _GALAXY_JOB_TMP_DIR=$tmp_dir_creation_statement
+    fi
+
     $env_setup_commands
     if [ "$GALAXY_LIB" != "None" -a "$_use_framework_galaxy" = "True" ]; then
         if [ -n "$PYTHONPATH" ]; then


### PR DESCRIPTION
We call `_galaxy_setup_environment` twice, once before the tool script call and once before set_metadata. The second time around we don't need to do anything. It's a minor tweak that avoids permission errors when the tmpdir has been mounted in docker (where on OSX the permissions somehow get altered in a way I don't understand at all).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
