### PR TITLE
[23.1] Bump minimum tpv version to 2.3.2

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -13,7 +13,7 @@ ldap3==2.9.1
 python-pam
 galaxycloudrunner
 pkce
-total-perspective-vortex>=2.2.4,<3
+total-perspective-vortex>=2.3.2,<3
 
 # For file sources plugins
 fs.webdavfs>=0.4.2  # type: webdav


### PR DESCRIPTION
This version fixes the version parsing for tools that don't use PEP 440 versions (https://github.com/galaxyproject/total-perspective-vortex/issues/111)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
