### PR TITLE
Document that required text parameters need a validator

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3248,6 +3248,19 @@ value of "V1".
 <param name="xlab" type="text" value="V1" label="Label for x axis" />
 ```
 
+Unlike other types of parameters, type="text" parameters are always optional, and tool
+author need to restrict the input with validator elements. By using a profile of at
+least 23.0 text parameters that set ``optional="false"`` or define a validator are
+indicated as required, but without validator the tool can be executed in any case.
+That is a mandatory text parameter should be implemented as:
+
+```
+  <param name="mandatory" type="text" optional="false">
+    <validator type="empty_field"/>
+  </param>
+```
+
+
 The ``area`` boolean attribute can be used to change the ``text`` parameter to a
 two-dimensional text area instead of a single line text box.
 


### PR DESCRIPTION
Just stumbled over https://github.com/galaxyproject/galaxy/pull/15491 and found that it deserves a bit more prominent docs.

In my experiments, I found that tools with mandatory text parameters (without validator) can be executed and the parameter is still treated as `""` in cheetah. **Is the latter a bug?** When reading https://github.com/galaxyproject/galaxy/pull/15491 I got the impression that it should be `None`. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
