### PR TITLE
[23.0] Don't read request body into memory

### DIFF
--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -282,7 +282,7 @@ class MockTrans:
         self.security = self.app.security
         self.history = history
 
-        self.request: Any = Bunch(headers={}, body=None)
+        self.request: Any = Bunch(headers={}, is_body_readable=False)
         self.response: Any = Bunch(headers={}, set_content_type=lambda i: None)
 
     def check_csrf_token(self, payload):

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -158,7 +158,7 @@ def legacy_expose_api(func, to_json=True, user_required=True):
         if user_required and trans.anonymous:
             error_message = "API Authentication Required for this request"
             return error
-        if trans.request.body:
+        if trans.request.is_body_readable:
             try:
                 kwargs["payload"] = __extract_payload_from_request(trans, func, kwargs)
             except ValueError:
@@ -296,7 +296,7 @@ def expose_api(func, to_json=True, user_required=True, user_or_session_required=
                     err_msg="API authentication or Galaxy session required for this request",
                 )
 
-        if trans.request.body:
+        if trans.request.is_body_readable:
             try:
                 kwargs["payload"] = __extract_payload_from_request(trans, func, kwargs)
             except ValueError:


### PR DESCRIPTION
The implementation of webob.Request.body is this:
```python
    @property
    def body(self):
        """
        Return the content of the request body.
        """
        if not self.is_body_readable:
            return b''

        self.make_body_seekable() # we need this to have content_length
        r = self.body_file.read(self.content_length)
        self.body_file_raw.seek(0)
        return r
```

I don't think the check is necessary, but let's see what blows up.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
