### PR TITLE
[22.01] Fix up tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,21 @@
 [tox]
 # envlist is the list of environments that are tested when `tox` is run without any option
 # hyphens in an environment name are used to delimit factors
-envlist = py37-first_startup, py37-lint, py37-lint_docstring_include_list, py37-mypy, py37-reports_startup, py37-unit, test_galaxy_packages, validate_test_tools
+envlist =
+    py{37,38,39,310,311}-first_startup
+    py{37,38,39,310,311}-lint
+    py{37,38,39,310,311}-lint_docstring_include_list
+    py{37,38,39,310,311}-mypy
+    py{37,38,39,310,311}-reports_startup
+    py{37,38,39,310,311}-unit
+    first_startup
+    lint
+    lint_docstring_include_list
+    mypy
+    reports_startup
+    unit
+    test_galaxy_packages
+    validate_test_tools
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Implicit environments have been disallowed in the latest tox, so I've added unprefixed variants so we don't need to always include the py* prefix.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
