### PR TITLE
Run eslint autofix as a part of client format when using Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,10 @@ client-production: client-node-deps ## Rebuild client-side artifacts for a produ
 client-production-maps: client-node-deps ## Rebuild client-side artifacts for a production deployment with sourcemaps.
 	$(IN_VENV) cd client && $(NODE_ENV) yarn run build-production-maps
 
-client-format: client-node-deps ## Reformat client code
+client-lint-autofix: client-node-deps ## Automatically fix linting errors in client code
+	$(IN_VENV) cd client && yarn run eslint --quiet --fix
+
+client-format: client-node-deps client-lint-autofix ## Reformat client code, ensures autofixes are applied first
 	$(IN_VENV) cd client && yarn run format
 
 client-dev-server: client-node-deps ## Starts a webpack dev server for client development (HMR enabled)


### PR DESCRIPTION
xref conversation in UI/UX -- thanks @jmchilton, it's a good idea -- these are all stable fixes at this point and this makes it a bit more convenient for folks who use the make targets.  Folks can use the package scripts to format without this behavior if desired.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Mess up a fixable linting rule like kebab case and run `make client-format`

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
