### PR TITLE
[23.1] xsd: allow name attribute of test collections

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1577,6 +1577,11 @@ non-optional composite inputs must be specified as part of the ``param``.
         <xs:documentation xml:lang="en">Type of collection to create.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">The identifier of the collection. Default is ``"Unnamed Collection"``</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="tags" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">Comma separated list of tags to apply to the dataset (only works for elements of collections - e.g. ``element`` XML tags).</xs:documentation>

--- a/test/functional/tools/collection_paired_test.xml
+++ b/test/functional/tools/collection_paired_test.xml
@@ -1,6 +1,7 @@
 <tool id="collection_paired_test" name="collection_paired_test" version="0.1.0">
   <command>
     cat $f1.forward $f1['reverse'] >> $out1;
+    echo 'collection identifier: $f1.element_identifier'
   </command>
   <inputs>
     <param name="f1" type="data_collection" collection_type="paired" label="Input pair" />
@@ -11,7 +12,7 @@
   <tests>
     <test>
       <param name="f1">
-        <collection type="paired">
+        <collection type="paired" name="collection name">
           <element name="forward" value="simple_line.txt" />
           <element name="reverse" value="simple_line_alternative.txt" />
         </collection>
@@ -22,6 +23,9 @@
           <has_line line="This is a different line of text." />
         </assert_contents>
       </output>
+      <assert_stdout>
+          <has_line line="collection identifier: collection name" />
+      </assert_stdout>
     </test>
   </tests>
 </tool>

--- a/test/functional/tools/collection_paired_test.xml
+++ b/test/functional/tools/collection_paired_test.xml
@@ -1,7 +1,7 @@
 <tool id="collection_paired_test" name="collection_paired_test" version="0.1.0">
   <command>
     cat $f1.forward $f1['reverse'] >> $out1;
-    echo 'collection identifier: $f1.element_identifier'
+    echo 'Collection name: $f1.name'
   </command>
   <inputs>
     <param name="f1" type="data_collection" collection_type="paired" label="Input pair" />
@@ -24,7 +24,7 @@
         </assert_contents>
       </output>
       <assert_stdout>
-          <has_line line="collection identifier: collection name" />
+          <has_line line="Collection name: collection name" />
       </assert_stdout>
     </test>
   </tests>


### PR DESCRIPTION
already supported by the framework

fixes: https://github.com/galaxyproject/galaxy/issues/16654

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
