### PR TITLE
[23.1] Limit tool document cache to tool configs with explicit cache path

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -59,8 +59,7 @@
 
 :Description:
     Top level cache directory. Any other cache directories
-    (tool_cache_data_dir, template_cache_path, etc.) should be
-    subdirectories.
+    (template_cache_path, etc.) should be subdirectories.
     The value of this option will be resolved with respect to
     <data_dir>.
 :Default: ``cache``
@@ -1151,25 +1150,10 @@
     expanded XML strings. Enabling the tool cache results in slightly
     faster startup times. The tool cache is backed by a SQLite
     database, which cannot be stored on certain network disks. The
-    cache location is configurable using the ``tool_cache_data_dir``
-    setting, but can be disabled completely here.
+    cache location is configurable with the ``tool_cache_data_dir``
+    tag in tool config files.
 :Default: ``false``
 :Type: bool
-
-
-~~~~~~~~~~~~~~~~~~~~~~~
-``tool_cache_data_dir``
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Tool related caching. Fully expanded tools and metadata will be
-    stored at this path. Per tool_conf cache locations can be
-    configured in (``shed_``)tool_conf.xml files using the
-    tool_cache_data_dir attribute.
-    The value of this option will be resolved with respect to
-    <cache_dir>.
-:Default: ``tool_cache``
-:Type: str
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -227,7 +227,6 @@ class MockAppConfig(GalaxyDataTestConfig, CommonConfigurationMixin):
 
         # set by MockDir
         self.enable_tool_document_cache = False
-        self.tool_cache_data_dir = os.path.join(self.root, "tool_cache")
         self.delay_tool_initialization = True
         self.external_chown_script = None
         self.check_job_script_integrity = False

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -366,8 +366,7 @@ galaxy:
   #templates_dir: templates
 
   # Top level cache directory. Any other cache directories
-  # (tool_cache_data_dir, template_cache_path, etc.) should be
-  # subdirectories.
+  # (template_cache_path, etc.) should be subdirectories.
   # The value of this option will be resolved with respect to
   # <data_dir>.
   #cache_dir: cache
@@ -892,17 +891,9 @@ galaxy:
   # expanded XML strings. Enabling the tool cache results in slightly
   # faster startup times. The tool cache is backed by a SQLite database,
   # which cannot be stored on certain network disks. The cache location
-  # is configurable using the ``tool_cache_data_dir`` setting, but can
-  # be disabled completely here.
+  # is configurable with the ``tool_cache_data_dir`` tag in tool config
+  # files.
   #enable_tool_document_cache: false
-
-  # Tool related caching. Fully expanded tools and metadata will be
-  # stored at this path. Per tool_conf cache locations can be configured
-  # in (``shed_``)tool_conf.xml files using the tool_cache_data_dir
-  # attribute.
-  # The value of this option will be resolved with respect to
-  # <cache_dir>.
-  #tool_cache_data_dir: tool_cache
 
   # Directory in which the toolbox search index is stored. The value of
   # this option will be resolved with respect to <data_dir>.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -65,8 +65,8 @@ mapping:
         path_resolves_to: data_dir
         required: false
         desc: |
-          Top level cache directory. Any other cache directories (tool_cache_data_dir,
-          template_cache_path, etc.) should be subdirectories.
+          Top level cache directory. Any other cache directories
+          (template_cache_path, etc.) should be subdirectories.
 
       database_connection:
         type: str
@@ -836,17 +836,7 @@ mapping:
           expanded XML strings. Enabling the tool cache results in slightly faster startup
           times. The tool cache is backed by a SQLite database, which cannot
           be stored on certain network disks. The cache location is configurable
-          using the ``tool_cache_data_dir`` setting, but can be disabled completely here.
-
-      tool_cache_data_dir:
-        type: str
-        default: tool_cache
-        path_resolves_to: cache_dir
-        required: false
-        desc: |
-          Tool related caching. Fully expanded tools and metadata will be stored at this path.
-          Per tool_conf cache locations can be configured in (``shed_``)tool_conf.xml files using
-          the tool_cache_data_dir attribute.
+          with the ``tool_cache_data_dir`` tag in tool config files.
 
       tool_search_index_dir:
         type: str

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -490,13 +490,13 @@ class ToolBox(AbstractToolBox):
         return self._tools_by_id
 
     def get_cache_region(self, tool_cache_data_dir):
-        if self.app.config.enable_tool_document_cache:
+        if self.app.config.enable_tool_document_cache and tool_cache_data_dir:
             if tool_cache_data_dir not in self.cache_regions:
                 self.cache_regions[tool_cache_data_dir] = ToolDocumentCache(cache_dir=tool_cache_data_dir)
             return self.cache_regions[tool_cache_data_dir]
 
     def create_tool(self, config_file, tool_cache_data_dir=None, **kwds):
-        cache = self.get_cache_region(tool_cache_data_dir or self.app.config.tool_cache_data_dir)
+        cache = self.get_cache_region(tool_cache_data_dir)
         if config_file.endswith(".xml") and cache and not cache.disabled:
             tool_document = cache.get(config_file)
             if tool_document:

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -49,7 +49,7 @@ class ToolDocumentCache:
             else:
                 cache_file = self.writeable_cache_file.name if self.writeable_cache_file else self.cache_file
                 self._cache = SqliteDict(cache_file, flag=flag, encode=encoder, decode=decoder, autocommit=False)
-        except sqlite3.OperationalError:
+        except (sqlite3.OperationalError, RuntimeError):
             log.warning("Tool document cache unavailable")
             self._cache = None
             self.disabled = True


### PR DESCRIPTION
The sqlite file exchange when the cache gets updated is pretty brittle, and there's only an advantage if you're reading from cold CVMFS, so let's limit it to that.
Also ignores one more exception and disables the runtime cache if we encounter it. Should help with https://github.com/galaxyproject/galaxy-helm/issues/406#issuecomment-1672026051

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
