### PR TITLE
[23.1] Make sort_collection tool require terminal datasets

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3513,7 +3513,7 @@ class FlattenTool(DatabaseOperationTool):
 
 class SortTool(DatabaseOperationTool):
     tool_type = "sort_collection"
-    require_terminal_states = False
+    require_terminal_states = True
     require_dataset_ok = False
 
     def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):


### PR DESCRIPTION
It would be nice if we could limit this just to the dataset that we're reading the element identifiers from, but this will do as a bugfix.

Fixes
```
Exception: Number of lines must match number of list elements (2), but file has 0 lines
  File "galaxy/tools/__init__.py", line 1937, in handle_single_execution
    rval = self.execute(
  File "galaxy/tools/__init__.py", line 2034, in execute
    return self.tool_action.execute(
  File "galaxy/tools/actions/model_operations.py", line 88, in execute
    self._produce_outputs(
  File "galaxy/tools/actions/model_operations.py", line 119, in _produce_outputs
    tool.produce_outputs(
  File "galaxy/tools/__init__.py", line 3545, in produce_outputs
    raise Exception(message)
```
because in a workflow the dataset with identifiers might not be ready at the time the tool is run.

Broken in https://github.com/galaxyproject/galaxy/commit/314f13533000c2f9e9535956fcc8885299e1ec8b

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
