### PR TITLE
Make tool id searchable in side panel search

### DIFF
--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -108,6 +108,30 @@ describe("test helpers in tool searching utilities", () => {
                 keys: { description: 1, name: 2 },
                 list: tempToolsList,
             },
+            {
+                // id is not searchable if not identified by colon
+                q: "__ZIP_COLLECTION__",
+                expectedResults: [],
+                keys: { description: 1, name: 2 },
+                list: toolsList,
+            },
+            {
+                // id is searchable if provided "id:"
+                q: "id:__ZIP_COLLECTION__",
+                expectedResults: ["__ZIP_COLLECTION__"],
+                keys: { description: 1, name: 2 },
+                list: toolsList,
+            },
+            {
+                // id is searchable if provided "tool_id:"
+                q: "tool_id:umi_tools",
+                expectedResults: [
+                    "toolshed.g2.bx.psu.edu/repos/iuc/umi_tools_extract/umi_tools_extract/1.1.2+galaxy2",
+                    "umi_tools_reduplicate",
+                ],
+                keys: { description: 1, name: 2 },
+                list: tempToolsList,
+            },
         ];
         searches.forEach((search) => {
             const { results } = searchToolsByKeys(flattenTools(search.list), search.keys, search.q);


### PR DESCRIPTION
Tool ids are now searchable with query: "id:sample_id" or "tool_id:sample_id". Fixes https://github.com/galaxyproject/galaxy/issues/16525

https://github.com/galaxyproject/galaxy/assets/78516064/4945b382-8866-484b-8e10-a874f1546c51

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
