### PR TITLE
Add input datatype as an Advanced Tool Search filter

### DIFF
--- a/client/src/components/Panels/Common/ToolSearch.test.js
+++ b/client/src/components/Panels/Common/ToolSearch.test.js
@@ -54,6 +54,7 @@ describe("ToolSearch", () => {
             "[placeholder='any section']": "section-filter",
             "[placeholder='any id']": "id-filter",
             "[placeholder='any owner']": "owner-filter",
+            "[placeholder='any datatype']": "inputs-filter",
             "[placeholder='any help text']": "help-filter",
         };
 
@@ -77,6 +78,7 @@ describe("ToolSearch", () => {
             section: "section-filter",
             id: "id-filter",
             owner: "owner-filter",
+            inputs: "inputs-filter",
             help: "help-filter",
         };
         expect(mockMethod).toHaveBeenCalledWith({

--- a/client/src/components/Panels/Common/ToolSearch.vue
+++ b/client/src/components/Panels/Common/ToolSearch.vue
@@ -169,6 +169,8 @@ function onToggle(toggleAdvanced: boolean) {
             <b-form-input v-model="filterSettings['id']" size="sm" placeholder="any id" />
             <small class="mt-1">Filter by repository owner:</small>
             <b-form-input v-model="filterSettings['owner']" size="sm" placeholder="any owner" />
+            <small class="mt-1">Filter by input data type:</small>
+            <b-form-input v-model="filterSettings['inputs']" size="sm" placeholder="any datatype" />
             <small class="mt-1">Filter by help text:</small>
             <b-form-input v-model="filterSettings['help']" size="sm" placeholder="any help text" />
             <div class="mt-3">
@@ -221,6 +223,12 @@ function onToggle(toggleAdvanced: boolean) {
                                 <a href="https://toolshed.g2.bx.psu.edu/" target="_blank">ToolShed</a>
                                 , this <i>owner</i> filter allows you to search for tools from a specific ToolShed
                                 repository <b>owner</b>.
+                            </dd>
+                            <dt><code>input datatype</code></dt>
+                            <dd>
+                                Many tools can only take particular datatypes/extensions as inputs. This filter allows
+                                you to filter on a specific datatype. Example inputs:
+                                <i>"fasta"</i>, <i>"bam"</i>, <i>"vcf"</i>, <i>"bed"</i>, etc.
                             </dd>
                             <dt><code>help text</code></dt>
                             <dd>

--- a/client/src/components/Panels/utilities.test.js
+++ b/client/src/components/Panels/utilities.test.js
@@ -48,6 +48,7 @@ describe("test helpers in tool searching utilities", () => {
             id: "__FILTER_FAILED_DATASETS__",
             help: "downstream",
             owner: "devteam",
+            inputs: "bed",
         };
         const q = createWhooshQuery(settings, "default", []);
 
@@ -57,7 +58,7 @@ describe("test helpers in tool searching utilities", () => {
         expect(q).toContain("id_exact:(__FILTER_FAILED_DATASETS__) AND help:(downstream) AND owner:(devteam)");
         // Combined query results in:
         expect(q).toEqual(
-            "(name:(Filter) name_exact:(Filter) description:(Filter)) AND (id_exact:(__FILTER_FAILED_DATASETS__) AND help:(downstream) AND owner:(devteam) AND )"
+            "(name:(Filter) name_exact:(Filter) description:(Filter)) AND (id_exact:(__FILTER_FAILED_DATASETS__) AND help:(downstream) AND owner:(devteam) AND inputs:(bed) AND )"
         );
     });
 

--- a/client/src/components/ToolsList/ToolsList.vue
+++ b/client/src/components/ToolsList/ToolsList.vue
@@ -86,6 +86,10 @@ export default {
             type: String,
             default: "",
         },
+        inputs: {
+            type: String,
+            default: "",
+        },
         help: {
             type: String,
             default: "",

--- a/client/src/components/ToolsList/ToolsListItem.vue
+++ b/client/src/components/ToolsList/ToolsListItem.vue
@@ -20,7 +20,7 @@ library.add(faWrench, faExternalLinkAlt, faCheck, faTimes, faAngleDown, faAngleU
 const props = defineProps({
     id: { type: String, required: true },
     name: { type: String, required: true },
-    section: { type: String, required: true },
+    section: { type: String, required: false, default: null },
     description: { type: String, default: null },
     summary: { type: String, default: null },
     help: { type: String, default: null },

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -57,6 +57,7 @@ from whoosh.scoring import (
 from whoosh.writing import AsyncWriter
 
 from galaxy.config import GalaxyAppConfiguration
+from galaxy.tools.parameters.basic import DataToolParameter
 from galaxy.util import ExecutionTimer
 from galaxy.web.framework.helpers import to_unicode
 
@@ -169,6 +170,8 @@ class ToolPanelViewSearch:
             # Help text parsed from the tool XML
             "help": TEXT(field_boost=config.tool_help_boost, analyzer=analysis.StemmingAnalyzer()),
             "labels": KEYWORD(field_boost=float(config.tool_label_boost)),
+            # Input parameters defined in the tool XML, converted into a list in _create_doc
+            "inputs": KEYWORD(field_boost=float(config.tool_label_boost)),
         }
 
         if config.tool_enable_ngram_search:
@@ -297,6 +300,7 @@ class ToolPanelViewSearch:
             "repository": to_unicode(tool.repository_name),
             "owner": to_unicode(tool.repository_owner),
             "help": to_unicode(""),
+            "inputs": to_unicode(""),
         }
         if tool.guid:
             # Create a stub consisting of owner, repo, and tool from guid
@@ -305,6 +309,10 @@ class ToolPanelViewSearch:
             add_doc_kwds["stub"] = clean(id_stub)
         else:
             add_doc_kwds["stub"] = to_unicode(id)
+        if tool.inputs:
+            data_tool_params = [value for value in tool.inputs.values() if isinstance(value, DataToolParameter)]
+            inputs = list({ext for param in data_tool_params for ext in param.extensions})
+            add_doc_kwds["inputs"] = to_unicode(" ".join(inputs))
         if tool.labels:
             add_doc_kwds["labels"] = to_unicode(" ".join(tool.labels))
         if index_help:
@@ -346,6 +354,7 @@ class ToolPanelViewSearch:
             "owner",
             "help",
             "labels",
+            "inputs",
             "stub",
         ]
         self.parser = MultifieldParser(

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -57,7 +57,7 @@ from whoosh.scoring import (
 from whoosh.writing import AsyncWriter
 
 from galaxy.config import GalaxyAppConfiguration
-from galaxy.tools.parameters.basic import DataToolParameter
+from galaxy.tools.parameters.basic import BaseDataToolParameter
 from galaxy.util import ExecutionTimer
 from galaxy.web.framework.helpers import to_unicode
 
@@ -310,9 +310,12 @@ class ToolPanelViewSearch:
         else:
             add_doc_kwds["stub"] = to_unicode(id)
         if tool.inputs:
-            data_tool_params = [value for value in tool.inputs.values() if isinstance(value, DataToolParameter)]
-            inputs = list({ext for param in data_tool_params for ext in param.extensions})
-            add_doc_kwds["inputs"] = to_unicode(" ".join(inputs))
+            input_extensions = set()
+            for tool_input in tool.inputs.values():
+                if isinstance(tool_input, BaseDataToolParameter):
+                    for extension in tool_input.extensions:
+                        input_extensions.add(extension)
+            add_doc_kwds["inputs"] = to_unicode(" ".join(input_extensions))
         if tool.labels:
             add_doc_kwds["labels"] = to_unicode(" ".join(tool.labels))
         if index_help:


### PR DESCRIPTION
Fixes #16437
Users are able to search for tools that take in certain datatypes

https://github.com/galaxyproject/galaxy/assets/78516064/07d2d14d-dc11-4b75-8bf1-e04f5f8c61f2



## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
