### PR TITLE
Adding wlcg oidc endpoint. 

### DIFF
--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -40,6 +40,7 @@ BACKENDS = {
     "elixir": "social_core.backends.elixir.ElixirOpenIdConnect",
     "okta": "social_core.backends.okta_openidconnect.OktaOpenIdConnect",
     "azure": "social_core.backends.azuread_tenant.AzureADV2TenantOAuth2",
+    "wlcg": "social_core.backends.wlcg.WLCGOAuth2",
 }
 
 BACKENDS_NAME = {
@@ -48,6 +49,7 @@ BACKENDS_NAME = {
     "elixir": "elixir",
     "okta": "okta-openidconnect",
     "azure": "azuread-v2-tenant-oauth2",
+    "wlcg": "wlcg",
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -197,4 +197,28 @@ Please mind `http` and `https`.
         <api_url> ... </api_url>
     </provider>
 
+
+    <provider name="wlcg">
+      <url>https://wlcg.cloud.cnaf.infn.it/login</url>
+      <client_id> ... </client_id>
+      <client_secret> ... </client_secret>
+      <redirect_uri>http://localhost:8080/authnz/wlcg/callback</redirect_uri>
+      <!-- Create a WLCG IAM client at https://wlcg.cloud.cnaf.infn.it/login
+	   Sign in with x509 certificate or CERN SSO
+	   Scopes need to be: offline_access, openid, profile, wlcg
+	   Grant types: authorization_code, refresh_token
+	   Add the correct redirect uri
+
+	   Otherwise keep defaults. 
+
+	   Replace client_id, client_secret and redirect_uri with actual values. 
+	   Example value of redirect_uri: 
+	   https://yourgalaxy.com/authnz/wlcg/callback 
+
+           A token from The WLCG IAM can be used to submit jobs to an ARC distributed computing endpoint 
+	   if the ARC endpoint is configured to allow it. 
+      -->
+    </provider>
+    
+
 </OIDC>

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -203,6 +203,8 @@ Please mind `http` and `https`.
       <client_id> ... </client_id>
       <client_secret> ... </client_secret>
       <redirect_uri>http://localhost:8080/authnz/wlcg/callback</redirect_uri>
+      <icon>https://wlcg-docs.web.cern.ch/outreach/logos/WLCG-Logo-HI-res/WLCG-Logo-Comp2L-B-Hi.png</icon>
+      
       <!-- Create a WLCG IAM client at https://wlcg.cloud.cnaf.infn.it/login
 	   Sign in with x509 certificate or CERN SSO
 	   Scopes need to be: offline_access, openid, profile, wlcg


### PR DESCRIPTION
It is related to the added endpoint in social-core: https://github.com/python-social-auth/social-core/pull/820 (not yet merged).



## How to test the changes?
Update your social-core package with the changes in https://github.com/python-social-auth/social-core/pull/820

Create a WLCG IAM client at https://wlcg.cloud.cnaf.infn.it 
See instructions on client settings in oidc_backends_config.xml.sample
Update your oidc_backends_config.yml with the new backend

Update your galaxy.yml config file pointing to the correct oidc_config.xml, and the oidc_backends_config.xml - and enable_oidc - example: 

```
oidc_config_file: /srv/galaxy/config/oidc_config.xml
oidc_backends_config_file: /srv/galaxy/config/oidc_backends_config.xml
enable_oidc: true
```

Log into your galaxy instance using the wlcg oidc.

<img width="631" alt="Screenshot 2023-08-30 at 10 29 54" src="https://github.com/galaxyproject/galaxy/assets/22190352/081a86ef-483b-4fe4-a52b-bfe808cf9bb2">



## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
