### PR TITLE
[23.1] Fix shared item notification link

### DIFF
--- a/client/src/components/Notifications/Categories/SharedItemNotification.vue
+++ b/client/src/components/Notifications/Categories/SharedItemNotification.vue
@@ -8,6 +8,7 @@ import { useNotificationsStore } from "@/stores/notificationsStore";
 import { faExternalLinkAlt, faRetweet } from "@fortawesome/free-solid-svg-icons";
 import NotificationActions from "@/components/Notifications/NotificationActions.vue";
 import type { SharedItemNotification } from "@/components/Notifications";
+import { absPath } from "@/utils/redirect";
 
 library.add(faExternalLinkAlt, faRetweet);
 
@@ -41,9 +42,12 @@ const notificationVariant = computed(() => {
     }
 });
 
-function onClick(link: string) {
+const sharedItemUrl = computed(() => {
+    return absPath(content.value.slug);
+});
+
+function markNotificationAsSeen() {
     notificationsStore.updateNotification(props.notification, { seen: true });
-    window.open(link, "_blank");
 }
 </script>
 
@@ -65,7 +69,9 @@ function onClick(link: string) {
                     v-b-tooltip.bottom
                     :title="`View ${content.item_type} in new tab`"
                     class="text-primary"
-                    @click="onClick(content.slug)">
+                    :href="sharedItemUrl"
+                    target="_blank"
+                    @click="markNotificationAsSeen()">
                     {{ content.item_name }}
                     <FontAwesomeIcon icon="external-link-alt" />
                 </b-link>


### PR DESCRIPTION
Fixes #16580

![AfterFixNotifLink](https://github.com/galaxyproject/galaxy/assets/46503462/5cecf3b4-34da-4731-b504-ef91debc0348)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow the steps in #16580

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
