### PR TITLE
[23.1] Fix Published Pages and Pages view showing same content

### DIFF
--- a/client/src/components/Page/PageList.test.js
+++ b/client/src/components/Page/PageList.test.js
@@ -30,6 +30,8 @@ describe("PgeList.vue", () => {
         offset: 0,
         sort_by: "update_time",
         sort_desc: true,
+        show_published: false,
+        show_shared: true,
     };
     const publishedGridApiParams = {
         ...personalGridApiParams,

--- a/client/src/components/Page/PageList.vue
+++ b/client/src/components/Page/PageList.vue
@@ -177,9 +177,9 @@ export default {
     computed: {
         dataProviderParameters() {
             const extraParams = { search: this.effectiveFilter };
-            if (this.published) {
-                extraParams.show_published = true;
-                extraParams.show_shared = false;
+            if (!this.published) {
+                extraParams.show_published = false;
+                extraParams.show_shared = true;
             }
             return extraParams;
         },

--- a/client/src/components/Page/PageList.vue
+++ b/client/src/components/Page/PageList.vue
@@ -176,10 +176,14 @@ export default {
     },
     computed: {
         dataProviderParameters() {
-            const extraParams = { search: this.effectiveFilter };
-            if (!this.published) {
-                extraParams.show_published = false;
-                extraParams.show_shared = true;
+            const extraParams = {
+                search: this.effectiveFilter,
+                show_published: false,
+                show_shared: true,
+            };
+            if (this.published) {
+                extraParams.show_published = true;
+                extraParams.show_shared = false;
             }
             return extraParams;
         },


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/16613
Pages will now show the current user's pages and Published Pages will show publicly available items.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
