### PR TITLE
Update the client to make use of schema models for the users API

### DIFF
--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -11,18 +11,10 @@ import {
     setCurrentThemeQuery,
 } from "@/stores/users/queries";
 
-type QuotaUsageResponse = components["schemas"]["UserQuotaUsage"];
 
-interface User extends QuotaUsageResponse {
-    id: string;
-    email: string;
-    tags_used: string[];
-    isAnonymous: false;
-}
+type AnonymousUser = components["schemas"]["AnonUserModel"]
+type User = components["schemas"]["DetailedUserModel"]
 
-interface AnonymousUser {
-    isAnonymous: true;
-}
 
 interface Preferences {
     theme: string;

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -61,8 +61,15 @@ export const useUserStore = defineStore("userStore", () => {
         if (!loadPromise) {
             loadPromise = getCurrentUser()
                 .then(async (user) => {
-                    currentUser.value = { ...user, isAnonymous: !user.email };
-                    currentPreferences.value = user?.preferences ?? null;
+                    const historyStore = useHistoryStore();
+                    if ('email' in user) {
+                        currentUser.value = { ...user, isAnonymous: false };
+                        currentPreferences.value = user.preferences;
+                    }
+                    else {
+                        currentUser.value = { isAnonymous: true };
+                        currentPreferences.value = null;
+                    }
                     // TODO: This is a hack to get around the fact that the API returns a string
                     if (currentPreferences.value?.favorites) {
                         currentPreferences.value.favorites = JSON.parse(user?.preferences?.favorites ?? { tools: [] });

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -61,7 +61,6 @@ export const useUserStore = defineStore("userStore", () => {
         if (!loadPromise) {
             loadPromise = getCurrentUser()
                 .then(async (user) => {
-                    const historyStore = useHistoryStore();
                     if ('email' in user) {
                         currentUser.value = { ...user, isAnonymous: false };
                         currentPreferences.value = user.preferences;

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -69,7 +69,7 @@ export const useUserStore = defineStore("userStore", () => {
                         currentPreferences.value = null;
                     }
                     // TODO: This is a hack to get around the fact that the API returns a string
-                    if (currentPreferences.value?.favorites) {
+                    if (currentPreferences.value?.favorites && isRegisteredUser(user)) {
                         currentPreferences.value.favorites = JSON.parse(user?.preferences?.favorites ?? { tools: [] });
                     }
                     if (includeHistories) {
@@ -87,7 +87,11 @@ export const useUserStore = defineStore("userStore", () => {
                 });
         }
     }
-
+    function isRegisteredUser(user?: any): user is User {
+        return (
+            user !== undefined && "email" in user
+        );
+    }
     async function setCurrentTheme(theme: string) {
         if (!currentUser.value || currentUser.value.isAnonymous) {
             return;

--- a/client/src/stores/userStore.ts
+++ b/client/src/stores/userStore.ts
@@ -10,12 +10,19 @@ import {
     removeFavoriteToolQuery,
     setCurrentThemeQuery,
 } from "@/stores/users/queries";
+import { expand } from "rxjs";
 
 
-type AnonymousUser = components["schemas"]["AnonUserModel"]
-type User = components["schemas"]["DetailedUserModel"]
+type DetailedAnonymousUser = components["schemas"]["AnonUserModel"]
+type DetailedUserModelUser = components["schemas"]["DetailedUserModel"]
 
+interface AnonymousUser extends DetailedAnonymousUser {
+    isAnonymous: true
+}
 
+interface User extends DetailedUserModelUser {
+    isAnonymous: false;
+}
 interface Preferences {
     theme: string;
     favorites: { tools: string[] };
@@ -55,10 +62,10 @@ export const useUserStore = defineStore("userStore", () => {
                 .then(async (user) => {
                     if ('email' in user) {
                         currentUser.value = { ...user, isAnonymous: false };
-                        currentPreferences.value = user.preferences;
+                        currentPreferences.value = user.preferences as unknown as Preferences;
                     }
                     else {
-                        currentUser.value = { isAnonymous: true };
+                        currentUser.value = { ...user, isAnonymous: true };
                         currentPreferences.value = null;
                     }
                     // TODO: This is a hack to get around the fact that the API returns a string

--- a/client/src/stores/users/queries.ts
+++ b/client/src/stores/users/queries.ts
@@ -1,11 +1,12 @@
-import axios from "axios";
+import { fetcher } from "@/schema"
 
-import { prependPath } from "@/utils/redirect";
-import { rethrowSimple } from "@/utils/simple-error";
+const getUser = fetcher.path("/api/users/{user_id}").method("get").create();
+const setTheme = fetcher.path("/api/users/{user_id}/theme/{theme}").method("put").create();
+const addFavoriteTool = fetcher.path("/api/users/{user_id}/favorites/{object_type}").method("put").create();
+const removeFavoriteTool = fetcher.path("/api/users/{user_id}/favorites/{object_type}/{object_id}").method("delete").create();
 
 export async function getCurrentUser() {
-    const url = prependPath("/api/users/current");
-    const response = await axios.get(url);
+    const response = await getUser({ user_id: "current" })
     if (response.status != 200) {
         throw new Error("Failed to get current user");
     }
@@ -13,31 +14,25 @@ export async function getCurrentUser() {
 }
 
 export async function addFavoriteToolQuery(userId: string, toolId: string) {
-    const url = prependPath(`/api/users/${userId}/favorites/tools`);
-    try {
-        const { data } = await axios.put(url, { object_id: toolId });
-        return data["tools"];
-    } catch (e) {
-        rethrowSimple(e);
+    const response = await addFavoriteTool({ user_id: userId, object_type: "tools", object_id: toolId })
+    if (response.status != 200) {
+        throw new Error("Failed to add tool to favorites");
     }
+    return response.data["tools"];
 }
 
 export async function removeFavoriteToolQuery(userId: string, toolId: string) {
-    const url = prependPath(`/api/users/${userId}/favorites/tools/${encodeURIComponent(toolId)}`);
-    try {
-        const { data } = await axios.delete(url);
-        return data["tools"];
-    } catch (e) {
-        rethrowSimple(e);
+    const response = await removeFavoriteTool({ user_id: userId, object_type: "tools", object_id: toolId })
+    if (response.status != 200) {
+        throw new Error("Failed to remove tool from favorites");
     }
+    return response.data["tools"];
 }
 
 export async function setCurrentThemeQuery(userId: string, theme: string) {
-    const url = prependPath(`/api/users/${userId}/theme/${theme}`);
-    try {
-        const { data } = await axios.put(url, { theme: theme });
-        return data;
-    } catch (e) {
-        rethrowSimple(e);
+    const response = await setTheme({ user_id: userId, theme: theme })
+    if (response.status != 200) {
+        throw new Error("Failed to set theme");
     }
+    return response.data;
 }


### PR DESCRIPTION
This is an extension of #16341. 
The goal is to update the client so that it makes use of the newly created schema models from the referenced pull request.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. I do not know how to test this manually

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
