### PR TITLE
[23.1] Fix double-encoding notification content

### DIFF
--- a/lib/galaxy/managers/notification.py
+++ b/lib/galaxy/managers/notification.py
@@ -323,7 +323,7 @@ class NotificationManager:
             payload.source,
             payload.category,
             payload.variant,
-            payload.content.json(),
+            payload.content.dict(),
         )
         notification.publication_time = payload.publication_time
         notification.expiration_time = payload.expiration_time

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -119,6 +119,7 @@ import galaxy.security.passwords
 import galaxy.util
 from galaxy.model.base import transaction
 from galaxy.model.custom_types import (
+    DoubleEncodedJsonType,
     JSONType,
     MetadataType,
     MutableJSONType,
@@ -2788,7 +2789,9 @@ class Notification(Base, Dictifiable, RepresentById):
     variant = Column(
         String(16), index=True
     )  # Defines the 'importance' of the notification ('info', 'warning', 'urgent', etc.). Used for filtering, highlight rendering, etc
-    content = Column(JSONType)  # Structured content in JSON. Depending on the category of the notification
+    # A bug in early 23.1 led to values being stored as json string, so we use this special type to process the result value twice.
+    # content should always be a dict
+    content = Column(DoubleEncodedJsonType)
 
     user_notification_associations = relationship("UserNotificationAssociation", back_populates="notification")
 

--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -116,6 +116,17 @@ class JSONType(TypeDecorator):
         return x == y
 
 
+class DoubleEncodedJsonType(JSONType):
+    def process_result_value(self, value, dialect):
+        value = super().process_result_value(value, dialect)
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except ValueError:
+                return value
+        return value
+
+
 class MutableJSONType(JSONType):
     """Associated with MutationObj"""
 

--- a/lib/galaxy/schema/notifications.py
+++ b/lib/galaxy/schema/notifications.py
@@ -1,8 +1,6 @@
-import json
 from datetime import datetime
 from enum import Enum
 from typing import (
-    Any,
     Dict,
     List,
     Optional,
@@ -14,7 +12,6 @@ from pydantic import (
     Field,
     Required,
 )
-from pydantic.utils import GetterDict
 from typing_extensions import (
     Annotated,
     Literal,
@@ -125,21 +122,6 @@ AnyNotificationContent = Annotated[
     ),
 ]
 
-
-class NotificationGetter(GetterDict):
-    """Helper to convert a Notification ORM model into a NotificationResponse.
-    For more information: https://docs.pydantic.dev/usage/models/#data-binding
-    """
-
-    def get(self, key: Any, default: Any = None) -> Any:
-        # The `content` column of the ORM model is a JSON string that needs to be passed
-        # as a dictionary to the `from_orm` constructor to build the correct `AnyNotificationContent`.
-        if key in {"content"} and isinstance(self._obj.content, str):
-            return json.loads(self._obj.content)
-
-        return super().get(key, default)
-
-
 NotificationIdField = Field(
     Required,
     title="ID",
@@ -204,7 +186,6 @@ class NotificationResponse(Model):
 
     class Config:
         orm_mode = True
-        getter_dict = NotificationGetter
 
 
 class UserNotificationResponse(NotificationResponse):

--- a/test/unit/app/managers/test_NotificationManager.py
+++ b/test/unit/app/managers/test_NotificationManager.py
@@ -1,4 +1,3 @@
-import json
 from datetime import (
     datetime,
     timedelta,
@@ -109,7 +108,7 @@ class NotificationManagerBaseTestCase(NotificationsBaseTestCase):
             assert actual_notification.expiration_time is not None
 
         assert actual_notification.content
-        user_notification_content = json.loads(actual_notification.content)
+        user_notification_content = actual_notification.content
         assert user_notification_content["category"] == expected_notification["content"]["category"]
         assert user_notification_content["subject"] == expected_notification["content"]["subject"]
         assert user_notification_content["message"] == expected_notification["content"]["message"]
@@ -122,7 +121,7 @@ class TestBroadcastNotifications(NotificationManagerBaseTestCase):
 
         assert actual_notification.id
         assert actual_notification.category == "broadcast"
-        notification_content = json.loads(actual_notification.content)
+        notification_content = actual_notification.content
         assert notification_content["category"] == "broadcast"
         assert notification_content["subject"] == "Testing Broadcast Subject"
         assert notification_content["message"] == "Testing Broadcast Message"
@@ -161,16 +160,16 @@ class TestBroadcastNotifications(NotificationManagerBaseTestCase):
 
         notifications = self.notification_manager.get_all_broadcasted_notifications()
         assert len(notifications) == 1
-        assert json.loads(notifications[0].content)["subject"] == "Recent Notification"
+        assert notifications[0].content["subject"] == "Recent Notification"
 
         notifications = self.notification_manager.get_all_broadcasted_notifications(since=next_week, active_only=False)
         assert len(notifications) == 2
-        assert json.loads(notifications[0].content)["subject"] == "Scheduled Next Week Notification"
-        assert json.loads(notifications[1].content)["subject"] == "Scheduled Next Month Notification"
+        assert notifications[0].content["subject"] == "Scheduled Next Week Notification"
+        assert notifications[1].content["subject"] == "Scheduled Next Month Notification"
 
         notifications = self.notification_manager.get_all_broadcasted_notifications(since=next_month, active_only=False)
         assert len(notifications) == 1
-        assert json.loads(notifications[0].content)["subject"] == "Scheduled Next Month Notification"
+        assert notifications[0].content["subject"] == "Scheduled Next Month Notification"
 
     def test_update_broadcasted_notification(self):
         next_month = datetime.utcnow() + timedelta(days=30)
@@ -195,7 +194,7 @@ class TestBroadcastNotifications(NotificationManagerBaseTestCase):
         assert updated_notification.source == update_request.source
         assert updated_notification.variant == update_request.variant
         assert updated_notification.publication_time == update_request.publication_time
-        content = json.loads(updated_notification.content)
+        content = updated_notification.content
         assert content["subject"] == expected_content.subject
         assert content["message"] == expected_content.message
 


### PR DESCRIPTION
The additional column type keeps backwards compatibility with existing notifications.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
flip `payload.content.dict()` back to `payload.content.json()` and run 
test/integration/test_notifications.py::TestNotificationsIntegration::test_update_notifications, it'll pass, meaning the new column type did its job

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
