### PR TITLE
[23.1] Reload toolbox after forking when using `--preload`

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -84,6 +84,7 @@ from galaxy.objectstore import (
 )
 from galaxy.queue_worker import (
     GalaxyQueueWorker,
+    reload_toolbox,
     send_local_control_task,
 )
 from galaxy.quota import (
@@ -746,6 +747,10 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         # Start web stack message handling
         self.application_stack.register_postfork_function(self.application_stack.start)
         self.application_stack.register_postfork_function(self.queue_worker.bind_and_start)
+        # Reload toolbox to pick up changes to toolbox made after master was ready
+        self.application_stack.register_postfork_function(
+            lambda: reload_toolbox(self, save_integrated_tool_panel=False), post_fork_only=True
+        )
         # Delay toolbox index until after startup
         self.application_stack.register_postfork_function(
             lambda: send_local_control_task(self, "rebuild_toolbox_search_index")

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -6,6 +6,10 @@ import sqlite3
 import tempfile
 import zlib
 from threading import Lock
+from typing import (
+    Dict,
+    Optional,
+)
 
 from sqlitedict import SqliteDict
 
@@ -134,7 +138,7 @@ class ToolCache:
 
     def __init__(self):
         self._lock = Lock()
-        self._hash_by_tool_paths = {}
+        self._hash_by_tool_paths: Dict[str, ToolHash] = {}
         self._tools_by_path = {}
         self._tool_paths_by_id = {}
         self._macro_paths_by_id = {}
@@ -195,9 +199,12 @@ class ToolCache:
         try:
             new_mtime = os.path.getmtime(config_filename)
             tool_hash = self._hash_by_tool_paths.get(config_filename)
-            if tool_hash.modtime < new_mtime:
-                if md5_hash_file(config_filename) != tool_hash.hash:
+            if tool_hash and tool_hash.modtime_less_than(new_mtime):
+                if not tool_hash.hash_equals(md5_hash_file(config_filename)):
                     return True
+                else:
+                    # No change of content, so not necessary to calculate the md5 checksum every time
+                    tool_hash.modtime = new_mtime
             tool = self._tools_by_path[config_filename]
             for macro_path in tool._macro_paths:
                 new_mtime = os.path.getmtime(macro_path)
@@ -256,12 +263,36 @@ class ToolCache:
 
 
 class ToolHash:
-    def __init__(self, path, modtime=None, lazy_hash=False):
+    def __init__(self, path: str, modtime: Optional[float] = None, lazy_hash: bool = False):
         self.path = path
-        self.modtime = modtime or os.path.getmtime(path)
+        self._modtime = modtime or os.path.getmtime(path)
         self._tool_hash = None
         if not lazy_hash:
             self.hash  # noqa: B018
+
+    def modtime_less_than(self, other_modtime: float):
+        if self._modtime is None:
+            # For the purposes of the tool cache,
+            # if we haven't seen the modtime we consider it not equal
+            return True
+        return self._modtime < other_modtime
+
+    def hash_equals(self, other_hash: Optional[str]):
+        if self._tool_hash is None or other_hash is None:
+            # For the purposes of the tool cache,
+            # if we haven't seen the hash yet we consider it not equal
+            return False
+        return self.hash == other_hash
+
+    @property
+    def modtime(self) -> float:
+        if self._modtime is None:
+            self._modtime = os.path.getmtime(self.path)
+        return self._modtime
+
+    @modtime.setter
+    def modtime(self, new_value: float):
+        self._modtime = new_value
 
     @property
     def hash(self):


### PR DESCRIPTION
When adding gunicorn workers or restarting workers the new workers need
to load up the current toolbox, as it may have changed from when the
master process became ready.

To test this, start gunicorn with `--preload` and `--max-requests 50`.
After the instance has booted change the tool version in a single tool.
The tool watcher will pick this up and you get the new tool version.

Now trigger the worker replacement by making 50 requests. Without
this PR you would get the old version.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
