### PR TITLE
[23.1] Fix `multiple` remote test data

### DIFF
--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -864,6 +864,9 @@ def __parse_param_elem(param_elem, i=0):
     else:
         value = None
 
+    if value is None and attrib.get("location", None) is not None:
+        value = os.path.basename(attrib["location"])
+
     children_elem = param_elem
     if children_elem is not None:
         # At this time, we can assume having children only

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -183,16 +183,25 @@ def _process_raw_inputs(
                 param_value = raw_input_dict["value"]
                 param_extra = raw_input_dict["attributes"]
                 location = param_extra.get("location")
-                if param_value is None and location:
-                    # If no value is given, we try to get the file name directly from the URL
-                    param_value = os.path.basename(location)
                 if not value.type == "text":
                     param_value = _split_if_str(param_value)
                 if isinstance(value, galaxy.tools.parameters.basic.DataToolParameter):
-                    if not isinstance(param_value, list):
-                        param_value = [param_value]
-                    for v in param_value:
-                        _add_uploaded_dataset(context.for_state(), v, param_extra, value, required_files)
+                    if param_value is None and location:
+                        # We get the input/s from the location which can be a list of urls separated by commas
+                        locations = _split_if_str(location)
+                        param_value = []
+                        for location in locations:
+                            v = os.path.basename(location)
+                            param_value.append(v)
+                            # param_extra should contain only the corresponding location
+                            extra = dict(param_extra)
+                            extra["location"] = location
+                            _add_uploaded_dataset(context.for_state(), v, extra, value, required_files)
+                    else:
+                        if not isinstance(param_value, list):
+                            param_value = [param_value]
+                        for v in param_value:
+                            _add_uploaded_dataset(context.for_state(), v, param_extra, value, required_files)
                     processed_value = param_value
                 elif isinstance(value, galaxy.tools.parameters.basic.DataCollectionToolParameter):
                     assert "collection" in param_extra

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -186,7 +186,7 @@ def _process_raw_inputs(
                 if not value.type == "text":
                     param_value = _split_if_str(param_value)
                 if isinstance(value, galaxy.tools.parameters.basic.DataToolParameter):
-                    if param_value is None and location:
+                    if location and value.multiple:
                         # We get the input/s from the location which can be a list of urls separated by commas
                         locations = _split_if_str(location)
                         param_value = []


### PR DESCRIPTION
xref #16495

I consider this a bug fix because I was not aware of the `multiple=true` on param inputs (and also collection elements) when I fixed #16311 but I can also retarget to `dev` if is it more adequate.

I used this tool for testing locally:
```xml
<tool id="remote_test_multi_data_location" name="Remote test multi data location" version="1.1.0" profile="22.01">
    <command><![CDATA[
cat
#for $input in $inputs:
    '$input'
#end for
> '$output';

#for $key in $input_collection.keys():
    cat '$input_collection[key]' > '$output_collection[key]';
#end for

    ]]></command>
    <inputs>
        <param name="inputs" type="data" multiple="true" format="txt" label="Input"/>
        <param name="input_collection" type="data_collection" collection_type="list" format="txt" label="Input" help="Input collection..."/>
    </inputs>
    <outputs>
        <data name="output" format="txt"/>
        <collection name="output_collection" type="list" structured_like="input_collection" format_source="input_collection" label="Duplicate List" />
    </outputs>
    <tests>
        <test>
            <param name="inputs" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt,https://raw.githubusercontent.com/galaxyproject/planemo/b2135cb22a6974b595bc3579a99366972efcb802/tests/data/hello_truncated.txt"/>
            <param name="input_collection">
                <collection type="list">
                    <element name="full" location="https://raw.githubusercontent.com/galaxyproject/planemo/7be1bf5b3971a43eaa73f483125bfb8cabf1c440/tests/data/hello.txt"/>
                    <element name="truncated" location="https://raw.githubusercontent.com/galaxyproject/planemo/b2135cb22a6974b595bc3579a99366972efcb802/tests/data/hello_truncated.txt"/>
                </collection>
            </param>
            <output name="output">
                <assert_contents>
                    <has_line line="Hello World!"/>
                    <has_line line="Hello Wor"/>
                    <has_n_lines n="2"/>
                </assert_contents>
            </output>
            <output_collection name="output_collection" type="list" count="2">
                <element name="full">
                    <assert_contents>
                        <has_line line="Hello World!"/>
                    </assert_contents>
                </element>
                <element name="truncated">
                    <assert_contents>
                        <has_line line="Hello Wor"/>
                    </assert_contents>
                </element>
            </output_collection>
        </test>
    </tests>
</tool>
```

### Resulting `tool_test_output.json`:

<details>
  <summary>Expand this to see results</summary>

  ```json
  {
      "version": "0.1",
      "suitename": "Galaxy Tool Tests",
      "results": {
          "total": 1,
          "errors": 0,
          "failures": 0,
          "skips": 0
      },
      "tests": [
          {
              "id": "remote_test_multi_data_location/1.1.0-0",
              "has_data": true,
              "data": {
                  "tool_id": "remote_test_multi_data_location",
                  "tool_version": "1.1.0",
                  "test_index": 0,
                  "time_seconds": 14.753914833068848,
                  "inputs": {
                      "inputs": [
                          {
                              "src": "hda",
                              "id": "6a65222fe2393f8f"
                          },
                          {
                              "src": "hda",
                              "id": "ea8cd5be190fc233"
                          }
                      ],
                      "input_collection": {
                          "src": "hdca",
                          "id": "cbbbf59e8f08c98c"
                      }
                  },
                  "job": {
                      "model_class": "Job",
                      "id": "c0279aab05812500",
                      "state": "ok",
                      "exit_code": 0,
                      "update_time": "2023-08-18T14:31:11.119239",
                      "create_time": "2023-08-18T14:31:09.077617",
                      "galaxy_version": "23.1",
                      "command_version": "",
                      "copied_from_job_id": null,
                      "tool_id": "remote_test_multi_data_location",
                      "history_id": "f30a35c999095ed7",
                      "params": {
                          "input_collection": "{\"values\": [{\"id\": 37, \"src\": \"hdca\"}]}",
                          "chromInfo": "\"/home/davelopez/sandbox/gx-versions/release/23.1/galaxy/tool-data/shared/ucsc/chrom/?.len\"",
                          "dbkey": "\"?\"",
                          "__input_ext": "\"input\""
                      },
                      "inputs": {
                          "inputs": {
                              "id": "6a65222fe2393f8f",
                              "src": "hda",
                              "uuid": "afa47450-2007-477a-833f-c554c8d8473c"
                          },
                          "inputs1": {
                              "id": "6a65222fe2393f8f",
                              "src": "hda",
                              "uuid": "afa47450-2007-477a-833f-c554c8d8473c"
                          },
                          "inputs2": {
                              "id": "ea8cd5be190fc233",
                              "src": "hda",
                              "uuid": "d2436e18-34fe-489a-b39a-1b90aac25431"
                          },
                          "input_collection1": {
                              "id": "6a65222fe2393f8f",
                              "src": "hda",
                              "uuid": "afa47450-2007-477a-833f-c554c8d8473c"
                          },
                          "input_collection2": {
                              "id": "ea8cd5be190fc233",
                              "src": "hda",
                              "uuid": "d2436e18-34fe-489a-b39a-1b90aac25431"
                          }
                      },
                      "outputs": {
                          "output_collection|__part__|full": {
                              "id": "9ec39b9650fa3424",
                              "src": "hda",
                              "uuid": "46776925-a25d-479c-9d11-13f19d518d00"
                          },
                          "output_collection|__part__|truncated": {
                              "id": "e4ce61a6ecb936ab",
                              "src": "hda",
                              "uuid": "fc81e6de-9e4b-490e-9d10-d4ce24b7d967"
                          },
                          "output": {
                              "id": "d7ee944608c6557c",
                              "src": "hda",
                              "uuid": "f19c21d2-6db3-4660-b30c-f07a01bada2f"
                          }
                      },
                      "output_collections": {
                          "output_collection": {
                              "id": "964b37715ec9bd22",
                              "src": "hdca"
                          }
                      },
                      "tool_stdout": "",
                      "tool_stderr": "",
                      "job_stdout": "",
                      "job_stderr": "",
                      "stderr": "",
                      "stdout": "",
                      "job_messages": [],
                      "dependencies": []
                  },
                  "status": "success"
              }
          }
      ],
      "galaxy_url": "http://127.0.0.1:8080/"
  }
  ```

</details>


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Make sure you have a tool similar to the one above
  - Call `galaxy-tool-test` with the appropriate parameters to test your tool

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
