### PR TITLE
Add scroll pagination and username filter to `HistoryPublishedList`

### DIFF
--- a/client/src/components/History/HistoryPublishedList.vue
+++ b/client/src/components/History/HistoryPublishedList.vue
@@ -306,7 +306,12 @@ watch([filterText, sortBy, sortDesc], async () => {
                     </router-link>
                 </template>
                 <template v-slot:cell(username)="row">
-                    <a href="#" @click="setFilter('user', row.item.username)">{{ row.item.username }}</a>
+                    <a
+                        href="#"
+                        class="published-histories-username-link"
+                        @click="setFilter('user', row.item.username)"
+                        >{{ row.item.username }}</a
+                    >
                 </template>
                 <template v-slot:cell(tags)="row">
                     <StatelessTags

--- a/client/src/entry/analysis/router.js
+++ b/client/src/entry/analysis/router.js
@@ -266,7 +266,11 @@ export function getRouter(Galaxy) {
                     {
                         path: "histories/list_published",
                         component: HistoryPublishedList,
-                        props: true,
+                        props: (route) => {
+                            return {
+                                ...route.query,
+                            };
+                        },
                     },
                     {
                         path: "histories/archived",

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -885,7 +885,14 @@ class HistoryFilters(sharable.SharableModelFilters, deletable.PurgableFiltersMix
             }
         )
         self.fn_filter_parsers.update(
-            {"username": {"op": {"eq": self.username_eq, "contains": self.username_contains, }, }, }
+            {
+                "username": {
+                    "op": {
+                        "eq": self.username_eq,
+                        "contains": self.username_contains,
+                    },
+                },
+            }
         )
 
     def username_eq(self, item, val: str) -> bool:

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -885,7 +885,7 @@ class HistoryFilters(sharable.SharableModelFilters, deletable.PurgableFiltersMix
             }
         )
         self.fn_filter_parsers.update(
-            {"username": {"op": {"eq": self.username_eq, "contains": self.username_contains,},},}
+            {"username": {"op": {"eq": self.username_eq, "contains": self.username_contains, }, }, }
         )
 
     def username_eq(self, item, val: str) -> bool:

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -884,3 +884,12 @@ class HistoryFilters(sharable.SharableModelFilters, deletable.PurgableFiltersMix
                 "update_time": {"op": ("le", "ge", "gt", "lt"), "val": self.parse_date},
             }
         )
+        self.fn_filter_parsers.update(
+            {"username": {"op": {"eq": self.username_eq, "contains": self.username_contains,},},}
+        )
+
+    def username_eq(self, item, val: str) -> bool:
+        return val.lower() == str(item.user.username).lower()
+
+    def username_contains(self, item, val: str) -> bool:
+        return val.lower() in str(item.user.username).lower()

--- a/lib/galaxy_test/selenium/test_histories_published.py
+++ b/lib/galaxy_test/selenium/test_histories_published.py
@@ -55,6 +55,29 @@ class TestPublishedHistories(SharedStateSeleniumTestCase):
         self.assert_histories_present([self.history3_name, self.history1_name])
 
     @selenium_test
+    def test_published_histories_username_click(self):
+        self._login()
+        self.navigate_to_published_histories()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        present_histories = self.get_present_histories()
+        clicked = False
+        for row in present_histories:
+            his = row.find_elements(By.TAG_NAME, "td")[0]
+            if self.history2_name in his.text:
+                row.find_elements(By.TAG_NAME, "td")[2].find_elements(
+                    By.CSS_SELECTOR, ".published-histories-username-link"
+                )[0].click()
+                clicked = True
+                break
+
+        assert clicked
+        text = self.components.published_histories.search_input.wait_for_value()
+        if "test2" not in text:
+            raise AssertionError("Failed to update search filter with username on username click")
+
+        self.assert_histories_present([self.history2_name])
+
+    @selenium_test
     def test_published_histories_search_standard(self):
         self._login()
         self.navigate_to_published_histories()

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -795,10 +795,57 @@ class TestHistoryFilters(BaseTestCase):
 
     def test_fn_filter_parsing(self):
         user2 = self.user_manager.create(**user2_data)
+        user3 = self.user_manager.create(**user3_data)
         history1 = self.history_manager.create(name="history1", user=user2)
         history2 = self.history_manager.create(name="history2", user=user2)
         history3 = self.history_manager.create(name="history3", user=user2)
+        history4 = self.history_manager.create(name="history4", user=user3)
 
+        # test username eq filter
+        filters_2 = self.filter_parser.parse_filters(
+            [
+                ("username", "eq", "user2"),
+            ]
+        )
+        filters_3 = self.filter_parser.parse_filters(
+            [
+                ("username", "eq", "user3"),
+            ]
+        )
+        username_filter_2 = filters_2[0].filter
+        username_filter_3 = filters_3[0].filter
+
+        assert username_filter_2(history1)
+        assert username_filter_2(history2)
+        assert username_filter_2(history3)
+        assert not username_filter_2(history4)
+        assert not username_filter_3(history1)
+        assert not username_filter_3(history2)
+        assert not username_filter_3(history3)
+        assert username_filter_3(history4)
+
+        assert self.history_manager.list(filters=filters_2) == [history1, history2, history3]
+        assert self.history_manager.list(filters=filters_3) == [history4]
+
+        # test username contains filter
+        filters = self.filter_parser.parse_filters(
+            [
+                ("username", "contains", "user"),
+            ]
+        )
+
+        assert self.history_manager.list(filters=filters) == [history1, history2, history3, history4]
+
+        # test username eq filter (inequality)
+        filters = self.filter_parser.parse_filters(
+            [
+                ("username", "eq", "user"),
+            ]
+        )
+
+        assert self.history_manager.list(filters=filters) == []
+
+        # test annotation filter
         filters = self.filter_parser.parse_filters(
             [
                 ("annotation", "has", "no play"),


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/16568

## Added scroll pagination (page previously had no pagination):

https://github.com/galaxyproject/galaxy/assets/78516064/faea13f8-aa19-4d82-af04-618f01c60d1d

## Added username (owner) filter:
Also allows you to link to the `HistoryPublishedList` page with username filter:
`/histories/list_published?f-username=testuser`

https://github.com/galaxyproject/galaxy/assets/78516064/ad31eb3b-cb5f-4a22-8111-70818c7925ae

## Possible Future Directions?:
- Should we change `b-table` to list similar to list of histories seen in the SelectorModal?:
  ![image](https://github.com/galaxyproject/galaxy/assets/78516064/e9ee39be-f9e8-4b8a-a77c-ddaa9cd86774)


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
