### PR TITLE
Galaxy Markdown - add workflow image and license to Galaxy markdown.

### DIFF
--- a/client/src/components/Markdown/Elements/Workflow/WorkflowImage.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowImage.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { getAppRoot } from "@/onload/loadConfig";
+
+interface WorkflowImageProps {
+    workflowId: string;
+    size?: string;
+}
+
+const props = withDefaults(defineProps<WorkflowImageProps>(), {
+    size: "lg",
+});
+
+const src = computed(() => {
+    return `${getAppRoot()}workflow/gen_image?id=${props.workflowId}&embed=true`;
+});
+const width = computed(() => {
+    const size = props.size;
+    if (size == "sm") {
+        return "300px";
+    } else if (size == "md") {
+        return "550px";
+    } else {
+        return "100%";
+    }
+});
+</script>
+
+<template>
+    <img alt="Preview of Galaxy Workflow" :src="src" :width="width" height="auto" />
+</template>

--- a/client/src/components/Markdown/Elements/Workflow/WorkflowLicense.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowLicense.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import License from "@/components/License/License.vue";
+
+interface WorkflowLicenseProps {
+    licenseId?: string;
+}
+
+const props = withDefaults(defineProps<WorkflowLicenseProps>(), {
+    licenseId: null,
+});
+</script>
+
+<template>
+    <span>
+        <p v-if="!props.licenseId">
+            <i>Workflow does not define a license.</i>
+        </p>
+        <License v-else :license-id="props.licenseId" />
+    </span>
+</template>

--- a/client/src/components/Markdown/MarkdownContainer.vue
+++ b/client/src/components/Markdown/MarkdownContainer.vue
@@ -14,6 +14,8 @@ import JobParameters from "./Elements/JobParameters.vue";
 import ToolStd from "./Elements/ToolStd.vue";
 import Visualization from "./Elements/Visualization.vue";
 import WorkflowDisplay from "./Elements/Workflow/WorkflowDisplay.vue";
+import WorkflowImage from "./Elements/Workflow/WorkflowImage.vue";
+import WorkflowLicense from "./Elements/Workflow/WorkflowLicense.vue";
 
 const toggle = ref(false);
 const props = defineProps({
@@ -74,6 +76,12 @@ const isVisible = computed(() => !isCollapsible.value || toggle.value);
             </div>
             <div v-else-if="name == 'generate_time'" class="galaxy-time">
                 <pre><code>{{ time }}</code></pre>
+            </div>
+            <div v-else-if="name == 'workflow_image'" class="workflow-image" style="text-align: center">
+                <WorkflowImage :workflow-id="args.workflow_id" :size="args.size || 'lg'" />
+            </div>
+            <div v-else-if="name == 'workflow_license'" class="workflow-license">
+                <WorkflowLicense :license-id="workflows[args.workflow_id]['license']" />
             </div>
             <HistoryLink v-else-if="name == 'history_link'" :args="args" :histories="histories" />
             <HistoryDatasetAsImage v-else-if="name == 'history_dataset_as_image'" :args="args" />

--- a/client/src/components/Markdown/MarkdownDialog.vue
+++ b/client/src/components/Markdown/MarkdownDialog.vue
@@ -177,7 +177,7 @@ export default {
         },
         onWorkflow(response) {
             this.workflowShow = false;
-            this.$emit("onInsert", `workflow_display(workflow_id=${response.id})`);
+            this.$emit("onInsert", `${this.argumentName}(workflow_id=${response.id})`);
         },
         onVisualization(response) {
             this.visualizationShow = false;

--- a/client/src/components/Markdown/MarkdownToolBox.vue
+++ b/client/src/components/Markdown/MarkdownToolBox.vue
@@ -190,6 +190,16 @@ export default {
                         name: "Workflow Display",
                         emitter: "onWorkflowId",
                     },
+                    {
+                        id: "workflow_license",
+                        name: "Workflow License",
+                        emitter: "onWorkflowId",
+                    },
+                    {
+                        id: "workflow_image",
+                        name: "Workflow Image",
+                        emitter: "onWorkflowId",
+                    },
                 ],
             },
             workflowInEditorSection: {
@@ -213,6 +223,14 @@ export default {
                         id: "workflow_display",
                         name: "Current Workflow",
                         description: "containing all steps",
+                    },
+                    {
+                        id: "workflow_image",
+                        name: "Current Workflow Image",
+                    },
+                    {
+                        id: "workflow_license",
+                        name: "Current Workflow License",
                     },
                 ],
             },

--- a/lib/galaxy/managers/markdown_parse.py
+++ b/lib/galaxy/managers/markdown_parse.py
@@ -38,6 +38,8 @@ VALID_ARGUMENTS: Dict[str, Union[List[str], DynamicArguments]] = {
     "history_dataset_type": ["input", "output", "history_dataset_id"],
     "history_dataset_collection_display": ["input", "output", "history_dataset_collection_id"],
     "workflow_display": ["workflow_id"],
+    "workflow_license": ["workflow_id"],
+    "workflow_image": ["workflow_id", "size"],
     "job_metrics": ["step", "job_id"],
     "job_parameters": ["step", "job_id"],
     "tool_stderr": ["step", "job_id"],

--- a/lib/galaxy/workflow/render.py
+++ b/lib/galaxy/workflow/render.py
@@ -23,7 +23,7 @@ class WorkflowCanvas:
         self.max_width = 0
         self.data = []
 
-    def finish(self):
+    def finish(self, for_embed=False):
         # max_x, max_y, max_width = self.max_x, self.max_y, self.max_width
         for box in self.boxes:
             self.canvas.add(box)
@@ -33,6 +33,11 @@ class WorkflowCanvas:
         for text in self.text:
             text_style_layer.add(text)
         self.canvas.add(text_style_layer)
+        # if we're embedding this in HTML - setup a viewbox and preserve aspect ratio
+        # https://css-tricks.com/scale-svg/#aa-the-viewbox-attribute
+        if for_embed:
+            self.canvas.viewbox(-5, -5, self.max_x + self.max_width, self.max_y + 150)
+            self.canvas.fit()
         return self.canvas
 
     def add_boxes(self, step_dict, width, name_fill):


### PR DESCRIPTION
Screenshots:

<img width="636" alt="Screenshot 2023-09-08 at 1 12 19 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/2579c289-834c-40ba-b0f5-767dc9a94bfa">

---------

<img width="1164" alt="Screenshot 2023-09-08 at 1 13 04 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/f9150468-abf6-40ab-bf84-f24cfff3c7f9">

--------

<img width="1161" alt="Screenshot 2023-09-08 at 1 13 33 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/f6709478-4289-445c-9e65-63e105dc2e7c">

--------

PDF implementation:

<img width="904" alt="Screenshot 2023-09-11 at 1 10 53 PM" src="https://github.com/galaxyproject/galaxy/assets/216771/e3048a71-690a-413d-b652-07bde98d8074">


--------


I think Github is going to shrink these images - and they won't be SVGs - so the screenshots are... deceptive in a way? Expand them to full screen and imagine everything looks better at runtime.

The markdown I implemented here supports three different sizes for the workflow image preview (sm, md, and lg (the default)). lg is just 100% with auto height. sm and md are more for like quick visual ques and fix the widths at 300 and 550 pixels respectively and set the height to auto. I think the height at auto with a fixed width will just set the size of the height of the image to whatever makes sense to prevent distortion for that height. I'm not really a CSS or SVG person so I'm not sure this is the case but it seems right based on my testing - some background reading I found useful is here - https://css-tricks.com/scale-svg/#aa-the-viewbox-attribute.

I have no idea how to embed these SVGs into a png or something for inclusion in the PDF - it seems all the obvious candidates are LGPL but maybe weasyprint will just work - the PDF stuff here is WIP.

Please please please do not bike shed the content of the image previews. If you don't love them - it is all based on existing preview images we already generate and expose to users. Open an issue and comment there - please 😇 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create a page and embed these things in there.

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
