### PR TITLE
[23.1] Make datatype edit default value a string instead of list of strings

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -253,13 +253,17 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             # datatype changing
             datatype_options = [(ext_name, ext_id) for ext_id, ext_name in ldatatypes]
             datatype_disable = len(datatype_options) == 0
+            datatype_input_default_value = None
+            current_datatype = trans.app.datatypes_registry.datatypes_by_extension.get(data.ext)
+            if current_datatype and current_datatype.is_datatype_change_allowed():
+                datatype_input_default_value = data.ext
             datatype_inputs = [
                 {
                     "type": "select",
                     "name": "datatype",
                     "label": "New Type",
                     "options": datatype_options,
-                    "value": [ext_id for ext_id, ext_name in ldatatypes if ext_id == data.ext],
+                    "value": datatype_input_default_value,
                     "help": "This will change the datatype of the existing dataset but not modify its contents. Use this if Galaxy has incorrectly guessed the type of your dataset.",
                 }
             ]


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/share/issue/66a8f651532a452696db400eb4bc5b94/:

```
TypeError: unhashable type: 'list'
  File "galaxy/web/framework/decorators.py", line 337, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 371, in set_edit
    self.hda_deserializer.deserialize(data, {"datatype": datatype}, trans=trans)
  File "galaxy/managers/base.py", line 959, in deserialize
    new_dict[key] = self.deserializers[key](item, key, val, **context)
  File "galaxy/managers/datasets.py", line 815, in deserialize_datatype
    target_datatype = self.app.datatypes_registry.get_datatype_by_extension(val)
  File "galaxy/datatypes/registry.py", line 590, in get_datatype_by_extension
    return self.datatypes_by_extension.get(ext, None)

```
which happens when the user doesn't change the datatype selection.
I think this happens now because both buttons are on the same page now and users now click both to be on the safe side:

<img width="878" alt="Screenshot 2023-08-24 at 18 13 29" src="https://github.com/galaxyproject/galaxy/assets/6804901/ec4adb14-144e-4f68-aad8-abcf371b39db">


<img width="329" alt="Screenshot 2023-08-24 at 18 13 11" src="https://github.com/galaxyproject/galaxy/assets/6804901/e169d6ca-3d6a-4983-946c-5313b0cc81dd">


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
