### PR TITLE
cwl testing: use the proposed 1.2.1 CWL conformance tests.

### DIFF
--- a/scripts/cwl_conformance_to_test_cases.py
+++ b/scripts/cwl_conformance_to_test_cases.py
@@ -23,7 +23,7 @@ $tests'''
 
 TEST_TEMPLATE = string.Template(
     '''
-${marks}    def test_conformance_${version_simple}_${label}(self):
+${marks}    def test_conformance_${version_simple}_${id_}(self):
         """${doc}
 
         Generated from::
@@ -314,9 +314,9 @@ def main():
         del test_with_doc["doc"]
         cwl_test_def = yaml.dump(test_with_doc, default_flow_style=False)
         cwl_test_def = "\n".join(f"            {line}" for line in cwl_test_def.splitlines())
-        label = conformance_test.get("label", str(i))
+        id_ = conformance_test.get("id", str(i))
         tags = conformance_test.get("tags", [])
-        is_red = label in red_tests_list
+        is_red = id_ in red_tests_list
 
         marks = "    @pytest.mark.cwl_conformance\n"
         marks += f"    @pytest.mark.cwl_conformance_{version_simple}\n"
@@ -329,7 +329,7 @@ def main():
 
         if not {"command_line_tool", "expression_tool", "workflow"}.intersection(tags):
             print(
-                f"PROBLEM - test [{label}] tagged with neither command_line_tool, expression_tool, nor workflow",
+                f"PROBLEM - test [{id_}] tagged with neither command_line_tool, expression_tool, nor workflow",
                 file=sys.stderr,
             )
 
@@ -338,17 +338,17 @@ def main():
             "version": version,
             "doc": conformance_test["doc"],
             "cwl_test_def": cwl_test_def,
-            "label": label.replace("-", "_"),
+            "id_": id_.replace("-", "_"),
             "marks": marks,
         }
         test_body = TEST_TEMPLATE.safe_substitute(template_kwargs)
         tests += test_body
 
-        if label in all_tests_found:
-            print(f"PROBLEM - Duplicate label found [{label}]", file=sys.stderr)
-        all_tests_found.add(label)
+        if id_ in all_tests_found:
+            print(f"PROBLEM - Duplicate id found [{id_}]", file=sys.stderr)
+        all_tests_found.add(id_)
         if is_red:
-            red_tests_found.add(label)
+            red_tests_found.add(id_)
 
     test_file_contents = TEST_FILE_TEMPLATE.safe_substitute(
         {

--- a/scripts/update_cwl_conformance_tests.sh
+++ b/scripts/update_cwl_conformance_tests.sh
@@ -17,13 +17,18 @@ for version in $VERSIONS; do
         conformance_filepath=conformance_tests.yaml
         tests_dir=tests
     fi
-    wget "https://github.com/common-workflow-language/${repo_name}/archive/main.zip"
-    unzip main.zip
+    if [ "$version" = '1.2' ]; then
+	branch=1.2.1_proposed
+    else
+	branch=main
+    fi
+    wget "https://github.com/common-workflow-language/${repo_name}/archive/${branch}.zip"
+    unzip ${branch}.zip
     rm -rf "${DEST_DIR}/v${version}"
     mkdir -p "${DEST_DIR}/v${version}"
-    cp "${repo_name}-main/${conformance_filepath}" "${DEST_DIR}/v${version}/conformance_tests.yaml"
-    cp -r "${repo_name}-main/${tests_dir}" "${DEST_DIR}/v${version}"/
-    rm -rf "${repo_name}-main"
-    rm -rf main.zip
+    cp "${repo_name}-${branch}/${conformance_filepath}" "${DEST_DIR}/v${version}/conformance_tests.yaml"
+    cp -r "${repo_name}-${branch}/${tests_dir}" "${DEST_DIR}/v${version}"/
+    rm -rf "${repo_name}-${branch}"
+    rm -rf ${branch}.zip
     python3 scripts/cwl_conformance_to_test_cases.py "${DEST_DIR}" "v${version}"
 done


### PR DESCRIPTION
When fetching the CWL v1.2 conformance tests, pull from the proposed CWL v1.2.1 branch.

These nearly-ratified [changes fix some conformance tests, and add new tests](https://github.com/common-workflow-language/cwl-v1.2/pull/115#issue-986539366). Likely the `red` lists for CWL v1.2 will need to be updated.

## How to test the changes?
(Select all options that apply)
- ~~I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).~~
- [x] This is a refactoring of components with existing test coverage.
- ~~Instructions for manual testing are as follows:~~

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
