### PR TITLE
[23.0] Add missing unit-coverage environment

### DIFF
--- a/packages/selenium/setup.cfg
+++ b/packages/selenium/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     galaxy-util
     PyYAML
     requests
-    selenium
+    selenium!=4.11.0,!=4.11.1,!=4.11.2
 packages = find:
 python_requires = >=3.7
 

--- a/packages/test_selenium/setup.cfg
+++ b/packages/test_selenium/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     pytest
     PyYAML
     requests
-    selenium
+    selenium!=4.11.0,!=4.11.1,!=4.11.2
 packages = find:
 python_requires = >=3.7
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,12 +8,14 @@ envlist =
     py{37,38,39,310,311}-mypy
     py{37,38,39,310,311}-reports_startup
     py{37,38,39,310,311}-unit
+    py{37,38,39,310,311}-unit-coverage
     first_startup
     lint
     lint_docstring_include_list
     mypy
     reports_startup
     unit
+    unit-coverage
     test_galaxy_packages
     validate_test_tools
 skipsdist = True


### PR DESCRIPTION
This wasn't part of 22.01, to which I had targeted #16567 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
