### PR TITLE
[23.1] Only reindex tool search once after forking

### DIFF
--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -238,7 +238,7 @@ def reload_tool_data_tables(app, **kwargs):
 
 
 def rebuild_toolbox_search_index(app, **kwargs):
-    if app.is_webapp:
+    if app.is_webapp and app.database_heartbeat.is_config_watcher:
         if app.toolbox_search.index_count < app.toolbox._reload_count:
             app.reindex_tool_search()
     else:


### PR DESCRIPTION
Makes forking new workers with gunicorns `--max-requests` setting more efficient ... and anyway no point in doing this more than once.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
