### PR TITLE
Rename to_dict to populate in FormDefintion to fix bug

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -9147,7 +9147,7 @@ class FormDefinition(Base, Dictifiable, RepresentById):
     dict_collection_visible_keys = ["id", "name"]
     dict_element_visible_keys = ["id", "name", "desc", "form_definition_current_id", "fields", "layout"]
 
-    def to_dict(self, user=None, values=None, security=None):
+    def populate(self, user=None, values=None, security=None):
         values = values or {}
         form_def = {"id": security.encode_id(self.id) if security else self.id, "name": self.name, "inputs": []}
         for field in self.fields:

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -800,7 +800,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
                     values = None
                     if info_form_id == trans.security.encode_id(f.id) and user.values:
                         values = user.values.content
-                    info_form = f.to_dict(user=user, values=values, security=trans.security)
+                    info_form = f.populate(user=user, values=values, security=trans.security)
                     info_field["test_param"]["data"].append({"label": info_form["name"], "value": info_form["id"]})
                     info_field["cases"].append({"value": info_form["id"], "inputs": info_form["inputs"]})
                 inputs.append(info_field)


### PR DESCRIPTION
Old method was overriding the method defined in a mixin (with a different signature) that was called from api.forms

For context, see [discussion on backend channel](https://app.element.io/#/room/#galaxyproject_backend:gitter.im/$TJCv12X_UdHUSYQXTvERHD1R7dTIZFQPPWbePf2MkpQ):
The model.FormDefinition.to_dict() method (added in 09/2016 in [#3118](https://github.com/galaxyproject/galaxy/pull/3118)) takes user, value, and security arguments, which overrides the to_dict definition in the Dictifiable mixin, which takes view and value_mapper as arguments. So, if we call the to_dict method on a FormDefinition object passing it the view/value_mapper arguments, an error will be raised. However, we have (at least) 4 places where we call this method on this object: in galaxy.api.forms it's called in the index, show and create methods with the WRONG arguments (view, value_mapper), and in galaxy.api.users with the CORRECT arguments (user, values, security), which is the ONLY place in lib where it's called with those arguments.



Bug discovered via mypy after adding type annotations in https://github.com/galaxyproject/galaxy/pull/16434.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
