### PR TITLE
[23.1] Ignore errors with user-set job resources

### DIFF
--- a/test/integration/dummy_job_resource_parameters.xml
+++ b/test/integration/dummy_job_resource_parameters.xml
@@ -1,0 +1,7 @@
+<parameters>
+    <param label="Compute Resource" name="multi_compute_resource" type="select"
+        help="Need help selecting a compute resource? Options and limits are explained in detail &lt;a href='https://galaxyproject.org/main/' target='_blank'&gt;in the Galaxy Hub&lt;/a&gt;">
+        <option value="does not matter">Galaxy cluster</option>
+        <option value="or this">Jetstream 2</option>
+    </param>
+</parameters>

--- a/test/integration/job_resource_error_recovery_job_conf.yml
+++ b/test/integration/job_resource_error_recovery_job_conf.yml
@@ -1,0 +1,22 @@
+# job config that fails submission if job resource parameters are requested
+runners:
+  local:
+    load: galaxy.jobs.runners.local:LocalJobRunner
+    workers: 1
+  dynamic:
+    rules_module: integration.job_resource_rules
+
+execution:
+  default: initial_destination
+  environments:
+    initial_destination:
+      runner: dynamic
+      type: python
+      function: local_or_exception
+    local:
+      runner: local
+
+tools:
+  - class: local
+    environment: local
+    resources: upload

--- a/test/integration/job_resource_rules/fail_if_job_resource_present.py
+++ b/test/integration/job_resource_rules/fail_if_job_resource_present.py
@@ -1,0 +1,5 @@
+def local_or_exception(resource_params):
+    """Build environment that fails if resource_params are passed."""
+    if resource_params:
+        raise Exception("boo!")
+    return "local"

--- a/test/integration/test_job_resource_error_recovery.py
+++ b/test/integration/test_job_resource_error_recovery.py
@@ -1,0 +1,43 @@
+import os
+
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    WorkflowPopulator,
+)
+from galaxy_test.driver import integration_util
+
+SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+JOB_RESOURCES_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "dummy_job_resource_parameters.xml")
+JOB_CONFIG = os.path.join(SCRIPT_DIRECTORY, "job_resource_error_recovery_job_conf.yml")
+
+
+class TestJobRecoveryBeforeHandledIntegration(integration_util.IntegrationTestCase):
+    dataset_populator: DatasetPopulator
+    framework_tool_and_types = True
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config) -> None:
+        super().handle_galaxy_config_kwds(config)
+        config["job_config_file"] = JOB_CONFIG
+        config["job_resource_params_file"] = JOB_RESOURCES_CONFIG_FILE
+
+    def test_recovers_from_job_resource_errors(self):
+        with self.dataset_populator.test_history() as history_id:
+            self.workflow_populator.run_workflow(
+                """
+class: GalaxyWorkflow
+steps:
+  simple_step:
+    tool_id: create_2
+    tool_state:
+      __job_resource:
+        __job_resource__select: 'yes'
+        cores: '32'
+""",
+                history_id=history_id,
+            )


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/share/issue/735cef91223e42888ff9bc54ec93c2cb/, which is a problem that happens when a workflow with resource parameters is imported from another Galaxy instance, or when we change the available resource parameters and the selection becomes invalid.

Medium-term we need to stop doing this completely IMO and work with more abstract job requirements IMO, as this is a big barrier to transfer workflows from instance to instance and having them just work.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
