### PR TITLE
[23.0] Don't fail invocation message without dependent_workflow_step_id

### DIFF
--- a/lib/galaxy/schema/invocation.py
+++ b/lib/galaxy/schema/invocation.py
@@ -53,7 +53,10 @@ class StepOrderIndexGetter(GetterDict):
         if key == "workflow_step_id":
             return self._obj.workflow_step.order_index
         elif key == "dependent_workflow_step_id":
-            return self._obj.dependent_workflow_step.order_index
+            if self._obj.dependent_workflow_step_id:
+                return self._obj.dependent_workflow_step.order_index
+            else:
+                return default
 
         return super().get(key, default)
 


### PR DESCRIPTION
We don't always have a dependent workflow step id for certain errors, this is fine.

Fixes https://github.com/galaxyproject/galaxy/issues/16626#issuecomment-1700638448:

```
AttributeError: 'NoneType' object has no attribute 'order_index'
  File "galaxy/web/framework/decorators.py", line 337, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/workflows.py", line 827, in index_invocations
    invocations, total_matches = self.invocations_service.index(trans, invocation_payload, serialization_params)
  File "galaxy/webapps/galaxy/services/invocations.py", line 146, in index
    invocation_dict = self.serialize_workflow_invocations(invocations, serialization_params)
  File "galaxy/webapps/galaxy/services/invocations.py", line 215, in serialize_workflow_invocations
    return list(
  File "galaxy/webapps/galaxy/services/invocations.py", line 216, in <lambda>
    map(lambda i: self.serialize_workflow_invocation(i, params, default_view=default_view), invocations)
  File "galaxy/webapps/galaxy/services/invocations.py", line 204, in serialize_workflow_invocation
    as_dict["messages"] = [
  File "galaxy/webapps/galaxy/services/invocations.py", line 205, in <listcomp>
    InvocationMessageResponseModel.parse_obj(message).__root__.dict() for message in invocation.messages
  File "pydantic/main.py", line 526, in pydantic.main.BaseModel.parse_obj
  File "pydantic/main.py", line 339, in pydantic.main.BaseModel.__init__
  File "pydantic/main.py", line 1076, in pydantic.main.validate_model
  File "pydantic/fields.py", line 884, in pydantic.fields.ModelField.validate
  File "pydantic/fields.py", line 1061, in pydantic.fields.ModelField._validate_singleton
  File "pydantic/fields.py", line 1150, in pydantic.fields.ModelField._validate_discriminated_union
  File "pydantic/fields.py", line 884, in pydantic.fields.ModelField.validate
  File "pydantic/fields.py", line 1101, in pydantic.fields.ModelField._validate_singleton
  File "pydantic/fields.py", line 1157, in pydantic.fields.ModelField._apply_validators
  File "pydantic/class_validators.py", line 337, in pydantic.class_validators._generic_validator_basic.lambda13
  File "pydantic/main.py", line 713, in pydantic.main.BaseModel.validate
  File "pydantic/main.py", line 577, in pydantic.main.BaseModel.from_orm
  File "pydantic/main.py", line 1055, in pydantic.main.validate_model
  File "galaxy/schema/invocation.py", line 56, in get
    return self._obj.dependent_workflow_step.order_index
```

from https://sentry.galaxyproject.org/share/issue/021a1833a4744783a9922ed37b0278c2/

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
