### PR TITLE
[23.0] Force `__DUPLICATE_FILE_TO_COLLECTION__` 'size' param to integer

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3706,7 +3706,7 @@ class DuplicateFileToCollectionTool(DatabaseOperationTool):
 
     def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
         hda = incoming["input"]
-        number = incoming["number"]
+        number = int(incoming["number"])
         element_identifier = incoming["element_identifier"]
         elements = {
             f"{element_identifier} {n}": hda.copy(copy_tags=hda.tags, flush=False) for n in range(1, number + 1)


### PR DESCRIPTION
I have a workflow containing the `__DUPLICATE_FILE_TO_COLLECTION__ ` tool, with the parameter specifying the size of the output collection exposed as an integer workflow parameter. Workflow execution fails with this error:

```
Traceback (most recent call last):
  File "/srv/galaxy/server/lib/galaxy/tools/__init__.py", line 2047, in handle_single_execution
    rval = self.execute(
  File "/srv/galaxy/server/lib/galaxy/tools/__init__.py", line 2144, in execute
    return self.tool_action.execute(
  File "/srv/galaxy/server/lib/galaxy/tools/actions/model_operations.py", line 87, in execute
    self._produce_outputs(
  File "/srv/galaxy/server/lib/galaxy/tools/actions/model_operations.py", line 114, in _produce_outputs
    tool.produce_outputs(
  File "/srv/galaxy/server/lib/galaxy/tools/__init__.py", line 3902, in produce_outputs
    f"{element_identifier} {n}": hda.copy(copy_tags=hda.tags, flush=False) for n in range(1, number + 1)
TypeError: can only concatenate str (not "int") to str
```

whereas running `__DUPLICATE_FILE_TO_COLLECTION__ ` as a tool, outside the workflow, succeeds as expected. With this change both tool and workflow complete successfully.

I can't help but feel there must be some deeper issue, the workflow integer param presumably shouldn't be turned into an string, so this is more of a sticking plaster - feel free to close if the underlying issue can be solved instead.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. follow description above

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
