### PR TITLE
[23.0] Allow the legacy DELETE dataset endpoint to accept any string for the history_id

### DIFF
--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -10621,7 +10621,7 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
-            /** @description The ID of the History. */
+            /** @description History ID or any string. */
             /** @description The ID of the item (`HDA`/`HDCA`) contained in the history. */
             path: {
                 history_id: string;

--- a/client/src/schema/schema.ts
+++ b/client/src/schema/schema.ts
@@ -10621,7 +10621,7 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
-            /** @description History ID or any string. */
+            /** @description The ID of the History. */
             /** @description The ID of the item (`HDA`/`HDCA`) contained in the history. */
             path: {
                 history_id: string;
@@ -10979,7 +10979,7 @@ export interface operations {
             header?: {
                 "run-as"?: string;
             };
-            /** @description The ID of the History. */
+            /** @description History ID or any string. */
             /** @description The ID of the item (`HDA`/`HDCA`) contained in the history. */
             /**
              * @description The type of the target history element.

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -824,7 +824,7 @@ class FastAPIHistoryContents:
         self,
         response: Response,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: str = "",
+        history_id: str = Path(..., description="History ID or any string."),
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypePathParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -787,7 +787,7 @@ class FastAPIHistoryContents:
     def update_typed(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: str = "",
+        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypePathParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -787,7 +787,7 @@ class FastAPIHistoryContents:
     def update_typed(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        history_id: str = "",
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypePathParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),
@@ -824,7 +824,7 @@ class FastAPIHistoryContents:
         self,
         response: Response,
         trans: ProvidesHistoryContext = DependsOnTrans,
-        history_id: DecodedDatabaseIdField = HistoryIDPathParam,
+        history_id: str = "",
         id: DecodedDatabaseIdField = HistoryItemIDPathParam,
         type: HistoryContentType = ContentTypePathParam,
         serialization_params: SerializationParams = Depends(query_serialization_params),


### PR DESCRIPTION
Fix for #16191 

This fix works in cooperation with[ this PR in galaxy-visualizations](https://github.com/galaxyproject/galaxy-visualizations/pull/1) 
The first  part of the fix here was to correct the 400 error, that was unable to decode a history_id for "none", therefore I changed the type of the parameter and it's default (thanks to @mvdbeek for helping me step through that)

After making that change, I made the changes in the galaxy-visualizations repo (with thanks to @dannon) for the tip off

**MOVED TO A SEPARATE PR #16598** 
Finally, I was getting a 200 response, but still was not able to view the chart, whereupon I dug around the dev console long enough to find that target was undefined, since it was misnamed as targets as a parameter. After fixing that, the boxplot renders fine. 😅 

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Create a tabular file
  2. Create a boxplot visualization for it
  3. Check the visualization under Users > Visualizations
  4. Note that the graph is visible

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
