### PR TITLE
Added simple form for adding ARC compute element endpoint

### DIFF
--- a/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
+++ b/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
@@ -1,5 +1,15 @@
 preferences:
     # the key you can refer to
+
+
+    distributed_arc_compute:
+        description: The URL to your ARC remote HPC compute resource.
+        inputs:
+            - name: remote_arc_resources
+              label: Add your remote resource url (example: https://arctestcluster-slurm-el9-arc7-ce1.cern-test.uiocloud.no)
+              type: text
+              required: False
+	
     apollo_url_01:
         # description that is displayed to the user
         description: The URL to your personal Apollo instance


### PR DESCRIPTION
A simple user form to add one ARC endpoint to go with the new (not yet available) ARC runner. 
The user can with this form add his own ARC endpoint and use that to submit the jobs from Galaxy. 

In the future it would be nice if the user could add more than one endpoint, see related request: https://github.com/galaxyproject/galaxy/issues/16596


## How to test the changes?
Once the ARC runner is merged, the entries in this form can actually be tested. 
A user can right away add an endpoint, but it will not be used in any jobs at the moment. 

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
