### PR TITLE
[22.01] Passing Identifier for div to Write the Chart Panel to

### DIFF
--- a/config/plugins/visualizations/jqplot/jqplot_bar/src/script.js
+++ b/config/plugins/visualizations/jqplot/jqplot_bar/src/script.js
@@ -261,7 +261,7 @@ window.bundleEntries.jqplot_box = function (options) {
             chart               : options.chart,
             dataset_id          : dataset.id,
             dataset_groups      : dataset_groups,
-            targets             : options.targets,
+            target              : options.target,
             makeConfig          : function( groups, plot_config ){
                 var boundary = getDomains( groups, 'x' );
                 $.extend( true, plot_config, {


### PR DESCRIPTION
Fix for #16191 

Moving this change to a separate PR since it should target a different release branch 
See PR #16593 for additional details, relevant description copied below.

After making the other changes in that PR, I was getting a 200 response, but still was not able to view the chart, whereupon I dug around the dev console long enough to find that target was undefined, since it was misnamed as targets as a parameter. After fixing that, the boxplot renders fine. 😅

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Create a tabular file
  2. Create a boxplot visualization for it
  3. Check the visualization under Users > Visualizations
  4. Note that the graph is visible

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
