### PR TITLE
[23.1] Login/Register fixes

### DIFF
--- a/client/src/components/History/Modals/CopyModal.vue
+++ b/client/src/components/History/Modals/CopyModal.vue
@@ -2,7 +2,7 @@
     <b-modal v-bind="$attrs" :title="title" title-tag="h2" v-on="$listeners">
         <transition name="fade">
             <b-alert v-localize :show="isAnonymous" variant="warning">
-                As an anonymous user, unless you login or register, you will lose your current history after copying
+                As an anonymous user, unless you log in or register, you will lose your current history after copying
                 this history. You can <a href="/user/login">log in here</a> or <a href="/user/create">register here</a>.
             </b-alert>
         </transition>

--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -65,19 +65,18 @@
                                         dashes ('.', '_', '-').
                                     </b-form-text>
                                 </b-form-group>
-                                <b-form-group
-                                    v-if="mailingJoinAddr && serverMailConfigured"
-                                    :label="labelSubscribe"
-                                    label-for="register-form-subscribe">
+                                <b-form-group v-if="mailingJoinAddr && serverMailConfigured">
                                     <b-form-checkbox
                                         id="register-form-subscribe"
                                         v-model="subscribe"
                                         name="subscribe"
-                                        type="checkbox" />
+                                        type="checkbox">
+                                        {{ labelSubscribe }}
+                                    </b-form-checkbox>
                                 </b-form-group>
-                                <b-button v-localize name="create" type="submit" :disabled="disableCreate"
-                                    >Create</b-button
-                                >
+                                <b-button v-localize name="create" type="submit" :disabled="disableCreate">
+                                    Create
+                                </b-button>
                             </b-card-body>
                         </b-collapse>
                         <b-card-footer v-if="showLoginLink">

--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -3,7 +3,7 @@
         <div class="row justify-content-md-center">
             <div class="col col-lg-6">
                 <b-alert :show="!!registrationWarningMessage" variant="info">
-                    {{ registrationWarningMessage }}
+                    <span v-html="registrationWarningMessage" />
                 </b-alert>
                 <b-alert :show="!!messageText" :variant="messageVariant">
                     {{ messageText }}

--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -3,6 +3,7 @@
         <div class="row justify-content-md-center">
             <div class="col col-lg-6">
                 <b-alert :show="!!registrationWarningMessage" variant="info">
+                    <!-- eslint-disable-next-line vue/no-v-html -->
                     <span v-html="registrationWarningMessage" />
                 </b-alert>
                 <b-alert :show="!!messageText" :variant="messageVariant">

--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -68,7 +68,7 @@
                                     v-if="mailingJoinAddr && serverMailConfigured"
                                     :label="labelSubscribe"
                                     label-for="register-form-subscribe">
-                                    <input
+                                    <b-form-checkbox
                                         id="register-form-subscribe"
                                         v-model="subscribe"
                                         name="subscribe"

--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -217,6 +217,7 @@ export default {
     left: 50%;
     transform: translateX(-50%);
     background-color: rgba(255, 255, 255, 0.9);
+    border: 1px solid #ccc;
     padding: 2px 5px;
     border-radius: 4px;
 }

--- a/client/src/components/Login/RegisterForm.vue
+++ b/client/src/components/Login/RegisterForm.vue
@@ -93,8 +93,9 @@
                     </b-card>
                 </b-form>
             </div>
-            <div v-if="termsUrl" class="col">
-                <b-embed type="iframe" :src="termsUrl" aspect="1by1" />
+            <div v-if="termsUrl" class="col position-relative embed-container">
+                <iframe title="terms-of-use" :src="termsUrl" frameborder="0" class="terms-iframe"></iframe>
+                <div v-localize class="scroll-hint">↓ Scroll to review ↓</div>
             </div>
         </div>
     </div>
@@ -204,3 +205,25 @@ export default {
     },
 };
 </script>
+<style scoped>
+.embed-container {
+    position: relative;
+}
+
+.scroll-hint {
+    position: absolute;
+    bottom: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: rgba(255, 255, 255, 0.9);
+    padding: 2px 5px;
+    border-radius: 4px;
+}
+
+.terms-iframe {
+    width: 100%;
+    height: 90vh;
+    border: none;
+    overflow-y: auto;
+}
+</style>

--- a/client/src/entry/analysis/menu.js
+++ b/client/src/entry/analysis/menu.js
@@ -166,7 +166,7 @@ export function fetchMenu(options = {}) {
         if (options.allow_user_creation) {
             userTab = {
                 id: "user",
-                title: _l("Login or Register"),
+                title: _l("Log in or Register"),
                 cls: "loggedout-only",
                 url: "/login",
                 tooltip: _l("Log in or register a new account"),

--- a/client/src/nls/de/locale.js
+++ b/client/src/nls/de/locale.js
@@ -23,7 +23,7 @@ define({
     User: "Benutzer",
     Login: "Anmeldung",
     Register: "Neu registrieren",
-    "Login or Register": "Einloggen oder Registrieren",
+    "Log in or Register": "Einloggen oder Registrieren",
     "Signed in as": "Angemeldet als",
     Preferences: "Präferenzen",
     "Custom Builds": "Custom Builds",

--- a/client/src/nls/es/locale.js
+++ b/client/src/nls/es/locale.js
@@ -54,7 +54,7 @@ define({
 
     Register: "Registro",
 
-    "Login or Register": "Iniciar sesión o Registrarse",
+    "Log in or Register": "Iniciar sesión o Registrarse",
     "Subscribe to mailing list": false,
     "Already have an account?": false,
     "Log in here.": false,

--- a/client/src/nls/fr/locale.js
+++ b/client/src/nls/fr/locale.js
@@ -24,7 +24,7 @@ define({
     User: "Utilisateur",
     Login: "Authentification",
     Register: "Enregistrement",
-    "Login or Register": "Authentification et Enregistrement",
+    "Log in or Register": "Authentification et Enregistrement",
     "Signed in as": "Authentifié en tant que",
     Preferences: "Préférences",
     "Custom Builds": "Mes génomes Builds de référence",

--- a/client/src/nls/ja/locale.js
+++ b/client/src/nls/ja/locale.js
@@ -26,7 +26,7 @@ define({
     User: "ユーザー",
     Login: "ログイン",
     Register: "登録",
-    "Login or Register": "ログイン/登録",
+    "Log in or Register": "ログイン/登録",
     Preferences: "設定",
     "Custom Builds": "カスタムビルド",
     Logout: "ログアウト",

--- a/client/src/nls/locale.js
+++ b/client/src/nls/locale.js
@@ -25,7 +25,7 @@ define({
         User: false,
         Login: false,
         Register: false,
-        "Login or Register": false,
+        "Log in or Register": false,
         "Signed in as": false,
         Preferences: false,
         "Custom Builds": false,

--- a/client/src/nls/zh/locale.js
+++ b/client/src/nls/zh/locale.js
@@ -26,7 +26,7 @@ define({
     User: "账号管理",
     Login: "登陆",
     Register: "注册",
-    "Login or Register": "注册登陆",
+    "Log in or Register": "注册登陆",
     "Signed in as": "您已登陆为",
     Preferences: "用户偏好性",
     "Custom Builds": "自定义构建集",

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -719,7 +719,7 @@ class NavigatesGalaxy(HasDriver):
             ui_logged_out = self.components.masthead.logged_out_only.is_displayed
             if ui_logged_out:
                 dom_message = (
-                    "Element a.loggedout-only is present in DOM, indicating Login or Register button still in masthead."
+                    "Element a.loggedout-only is present in DOM, indicating Log in or Register button still in masthead."
                 )
             else:
                 dom_message = "Element a.loggedout-only is *not* present in DOM."

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -718,9 +718,7 @@ class NavigatesGalaxy(HasDriver):
         except SeleniumTimeoutException as e:
             ui_logged_out = self.components.masthead.logged_out_only.is_displayed
             if ui_logged_out:
-                dom_message = (
-                    "Element a.loggedout-only is present in DOM, indicating Log in or Register button still in masthead."
-                )
+                dom_message = "Element a.loggedout-only is present in DOM, indicating Log in or Register button still in masthead."
             else:
                 dom_message = "Element a.loggedout-only is *not* present in DOM."
             user_info = self.api_get("users/current")
@@ -1917,7 +1915,7 @@ class NavigatesGalaxy(HasDriver):
         try:
             self.components.masthead.logged_out_only.wait_for_visible()
         except SeleniumTimeoutException as e:
-            message = "Clicked logout button but waiting for 'Login or Registration' button failed, perhaps the logout button was clicked before the handler was setup?"
+            message = "Clicked logout button but waiting for 'Log in or Registration' button failed, perhaps the logout button was clicked before the handler was setup?"
             raise self.prepend_timeout_message(e, message)
         assert (
             not self.is_logged_in()


### PR DESCRIPTION
Mostly minor fixes.  Closes #16646 

- Standardizes Login/Log in.
- Checkbox alignment for mailing list registration.
- Allow html contents in registration message alert (like bold, italic, etc) 
- Fix up terms display, add indicator for scrolling and show more by default.

![image](https://github.com/galaxyproject/galaxy/assets/155398/d4cc3c5f-daad-4e7d-ae22-0449718f75f6)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
