### PR TITLE
[23.1] Optimize getting current user session

### DIFF
--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -835,7 +835,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         history = None
         set_permissions = False
         try:
-            users_last_session = user.galaxy_sessions[0]
+            users_last_session = user.current_galaxy_session
         except Exception:
             users_last_session = None
         if (

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -77,7 +77,7 @@ class UserListGrid(grids.Grid):
     class LastLoginColumn(grids.GridColumn):
         def get_value(self, trans, grid, user):
             if user.galaxy_sessions:
-                return self.format(user.galaxy_sessions[0].update_time)
+                return self.format(user.current_galaxy_session.update_time)
             return "never"
 
         def sort(self, trans, query, ascending, column_name=None):

--- a/lib/galaxy/webapps/reports/controllers/users.py
+++ b/lib/galaxy/webapps/reports/controllers/users.py
@@ -164,8 +164,9 @@ class Users(BaseUIController, ReportQueryBuilder):
             .filter(galaxy.model.User.table.c.deleted == false())
             .order_by(galaxy.model.User.table.c.email)
         ):
-            if user.galaxy_sessions:
-                last_galaxy_session = user.galaxy_sessions[0]
+            current_galaxy_session = user.current_galaxy_session
+            if current_galaxy_session:
+                last_galaxy_session = current_galaxy_session
                 if last_galaxy_session.update_time < cutoff_time:
                     users.append((user.email, last_galaxy_session.update_time.strftime("%Y-%m-%d")))
             else:

--- a/lib/tool_shed/grids/admin_grids.py
+++ b/lib/tool_shed/grids/admin_grids.py
@@ -46,8 +46,8 @@ class UserGrid(grids.Grid):
 
     class LastLoginColumn(grids.GridColumn):
         def get_value(self, trans, grid, user):
-            if user.galaxy_sessions:
-                return self.format(user.galaxy_sessions[0].update_time)
+            if user.current_galaxy_session:
+                return self.format(user.current_galaxy_session.update_time)
             return "never"
 
     class StatusColumn(grids.GridColumn):


### PR DESCRIPTION
We get all user session when logging in, this isn't necessary and does show up in a memray trace. I don't think it's a leak, but this is going to be more efficient.

<img width="2340" alt="Screenshot 2023-08-27 at 11 43 14" src="https://github.com/galaxyproject/galaxy/assets/6804901/7d6ca61b-cec5-42fc-a809-a146bcd2aa1b">



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
