### PR TITLE
[23.0] Fix conditional step evaluation with datasets in repeats

### DIFF
--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -249,6 +249,18 @@ def test_subworkflow_new_outputs():
     assert output2["name"] == "4:out_file1", output2["name"]
 
 
+def test_to_cwl():
+    hda = model.HistoryDatasetAssociation(create_dataset=True, flush=False)
+    hda.dataset.state = model.Dataset.states.OK
+    hdas = [hda]
+    hda_references = []
+    result = modules.to_cwl(hdas, hda_references, model.WorkflowStep())
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["class"] == "File"
+    assert hda_references == hdas
+
+
 class MapOverTestCase(NamedTuple):
     data_input: str
     step_input_def: Union[str, List[str]]


### PR DESCRIPTION
For instance when this is the step state:

```python
{
    queries: [
        {
            __index__: 0,
            inputs2: ["<galaxy.model.HistoryDatasetAssociation(141277566) at 0x7fc2099417f0>"]
        }
    ],
    when: False
}
```

as seen in https://sentry.galaxyproject.org/share/issue/995445a10402461aa80328db5ceba491/

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
