### PR TITLE
Create `GDateTime` component

### DIFF
--- a/client/src/components/GDateTime.test.ts
+++ b/client/src/components/GDateTime.test.ts
@@ -1,0 +1,43 @@
+import { getLocalVue } from "@tests/jest/helpers";
+import { mount } from "@vue/test-utils";
+
+import GDateTime from "./GDateTime.vue";
+
+const localVue = getLocalVue(true);
+
+async function mountGDateTime(props: object) {
+    const wrapper = mount(GDateTime as object, {
+        propsData: {
+            ...props,
+        },
+        localVue,
+    });
+
+    return wrapper;
+}
+
+describe("GDateTime.vue", () => {
+    it("emits updated date when input changes", async () => {
+        const wrapper = await mountGDateTime({
+            value: new Date("1970-01-01T00:00:00"),
+        });
+
+        const dateInput = wrapper.find('input[type="date"]');
+        await dateInput.setValue("2023-08-30");
+
+        expect(wrapper.emitted()).toHaveProperty("input");
+        expect(wrapper.emitted()?.["input"]?.[0]?.[0]).toEqual(new Date("2023-08-30T00:00:00"));
+    });
+
+    it("emits updated time when input changes", async () => {
+        const wrapper = await mountGDateTime({
+            value: new Date("1970-01-01T00:00:00"),
+        });
+
+        const timeInput = wrapper.find('input[type="time"]');
+        await timeInput.setValue("12:30");
+
+        expect(wrapper.emitted()).toHaveProperty("input");
+        expect(wrapper.emitted()?.["input"]?.[0]?.[0]).toEqual(new Date("1970-01-01T12:30:00"));
+    });
+});

--- a/client/src/components/GDateTime.vue
+++ b/client/src/components/GDateTime.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { Tuple } from "types/utilityTypes";
+import { computed } from "vue";
+
+const props = defineProps<{
+    value: Date;
+}>();
+
+const emit = defineEmits<{
+    (e: "input", value: Date): void;
+}>();
+
+const date = computed(() => {
+    const year = props.value.getFullYear().toString().padStart(4, "0");
+    const month = (props.value.getMonth() + 1).toString().padStart(2, "0");
+    const day = props.value.getDate().toString().padStart(2, "0");
+
+    return `${year}-${month}-${day}`;
+});
+
+const time = computed(() => {
+    const hours = props.value.getHours().toString().padStart(2, "0");
+    const minutes = props.value.getMinutes().toString().padStart(2, "0");
+
+    return `${hours}:${minutes}`;
+});
+function updateDate(newDate: string) {
+    const matches = newDate.match(/(\d{4})-(\d{2})-(\d{2})/);
+
+    if (matches?.length && matches.length >= 4) {
+        const [_, year, month, day] = matches as Tuple<4, string>;
+
+        const date = new Date(props.value);
+
+        try {
+            date.setFullYear(parseInt(year));
+            date.setDate(1);
+            date.setMonth(0);
+            date.setMonth(parseInt(month) - 1);
+            date.setDate(parseInt(day));
+        } finally {
+            emit("input", date);
+        }
+    }
+}
+
+function updateTime(newTime: string) {
+    const matches = newTime.match(/(\d{2}):(\d{2})/);
+
+    if (matches?.length && matches.length >= 3) {
+        const [_, hours, minutes] = matches as Tuple<3, string>;
+
+        const date = new Date(props.value);
+
+        try {
+            date.setHours(parseInt(hours), parseInt(minutes));
+        } finally {
+            emit("input", date);
+        }
+    }
+}
+</script>
+
+<template>
+    <BInputGroup>
+        <BFormInput :value="date" type="date" @input="updateDate" />
+        <BFormInput :value="time" type="time" @change="updateTime" />
+    </BInputGroup>
+</template>

--- a/client/src/components/GDateTime.vue
+++ b/client/src/components/GDateTime.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { BFormInput, BInputGroup } from "bootstrap-vue";
 import { Tuple } from "types/utilityTypes";
 import { computed } from "vue";
 
@@ -24,6 +25,7 @@ const time = computed(() => {
 
     return `${hours}:${minutes}`;
 });
+
 function updateDate(newDate: string) {
     const matches = newDate.match(/(\d{4})-(\d{2})-(\d{2})/);
 
@@ -64,6 +66,6 @@ function updateTime(newTime: string) {
 <template>
     <BInputGroup>
         <BFormInput :value="date" type="date" @input="updateDate" />
-        <BFormInput :value="time" type="time" @change="updateTime" />
+        <BFormInput :value="time" type="time" @input="updateTime" />
     </BInputGroup>
 </template>

--- a/client/src/components/GDateTime.vue
+++ b/client/src/components/GDateTime.vue
@@ -28,7 +28,7 @@ function updateDate(newDate: string) {
     const matches = newDate.match(/(\d{4})-(\d{2})-(\d{2})/);
 
     if (matches?.length && matches.length >= 4) {
-        const [_, year, month, day] = matches as Tuple<4, string>;
+        const [_v, year, month, day] = matches as Tuple<4, string>;
 
         const date = new Date(props.value);
 
@@ -48,7 +48,7 @@ function updateTime(newTime: string) {
     const matches = newTime.match(/(\d{2}):(\d{2})/);
 
     if (matches?.length && matches.length >= 3) {
-        const [_, hours, minutes] = matches as Tuple<3, string>;
+        const [_v, hours, minutes] = matches as Tuple<3, string>;
 
         const date = new Date(props.value);
 


### PR DESCRIPTION
This PR adds a new reusable component called `GDateTime` that provides a date and time picker in a single input group. The component takes/returns a Date object and modifies its time and date whenever the user selects a new date or time.

There is no single component in the current components framework (Bootstrap-Vue) that can handle date and time using a single value at the same time.

![image](https://github.com/galaxyproject/galaxy/assets/8046843/3248d066-0e9a-4402-a0b0-7e25327dec1c)


## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
