### PR TITLE
[23.0] Fix extra files path handling

### DIFF
--- a/lib/galaxy/job_execution/compute_environment.py
+++ b/lib/galaxy/job_execution/compute_environment.py
@@ -121,15 +121,10 @@ class SharedComputeEnvironment(SimpleComputeEnvironment, ComputeEnvironment):
         return self.job_io.get_output_fnames()
 
     def input_path_rewrite(self, dataset):
-        dataset_path = self.job_io.get_input_path(dataset)
-        return dataset_path.false_path or dataset_path.real_path
+        return str(self.job_io.get_input_path(dataset))
 
     def output_path_rewrite(self, dataset):
-        dataset_path = self.job_io.get_output_path(dataset)
-        if getattr(dataset_path, "false_path", None):
-            return dataset_path.false_path
-        else:
-            return dataset_path.real_path
+        return str(self.job_io.get_output_path(dataset))
 
     def input_extra_files_rewrite(self, dataset):
         input_path_rewrite = self.input_path_rewrite(dataset)

--- a/lib/galaxy/job_execution/compute_environment.py
+++ b/lib/galaxy/job_execution/compute_environment.py
@@ -125,16 +125,19 @@ class SharedComputeEnvironment(SimpleComputeEnvironment, ComputeEnvironment):
 
     def output_path_rewrite(self, dataset):
         dataset_path = self.job_io.get_output_path(dataset)
-        if hasattr(dataset_path, "false_path"):
+        if getattr(dataset_path, "false_path", None):
             return dataset_path.false_path
         else:
-            return dataset_path
+            return dataset_path.real_path
 
     def input_extra_files_rewrite(self, dataset):
         return None
 
     def output_extra_files_rewrite(self, dataset):
-        return None
+        output_path_rewrite = self.output_path_rewrite(dataset)
+        base_output_path = output_path_rewrite[0 : -len(".dat")]
+        remote_extra_files_path_rewrite = f"{base_output_path}_files"
+        return remote_extra_files_path_rewrite
 
     def input_metadata_rewrite(self, dataset, metadata_value):
         return None

--- a/lib/galaxy/job_execution/compute_environment.py
+++ b/lib/galaxy/job_execution/compute_environment.py
@@ -121,7 +121,8 @@ class SharedComputeEnvironment(SimpleComputeEnvironment, ComputeEnvironment):
         return self.job_io.get_output_fnames()
 
     def input_path_rewrite(self, dataset):
-        return self.job_io.get_input_path(dataset).false_path
+        dataset_path = self.job_io.get_input_path(dataset)
+        return dataset_path.false_path or dataset_path.real_path
 
     def output_path_rewrite(self, dataset):
         dataset_path = self.job_io.get_output_path(dataset)
@@ -131,7 +132,10 @@ class SharedComputeEnvironment(SimpleComputeEnvironment, ComputeEnvironment):
             return dataset_path.real_path
 
     def input_extra_files_rewrite(self, dataset):
-        return None
+        input_path_rewrite = self.input_path_rewrite(dataset)
+        base_input_path = input_path_rewrite[0 : -len(".dat")]
+        remote_extra_files_path_rewrite = f"{base_input_path}_files"
+        return remote_extra_files_path_rewrite
 
     def output_extra_files_rewrite(self, dataset):
         output_path_rewrite = self.output_path_rewrite(dataset)

--- a/lib/galaxy/job_execution/compute_environment.py
+++ b/lib/galaxy/job_execution/compute_environment.py
@@ -12,6 +12,11 @@ from galaxy.job_execution.setup import JobIO
 from galaxy.model import Job
 
 
+def dataset_path_to_extra_path(path: str) -> str:
+    base_path = path[0 : -len(".dat")]
+    return f"{base_path}_files"
+
+
 class ComputeEnvironment(metaclass=ABCMeta):
     """Definition of the job as it will be run on the (potentially) remote
     compute server.
@@ -128,15 +133,11 @@ class SharedComputeEnvironment(SimpleComputeEnvironment, ComputeEnvironment):
 
     def input_extra_files_rewrite(self, dataset):
         input_path_rewrite = self.input_path_rewrite(dataset)
-        base_input_path = input_path_rewrite[0 : -len(".dat")]
-        remote_extra_files_path_rewrite = f"{base_input_path}_files"
-        return remote_extra_files_path_rewrite
+        return dataset_path_to_extra_path(input_path_rewrite)
 
     def output_extra_files_rewrite(self, dataset):
         output_path_rewrite = self.output_path_rewrite(dataset)
-        base_output_path = output_path_rewrite[0 : -len(".dat")]
-        remote_extra_files_path_rewrite = f"{base_output_path}_files"
-        return remote_extra_files_path_rewrite
+        return dataset_path_to_extra_path(output_path_rewrite)
 
     def input_metadata_rewrite(self, dataset, metadata_value):
         return None

--- a/lib/galaxy/job_execution/datasets.py
+++ b/lib/galaxy/job_execution/datasets.py
@@ -94,7 +94,7 @@ class OutputsToWorkingDirectoryPathRewriter(DatasetPathRewriter):
             if self.outputs_directory_name is not None:
                 base_output_directory = os.path.join(base_output_directory, self.outputs_directory_name)
             # set false_path to uuid, no harm even if object store uses id
-            false_path = os.path.join(base_output_directory, f"galaxy_dataset_{dataset.dataset.uuid}.dat")
+            false_path = os.path.join(base_output_directory, f"dataset_{dataset.dataset.uuid}.dat")
             return false_path
         else:
             return None

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -719,8 +719,14 @@ def default_exit_code_file(files_dir, id_tag):
 
 
 def collect_extra_files(object_store, dataset, job_working_directory):
+    # TODO: should this use compute_environment to determine the extra files path ?
     file_name = dataset.dataset.extra_files_path_name_from(object_store)
-    temp_file_path = os.path.join(job_working_directory, "working", file_name)
+    output_location = "outputs"
+    temp_file_path = os.path.join(job_working_directory, output_location, file_name)
+    if not os.path.exists(temp_file_path):
+        # Fall back to working dir, remove in 23.2
+        output_location = "working"
+        temp_file_path = os.path.join(job_working_directory, output_location, file_name)
     extra_dir = None
     try:
         # This skips creation of directories - object store
@@ -728,7 +734,7 @@ def collect_extra_files(object_store, dataset, job_working_directory):
         # not be created in the object store at all, which might be a
         # problem.
         for root, _dirs, files in os.walk(temp_file_path):
-            extra_dir = root.replace(os.path.join(job_working_directory, "working"), "", 1).lstrip(os.path.sep)
+            extra_dir = root.replace(os.path.join(job_working_directory, output_location), "", 1).lstrip(os.path.sep)
             for f in files:
                 object_store.update_from_file(
                     dataset.dataset,

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -37,7 +37,10 @@ from pulsar.client import (
 from pulsar.client.staging import DEFAULT_DYNAMIC_COLLECTION_PATTERN
 
 from galaxy import model
-from galaxy.job_execution.compute_environment import ComputeEnvironment
+from galaxy.job_execution.compute_environment import (
+    ComputeEnvironment,
+    dataset_path_to_extra_path,
+)
 from galaxy.jobs import JobDestination
 from galaxy.jobs.command_factory import build_command
 from galaxy.jobs.runners import (
@@ -1104,15 +1107,13 @@ class PulsarComputeEnvironment(ComputeEnvironment):
 
     def input_extra_files_rewrite(self, dataset):
         input_path_rewrite = self.input_path_rewrite(dataset)
-        base_input_path = input_path_rewrite[0 : -len(".dat")]
-        remote_extra_files_path_rewrite = f"{base_input_path}_files"
+        remote_extra_files_path_rewrite = dataset_path_to_extra_path(input_path_rewrite)
         self.path_rewrites_input_extra[dataset.extra_files_path] = remote_extra_files_path_rewrite
         return remote_extra_files_path_rewrite
 
     def output_extra_files_rewrite(self, dataset):
         output_path_rewrite = self.output_path_rewrite(dataset)
-        base_output_path = output_path_rewrite[0 : -len(".dat")]
-        remote_extra_files_path_rewrite = f"{base_output_path}_files"
+        remote_extra_files_path_rewrite = dataset_path_to_extra_path(output_path_rewrite)
         return remote_extra_files_path_rewrite
 
     def input_metadata_rewrite(self, dataset, metadata_val):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3574,7 +3574,9 @@ class Dataset(Base, StorableObject, Serializable):
         if not getattr(self, "external_extra_files_path", None):
             if self.object_store.exists(self, dir_only=True, extra_dir=self._extra_files_rel_path):
                 return self.object_store.get_filename(self, dir_only=True, extra_dir=self._extra_files_rel_path)
-            return ""
+            return self.object_store.construct_path(
+                self, dir_only=True, extra_dir=self._extra_files_rel_path, in_cache=True
+            )
         else:
             return os.path.abspath(self.external_extra_files_path)
 

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -172,6 +172,7 @@ class AzureBlobObjectStore(ConcreteObjectStore):
         extra_dir_at_root=False,
         alt_name=None,
         obj_dir=False,
+        in_cache=False,
         **kwargs,
     ):
         # extra_dir should never be constructed from provided data but just
@@ -209,6 +210,9 @@ class AzureBlobObjectStore(ConcreteObjectStore):
 
         if not dir_only:
             rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
+
+        if in_cache:
+            return self._get_cache_path(rel_path)
 
         return rel_path
 

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -354,6 +354,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         extra_dir_at_root=False,
         alt_name=None,
         obj_dir=False,
+        in_cache=False,
         **kwargs,
     ):
         # extra_dir should never be constructed from provided data but just
@@ -389,6 +390,10 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
 
         if not dir_only:
             rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
+
+        if in_cache:
+            return self._get_cache_path(rel_path)
+
         return rel_path
 
     def _get_cache_path(self, rel_path):

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -329,6 +329,7 @@ class IRODSObjectStore(DiskObjectStore, CloudConfigMixin):
         extra_dir_at_root=False,
         alt_name=None,
         obj_dir=False,
+        in_cache=False,
         **kwargs,
     ):
         ipt_timer = ExecutionTimer()
@@ -364,6 +365,10 @@ class IRODSObjectStore(DiskObjectStore, CloudConfigMixin):
         if not dir_only:
             rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
         log.debug("irods_pt _construct_path: %s", ipt_timer)
+
+        if in_cache:
+            return self._get_cache_path(rel_path)
+
         return rel_path
 
     def _get_cache_path(self, rel_path):

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -160,6 +160,7 @@ class PithosObjectStore(ConcreteObjectStore):
         extra_dir_at_root=False,
         alt_name=None,
         obj_dir=False,
+        in_cache=False,
         **kwargs,
     ):
         """Construct path from object and parameters"""
@@ -197,6 +198,10 @@ class PithosObjectStore(ConcreteObjectStore):
         if not dir_only:
             an = alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat"
             rel_path = os.path.join(rel_path, an)
+
+        if in_cache:
+            return self._get_cache_path(rel_path)
+
         return rel_path
 
     def _get_cache_path(self, rel_path):

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -338,6 +338,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
         extra_dir_at_root=False,
         alt_name=None,
         obj_dir=False,
+        in_cache=False,
         **kwargs,
     ):
         # extra_dir should never be constructed from provided data but just
@@ -373,6 +374,8 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
 
         if not dir_only:
             rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
+        if in_cache:
+            return self._get_cache_path(rel_path)
         return rel_path
 
     def _get_cache_path(self, rel_path):

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -446,12 +446,6 @@ class ToolEvaluator:
             if not os.path.exists(output_path) and os.path.exists(os.path.dirname(output_path)):
                 open(output_path, "w").close()
 
-            # Provide access to a path to store additional files
-            # TODO: move compute path logic into compute environment, move setting files_path
-            # logic into DatasetFilenameWrapper. Currently this sits in the middle and glues
-            # stuff together inconsistently with the way the rest of path rewriting works.
-            file_name = hda.dataset.extra_files_path_name
-            param_dict[name].files_path = os.path.abspath(os.path.join(job_working_directory, "working", file_name))
         for out_name, output in self.tool.outputs.items():
             if out_name not in param_dict and output.filters:
                 # Assume the reason we lack this output is because a filter

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -19,7 +19,6 @@ from typing import (
     Union,
 )
 
-from galaxy import exceptions
 from galaxy.model import (
     DatasetCollection,
     DatasetCollectionElement,
@@ -476,33 +475,13 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
             # Path to dataset was rewritten for this job.
             return self.false_path
         elif key in ("extra_files_path", "files_path"):
+            if not self.compute_environment:
+                # Only happens in WrappedParameters context, refactor!
+                return self.unsanitized.extra_files_path
             if self.__io_type == "input":
-                path_rewrite = self.compute_environment and self.compute_environment.input_extra_files_rewrite(
-                    self.unsanitized
-                )
+                return self.compute_environment.input_extra_files_rewrite(self.unsanitized)
             else:
-                path_rewrite = self.compute_environment and self.compute_environment.output_extra_files_rewrite(
-                    self.unsanitized
-                )
-            if path_rewrite:
-                return path_rewrite
-            else:
-                try:
-                    # Assume it is an output and that this wrapper
-                    # will be set with correct "files_path" for this
-                    # job.
-                    return self.files_path
-                except AttributeError:
-                    # Otherwise, we have an input - delegate to model and
-                    # object store to find the static location of this
-                    # directory.
-                    try:
-                        return self.unsanitized.extra_files_path
-                    except exceptions.ObjectNotFound:
-                        # NestedObjectstore raises an error here
-                        # instead of just returning a non-existent
-                        # path like DiskObjectStore.
-                        raise
+                return self.compute_environment.output_extra_files_rewrite(self.unsanitized)
         elif key == "serialize":
             return self.serialize
         else:

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -475,7 +475,7 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
         if self.false_path is not None and key == "file_name":
             # Path to dataset was rewritten for this job.
             return self.false_path
-        elif key == "extra_files_path":
+        elif key in ("extra_files_path", "files_path"):
             if self.__io_type == "input":
                 path_rewrite = self.compute_environment and self.compute_environment.input_extra_files_rewrite(
                     self.unsanitized

--- a/test/functional/tools/composite_output.xml
+++ b/test/functional/tools/composite_output.xml
@@ -1,5 +1,6 @@
 <tool id="composite_output" name="composite_output" version="1.0.0">
     <command><![CDATA[
+touch '$output' &&
 mkdir '$output.extra_files_path' &&
 cp '$input.extra_files_path'/* '$output.extra_files_path' &&
 cp '$input.extra_files_path'/Log '$output.extra_files_path'/second_log &&

--- a/test/functional/tools/composite_output_tests.xml
+++ b/test/functional/tools/composite_output_tests.xml
@@ -1,5 +1,5 @@
 <tool id="composite_output_tests" name="composite_output_tests" version="1.0.0">
-  <!-- command mixes files_path and extra_files_path, both shuold work -->
+  <!-- command mixes files_path and extra_files_path, both should work -->
   <command>
     mkdir '$output.files_path';
     mkdir '$output.files_path/output';

--- a/test/functional/tools/composite_output_tests.xml
+++ b/test/functional/tools/composite_output_tests.xml
@@ -1,9 +1,10 @@
 <tool id="composite_output_tests" name="composite_output_tests" version="1.0.0">
+  <!-- command mixes files_path and extra_files_path, both shuold work -->
   <command>
-    mkdir '$output.extra_files_path';
-    mkdir '$output.extra_files_path/output';
-    cp '$input.extra_files_path'/* '$output.extra_files_path';
-    echo "1 2 3" > '$output.extra_files_path/md5out';
+    mkdir '$output.files_path';
+    mkdir '$output.files_path/output';
+    cp '$input.extra_files_path'/* '$output.files_path';
+    echo "1 2 3" > '$output.files_path/md5out';
     echo "1" > '$output.extra_files_path/output/1';
   </command>
   <inputs>

--- a/test/functional/tools/composite_output_tests.xml
+++ b/test/functional/tools/composite_output_tests.xml
@@ -3,6 +3,7 @@
   <command>
     mkdir '$output.files_path';
     mkdir '$output.files_path/output';
+    touch '$output';
     cp '$input.extra_files_path'/* '$output.files_path';
     echo "1 2 3" > '$output.files_path/md5out';
     echo "1" > '$output.extra_files_path/output/1';

--- a/test/integration/test_pulsar_embedded.py
+++ b/test/integration/test_pulsar_embedded.py
@@ -36,6 +36,7 @@ test_tools = integration_util.integration_tool_runner(
         "tool_provided_metadata_9",
         "simple_constructs_y",
         "composite_output",
+        "composite_output_tests",
         "detect_errors",
     ]
 )

--- a/test/integration/test_pulsar_embedded_mq.py
+++ b/test/integration/test_pulsar_embedded_mq.py
@@ -76,4 +76,4 @@ class EmbeddedMessageQueuePulsarIntegrationInstance(integration_util.Integration
 
 instance = integration_util.integration_module_instance(EmbeddedMessageQueuePulsarIntegrationInstance)
 
-test_tools = integration_util.integration_tool_runner(["simple_constructs"])
+test_tools = integration_util.integration_tool_runner(["simple_constructs", "composite_output_tests"])

--- a/test/unit/app/jobs/test_job_wrapper.py
+++ b/test/unit/app/jobs/test_job_wrapper.py
@@ -207,6 +207,9 @@ class MockObjectStore:
     def exists(self, *args, **kwargs):
         return True
 
+    def construct_path(self, *args, **kwds):
+        return self.working_directory
+
     def get_filename(self, *args, **kwds):
         if kwds.get("base_dir", "") == "job_work":
             return self.working_directory

--- a/test/unit/app/tools/test_wrappers.py
+++ b/test/unit/app/tools/test_wrappers.py
@@ -248,7 +248,10 @@ def test_dataset_false_extra_files_path():
     new_path = "/new/path/dataset_123.dat"
     dataset_path = DatasetPath(123, MOCK_DATASET_PATH, false_path=new_path)
     wrapper = DatasetFilenameWrapper(
-        dataset, compute_environment=cast(ComputeEnvironment, MockComputeEnvironment(dataset_path))
+        dataset,
+        compute_environment=cast(
+            ComputeEnvironment, MockComputeEnvironment(dataset_path, MOCK_DATASET_EXTRA_FILES_PATH)
+        ),
     )
     # Setting false_path is not enough to override
     assert wrapper.extra_files_path == MOCK_DATASET_EXTRA_FILES_PATH

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -1039,6 +1039,9 @@ class MockObjectStore:
     def get_filename(self, *args, **kwds):
         return "mock_dataset_14.dat"
 
+    def construct_path(self, *args, **kwds):
+        return "mock_dataset_14.dat"
+
     def get_store_by(self, *args, **kwds):
         return "id"
 


### PR DESCRIPTION
Should fix https://github.com/galaxyproject/galaxy/issues/16508, for `output.files_path` and `output.extra_files_path`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
