### PR TITLE
Tweak tool memory use and optimize shared memory when using preload

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1167,18 +1167,6 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``delay_tool_initialization``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Set this to true to delay parsing of tool inputs and outputs until
-    they are needed. This results in faster startup times but uses
-    more memory when using forked Galaxy processes.
-:Default: ``false``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``biotools_content_directory``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -646,6 +646,8 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
             ("application stack", self._shutdown_application_stack),
         ]
         self._register_singleton(StructuredApp, self)  # type: ignore[type-abstract]
+        if kwargs.get("is_webapp"):
+            self.is_webapp = kwargs["is_webapp"]
         # A lot of postfork initialization depends on the server name, ensure it is set immediately after forking before other postfork functions
         self.application_stack.register_postfork_function(self.application_stack.set_postfork_server_name, self)
         self.config.reload_sanitize_allowlist(explicit="sanitize_allowlist_file" in kwargs)

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -227,7 +227,7 @@ class MockAppConfig(GalaxyDataTestConfig, CommonConfigurationMixin):
 
         # set by MockDir
         self.enable_tool_document_cache = False
-        self.delay_tool_initialization = True
+        self.tool_cache_data_dir = os.path.join(self.root, "tool_cache")
         self.external_chown_script = None
         self.check_job_script_integrity = False
         self.check_job_script_integrity_count = 0

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -104,6 +104,7 @@ class MockApp(di.Container, GalaxyDataTestApp):
     history_manager: HistoryManager
     job_metrics: JobMetrics
     stop: bool
+    is_webapp: bool = True
 
     def __init__(self, config=None, **kwargs) -> None:
         super().__init__()

--- a/lib/galaxy/app_unittest_utils/tools_support.py
+++ b/lib/galaxy/app_unittest_utils/tools_support.py
@@ -109,7 +109,6 @@ class UsesTools(UsesApp):
     def __setup_tool(self):
         tool_source = get_tool_source(self.tool_file)
         self.tool = create_tool_from_source(self.app, tool_source, config_file=self.tool_file)
-        self.tool.assert_finalized()
         if getattr(self, "tool_action", None):
             self.tool.tool_action = self.tool_action
         return self.tool

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -899,11 +899,6 @@ galaxy:
   # this option will be resolved with respect to <data_dir>.
   #tool_search_index_dir: tool_search_index
 
-  # Set this to true to delay parsing of tool inputs and outputs until
-  # they are needed. This results in faster startup times but uses more
-  # memory when using forked Galaxy processes.
-  #delay_tool_initialization: false
-
   # Point Galaxy at a repository consisting of a copy of the bio.tools
   # database (e.g. https://github.com/bio-tools/content/) to resolve
   # bio.tools data for tool metadata.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -846,15 +846,6 @@ mapping:
         desc:
           Directory in which the toolbox search index is stored.
 
-      delay_tool_initialization:
-        type: bool
-        default: false
-        required: false
-        desc: |
-          Set this to true to delay parsing of tool inputs and outputs until they are needed.
-          This results in faster startup times but uses more memory when using forked Galaxy
-          processes.
-
       biotools_content_directory:
         type: str
         required: false

--- a/lib/galaxy/structured_app.py
+++ b/lib/galaxy/structured_app.py
@@ -73,6 +73,7 @@ class BasicSharedApp(Container):
 
 
 class MinimalToolApp(Protocol):
+    is_webapp: bool
     name: str
     # Leave config as Any: in a full Galaxy app this is a GalaxyAppConfiguration object, but this is mostly dynamically
     # generated, and here we want to also allow other kinds of configuration objects (e.g. a Bunch).

--- a/lib/galaxy/tool_shed/tools/tool_validator.py
+++ b/lib/galaxy/tool_shed/tools/tool_validator.py
@@ -89,7 +89,6 @@ class ToolValidator:
                 repository_id=repository_id,
                 allow_code_files=False,
             )
-            tool.assert_finalized(raise_if_invalid=True)
             valid = True
             error_message = None
         except KeyError as e:

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -270,7 +270,7 @@ class ToolSource(metaclass=ABCMeta):
         return [], []
 
     @abstractmethod
-    def parse_help(self):
+    def parse_help(self) -> Optional[str]:
         """Return RST definition of help text for tool or None if the tool
         doesn't define help text.
         """

--- a/lib/galaxy/tool_util/parser/output_objects.py
+++ b/lib/galaxy/tool_util/parser/output_objects.py
@@ -5,6 +5,8 @@ from typing import (
     Optional,
 )
 
+from typing_extensions import TypedDict
+
 from galaxy.util import Element
 from galaxy.util.dictifiable import Dictifiable
 from .output_actions import ToolOutputActionGroup
@@ -12,6 +14,14 @@ from .output_collection_def import (
     dataset_collector_descriptions_from_output_dict,
     DatasetCollectionDescription,
 )
+
+
+class ChangeFormatModel(TypedDict):
+    value: Optional[str]
+    format: Optional[str]
+    input: Optional[str]
+    input_dataset: Optional[str]
+    check_attribute: Optional[str]
 
 
 class ToolOutputBase(Dictifiable):
@@ -84,7 +94,7 @@ class ToolOutput(ToolOutputBase):
         self.actions = actions
 
         # Initialize default values
-        self.change_format: List[Element] = []
+        self.change_format: List[ChangeFormatModel] = []
         self.implicit = implicit
         self.from_work_dir: Optional[str] = None
         self.dataset_collector_descriptions: List[DatasetCollectionDescription] = []

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -1214,21 +1214,16 @@ class XmlInputSource(InputSource):
         >>> xis.parse_static_options()
         [('a', 'a', True), ('b', 'b', False)]
         """
-        static_options = list()
+
+        deduplicated_static_options = {}
+
         elem = self.input_elem
         for option in elem.findall("option"):
             value = option.get("value")
             text = option.text or value
             selected = string_as_bool(option.get("selected", False))
-            present = False
-            for i, o in enumerate(static_options):
-                if o[1] == value:
-                    present = True
-                    static_options[i] = (text, value, selected)
-                    break
-            if not present:
-                static_options.append((text, value, selected))
-        return static_options
+            deduplicated_static_options[value] = (text, value, selected)
+        return list(deduplicated_static_options.values())
 
     def parse_optional(self, default=None):
         """Return boolean indicating whether parameter is optional."""

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -62,6 +62,27 @@ def inject_validates(inject):
     return match is not None
 
 
+def destroy_tree(tree):
+    root = tree.getroot()
+
+    node_tracker = {root: [0, None]}
+
+    for node in root.iterdescendants():
+        parent = node.getparent()
+        node_tracker[node] = [node_tracker[parent][0] + 1, parent]
+
+    node_tracker = sorted(
+        [(depth, parent, child) for child, (depth, parent) in node_tracker.items()], key=lambda x: x[0], reverse=True
+    )
+
+    for _, parent, child in node_tracker:
+        if parent is None:
+            break
+        parent.remove(child)
+
+    del tree
+
+
 class XmlToolSource(ToolSource):
     """Responsible for parsing a tool from classic Galaxy representation."""
 
@@ -80,6 +101,7 @@ class XmlToolSource(ToolSource):
         return self._string
 
     def mem_optimize(self):
+        destroy_tree(self.xml_tree)
         self.root = None
         self._xml_tree = None
 

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -70,13 +70,18 @@ class XmlToolSource(ToolSource):
 
     def __init__(self, xml_tree: ElementTree, source_path=None, macro_paths=None):
         self.xml_tree = xml_tree
-        self.root = xml_tree.getroot()
+        self.root = self.xml_tree.getroot()
         self._source_path = source_path
         self._macro_paths = macro_paths or []
         self.legacy_defaults = self.parse_profile() == "16.01"
+        self._string = xml_to_string(self.root)
 
     def to_string(self):
-        return xml_to_string(self.root)
+        return self._string
+
+    def mem_optimize(self):
+        self.root = None
+        self._xml_tree = None
 
     def parse_version(self):
         return self.root.get("version", None)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1282,7 +1282,7 @@ class Tool(Dictifiable):
     def tests(self):
         if self.__tests:
             return [ToolTestDescription(d) for d in json.loads(self.__tests)]
-        return self.__tests
+        return None
 
     @property
     def _repository_dir(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -819,7 +819,7 @@ class Tool(Dictifiable):
             try:
                 self.parse_inputs(self.tool_source)
                 self.parse_outputs(self.tool_source)
-                self.is_workflow_compatible
+                _ = self.is_workflow_compatible
                 self.finalized = True
                 mem_optimize = getattr(self.tool_source, "mem_optimize", None)
                 if mem_optimize is not None:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1140,7 +1140,7 @@ class Tool(Dictifiable):
                 try:
                     expressions.find_engine(self.app.config)
                 except Exception:
-                    message = REQUIRES_JS_RUNTIME_MESSAGE % self.tool_id or self.tool_uuid
+                    message = REQUIRES_JS_RUNTIME_MESSAGE % self.id or getattr(self, "uuid", "unknown tool id")
                     raise Exception(message)
         # Tests
         self.__parse_tests(tool_source)
@@ -3450,6 +3450,10 @@ class FilterDatasetsTool(DatabaseOperationTool):
                 copied_value = dce.element_object.copy()
             new_elements[element_identifier] = copied_value
         return new_elements
+
+    @staticmethod
+    def element_is_valid(element: model.DatasetCollectionElement):
+        return element.element_object.is_ok
 
     def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
         collection = incoming["input"]

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -79,6 +79,7 @@ from galaxy.tool_util.toolbox import (
     ToolSection,
 )
 from galaxy.tool_util.toolbox.views.sources import StaticToolBoxViewSources
+from galaxy.tool_util.verify.interactor import ToolTestDescription
 from galaxy.tool_util.verify.test_data import TestDataNotFoundError
 from galaxy.tool_util.version import (
     LegacyVersion,
@@ -131,10 +132,7 @@ from galaxy.tools.parameters.grouping import (
 from galaxy.tools.parameters.input_translation import ToolInputTranslator
 from galaxy.tools.parameters.meta import expand_meta_parameters
 from galaxy.tools.parameters.wrapped_json import json_wrap
-from galaxy.tools.test import (
-    parse_tests,
-    ToolTestDescription,
-)
+from galaxy.tools.test import parse_tests
 from galaxy.util import (
     in_directory,
     listify,
@@ -779,6 +777,7 @@ class Tool(Dictifiable):
         self.tool_source = tool_source
         self._is_workflow_compatible = None
         self.__help = None
+        self.__tests: Optional[str] = None
         try:
             self.parse(tool_source, guid=guid, dynamic=dynamic)
         except Exception as e:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -704,7 +704,7 @@ class Tool(Dictifiable):
     tool_action: ToolAction
     tool_type_local = False
     dict_collection_visible_keys = ["id", "name", "version", "description", "labels"]
-    __help: Optional[threading.Lock]
+    __help: Optional[Union[threading.Lock, Template]]
     __help_by_page: Union[threading.Lock, List[str]]
     job_search: "JobSearch"
     version: str
@@ -1749,12 +1749,13 @@ class Tool(Dictifiable):
                     encoding_errors="replace",
                 )
             except Exception:
+                self.__help = Template("", input_encoding="utf-8")
                 log.exception("Exception while parsing help for tool with id '%s'", self.id)
 
             # Handle deprecated multi-page help text in XML case.
             self.__help_by_page = []
             tool_source = self.tool_source
-            if getattr(tool_source, "root", None):
+            if isinstance(tool_source, XmlToolSource):
                 help_elem = tool_source.root.find("help")
                 help_header = help_text
                 help_pages = help_elem.findall("page")

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -776,6 +776,7 @@ class Tool(Dictifiable):
         self.tool_source = tool_source
         self._is_workflow_compatible = None
         self.__help = None
+        self.__tests_populated = False
         try:
             self.parse(tool_source, guid=guid, dynamic=dynamic)
         except Exception as e:
@@ -1143,8 +1144,6 @@ class Tool(Dictifiable):
                 except Exception:
                     message = REQUIRES_JS_RUNTIME_MESSAGE % self.id or getattr(self, "uuid", "unknown tool id")
                     raise Exception(message)
-        # Tests
-        self.__parse_tests(tool_source)
 
         # Requirements (dependencies)
         requirements, containers, resource_requirements = tool_source.parse_requirements_and_containers()
@@ -1232,10 +1231,6 @@ class Tool(Dictifiable):
             for key, value in uihints_elem.attrib.items():
                 self.uihints[key] = value
 
-    def __parse_tests(self, tool_source):
-        self.__tests_source = tool_source
-        self.__tests_populated = False
-
     def __parse_config_files(self, tool_source):
         self.config_files = []
         if not hasattr(tool_source, "root"):
@@ -1277,7 +1272,7 @@ class Tool(Dictifiable):
     @property
     def tests(self):
         if not self.__tests_populated:
-            tests_source = self.__tests_source
+            tests_source = self.tool_source
             if tests_source:
                 try:
                     self.__tests = parse_tests(self, tests_source)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1102,10 +1102,12 @@ class Tool(Dictifiable):
         self.license = tool_source.parse_license()
         self.creator = tool_source.parse_creator()
         self.raw_help = tool_source.parse_help()
-        self.__initialize_help()
         self.parse_inputs(self.tool_source)
         self.parse_outputs(self.tool_source)
 
+        if self.app.is_webapp:
+            self.__initialize_help()
+            _ = self.tests
         self.__parse_legacy_features(tool_source)
 
         # Load any tool specific options (optional)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -9,7 +9,6 @@ import os
 import re
 import tarfile
 import tempfile
-import threading
 from collections.abc import MutableMapping
 from pathlib import Path
 from typing import (
@@ -181,7 +180,6 @@ REQUIRES_JS_RUNTIME_MESSAGE = (
     "but node or nodejs could not be found. Please contact the Galaxy adminstrator"
 )
 
-HELP_UNINITIALIZED = threading.Lock()
 MODEL_TOOLS_PATH = os.path.abspath(os.path.dirname(__file__))
 # Tools that require Galaxy's Python environment to be preserved.
 GALAXY_LIB_TOOLS_UNVERSIONED = [
@@ -701,8 +699,8 @@ class Tool(Dictifiable):
     tool_action: ToolAction
     tool_type_local = False
     dict_collection_visible_keys = ["id", "name", "version", "description", "labels"]
-    __help: Optional[Union[threading.Lock, Template]]
-    __help_by_page: Union[threading.Lock, List[str]]
+    __help: Optional[Template]
+    __help_by_page: List[str]
     job_search: "JobSearch"
     version: str
 
@@ -777,6 +775,7 @@ class Tool(Dictifiable):
         # Parse XML element containing configuration
         self.tool_source = tool_source
         self._is_workflow_compatible = None
+        self.__help = None
         try:
             self.parse(tool_source, guid=guid, dynamic=dynamic)
         except Exception as e:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1752,7 +1752,7 @@ class Tool(Dictifiable):
                 log.exception("Exception while parsing help for tool with id '%s'", self.id)
 
             # Handle deprecated multi-page help text in XML case.
-            __help_by_page = []
+            self.__help_by_page = []
             tool_source = self.tool_source
             if getattr(tool_source, "root", None):
                 help_elem = tool_source.root.find("help")
@@ -1762,25 +1762,24 @@ class Tool(Dictifiable):
                 help_footer = ""
                 if help_pages:
                     for help_page in help_pages:
-                        __help_by_page.append(help_page.text)
+                        self.__help_by_page.append(help_page.text)
                         help_footer = help_footer + help_page.tail
                 # Each page has to rendered all-together because of backreferences allowed by rst
                 try:
-                    __help_by_page = [
+                    self.__help_by_page = [
                         Template(
                             rst_to_html(help_header + x + help_footer),
                             input_encoding="utf-8",
                             default_filters=["decode.utf8"],
                             encoding_errors="replace",
                         )
-                        for x in __help_by_page
+                        for x in self.__help_by_page
                     ]
                 except Exception:
                     log.exception("Exception while parsing multi-page help for tool with id '%s'", self.id)
-        # Pad out help pages to match npages ... could this be done better?
-        while len(__help_by_page) < self.npages:
-            __help_by_page.append(self.__help)
-        self.__help_by_page = __help_by_page
+                # Pad out help pages to match npages ... could this be done better?
+                while len(self.__help_by_page) < self.npages:
+                    self.__help_by_page.append(self.__help)
 
     def find_output_def(self, name):
         # name is JobToOutputDatasetAssociation name.

--- a/lib/galaxy/tools/remote_tool_eval.py
+++ b/lib/galaxy/tools/remote_tool_eval.py
@@ -49,6 +49,7 @@ class ToolApp(MinimalToolApp):
     """Dummy App that allows loading tools"""
 
     name = "tool_app"
+    is_webapp = False
 
     def __init__(
         self,

--- a/lib/galaxy/tools/repositories.py
+++ b/lib/galaxy/tools/repositories.py
@@ -12,6 +12,8 @@ from galaxy.util.bunch import Bunch
 class ValidationContext:
     """Minimal App object for tool validation."""
 
+    is_webapp = True
+
     def __init__(
         self,
         app_name,

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -2,6 +2,7 @@ import logging
 import os
 import os.path
 from typing import (
+    Iterable,
     List,
     Tuple,
     Union,
@@ -23,13 +24,13 @@ from galaxy.util import (
 log = logging.getLogger(__name__)
 
 
-def parse_tests(tool, tests_source):
+def parse_tests(tool, tests_source) -> Iterable[ToolTestDescription]:
     """
     Build ToolTestDescription objects for each "<test>" elements and
     return default interactor (if any).
     """
     raw_tests_dict = tests_source.parse_tests_to_dict()
-    tests = []
+    tests: List[ToolTestDescription] = []
     for i, raw_test_dict in enumerate(raw_tests_dict.get("tests", [])):
         test = description_from_tool_object(tool, i, raw_test_dict)
         tests.append(test)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -980,9 +980,11 @@ def rst_to_html(s, error=False):
         "warning_stream": FakeStream(),
         "doctitle_xform": False,  # without option, very different rendering depending on
         # number of sections in help content.
-        "report_level": no_report_level,
         "halt_level": no_report_level,
     }
+    if not error:
+        # in normal operation we don't want noisy warnings, that's tool author business
+        settings_overrides["report_level"] = no_report_level
 
     return unicodify(
         docutils_core.publish_string(s, writer=docutils_html4css1.Writer(), settings_overrides=settings_overrides)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -88,10 +88,12 @@ except ImportError:
 
 try:
     import docutils.core as docutils_core
+    import docutils.utils as docutils_utils
     import docutils.writers.html4css1 as docutils_html4css1
 except ImportError:
     docutils_core = None  # type: ignore[assignment]
     docutils_html4css1 = None  # type: ignore[assignment]
+    docutils_utils = None  # type: ignore[assignment]
 
 from .custom_logging import get_logger
 from .inflection import Inflector
@@ -960,7 +962,7 @@ def rst_to_html(s, error=False):
     """Convert a blob of reStructuredText to HTML"""
     log = get_logger("docutils")
 
-    if docutils_core is None:
+    if docutils_core is None or docutils_utils is None:
         raise Exception("Attempted to use rst_to_html but docutils unavailable.")
 
     class FakeStream:
@@ -970,12 +972,16 @@ def rst_to_html(s, error=False):
                     raise Exception(str)
                 log.warning(str)
 
+    no_report_level = docutils_utils.Reporter.SEVERE_LEVEL + 1
+
     settings_overrides = {
         "embed_stylesheet": False,
         "template": os.path.join(os.path.dirname(__file__), "docutils_template.txt"),
         "warning_stream": FakeStream(),
         "doctitle_xform": False,  # without option, very different rendering depending on
         # number of sections in help content.
+        "report_level": no_report_level,
+        "halt_level": no_report_level,
     }
 
     return unicodify(

--- a/lib/galaxy/util/rst_to_html.py
+++ b/lib/galaxy/util/rst_to_html.py
@@ -1,0 +1,68 @@
+import functools
+import os
+
+try:
+    import docutils.core
+    import docutils.io
+    import docutils.utils
+    import docutils.writers.html4css1
+except ImportError:
+    docutils = None  # type: ignore[assignment]
+
+from .custom_logging import get_logger
+
+
+class FakeStream:
+    def __init__(self, error):
+        self.__error = error
+
+    log_ = get_logger("docutils")
+
+    def write(self, str):
+        if len(str) > 0 and not str.isspace():
+            if self.__error:
+                raise Exception(str)
+            self.log_.warning(str)
+
+
+@functools.cache
+def get_publisher(error=False):
+    docutils_writer = docutils.writers.html4css1.Writer()
+    docutils_template_path = os.path.join(os.path.dirname(__file__), "docutils_template.txt")
+    no_report_level = docutils.utils.Reporter.SEVERE_LEVEL + 1
+    settings_overrides = {
+        "embed_stylesheet": False,
+        "template": docutils_template_path,
+        "warning_stream": FakeStream(error),
+        "doctitle_xform": False,  # without option, very different rendering depending on
+        # number of sections in help content.
+        "halt_level": no_report_level,
+        "output_encoding": "unicode",
+    }
+
+    if not error:
+        # in normal operation we don't want noisy warnings, that's tool author business
+        settings_overrides["report_level"] = no_report_level
+
+    Publisher = docutils.core.Publisher
+    pub = Publisher(
+        parser=None,
+        writer=docutils_writer,
+        settings=None,
+        source_class=docutils.io.StringInput,
+        destination_class=docutils.io.StringOutput,
+    )
+    pub.set_components("standalone", "restructuredtext", "pseudoxml")
+    pub.process_programmatic_settings(None, settings_overrides, None)
+    return pub
+
+
+@functools.cache
+def rst_to_html(s, error=False):
+    if docutils is None:
+        raise Exception("Attempted to use rst_to_html but docutils unavailable.")
+
+    publisher = get_publisher(error=error)
+    publisher.set_source(s, None)
+    publisher.set_destination(None, None)
+    return publisher.publish(enable_exit_status=False)

--- a/lib/galaxy/util/rst_to_html.py
+++ b/lib/galaxy/util/rst_to_html.py
@@ -25,7 +25,7 @@ class FakeStream:
             self.log_.warning(str)
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def get_publisher(error=False):
     docutils_writer = docutils.writers.html4css1.Writer()
     docutils_template_path = os.path.join(os.path.dirname(__file__), "docutils_template.txt")
@@ -57,7 +57,7 @@ def get_publisher(error=False):
     return pub
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def rst_to_html(s, error=False):
     if docutils is None:
         raise Exception("Attempted to use rst_to_html but docutils unavailable.")

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -56,7 +56,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
         galaxy.app.app = app
     else:
         try:
-            app = galaxy.app.UniverseApplication(global_conf=global_conf, **kwargs)
+            app = galaxy.app.UniverseApplication(global_conf=global_conf, is_webapp=True, **kwargs)
             galaxy.app.app = app
         except Exception:
             traceback.print_exc()

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1905,11 +1905,10 @@ class ToolModule(WorkflowModule):
                     formats = ["input"]  # default to special name "input" which remove restrictions on connections
                 else:
                     formats = [tool_output.format]
-                for change_elem in tool_output.change_format:
-                    for when_elem in change_elem.findall("when"):
-                        format = when_elem.get("format", None)
-                        if format and format not in formats:
-                            formats.append(format)
+                for change_format_model in tool_output.change_format:
+                    format = change_format_model["format"]
+                    if format and format not in formats:
+                        formats.append(format)
                 if tool_output.label:
                     try:
                         params = make_dict_copy(self.state.inputs)

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -585,7 +585,7 @@ def build_galaxy_app(simple_kwargs) -> GalaxyUniverseApplication:
     simple_kwargs["global_conf"]["__file__"] = "lib/galaxy/config/sample/galaxy.yml.sample"
     simple_kwargs = load_app_properties(kwds=simple_kwargs)
     # Build the Universe Application
-    app = GalaxyUniverseApplication(**simple_kwargs)
+    app = GalaxyUniverseApplication(**simple_kwargs, is_webapp=True)
     log.info("Embedded Galaxy application started")
 
     global install_context

--- a/test/unit/app/tools/test_actions.py
+++ b/test/unit/app/tools/test_actions.py
@@ -10,6 +10,7 @@ from galaxy.exceptions import UserActivationRequiredException
 from galaxy.model.base import transaction
 from galaxy.objectstore import BaseObjectStore
 from galaxy.tool_util.parser.output_objects import ToolOutput
+from galaxy.tool_util.parser.xml import parse_change_format
 from galaxy.tools.actions import (
     DefaultToolAction,
     determine_output_format,
@@ -243,7 +244,7 @@ def quick_output(
     test_output.format = format
     test_output.format_source = format_source
     if change_format_xml:
-        test_output.change_format = XML(change_format_xml).findall("change_format")
+        test_output.change_format = parse_change_format(XML(change_format_xml).findall("change_format"))
     else:
         test_output.change_format = []
     return test_output

--- a/test/unit/app/tools/test_tool_deserialization.py
+++ b/test/unit/app/tools/test_tool_deserialization.py
@@ -42,6 +42,7 @@ class ToolApp(GalaxyDataTestApp):
     name = "galaxy"
     biotools_metadata_source = None
     job_search = None
+    is_webapp = True
 
 
 @pytest.fixture

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -480,7 +480,6 @@ def __mock_tool(
         params_from_strings=mock.Mock(),
         check_and_update_param_values=mock.Mock(),
         to_json=_to_json,
-        assert_finalized=lambda: None,
     )
 
     return tool


### PR DESCRIPTION
The first and most effective change is to drop the ElementTree objects after we're done parsing the tool inputs (https://github.com/galaxyproject/galaxy/pull/16536/commits/5e90cfec986123189b12f9e61728de9ee0459c0c, https://github.com/galaxyproject/galaxy/pull/16536/commits/5d9b010a44ff820832eba4d778112d3b2916e5cb).
This means we have to really be sure to have parsed everything. In particular that means we need to parse help and tests (I've limited this to the webapp) and the `change_format` tags.

We're only partially parsing the tool help, since rst_to_html is relatively slow (~ 30 seconds for 5620 help sections prior to https://github.com/galaxyproject/galaxy/pull/16536/commits/fc8543b87a2626cd95083078967d69ee2b94c636, but even then it is 21 seconds, or 13 with the lru_cache). Instead we're lazily converting from the raw help string to rst, where we cache the rst_to_html function.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
