### PR TITLE
Fix: serialize `tool_shed_urls` directly from the API

### DIFF
--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -233,5 +233,9 @@ class AdminConfigSerializer(ConfigSerializer):
                 "user_library_import_dir": _defaults_to(None),
                 "allow_library_path_paste": _defaults_to(False),
                 "allow_user_deletion": _defaults_to(False),
+                "tool_shed_urls": self._serialize_tool_shed_urls,
             }
         )
+
+    def _serialize_tool_shed_urls(self, item: Any, key: str, **context):
+        return list(self.app.tool_shed_registry.tool_sheds.values()) if self.app.tool_shed_registry else []

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -237,5 +237,5 @@ class AdminConfigSerializer(ConfigSerializer):
             }
         )
 
-    def _serialize_tool_shed_urls(self, item: Any, key: str, **context):
+    def _serialize_tool_shed_urls(self, item: Any, key: str, **context) -> List[str]:
         return list(self.app.tool_shed_registry.tool_sheds.values()) if self.app.tool_shed_registry else []

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -300,9 +300,6 @@ class JSAppLauncher(BaseUIController):
             "enable_webhooks": True if trans.app.webhooks_registry.webhooks else False,
             "message_box_visible": trans.app.config.message_box_visible,
             "show_inactivity_warning": trans.app.config.user_activation_on and trans.user and not trans.user.active,
-            "tool_shed_urls": list(trans.app.tool_shed_registry.tool_sheds.values())
-            if trans.app.tool_shed_registry
-            else [],
             "tool_dynamic_configs": list(trans.app.toolbox.dynamic_conf_filenames()),
         }
 

--- a/lib/galaxy_test/api/test_configuration.py
+++ b/lib/galaxy_test/api/test_configuration.py
@@ -20,6 +20,7 @@ TEST_KEYS_FOR_ADMIN_ONLY = [
     "user_library_import_dir",
     "allow_library_path_paste",
     "allow_user_deletion",
+    "tool_shed_urls",
 ]
 
 


### PR DESCRIPTION
Fixes #16544

The `tool_shed_urls` are now serialized as part of the `api/configuration` response for Admins instead of injected later through the client controller.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
