### PR TITLE
[23.0] Fix incorrect ASGI request host

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -216,9 +216,7 @@ class GalaxyASGIRequest(GalaxyAbstractRequest):
 
     @property
     def host(self) -> str:
-        client = self.__request.client
-        assert client is not None
-        return str(client.host)
+        return self.__request.base_url.netloc
 
     @property
     def environ(self) -> MutableMapping[str, Any]:


### PR DESCRIPTION
Fixes #16454

I'm sorry, I think I mistakenly used the wrong host. It was returning the client host but I believe it should have been the application host instead :man_facepalming: 

This was introduced in 22.01 should I target that branch instead?

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
