### PR TITLE
[23.1] Don't use ``docker run`` --user flag on OSX

### DIFF
--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -4,6 +4,7 @@
 """
 import os
 import shlex
+import sys
 from typing import (
     List,
     Optional,
@@ -26,7 +27,7 @@ DEFAULT_NET = None
 DEFAULT_MEMORY = None
 DEFAULT_VOLUMES_FROM = None
 DEFAULT_AUTO_REMOVE = True
-DEFAULT_SET_USER = "$UID"
+DEFAULT_SET_USER = None if sys.platform == "darwin" else "$UID"
 DEFAULT_RUN_EXTRA_ARGUMENTS = None
 
 
@@ -106,7 +107,7 @@ def build_docker_run_command(
     sudo: bool = DEFAULT_SUDO,
     sudo_cmd: str = DEFAULT_SUDO_COMMAND,
     auto_rm: bool = DEFAULT_AUTO_REMOVE,
-    set_user: str = DEFAULT_SET_USER,
+    set_user: Optional[str] = DEFAULT_SET_USER,
     host: Optional[str] = DEFAULT_HOST,
     guest_ports: Union[bool, List[str]] = False,
     container_name: Optional[str] = None,


### PR DESCRIPTION
On OSX files touched by the docker daemon belong to the proper user. Using `--user` actually breaks permissions when mounting $TMPDIR in a really bizarre way.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
