### PR TITLE
Remove unnecessary check: item cannot be None

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -307,10 +307,7 @@ class LibraryActions:
     def _create_folder(self, trans, parent_id: int, **kwd):
         is_admin = trans.user_is_admin
         current_user_roles = trans.get_current_user_roles()
-        try:
-            parent_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(parent_id)
-        except Exception:
-            parent_folder = None
+        parent_folder = trans.sa_session.query(trans.app.model.LibraryFolder).get(parent_id)
         # Check the library which actually contains the user-supplied parent folder, not the user-supplied
         # library, which could be anything.
         self._check_access(trans, is_admin, parent_folder, current_user_roles)


### PR DESCRIPTION
The value of `parent_folder` cannot be `None`:
- `_create_folder` is called from `galaxy.api.library_contents` which [raises an exception if the value is missing](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/galaxy/api/library_contents.py#L259).
- if the value were indeed `None`, the subsequent call to `parent_folder.add_folder(new_folder)` would raise an error.

Bug discovered via mypy after adding type annotations in #16434.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
